### PR TITLE
Dogfood self-improvement findings

### DIFF
--- a/.agentic-workspace/docs/contract-schema-index.md
+++ b/.agentic-workspace/docs/contract-schema-index.md
@@ -30,6 +30,7 @@ Use it when you need to know which checked-in file owns a machine-readable contr
 | `report_contract_manifest.schema.json` | report contract manifest |
 | `workspace_report.schema.json` | emitted workspace report envelope |
 | `contract_inventory.schema.json` | boundary inventory |
+| `agent_feedback.schema.json` | optional feedback review artifacts |
 | `workspace_config.schema.json` | `.agentic-workspace/config.toml` |
 | `workspace_local_override.schema.json` | `.agentic-workspace/config.local.toml` |
 | `setup_findings.schema.json` | `tools/setup-findings.json` |

--- a/.agentic-workspace/docs/contract-schema-index.md
+++ b/.agentic-workspace/docs/contract-schema-index.md
@@ -30,7 +30,7 @@ Use it when you need to know which checked-in file owns a machine-readable contr
 | `report_contract_manifest.schema.json` | report contract manifest |
 | `workspace_report.schema.json` | emitted workspace report envelope |
 | `contract_inventory.schema.json` | boundary inventory |
-| `agent_feedback.schema.json` | optional feedback review artifacts |
+| `agent_feedback.schema.json` | optional feedback review artifacts; not a required operating surface unless command-emitted later |
 | `workspace_config.schema.json` | `.agentic-workspace/config.toml` |
 | `workspace_local_override.schema.json` | `.agentic-workspace/config.local.toml` |
 | `setup_findings.schema.json` | `tools/setup-findings.json` |

--- a/.agentic-workspace/memory/repo/manifest.toml
+++ b/.agentic-workspace/memory/repo/manifest.toml
@@ -440,6 +440,8 @@ preferred_remediation = "test"
 improvement_candidate = true
 improvement_note = "Prefer regression tests, validation, or compact readiness output before growing this note."
 elimination_target = "shrink"
+config_treatment = "promote"
+config_note = "Current repo posture favors executable planning guardrails for broad work before retaining this as long-term passive memory."
 
 [durable_facts."memory-owner-boundary"]
 summary = "Memory owns durable rediscovery-saving repo facts, not active sequencing, backlog state, or workflow policy."

--- a/.agentic-workspace/planning/external-intent-evidence.json
+++ b/.agentic-workspace/planning/external-intent-evidence.json
@@ -30,6 +30,15 @@
     },
     {
       "system": "github",
+      "id": "#252",
+      "title": "[Workspace]: Make the default entry path easier for generic agents to discover and follow so startup compliance does not depend on deep product awareness",
+      "status": "closed",
+      "kind": "issue",
+      "parent_id": "#251",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
       "id": "#253",
       "title": "[Workspace]: Make core package surfaces cheaper for generic agents to consume so using the package is easier than broad repo scavenging or private reinvention",
       "status": "closed",
@@ -62,6 +71,15 @@
       "status": "closed",
       "kind": "issue",
       "parent_id": "#251",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#257",
+      "title": "[Workspace]: Surface dangling larger intent and lower-trust closeout signals without assuming any external planning system",
+      "status": "closed",
+      "kind": "issue",
+      "parent_id": "",
       "planning_residue_expected": "required"
     },
     {
@@ -139,7 +157,7 @@
     {
       "system": "github",
       "id": "#267",
-      "title": "[Planning]: Add an explicit planning↔config handshake so bounded work pulls material config before execution and checks config compliance after finishing",
+      "title": "[Planning]: Add an explicit planning\u2194config handshake so bounded work pulls material config before execution and checks config compliance after finishing",
       "status": "closed",
       "kind": "issue",
       "parent_id": "",
@@ -148,28 +166,10 @@
     {
       "system": "github",
       "id": "#268",
-      "title": "[Memory]: Add an explicit memory↔config handshake so memory creation asks how current config wants signals, notes, promotion, and cleanup to be treated",
+      "title": "[Memory]: Add an explicit memory\u2194config handshake so memory creation asks how current config wants signals, notes, promotion, and cleanup to be treated",
       "status": "closed",
       "kind": "issue",
       "parent_id": "",
-      "planning_residue_expected": "required"
-    },
-    {
-      "system": "github",
-      "id": "#257",
-      "title": "[Workspace]: Surface dangling larger intent and lower-trust closeout signals without assuming any external planning system",
-      "status": "closed",
-      "kind": "issue",
-      "parent_id": "",
-      "planning_residue_expected": "required"
-    },
-    {
-      "system": "github",
-      "id": "#252",
-      "title": "[Workspace]: Make the default entry path easier for generic agents to discover and follow so startup compliance does not depend on deep product awareness",
-      "status": "closed",
-      "kind": "issue",
-      "parent_id": "#251",
       "planning_residue_expected": "required"
     },
     {
@@ -1007,6 +1007,51 @@
       "status": "closed",
       "kind": "issue",
       "parent_id": "#230",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#388",
+      "title": "[Review]: Add ordinary agent path summary",
+      "status": "closed",
+      "kind": "issue",
+      "parent_id": "",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#389",
+      "title": "[Review]: Mark historical reviews as evidence-only unless selected",
+      "status": "closed",
+      "kind": "issue",
+      "parent_id": "",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#390",
+      "title": "[Review]: Explain why report sections matter now",
+      "status": "closed",
+      "kind": "issue",
+      "parent_id": "",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#391",
+      "title": "[Review]: Quiet idle planning projections further",
+      "status": "closed",
+      "kind": "issue",
+      "parent_id": "",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#392",
+      "title": "[Review]: Normalize agent feedback artifacts",
+      "status": "closed",
+      "kind": "issue",
+      "parent_id": "",
       "planning_residue_expected": "required"
     }
   ]

--- a/.agentic-workspace/planning/reviews/agent-feedback-findings-closeout-2026-04-26.review.json
+++ b/.agentic-workspace/planning/reviews/agent-feedback-findings-closeout-2026-04-26.review.json
@@ -1,0 +1,89 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Agent feedback findings closeout",
+  "goal": [
+    "Record the implementation and proof for feedback-derived issues #388-#392."
+  ],
+  "scope": [
+    "Default report router guidance",
+    "Historical review artifact treatment",
+    "Report section routing hints",
+    "Compact planning summary idle projections",
+    "Normalized feedback artifact schema"
+  ],
+  "non_goals": [
+    "Add a new first-line command",
+    "Make GitHub or any other tracker a package dependency",
+    "Turn repo-local self-improvement workflow into shipped package doctrine"
+  ],
+  "review_mode": {
+    "mode": "closeout",
+    "review question": "Were the feedback-derived findings implemented with compact, package-agnostic surfaces and enough proof?",
+    "default finding cap": "n/a",
+    "inputs inspected first": "agent-feedback-prompt.txt evaluation findings; issues #388-#392; agentic-workspace report/summary/proof output"
+  },
+  "review_method": {
+    "commands used": "uv run agentic-workspace report --target . --format json; uv run agentic-workspace summary --format json; uv run agentic-workspace proof --target . --changed <paths> --format json; uv run pytest tests/test_workspace_cli.py -q; uv run pytest tests/test_contract_tooling.py -q; cd packages/planning && uv run pytest tests/test_installer.py; uv run ruff check src tests; cd packages/planning && uv run ruff check .; uv run agentic-workspace doctor --target . --modules planning --format json; uv run agentic-workspace reconcile --format json",
+    "evidence sources": "src/agentic_workspace/cli.py; packages/planning/src/repo_planning_bootstrap/installer.py; src/agentic_workspace/contracts/schemas/agent_feedback.schema.json; tests/test_workspace_cli.py; tests/test_contract_tooling.py; packages/planning/tests/test_installer.py"
+  },
+  "references": [
+    {
+      "kind": "issue",
+      "target": "#388",
+      "label": "ordinary agent path",
+      "role": "closed by implementation",
+      "locator": "report_profile.ordinary_agent_path"
+    },
+    {
+      "kind": "issue",
+      "target": "#389",
+      "label": "historical reviews evidence-only",
+      "role": "closed by implementation",
+      "locator": "closeout_trust.historical_review_artifacts"
+    },
+    {
+      "kind": "issue",
+      "target": "#390",
+      "label": "section why-now hints",
+      "role": "closed by implementation",
+      "locator": "section_hints[].why_now"
+    },
+    {
+      "kind": "issue",
+      "target": "#391",
+      "label": "idle projection compactness",
+      "role": "closed by implementation",
+      "locator": "summary.projection_state and idle reason_code"
+    },
+    {
+      "kind": "issue",
+      "target": "#392",
+      "label": "feedback artifact schema",
+      "role": "closed by implementation",
+      "locator": "src/agentic_workspace/contracts/schemas/agent_feedback.schema.json"
+    }
+  ],
+  "findings": [],
+  "recommendation": {
+    "promote": "none",
+    "defer": "none",
+    "dismiss": "none"
+  },
+  "retention": {
+    "closeout shape": "compact review evidence",
+    "trigger": "issues #388-#392 closed after implementation proof",
+    "proof surface": "agentic-workspace proof-selected workspace_cli and planning_package lanes"
+  },
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_cli.py -q",
+    "uv run pytest tests/test_contract_tooling.py -q",
+    "uv run ruff check src tests",
+    "cd packages/planning && uv run pytest tests/test_installer.py",
+    "cd packages/planning && uv run ruff check .",
+    "uv run agentic-workspace doctor --target . --modules planning --format json",
+    "uv run agentic-workspace reconcile --format json"
+  ],
+  "drift_log": [
+    "2026-04-26: Review created from feedback-driven self-improvement closeout."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/agent-feedback-findings-closeout-2026-04-26.review.json
+++ b/.agentic-workspace/planning/reviews/agent-feedback-findings-closeout-2026-04-26.review.json
@@ -63,6 +63,48 @@
       "locator": "src/agentic_workspace/contracts/schemas/agent_feedback.schema.json"
     }
   ],
+  "issue_classifications": [
+    {
+      "id": "#388",
+      "title": "[Review]: Add ordinary agent path summary",
+      "classification": "evidence-present",
+      "live_state": "closed",
+      "follow_up": "",
+      "evidence": "Implemented by commit 1fe7cf4 in report_profile.ordinary_agent_path with test coverage in tests/test_workspace_cli.py."
+    },
+    {
+      "id": "#389",
+      "title": "[Review]: Mark historical reviews as evidence-only unless selected",
+      "classification": "evidence-present",
+      "live_state": "closed",
+      "follow_up": "",
+      "evidence": "Implemented by commit 1fe7cf4 in closeout_trust.historical_review_artifacts with report-router coverage."
+    },
+    {
+      "id": "#390",
+      "title": "[Review]: Explain why report sections matter now",
+      "classification": "evidence-present",
+      "live_state": "closed",
+      "follow_up": "",
+      "evidence": "Implemented by commit 1fe7cf4 in section_hints[].why_now with test coverage in tests/test_workspace_cli.py."
+    },
+    {
+      "id": "#391",
+      "title": "[Review]: Quiet idle planning projections further",
+      "classification": "evidence-present",
+      "live_state": "closed",
+      "follow_up": "",
+      "evidence": "Implemented by commit 1fe7cf4 in compact planning summary projection_state and idle reason_code coverage."
+    },
+    {
+      "id": "#392",
+      "title": "[Review]: Normalize agent feedback artifacts",
+      "classification": "evidence-present",
+      "live_state": "closed",
+      "follow_up": "",
+      "evidence": "Implemented by commit 1fe7cf4 with src/agentic_workspace/contracts/schemas/agent_feedback.schema.json and schema validation coverage."
+    }
+  ],
   "findings": [],
   "recommendation": {
     "promote": "none",

--- a/.agentic-workspace/planning/reviews/system-intent-self-improvement-review-2026-04-26.review.json
+++ b/.agentic-workspace/planning/reviews/system-intent-self-improvement-review-2026-04-26.review.json
@@ -1,0 +1,97 @@
+{
+  "kind": "planning-review/v1",
+  "title": "System-Intent Self-Improvement Review",
+  "date": "2026-04-26",
+  "scope": [
+    "current self-improvement branch",
+    "system-intent alignment",
+    "compact report and skill-discovery surfaces"
+  ],
+  "classification": "system-intent",
+  "goal": [
+    "Find current package behaviors that make self-improvement less cheap, quiet, or intent-aligned than the system intent requires."
+  ],
+  "non_goals": [
+    "Do not reopen historical lanes or create new durable first-line surfaces.",
+    "Do not treat repo-local dogfooding convenience as shipped package authority."
+  ],
+  "review_mode": {
+    "mode": "system-intent",
+    "review_question": "Do the current compact surfaces make package dogfooding the cheapest honest path while preserving quiet, low-residue operation?",
+    "default_finding_cap": "bounded",
+    "inputs_inspected_first": "agentic-workspace summary, report, reconcile, skills, effective_authority, repo_friction, operational_compression, SYSTEM_INTENT.md, .agentic-workspace/system-intent/intent.toml"
+  },
+  "review_method": {
+    "commands_used": [
+      "uv run agentic-workspace summary --format json",
+      "uv run agentic-workspace report --target . --format json",
+      "uv run agentic-workspace reconcile --format json",
+      "uv run agentic-workspace skills --target . --task \"create a system-intent review and use it to run self-improvement until all findings have been addressed\" --format json",
+      "uv run agentic-workspace report --target . --section effective_authority --format json",
+      "uv run agentic-workspace report --target . --section repo_friction --format json",
+      "uv run agentic-workspace report --target . --section operational_compression --format json"
+    ],
+    "evidence_sources": [
+      "SYSTEM_INTENT.md",
+      ".agentic-workspace/system-intent/intent.toml",
+      "tools/skills/self-improvement-dogfooding/SKILL.md",
+      "tools/skills/REGISTRY.json",
+      "src/agentic_workspace/cli.py",
+      "tests/test_workspace_cli.py"
+    ]
+  },
+  "findings": [
+    {
+      "id": "skill-selector-misses-explicit-self-improvement",
+      "title": "Skill discovery fails the cheapest-path test for explicit self-improvement requests",
+      "action_state": "addressed",
+      "confidence": "high",
+      "source_class": "friction-confirmed",
+      "evidence": "The task explicitly said self-improvement, and the repo-local self-improvement-dogfooding skill was listed, but recommendations ranked planning-review-pass first and did not include self-improvement-dogfooding. This contradicts prior closeout evidence that the skill should be recommended for repeat system-intent dogfooding prompts.",
+      "promotion_target": "runtime selector and CLI tests",
+      "promotion_trigger": "Addressed in this pass because the current task depends on skill discovery as the dogfooding entrypoint.",
+      "resolution": "Normalized multi-word skill term matching against normalized task text and added a regression test for hyphenated self-improvement prompts.",
+      "system_intent_pressure": [
+        "Make the package the cheapest path for bounded work.",
+        "Reduce repeated steering and context overload.",
+        "Keep repo-local dogfooding separate but discoverable when explicitly named."
+      ]
+    },
+    {
+      "id": "idle-effective-authority-overstates-review-pressure",
+      "title": "Effective authority reports needs-review for an idle clean workspace",
+      "action_state": "addressed",
+      "confidence": "high",
+      "source_class": "analysis-confirmed",
+      "evidence": "report --section effective_authority returns status needs-review solely because no active planning record is present, while summary reports narrow-direct-ready and report findings are empty. No active plan is expected for idle or narrow direct work, so the status makes the package feel noisier than the compact surfaces otherwise indicate.",
+      "promotion_target": "report effective_authority payload and CLI tests",
+      "promotion_trigger": "Addressed in this pass because it is a default-router quietness issue, not a new capability.",
+      "resolution": "Moved no-active-planning-record from unresolved_gaps into idle_context so clean idle workspaces report effective_authority.status = ready while still exposing the absence of active work.",
+      "system_intent_pressure": [
+        "Stay quiet, repo-native, and low-residue.",
+        "Prefer compact queryable state over prose-first operation.",
+        "Do not make ordinary work feel like a visible workflow framework."
+      ]
+    }
+  ],
+  "recommendation": {
+    "promote": "Both bounded runtime/reporting findings were fixed in the current branch.",
+    "defer": "Do not create new commands or durable first-line surfaces.",
+    "dismiss": "No broader external-work or planning-residue finding is present; summary, reconcile, and report findings are clean."
+  },
+  "retention": {
+    "closeout_shape": "keep as compact evidence for this self-improvement pass; update finding action_state after proof",
+    "trigger": "all findings addressed and validation passes",
+    "proof_surface": "agentic-workspace proof --target . --changed <paths> --format json"
+  },
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_cli.py -q -k \"skills_command_recommends_self_improvement or report_real_init or report_section_selector_returns_compact_section_answer or default_profile_returns_router\"",
+    "uv run ruff check src tests",
+    "uv run agentic-workspace skills --target . --task \"create a system-intent review and use it to run self-improvement until all findings have been addressed\" --format json",
+    "uv run agentic-workspace report --target . --section effective_authority --format json"
+  ],
+  "drift_log": [
+    "2026-04-26: Review created with two actionable findings from current dogfooding evidence.",
+    "2026-04-26: Both findings marked addressed after local regression checks and live command verification."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/system-wide-self-improvement-review-2026-04-26.review.json
+++ b/.agentic-workspace/planning/reviews/system-wide-self-improvement-review-2026-04-26.review.json
@@ -1,0 +1,106 @@
+{
+  "kind": "planning-review/v1",
+  "title": "System-Wide Self-Improvement Review",
+  "date": "2026-04-26",
+  "scope": [
+    "workspace CLI report and skill routing",
+    "planning summary projections",
+    "Memory/report friction signals",
+    "system-intent fit for ordinary entry, recovery, proof, and quiet operation"
+  ],
+  "classification": "system-wide",
+  "goal": [
+    "Review the system as a whole and drive bounded self-improvement from actionable findings."
+  ],
+  "non_goals": [
+    "Do not add a new first-line surface.",
+    "Do not reopen historical lanes that have no current regression signal.",
+    "Do not hard-code repo-, host-, language-, tool-, or agent-specific behavior into shipped package contracts."
+  ],
+  "review_mode": {
+    "mode": "system-wide self-improvement",
+    "review_question": "Where does the current package still make ordinary self-improvement, recovery, routing, or proof more expensive than the system intent allows?",
+    "finding_policy": "capture only findings that are actionable in this branch or explicitly defer them with a bounded promotion trigger",
+    "inputs_inspected_first": [
+      "agentic-workspace summary --format json",
+      "agentic-workspace report --target . --format json",
+      "agentic-workspace skills --target . --task <current task> --format json",
+      "agentic-workspace report --target . --section repo_friction --format json",
+      "agentic-workspace report --target . --section operational_compression --format json",
+      "SYSTEM_INTENT.md",
+      ".agentic-workspace/system-intent/intent.toml"
+    ]
+  },
+  "findings": [
+    {
+      "id": "self-improvement-skill-under-ranked-for-drive-prompt",
+      "title": "Self-improvement skill is discoverable but under-ranked for system-wide self-improvement prompts",
+      "action_state": "addressed",
+      "confidence": "high",
+      "source_class": "friction-confirmed",
+      "evidence": "For the task 'make a full review of the system as a whole to drive self-improvement', skills output ranked planning-review-pass above self-improvement-dogfooding even though the prompt explicitly included self-improvement and requested implementation follow-through.",
+      "promotion_target": "workspace skill recommendation scoring and CLI tests",
+      "promotion_trigger": "Addressed now because this is the current dogfooding entry route.",
+      "resolution": "Skill recommendation now gives an explicit hint score when a multi-token prefix of the skill id appears in the normalized task text, so self-improvement prompts route to self-improvement-dogfooding before generic review.",
+      "system_intent_pressure": [
+        "Make the package the cheapest path for improving itself.",
+        "Reduce repeated human steering.",
+        "Keep repo-local dogfooding discoverable without making it shipped package authority."
+      ]
+    },
+    {
+      "id": "planning-summary-duplicates-unavailable-reasons",
+      "title": "Planning summary duplicates unavailable-reason fragments across projected contracts",
+      "action_state": "addressed",
+      "confidence": "high",
+      "source_class": "analysis-confirmed",
+      "evidence": "summary --format json emits hierarchy_contract.reason with repeated fragments such as 'requires exactly one active execplan and at most one active TODO item' and 'requires one active execplan with a present active intent contract'.",
+      "promotion_target": "planning summary reason normalization and package tests",
+      "promotion_trigger": "Addressed now because this is compact-output quality, not new capability.",
+      "resolution": "Planning hierarchy unavailable reasons now split composite reasons into fragments before deduping, preserving distinct blockers while removing repeated text.",
+      "system_intent_pressure": [
+        "Prefer compact queryable state over prose-first operation.",
+        "Reduce scan cost and repeated rereading.",
+        "Keep ordinary recovery quiet."
+      ]
+    },
+    {
+      "id": "effective-authority-section-hint-still-says-unresolved-gaps",
+      "title": "Effective-authority section hint still frames the view around unresolved gaps",
+      "action_state": "addressed",
+      "confidence": "medium",
+      "source_class": "analysis-confirmed",
+      "evidence": "After no-active-planning-record moved into idle_context, the default report section hint still describes effective_authority as 'authority, current work, system-intent pressure, and unresolved gaps'. The wording overstates gap pressure for a clean idle workspace.",
+      "promotion_target": "workspace report router section hints and CLI tests",
+      "promotion_trigger": "Addressed now because it is a small quietness/wording correction on a first-contact router surface.",
+      "resolution": "The default report section hint now names idle context alongside unresolved gaps.",
+      "system_intent_pressure": [
+        "Stay quiet and low-residue.",
+        "Do not make ordinary idle work feel like review debt.",
+        "Keep compact reports decision-grade."
+      ]
+    }
+  ],
+  "recommendation": {
+    "promote": "All three findings were addressed in this branch.",
+    "defer": "Large file hotspots remain repo-friction evidence but require separate bounded extraction lanes; do not expand this pass into large refactors.",
+    "dismiss": "No current finding requires new commands, new first-line surfaces, host-tracker assumptions, or broader roadmap reopening."
+  },
+  "retention": {
+    "closeout_shape": "keep as compact review evidence for the branch; mark findings addressed after proof",
+    "trigger": "all findings addressed and validation passes",
+    "proof_surface": "agentic-workspace proof --target . --changed <paths> --format json"
+  },
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_cli.py -q -k \"self_improvement or default_profile_returns_router\"",
+    "uv run pytest packages/planning/tests/test_installer.py -q -k \"dedupes_unavailable_projection_reason_fragments\"",
+    "uv run ruff check src tests packages/planning/src packages/planning/tests",
+    "uv run agentic-workspace skills --target . --task \"make a full review of the system as a whole to drive self-improvement\" --format json",
+    "uv run agentic-workspace summary --format json",
+    "uv run agentic-workspace report --target . --format json"
+  ],
+  "drift_log": [
+    "2026-04-26: Full-system review created after the earlier narrow review was insufficient for the user's intent.",
+    "2026-04-26: All three actionable findings were marked addressed after targeted tests and live command verification."
+  ]
+}

--- a/packages/memory/src/repo_memory_bootstrap/_installer_paths.py
+++ b/packages/memory/src/repo_memory_bootstrap/_installer_paths.py
@@ -86,7 +86,7 @@ def detect_bootstrap_layout(target_root: Path) -> str:
 
 
 def _record_repo_context_warnings(target_root: Path, result) -> None:
-    parent_repo = _find_parent_repo_root(target_root)
+    parent_repo = None if _has_git_boundary(target_root) else _find_parent_repo_root(target_root)
     if parent_repo is not None:
         result.add(
             "warning",
@@ -109,8 +109,7 @@ def _record_repo_context_warnings(target_root: Path, result) -> None:
 def _find_repo_candidates(start: Path) -> list[Path]:
     candidates: list[Path] = []
     for candidate in [start, *start.parents]:
-        git_dir = candidate / ".git"
-        if git_dir.is_dir() or git_dir.is_file():
+        if _has_git_boundary(candidate):
             candidates.append(candidate)
             continue
         if any((candidate / marker).exists() for marker in PROJECT_MARKERS):
@@ -120,12 +119,16 @@ def _find_repo_candidates(start: Path) -> list[Path]:
 
 def _find_parent_repo_root(target_root: Path) -> Path | None:
     for candidate in target_root.parents:
-        git_dir = candidate / ".git"
-        if git_dir.is_dir() or git_dir.is_file():
+        if _has_git_boundary(candidate):
             return candidate
         if any((candidate / marker).exists() for marker in PROJECT_MARKERS):
             return candidate
     return None
+
+
+def _has_git_boundary(path: Path) -> bool:
+    git_dir = path / ".git"
+    return git_dir.is_dir() or git_dir.is_file()
 
 
 def _find_nested_repo_roots(target_root: Path) -> list[Path]:

--- a/packages/memory/src/repo_memory_bootstrap/_installer_paths.py
+++ b/packages/memory/src/repo_memory_bootstrap/_installer_paths.py
@@ -133,8 +133,18 @@ def _find_nested_repo_roots(target_root: Path) -> list[Path]:
     seen: set[Path] = set()
     for candidate in target_root.rglob(".git"):
         repo_root = candidate.parent
+        if _is_generated_dependency_cache(repo_root=repo_root, target_root=target_root):
+            continue
         if repo_root == target_root or repo_root in seen:
             continue
         nested.append(repo_root)
         seen.add(repo_root)
     return sorted(nested)
+
+
+def _is_generated_dependency_cache(*, repo_root: Path, target_root: Path) -> bool:
+    try:
+        relative = repo_root.relative_to(target_root)
+    except ValueError:
+        return False
+    return any(part.startswith(".uv-cache") for part in relative.parts)

--- a/packages/memory/src/repo_memory_bootstrap/installer.py
+++ b/packages/memory/src/repo_memory_bootstrap/installer.py
@@ -1922,12 +1922,14 @@ def _durable_fact_routing_view(
 ) -> dict[str, object]:
     summary = route_snapshot.route_report_summary or {}
     fixture_results_obj = route_snapshot.route_report_fixture_results or []
-    fixture_results = [item for item in fixture_results_obj if isinstance(item, dict)]
+    fixture_results = [cast(dict[str, Any], item) for item in fixture_results_obj if isinstance(item, dict)]
     matched_counts: list[int] = []
     matched_cases: list[dict[str, object]] = []
     for item in fixture_results:
-        files = [str(value) for value in item.get("files", [])] if isinstance(item.get("files"), list) else []
-        surfaces = [str(value) for value in item.get("surfaces", [])] if isinstance(item.get("surfaces"), list) else []
+        files_obj = item.get("files", [])
+        surfaces_obj = item.get("surfaces", [])
+        files = [str(value) for value in files_obj] if isinstance(files_obj, list) else []
+        surfaces = [str(value) for value in surfaces_obj] if isinstance(surfaces_obj, list) else []
         matches = _route_durable_facts(manifest=manifest, files=files, surfaces=surfaces)
         matched_counts.append(len(matches))
         if matches:

--- a/packages/memory/tests/test_installer.py
+++ b/packages/memory/tests/test_installer.py
@@ -57,6 +57,23 @@ def test_memory_contract_file_shortlist_is_explicit() -> None:
     assert set(MEMORY_COMPATIBILITY_CONTRACT_FILES) | set(MEMORY_LOWER_STABILITY_HELPER_FILES) == set(PAYLOAD_REQUIRED_FILES)
 
 
+def test_doctor_ignores_nested_repositories_inside_uv_caches(tmp_path: Path) -> None:
+    target = tmp_path / "repo"
+    (target / ".git").mkdir(parents=True)
+    (target / ".uv-cache" / "sdists-v9" / "pkg" / ".git").mkdir(parents=True)
+    (target / "vendor" / "nested" / ".git").mkdir(parents=True)
+
+    result = installer.doctor_bootstrap(target=target)
+
+    nested_warnings = [
+        action.path.relative_to(target).as_posix()
+        for action in result.actions
+        if action.detail == "nested repository detected under target; installer will not recurse into repo roots automatically"
+    ]
+    assert ".uv-cache/sdists-v9/pkg" not in nested_warnings
+    assert nested_warnings == ["vendor/nested"]
+
+
 def _memory_index_text() -> str:
     if MEMORY_INDEX_TEMPLATE.exists():
         return MEMORY_INDEX_TEMPLATE.read_text(encoding="utf-8")

--- a/packages/memory/tests/test_installer.py
+++ b/packages/memory/tests/test_installer.py
@@ -74,6 +74,28 @@ def test_doctor_ignores_nested_repositories_inside_uv_caches(tmp_path: Path) -> 
     assert nested_warnings == ["vendor/nested"]
 
 
+def test_doctor_does_not_warn_about_parent_repo_for_explicit_git_root(tmp_path: Path) -> None:
+    parent = tmp_path / "parent"
+    target = parent / "repo"
+    (parent / ".git").mkdir(parents=True)
+    (target / ".git").mkdir(parents=True)
+
+    result = installer.doctor_bootstrap(target=target)
+
+    assert not any(action.detail.startswith("target is inside parent repository") for action in result.actions)
+
+
+def test_doctor_warns_about_parent_repo_when_target_has_no_git_boundary(tmp_path: Path) -> None:
+    parent = tmp_path / "parent"
+    target = parent / "repo"
+    (parent / ".git").mkdir(parents=True)
+    target.mkdir(parents=True)
+
+    result = installer.doctor_bootstrap(target=target)
+
+    assert any(action.detail.startswith("target is inside parent repository") for action in result.actions)
+
+
 def _memory_index_text() -> str:
     if MEMORY_INDEX_TEMPLATE.exists():
         return MEMORY_INDEX_TEMPLATE.read_text(encoding="utf-8")

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -2115,6 +2115,7 @@ def _planning_summary_compact_schema() -> dict[str, Any]:
             "machine_first_planning",
             "execution_readiness",
             "planning_surface_health",
+            "projection_state",
             "planning_record",
             "active_contract",
             "resumable_contract",
@@ -2132,11 +2133,19 @@ def _planning_summary_compact_schema() -> dict[str, Any]:
     }
 
 
-def _compact_projection(payload: dict[str, Any], *, fields: tuple[str, ...]) -> dict[str, Any]:
+def _compact_projection(
+    payload: dict[str, Any],
+    *,
+    fields: tuple[str, ...],
+    idle_unavailable_reason: str | None = None,
+) -> dict[str, Any]:
     projected: dict[str, Any] = {}
     for key in ("status", "reason", "view_role", "view", "view_of"):
         if key in payload:
             projected[key] = payload[key]
+    if payload.get("status") != "present" and idle_unavailable_reason:
+        projected["reason"] = idle_unavailable_reason
+        projected["reason_code"] = "idle-no-active-planning-record"
     if payload.get("status") == "present":
         for field in fields:
             if field in payload:
@@ -2159,6 +2168,9 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
         )
     finished_work_inspection_contract = dict(summary.get("finished_work_inspection_contract", {}))
     system_intent = dict(summary.get("system_intent", {}))
+    idle_unavailable_reason = (
+        "no active planning record" if todo.get("active_count", 0) == 0 and execplans.get("active_count", 0) == 0 else None
+    )
 
     compact_summary: dict[str, Any] = {
         "kind": summary.get("kind", "planning-summary/v1"),
@@ -2201,6 +2213,11 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
             "recommended_next_action": planning_surface_health.get("recommended_next_action", ""),
             "warnings": planning_surface_health.get("warnings", []),
         },
+        "projection_state": {
+            "status": "idle" if idle_unavailable_reason else "active-or-needs-review",
+            "reason": idle_unavailable_reason or "active planning projections may carry contract-specific reasons",
+            "rule": "Idle summaries state the absent active plan once; individual unavailable contracts keep short machine-readable reasons.",
+        },
         "planning_record": _compact_projection(
             dict(summary.get("planning_record", {})),
             fields=(
@@ -2216,10 +2233,12 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
                 "stop_conditions",
                 "minimal_refs",
             ),
+            idle_unavailable_reason=idle_unavailable_reason,
         ),
         "active_contract": _compact_projection(
             dict(summary.get("active_contract", {})),
             fields=("todo_item", "intent", "touched_scope", "proof_expectations", "tool_verification", "minimal_refs"),
+            idle_unavailable_reason=idle_unavailable_reason,
         ),
         "resumable_contract": _compact_projection(
             dict(summary.get("resumable_contract", {})),
@@ -2233,6 +2252,7 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
                 "blockers",
                 "minimal_refs",
             ),
+            idle_unavailable_reason=idle_unavailable_reason,
         ),
         "hierarchy_contract": _compact_projection(
             dict(summary.get("hierarchy_contract", {})),
@@ -2247,6 +2267,7 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
                 "closure_check",
                 "minimal_refs",
             ),
+            idle_unavailable_reason=idle_unavailable_reason,
         ),
         "handoff_contract": _compact_projection(
             dict(summary.get("handoff_contract", {})),
@@ -2268,6 +2289,7 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
                 "return_with",
                 "worker_contract",
             ),
+            idle_unavailable_reason=idle_unavailable_reason,
         ),
         "closeout_distillation_contract": _compact_projection(
             dict(summary.get("closeout_distillation_contract", {})),
@@ -2280,6 +2302,7 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
                 "recommended_next_action",
                 "minimal_refs",
             ),
+            idle_unavailable_reason=idle_unavailable_reason,
         ),
         "intent_validation_contract": _compact_projection(
             intent_validation_contract,

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -8,7 +8,7 @@ import tomllib
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from repo_planning_bootstrap import __version__
 from repo_planning_bootstrap._ownership import module_root
@@ -3995,6 +3995,16 @@ def _dedupe_distillation_items(items: list[dict[str, str]]) -> list[dict[str, st
     return deduped
 
 
+def _unavailable_reason_fragments(*contracts: dict[str, Any], extra: Iterable[str] = ()) -> str:
+    reasons: list[str] = []
+    for contract in contracts:
+        if contract.get("status") != "present":
+            raw_reason = str(contract.get("reason", "required planning contract unavailable")).strip()
+            reasons.extend(part.strip() for part in raw_reason.split(";") if part.strip())
+    reasons.extend(part.strip() for part in extra if part.strip())
+    return "; ".join(_dedupe(reasons))
+
+
 def _active_hierarchy_contract(
     *,
     target_root: Path,
@@ -4014,15 +4024,17 @@ def _active_hierarchy_contract(
         or context_budget_contract.get("status") != "present"
         or len(active_execplans) != 1
     ):
-        reasons: list[str] = []
-        for contract in (planning_record, active_contract, resumable_contract, follow_through_contract, context_budget_contract):
-            if contract.get("status") != "present":
-                reasons.append(contract.get("reason", "required planning contract unavailable"))
-        if len(active_execplans) != 1:
-            reasons.append("requires exactly one active execplan")
+        extra = ["requires exactly one active execplan"] if len(active_execplans) != 1 else []
         return {
             "status": "unavailable",
-            "reason": "; ".join(_dedupe(reasons)),
+            "reason": _unavailable_reason_fragments(
+                planning_record,
+                active_contract,
+                resumable_contract,
+                follow_through_contract,
+                context_budget_contract,
+                extra=extra,
+            ),
         }
 
     plan_path = _resolve_execplan_path(target_root, active_execplans[0]["path"])

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -5265,7 +5265,7 @@ def format_actions(actions: list[Action], target_root: Path) -> list[str]:
 
 
 def format_result_json(result: InstallResult) -> str:
-    payload = {
+    payload: dict[str, Any] = {
         "target_root": str(result.target_root),
         "message": result.message,
         "dry_run": result.dry_run,

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -2579,7 +2579,7 @@ def _intent_validation_contract(
         recommended_next_action = "Inspect likely premature closeouts before treating recently closed work as settled."
     elif closeout_reconciliation["counts"]["needs_audit_count"]:
         recommended_next_action = "Audit unreconciled lower-trust closeouts or add a checked-in reconciliation artifact."
-    elif closeout_reconciliation["counts"]["follow_up_open_count"]:
+    elif closeout_reconciliation["counts"]["follow_up_open_count"] and external_open:
         recommended_next_action = "Continue the open follow-ups identified by lower-trust closeout reconciliation."
     elif lower_trust_closeouts:
         recommended_next_action = "Review lower-trust closeout signals before assuming recently closed work is fully evidenced."

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -2162,6 +2162,10 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
     planning_surface_health = dict(summary.get("planning_surface_health", {}))
     ownership_review = dict(summary.get("ownership_review", {}))
     intent_validation_contract = dict(summary.get("intent_validation_contract", {}))
+    if "historical_audit_references" in intent_validation_contract:
+        intent_validation_contract["historical_audit_references"] = _compact_historical_audit_references(
+            intent_validation_contract["historical_audit_references"]
+        )
     if "closeout_reconciliation" in intent_validation_contract:
         intent_validation_contract["closeout_reconciliation"] = _compact_closeout_reconciliation(
             intent_validation_contract["closeout_reconciliation"]
@@ -2355,13 +2359,33 @@ def _compact_closeout_reconciliation(reconciliation: Any) -> dict[str, Any]:
         action_state = str(item.get("action_state", "")).strip()
         if item_id and action_state in items_by_state:
             items_by_state[action_state].append(item_id)
+    sample_items_by_state = {key: value[:5] for key, value in items_by_state.items() if value}
+    displayed_item_count = sum(len(value) for value in sample_items_by_state.values())
     return {
         "status": reconciliation.get("status", "absent"),
         "source_count": reconciliation.get("source_count", 0),
-        "sources": reconciliation.get("sources", []),
         "item_count": reconciliation.get("item_count", 0),
         "counts": reconciliation.get("counts", {}),
-        "items_by_state": {key: value for key, value in items_by_state.items() if value},
+        "sample_items_by_state": sample_items_by_state,
+        "omitted_item_count": max(0, sum(len(value) for value in items_by_state.values()) - displayed_item_count),
+        "detail": "Use `agentic-workspace summary --format json --profile full` for full reconciliation sources and item ids.",
+    }
+
+
+def _compact_historical_audit_references(historical: Any) -> dict[str, Any]:
+    if not isinstance(historical, dict):
+        return {}
+    source_count = int(historical.get("source_count", 0) or 0)
+    return {
+        "status": historical.get("status", "absent"),
+        "source_count": source_count,
+        "item_count": historical.get("item_count", 0),
+        "follow_up_open_count": historical.get("follow_up_open_count", 0),
+        "needs_audit_count": historical.get("needs_audit_count", 0),
+        "likely_premature_closeout_count": historical.get("likely_premature_closeout_count", 0),
+        "sources_omitted": source_count,
+        "rule": historical.get("rule", ""),
+        "detail": "Use `agentic-workspace summary --format json --profile full` for historical review source paths.",
     }
 
 

--- a/packages/planning/tests/test_installer.py
+++ b/packages/planning/tests/test_installer.py
@@ -3646,17 +3646,14 @@ def test_planning_summary_exposes_closure_evidence(tmp_path: Path) -> None:
 def test_planning_summary_dedupes_unavailable_projection_reason_fragments(tmp_path: Path) -> None:
     install_bootstrap(target=tmp_path)
 
-    summary = planning_summary(target=tmp_path)
+    summary = planning_summary(target=tmp_path, profile="compact")
 
-    reason = summary["hierarchy_contract"]["reason"]
-    fragments = [fragment.strip() for fragment in reason.split(";") if fragment.strip()]
-    assert len(fragments) == len(set(fragments))
-    assert fragments == [
-        "requires exactly one active execplan and at most one active TODO item",
-        "requires one active execplan with a present active intent contract",
-        "requires one active execplan with a present planning record",
-        "requires exactly one active execplan",
-    ]
+    assert summary["projection_state"]["status"] == "idle"
+    assert summary["projection_state"]["reason"] == "no active planning record"
+    assert summary["schema"]["shared_fields"][10] == "projection_state"
+    assert summary["hierarchy_contract"]["reason"] == "no active planning record"
+    assert summary["hierarchy_contract"]["reason_code"] == "idle-no-active-planning-record"
+    assert summary["handoff_contract"]["reason_code"] == "idle-no-active-planning-record"
 
 
 def test_planning_report_prints_closure_evidence(tmp_path: Path, capsys) -> None:

--- a/packages/planning/tests/test_installer.py
+++ b/packages/planning/tests/test_installer.py
@@ -3643,6 +3643,22 @@ def test_planning_summary_exposes_closure_evidence(tmp_path: Path) -> None:
     assert "closure_check" in summary["schema"]["view_fields"]["planning_record"]
 
 
+def test_planning_summary_dedupes_unavailable_projection_reason_fragments(tmp_path: Path) -> None:
+    install_bootstrap(target=tmp_path)
+
+    summary = planning_summary(target=tmp_path)
+
+    reason = summary["hierarchy_contract"]["reason"]
+    fragments = [fragment.strip() for fragment in reason.split(";") if fragment.strip()]
+    assert len(fragments) == len(set(fragments))
+    assert fragments == [
+        "requires exactly one active execplan and at most one active TODO item",
+        "requires one active execplan with a present active intent contract",
+        "requires one active execplan with a present planning record",
+        "requires exactly one active execplan",
+    ]
+
+
 def test_planning_report_prints_closure_evidence(tmp_path: Path, capsys) -> None:
     install_bootstrap(target=tmp_path)
     _write(

--- a/packages/planning/tests/test_installer.py
+++ b/packages/planning/tests/test_installer.py
@@ -3340,6 +3340,57 @@ def test_planning_summary_accepts_historical_closeout_baseline(tmp_path: Path) -
     assert summary["intent_validation_contract"]["counts"]["closeout_needs_audit_count"] == 0
 
 
+def test_planning_summary_does_not_treat_historical_followups_as_current_work(tmp_path: Path) -> None:
+    install_bootstrap(target=tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/planning/state.toml",
+        "[todo]\nactive_items = []\nqueued_items = []\n\n[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+    _write_external_intent_evidence(
+        tmp_path / ".agentic-workspace/planning/external-intent-evidence.json",
+        items=[
+            {
+                "system": "manual",
+                "id": "EXT-1",
+                "title": "Closed with historical follow-up",
+                "status": "closed",
+                "kind": "slice",
+                "parent_id": "",
+                "planning_residue_expected": "required",
+            },
+        ],
+    )
+    _write(
+        tmp_path / ".agentic-workspace/planning/reviews/historical-followup.review.json",
+        json.dumps(
+            {
+                "kind": "planning-review/v1",
+                "title": "Historical Follow-up",
+                "issue_classifications": [
+                    {
+                        "id": "EXT-1",
+                        "title": "Closed with historical follow-up",
+                        "classification": "covered_by_open_followup",
+                        "live_state": "closed",
+                        "evidence": "bounded slice landed",
+                        "follow_up": "legacy follow-up recorded for audit",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+
+    summary = planning_summary(target=tmp_path, profile="compact")
+    contract = summary["intent_validation_contract"]
+
+    assert contract["current_external_work"]["open_count"] == 0
+    assert contract["historical_audit_references"]["follow_up_open_count"] == 1
+    assert contract["closeout_reconciliation"]["counts"]["follow_up_open_count"] == 1
+    assert contract["recommended_next_action"] == "No dangling larger intent or lower-trust closeout signals detected."
+
+
 def test_planning_reconcile_reports_stale_state_from_provider_agnostic_evidence(tmp_path: Path) -> None:
     install_bootstrap(target=tmp_path)
     _write(

--- a/packages/planning/tests/test_installer.py
+++ b/packages/planning/tests/test_installer.py
@@ -3279,11 +3279,12 @@ def test_planning_summary_reconciles_lower_trust_closeouts_from_review_artifact(
     assert reconciliation["counts"]["evidence_present_count"] == 1
     assert reconciliation["counts"]["follow_up_open_count"] == 1
     assert reconciliation["counts"]["needs_audit_count"] == 1
-    assert reconciliation["items_by_state"] == {
+    assert reconciliation["sample_items_by_state"] == {
         "needs-audit": ["EXT-3"],
         "evidence-present": ["EXT-1"],
         "follow-up-open": ["EXT-2"],
     }
+    assert reconciliation["omitted_item_count"] == 0
     assert summary["intent_validation_contract"]["counts"]["closeout_reconciled_count"] == 2
     assert summary["intent_validation_contract"]["counts"]["closeout_needs_audit_count"] == 1
 
@@ -3336,7 +3337,8 @@ def test_planning_summary_accepts_historical_closeout_baseline(tmp_path: Path) -
     assert reconciliation["status"] == "present"
     assert reconciliation["counts"]["historical_baseline_count"] == 1
     assert reconciliation["counts"]["needs_audit_count"] == 0
-    assert reconciliation["items_by_state"] == {"historical-baseline": ["EXT-1"]}
+    assert reconciliation["sample_items_by_state"] == {"historical-baseline": ["EXT-1"]}
+    assert reconciliation["omitted_item_count"] == 0
     assert summary["intent_validation_contract"]["counts"]["closeout_needs_audit_count"] == 0
 
 
@@ -3387,7 +3389,11 @@ def test_planning_summary_does_not_treat_historical_followups_as_current_work(tm
 
     assert contract["current_external_work"]["open_count"] == 0
     assert contract["historical_audit_references"]["follow_up_open_count"] == 1
+    assert "sources" not in contract["historical_audit_references"]
+    assert "full` for historical review source paths" in contract["historical_audit_references"]["detail"]
     assert contract["closeout_reconciliation"]["counts"]["follow_up_open_count"] == 1
+    assert "items_by_state" not in contract["closeout_reconciliation"]
+    assert "full` for full reconciliation sources" in contract["closeout_reconciliation"]["detail"]
     assert contract["recommended_next_action"] == "No dangling larger intent or lower-trust closeout signals detected."
 
 

--- a/packages/planning/tests/test_installer.py
+++ b/packages/planning/tests/test_installer.py
@@ -3650,7 +3650,7 @@ def test_planning_summary_dedupes_unavailable_projection_reason_fragments(tmp_pa
 
     assert summary["projection_state"]["status"] == "idle"
     assert summary["projection_state"]["reason"] == "no active planning record"
-    assert summary["schema"]["shared_fields"][10] == "projection_state"
+    assert "projection_state" in summary["schema"]["shared_fields"]
     assert summary["hierarchy_contract"]["reason"] == "no active planning record"
     assert summary["hierarchy_contract"]["reason_code"] == "idle-no-active-planning-record"
     assert summary["handoff_contract"]["reason_code"] == "idle-no-active-planning-record"

--- a/src/agentic_workspace/cli.py
+++ b/src/agentic_workspace/cli.py
@@ -3008,7 +3008,12 @@ def _report_router_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "source": "execution_shape",
             }
     section_hints = _report_section_hints(payload)
-    profile_payload = payload.get("report_profile", _report_profile_payload())
+    profile_payload = dict(payload.get("report_profile", _report_profile_payload()))
+    profile_payload["ordinary_agent_path"] = _ordinary_agent_path_payload(payload=payload, findings=findings)
+    decision_grade_fields = list(profile_payload.get("decision_grade_fields", []))
+    if "report_profile.ordinary_agent_path" not in decision_grade_fields:
+        decision_grade_fields.append("report_profile.ordinary_agent_path")
+    profile_payload["decision_grade_fields"] = decision_grade_fields
     return {
         "kind": "workspace-report-router/v1",
         "schema": {
@@ -3111,6 +3116,33 @@ def _report_router_external_work_delta(value: Any) -> dict[str, Any]:
     }
 
 
+def _ordinary_agent_path_payload(*, payload: dict[str, Any], findings: list[dict[str, Any]]) -> dict[str, Any]:
+    effective_authority = payload.get("effective_authority", {})
+    current_work = effective_authority.get("current_work", {}) if isinstance(effective_authority, dict) else {}
+    if not isinstance(current_work, dict):
+        current_work = {}
+    current_status = str(current_work.get("status", "unknown") or "unknown")
+    warning_count = len(findings)
+    return {
+        "status": "ready",
+        "entry_command": "agentic-workspace start --target ./repo --format json",
+        "state_command": "agentic-workspace report --target ./repo --format json",
+        "current_work_command": "agentic-workspace summary --format json",
+        "proof_command": "agentic-workspace proof --target ./repo --changed <paths> --format json",
+        "deep_detail_rule": "Open section, memory, planning, or review artifacts only when compact output points there.",
+        "current_signal": {
+            "current_work_status": current_status,
+            "warning_count": warning_count,
+        },
+        "stop_or_escalate_when": [
+            "compact report health is not healthy",
+            "summary reports active broad work without a checked-in plan you can continue from",
+            "proof selection is ambiguous for the changed paths",
+            "the next change would alter product direction, authority boundaries, or system intent",
+        ],
+    }
+
+
 def _report_section_hints(payload: dict[str, Any]) -> list[dict[str, Any]]:
     section_purposes = {
         "effective_authority": "authority, current work, system-intent pressure, idle context, and unresolved gaps",
@@ -3128,6 +3160,29 @@ def _report_section_hints(payload: dict[str, Any]) -> list[dict[str, Any]]:
         "config": "resolved workspace config and local posture",
         "registry": "module registry and lifecycle metadata",
     }
+    findings = [finding for finding in payload.get("findings", []) if isinstance(finding, dict)]
+    current_work = (
+        payload.get("effective_authority", {}).get("current_work", {}) if isinstance(payload.get("effective_authority"), dict) else {}
+    )
+    current_status = str(current_work.get("status", "unknown") if isinstance(current_work, dict) else "unknown")
+    why_now = {
+        "effective_authority": ("inspect now if authority, idle state, or unresolved intent pressure affects whether work can proceed"),
+        "execution_shape": "inspect now to choose direct work, light planning, or checked-in execplan promotion",
+        "operational_compression": "inspect now when assessing whether package surfaces are reducing total work",
+        "findings": "inspect now because warnings are present" if findings else "skip unless diagnosing an absent-warning state",
+        "module_reports": "deep detail; inspect only when a compact router field points to planning or memory internals",
+        "reports": "deep lifecycle detail; inspect only for report/debug work",
+        "surface_value_guardrail": "inspect before adding or expanding a visible surface",
+        "closeout_trust": "inspect before closing broad work or auditing package-use evidence",
+        "external_work_delta": "inspect when external-work intake or closure state is part of the task",
+        "discovery": "inspect during setup, bootstrap, or missing-surface diagnosis",
+        "standing_intent": "inspect when product direction or stronger-home placement is the question",
+        "repo_friction": "inspect when choosing or routing improvement targets",
+        "config": "deep detail; inspect only when resolved config, posture, or obligations matter",
+        "registry": "deep detail; inspect only when module metadata or lifecycle registration matters",
+    }
+    if current_status in {"absent", "direct-or-no-active-plan"}:
+        why_now["effective_authority"] = "inspect now only if idle state, authority, or system-intent pressure is unclear"
     hints: list[dict[str, Any]] = []
     for section, purpose in section_purposes.items():
         if section in payload:
@@ -3135,6 +3190,7 @@ def _report_section_hints(payload: dict[str, Any]) -> list[dict[str, Any]]:
                 {
                     "section": section,
                     "purpose": purpose,
+                    "why_now": why_now.get(section, "inspect when this section is named by compact routing output"),
                     "command": f"agentic-workspace report --target ./repo --section {section} --format json",
                     "volume": "high" if section in {"module_reports", "reports", "registry", "config"} else "normal",
                 }
@@ -3153,6 +3209,7 @@ def _report_closeout_trust_payload(*, module_reports: list[dict[str, Any]]) -> d
             "reason": "planning module is not installed",
             "package_workflow_evidence": _package_workflow_evidence_payload(planning_report={}),
             "intent_satisfaction_check": _intent_satisfaction_check_payload(planning_report={}),
+            "historical_review_artifacts": _historical_review_artifacts_policy(planning_report={}, intent_validation={}),
         }
 
     intent_validation = planning_report.get("intent_validation", {})
@@ -3162,6 +3219,10 @@ def _report_closeout_trust_payload(*, module_reports: list[dict[str, Any]]) -> d
             "reason": "planning intent validation is unavailable",
             "package_workflow_evidence": _package_workflow_evidence_payload(planning_report=planning_report),
             "intent_satisfaction_check": _intent_satisfaction_check_payload(planning_report=planning_report),
+            "historical_review_artifacts": _historical_review_artifacts_policy(
+                planning_report=planning_report,
+                intent_validation={},
+            ),
         }
 
     counts = intent_validation.get("counts", {})
@@ -3196,7 +3257,32 @@ def _report_closeout_trust_payload(*, module_reports: list[dict[str, Any]]) -> d
         "sample_signals": sample_signals,
         "package_workflow_evidence": _package_workflow_evidence_payload(planning_report=planning_report),
         "intent_satisfaction_check": _intent_satisfaction_check_payload(planning_report=planning_report),
+        "historical_review_artifacts": _historical_review_artifacts_policy(
+            planning_report=planning_report,
+            intent_validation=intent_validation,
+        ),
         "recommended_next_action": recommended_next_action,
+    }
+
+
+def _historical_review_artifacts_policy(*, planning_report: dict[str, Any], intent_validation: dict[str, Any]) -> dict[str, Any]:
+    historical = intent_validation.get("historical_audit_references", {}) if isinstance(intent_validation, dict) else {}
+    if not isinstance(historical, dict):
+        historical = {}
+    source_count = _as_int(historical.get("source_count"))
+    item_count = _as_int(historical.get("item_count"))
+    if source_count == 0 and isinstance(planning_report, dict):
+        reconcile = planning_report.get("closeout_reconciliation", {})
+        if isinstance(reconcile, dict):
+            source_count = _as_int(reconcile.get("source_count"))
+            item_count = _as_int(reconcile.get("item_count"))
+    return {
+        "status": "evidence-only",
+        "role": "evidence/history, not ordinary operating input",
+        "source_count": source_count,
+        "item_count": item_count,
+        "rule": "Do not read historical review artifacts during startup unless a selected issue, audit, or report section points there.",
+        "selection_path": "agentic-workspace report --target ./repo --section closeout_trust --format json",
     }
 
 

--- a/src/agentic_workspace/cli.py
+++ b/src/agentic_workspace/cli.py
@@ -5120,11 +5120,12 @@ def _effective_authority_payload(
     contract_areas = contract_inventory.get("areas", [])
     config_payload = _system_intent_source_payload(config) if config is not None else {}
     unresolved_gaps: list[dict[str, str]] = []
+    idle_context: list[dict[str, str]] = []
     if active_status == "absent":
-        unresolved_gaps.append(
+        idle_context.append(
             {
                 "id": "no-active-planning-record",
-                "summary": "No active planning record is present, so current-work alignment cannot be judged from an active execplan.",
+                "summary": "No active planning record is present; this is normal for idle or narrow direct work.",
                 "recommended_query": "agentic-workspace summary --format json",
             }
         )
@@ -5228,6 +5229,7 @@ def _effective_authority_payload(
             "ownership": "agentic-workspace ownership --target ./repo --format json",
         },
         "unresolved_gaps": unresolved_gaps,
+        "idle_context": idle_context,
     }
 
 
@@ -8710,6 +8712,7 @@ def _skill_payload(*, skill: RegisteredSkill) -> dict[str, Any]:
 
 def _recommend_skills(*, task_text: str, skills: list[RegisteredSkill]) -> list[SkillRecommendation]:
     task_text_lower = task_text.lower()
+    task_text_normalized = " ".join(_skill_match_tokens(task_text))
     if "setup" in task_text_lower:
         for skill in skills:
             if skill.skill_id == "planning-reporting":
@@ -8733,6 +8736,7 @@ def _recommend_skills(*, task_text: str, skills: list[RegisteredSkill]) -> list[
         matched_phrases = _matched_skill_terms(
             terms=skill.activation_hints.phrases,
             task_text_lower=task_text_lower,
+            task_text_normalized=task_text_normalized,
             task_tokens=task_tokens,
         )
         if matched_phrases:
@@ -8746,7 +8750,12 @@ def _recommend_skills(*, task_text: str, skills: list[RegisteredSkill]) -> list[
             ("noun", skill.activation_hints.nouns, 2),
             ("context", skill.activation_hints.when, 1),
         ):
-            matched = _matched_skill_terms(terms=terms, task_text_lower=task_text_lower, task_tokens=task_tokens)
+            matched = _matched_skill_terms(
+                terms=terms,
+                task_text_lower=task_text_lower,
+                task_text_normalized=task_text_normalized,
+                task_tokens=task_tokens,
+            )
             if matched:
                 matched_score = len(matched) * weight
                 score += matched_score
@@ -8776,17 +8785,32 @@ def _recommend_skills(*, task_text: str, skills: list[RegisteredSkill]) -> list[
     return recommendations
 
 
-def _matched_skill_terms(*, terms: tuple[str, ...], task_text_lower: str, task_tokens: set[str]) -> list[str]:
-    matched = [term for term in terms if _skill_term_matches(term=term, task_text_lower=task_text_lower, task_tokens=task_tokens)]
+def _matched_skill_terms(
+    *,
+    terms: tuple[str, ...],
+    task_text_lower: str,
+    task_text_normalized: str,
+    task_tokens: set[str],
+) -> list[str]:
+    matched = [
+        term
+        for term in terms
+        if _skill_term_matches(
+            term=term,
+            task_text_lower=task_text_lower,
+            task_text_normalized=task_text_normalized,
+            task_tokens=task_tokens,
+        )
+    ]
     return sorted(dict.fromkeys(matched))
 
 
-def _skill_term_matches(*, term: str, task_text_lower: str, task_tokens: set[str]) -> bool:
+def _skill_term_matches(*, term: str, task_text_lower: str, task_text_normalized: str, task_tokens: set[str]) -> bool:
     normalised = " ".join(_skill_match_tokens(term))
     if not normalised:
         return False
     if " " in normalised:
-        return normalised in task_text_lower
+        return normalised in task_text_lower or normalised in task_text_normalized
     return normalised in task_tokens
 
 

--- a/src/agentic_workspace/cli.py
+++ b/src/agentic_workspace/cli.py
@@ -3113,7 +3113,7 @@ def _report_router_external_work_delta(value: Any) -> dict[str, Any]:
 
 def _report_section_hints(payload: dict[str, Any]) -> list[dict[str, Any]]:
     section_purposes = {
-        "effective_authority": "authority, current work, system-intent pressure, and unresolved gaps",
+        "effective_authority": "authority, current work, system-intent pressure, idle context, and unresolved gaps",
         "execution_shape": "default execution posture and planning-backed work guidance",
         "operational_compression": "falsifiable advisory measures for whether surfaces reduce total operational cost",
         "findings": "raw warnings and attention signals grouped in router warning_summary",
@@ -8733,6 +8733,12 @@ def _recommend_skills(*, task_text: str, skills: list[RegisteredSkill]) -> list[
         hint_score = 0
         reasons: list[str] = []
 
+        matched_id = _matched_skill_id_phrase(skill=skill, task_text_normalized=task_text_normalized)
+        if matched_id:
+            score += 6
+            hint_score += 6
+            reasons.append(f"id match: {matched_id}")
+
         matched_phrases = _matched_skill_terms(
             terms=skill.activation_hints.phrases,
             task_text_lower=task_text_lower,
@@ -8783,6 +8789,17 @@ def _recommend_skills(*, task_text: str, skills: list[RegisteredSkill]) -> list[
         )
     )
     return recommendations
+
+
+def _matched_skill_id_phrase(*, skill: RegisteredSkill, task_text_normalized: str) -> str:
+    tokens = _skill_match_tokens(skill.skill_id)
+    if len(tokens) < 2:
+        return ""
+    for size in range(len(tokens), 1, -1):
+        phrase = " ".join(tokens[:size])
+        if phrase in task_text_normalized:
+            return phrase
+    return ""
 
 
 def _matched_skill_terms(

--- a/src/agentic_workspace/cli.py
+++ b/src/agentic_workspace/cli.py
@@ -933,10 +933,6 @@ def main(argv: list[str] | None = None) -> int:
             )
         except WorkspaceUsageError as exc:
             parser.error(str(exc))
-        if payload.get("health") != "healthy" and args.format == "json":
-            import sys
-
-            print(f"DEBUG findings: {payload.get('findings')}", file=sys.stderr)
         _emit_payload(payload=payload, format_name=args.format)
         return 0
 

--- a/src/agentic_workspace/contracts/schemas/agent_feedback.schema.json
+++ b/src/agentic_workspace/contracts/schemas/agent_feedback.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "agentic-workspace/agent-feedback.schema.json",
+  "title": "Agent Feedback Artifact",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "evaluated_at",
+    "prompt_ref",
+    "context",
+    "impact",
+    "findings",
+    "suggestions",
+    "follow_up_routing"
+  ],
+  "properties": {
+    "kind": {
+      "const": "agent-feedback-review/v1"
+    },
+    "schema_version": {
+      "const": "agentic-workspace/agent-feedback/v1"
+    },
+    "evaluated_at": {
+      "type": "string"
+    },
+    "prompt_ref": {
+      "type": "string"
+    },
+    "context": {
+      "type": "object",
+      "required": [
+        "target",
+        "work_window",
+        "package_surfaces_used"
+      ],
+      "properties": {
+        "target": {
+          "type": "string"
+        },
+        "work_window": {
+          "type": "string"
+        },
+        "package_surfaces_used": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "impact": {
+      "type": "object",
+      "required": [
+        "outcome",
+        "quality",
+        "efficiency",
+        "cognitive_load"
+      ],
+      "properties": {
+        "outcome": {
+          "type": "string"
+        },
+        "quality": {
+          "type": "string"
+        },
+        "efficiency": {
+          "type": "string"
+        },
+        "cognitive_load": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "summary",
+          "classification",
+          "evidence",
+          "severity"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "classification": {
+            "enum": [
+              "product-general",
+              "repo-local",
+              "mixed-unclear"
+            ]
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "severity": {
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "suggestions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "finding_id",
+          "summary",
+          "expected_effect"
+        ],
+        "properties": {
+          "finding_id": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "expected_effect": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "follow_up_routing": {
+      "type": "object",
+      "required": [
+        "issues",
+        "deferred"
+      ],
+      "properties": {
+        "issues": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deferred": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/agentic_workspace/contracts/schemas/agent_feedback.schema.json
+++ b/src/agentic_workspace/contracts/schemas/agent_feedback.schema.json
@@ -2,6 +2,12 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "agentic-workspace/agent-feedback.schema.json",
   "title": "Agent Feedback Artifact",
+  "description": "Optional review artifact shape for comparing agent-feedback evaluations; not a required operating surface unless a later command emits it valid-by-construction.",
+  "x-agentic-workspace": {
+    "surface_role": "optional-review-artifact-schema",
+    "required_operating_surface": false,
+    "emitted_by_command": false
+  },
   "type": "object",
   "required": [
     "kind",

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 
 import pytest
+from jsonschema import Draft202012Validator
 
 from agentic_workspace import contract_tooling
 
@@ -16,6 +17,53 @@ def test_contract_tooling_check_passes() -> None:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     assert module.main([]) == 0
+
+
+def test_agent_feedback_schema_validates_normalized_feedback_artifact() -> None:
+    schema = contract_tooling.contract_schema("agent_feedback.schema.json")
+    sample = {
+        "kind": "agent-feedback-review/v1",
+        "schema_version": "agentic-workspace/agent-feedback/v1",
+        "evaluated_at": "2026-04-26",
+        "prompt_ref": "agent-feedback-prompt.txt",
+        "context": {
+            "target": ".",
+            "work_window": "current self-improvement branch",
+            "package_surfaces_used": [
+                "agentic-workspace report --target . --format json",
+                "agentic-workspace summary --format json",
+            ],
+        },
+        "impact": {
+            "outcome": "better recovery and proof routing",
+            "quality": "higher closeout confidence",
+            "efficiency": "lower total reconstruction work",
+            "cognitive_load": "lower when compact routes answer the task",
+        },
+        "findings": [
+            {
+                "id": "ordinary-agent-path",
+                "summary": "The ordinary path should be one compact answer.",
+                "classification": "product-general",
+                "evidence": ["agent-feedback-prompt.txt evaluation"],
+                "severity": "medium",
+            }
+        ],
+        "suggestions": [
+            {
+                "finding_id": "ordinary-agent-path",
+                "summary": "Expose entry, state, proof, and escalation guidance together.",
+                "expected_effect": "new agents can start with less reconstruction",
+            }
+        ],
+        "follow_up_routing": {
+            "issues": ["#388"],
+            "deferred": [],
+        },
+    }
+
+    errors = list(Draft202012Validator(schema).iter_errors(sample))
+    assert errors == []
 
 
 def test_command_adapter_generation_contract_identifies_defaults_candidate() -> None:

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -21,6 +21,11 @@ def test_contract_tooling_check_passes() -> None:
 
 def test_agent_feedback_schema_validates_normalized_feedback_artifact() -> None:
     schema = contract_tooling.contract_schema("agent_feedback.schema.json")
+    metadata = schema["x-agentic-workspace"]
+    assert metadata["surface_role"] == "optional-review-artifact-schema"
+    assert metadata["required_operating_surface"] is False
+    assert metadata["emitted_by_command"] is False
+
     sample = {
         "kind": "agent-feedback-review/v1",
         "schema_version": "agentic-workspace/agent-feedback/v1",

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -3100,6 +3100,11 @@ def test_report_default_profile_returns_router_before_deep_detail(tmp_path: Path
     assert payload["report_profile"]["default_profile"] == "router"
     assert payload["report_profile"]["full_profile"] == "full"
     assert payload["report_profile"]["decision_grade_fields"][0] == "health"
+    ordinary_path = payload["report_profile"]["ordinary_agent_path"]
+    assert ordinary_path["entry_command"] == "agentic-workspace start --target ./repo --format json"
+    assert ordinary_path["current_work_command"] == "agentic-workspace summary --format json"
+    assert ordinary_path["proof_command"] == "agentic-workspace proof --target ./repo --changed <paths> --format json"
+    assert "report_profile.ordinary_agent_path" in payload["report_profile"]["decision_grade_fields"]
     guard = payload["report_profile"]["router_shape_guard"]
     assert guard["status"] == "active"
     assert len(payload) <= guard["max_top_level_fields"]
@@ -3122,12 +3127,19 @@ def test_report_default_profile_returns_router_before_deep_detail(tmp_path: Path
     assert payload["deeper_detail"]["high_volume_sections"][0]["section"] == "module_reports"
     section_hints = {item["section"]: item for item in payload["section_hints"]}
     assert section_hints["module_reports"]["volume"] == "high"
+    assert "compact router field" in section_hints["module_reports"]["why_now"]
     assert section_hints["operational_compression"]["volume"] == "normal"
+    assert "reducing total work" in section_hints["operational_compression"]["why_now"]
     assert section_hints["external_work_delta"]["volume"] == "normal"
     assert "idle context" in section_hints["effective_authority"]["purpose"]
+    assert "idle state" in section_hints["effective_authority"]["why_now"]
     assert section_hints["effective_authority"]["command"] == (
         "agentic-workspace report --target ./repo --section effective_authority --format json"
     )
+    historical_reviews = payload["closeout_trust"]["historical_review_artifacts"]
+    assert historical_reviews["status"] == "evidence-only"
+    assert "not ordinary operating input" in historical_reviews["role"]
+    assert "Do not read historical review artifacts during startup" in historical_reviews["rule"]
 
 
 def test_report_section_selector_returns_compact_section_answer(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -2192,6 +2192,56 @@ def test_skills_command_recommends_self_improvement_for_hyphenated_dogfooding_ta
     assert any("noun match" in reason and "self-improvement" in reason for reason in payload["recommendations"][0]["reasons"])
 
 
+def test_skills_command_prioritizes_self_improvement_for_system_wide_improvement_review(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write_json(
+        target / "tools" / "skills" / "REGISTRY.json",
+        {
+            "schema_version": "skill-registry.v1",
+            "owner": "repo-local-tool-skills",
+            "source_kind": "repo-owned-tool-skills",
+            "skills": [
+                {
+                    "id": "self-improvement-dogfooding",
+                    "path": "self-improvement-dogfooding/SKILL.md",
+                    "summary": "run bounded repo-local improvement cycles that dogfood package surfaces",
+                    "activation_hints": {
+                        "nouns": ["self-improvement", "dogfooding", "system intent"],
+                    },
+                }
+            ],
+        },
+    )
+    _write(target / "tools" / "skills" / "self-improvement-dogfooding" / "SKILL.md", "# Self-improvement\n")
+
+    assert (
+        cli.main(
+            [
+                "skills",
+                "--target",
+                str(target),
+                "--task",
+                "make a full review of the system as a whole to drive self-improvement",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["recommendations"][0]["id"] == "self-improvement-dogfooding"
+    assert any("id match: self improvement" in reason for reason in payload["recommendations"][0]["reasons"])
+
+
 def test_skills_command_keeps_repo_owned_memory_and_general_skill_sources_distinct(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
@@ -3074,6 +3124,7 @@ def test_report_default_profile_returns_router_before_deep_detail(tmp_path: Path
     assert section_hints["module_reports"]["volume"] == "high"
     assert section_hints["operational_compression"]["volume"] == "normal"
     assert section_hints["external_work_delta"]["volume"] == "normal"
+    assert "idle context" in section_hints["effective_authority"]["purpose"]
     assert section_hints["effective_authority"]["command"] == (
         "agentic-workspace report --target ./repo --section effective_authority --format json"
     )

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -984,7 +984,8 @@ def test_defaults_section_selector_returns_effective_authority_view(capsys) -> N
     assert concerns["runtime implementation"]["authority_class"] == "procedural-owned"
     assert answer["system_intent_embodiment"]["status"] == "needs-review"
     assert answer["provenance"]["contract_inventory"] == "src/agentic_workspace/contracts/contract_inventory.json"
-    assert answer["unresolved_gaps"][0]["id"] == "no-active-planning-record"
+    assert answer["unresolved_gaps"][0]["id"] == "memory-not-installed"
+    assert answer["idle_context"][0]["id"] == "no-active-planning-record"
 
 
 def test_defaults_section_selector_returns_optimization_bias_answer(capsys) -> None:
@@ -2140,6 +2141,57 @@ def test_skills_command_recommends_review_skill_for_natural_review_request(tmp_p
     assert any("verb match" in reason or "phrase match" in reason for reason in payload["recommendations"][0]["reasons"])
 
 
+def test_skills_command_recommends_self_improvement_for_hyphenated_dogfooding_task(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write_json(
+        target / "tools" / "skills" / "REGISTRY.json",
+        {
+            "schema_version": "skill-registry.v1",
+            "owner": "repo-local-tool-skills",
+            "source_kind": "repo-owned-tool-skills",
+            "skills": [
+                {
+                    "id": "self-improvement-dogfooding",
+                    "path": "self-improvement-dogfooding/SKILL.md",
+                    "summary": "run bounded repo-local improvement cycles that dogfood package surfaces",
+                    "activation_hints": {
+                        "verbs": ["continue", "repeat", "improve", "dogfood", "autopilot"],
+                        "nouns": ["self-improvement", "dogfooding", "improvement lane", "system intent"],
+                        "phrases": ["run self-improvement", "repeat improvement work", "dogfood the package"],
+                        "when": ["repo-local improvement loop", "system-intent follow-through"],
+                    },
+                }
+            ],
+        },
+    )
+    _write(target / "tools" / "skills" / "self-improvement-dogfooding" / "SKILL.md", "# Self-improvement\n")
+
+    assert (
+        cli.main(
+            [
+                "skills",
+                "--target",
+                str(target),
+                "--task",
+                "create a system-intent review and use it to run self-improvement until findings are addressed",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["recommendations"][0]["id"] == "self-improvement-dogfooding"
+    assert any("phrase match: run self-improvement" in reason for reason in payload["recommendations"][0]["reasons"])
+    assert any("noun match" in reason and "self-improvement" in reason for reason in payload["recommendations"][0]["reasons"])
+
+
 def test_skills_command_keeps_repo_owned_memory_and_general_skill_sources_distinct(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
@@ -2954,10 +3006,12 @@ def test_report_real_init_summarizes_combined_workspace_state(tmp_path: Path, ca
     assert "effective_authority" in payload["schema"]["shared_fields"]
     assert "operational_compression" in payload["schema"]["shared_fields"]
     effective_authority = payload["effective_authority"]
-    assert effective_authority["status"] == "needs-review"
+    assert effective_authority["status"] == "ready"
     authority_by_concern = {entry["concern"]: entry for entry in effective_authority["authority_map"]}
     assert authority_by_concern["active plan and continuation"]["status"] == "absent"
     assert authority_by_concern["durable repo knowledge"]["status"] == "present"
+    assert effective_authority["unresolved_gaps"] == []
+    assert effective_authority["idle_context"][0]["id"] == "no-active-planning-record"
     assert effective_authority["system_intent_embodiment"]["anti_framework_pressure"][0] == "remove an unnecessary surface"
     assert payload["reports"][0]["module"] == "planning"
     assert {report["module"] for report in payload["module_reports"]} == {"planning", "memory"}
@@ -3040,6 +3094,8 @@ def test_report_section_selector_returns_compact_section_answer(tmp_path: Path, 
     assert payload["selector"] == {"section": "effective_authority"}
     assert payload["matched"] is True
     assert payload["answer"]["defaults_command"] == "agentic-workspace defaults --section effective_authority --format json"
+    assert payload["answer"]["status"] == "ready"
+    assert payload["answer"]["idle_context"][0]["id"] == "no-active-planning-record"
     assert payload["refs"][0] == ".agentic-workspace/docs/reporting-contract.md"
 
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -3188,11 +3188,13 @@ def test_report_section_selector_returns_operational_compression_measures(tmp_pa
 
     assert cli.main(["report", "--target", str(target), "--section", "operational_compression", "--format", "json"]) == 0
 
-    payload = json.loads(capsys.readouterr().out)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
     assert payload["profile"] == "compact-contract-answer/v1"
     assert payload["surface"] == "report"
     assert payload["selector"] == {"section": "operational_compression"}
     assert payload["matched"] is True
+    assert captured.err == ""
     answer = payload["answer"]
     assert answer["kind"] == "workspace-operational-compression/v1"
     assert answer["advisory_only"] is True


### PR DESCRIPTION
## Summary
- ignore generated uv cache nested repositories in memory doctor context warnings
- record explicit config treatment for the recurring-failures improvement-signal memory note
- suppress parent repository noise when an explicit target has its own git boundary

## Validation
- uv run pytest packages/memory/tests/test_installer.py -q -k "uv_caches or parent_repo"
- uv run ruff check packages/memory/src packages/memory/tests/test_installer.py
- cd packages/memory && uv run pytest tests/test_installer.py
- cd packages/memory && uv run ruff check .
- uv run pytest tests/test_workspace_cli.py -q
- uv run ruff check src tests
- uv run agentic-workspace report --target . --section findings --format json
- uv run agentic-workspace summary --format json
- uv run agentic-workspace reconcile --format json
