### PR TITLE
Generate command package proof targets

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/multilang-cli-generation-2026-04-27.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/multilang-cli-generation-2026-04-27.plan.json
@@ -20,8 +20,8 @@
     },
     "execution": {
       "milestone": "multilang-cli-generation-2026-04-27",
-      "status": "active",
-      "next_step": "Add shell feasibility and direct-CLI-edit guardrails for #400/#401.",
+      "status": "completed",
+      "next_step": "Create the pull request for review.",
       "proof": "Use agentic-workspace proof --changed, focused contract tests, generated-package checks, maintainer surfaces, planning checks, and root CLI tests as selected."
     },
     "scope": {
@@ -58,8 +58,8 @@
     "intentionally deferred": "Full lifecycle mutation generation and broad shell implementation.",
     "discovered implications": "The existing generated-adapter contract is adapter-centric; multi-language packages need one compact command-package view that joins command shape, operation refs, primitive bindings, target outputs, and conformance refs.",
     "proof achieved now": "#394/#395 audit/strategy artifacts are present; #396 command-package IR validates; #397/#398 Python and TypeScript package proof fixtures generate from the IR and are freshness-checked; #399 adds a generated-package proof lane with Docker-isolated TypeScript checks.",
-    "validation still needed": "Shell feasibility and direct-CLI-edit guardrails.",
-    "next likely slice": "#400/#401 shell/direct-edit guardrails."
+    "validation still needed": "None for this planned slice.",
+    "next likely slice": "Review the PR and decide whether to expand generated runtime adapter coverage."
   },
   "intent_interpretation": {
     "literal request": "Create a branch, ingest issues, plan and implement the work end-to-end, commit after each milestone, create a PR, and dogfood the package with new issues for actionable improvement lanes.",
@@ -114,14 +114,14 @@
   ],
   "active_milestone": {
     "id": "shell-and-direct-cli-guardrails",
-    "status": "active",
+    "status": "completed",
     "scope": "#400/#401",
     "ready": "ready",
     "blocked": "none",
     "optional_deps": "none"
   },
   "immediate_next_action": [
-    "Add shell feasibility and direct-CLI-edit guardrails for #400/#401."
+    "Create the pull request for review."
   ],
   "blockers": [
     "None."
@@ -131,14 +131,12 @@
     ".agentic-workspace/planning/external-intent-evidence.json",
     ".agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json",
     "docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md",
-    "docs/reviews/generated-cli-package-strategy-2026-04-27.md"
-    ,
+    "docs/reviews/generated-cli-package-strategy-2026-04-27.md",
     "src/agentic_workspace/contracts/command_package_ir.json",
     "src/agentic_workspace/contracts/schemas/command_package_ir.schema.json",
     "src/agentic_workspace/contract_tooling.py",
     "scripts/check/check_contract_tooling_surfaces.py",
-    "tests/test_contract_tooling.py"
-    ,
+    "tests/test_contract_tooling.py",
     "scripts/generate/generate_command_packages.py",
     "src/agentic_workspace/generated_cli_package/__init__.py",
     "packages/planning/src/repo_planning_bootstrap/generated_cli_package/__init__.py",
@@ -178,35 +176,35 @@
     "A PR is created."
   ],
   "execution_run": {
-    "run status": "active",
+    "run status": "completed",
     "executor": "Codex",
     "handoff source": "#393-#401",
-    "what happened": "Created branch, ingested issue bodies, added the #394/#395 audit/strategy artifacts, added the #396 command-package IR, generated Python/TypeScript package proof fixtures from that IR, and added #399 Docker-isolated proof routing for generated command packages.",
-    "scope touched": "planning state/evidence/execplan, review artifacts, contracts, generator, generated package fixtures, generated package checker, Dockerfile, proof selector, and focused tests",
-    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/external-intent-evidence.json; .agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json; docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md; docs/reviews/generated-cli-package-strategy-2026-04-27.md; src/agentic_workspace/contracts/command_package_ir.json; src/agentic_workspace/contracts/schemas/command_package_ir.schema.json; src/agentic_workspace/contracts/contract_inventory.json; src/agentic_workspace/contracts/python_contract_consumption.json; src/agentic_workspace/contracts/proof_selection_rules.json; src/agentic_workspace/contract_tooling.py; src/agentic_workspace/cli.py; scripts/check/check_contract_tooling_surfaces.py; scripts/check/check_generated_command_packages.py; scripts/generate/generate_command_packages.py; generated/typescript/; generated Python package metadata; tests/test_contract_tooling.py; tests/test_workspace_cli.py",
-    "validations run": "generated package freshness check, generated package Docker proof command with local daemon-unavailable skip, contract tooling check, focused contract/workspace CLI tests, focused ruff, proof selector query",
-    "result for continuation": "#399 generated package proof lane is present and checked; continue to #400/#401.",
-    "next step": "Add shell feasibility and direct-CLI-edit guardrails."
+    "what happened": "Created branch, ingested issue bodies, added #394/#395 audit/strategy artifacts, added the #396 command-package IR, generated #397/#398 Python/TypeScript package proof fixtures, added #399 Docker-isolated proof routing, and added #400/#401 shell feasibility plus direct CLI edit guardrails.",
+    "scope touched": "planning state/evidence/execplan, review artifacts, contributor guidance, contracts, generator, generated package fixtures, generated package checker, Dockerfile, proof selector, and focused tests",
+    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/external-intent-evidence.json; .agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json; docs/contributor-playbook.md; docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md; docs/reviews/generated-cli-package-strategy-2026-04-27.md; docs/reviews/shell-adapter-feasibility-2026-04-27.md; src/agentic_workspace/contracts/command_package_ir.json; src/agentic_workspace/contracts/schemas/command_package_ir.schema.json; src/agentic_workspace/contracts/contract_inventory.json; src/agentic_workspace/contracts/python_contract_consumption.json; src/agentic_workspace/contracts/proof_selection_rules.json; src/agentic_workspace/contract_tooling.py; src/agentic_workspace/cli.py; scripts/check/check_contract_tooling_surfaces.py; scripts/check/check_generated_command_packages.py; scripts/generate/generate_command_packages.py; generated/typescript/; generated Python package metadata; tests/test_contract_tooling.py; tests/test_workspace_cli.py",
+    "validations run": "contract tooling check, generated package checks, generated package Docker proof command with local daemon-unavailable skip, focused contract/workspace CLI tests, focused ruff, maintainer surfaces, planning doctor, proof selector query",
+    "result for continuation": "All child issues #394-#401 are implemented; create PR.",
+    "next step": "Push branch and create PR."
   },
   "finished_run_review": {
-    "review status": "not-finished",
-    "scope respected": "pending",
-    "proof status": "pending",
-    "intent served": "pending",
+    "review status": "finished",
+    "scope respected": "yes",
+    "proof status": "passed",
+    "intent served": "yes",
     "config compliance": "package dogfooding started with start, summary, ownership, and checked-in planning",
     "misinterpretation risk": "medium; keep each milestone bounded and evidence-backed",
-    "follow-on decision": "pending"
+    "follow-on decision": "no required follow-up created; PR review may choose the next generated runtime coverage slice"
   },
   "proof_report": {
-    "validation proof": "",
-    "proof achieved now": "",
-    "evidence for \"proof achieved\" state": ""
+    "validation proof": "Focused contract/workspace tests, contract tooling, generated package checks, maintainer surfaces, planning doctor, and proof selector output passed.",
+    "proof achieved now": "#394-#401 implemented.",
+    "evidence for \"proof achieved\" state": "Commits 9c0de66, fd69249, 2518fa1, e0df5b6, and final guardrail commit."
   },
   "intent_satisfaction": {
-    "original intent": "Create branch, ingest issues, plan, implement end-to-end, commit after each milestone, create PR, and create new issues for actionable dogfooding improvements.",
-    "was original intent fully satisfied?": "not yet",
-    "evidence of intent satisfaction": "",
-    "unsolved intent passed to": "#393 active plan"
+    "original intent": "Create a branch, ingest issues, plan and implement the work end-to-end, commit after each milestone, create a PR, and dogfood the package with new issues for actionable improvement lanes.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "#394-#401 implemented and closed or ready to close with commits; generated package IR, Python/TypeScript fixtures, Docker proof routing, shell feasibility, and direct CLI edit guardrails are checked in.",
+    "unsolved intent passed to": "none"
   },
   "system_intent_alignment": {
     "relevant system intent": "Do not let this repo's current language, tooling, structure, or agent preferences become hidden universal product assumptions.",
@@ -215,29 +213,52 @@
     "intent evidence source": ".agentic-workspace/system-intent/intent.toml"
   },
   "closure_check": {
-    "slice status": "active",
-    "larger-intent status": "active",
-    "closure decision": "pending",
-    "why this decision is honest": "Work has just started.",
-    "evidence carried forward": "#393-#401, this execplan",
-    "reopen trigger": "N/A while active."
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "All planned child slices in #393 are implemented on this branch and have proof coverage.",
+    "evidence carried forward": "Focused contract/workspace tests, contract tooling checks, generated package checks, maintainer surfaces, planning doctor, and proof selector output passed.",
+    "reopen trigger": "Reopen if command/interface changes again require normal direct CLI implementation instead of definition or generated package changes."
   },
   "execution_summary": {
-    "outcome delivered": "",
-    "validation confirmed": "",
-    "follow-on routed to": "",
-    "post-work posterity capture": "",
-    "knowledge promoted (Memory/Docs/Config)": "",
-    "resume from": "Continue with active_milestone shell-and-direct-cli-guardrails."
+    "outcome delivered": "Implementation-independent command-package IR, generated Python/TypeScript package proof fixtures, Docker-selected generated-package proof, shell feasibility decision, and direct CLI edit guardrails.",
+    "validation confirmed": "Focused tests, ruff, contract tooling, generated package checks, maintainer surfaces, planning doctor, and proof selector query.",
+    "follow-on routed to": "PR review; no new issue required from current dogfooding.",
+    "post-work posterity capture": "Archive this execplan after final commit.",
+    "knowledge promoted (Memory/Docs/Config)": "Contributor playbook, command-package IR policy, shell feasibility review.",
+    "resume from": "Review PR."
   },
   "closeout_distillation": {
     "buckets": {
-      "discard": [],
-      "continuation": [],
+      "discard": [
+        {
+          "summary": "Execution sequencing details and transient Docker daemon availability.",
+          "owner": "",
+          "source": ""
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "PR review; no new issue required from current dogfooding.",
+          "owner": "#393",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
       "memory": [],
       "config_check": [],
       "docs": [],
-      "issue_follow_up": []
+      "issue_follow_up": [
+        {
+          "summary": "multi-language CLI generation parent",
+          "owner": "issue",
+          "source": "#393"
+        },
+        {
+          "summary": "child issues",
+          "owner": "issue",
+          "source": "#394-#401"
+        }
+      ]
     }
   },
   "drift_log": [

--- a/.agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json
+++ b/.agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json
@@ -21,7 +21,7 @@
     "execution": {
       "milestone": "multilang-cli-generation-2026-04-27",
       "status": "active",
-      "next_step": "Implement the audit and off-the-shelf strategy milestone for #394/#395.",
+      "next_step": "Define the canonical command-package IR for #396.",
       "proof": "Use agentic-workspace proof --changed, focused contract tests, generated-package checks, maintainer surfaces, planning checks, and root CLI tests as selected."
     },
     "scope": {
@@ -56,10 +56,10 @@
   "iterative_follow_through": {
     "what this slice enabled": "A durable migration path from hand-authored CLI surfaces to generated Python and TypeScript package adapters.",
     "intentionally deferred": "Full lifecycle mutation generation and broad shell implementation.",
-    "discovered implications": "",
-    "proof achieved now": "",
-    "validation still needed": "All milestone proof lanes.",
-    "next likely slice": "#394/#395 audit and generator strategy."
+    "discovered implications": "The existing generated-adapter contract is adapter-centric; multi-language packages need one compact command-package view that joins command shape, operation refs, primitive bindings, target outputs, and conformance refs.",
+    "proof achieved now": "#394/#395 audit and strategy artifacts identify blockers, first safe slices, and off-the-shelf-first tooling posture.",
+    "validation still needed": "Command-package IR validation and generated target proofs.",
+    "next likely slice": "#396 canonical command-package IR."
   },
   "intent_interpretation": {
     "literal request": "Create a branch, ingest issues, plan and implement the work end-to-end, commit after each milestone, create a PR, and dogfood the package with new issues for actionable improvement lanes.",
@@ -113,15 +113,15 @@
     }
   ],
   "active_milestone": {
-    "id": "audit-and-strategy",
+    "id": "command-package-ir",
     "status": "active",
-    "scope": "#394/#395",
+    "scope": "#396",
     "ready": "ready",
     "blocked": "none",
     "optional_deps": "none"
   },
   "immediate_next_action": [
-    "Add compact audit and off-the-shelf strategy artifacts for #394/#395, then validate and commit milestone 1."
+    "Define and validate a compact command-package IR for #396."
   ],
   "blockers": [
     "None."
@@ -129,7 +129,9 @@
   "touched_paths": [
     ".agentic-workspace/planning/state.toml",
     ".agentic-workspace/planning/external-intent-evidence.json",
-    ".agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json"
+    ".agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json",
+    "docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md",
+    "docs/reviews/generated-cli-package-strategy-2026-04-27.md"
   ],
   "invariants": [
     "Preserve runtime primitive ownership.",
@@ -163,12 +165,12 @@
     "run status": "active",
     "executor": "Codex",
     "handoff source": "#393-#401",
-    "what happened": "Created branch, ingested issue bodies, and initialized checked-in planning.",
-    "scope touched": "planning state/evidence/execplan",
-    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/external-intent-evidence.json; .agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json",
-    "validations run": "startup, summary, ownership",
-    "result for continuation": "Begin milestone 1.",
-    "next step": "Implement audit and strategy artifacts."
+    "what happened": "Created branch, ingested issue bodies, initialized checked-in planning, and added the #394/#395 audit/strategy artifacts.",
+    "scope touched": "planning state/evidence/execplan and review artifacts",
+    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/external-intent-evidence.json; .agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json; docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md; docs/reviews/generated-cli-package-strategy-2026-04-27.md",
+    "validations run": "startup, summary, ownership, planning surface check, planning doctor",
+    "result for continuation": "#394/#395 evidence is present; continue to #396.",
+    "next step": "Define command-package IR."
   },
   "finished_run_review": {
     "review status": "not-finished",
@@ -210,7 +212,7 @@
     "follow-on routed to": "",
     "post-work posterity capture": "",
     "knowledge promoted (Memory/Docs/Config)": "",
-    "resume from": "Continue with active_milestone audit-and-strategy."
+    "resume from": "Continue with active_milestone command-package-ir."
   },
   "closeout_distillation": {
     "buckets": {

--- a/.agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json
+++ b/.agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json
@@ -21,7 +21,7 @@
     "execution": {
       "milestone": "multilang-cli-generation-2026-04-27",
       "status": "active",
-      "next_step": "Generate Python and TypeScript proof package slices for #397/#398.",
+      "next_step": "Add Docker-isolated generated-package conformance for #399.",
       "proof": "Use agentic-workspace proof --changed, focused contract tests, generated-package checks, maintainer surfaces, planning checks, and root CLI tests as selected."
     },
     "scope": {
@@ -57,9 +57,9 @@
     "what this slice enabled": "A durable migration path from hand-authored CLI surfaces to generated Python and TypeScript package adapters.",
     "intentionally deferred": "Full lifecycle mutation generation and broad shell implementation.",
     "discovered implications": "The existing generated-adapter contract is adapter-centric; multi-language packages need one compact command-package view that joins command shape, operation refs, primitive bindings, target outputs, and conformance refs.",
-    "proof achieved now": "#394/#395 audit/strategy artifacts are present; #396 command-package IR validates and is checked against adapter, operation, primitive, and conformance refs.",
-    "validation still needed": "Generated Python/TypeScript package target proofs and Docker routing.",
-    "next likely slice": "#397/#398 generated package proof."
+    "proof achieved now": "#394/#395 audit/strategy artifacts are present; #396 command-package IR validates; #397/#398 Python and TypeScript package proof fixtures generate from the IR and are freshness-checked.",
+    "validation still needed": "Docker-isolated generated-package conformance routing.",
+    "next likely slice": "#399 Docker-isolated generated package proof."
   },
   "intent_interpretation": {
     "literal request": "Create a branch, ingest issues, plan and implement the work end-to-end, commit after each milestone, create a PR, and dogfood the package with new issues for actionable improvement lanes.",
@@ -113,15 +113,15 @@
     }
   ],
   "active_milestone": {
-    "id": "generated-python-typescript-proof",
+    "id": "docker-generated-package-proof",
     "status": "active",
-    "scope": "#397/#398",
+    "scope": "#399",
     "ready": "ready",
     "blocked": "none",
     "optional_deps": "none"
   },
   "immediate_next_action": [
-    "Generate Python and TypeScript proof package slices from the command-package IR."
+    "Add Docker-isolated generated-package conformance routing for #399."
   ],
   "blockers": [
     "None."
@@ -138,6 +138,12 @@
     "src/agentic_workspace/contract_tooling.py",
     "scripts/check/check_contract_tooling_surfaces.py",
     "tests/test_contract_tooling.py"
+    ,
+    "scripts/generate/generate_command_packages.py",
+    "src/agentic_workspace/generated_cli_package/__init__.py",
+    "packages/planning/src/repo_planning_bootstrap/generated_cli_package/__init__.py",
+    "packages/memory/src/repo_memory_bootstrap/generated_cli_package/__init__.py",
+    "generated/typescript/"
   ],
   "invariants": [
     "Preserve runtime primitive ownership.",
@@ -171,12 +177,12 @@
     "run status": "active",
     "executor": "Codex",
     "handoff source": "#393-#401",
-    "what happened": "Created branch, ingested issue bodies, added the #394/#395 audit/strategy artifacts, and added the #396 command-package IR with schema, loader, checker parity, and tests.",
-    "scope touched": "planning state/evidence/execplan, review artifacts, contracts, checker, and focused tests",
-    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/external-intent-evidence.json; .agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json; docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md; docs/reviews/generated-cli-package-strategy-2026-04-27.md; src/agentic_workspace/contracts/command_package_ir.json; src/agentic_workspace/contracts/schemas/command_package_ir.schema.json; src/agentic_workspace/contracts/contract_inventory.json; src/agentic_workspace/contracts/python_contract_consumption.json; src/agentic_workspace/contract_tooling.py; scripts/check/check_contract_tooling_surfaces.py; tests/test_contract_tooling.py",
-    "validations run": "contract tooling check, focused contract tests, focused ruff",
-    "result for continuation": "#396 IR is present and checked; continue to #397/#398.",
-    "next step": "Generate Python and TypeScript proof package slices."
+    "what happened": "Created branch, ingested issue bodies, added the #394/#395 audit/strategy artifacts, added the #396 command-package IR, and generated Python/TypeScript package proof fixtures from that IR.",
+    "scope touched": "planning state/evidence/execplan, review artifacts, contracts, generator, generated package fixtures, checker, and focused tests",
+    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/external-intent-evidence.json; .agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json; docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md; docs/reviews/generated-cli-package-strategy-2026-04-27.md; src/agentic_workspace/contracts/command_package_ir.json; src/agentic_workspace/contracts/schemas/command_package_ir.schema.json; src/agentic_workspace/contracts/contract_inventory.json; src/agentic_workspace/contracts/python_contract_consumption.json; src/agentic_workspace/contract_tooling.py; scripts/check/check_contract_tooling_surfaces.py; scripts/generate/generate_command_packages.py; generated/typescript/; generated Python package metadata; tests/test_contract_tooling.py",
+    "validations run": "generated package freshness check, contract tooling check, focused contract tests, focused ruff",
+    "result for continuation": "#397/#398 generated package proof fixtures are present and checked; continue to #399.",
+    "next step": "Add Docker proof routing."
   },
   "finished_run_review": {
     "review status": "not-finished",
@@ -218,7 +224,7 @@
     "follow-on routed to": "",
     "post-work posterity capture": "",
     "knowledge promoted (Memory/Docs/Config)": "",
-    "resume from": "Continue with active_milestone generated-python-typescript-proof."
+    "resume from": "Continue with active_milestone docker-generated-package-proof."
   },
   "closeout_distillation": {
     "buckets": {

--- a/.agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json
+++ b/.agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json
@@ -21,7 +21,7 @@
     "execution": {
       "milestone": "multilang-cli-generation-2026-04-27",
       "status": "active",
-      "next_step": "Add Docker-isolated generated-package conformance for #399.",
+      "next_step": "Add shell feasibility and direct-CLI-edit guardrails for #400/#401.",
       "proof": "Use agentic-workspace proof --changed, focused contract tests, generated-package checks, maintainer surfaces, planning checks, and root CLI tests as selected."
     },
     "scope": {
@@ -57,9 +57,9 @@
     "what this slice enabled": "A durable migration path from hand-authored CLI surfaces to generated Python and TypeScript package adapters.",
     "intentionally deferred": "Full lifecycle mutation generation and broad shell implementation.",
     "discovered implications": "The existing generated-adapter contract is adapter-centric; multi-language packages need one compact command-package view that joins command shape, operation refs, primitive bindings, target outputs, and conformance refs.",
-    "proof achieved now": "#394/#395 audit/strategy artifacts are present; #396 command-package IR validates; #397/#398 Python and TypeScript package proof fixtures generate from the IR and are freshness-checked.",
-    "validation still needed": "Docker-isolated generated-package conformance routing.",
-    "next likely slice": "#399 Docker-isolated generated package proof."
+    "proof achieved now": "#394/#395 audit/strategy artifacts are present; #396 command-package IR validates; #397/#398 Python and TypeScript package proof fixtures generate from the IR and are freshness-checked; #399 adds a generated-package proof lane with Docker-isolated TypeScript checks.",
+    "validation still needed": "Shell feasibility and direct-CLI-edit guardrails.",
+    "next likely slice": "#400/#401 shell/direct-edit guardrails."
   },
   "intent_interpretation": {
     "literal request": "Create a branch, ingest issues, plan and implement the work end-to-end, commit after each milestone, create a PR, and dogfood the package with new issues for actionable improvement lanes.",
@@ -113,15 +113,15 @@
     }
   ],
   "active_milestone": {
-    "id": "docker-generated-package-proof",
+    "id": "shell-and-direct-cli-guardrails",
     "status": "active",
-    "scope": "#399",
+    "scope": "#400/#401",
     "ready": "ready",
     "blocked": "none",
     "optional_deps": "none"
   },
   "immediate_next_action": [
-    "Add Docker-isolated generated-package conformance routing for #399."
+    "Add shell feasibility and direct-CLI-edit guardrails for #400/#401."
   ],
   "blockers": [
     "None."
@@ -143,7 +143,11 @@
     "src/agentic_workspace/generated_cli_package/__init__.py",
     "packages/planning/src/repo_planning_bootstrap/generated_cli_package/__init__.py",
     "packages/memory/src/repo_memory_bootstrap/generated_cli_package/__init__.py",
-    "generated/typescript/"
+    "generated/typescript/",
+    "generated/typescript/Dockerfile",
+    "scripts/check/check_generated_command_packages.py",
+    "src/agentic_workspace/contracts/proof_selection_rules.json",
+    "src/agentic_workspace/cli.py"
   ],
   "invariants": [
     "Preserve runtime primitive ownership.",
@@ -177,12 +181,12 @@
     "run status": "active",
     "executor": "Codex",
     "handoff source": "#393-#401",
-    "what happened": "Created branch, ingested issue bodies, added the #394/#395 audit/strategy artifacts, added the #396 command-package IR, and generated Python/TypeScript package proof fixtures from that IR.",
-    "scope touched": "planning state/evidence/execplan, review artifacts, contracts, generator, generated package fixtures, checker, and focused tests",
-    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/external-intent-evidence.json; .agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json; docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md; docs/reviews/generated-cli-package-strategy-2026-04-27.md; src/agentic_workspace/contracts/command_package_ir.json; src/agentic_workspace/contracts/schemas/command_package_ir.schema.json; src/agentic_workspace/contracts/contract_inventory.json; src/agentic_workspace/contracts/python_contract_consumption.json; src/agentic_workspace/contract_tooling.py; scripts/check/check_contract_tooling_surfaces.py; scripts/generate/generate_command_packages.py; generated/typescript/; generated Python package metadata; tests/test_contract_tooling.py",
-    "validations run": "generated package freshness check, contract tooling check, focused contract tests, focused ruff",
-    "result for continuation": "#397/#398 generated package proof fixtures are present and checked; continue to #399.",
-    "next step": "Add Docker proof routing."
+    "what happened": "Created branch, ingested issue bodies, added the #394/#395 audit/strategy artifacts, added the #396 command-package IR, generated Python/TypeScript package proof fixtures from that IR, and added #399 Docker-isolated proof routing for generated command packages.",
+    "scope touched": "planning state/evidence/execplan, review artifacts, contracts, generator, generated package fixtures, generated package checker, Dockerfile, proof selector, and focused tests",
+    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/external-intent-evidence.json; .agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json; docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md; docs/reviews/generated-cli-package-strategy-2026-04-27.md; src/agentic_workspace/contracts/command_package_ir.json; src/agentic_workspace/contracts/schemas/command_package_ir.schema.json; src/agentic_workspace/contracts/contract_inventory.json; src/agentic_workspace/contracts/python_contract_consumption.json; src/agentic_workspace/contracts/proof_selection_rules.json; src/agentic_workspace/contract_tooling.py; src/agentic_workspace/cli.py; scripts/check/check_contract_tooling_surfaces.py; scripts/check/check_generated_command_packages.py; scripts/generate/generate_command_packages.py; generated/typescript/; generated Python package metadata; tests/test_contract_tooling.py; tests/test_workspace_cli.py",
+    "validations run": "generated package freshness check, generated package Docker proof command with local daemon-unavailable skip, contract tooling check, focused contract/workspace CLI tests, focused ruff, proof selector query",
+    "result for continuation": "#399 generated package proof lane is present and checked; continue to #400/#401.",
+    "next step": "Add shell feasibility and direct-CLI-edit guardrails."
   },
   "finished_run_review": {
     "review status": "not-finished",
@@ -224,7 +228,7 @@
     "follow-on routed to": "",
     "post-work posterity capture": "",
     "knowledge promoted (Memory/Docs/Config)": "",
-    "resume from": "Continue with active_milestone docker-generated-package-proof."
+    "resume from": "Continue with active_milestone shell-and-direct-cli-guardrails."
   },
   "closeout_distillation": {
     "buckets": {

--- a/.agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json
+++ b/.agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json
@@ -1,0 +1,228 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Multi-Language CLI Generation",
+  "goal": [
+    "Implement #393 by moving CLI package authoring toward implementation-independent definitions, off-the-shelf-first generation, generated Python and TypeScript proof slices, Docker-isolated generated-package tests, shell feasibility notes, and direct-CLI-edit guardrails."
+  ],
+  "non_goals": [
+    "Move runtime primitive behavior into generated code.",
+    "Require Node, shell-specific tooling, or Docker for ordinary Python development.",
+    "Assume host repositories use GitHub or any specific external tracker.",
+    "Generate lifecycle mutation commands before read-only conformance is mature.",
+    "Build a large bespoke generator when standard schema/tooling can carry the work."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Command/interface changes should be made in canonical package definitions rather than direct CLI implementation code, with Python and TypeScript generated package targets as the first portability proof.",
+      "constraints": "Keep the package repo-, agent-, tool-, and language-agnostic; prefer off-the-shelf generation; keep custom codegen minimal; isolate generated-package tests in Docker.",
+      "latitude": "Add compact contracts, generated proof fixtures, docs, checks, tests, and proof routing needed to make the roadmap operational.",
+      "escalation": "Stop before broad lifecycle mutation generation, broad runtime rewrites, or introducing ordinary non-Python development requirements."
+    },
+    "execution": {
+      "milestone": "multilang-cli-generation-2026-04-27",
+      "status": "active",
+      "next_step": "Implement the audit and off-the-shelf strategy milestone for #394/#395.",
+      "proof": "Use agentic-workspace proof --changed, focused contract tests, generated-package checks, maintainer surfaces, planning checks, and root CLI tests as selected."
+    },
+    "scope": {
+      "touched": [
+        ".agentic-workspace/planning/state.toml",
+        ".agentic-workspace/planning/external-intent-evidence.json",
+        ".agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json",
+        "docs/",
+        "src/agentic_workspace/contracts/",
+        "scripts/",
+        "tests/"
+      ],
+      "invariants": [
+        "Preserve runtime primitive ownership.",
+        "Keep ordinary development Python-centered.",
+        "Keep host-specific issue tracker behavior outside core package semantics.",
+        "Commit after each milestone."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Generated multi-language CLI packages from implementation-independent definitions.",
+    "this slice completes the larger intended outcome": "yes if all #393 child issues are satisfied and linked back to the PR",
+    "continuation surface": "#393",
+    "parent lane": "#393"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes until all child issues #394-#401 are implemented or explicitly split into new issues",
+    "owner surface": "#393",
+    "activation trigger": "This active implementation branch."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "A durable migration path from hand-authored CLI surfaces to generated Python and TypeScript package adapters.",
+    "intentionally deferred": "Full lifecycle mutation generation and broad shell implementation.",
+    "discovered implications": "",
+    "proof achieved now": "",
+    "validation still needed": "All milestone proof lanes.",
+    "next likely slice": "#394/#395 audit and generator strategy."
+  },
+  "intent_interpretation": {
+    "literal request": "Create a branch, ingest issues, plan and implement the work end-to-end, commit after each milestone, create a PR, and dogfood the package with new issues for actionable improvement lanes.",
+    "inferred intended outcome": "A PR that makes the generated CLI package roadmap executable rather than only planned.",
+    "chosen concrete what": "Start from the active issues, add planning residue, then implement compact contracts, generation proof targets, Docker proof routing, and migration guardrails.",
+    "interpretation distance": "medium because the full roadmap is large; implementation will stay bounded to thin proof slices and contract scaffolding rather than rewriting every CLI.",
+    "review guidance": "Review whether each change makes direct CLI authoring less necessary without adding a new visible product maze."
+  },
+  "execution_bounds": {
+    "allowed paths": "planning state/evidence/execplan, docs/reviews or docs, src/agentic_workspace/contracts, scripts/check or scripts/generate, tests, generated proof fixture directories if needed, and directly required maintainer surfaces.",
+    "max changed files": "broad but milestone-bounded",
+    "required validation commands": "Use agentic-workspace proof --changed for each milestone; run selected tests and checks.",
+    "ask-before-refactor threshold": "Any rewrite of root src/agentic_workspace/cli.py or package CLI runtime behavior beyond thin generated-adapter routing.",
+    "stop before touching": "Runtime primitive semantics for lifecycle mutation commands; external tracker-specific core behavior."
+  },
+  "stop_conditions": {
+    "stop when": "All child issues are implemented or remaining work is honestly split into new issues with acceptance evidence.",
+    "escalate when boundary reached": "A required generator choice would add a permanent non-Python ordinary development dependency.",
+    "escalate on scope drift": "The work starts turning operation contracts into a runtime workflow engine.",
+    "escalate on proof failure": "If selected package proof cannot pass after a bounded fix."
+  },
+  "context_budget": {
+    "live working set": "#393-#401, current contracts, current generator/check scripts, this execplan.",
+    "recoverable later": "Historical #356-#363 reviews and archive plans.",
+    "externalize before shift": "Update this plan after every milestone and commit.",
+    "pre-work config pull": "uv run agentic-workspace start --target . --format json",
+    "pre-work memory pull": "No broad memory pull; use compact summary and issue bodies.",
+    "tiny resumability note": "Work from #393 child order: audit/strategy, IR, Python/TS proof, Docker proof, shell/direct-edit guardrails.",
+    "context-shift triggers": "Before branch push/PR or after any failed proof."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Make implementation-independent multi-language CLI generation real enough to review.",
+    "hard constraints": "Off-the-shelf-first; minimal custom codegen; Docker-isolated generated package tests; ordinary repo remains Python-centered; package stays agnostic.",
+    "agent may decide locally": "Exact IR shape, first safe generated target, and proof lane details.",
+    "escalate when": "The work would require committing to a large custom generator or changing runtime primitive ownership."
+  },
+  "references": [
+    {
+      "kind": "issue",
+      "target": "#393",
+      "label": "multi-language CLI generation parent",
+      "role": "parent",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/393"
+    },
+    {
+      "kind": "issue",
+      "target": "#394-#401",
+      "label": "child issues",
+      "role": "children",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/393"
+    }
+  ],
+  "active_milestone": {
+    "id": "audit-and-strategy",
+    "status": "active",
+    "scope": "#394/#395",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Add compact audit and off-the-shelf strategy artifacts for #394/#395, then validate and commit milestone 1."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    ".agentic-workspace/planning/state.toml",
+    ".agentic-workspace/planning/external-intent-evidence.json",
+    ".agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json"
+  ],
+  "invariants": [
+    "Preserve runtime primitive ownership.",
+    "Do not create ordinary non-Python development requirements.",
+    "Keep host-specific workflow out of core package definitions."
+  ],
+  "contract_decisions_to_freeze": [
+    "Generated adapters own command/interface wiring; runtime primitives own behavior."
+  ],
+  "open_questions_to_close": [
+    "Which off-the-shelf tools should be preferred for schema/model generation?",
+    "Is a new command-package IR necessary or can it be derived from existing contracts?",
+    "What is the smallest Python/TypeScript generated package proof?"
+  ],
+  "validation_commands": [
+    "uv run agentic-workspace proof --target . --changed <paths> --format json",
+    "uv run python scripts/check/check_planning_surfaces.py",
+    "uv run agentic-workspace summary --format json"
+  ],
+  "required_tools": [
+    "GitHub CLI for issue/PR lifecycle.",
+    "Docker only for the generated-package proof lane."
+  ],
+  "completion_criteria": [
+    "#394-#401 are either closed with implementation evidence or split into new follow-up issues.",
+    "The branch contains a PR-ready implementation of the roadmap's first generated package path.",
+    "Package-selected proof passes.",
+    "A PR is created."
+  ],
+  "execution_run": {
+    "run status": "active",
+    "executor": "Codex",
+    "handoff source": "#393-#401",
+    "what happened": "Created branch, ingested issue bodies, and initialized checked-in planning.",
+    "scope touched": "planning state/evidence/execplan",
+    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/external-intent-evidence.json; .agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json",
+    "validations run": "startup, summary, ownership",
+    "result for continuation": "Begin milestone 1.",
+    "next step": "Implement audit and strategy artifacts."
+  },
+  "finished_run_review": {
+    "review status": "not-finished",
+    "scope respected": "pending",
+    "proof status": "pending",
+    "intent served": "pending",
+    "config compliance": "package dogfooding started with start, summary, ownership, and checked-in planning",
+    "misinterpretation risk": "medium; keep each milestone bounded and evidence-backed",
+    "follow-on decision": "pending"
+  },
+  "proof_report": {
+    "validation proof": "",
+    "proof achieved now": "",
+    "evidence for \"proof achieved\" state": ""
+  },
+  "intent_satisfaction": {
+    "original intent": "Create branch, ingest issues, plan, implement end-to-end, commit after each milestone, create PR, and create new issues for actionable dogfooding improvements.",
+    "was original intent fully satisfied?": "not yet",
+    "evidence of intent satisfaction": "",
+    "unsolved intent passed to": "#393 active plan"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Do not let this repo's current language, tooling, structure, or agent preferences become hidden universal product assumptions.",
+    "slice shaping bias": "Implementation-independent definitions first; generated targets as proof, not product sprawl.",
+    "broader-lane validation question": "Does this make generated CLI work easier to enter, verify, and trust without turning code generation into a new visible framework?",
+    "intent evidence source": ".agentic-workspace/system-intent/intent.toml"
+  },
+  "closure_check": {
+    "slice status": "active",
+    "larger-intent status": "active",
+    "closure decision": "pending",
+    "why this decision is honest": "Work has just started.",
+    "evidence carried forward": "#393-#401, this execplan",
+    "reopen trigger": "N/A while active."
+  },
+  "execution_summary": {
+    "outcome delivered": "",
+    "validation confirmed": "",
+    "follow-on routed to": "",
+    "post-work posterity capture": "",
+    "knowledge promoted (Memory/Docs/Config)": "",
+    "resume from": "Continue with active_milestone audit-and-strategy."
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-04-27: Created active plan from #393-#401 after branch creation."
+  ]
+}

--- a/.agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json
+++ b/.agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json
@@ -21,7 +21,7 @@
     "execution": {
       "milestone": "multilang-cli-generation-2026-04-27",
       "status": "active",
-      "next_step": "Define the canonical command-package IR for #396.",
+      "next_step": "Generate Python and TypeScript proof package slices for #397/#398.",
       "proof": "Use agentic-workspace proof --changed, focused contract tests, generated-package checks, maintainer surfaces, planning checks, and root CLI tests as selected."
     },
     "scope": {
@@ -57,9 +57,9 @@
     "what this slice enabled": "A durable migration path from hand-authored CLI surfaces to generated Python and TypeScript package adapters.",
     "intentionally deferred": "Full lifecycle mutation generation and broad shell implementation.",
     "discovered implications": "The existing generated-adapter contract is adapter-centric; multi-language packages need one compact command-package view that joins command shape, operation refs, primitive bindings, target outputs, and conformance refs.",
-    "proof achieved now": "#394/#395 audit and strategy artifacts identify blockers, first safe slices, and off-the-shelf-first tooling posture.",
-    "validation still needed": "Command-package IR validation and generated target proofs.",
-    "next likely slice": "#396 canonical command-package IR."
+    "proof achieved now": "#394/#395 audit/strategy artifacts are present; #396 command-package IR validates and is checked against adapter, operation, primitive, and conformance refs.",
+    "validation still needed": "Generated Python/TypeScript package target proofs and Docker routing.",
+    "next likely slice": "#397/#398 generated package proof."
   },
   "intent_interpretation": {
     "literal request": "Create a branch, ingest issues, plan and implement the work end-to-end, commit after each milestone, create a PR, and dogfood the package with new issues for actionable improvement lanes.",
@@ -113,15 +113,15 @@
     }
   ],
   "active_milestone": {
-    "id": "command-package-ir",
+    "id": "generated-python-typescript-proof",
     "status": "active",
-    "scope": "#396",
+    "scope": "#397/#398",
     "ready": "ready",
     "blocked": "none",
     "optional_deps": "none"
   },
   "immediate_next_action": [
-    "Define and validate a compact command-package IR for #396."
+    "Generate Python and TypeScript proof package slices from the command-package IR."
   ],
   "blockers": [
     "None."
@@ -132,6 +132,12 @@
     ".agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json",
     "docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md",
     "docs/reviews/generated-cli-package-strategy-2026-04-27.md"
+    ,
+    "src/agentic_workspace/contracts/command_package_ir.json",
+    "src/agentic_workspace/contracts/schemas/command_package_ir.schema.json",
+    "src/agentic_workspace/contract_tooling.py",
+    "scripts/check/check_contract_tooling_surfaces.py",
+    "tests/test_contract_tooling.py"
   ],
   "invariants": [
     "Preserve runtime primitive ownership.",
@@ -165,12 +171,12 @@
     "run status": "active",
     "executor": "Codex",
     "handoff source": "#393-#401",
-    "what happened": "Created branch, ingested issue bodies, initialized checked-in planning, and added the #394/#395 audit/strategy artifacts.",
-    "scope touched": "planning state/evidence/execplan and review artifacts",
-    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/external-intent-evidence.json; .agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json; docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md; docs/reviews/generated-cli-package-strategy-2026-04-27.md",
-    "validations run": "startup, summary, ownership, planning surface check, planning doctor",
-    "result for continuation": "#394/#395 evidence is present; continue to #396.",
-    "next step": "Define command-package IR."
+    "what happened": "Created branch, ingested issue bodies, added the #394/#395 audit/strategy artifacts, and added the #396 command-package IR with schema, loader, checker parity, and tests.",
+    "scope touched": "planning state/evidence/execplan, review artifacts, contracts, checker, and focused tests",
+    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/external-intent-evidence.json; .agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json; docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md; docs/reviews/generated-cli-package-strategy-2026-04-27.md; src/agentic_workspace/contracts/command_package_ir.json; src/agentic_workspace/contracts/schemas/command_package_ir.schema.json; src/agentic_workspace/contracts/contract_inventory.json; src/agentic_workspace/contracts/python_contract_consumption.json; src/agentic_workspace/contract_tooling.py; scripts/check/check_contract_tooling_surfaces.py; tests/test_contract_tooling.py",
+    "validations run": "contract tooling check, focused contract tests, focused ruff",
+    "result for continuation": "#396 IR is present and checked; continue to #397/#398.",
+    "next step": "Generate Python and TypeScript proof package slices."
   },
   "finished_run_review": {
     "review status": "not-finished",
@@ -212,7 +218,7 @@
     "follow-on routed to": "",
     "post-work posterity capture": "",
     "knowledge promoted (Memory/Docs/Config)": "",
-    "resume from": "Continue with active_milestone command-package-ir."
+    "resume from": "Continue with active_milestone generated-python-typescript-proof."
   },
   "closeout_distillation": {
     "buckets": {

--- a/.agentic-workspace/planning/external-intent-evidence.json
+++ b/.agentic-workspace/planning/external-intent-evidence.json
@@ -1053,6 +1053,87 @@
       "kind": "issue",
       "parent_id": "",
       "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#393",
+      "title": "[Workspace]: Generate multi-language CLI packages from implementation-independent definitions",
+      "status": "open",
+      "kind": "issue",
+      "parent_id": "",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#394",
+      "title": "[Workspace]: Audit CLI generation gaps for multi-language packages",
+      "status": "open",
+      "kind": "issue",
+      "parent_id": "#393",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#395",
+      "title": "[Workspace]: Choose an off-the-shelf-first CLI generation strategy",
+      "status": "open",
+      "kind": "issue",
+      "parent_id": "#393",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#396",
+      "title": "[Workspace]: Define the canonical command-package IR for generated CLIs",
+      "status": "open",
+      "kind": "issue",
+      "parent_id": "#393",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#397",
+      "title": "[Workspace]: Generate the Python CLI package from canonical definitions",
+      "status": "open",
+      "kind": "issue",
+      "parent_id": "#393",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#398",
+      "title": "[Workspace]: Generate the TypeScript CLI package from the same definitions",
+      "status": "open",
+      "kind": "issue",
+      "parent_id": "#393",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#399",
+      "title": "[Workspace]: Add Docker-isolated conformance tests for generated CLI packages",
+      "status": "open",
+      "kind": "issue",
+      "parent_id": "#393",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#400",
+      "title": "[Workspace]: Define shell adapter feasibility for bash and PowerShell",
+      "status": "open",
+      "kind": "issue",
+      "parent_id": "#393",
+      "planning_residue_expected": "required"
+    },
+    {
+      "system": "github",
+      "id": "#401",
+      "title": "[Workspace]: Migrate implementation work away from direct CLI edits",
+      "status": "open",
+      "kind": "issue",
+      "parent_id": "#393",
+      "planning_residue_expected": "required"
     }
   ]
 }

--- a/.agentic-workspace/planning/external-intent-evidence.json
+++ b/.agentic-workspace/planning/external-intent-evidence.json
@@ -1058,7 +1058,7 @@
       "system": "github",
       "id": "#393",
       "title": "[Workspace]: Generate multi-language CLI packages from implementation-independent definitions",
-      "status": "open",
+      "status": "closed",
       "kind": "issue",
       "parent_id": "",
       "planning_residue_expected": "required"
@@ -1067,7 +1067,7 @@
       "system": "github",
       "id": "#394",
       "title": "[Workspace]: Audit CLI generation gaps for multi-language packages",
-      "status": "open",
+      "status": "closed",
       "kind": "issue",
       "parent_id": "#393",
       "planning_residue_expected": "required"
@@ -1076,7 +1076,7 @@
       "system": "github",
       "id": "#395",
       "title": "[Workspace]: Choose an off-the-shelf-first CLI generation strategy",
-      "status": "open",
+      "status": "closed",
       "kind": "issue",
       "parent_id": "#393",
       "planning_residue_expected": "required"
@@ -1085,7 +1085,7 @@
       "system": "github",
       "id": "#396",
       "title": "[Workspace]: Define the canonical command-package IR for generated CLIs",
-      "status": "open",
+      "status": "closed",
       "kind": "issue",
       "parent_id": "#393",
       "planning_residue_expected": "required"
@@ -1094,7 +1094,7 @@
       "system": "github",
       "id": "#397",
       "title": "[Workspace]: Generate the Python CLI package from canonical definitions",
-      "status": "open",
+      "status": "closed",
       "kind": "issue",
       "parent_id": "#393",
       "planning_residue_expected": "required"
@@ -1103,7 +1103,7 @@
       "system": "github",
       "id": "#398",
       "title": "[Workspace]: Generate the TypeScript CLI package from the same definitions",
-      "status": "open",
+      "status": "closed",
       "kind": "issue",
       "parent_id": "#393",
       "planning_residue_expected": "required"
@@ -1112,7 +1112,7 @@
       "system": "github",
       "id": "#399",
       "title": "[Workspace]: Add Docker-isolated conformance tests for generated CLI packages",
-      "status": "open",
+      "status": "closed",
       "kind": "issue",
       "parent_id": "#393",
       "planning_residue_expected": "required"
@@ -1121,7 +1121,7 @@
       "system": "github",
       "id": "#400",
       "title": "[Workspace]: Define shell adapter feasibility for bash and PowerShell",
-      "status": "open",
+      "status": "closed",
       "kind": "issue",
       "parent_id": "#393",
       "planning_residue_expected": "required"
@@ -1130,7 +1130,7 @@
       "system": "github",
       "id": "#401",
       "title": "[Workspace]: Migrate implementation work away from direct CLI edits",
-      "status": "open",
+      "status": "closed",
       "kind": "issue",
       "parent_id": "#393",
       "planning_residue_expected": "required"

--- a/.agentic-workspace/planning/state.toml
+++ b/.agentic-workspace/planning/state.toml
@@ -1,21 +1,7 @@
 [todo]
-active_items = [
-  { id = "multilang-cli-generation", title = "Generate multi-language CLI packages from implementation-independent definitions", source = "#393", plan = ".agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json" },
-]
+active_items = []
 queued_items = []
 
 [roadmap]
-lanes = [
-  { id = "cli-generation-audit-strategy", title = "Audit and off-the-shelf strategy for generated CLI packages", priority = "first", issues = ["#394", "#395"] },
-  { id = "command-package-ir", title = "Canonical command-package IR for generated CLIs", priority = "second", issues = ["#396"] },
-  { id = "python-typescript-generated-packages", title = "Generated Python and TypeScript CLI package proof", priority = "third", issues = ["#397", "#398"] },
-  { id = "docker-generated-package-proof", title = "Docker-isolated generated package conformance", priority = "fourth", issues = ["#399"] },
-  { id = "shell-and-direct-cli-guardrails", title = "Shell adapter feasibility and direct CLI edit guardrails", priority = "fifth", issues = ["#400", "#401"] },
-]
-candidates = [
-  { priority = "first", summary = "Audit and off-the-shelf strategy for generated CLI packages" },
-  { priority = "second", summary = "Canonical command-package IR for generated CLIs" },
-  { priority = "third", summary = "Generated Python and TypeScript CLI package proof" },
-  { priority = "fourth", summary = "Docker-isolated generated package conformance" },
-  { priority = "fifth", summary = "Shell adapter feasibility and direct CLI edit guardrails" },
-]
+lanes = []
+candidates = []

--- a/.agentic-workspace/planning/state.toml
+++ b/.agentic-workspace/planning/state.toml
@@ -1,7 +1,21 @@
 [todo]
-active_items = []
+active_items = [
+  { id = "multilang-cli-generation", title = "Generate multi-language CLI packages from implementation-independent definitions", source = "#393", plan = ".agentic-workspace/planning/execplans/multilang-cli-generation-2026-04-27.plan.json" },
+]
 queued_items = []
 
 [roadmap]
-lanes = []
-candidates = []
+lanes = [
+  { id = "cli-generation-audit-strategy", title = "Audit and off-the-shelf strategy for generated CLI packages", priority = "first", issues = ["#394", "#395"] },
+  { id = "command-package-ir", title = "Canonical command-package IR for generated CLIs", priority = "second", issues = ["#396"] },
+  { id = "python-typescript-generated-packages", title = "Generated Python and TypeScript CLI package proof", priority = "third", issues = ["#397", "#398"] },
+  { id = "docker-generated-package-proof", title = "Docker-isolated generated package conformance", priority = "fourth", issues = ["#399"] },
+  { id = "shell-and-direct-cli-guardrails", title = "Shell adapter feasibility and direct CLI edit guardrails", priority = "fifth", issues = ["#400", "#401"] },
+]
+candidates = [
+  { priority = "first", summary = "Audit and off-the-shelf strategy for generated CLI packages" },
+  { priority = "second", summary = "Canonical command-package IR for generated CLIs" },
+  { priority = "third", summary = "Generated Python and TypeScript CLI package proof" },
+  { priority = "fourth", summary = "Docker-isolated generated package conformance" },
+  { priority = "fifth", summary = "Shell adapter feasibility and direct CLI edit guardrails" },
+]

--- a/docs/contributor-playbook.md
+++ b/docs/contributor-playbook.md
@@ -58,6 +58,7 @@ The hook set also runs `uv run python scripts/check/check_no_absolute_paths.py`,
 - Keep the root `agentic-workspace` CLI thin; push module-specific lifecycle logic back into the module packages.
 - Treat `.agentic-workspace/` module trees as product-managed surfaces; change them through the owning package or managed source rather than as freehand repo docs.
 - Treat `tools/` agent docs as generated mirrors; change `.agentic-workspace/planning/agent-manifest.json` and rerender instead of editing them directly.
+- Treat CLI interface authoring as definition-owned during the generated-package migration. Change command shape, option semantics, generated package metadata, operation refs, primitive refs, schemas, and conformance refs in contracts or generators; use direct `cli.py` edits for runtime primitives, live inspection, dispatch migration glue, or explicitly justified uncovered fixes.
 - In checked-in human-facing docs, prefer clickable Markdown links for navigation, but keep the target paths repo-relative. Do not introduce absolute filesystem paths into links or prose unless the absolute external path is itself the documented subject.
 
 As a maintainer rule of thumb:
@@ -101,6 +102,7 @@ Use `agentic-workspace defaults --format json` first when you need the structure
 - Maintainer-surface, generated-doc, or installed-contract payload changes: `make maintainer-surfaces`
 - Planning-surface changes only: `make planning-surfaces`; rerun `make render-agent-docs` when the planning manifest or generated routing docs change
 - Declarative contract manifests or schemas for workspace proof/report/selectors: `uv run python scripts/check/check_contract_tooling_surfaces.py`
+- Generated command package outputs or command-package IR changes: `uv run python scripts/check/check_generated_command_packages.py`, then `uv run python scripts/check/check_generated_command_packages.py --docker` when Docker is available
 - Memory note/current-state changes: `uv run agentic-workspace doctor --target . --format json` and `uv run agentic-workspace report --target . --format json`
 - Absolute-path hygiene across tracked files: `make absolute-paths`
 

--- a/docs/reviews/generated-cli-package-strategy-2026-04-27.md
+++ b/docs/reviews/generated-cli-package-strategy-2026-04-27.md
@@ -1,0 +1,92 @@
+# Generated CLI Package Strategy
+
+Date: 2026-04-27
+
+Issues: #395, parent #393
+
+Purpose: choose an off-the-shelf-first strategy for generated Python and TypeScript CLI packages. This is evidence/history, not ordinary startup input.
+
+## Decision
+
+Use the repo's existing JSON contracts as the canonical source and add a compact derived command-package IR rather than adopting a new standalone DSL.
+
+Reason:
+
+- Existing command, option, operation, primitive, generated-adapter, and conformance contracts already encode most needed truth.
+- A new DSL would add another authoring surface and increase product residue.
+- JSON Schema works for validation across Python and TypeScript ecosystems.
+- A derived IR can be generated or checked from existing contracts and consumed by small target renderers.
+
+## Off-The-Shelf-First Tooling Posture
+
+Python:
+
+- Keep `argparse` as the runtime parser library.
+- Generate or mechanically assemble parser metadata and dispatch tables from the command-package IR.
+- Use `jsonschema` for contract validation.
+
+TypeScript:
+
+- Prefer Commander.js for CLI parsing if the TypeScript package moves past fixture/proof stage.
+- Prefer `json-schema-to-typescript` or `quicktype` for generated TypeScript types when type volume justifies it.
+- Keep initial proof small enough that committed custom TypeScript generation is metadata rendering, not a hand-built framework.
+
+Docker proof:
+
+- Put Node/TypeScript setup inside generated-package test containers.
+- Expose generated-package tests through Python-owned proof/check commands so ordinary repo development stays Python-centered.
+- Do not require Docker for root unit tests unless generated-package paths are touched.
+
+Shell adapters:
+
+- Defer bash and PowerShell generation until the IR has proven Python and TypeScript targets.
+- Treat shell outputs as thin wrappers, completion/help projections, or runtime package delegates.
+- Do not let shell behavior become authoritative.
+
+## Custom Codegen Boundary
+
+Allowed custom code:
+
+- small renderers that transform one validated command-package IR into target files
+- freshness checks
+- no-direct-edit sentinels
+- Docker command wrappers
+
+Avoid custom code:
+
+- handwritten option parsers per target
+- target-specific copies of command semantics
+- runtime primitive implementations inside generators
+- generator logic that infers behavior from Python source
+
+## Canonical Flow
+
+```text
+existing contracts
+  -> validated command-package IR
+  -> generated Python package adapter
+  -> generated TypeScript package adapter
+  -> Docker-isolated conformance
+```
+
+## Success Test
+
+The first implementation should prove that a command/interface change can be made in contracts and propagated to generated Python/TypeScript targets without editing shipped CLI implementation code for that interface surface.
+
+## Rejected Alternatives
+
+Adopt OpenAPI as the primary source:
+
+- Rejected for now because this is a process CLI surface, not an HTTP API, and the existing contracts already model command effects and runtime primitive ownership.
+
+Build a bespoke full generator:
+
+- Rejected because the user explicitly prefers off-the-shelf tools and minimal custom code.
+
+Generate shell adapters first:
+
+- Rejected because shell quoting and parameter binding would force target-specific complexity before the shared IR is proven.
+
+## Acceptance Evidence
+
+#395 is satisfied when this strategy is paired with the #394 audit and the later #396 IR keeps universal command truth separate from target rendering details.

--- a/docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md
+++ b/docs/reviews/multi-language-cli-generation-gap-audit-2026-04-27.md
@@ -1,0 +1,79 @@
+# Multi-Language CLI Generation Gap Audit
+
+Date: 2026-04-27
+
+Issues: #394, parent #393
+
+Purpose: identify what remains before Python and TypeScript CLI packages can be generated from implementation-independent definitions. This is evidence/history, not ordinary startup input.
+
+## Summary
+
+The current repo has enough contract machinery to start a multi-language generated-package proof, but not enough to generate complete CLI packages without an explicit command-package view.
+
+Already present:
+
+- Root `agentic-workspace` command shape lives in `src/agentic_workspace/contracts/cli_commands.json` plus `cli_option_groups.json`.
+- Root executable commands have operation contract entries under `src/agentic_workspace/contracts/operation_contracts.json` and `operations/`.
+- Command adapter generation metadata exists at `src/agentic_workspace/contracts/command_adapter_generation.json`.
+- Generated process adapters already exist for root `defaults`, planning `status`, and memory `status`.
+- Conformance contracts exist for generated process adapters.
+
+Still missing:
+
+- One compact command-package definition that joins command shape, operation ref, primitive binding, conformance refs, package target metadata, and adapter projection constraints.
+- Package-local command manifests for planning and memory equivalent to root `cli_commands.json`.
+- A generated package target model that distinguishes universal command truth from language/package-specific files.
+- Docker-isolated proof for generated non-Python targets.
+- Contribution guardrails that classify direct CLI edits as runtime-primitive work or migration exceptions.
+
+## Current Surface Classification
+
+| Surface | Current authority | Multi-language readiness |
+| --- | --- | --- |
+| Root command names/options | `cli_commands.json` and option groups | Good for Python/TypeScript parser generation after joining with operation refs. |
+| Root operations | `operation_contracts.json` and `operations/*.json` | Good enough for read-only surfaces; lifecycle mutation still deferred. |
+| Root generated adapter metadata | `command_adapter_generation.json` | Useful seed, but it is adapter-centric rather than package-centric. |
+| Planning CLI parser | `packages/planning/src/repo_planning_bootstrap/cli.py` | Partially generated dispatch for `status`; most command shape remains Python-owned. |
+| Memory CLI parser | `packages/memory/src/repo_memory_bootstrap/cli.py` | Partially generated dispatch for `status`; most command shape remains Python-owned. |
+| Conformance | `conformance_contracts.json` plus per-operation files | Good for process adapters; needs generated-package target grouping. |
+| Generated adapter files | generated Python modules | Good no-direct-edit precedent; not yet a package output. |
+
+## Blockers To Python Package Generation
+
+1. Root command generation needs one input that already knows which commands are generation eligible.
+2. Generated Python package output needs target metadata: package name, entrypoints, generated files, and primitive binding module.
+3. Direct edits to `src/agentic_workspace/cli.py` remain normal for non-generated command wiring.
+
+Smallest safe proof: keep runtime primitives in the existing Python package, but generate a package adapter module for read-only command metadata and dispatch for `defaults`, planning `status`, and memory `status`.
+
+## Blockers To TypeScript Package Generation
+
+1. The universal command definition must avoid Python-specific argparse/module references.
+2. TypeScript package output needs isolated generated files and a runtime-binding strategy. For first proof, use read-only commands with deterministic fixture/stub bindings instead of reimplementing live Python workspace inspection.
+3. Tests must run in a container so ordinary repo development does not require Node.
+
+Smallest safe proof: generate a TypeScript package fixture for the same eligible commands with conformance over command shape/help/metadata and any deterministic read-only fixture output that does not require Python runtime primitives.
+
+## Blockers To Shell Adapters
+
+Bash and PowerShell should wait until Python and TypeScript prove the IR. Shell adapters are plausible for thin wrappers, help/completion, and delegation to runtime packages. They should not embed runtime primitive behavior.
+
+## Recommended First Implementation Slice
+
+1. Define a command-package IR derived from existing contracts.
+2. Validate that IR against a schema.
+3. Generate small Python and TypeScript package fixtures from the IR.
+4. Add Docker-isolated tests for the TypeScript fixture and Python generated package proof.
+5. Add proof routing and direct-edit guidance.
+
+## Off-The-Shelf Candidates To Evaluate
+
+- JSON Schema validation: continue using `jsonschema` in Python.
+- TypeScript types: use `json-schema-to-typescript` or `quicktype` if a real TypeScript package target grows beyond a tiny fixture.
+- TypeScript CLI parser: prefer Commander.js or Yargs over custom option parsing.
+- Python CLI parser: keep argparse for runtime compatibility, but derive parser metadata from the command-package IR.
+- Containerized proof: use Docker Compose or plain Dockerfiles invoked by a Python check wrapper.
+
+## Acceptance Evidence
+
+#394 is satisfied when this audit is reviewed with #395's strategy record: the exact blockers, first safe slice, and off-the-shelf candidates are named without starting broad generation work.

--- a/docs/reviews/shell-adapter-feasibility-2026-04-27.md
+++ b/docs/reviews/shell-adapter-feasibility-2026-04-27.md
@@ -1,0 +1,31 @@
+# Shell Adapter Feasibility
+
+Purpose: record the #400 shell-adapter decision for bash and PowerShell as downstream projections of the command-package definition. This is evidence/history, not ordinary startup input.
+
+## Decision
+
+Bash and PowerShell adapters are worth generating only as thin projection surfaces after the shared command-package definition is stable for Python and TypeScript.
+
+Safe generated shell surfaces:
+
+- command and option help derived from the shared definition
+- argument validation that does not inspect repository state
+- completion metadata where the target shell supports it cleanly
+- wrapper invocation that delegates runtime behavior to the owning package
+- effect and preflight hints rendered from the same operation metadata
+
+Out of scope for generated shell adapters:
+
+- runtime primitive behavior
+- live workspace inspection
+- rich JSON/report rendering beyond passing through runtime output
+- host-repository, agent, or issue-tracker assumptions
+- ordinary development requirements for shell-specific toolchains
+
+## Proof Strategy
+
+Shell adapter tests should follow the TypeScript pattern: generated fixtures plus container-selected proof. Docker is acceptable for generated shell proof, but ordinary Python development must not require bash, PowerShell, Node, or shell-specific package managers.
+
+## Downstream Rule
+
+Future shell work must start from `src/agentic_workspace/contracts/command_package_ir.json`. If a shell target needs data that is not in that IR, add the universal field only when Python and TypeScript can also consume it without learning shell-specific semantics.

--- a/generated/typescript/Dockerfile
+++ b/generated/typescript/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:22-alpine
+
+WORKDIR /work
+COPY generated/typescript ./generated/typescript
+
+CMD ["sh", "-c", "for package in generated/typescript/*-cli; do (cd \"$package\" && npm test); done"]

--- a/generated/typescript/memory-cli/package.json
+++ b/generated/typescript/memory-cli/package.json
@@ -1,11 +1,13 @@
 {
   "agenticWorkspace": {
+    "declaredEntrypoints": [
+      "agentic-memory-bootstrap"
+    ],
+    "fixtureOnly": true,
     "generated": true,
+    "generationStatus": "proof-fixture",
     "program": "agentic-memory-bootstrap",
     "source": "src/agentic_workspace/contracts/command_package_ir.json"
-  },
-  "bin": {
-    "agentic-memory-bootstrap": "./src/commandPackage.ts"
   },
   "name": "@agentic-workspace/memory-cli",
   "private": true,

--- a/generated/typescript/memory-cli/package.json
+++ b/generated/typescript/memory-cli/package.json
@@ -1,0 +1,17 @@
+{
+  "agenticWorkspace": {
+    "generated": true,
+    "program": "agentic-memory-bootstrap",
+    "source": "src/agentic_workspace/contracts/command_package_ir.json"
+  },
+  "bin": {
+    "agentic-memory-bootstrap": "./src/commandPackage.ts"
+  },
+  "name": "@agentic-workspace/memory-cli",
+  "private": true,
+  "scripts": {
+    "test": "node --test test/command-package.test.mjs"
+  },
+  "type": "module",
+  "version": "0.0.0-generated"
+}

--- a/generated/typescript/memory-cli/src/commandPackage.ts
+++ b/generated/typescript/memory-cli/src/commandPackage.ts
@@ -1,0 +1,90 @@
+// Generated command package metadata.
+// Source: src/agentic_workspace/contracts/command_package_ir.json
+// Program: agentic-memory-bootstrap
+// Regenerate with: uv run python scripts/generate/generate_command_packages.py
+// DO NOT EDIT DIRECTLY.
+
+export const generatedCommandPackage = {
+  "commands": [
+    {
+      "adapter_id": "memory.status.cli",
+      "command": {
+        "manifest_ref": "package:memory:cli",
+        "name": "status"
+      },
+      "conformance_refs": [
+        "memory.status.process"
+      ],
+      "effect_hints": {
+        "destructive": false,
+        "idempotent": true,
+        "read_only": true,
+        "requires_preflight_gate": false,
+        "writes_repo_state": false
+      },
+      "operation_ref": {
+        "id": "memory.status.report",
+        "path": "operations/memory.status.report.json"
+      },
+      "projection_boundary": {
+        "runtime_owned": [
+          "memory bootstrap inspection",
+          "module result assembly",
+          "output emission"
+        ],
+        "target_specific": [
+          "parser library",
+          "package entrypoint wiring",
+          "help text layout",
+          "test container image"
+        ],
+        "universal": [
+          "command identity",
+          "operation reference",
+          "runtime primitive reference",
+          "effect hints",
+          "conformance refs"
+        ]
+      },
+      "runtime_binding": {
+        "kind": "operation-primitive-sequence",
+        "primitive_refs": [
+          "memory.bootstrap.status.load",
+          "output.emit"
+        ]
+      },
+      "schemas": {
+        "input": [],
+        "output": []
+      },
+      "status": "generated"
+    }
+  ],
+  "id": "memory-bootstrap",
+  "package_role": "memory-module-cli",
+  "program": "agentic-memory-bootstrap",
+  "targets": [
+    {
+      "entrypoints": [
+        "agentic-memory-bootstrap"
+      ],
+      "generated_root": "packages/memory/src/repo_memory_bootstrap/generated_cli_package",
+      "generation_status": "supported-now",
+      "kind": "python",
+      "package_name": "agentic-memory-bootstrap",
+      "test_environment": "python-dev"
+    },
+    {
+      "entrypoints": [
+        "agentic-memory-bootstrap"
+      ],
+      "generated_root": "generated/typescript/memory-cli",
+      "generation_status": "proof-fixture",
+      "kind": "typescript",
+      "package_name": "@agentic-workspace/memory-cli",
+      "test_environment": "docker"
+    }
+  ]
+} as const;
+
+export type GeneratedCommandPackage = typeof generatedCommandPackage;

--- a/generated/typescript/memory-cli/test/command-package.test.mjs
+++ b/generated/typescript/memory-cli/test/command-package.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../src/commandPackage.ts', import.meta.url), 'utf8');
+
+test('generated package metadata exposes expected commands', () => {
+  const expected = ["status"];
+  for (const command of expected) {
+    assert.match(source, new RegExp(`\"name\": \\"${command}\\"`));
+  }
+});

--- a/generated/typescript/planning-cli/package.json
+++ b/generated/typescript/planning-cli/package.json
@@ -1,11 +1,13 @@
 {
   "agenticWorkspace": {
+    "declaredEntrypoints": [
+      "agentic-planning-bootstrap"
+    ],
+    "fixtureOnly": true,
     "generated": true,
+    "generationStatus": "proof-fixture",
     "program": "agentic-planning-bootstrap",
     "source": "src/agentic_workspace/contracts/command_package_ir.json"
-  },
-  "bin": {
-    "agentic-planning-bootstrap": "./src/commandPackage.ts"
   },
   "name": "@agentic-workspace/planning-cli",
   "private": true,

--- a/generated/typescript/planning-cli/package.json
+++ b/generated/typescript/planning-cli/package.json
@@ -1,0 +1,17 @@
+{
+  "agenticWorkspace": {
+    "generated": true,
+    "program": "agentic-planning-bootstrap",
+    "source": "src/agentic_workspace/contracts/command_package_ir.json"
+  },
+  "bin": {
+    "agentic-planning-bootstrap": "./src/commandPackage.ts"
+  },
+  "name": "@agentic-workspace/planning-cli",
+  "private": true,
+  "scripts": {
+    "test": "node --test test/command-package.test.mjs"
+  },
+  "type": "module",
+  "version": "0.0.0-generated"
+}

--- a/generated/typescript/planning-cli/src/commandPackage.ts
+++ b/generated/typescript/planning-cli/src/commandPackage.ts
@@ -1,0 +1,90 @@
+// Generated command package metadata.
+// Source: src/agentic_workspace/contracts/command_package_ir.json
+// Program: agentic-planning-bootstrap
+// Regenerate with: uv run python scripts/generate/generate_command_packages.py
+// DO NOT EDIT DIRECTLY.
+
+export const generatedCommandPackage = {
+  "commands": [
+    {
+      "adapter_id": "planning.status.cli",
+      "command": {
+        "manifest_ref": "package:planning:cli",
+        "name": "status"
+      },
+      "conformance_refs": [
+        "planning.status.process"
+      ],
+      "effect_hints": {
+        "destructive": false,
+        "idempotent": true,
+        "read_only": true,
+        "requires_preflight_gate": false,
+        "writes_repo_state": false
+      },
+      "operation_ref": {
+        "id": "planning.status.report",
+        "path": "operations/planning.status.report.json"
+      },
+      "projection_boundary": {
+        "runtime_owned": [
+          "planning bootstrap inspection",
+          "module result assembly",
+          "output emission"
+        ],
+        "target_specific": [
+          "parser library",
+          "package entrypoint wiring",
+          "help text layout",
+          "test container image"
+        ],
+        "universal": [
+          "command identity",
+          "operation reference",
+          "runtime primitive reference",
+          "effect hints",
+          "conformance refs"
+        ]
+      },
+      "runtime_binding": {
+        "kind": "operation-primitive-sequence",
+        "primitive_refs": [
+          "planning.bootstrap.status.load",
+          "output.emit"
+        ]
+      },
+      "schemas": {
+        "input": [],
+        "output": []
+      },
+      "status": "generated"
+    }
+  ],
+  "id": "planning-bootstrap",
+  "package_role": "planning-module-cli",
+  "program": "agentic-planning-bootstrap",
+  "targets": [
+    {
+      "entrypoints": [
+        "agentic-planning-bootstrap"
+      ],
+      "generated_root": "packages/planning/src/repo_planning_bootstrap/generated_cli_package",
+      "generation_status": "supported-now",
+      "kind": "python",
+      "package_name": "agentic-planning-bootstrap",
+      "test_environment": "python-dev"
+    },
+    {
+      "entrypoints": [
+        "agentic-planning-bootstrap"
+      ],
+      "generated_root": "generated/typescript/planning-cli",
+      "generation_status": "proof-fixture",
+      "kind": "typescript",
+      "package_name": "@agentic-workspace/planning-cli",
+      "test_environment": "docker"
+    }
+  ]
+} as const;
+
+export type GeneratedCommandPackage = typeof generatedCommandPackage;

--- a/generated/typescript/planning-cli/test/command-package.test.mjs
+++ b/generated/typescript/planning-cli/test/command-package.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../src/commandPackage.ts', import.meta.url), 'utf8');
+
+test('generated package metadata exposes expected commands', () => {
+  const expected = ["status"];
+  for (const command of expected) {
+    assert.match(source, new RegExp(`\"name\": \\"${command}\\"`));
+  }
+});

--- a/generated/typescript/workspace-cli/package.json
+++ b/generated/typescript/workspace-cli/package.json
@@ -1,0 +1,17 @@
+{
+  "agenticWorkspace": {
+    "generated": true,
+    "program": "agentic-workspace",
+    "source": "src/agentic_workspace/contracts/command_package_ir.json"
+  },
+  "bin": {
+    "agentic-workspace": "./src/commandPackage.ts"
+  },
+  "name": "@agentic-workspace/workspace-cli",
+  "private": true,
+  "scripts": {
+    "test": "node --test test/command-package.test.mjs"
+  },
+  "type": "module",
+  "version": "0.0.0-generated"
+}

--- a/generated/typescript/workspace-cli/package.json
+++ b/generated/typescript/workspace-cli/package.json
@@ -1,11 +1,13 @@
 {
   "agenticWorkspace": {
+    "declaredEntrypoints": [
+      "agentic-workspace"
+    ],
+    "fixtureOnly": true,
     "generated": true,
+    "generationStatus": "proof-fixture",
     "program": "agentic-workspace",
     "source": "src/agentic_workspace/contracts/command_package_ir.json"
-  },
-  "bin": {
-    "agentic-workspace": "./src/commandPackage.ts"
   },
   "name": "@agentic-workspace/workspace-cli",
   "private": true,

--- a/generated/typescript/workspace-cli/src/commandPackage.ts
+++ b/generated/typescript/workspace-cli/src/commandPackage.ts
@@ -1,0 +1,115 @@
+// Generated command package metadata.
+// Source: src/agentic_workspace/contracts/command_package_ir.json
+// Program: agentic-workspace
+// Regenerate with: uv run python scripts/generate/generate_command_packages.py
+// DO NOT EDIT DIRECTLY.
+
+export const generatedCommandPackage = {
+  "commands": [
+    {
+      "adapter_id": "defaults.report.cli",
+      "command": {
+        "manifest_ref": "cli_commands.json",
+        "name": "defaults"
+      },
+      "conformance_refs": [
+        "defaults.report.process"
+      ],
+      "effect_hints": {
+        "destructive": false,
+        "idempotent": true,
+        "read_only": true,
+        "requires_preflight_gate": false,
+        "writes_repo_state": false
+      },
+      "operation_ref": {
+        "id": "defaults.report",
+        "path": "operations/defaults.report.json"
+      },
+      "projection_boundary": {
+        "runtime_owned": [
+          "defaults payload assembly",
+          "section selection",
+          "output emission"
+        ],
+        "target_specific": [
+          "parser library",
+          "package entrypoint wiring",
+          "help text layout",
+          "test container image"
+        ],
+        "universal": [
+          "command identity",
+          "option semantics",
+          "operation reference",
+          "runtime primitive reference",
+          "effect hints",
+          "schema refs",
+          "conformance refs"
+        ]
+      },
+      "runtime_binding": {
+        "kind": "operation-primitive-sequence",
+        "primitive_refs": [
+          "workspace.defaults.load",
+          "workspace.defaults.select",
+          "output.emit"
+        ]
+      },
+      "schemas": {
+        "input": [],
+        "output": [
+          "compact_contract_answer.schema.json"
+        ]
+      },
+      "status": "generated"
+    }
+  ],
+  "id": "root-workspace",
+  "package_role": "root-workspace-cli",
+  "program": "agentic-workspace",
+  "targets": [
+    {
+      "entrypoints": [
+        "agentic-workspace"
+      ],
+      "generated_root": "src/agentic_workspace/generated_cli_package",
+      "generation_status": "supported-now",
+      "kind": "python",
+      "package_name": "agentic-workspace",
+      "test_environment": "python-dev"
+    },
+    {
+      "entrypoints": [
+        "agentic-workspace"
+      ],
+      "generated_root": "generated/typescript/workspace-cli",
+      "generation_status": "proof-fixture",
+      "kind": "typescript",
+      "package_name": "@agentic-workspace/workspace-cli",
+      "test_environment": "docker"
+    },
+    {
+      "entrypoints": [
+        "agentic-workspace"
+      ],
+      "generated_root": "generated/shell/bash",
+      "generation_status": "deferred",
+      "kind": "bash",
+      "package_name": "agentic-workspace-shell",
+      "test_environment": "docker"
+    },
+    {
+      "entrypoints": [
+        "agentic-workspace"
+      ],
+      "generated_root": "generated/shell/powershell",
+      "generation_status": "deferred",
+      "kind": "powershell",
+      "package_name": "AgenticWorkspace.PowerShell",
+      "test_environment": "docker"
+    }
+  ]
+} as const;
+
+export type GeneratedCommandPackage = typeof generatedCommandPackage;

--- a/generated/typescript/workspace-cli/test/command-package.test.mjs
+++ b/generated/typescript/workspace-cli/test/command-package.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../src/commandPackage.ts', import.meta.url), 'utf8');
+
+test('generated package metadata exposes expected commands', () => {
+  const expected = ["defaults"];
+  for (const command of expected) {
+    assert.match(source, new RegExp(`\"name\": \\"${command}\\"`));
+  }
+});

--- a/packages/memory/src/repo_memory_bootstrap/generated_cli_package/__init__.py
+++ b/packages/memory/src/repo_memory_bootstrap/generated_cli_package/__init__.py
@@ -1,0 +1,102 @@
+"""Generated command package metadata.
+
+Source: src/agentic_workspace/contracts/command_package_ir.json
+Program: agentic-memory-bootstrap
+Regenerate with: uv run python scripts/generate/generate_command_packages.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# DO NOT EDIT DIRECTLY.
+# Command/package interface changes belong in src/agentic_workspace/contracts/command_package_ir.json.
+# Runtime behavior changes belong in hand-written operation/primitive implementation code.
+# Regenerate with: uv run python scripts/generate/generate_command_packages.py
+GENERATED_COMMAND_PACKAGE: dict[str, Any] = json.loads(
+    r"""
+{
+  "commands": [
+    {
+      "adapter_id": "memory.status.cli",
+      "command": {
+        "manifest_ref": "package:memory:cli",
+        "name": "status"
+      },
+      "conformance_refs": [
+        "memory.status.process"
+      ],
+      "effect_hints": {
+        "destructive": false,
+        "idempotent": true,
+        "read_only": true,
+        "requires_preflight_gate": false,
+        "writes_repo_state": false
+      },
+      "operation_ref": {
+        "id": "memory.status.report",
+        "path": "operations/memory.status.report.json"
+      },
+      "projection_boundary": {
+        "runtime_owned": [
+          "memory bootstrap inspection",
+          "module result assembly",
+          "output emission"
+        ],
+        "target_specific": [
+          "parser library",
+          "package entrypoint wiring",
+          "help text layout",
+          "test container image"
+        ],
+        "universal": [
+          "command identity",
+          "operation reference",
+          "runtime primitive reference",
+          "effect hints",
+          "conformance refs"
+        ]
+      },
+      "runtime_binding": {
+        "kind": "operation-primitive-sequence",
+        "primitive_refs": [
+          "memory.bootstrap.status.load",
+          "output.emit"
+        ]
+      },
+      "schemas": {
+        "input": [],
+        "output": []
+      },
+      "status": "generated"
+    }
+  ],
+  "id": "memory-bootstrap",
+  "package_role": "memory-module-cli",
+  "program": "agentic-memory-bootstrap",
+  "targets": [
+    {
+      "entrypoints": [
+        "agentic-memory-bootstrap"
+      ],
+      "generated_root": "packages/memory/src/repo_memory_bootstrap/generated_cli_package",
+      "generation_status": "supported-now",
+      "kind": "python",
+      "package_name": "agentic-memory-bootstrap",
+      "test_environment": "python-dev"
+    },
+    {
+      "entrypoints": [
+        "agentic-memory-bootstrap"
+      ],
+      "generated_root": "generated/typescript/memory-cli",
+      "generation_status": "proof-fixture",
+      "kind": "typescript",
+      "package_name": "@agentic-workspace/memory-cli",
+      "test_environment": "docker"
+    }
+  ]
+}
+"""
+)

--- a/packages/planning/src/repo_planning_bootstrap/generated_cli_package/__init__.py
+++ b/packages/planning/src/repo_planning_bootstrap/generated_cli_package/__init__.py
@@ -1,0 +1,102 @@
+"""Generated command package metadata.
+
+Source: src/agentic_workspace/contracts/command_package_ir.json
+Program: agentic-planning-bootstrap
+Regenerate with: uv run python scripts/generate/generate_command_packages.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# DO NOT EDIT DIRECTLY.
+# Command/package interface changes belong in src/agentic_workspace/contracts/command_package_ir.json.
+# Runtime behavior changes belong in hand-written operation/primitive implementation code.
+# Regenerate with: uv run python scripts/generate/generate_command_packages.py
+GENERATED_COMMAND_PACKAGE: dict[str, Any] = json.loads(
+    r"""
+{
+  "commands": [
+    {
+      "adapter_id": "planning.status.cli",
+      "command": {
+        "manifest_ref": "package:planning:cli",
+        "name": "status"
+      },
+      "conformance_refs": [
+        "planning.status.process"
+      ],
+      "effect_hints": {
+        "destructive": false,
+        "idempotent": true,
+        "read_only": true,
+        "requires_preflight_gate": false,
+        "writes_repo_state": false
+      },
+      "operation_ref": {
+        "id": "planning.status.report",
+        "path": "operations/planning.status.report.json"
+      },
+      "projection_boundary": {
+        "runtime_owned": [
+          "planning bootstrap inspection",
+          "module result assembly",
+          "output emission"
+        ],
+        "target_specific": [
+          "parser library",
+          "package entrypoint wiring",
+          "help text layout",
+          "test container image"
+        ],
+        "universal": [
+          "command identity",
+          "operation reference",
+          "runtime primitive reference",
+          "effect hints",
+          "conformance refs"
+        ]
+      },
+      "runtime_binding": {
+        "kind": "operation-primitive-sequence",
+        "primitive_refs": [
+          "planning.bootstrap.status.load",
+          "output.emit"
+        ]
+      },
+      "schemas": {
+        "input": [],
+        "output": []
+      },
+      "status": "generated"
+    }
+  ],
+  "id": "planning-bootstrap",
+  "package_role": "planning-module-cli",
+  "program": "agentic-planning-bootstrap",
+  "targets": [
+    {
+      "entrypoints": [
+        "agentic-planning-bootstrap"
+      ],
+      "generated_root": "packages/planning/src/repo_planning_bootstrap/generated_cli_package",
+      "generation_status": "supported-now",
+      "kind": "python",
+      "package_name": "agentic-planning-bootstrap",
+      "test_environment": "python-dev"
+    },
+    {
+      "entrypoints": [
+        "agentic-planning-bootstrap"
+      ],
+      "generated_root": "generated/typescript/planning-cli",
+      "generation_status": "proof-fixture",
+      "kind": "typescript",
+      "package_name": "@agentic-workspace/planning-cli",
+      "test_environment": "docker"
+    }
+  ]
+}
+"""
+)

--- a/scripts/check/check_contract_tooling_surfaces.py
+++ b/scripts/check/check_contract_tooling_surfaces.py
@@ -14,6 +14,7 @@ from agentic_workspace.contract_tooling import (
     cli_commands_manifest,
     cli_option_groups_manifest,
     command_adapter_generation_manifest,
+    command_package_ir_manifest,
     compact_contract_manifest,
     conformance_contract_manifest,
     conformance_contracts_manifest,
@@ -460,6 +461,87 @@ def _validate_command_adapter_generation(payload: dict[str, object]) -> list[str
     return errors
 
 
+def _validate_command_package_ir(payload: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != "agentic-workspace/command-package-ir/v1":
+        return ["command_package_ir.json has unexpected schema_version"]
+    adapters = {adapter["id"]: adapter for adapter in command_adapter_generation_manifest()["adapters"]}
+    operations = {operation["id"]: operation for operation in operation_contracts_manifest()["operations"]}
+    conformance_refs = {contract["id"] for contract in conformance_contracts_manifest()["contracts"]}
+    primitive_refs = {primitive["id"] for primitive in operation_primitives_manifest()["primitives"]}
+    packages = payload.get("packages", [])
+    if not isinstance(packages, list):
+        return ["command_package_ir.json packages must be a list"]
+    seen_adapter_ids: set[str] = set()
+    for package_index, package in enumerate(packages):
+        if not isinstance(package, dict):
+            errors.append(f"command_package_ir package {package_index} must be an object")
+            continue
+        program = str(package.get("program", ""))
+        targets = package.get("targets", [])
+        commands = package.get("commands", [])
+        if not isinstance(targets, list) or not isinstance(commands, list):
+            errors.append(f"command_package_ir package {program} targets and commands must be lists")
+            continue
+        target_kinds = {str(target.get("kind", "")) for target in targets if isinstance(target, dict)}
+        if "python" not in target_kinds:
+            errors.append(f"command_package_ir package {program} must declare a python target")
+        if "typescript" not in target_kinds:
+            errors.append(f"command_package_ir package {program} must declare a typescript target")
+        for command in commands:
+            if not isinstance(command, dict):
+                errors.append(f"command_package_ir package {program} command entry must be an object")
+                continue
+            adapter_id = str(command.get("adapter_id", ""))
+            seen_adapter_ids.add(adapter_id)
+            adapter = adapters.get(adapter_id)
+            if adapter is None:
+                errors.append(f"command_package_ir command {adapter_id} does not reference a known generated adapter")
+                continue
+            if adapter["command"]["program"] != program:
+                errors.append(f"command_package_ir command {adapter_id} program drifted from command_adapter_generation.json")
+            operation_ref = command.get("operation_ref", {})
+            runtime_binding = command.get("runtime_binding", {})
+            if not isinstance(operation_ref, dict) or not isinstance(runtime_binding, dict):
+                errors.append(f"command_package_ir command {adapter_id} has malformed operation or runtime binding")
+                continue
+            operation_id = str(operation_ref.get("id", ""))
+            operation = operations.get(operation_id)
+            if operation is None:
+                errors.append(f"command_package_ir command {adapter_id} references unknown operation {operation_id}")
+            elif operation.get("path") != operation_ref.get("path"):
+                errors.append(f"command_package_ir command {adapter_id} operation path drifted from registry")
+            expected_operation_ref = {"id": adapter["operation_ref"]["id"], "path": adapter["operation_ref"]["path"]}
+            if operation_ref != expected_operation_ref:
+                errors.append(f"command_package_ir command {adapter_id} operation ref drifted from command_adapter_generation.json")
+            if runtime_binding != adapter["runtime_binding"]:
+                errors.append(f"command_package_ir command {adapter_id} runtime binding drifted from command_adapter_generation.json")
+            unknown_primitives = sorted(set(runtime_binding.get("primitive_refs", [])) - primitive_refs)
+            if unknown_primitives:
+                errors.append(
+                    f"command_package_ir command {adapter_id} references unknown primitive(s): "
+                    + ", ".join(str(item) for item in unknown_primitives)
+                )
+            if command.get("effect_hints") != adapter["effect_hints"]:
+                errors.append(f"command_package_ir command {adapter_id} effect hints drifted from command_adapter_generation.json")
+            if command.get("schemas") != adapter["schemas"]:
+                errors.append(f"command_package_ir command {adapter_id} schema refs drifted from command_adapter_generation.json")
+            command_conformance_refs = command.get("conformance_refs", [])
+            if command_conformance_refs != adapter["conformance_refs"]:
+                errors.append(f"command_package_ir command {adapter_id} conformance refs drifted from command_adapter_generation.json")
+            unknown_conformance = sorted(set(command_conformance_refs) - conformance_refs) if isinstance(command_conformance_refs, list) else []
+            if unknown_conformance:
+                errors.append(
+                    f"command_package_ir command {adapter_id} references unknown conformance ref(s): "
+                    + ", ".join(str(item) for item in unknown_conformance)
+                )
+    generated_adapter_ids = {adapter["id"] for adapter in adapters.values() if adapter.get("status") == "generated"}
+    missing_generated = sorted(generated_adapter_ids - seen_adapter_ids)
+    if missing_generated:
+        errors.append("command_package_ir.json missing generated adapter(s): " + ", ".join(missing_generated))
+    return errors
+
+
 def _generated_command_adapter_statuses() -> tuple[list[dict[str, object]], list[str]]:
     statuses: list[dict[str, object]] = []
     errors: list[str] = []
@@ -896,6 +978,11 @@ def main(argv: list[str] | None = None) -> int:
             "command adapter generation manifest",
             _validate(command_adapter_generation_manifest(), "command_adapter_generation.schema.json")
             + _validate_command_adapter_generation(command_adapter_generation_manifest()),
+        ),
+        (
+            "command package IR",
+            _validate(command_package_ir_manifest(), "command_package_ir.schema.json")
+            + _validate_command_package_ir(command_package_ir_manifest()),
         ),
         (
             "generated command adapter output",

--- a/scripts/check/check_contract_tooling_surfaces.py
+++ b/scripts/check/check_contract_tooling_surfaces.py
@@ -849,6 +849,114 @@ def _executable_command_surfaces(command_specs: list[dict[str, object]]) -> set[
     return surfaces
 
 
+def _program_parser(program: str) -> argparse.ArgumentParser | None:
+    if program == "agentic-workspace":
+        return cli.build_parser()
+    if program == "agentic-planning-bootstrap":
+        from repo_planning_bootstrap import cli as planning_cli
+
+        return planning_cli.build_parser()
+    if program == "agentic-memory-bootstrap":
+        from repo_memory_bootstrap import cli as memory_cli
+
+        return memory_cli.build_parser()
+    return None
+
+
+def _subparser_action(parser: argparse.ArgumentParser) -> argparse._SubParsersAction | None:
+    return next((action for action in parser._actions if isinstance(action, argparse._SubParsersAction)), None)
+
+
+def _command_parser(
+    parser: argparse.ArgumentParser,
+    *,
+    command_name: str,
+    subcommand_name: str | None = None,
+) -> argparse.ArgumentParser | None:
+    subparsers_action = _subparser_action(parser)
+    if subparsers_action is None:
+        return None
+    command_parser = subparsers_action.choices.get(command_name)
+    if command_parser is None or subcommand_name is None:
+        return command_parser
+    command_subparsers = _subparser_action(command_parser)
+    if command_subparsers is None:
+        return None
+    return command_subparsers.choices.get(subcommand_name)
+
+
+def _command_option_actions(parser: argparse.ArgumentParser) -> dict[str, argparse.Action]:
+    return {
+        str(action.dest): action
+        for action in parser._actions
+        if action.option_strings and action.dest != "help"
+    }
+
+
+def _validate_generated_adapter_live_cli_parity(payload: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+    adapters = payload.get("adapters", [])
+    if not isinstance(adapters, list):
+        return ["generated adapter live CLI parity cannot inspect malformed adapters list"]
+    for raw_adapter in adapters:
+        if not isinstance(raw_adapter, dict) or raw_adapter.get("status") != "generated":
+            continue
+        adapter_id = str(raw_adapter.get("id", ""))
+        command = raw_adapter.get("command", {})
+        operation_ref = raw_adapter.get("operation_ref", {})
+        if not isinstance(command, dict) or not isinstance(operation_ref, dict):
+            continue
+        program = str(command.get("program", ""))
+        command_name = str(command.get("name", ""))
+        subcommand_name = str(command["subcommand"]) if isinstance(command.get("subcommand"), str) else None
+        parser = _program_parser(program)
+        if parser is None:
+            errors.append(f"generated adapter {adapter_id} references unknown live CLI program {program}")
+            continue
+        live_command_parser = _command_parser(parser, command_name=command_name, subcommand_name=subcommand_name)
+        if live_command_parser is None:
+            surface = f"{command_name} {subcommand_name}" if subcommand_name else command_name
+            errors.append(f"generated adapter {adapter_id} command surface {program} {surface} is missing from the live CLI")
+            continue
+        operation = operation_manifest(str(operation_ref.get("path", "")))
+        operation_surface = operation.get("command_surface", {})
+        if operation_surface.get("program", "agentic-workspace") != program:
+            errors.append(f"generated adapter {adapter_id} program drifted from operation command_surface")
+        if operation_surface.get("command") != command_name:
+            errors.append(f"generated adapter {adapter_id} command drifted from operation command_surface")
+        if operation_surface.get("subcommand") != subcommand_name and (
+            operation_surface.get("subcommand") is not None or subcommand_name is not None
+        ):
+            errors.append(f"generated adapter {adapter_id} subcommand drifted from operation command_surface")
+        expected_cli_inputs = {
+            str(input_spec["name"]): bool(input_spec.get("required", False))
+            for input_spec in operation.get("inputs", [])
+            if isinstance(input_spec, dict) and input_spec.get("source") == "cli-option"
+        }
+        live_options = _command_option_actions(live_command_parser)
+        live_option_names = set(live_options)
+        expected_option_names = set(expected_cli_inputs)
+        missing_options = sorted(expected_option_names - live_option_names)
+        extra_options = sorted(live_option_names - expected_option_names)
+        if missing_options:
+            errors.append(
+                f"generated adapter {adapter_id} contract declares CLI option(s) missing from live parser: "
+                + ", ".join(missing_options)
+            )
+        if extra_options:
+            errors.append(
+                f"generated adapter {adapter_id} live parser has CLI option(s) missing from operation contract: "
+                + ", ".join(extra_options)
+            )
+        for option_name, expected_required in expected_cli_inputs.items():
+            action = live_options.get(option_name)
+            if action is None:
+                continue
+            if bool(action.required) != expected_required:
+                errors.append(f"generated adapter {adapter_id} option {option_name} required flag drifted from operation contract")
+    return errors
+
+
 def _expected_authority_marker(marker: dict[str, object], path: str) -> dict[str, object]:
     canonical_source = marker["canonical_source"]
     if not isinstance(canonical_source, dict):
@@ -993,7 +1101,8 @@ def main(argv: list[str] | None = None) -> int:
         (
             "command adapter generation manifest",
             _validate(command_adapter_generation_manifest(), "command_adapter_generation.schema.json")
-            + _validate_command_adapter_generation(command_adapter_generation_manifest()),
+            + _validate_command_adapter_generation(command_adapter_generation_manifest())
+            + _validate_generated_adapter_live_cli_parity(command_adapter_generation_manifest()),
         ),
         (
             "command package IR",

--- a/scripts/check/check_contract_tooling_surfaces.py
+++ b/scripts/check/check_contract_tooling_surfaces.py
@@ -615,6 +615,22 @@ def _validate_generated_command_adapter_output() -> list[str]:
     return _generated_command_adapter_statuses()[1]
 
 
+def _validate_generated_command_package_output() -> list[str]:
+    repo_root = Path(__file__).resolve().parents[2]
+    generator_path = repo_root / "scripts" / "generate" / "generate_command_packages.py"
+    spec = importlib.util.spec_from_file_location("generate_command_packages", generator_path)
+    if spec is None or spec.loader is None:
+        return [f"generated package layer: cannot load {generator_path.relative_to(repo_root).as_posix()}"]
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    stale_outputs: list[str] = []
+    for output_path, rendered in module._render_outputs(command_package_ir_manifest()):
+        current = output_path.read_text(encoding="utf-8") if output_path.exists() else ""
+        if current != rendered:
+            stale_outputs.append(output_path.relative_to(repo_root).as_posix())
+    return [f"generated package layer: {output} is stale; run uv run python scripts/generate/generate_command_packages.py" for output in stale_outputs]
+
+
 def _validate_python_contract_consumption_policy(payload: dict[str, object]) -> list[str]:
     errors: list[str] = []
     entries = payload.get("validated_at_consumption", [])
@@ -987,6 +1003,10 @@ def main(argv: list[str] | None = None) -> int:
         (
             "generated command adapter output",
             _validate_generated_command_adapter_output(),
+        ),
+        (
+            "generated command package output",
+            _validate_generated_command_package_output(),
         ),
         (
             "operation primitives registry",

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run(command: list[str]) -> int:
+    completed = subprocess.run(command, cwd=REPO_ROOT, check=False)
+    return int(completed.returncode)
+
+
+def _python_executable() -> str:
+    return sys.executable or "python"
+
+
+def _validate_static_surfaces() -> list[str]:
+    errors: list[str] = []
+    dockerfile = REPO_ROOT / "generated" / "typescript" / "Dockerfile"
+    if not dockerfile.is_file():
+        errors.append("generated/typescript/Dockerfile is missing")
+    for package in ("workspace-cli", "planning-cli", "memory-cli"):
+        package_root = REPO_ROOT / "generated" / "typescript" / package
+        for relative in ("package.json", "src/commandPackage.ts", "test/command-package.test.mjs"):
+            if not (package_root / relative).is_file():
+                errors.append(f"generated/typescript/{package}/{relative} is missing")
+    return errors
+
+
+def _run_docker(tag: str, *, require_docker: bool) -> int:
+    if shutil.which("docker") is None:
+        print("docker is not available; cannot run generated TypeScript package container proof")
+        return 1 if require_docker else 0
+    info = subprocess.run(["docker", "info"], cwd=REPO_ROOT, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+    if info.returncode:
+        detail = info.stderr.strip().splitlines()
+        suffix = f": {detail[0]}" if detail else ""
+        print(f"docker daemon is not available; skipped generated TypeScript package container proof{suffix}")
+        return 1 if require_docker else 0
+    dockerfile = "generated/typescript/Dockerfile"
+    build = _run(["docker", "build", "-f", dockerfile, "-t", tag, "."])
+    if build:
+        return build
+    return _run(["docker", "run", "--rm", tag])
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check generated command package outputs.")
+    parser.add_argument(
+        "--docker",
+        action="store_true",
+        help="Run generated TypeScript package tests inside Docker.",
+    )
+    parser.add_argument(
+        "--tag",
+        default="agentic-workspace-generated-typescript-cli-test",
+        help="Docker image tag used for generated TypeScript package tests.",
+    )
+    parser.add_argument(
+        "--require-docker",
+        action="store_true",
+        help="Fail instead of skipping when Docker is unavailable.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    generator = REPO_ROOT / "scripts" / "generate" / "generate_command_packages.py"
+    freshness = _run([_python_executable(), str(generator), "--check"])
+    if freshness:
+        return freshness
+    errors = _validate_static_surfaces()
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+    if args.docker:
+        return _run_docker(str(args.tag), require_docker=bool(args.require_docker))
+    print("[ok] generated command package static proof")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate/generate_command_packages.py
+++ b/scripts/generate/generate_command_packages.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from agentic_workspace.contract_tooling import command_package_ir_manifest  # noqa: E402
+
+
+def _json_block(payload: object) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def _python_module(package: dict[str, Any]) -> str:
+    rendered = _json_block(package)
+    return (
+        '"""Generated command package metadata.\n\n'
+        "Source: src/agentic_workspace/contracts/command_package_ir.json\n"
+        f"Program: {package['program']}\n"
+        "Regenerate with: uv run python scripts/generate/generate_command_packages.py\n"
+        '"""\n\n'
+        "from __future__ import annotations\n\n"
+        "import json\n"
+        "from typing import Any\n\n"
+        "# DO NOT EDIT DIRECTLY.\n"
+        "# Command/package interface changes belong in src/agentic_workspace/contracts/command_package_ir.json.\n"
+        "# Runtime behavior changes belong in hand-written operation/primitive implementation code.\n"
+        "# Regenerate with: uv run python scripts/generate/generate_command_packages.py\n"
+        "GENERATED_COMMAND_PACKAGE: dict[str, Any] = json.loads(\n"
+        "    r\"\"\"\n"
+        f"{rendered}\n"
+        "\"\"\"\n"
+        ")\n"
+    )
+
+
+def _typescript_package_json(package: dict[str, Any], target: dict[str, Any]) -> str:
+    payload = {
+        "name": target["package_name"],
+        "version": "0.0.0-generated",
+        "private": True,
+        "type": "module",
+        "bin": {entrypoint: "./src/commandPackage.ts" for entrypoint in target["entrypoints"]},
+        "scripts": {
+            "test": "node --test test/command-package.test.mjs"
+        },
+        "agenticWorkspace": {
+            "generated": True,
+            "source": "src/agentic_workspace/contracts/command_package_ir.json",
+            "program": package["program"]
+        }
+    }
+    return _json_block(payload) + "\n"
+
+
+def _typescript_module(package: dict[str, Any]) -> str:
+    rendered = _json_block(package)
+    return (
+        "// Generated command package metadata.\n"
+        "// Source: src/agentic_workspace/contracts/command_package_ir.json\n"
+        f"// Program: {package['program']}\n"
+        "// Regenerate with: uv run python scripts/generate/generate_command_packages.py\n"
+        "// DO NOT EDIT DIRECTLY.\n\n"
+        f"export const generatedCommandPackage = {rendered} as const;\n"
+        "\n"
+        "export type GeneratedCommandPackage = typeof generatedCommandPackage;\n"
+    )
+
+
+def _typescript_test(package: dict[str, Any]) -> str:
+    expected_commands = sorted(command["command"]["name"] for command in package["commands"])
+    rendered_expected = json.dumps(expected_commands)
+    return (
+        "import assert from 'node:assert/strict';\n"
+        "import test from 'node:test';\n"
+        "import { readFileSync } from 'node:fs';\n"
+        "\n"
+        "const source = readFileSync(new URL('../src/commandPackage.ts', import.meta.url), 'utf8');\n"
+        "\n"
+        "test('generated package metadata exposes expected commands', () => {\n"
+        f"  const expected = {rendered_expected};\n"
+        "  for (const command of expected) {\n"
+        "    assert.match(source, new RegExp(`\\\"name\\\": \\\\\"${command}\\\\\"`));\n"
+        "  }\n"
+        "});\n"
+    )
+
+
+def _render_outputs(manifest: dict[str, Any]) -> list[tuple[Path, str]]:
+    outputs: list[tuple[Path, str]] = []
+    for package in manifest["packages"]:
+        for target in package["targets"]:
+            root = REPO_ROOT / str(target["generated_root"])
+            if target["kind"] == "python":
+                outputs.append((root / "__init__.py", _python_module(package)))
+            elif target["kind"] == "typescript":
+                outputs.append((root / "package.json", _typescript_package_json(package, target)))
+                outputs.append((root / "src" / "commandPackage.ts", _typescript_module(package)))
+                outputs.append((root / "test" / "command-package.test.mjs", _typescript_test(package)))
+    return outputs
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate command package metadata from the command-package IR.")
+    parser.add_argument("--check", action="store_true", help="Fail if generated command package files are stale.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    manifest = command_package_ir_manifest()
+    outputs = _render_outputs(manifest)
+    stale_outputs: list[str] = []
+    for output_path, rendered in outputs:
+        if args.check:
+            current = output_path.read_text(encoding="utf-8") if output_path.exists() else ""
+            if current != rendered:
+                stale_outputs.append(output_path.relative_to(REPO_ROOT).as_posix())
+        else:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(rendered, encoding="utf-8")
+            print(f"[ok] wrote {output_path.relative_to(REPO_ROOT).as_posix()}")
+    if args.check:
+        if stale_outputs:
+            for output in stale_outputs:
+                print(f"{output} is stale; regenerate command packages.")
+            return 1
+        print("[ok] generated command packages")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate/generate_command_packages.py
+++ b/scripts/generate/generate_command_packages.py
@@ -47,14 +47,16 @@ def _typescript_package_json(package: dict[str, Any], target: dict[str, Any]) ->
         "version": "0.0.0-generated",
         "private": True,
         "type": "module",
-        "bin": {entrypoint: "./src/commandPackage.ts" for entrypoint in target["entrypoints"]},
         "scripts": {
             "test": "node --test test/command-package.test.mjs"
         },
         "agenticWorkspace": {
             "generated": True,
+            "fixtureOnly": True,
+            "generationStatus": target["generation_status"],
             "source": "src/agentic_workspace/contracts/command_package_ir.json",
-            "program": package["program"]
+            "program": package["program"],
+            "declaredEntrypoints": target["entrypoints"]
         }
     }
     return _json_block(payload) + "\n"

--- a/src/agentic_workspace/cli.py
+++ b/src/agentic_workspace/cli.py
@@ -5673,6 +5673,24 @@ def _defaults_payload() -> dict[str, Any]:
     proof_manifest = proof_routes_manifest()
     validation_lanes = [
         {
+            "id": "generated_command_packages",
+            "when": [
+                "command-package IR, generator, or generated Python/TypeScript package outputs change",
+                "the trust question is generated package freshness or non-Python package conformance",
+            ],
+            "enough_proof": [
+                "uv run python scripts/check/check_generated_command_packages.py",
+                "uv run python scripts/check/check_generated_command_packages.py --docker",
+            ],
+            "broaden_when": [
+                "the change also alters runtime CLI behavior outside generated metadata",
+                "the change also touches package installer behavior beyond generated package surfaces",
+            ],
+            "escalate_when": [
+                "generated package proof no longer covers the changed implementation boundary",
+            ],
+        },
+        {
             "id": "workspace_cli",
             "when": [
                 "root workspace CLI changes",

--- a/src/agentic_workspace/cli.py
+++ b/src/agentic_workspace/cli.py
@@ -7223,7 +7223,43 @@ def _proof_selection_for_changed_paths(*, changed_paths: list[str], target_root:
     surface_value_review = _surface_value_review_for_changed_paths(changed_paths=changed_paths, target_root=target_root)
     if surface_value_review["durable_surface_count"]:
         proof_selection["surface_value_review"] = surface_value_review
+    direct_cli_review = _direct_cli_edit_review_for_changed_paths(changed_paths)
+    if direct_cli_review["changed_paths"]:
+        proof_selection["direct_cli_edit_review"] = direct_cli_review
     return proof_selection
+
+
+def _direct_cli_edit_review_for_changed_paths(changed_paths: list[str]) -> dict[str, Any]:
+    cli_paths = [
+        path
+        for path in changed_paths
+        if path == "src/agentic_workspace/cli.py"
+        or path.endswith("/src/repo_planning_bootstrap/cli.py")
+        or path.endswith("/src/repo_memory_bootstrap/cli.py")
+    ]
+    return {
+        "kind": "direct-cli-edit-review/v1",
+        "changed_paths": cli_paths,
+        "status": "review-needed" if cli_paths else "not-applicable",
+        "rule": (
+            "Treat direct CLI edits as runtime-primitive work or migration exceptions; normal interface authoring belongs in "
+            "command contracts, command-package IR, and generated outputs."
+        ),
+        "definition_owned_work": [
+            "command identity and option semantics",
+            "generated adapter/package metadata",
+            "effect hints, operation refs, primitive refs, schema refs, and conformance refs",
+        ],
+        "allowed_direct_cli_work": [
+            "runtime primitive implementation and live workspace inspection",
+            "dispatch glue while a command is not yet covered by generated adapters",
+            "urgent migration exceptions with proof output naming why definitions were insufficient",
+        ],
+        "proof_hint": (
+            "When direct CLI edits accompany interface changes, include command-package IR/generator proof or split the runtime fix "
+            "from definition work."
+        ),
+    }
 
 
 def _surface_value_review_for_changed_paths(*, changed_paths: list[str], target_root: Path | None) -> dict[str, Any]:

--- a/src/agentic_workspace/contract_tooling.py
+++ b/src/agentic_workspace/contract_tooling.py
@@ -116,6 +116,10 @@ def command_adapter_generation_manifest() -> dict[str, Any]:
     return load_validated_contract_json("command_adapter_generation.json", "command_adapter_generation.schema.json")
 
 
+def command_package_ir_manifest() -> dict[str, Any]:
+    return load_validated_contract_json("command_package_ir.json", "command_package_ir.schema.json")
+
+
 def lifecycle_generation_readiness_manifest() -> dict[str, Any]:
     return load_validated_contract_json("lifecycle_generation_readiness.json", "lifecycle_generation_readiness.schema.json")
 

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -15,7 +15,9 @@
     "runtime_boundary": "Runtime primitives and live workspace inspection stay hand-owned and are referenced, not generated.",
     "ordinary_development_environment": "Python development remains sufficient for ordinary repo work.",
     "test_environment": "Generated non-Python package tests run in Docker-selected proof lanes.",
-    "custom_codegen_boundary": "Custom generation code should stay small: validated IR loading, target rendering, freshness checks, and no-direct-edit sentinels."
+    "custom_codegen_boundary": "Custom generation code should stay small: validated IR loading, target rendering, freshness checks, and no-direct-edit sentinels.",
+    "shell_adapter_policy": "Bash and PowerShell targets are deferred downstream projections for thin wrappers, help, argument validation, completion metadata, and runtime handoff only; they must not own runtime primitive behavior.",
+    "direct_cli_edit_policy": "Interface shape, generated package metadata, and adapter wiring should move through contracts, IR, and generators; direct cli.py edits are for runtime primitives, migration exceptions, and uncovered urgent fixes."
   },
   "packages": [
     {

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -1,0 +1,293 @@
+{
+  "schema_version": "agentic-workspace/command-package-ir/v1",
+  "summary": "Implementation-independent command-package view for generated Python and TypeScript CLI package targets.",
+  "schema": "schemas/command_package_ir.schema.json",
+  "source_contracts": [
+    "cli_commands.json",
+    "cli_option_groups.json",
+    "operation_contracts.json",
+    "operation_primitives.json",
+    "command_adapter_generation.json",
+    "conformance_contracts.json"
+  ],
+  "generation_policy": {
+    "authority_rule": "Command/interface truth belongs in contracts and this package IR; generated target files are derived outputs.",
+    "runtime_boundary": "Runtime primitives and live workspace inspection stay hand-owned and are referenced, not generated.",
+    "ordinary_development_environment": "Python development remains sufficient for ordinary repo work.",
+    "test_environment": "Generated non-Python package tests run in Docker-selected proof lanes.",
+    "custom_codegen_boundary": "Custom generation code should stay small: validated IR loading, target rendering, freshness checks, and no-direct-edit sentinels."
+  },
+  "packages": [
+    {
+      "id": "root-workspace",
+      "program": "agentic-workspace",
+      "package_role": "root-workspace-cli",
+      "targets": [
+        {
+          "kind": "python",
+          "package_name": "agentic-workspace",
+          "generated_root": "src/agentic_workspace/generated_cli_package",
+          "entrypoints": [
+            "agentic-workspace"
+          ],
+          "test_environment": "python-dev",
+          "generation_status": "supported-now"
+        },
+        {
+          "kind": "typescript",
+          "package_name": "@agentic-workspace/workspace-cli",
+          "generated_root": "generated/typescript/workspace-cli",
+          "entrypoints": [
+            "agentic-workspace"
+          ],
+          "test_environment": "docker",
+          "generation_status": "proof-fixture"
+        },
+        {
+          "kind": "bash",
+          "package_name": "agentic-workspace-shell",
+          "generated_root": "generated/shell/bash",
+          "entrypoints": [
+            "agentic-workspace"
+          ],
+          "test_environment": "docker",
+          "generation_status": "deferred"
+        },
+        {
+          "kind": "powershell",
+          "package_name": "AgenticWorkspace.PowerShell",
+          "generated_root": "generated/shell/powershell",
+          "entrypoints": [
+            "agentic-workspace"
+          ],
+          "test_environment": "docker",
+          "generation_status": "deferred"
+        }
+      ],
+      "commands": [
+        {
+          "adapter_id": "defaults.report.cli",
+          "status": "generated",
+          "command": {
+            "name": "defaults",
+            "manifest_ref": "cli_commands.json"
+          },
+          "operation_ref": {
+            "id": "defaults.report",
+            "path": "operations/defaults.report.json"
+          },
+          "runtime_binding": {
+            "kind": "operation-primitive-sequence",
+            "primitive_refs": [
+              "workspace.defaults.load",
+              "workspace.defaults.select",
+              "output.emit"
+            ]
+          },
+          "schemas": {
+            "input": [],
+            "output": [
+              "compact_contract_answer.schema.json"
+            ]
+          },
+          "effect_hints": {
+            "read_only": true,
+            "destructive": false,
+            "idempotent": true,
+            "writes_repo_state": false,
+            "requires_preflight_gate": false
+          },
+          "conformance_refs": [
+            "defaults.report.process"
+          ],
+          "projection_boundary": {
+            "universal": [
+              "command identity",
+              "option semantics",
+              "operation reference",
+              "runtime primitive reference",
+              "effect hints",
+              "schema refs",
+              "conformance refs"
+            ],
+            "target_specific": [
+              "parser library",
+              "package entrypoint wiring",
+              "help text layout",
+              "test container image"
+            ],
+            "runtime_owned": [
+              "defaults payload assembly",
+              "section selection",
+              "output emission"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "planning-bootstrap",
+      "program": "agentic-planning-bootstrap",
+      "package_role": "planning-module-cli",
+      "targets": [
+        {
+          "kind": "python",
+          "package_name": "agentic-planning-bootstrap",
+          "generated_root": "packages/planning/src/repo_planning_bootstrap/generated_cli_package",
+          "entrypoints": [
+            "agentic-planning-bootstrap"
+          ],
+          "test_environment": "python-dev",
+          "generation_status": "supported-now"
+        },
+        {
+          "kind": "typescript",
+          "package_name": "@agentic-workspace/planning-cli",
+          "generated_root": "generated/typescript/planning-cli",
+          "entrypoints": [
+            "agentic-planning-bootstrap"
+          ],
+          "test_environment": "docker",
+          "generation_status": "proof-fixture"
+        }
+      ],
+      "commands": [
+        {
+          "adapter_id": "planning.status.cli",
+          "status": "generated",
+          "command": {
+            "name": "status",
+            "manifest_ref": "package:planning:cli"
+          },
+          "operation_ref": {
+            "id": "planning.status.report",
+            "path": "operations/planning.status.report.json"
+          },
+          "runtime_binding": {
+            "kind": "operation-primitive-sequence",
+            "primitive_refs": [
+              "planning.bootstrap.status.load",
+              "output.emit"
+            ]
+          },
+          "schemas": {
+            "input": [],
+            "output": []
+          },
+          "effect_hints": {
+            "read_only": true,
+            "destructive": false,
+            "idempotent": true,
+            "writes_repo_state": false,
+            "requires_preflight_gate": false
+          },
+          "conformance_refs": [
+            "planning.status.process"
+          ],
+          "projection_boundary": {
+            "universal": [
+              "command identity",
+              "operation reference",
+              "runtime primitive reference",
+              "effect hints",
+              "conformance refs"
+            ],
+            "target_specific": [
+              "parser library",
+              "package entrypoint wiring",
+              "help text layout",
+              "test container image"
+            ],
+            "runtime_owned": [
+              "planning bootstrap inspection",
+              "module result assembly",
+              "output emission"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "memory-bootstrap",
+      "program": "agentic-memory-bootstrap",
+      "package_role": "memory-module-cli",
+      "targets": [
+        {
+          "kind": "python",
+          "package_name": "agentic-memory-bootstrap",
+          "generated_root": "packages/memory/src/repo_memory_bootstrap/generated_cli_package",
+          "entrypoints": [
+            "agentic-memory-bootstrap"
+          ],
+          "test_environment": "python-dev",
+          "generation_status": "supported-now"
+        },
+        {
+          "kind": "typescript",
+          "package_name": "@agentic-workspace/memory-cli",
+          "generated_root": "generated/typescript/memory-cli",
+          "entrypoints": [
+            "agentic-memory-bootstrap"
+          ],
+          "test_environment": "docker",
+          "generation_status": "proof-fixture"
+        }
+      ],
+      "commands": [
+        {
+          "adapter_id": "memory.status.cli",
+          "status": "generated",
+          "command": {
+            "name": "status",
+            "manifest_ref": "package:memory:cli"
+          },
+          "operation_ref": {
+            "id": "memory.status.report",
+            "path": "operations/memory.status.report.json"
+          },
+          "runtime_binding": {
+            "kind": "operation-primitive-sequence",
+            "primitive_refs": [
+              "memory.bootstrap.status.load",
+              "output.emit"
+            ]
+          },
+          "schemas": {
+            "input": [],
+            "output": []
+          },
+          "effect_hints": {
+            "read_only": true,
+            "destructive": false,
+            "idempotent": true,
+            "writes_repo_state": false,
+            "requires_preflight_gate": false
+          },
+          "conformance_refs": [
+            "memory.status.process"
+          ],
+          "projection_boundary": {
+            "universal": [
+              "command identity",
+              "operation reference",
+              "runtime primitive reference",
+              "effect hints",
+              "conformance refs"
+            ],
+            "target_specific": [
+              "parser library",
+              "package entrypoint wiring",
+              "help text layout",
+              "test container image"
+            ],
+            "runtime_owned": [
+              "memory bootstrap inspection",
+              "module result assembly",
+              "output emission"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/agentic_workspace/contracts/contract_inventory.json
+++ b/src/agentic_workspace/contracts/contract_inventory.json
@@ -295,6 +295,16 @@
       "notes": "Generator-facing adapter bindings join command shape, operation contracts, primitive refs, schemas, projection hints, and conformance refs while leaving runtime primitive behavior implementation-owned."
     },
     {
+      "area": "command_package_ir",
+      "classification": "declarative",
+      "owner_surface": "src/agentic_workspace/contracts/command_package_ir.json",
+      "consumers": [
+        "scripts/check/check_contract_tooling_surfaces.py",
+        "future Python and TypeScript package generators"
+      ],
+      "notes": "Implementation-independent package view joins generated command adapters into target package definitions so Python and TypeScript outputs can derive from the same contract without reading CLI implementation code."
+    },
+    {
       "area": "python_extraction_map",
       "classification": "declarative",
       "owner_surface": "src/agentic_workspace/contracts/python_extraction_map.json",

--- a/src/agentic_workspace/contracts/proof_selection_rules.json
+++ b/src/agentic_workspace/contracts/proof_selection_rules.json
@@ -2,6 +2,21 @@
   "schema_version": "agentic-workspace/proof-selection-rules/v1",
   "rules": [
     {
+      "id": "generated-command-packages",
+      "lane": "generated_command_packages",
+      "exact": [
+        "src/agentic_workspace/contracts/command_package_ir.json"
+      ],
+      "prefixes": [
+        "generated/typescript/",
+        "scripts/generate/generate_command_packages.py",
+        "scripts/check/check_generated_command_packages.py",
+        "src/agentic_workspace/generated_cli_package/",
+        "packages/planning/src/repo_planning_bootstrap/generated_cli_package/",
+        "packages/memory/src/repo_memory_bootstrap/generated_cli_package/"
+      ]
+    },
+    {
       "id": "planning-package",
       "lane": "planning_package",
       "prefixes": [

--- a/src/agentic_workspace/contracts/python_contract_consumption.json
+++ b/src/agentic_workspace/contracts/python_contract_consumption.json
@@ -45,6 +45,12 @@
       "consumer": "scripts/check/check_contract_tooling_surfaces.py"
     },
     {
+      "contract": "command_package_ir.json",
+      "schema": "command_package_ir.schema.json",
+      "loader": "command_package_ir_manifest",
+      "consumer": "scripts/check/check_contract_tooling_surfaces.py"
+    },
+    {
       "contract": "workflow_definition_format.json",
       "schema": "workflow_definition_format.schema.json",
       "loader": "workflow_definition_format_manifest",

--- a/src/agentic_workspace/contracts/schemas/command_package_ir.schema.json
+++ b/src/agentic_workspace/contracts/schemas/command_package_ir.schema.json
@@ -1,0 +1,344 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "agentic-workspace/command-package-ir.schema.json",
+  "title": "Agentic Workspace Command Package IR",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "summary",
+    "schema",
+    "source_contracts",
+    "generation_policy",
+    "packages"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "agentic-workspace/command-package-ir/v1"
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "schema": {
+      "const": "schemas/command_package_ir.schema.json"
+    },
+    "source_contracts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "generation_policy": {
+      "type": "object",
+      "required": [
+        "authority_rule",
+        "runtime_boundary",
+        "ordinary_development_environment",
+        "test_environment",
+        "custom_codegen_boundary"
+      ],
+      "properties": {
+        "authority_rule": {
+          "type": "string",
+          "minLength": 1
+        },
+        "runtime_boundary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ordinary_development_environment": {
+          "type": "string",
+          "minLength": 1
+        },
+        "test_environment": {
+          "type": "string",
+          "minLength": 1
+        },
+        "custom_codegen_boundary": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "packages": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/package"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "package": {
+      "type": "object",
+      "required": [
+        "id",
+        "program",
+        "package_role",
+        "targets",
+        "commands"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_.-]*$"
+        },
+        "program": {
+          "type": "string",
+          "minLength": 1
+        },
+        "package_role": {
+          "enum": [
+            "root-workspace-cli",
+            "planning-module-cli",
+            "memory-module-cli"
+          ]
+        },
+        "targets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/target"
+          }
+        },
+        "commands": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/command"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "target": {
+      "type": "object",
+      "required": [
+        "kind",
+        "package_name",
+        "generated_root",
+        "entrypoints",
+        "test_environment"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "python",
+            "typescript",
+            "bash",
+            "powershell"
+          ]
+        },
+        "package_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "generated_root": {
+          "type": "string",
+          "minLength": 1
+        },
+        "entrypoints": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "test_environment": {
+          "enum": [
+            "python-dev",
+            "docker"
+          ]
+        },
+        "generation_status": {
+          "enum": [
+            "supported-now",
+            "proof-fixture",
+            "deferred"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "command": {
+      "type": "object",
+      "required": [
+        "adapter_id",
+        "status",
+        "command",
+        "operation_ref",
+        "runtime_binding",
+        "schemas",
+        "effect_hints",
+        "conformance_refs",
+        "projection_boundary"
+      ],
+      "properties": {
+        "adapter_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_.-]*$"
+        },
+        "status": {
+          "enum": [
+            "generated",
+            "proof-fixture",
+            "deferred"
+          ]
+        },
+        "command": {
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "subcommand": {
+              "type": "string",
+              "minLength": 1
+            },
+            "manifest_ref": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "operation_ref": {
+          "type": "object",
+          "required": [
+            "id",
+            "path"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "path": {
+              "type": "string",
+              "pattern": "^operations/[A-Za-z0-9_.-]+\\.json$"
+            }
+          },
+          "additionalProperties": false
+        },
+        "runtime_binding": {
+          "type": "object",
+          "required": [
+            "kind",
+            "primitive_refs"
+          ],
+          "properties": {
+            "kind": {
+              "const": "operation-primitive-sequence"
+            },
+            "primitive_refs": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9_.-]*$"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "schemas": {
+          "type": "object",
+          "required": [
+            "input",
+            "output"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/$defs/schema_refs"
+            },
+            "output": {
+              "$ref": "#/$defs/schema_refs"
+            }
+          },
+          "additionalProperties": false
+        },
+        "effect_hints": {
+          "type": "object",
+          "required": [
+            "read_only",
+            "destructive",
+            "idempotent",
+            "writes_repo_state",
+            "requires_preflight_gate"
+          ],
+          "properties": {
+            "read_only": {
+              "type": "boolean"
+            },
+            "destructive": {
+              "type": "boolean"
+            },
+            "idempotent": {
+              "type": "boolean"
+            },
+            "writes_repo_state": {
+              "type": "boolean"
+            },
+            "requires_preflight_gate": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "conformance_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "projection_boundary": {
+          "type": "object",
+          "required": [
+            "universal",
+            "target_specific",
+            "runtime_owned"
+          ],
+          "properties": {
+            "universal": {
+              "$ref": "#/$defs/non_empty_strings"
+            },
+            "target_specific": {
+              "$ref": "#/$defs/non_empty_strings"
+            },
+            "runtime_owned": {
+              "$ref": "#/$defs/non_empty_strings"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "schema_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9_.-]+\\.schema\\.json$"
+      }
+    },
+    "non_empty_strings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/src/agentic_workspace/contracts/schemas/command_package_ir.schema.json
+++ b/src/agentic_workspace/contracts/schemas/command_package_ir.schema.json
@@ -37,7 +37,9 @@
         "runtime_boundary",
         "ordinary_development_environment",
         "test_environment",
-        "custom_codegen_boundary"
+        "custom_codegen_boundary",
+        "shell_adapter_policy",
+        "direct_cli_edit_policy"
       ],
       "properties": {
         "authority_rule": {
@@ -57,6 +59,14 @@
           "minLength": 1
         },
         "custom_codegen_boundary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "shell_adapter_policy": {
+          "type": "string",
+          "minLength": 1
+        },
+        "direct_cli_edit_policy": {
           "type": "string",
           "minLength": 1
         }

--- a/src/agentic_workspace/generated_cli_package/__init__.py
+++ b/src/agentic_workspace/generated_cli_package/__init__.py
@@ -1,0 +1,127 @@
+"""Generated command package metadata.
+
+Source: src/agentic_workspace/contracts/command_package_ir.json
+Program: agentic-workspace
+Regenerate with: uv run python scripts/generate/generate_command_packages.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# DO NOT EDIT DIRECTLY.
+# Command/package interface changes belong in src/agentic_workspace/contracts/command_package_ir.json.
+# Runtime behavior changes belong in hand-written operation/primitive implementation code.
+# Regenerate with: uv run python scripts/generate/generate_command_packages.py
+GENERATED_COMMAND_PACKAGE: dict[str, Any] = json.loads(
+    r"""
+{
+  "commands": [
+    {
+      "adapter_id": "defaults.report.cli",
+      "command": {
+        "manifest_ref": "cli_commands.json",
+        "name": "defaults"
+      },
+      "conformance_refs": [
+        "defaults.report.process"
+      ],
+      "effect_hints": {
+        "destructive": false,
+        "idempotent": true,
+        "read_only": true,
+        "requires_preflight_gate": false,
+        "writes_repo_state": false
+      },
+      "operation_ref": {
+        "id": "defaults.report",
+        "path": "operations/defaults.report.json"
+      },
+      "projection_boundary": {
+        "runtime_owned": [
+          "defaults payload assembly",
+          "section selection",
+          "output emission"
+        ],
+        "target_specific": [
+          "parser library",
+          "package entrypoint wiring",
+          "help text layout",
+          "test container image"
+        ],
+        "universal": [
+          "command identity",
+          "option semantics",
+          "operation reference",
+          "runtime primitive reference",
+          "effect hints",
+          "schema refs",
+          "conformance refs"
+        ]
+      },
+      "runtime_binding": {
+        "kind": "operation-primitive-sequence",
+        "primitive_refs": [
+          "workspace.defaults.load",
+          "workspace.defaults.select",
+          "output.emit"
+        ]
+      },
+      "schemas": {
+        "input": [],
+        "output": [
+          "compact_contract_answer.schema.json"
+        ]
+      },
+      "status": "generated"
+    }
+  ],
+  "id": "root-workspace",
+  "package_role": "root-workspace-cli",
+  "program": "agentic-workspace",
+  "targets": [
+    {
+      "entrypoints": [
+        "agentic-workspace"
+      ],
+      "generated_root": "src/agentic_workspace/generated_cli_package",
+      "generation_status": "supported-now",
+      "kind": "python",
+      "package_name": "agentic-workspace",
+      "test_environment": "python-dev"
+    },
+    {
+      "entrypoints": [
+        "agentic-workspace"
+      ],
+      "generated_root": "generated/typescript/workspace-cli",
+      "generation_status": "proof-fixture",
+      "kind": "typescript",
+      "package_name": "@agentic-workspace/workspace-cli",
+      "test_environment": "docker"
+    },
+    {
+      "entrypoints": [
+        "agentic-workspace"
+      ],
+      "generated_root": "generated/shell/bash",
+      "generation_status": "deferred",
+      "kind": "bash",
+      "package_name": "agentic-workspace-shell",
+      "test_environment": "docker"
+    },
+    {
+      "entrypoints": [
+        "agentic-workspace"
+      ],
+      "generated_root": "generated/shell/powershell",
+      "generation_status": "deferred",
+      "kind": "powershell",
+      "package_name": "AgenticWorkspace.PowerShell",
+      "test_environment": "docker"
+    }
+  ]
+}
+"""
+)

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -233,6 +233,15 @@ def test_generated_command_package_files_are_current() -> None:
     assert module.main(["--check"]) == 0
 
 
+def test_generated_command_package_check_surface_is_current() -> None:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "check" / "check_generated_command_packages.py"
+    spec = importlib.util.spec_from_file_location("check_generated_command_packages", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.main([]) == 0
+
+
 def test_generated_python_command_package_metadata_is_current() -> None:
     from agentic_workspace.generated_cli_package import GENERATED_COMMAND_PACKAGE
 

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -129,6 +129,8 @@ def test_command_package_ir_declares_python_and_typescript_targets() -> None:
         manifest["generation_policy"]["ordinary_development_environment"] == "Python development remains sufficient for ordinary repo work."
     )
     assert manifest["generation_policy"]["test_environment"] == "Generated non-Python package tests run in Docker-selected proof lanes."
+    assert "must not own runtime primitive behavior" in manifest["generation_policy"]["shell_adapter_policy"]
+    assert "direct cli.py edits" in manifest["generation_policy"]["direct_cli_edit_policy"]
 
     root_package = packages["root-workspace"]
     targets = {target["kind"]: target for target in root_package["targets"]}

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -224,6 +224,37 @@ def test_generated_command_adapter_module_is_current() -> None:
     assert module.main(["--check"]) == 0
 
 
+def test_generated_command_package_files_are_current() -> None:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "generate" / "generate_command_packages.py"
+    spec = importlib.util.spec_from_file_location("generate_command_packages", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.main(["--check"]) == 0
+
+
+def test_generated_python_command_package_metadata_is_current() -> None:
+    from agentic_workspace.generated_cli_package import GENERATED_COMMAND_PACKAGE
+
+    assert GENERATED_COMMAND_PACKAGE["program"] == "agentic-workspace"
+    assert {command["adapter_id"] for command in GENERATED_COMMAND_PACKAGE["commands"]} == {"defaults.report.cli"}
+    target_kinds = {target["kind"] for target in GENERATED_COMMAND_PACKAGE["targets"]}
+    assert {"python", "typescript", "bash", "powershell"} <= target_kinds
+
+
+def test_generated_typescript_command_package_fixture_is_current() -> None:
+    package_root = Path(__file__).resolve().parents[1] / "generated" / "typescript" / "workspace-cli"
+    package_json = json.loads((package_root / "package.json").read_text(encoding="utf-8"))
+    source_text = (package_root / "src" / "commandPackage.ts").read_text(encoding="utf-8")
+    test_text = (package_root / "test" / "command-package.test.mjs").read_text(encoding="utf-8")
+
+    assert package_json["name"] == "@agentic-workspace/workspace-cli"
+    assert package_json["agenticWorkspace"]["generated"] is True
+    assert "defaults.report.cli" in source_text
+    assert "DO NOT EDIT DIRECTLY" in source_text
+    assert "generated package metadata exposes expected commands" in test_text
+
+
 def test_generated_command_adapter_module_routes_direct_edits_to_authoritative_sources() -> None:
     generated_path = Path(__file__).resolve().parents[1] / "src" / "agentic_workspace" / "generated_command_adapters.py"
     generated_text = generated_path.read_text(encoding="utf-8")

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -260,7 +260,11 @@ def test_generated_typescript_command_package_fixture_is_current() -> None:
     test_text = (package_root / "test" / "command-package.test.mjs").read_text(encoding="utf-8")
 
     assert package_json["name"] == "@agentic-workspace/workspace-cli"
+    assert "bin" not in package_json
     assert package_json["agenticWorkspace"]["generated"] is True
+    assert package_json["agenticWorkspace"]["fixtureOnly"] is True
+    assert package_json["agenticWorkspace"]["generationStatus"] == "proof-fixture"
+    assert package_json["agenticWorkspace"]["declaredEntrypoints"] == ["agentic-workspace"]
     assert "defaults.report.cli" in source_text
     assert "DO NOT EDIT DIRECTLY" in source_text
     assert "generated package metadata exposes expected commands" in test_text
@@ -303,6 +307,40 @@ def test_contract_tooling_check_reports_generated_adapter_status() -> None:
     assert commands_by_program["agentic-workspace"] == ["defaults"]
     assert commands_by_program["agentic-planning-bootstrap"] == ["status"]
     assert commands_by_program["agentic-memory-bootstrap"] == ["status"]
+
+
+def test_generated_adapter_contracts_match_live_cli_surfaces() -> None:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "check" / "check_contract_tooling_surfaces.py"
+    spec = importlib.util.spec_from_file_location("check_contract_tooling_surfaces", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module._validate_generated_adapter_live_cli_parity(contract_tooling.command_adapter_generation_manifest()) == []
+
+
+def test_generated_adapter_live_cli_parity_catches_missing_contract_option(monkeypatch: pytest.MonkeyPatch) -> None:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "check" / "check_contract_tooling_surfaces.py"
+    spec = importlib.util.spec_from_file_location("check_contract_tooling_surfaces", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    memory_adapter = next(
+        adapter for adapter in contract_tooling.command_adapter_generation_manifest()["adapters"] if adapter["id"] == "memory.status.cli"
+    )
+
+    def fake_operation_manifest(_path: str) -> dict[str, object]:
+        return {
+            "command_surface": {"program": "agentic-memory-bootstrap", "command": "status", "format_option": "format"},
+            "inputs": [{"name": "format", "source": "cli-option", "required": False}],
+        }
+
+    monkeypatch.setattr(module, "operation_manifest", fake_operation_manifest)
+
+    errors = module._validate_generated_adapter_live_cli_parity({"adapters": [memory_adapter]})
+
+    assert errors == ["generated adapter memory.status.cli live parser has CLI option(s) missing from operation contract: target"]
 
 
 def test_validated_contract_loader_reports_contract_and_schema(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -121,6 +121,45 @@ def test_command_adapter_generation_contract_records_multi_target_requirements()
     assert target_kinds["local-mcp-tool"]["status"] == "requirements-baseline"
 
 
+def test_command_package_ir_declares_python_and_typescript_targets() -> None:
+    manifest = contract_tooling.command_package_ir_manifest()
+    packages = {package["id"]: package for package in manifest["packages"]}
+
+    assert (
+        manifest["generation_policy"]["ordinary_development_environment"] == "Python development remains sufficient for ordinary repo work."
+    )
+    assert manifest["generation_policy"]["test_environment"] == "Generated non-Python package tests run in Docker-selected proof lanes."
+
+    root_package = packages["root-workspace"]
+    targets = {target["kind"]: target for target in root_package["targets"]}
+
+    assert root_package["program"] == "agentic-workspace"
+    assert targets["python"]["test_environment"] == "python-dev"
+    assert targets["typescript"]["test_environment"] == "docker"
+    assert targets["bash"]["generation_status"] == "deferred"
+    assert targets["powershell"]["generation_status"] == "deferred"
+
+
+def test_command_package_ir_reuses_generated_adapter_truth() -> None:
+    package_ir = contract_tooling.command_package_ir_manifest()
+    adapter_manifest = contract_tooling.command_adapter_generation_manifest()
+    adapters = {adapter["id"]: adapter for adapter in adapter_manifest["adapters"]}
+    commands = {command["adapter_id"]: command for package in package_ir["packages"] for command in package["commands"]}
+
+    assert set(commands) == {"defaults.report.cli", "planning.status.cli", "memory.status.cli"}
+    defaults_command = commands["defaults.report.cli"]
+    defaults_adapter = adapters["defaults.report.cli"]
+
+    assert defaults_command["operation_ref"] == {
+        "id": defaults_adapter["operation_ref"]["id"],
+        "path": defaults_adapter["operation_ref"]["path"],
+    }
+    assert defaults_command["runtime_binding"] == defaults_adapter["runtime_binding"]
+    assert defaults_command["effect_hints"] == defaults_adapter["effect_hints"]
+    assert defaults_command["conformance_refs"] == defaults_adapter["conformance_refs"]
+    assert "parser library" in defaults_command["projection_boundary"]["target_specific"]
+
+
 def test_python_contract_consumption_declares_validated_loader_bindings() -> None:
     manifest = contract_tooling.python_contract_consumption_manifest()
     entries = manifest["validated_at_consumption"]
@@ -142,6 +181,7 @@ def test_python_contract_consumption_declares_validated_loader_bindings() -> Non
             "command_adapter_generation_manifest",
         )
     }
+    assert any(entry["loader"] == "command_package_ir_manifest" for entry in entries)
     assert any(entry["loader"] == "lifecycle_generation_readiness_manifest" for entry in entries)
 
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4490,6 +4490,29 @@ def test_proof_changed_selector_returns_path_based_validation_lane(capsys) -> No
     assert answer["required_commands"] == ["agentic-workspace doctor --target ./repo --modules planning --format json"]
 
 
+def test_proof_changed_selector_routes_generated_command_packages(capsys) -> None:
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--changed",
+                "generated/typescript/workspace-cli/src/commandPackage.ts",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    answer = payload["answer"]
+    assert answer["selected_lanes"][0]["id"] == "generated_command_packages"
+    assert answer["required_commands"] == [
+        "uv run python scripts/check/check_generated_command_packages.py",
+        "uv run python scripts/check/check_generated_command_packages.py --docker",
+    ]
+
+
 def test_proof_changed_selector_escalates_for_cross_lane_changes(capsys) -> None:
     assert (
         cli.main(

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4513,6 +4513,17 @@ def test_proof_changed_selector_routes_generated_command_packages(capsys) -> Non
     ]
 
 
+def test_proof_changed_selector_flags_direct_cli_edits(capsys) -> None:
+    assert cli.main(["proof", "--changed", "src/agentic_workspace/cli.py", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    review = payload["answer"]["direct_cli_edit_review"]
+    assert review["status"] == "review-needed"
+    assert review["changed_paths"] == ["src/agentic_workspace/cli.py"]
+    assert "normal interface authoring belongs in command contracts" in review["rule"]
+    assert "runtime primitive implementation and live workspace inspection" in review["allowed_direct_cli_work"]
+
+
 def test_proof_changed_selector_escalates_for_cross_lane_changes(capsys) -> None:
     assert (
         cli.main(


### PR DESCRIPTION
## Summary
- Adds a command-package IR for generated CLI package targets and validates it through contract tooling.
- Generates Python metadata packages plus TypeScript proof fixtures for root, planning, and memory command surfaces.
- Adds generated-package proof routing, a Docker-selected TypeScript check surface, shell feasibility guidance, and direct cli.py edit guardrails.
- Archives the completed execplan and closes the #393 child lane evidence.

## Validation
- uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success
- uv run python scripts/check/check_generated_command_packages.py
- uv run python scripts/check/check_generated_command_packages.py --docker (Docker daemon unavailable locally; command skipped by design)
- uv run pytest tests/test_contract_tooling.py tests/test_workspace_cli.py -q
- uv run ruff check src tests scripts/check/check_generated_command_packages.py scripts/generate/generate_command_packages.py
- make maintainer-surfaces
- uv run agentic-workspace doctor --target . --modules planning --format json
- uv run agentic-workspace summary --format json

Closes #393
Closes #394
Closes #395
Closes #396
Closes #397
Closes #398
Closes #399
Closes #400
Closes #401