### PR TITLE
Preserve package-owned epic intent closeout

### DIFF
--- a/.agentic-workspace/planning/reviews/2026-05-12-epic-intent-satisfaction-915.review.json
+++ b/.agentic-workspace/planning/reviews/2026-05-12-epic-intent-satisfaction-915.review.json
@@ -1,0 +1,165 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Epic intent satisfaction review for #915",
+  "date": "2026-05-12",
+  "scope": [
+    "Package-owned planning surfaces must preserve original epic intent independently of external trackers"
+  ],
+  "classification": "dogfooding-intent-preservation",
+  "goal": [
+    "Review the #915 dogfooding signal and identify the package-owned planning semantics that must be changed before implementation."
+  ],
+  "non_goals": [
+    "Do not make GitHub, milestones, or any external tracker state authoritative for planning closeout.",
+    "Do not solve all epic planning semantics in one unbounded pass.",
+    "Do not convert review findings into implementation authority without preserving the upstream source reference."
+  ],
+  "review_mode": {
+    "mode": "planning-surface",
+    "review question": "Which package-owned Planning surface should prevent lane proof or external tracker state from substituting for original epic intent satisfaction?",
+    "default finding cap": "3 findings",
+    "inputs inspected first": "GitHub #915, GitHub #892 closeout comments, .agentic-workspace/planning/upstream-task-intake.md, .agentic-workspace/planning/state.toml, src/agentic_workspace/cli.py:_intent_satisfaction_check_payload"
+  },
+  "review_method": {
+    "commands used": "uv run agentic-workspace start --task \"Ingest #915, create a planning review, enrich the issue, then implement\" --format json; gh issue view 915 --json number,title,body,state,labels,url; gh issue view 892 --comments --json number,title,state,closed,closedAt,body,comments,url; rg intent satisfaction and closeout surfaces",
+    "evidence sources": "Issue #915 states the product-owned failure; #892 closeout demonstrates the failure pattern; upstream-task-intake states external trackers are intake only; _intent_satisfaction_check_payload separates validation proof from larger intent but only for active planning records."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/915",
+      "label": "#915",
+      "role": "upstream dogfooding signal",
+      "locator": "GitHub issue #915"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/892",
+      "label": "#892",
+      "role": "source event that exposed the gap",
+      "locator": "GitHub issue #892 closeout comments"
+    },
+    {
+      "kind": "planning-doc",
+      "target": ".agentic-workspace/planning/upstream-task-intake.md",
+      "label": "upstream intake contract",
+      "role": "authority rule for external trackers",
+      "locator": "Authority Rule"
+    },
+    {
+      "kind": "code",
+      "target": "src/agentic_workspace/cli.py",
+      "label": "_intent_satisfaction_check_payload",
+      "role": "current closeout trust implementation",
+      "locator": "function _intent_satisfaction_check_payload"
+    }
+  ],
+  "findings": [
+    {
+      "title": "Epic intent satisfaction only evaluates active planning records",
+      "summary": "The existing closeout trust payload correctly says validation success is not intent closure, but it returns unavailable when there is no active planning record. Epic-level work can therefore lose package-owned intent continuity after a bounded execplan is archived while decomposition or roadmap lanes still carry the larger outcome.",
+      "evidence": "src/agentic_workspace/cli.py:_intent_satisfaction_check_payload returns unavailable when no active planning record exposes intent-continuity evidence; #892 was closed after promoted lanes even though the larger codegen project and milestone remained open.",
+      "risk if unchanged": "Agents can complete and archive bounded lanes, then treat the absence of an active planning record as quiet state even when the original epic intent remains live elsewhere in package-owned surfaces.",
+      "suggested action": "Extend package-owned summary/closeout trust to inspect inactive epic/decomposition/roadmap continuation signals, not only active execplans, and classify unsatisfied original epic intent as follow-up-required.",
+      "confidence": "high",
+      "source": "mixed",
+      "promotion target": "Issue #915 implementation; src/agentic_workspace/cli.py closeout trust and planning summary tests",
+      "promotion trigger": "Before implementing #915, update the issue acceptance to require package-owned epic continuation detection without GitHub dependence.",
+      "post-remediation note shape": "shrink"
+    },
+    {
+      "title": "External tracker state can still be mistaken for intent authority",
+      "summary": "The upstream intake contract says external trackers are intake sources only, but the #892 failure shows closeout communication can still let external issue state imply that the package-owned epic intent is complete.",
+      "evidence": ".agentic-workspace/planning/upstream-task-intake.md says checked-in planning surfaces decide active scope and done state after promotion; #915 was created because #892 closure obscured open package-owned intent.",
+      "risk if unchanged": "The same failure can recur with any tracker, not only GitHub: Jira, Linear, Notion, or an internal task note could appear closed while package-owned intent remains unresolved.",
+      "suggested action": "Make issue enrichment and implementation language tracker-agnostic: external state may be recorded as evidence, but closeout trust must name package-owned continuation owners and satisfaction status.",
+      "confidence": "high",
+      "source": "friction-confirmed",
+      "promotion target": "Issue #915 acceptance and implementation tests",
+      "promotion trigger": "When enriching #915, remove GitHub-specific closure language from acceptance except as source event context.",
+      "post-remediation note shape": "shrink"
+    },
+    {
+      "title": "A minimal implementation slice can be bounded to detection and proof",
+      "summary": "The first implementation does not need to redesign all epic planning. A bounded slice can add a package-owned check that detects open decomposition or roadmap continuation after lane closeout and exposes it in summary/closeout trust as follow-up-required.",
+      "evidence": "#915 acceptance asks for a regression surface independent of GitHub; current planning summary already reports roadmap candidate counts and closeout trust already reports intent satisfaction state.",
+      "risk if unchanged": "Trying to solve the full epic model in one pass could add broad planning complexity while missing the dogfooding regression that triggered the work.",
+      "suggested action": "Implement the first slice as a tracker-agnostic planning-summary/closeout-trust guard with a test fixture modeled after #892: completed lane evidence plus open package-owned continuation must not be reported as satisfied.",
+      "confidence": "medium",
+      "source": "static-analysis",
+      "promotion target": "Active #915 implementation slice",
+      "promotion trigger": "After issue enrichment records the bounded first slice.",
+      "post-remediation note shape": "shrink"
+    }
+  ],
+  "recommendation": {
+    "promote": "Promote #915 into an active bounded implementation slice after enriching the issue with this review's tracker-agnostic package-owned acceptance.",
+    "defer": "Defer broader epic-model redesign until the first detection/proof slice exposes the exact missing package-owned state.",
+    "dismiss": "Do not pursue GitHub-specific issue-closure blocking; that was the symptom, not the planning contract owner."
+  },
+  "retention": {
+    "closeout shape": "shrink",
+    "trigger": "Issue #915 has been enriched and the first package-owned detection/proof slice lands.",
+    "proof surface": "Issue #915, planning summary/closeout trust tests, and the implementation commit",
+    "source retention rule": "Keep this review as compact evidence of the dogfooding judgment; do not retain full issue text once the issue and tests carry the durable contract.",
+    "distillation path": "After implementation, shrink to the findings that remain useful or stub to #915 and the regression test.",
+    "reconstructable refs": [
+      "GitHub issue #915",
+      "GitHub issue #892",
+      "src/agentic_workspace/cli.py:_intent_satisfaction_check_payload"
+    ],
+    "fields intentionally omitted": [
+      "full issue transcripts",
+      "long command output",
+      "GitHub milestone state snapshots"
+    ]
+  },
+  "prose_templates": {
+    "review_finding": {
+      "sections": [
+        "Finding",
+        "Evidence",
+        "Impact",
+        "Recommendation",
+        "Owner",
+        "Status"
+      ],
+      "field_map": {
+        "Finding": "findings[].title + findings[].summary",
+        "Evidence": "findings[].evidence + findings[].source",
+        "Impact": "findings[].risk if unchanged",
+        "Recommendation": "findings[].suggested action + findings[].promotion target",
+        "Owner": "findings[].promotion target",
+        "Status": "recommendation/promote|defer|dismiss"
+      },
+      "rule": "Use only these headings when a prose finding is needed; keep the canonical fields structured."
+    },
+    "handoff_or_closeout": {
+      "sections": [
+        "Intent",
+        "What changed",
+        "Proof",
+        "Remaining risk",
+        "Durable residue",
+        "Next owner"
+      ],
+      "field_map": {
+        "Intent": "intent/outcome or requested_outcome",
+        "What changed": "execution_summary/outcome delivered",
+        "Proof": "proof_report/validation proof",
+        "Remaining risk": "finished_run_review/misinterpretation risk or follow-on decision",
+        "Durable residue": "durable_residue + closeout_distillation",
+        "Next owner": "execution_summary/follow-on routed to or required_continuation/owner surface"
+      },
+      "rule": "Prefer structured fields; use this shape only for short human-readable summaries."
+    }
+  },
+  "validation_commands": [
+    "uv run agentic-planning create-review epic-intent-satisfaction-915 --title \"Epic intent satisfaction review for #915\" --scope \"Package-owned planning surfaces must preserve original epic intent independently of external trackers\" --classification \"dogfooding-intent-preservation\" --format json",
+    "uv run agentic-workspace summary --format json"
+  ],
+  "drift_log": [
+    "2026-05-12: Review record created by create-review.",
+    "2026-05-12: Review filled from #915/#892 dogfooding evidence before implementation."
+  ]
+}

--- a/docs/reference/proof-route-hints.md
+++ b/docs/reference/proof-route-hints.md
@@ -15,4 +15,10 @@ Advisory proof route hints discovered during lifecycle setup/adopt. Hints are no
 | `schema_version` | const `"proof-route-hints/v1"` | yes |  | Version of the proof route hints contract. |  |  |
 | `source` | string | yes |  | Repo-relative source path or setup phase that produced these hints. |  |  |
 | `rule` | string | yes |  | Human-readable safety rule explaining how consumers should treat these hints. |  |  |
+| `learning_policy` | object | yes |  | Policy separating setup/adopt-learned hints from live capabilities and configured proof policy. |  |  |
+| `learning_policy.kind` | const `"setup-adopt-proof-route-learning-policy/v1"` | yes |  | Discriminator identifying the policy that governs setup/adopt-learned proof route hints. |  |  |
+| `learning_policy.persistence` | const `"advisory-hints"` | yes |  | Declares that discovered proof routes are retained only as advisory hints, not authoritative proof policy. |  |  |
+| `learning_policy.authoritative_selection` | const `"live-target-capabilities"` | yes |  | Declares that current target capabilities remain authoritative when selecting proof commands. |  |  |
+| `learning_policy.configured_policy_role` | string | yes |  | Explains how configured proof policy relates to learned advisory hints. |  |  |
+| `learning_policy.route_map_decision` | const `"do-not-create-second-route-map-unless-live-discovery-proves-insufficient"` | yes |  | Prevents learned setup/adopt hints from becoming a parallel route map unless live discovery cannot select proof. |  |  |
 | `hints` | array of object | yes |  | Advisory proof command candidates that still require live confirmation before use. |  |  |

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -8749,8 +8749,10 @@ def create_execplan_scaffold(
 
     if dry_run:
         result.add("would create" if not record_path.exists() else "would update", record_path, "schema-valid execplan scaffold")
-        if activate and switch_active and isinstance((state.get("todo") or {}).get("active_items"), list):
-            active_count = len((state.get("todo") or {}).get("active_items", []))
+        state_todo = state.get("todo")
+        state_active_items = state_todo.get("active_items", []) if isinstance(state_todo, dict) else []
+        if activate and switch_active and isinstance(state_active_items, list):
+            active_count = len(state_active_items)
             if active_count:
                 result.add("would update", state_path, f"demote {active_count} active planning item(s) into todo.queued_items")
         if activate or queue:

--- a/src/agentic_workspace/cli.py
+++ b/src/agentic_workspace/cli.py
@@ -7983,6 +7983,7 @@ def _report_closeout_trust_payload(
     ]
     sample_signals = [message for message in sample_signals if message][:3]
     package_workflow_evidence = _package_workflow_evidence_payload(planning_report=planning_report)
+    intent_satisfaction_check = _intent_satisfaction_check_payload(planning_report=planning_report)
     acceptance_reconciliation = _acceptance_criteria_reconciliation_payload(planning_report=planning_report)
     active_planning_record = package_workflow_evidence.get("status") == "present"
     package_absence_signals: list[str] = []
@@ -7995,10 +7996,20 @@ def _report_closeout_trust_payload(
     effective_lower_trust_count = lower_trust_closeout_count + len(package_absence_signals)
     if acceptance_reconciliation.get("trust") == "lower-trust":
         effective_lower_trust_count += 1
+    intent_satisfaction_trust = str(intent_satisfaction_check.get("trust", ""))
+    intent_satisfaction_lower_trust_count = 1 if intent_satisfaction_trust in {"follow-up-required", "needs-review"} else 0
+    effective_lower_trust_count += intent_satisfaction_lower_trust_count
+    intent_satisfaction_signals: list[str] = []
+    if intent_satisfaction_lower_trust_count:
+        continuation_surface = str(intent_satisfaction_check.get("continuation_surface", "")).strip()
+        continuation_summary = f" via {continuation_surface}" if continuation_surface else ""
+        intent_satisfaction_signals.append(
+            f"Intent satisfaction is {intent_satisfaction_trust}{continuation_summary}; closeout needs package-owned continuation evidence before it is normal-trust."
+        )
     trust = "lower-trust" if effective_lower_trust_count > 0 else "normal"
     if trust == "lower-trust":
         summary = (
-            f"{effective_lower_trust_count} closeout signal(s) suggest package bypass, missing package evidence, or missing planning residue; "
+            f"{effective_lower_trust_count} closeout signal(s) suggest package bypass, missing package evidence, unsatisfied intent, or missing planning residue; "
             "treat closeout trust as lower until checked-in residue is visible."
         )
         recommended_next_action = str(
@@ -8020,11 +8031,12 @@ def _report_closeout_trust_payload(
         "planning_residue_lower_trust_count": lower_trust_closeout_count,
         "package_evidence_lower_trust_count": len(package_absence_signals),
         "acceptance_reconciliation_lower_trust_count": 1 if acceptance_reconciliation.get("trust") == "lower-trust" else 0,
+        "intent_satisfaction_lower_trust_count": intent_satisfaction_lower_trust_count,
         "summary": summary,
-        "sample_signals": [*sample_signals, *package_absence_signals][:3],
+        "sample_signals": [*sample_signals, *package_absence_signals, *intent_satisfaction_signals][:3],
         "absence_signals": package_absence_signals,
         "package_workflow_evidence": package_workflow_evidence,
-        "intent_satisfaction_check": _intent_satisfaction_check_payload(planning_report=planning_report),
+        "intent_satisfaction_check": intent_satisfaction_check,
         "acceptance_criteria_reconciliation": acceptance_reconciliation,
         "historical_review_artifacts": _historical_review_artifacts_policy(
             planning_report=planning_report,
@@ -8319,10 +8331,149 @@ def _package_workflow_evidence_payload(*, planning_report: dict[str, Any]) -> di
     }
 
 
+def _open_package_owned_continuation_payload(*, planning_report: dict[str, Any]) -> dict[str, Any]:
+    closed_statuses = {"archive", "archived", "cancelled", "canceled", "closed", "complete", "completed", "dismissed", "done"}
+
+    def is_open_status(value: Any) -> bool:
+        normalized = str(value or "").strip().lower()
+        return not normalized or normalized not in closed_statuses
+
+    surfaces: list[dict[str, Any]] = []
+    work_maturity = planning_report.get("work_maturity", {}) if isinstance(planning_report, dict) else {}
+    if isinstance(work_maturity, dict):
+        for bucket_name in ("ready_slices", "needs_shaping", "deferred_lanes", "blocked_items", "residue_routing_needed"):
+            bucket = work_maturity.get(bucket_name, [])
+            if not isinstance(bucket, list):
+                continue
+            for item in bucket:
+                if not isinstance(item, dict) or not is_open_status(item.get("status")):
+                    continue
+                source_bucket = str(item.get("source_bucket", "")).strip()
+                surfaces.append(
+                    {
+                        "kind": f"work_maturity.{bucket_name}",
+                        "id": item.get("id", ""),
+                        "title": item.get("title", item.get("summary", "")),
+                        "status": item.get("status", ""),
+                        "maturity": item.get("maturity", ""),
+                        "refs": item.get("refs", item.get("issues", "")),
+                        "owner_surface": (
+                            ".agentic-workspace/planning/state.toml"
+                            if source_bucket.startswith("roadmap.")
+                            else source_bucket or ".agentic-workspace/planning/state.toml"
+                        ),
+                        "suggested_first_slice": item.get("suggested_first_slice", ""),
+                    }
+                )
+
+    roadmap = planning_report.get("roadmap", {}) if isinstance(planning_report, dict) else {}
+    if isinstance(roadmap, dict):
+        for bucket_name in ("candidate_lanes", "candidates"):
+            bucket = roadmap.get(bucket_name, [])
+            if not isinstance(bucket, list):
+                continue
+            for item in bucket:
+                if not isinstance(item, dict) or not is_open_status(item.get("status")):
+                    continue
+                surfaces.append(
+                    {
+                        "kind": f"roadmap.{bucket_name}",
+                        "id": item.get("id", ""),
+                        "title": item.get("title", item.get("summary", "")),
+                        "status": item.get("status", ""),
+                        "maturity": item.get("maturity", ""),
+                        "refs": item.get("refs", item.get("issues", "")),
+                        "owner_surface": ".agentic-workspace/planning/state.toml",
+                        "suggested_first_slice": item.get("suggested_first_slice", ""),
+                    }
+                )
+
+    decomposition = planning_report.get("decomposition", {}) if isinstance(planning_report, dict) else {}
+    if isinstance(decomposition, dict):
+        for record in _list_payload(decomposition.get("records")):
+            if not isinstance(record, dict) or not is_open_status(record.get("status")):
+                continue
+            candidate_lanes = [lane for lane in _list_payload(record.get("candidate_lanes")) if isinstance(lane, dict)]
+            surfaces.append(
+                {
+                    "kind": "decomposition.record",
+                    "id": record.get("path", ""),
+                    "title": record.get("title", ""),
+                    "status": record.get("status", ""),
+                    "owner_surface": record.get("path", ".agentic-workspace/planning/decompositions/"),
+                    "lane_count": record.get("lane_count", len(candidate_lanes)),
+                    "ready_lane_count": record.get("ready_lane_count", 0),
+                    "candidate_lane_ids": [str(lane.get("id", "")) for lane in candidate_lanes if str(lane.get("id", "")).strip()][:5],
+                }
+            )
+
+    surfaces = [
+        surface for surface in surfaces if str(surface.get("id") or surface.get("title") or surface.get("owner_surface") or "").strip()
+    ]
+    if not surfaces:
+        return {
+            "status": "quiet",
+            "surface_count": 0,
+            "surfaces": [],
+            "rule": "When no active planning record exists, package-owned roadmap and decomposition surfaces are still checked before intent closeout is trusted.",
+        }
+    return {
+        "status": "present",
+        "surface_count": len(surfaces),
+        "surfaces": surfaces[:5],
+        "owner_surfaces": sorted(
+            {str(surface.get("owner_surface", "")).strip() for surface in surfaces if str(surface.get("owner_surface", "")).strip()}
+        ),
+        "rule": "Open package-owned roadmap or decomposition continuation means quiet active state is not evidence of epic intent satisfaction.",
+    }
+
+
 def _intent_satisfaction_check_payload(*, planning_report: dict[str, Any]) -> dict[str, Any]:
     active = planning_report.get("active", {}) if isinstance(planning_report, dict) else {}
     planning_record = active.get("planning_record", {}) if isinstance(active, dict) else {}
     if not isinstance(planning_record, dict) or planning_record.get("status") != "present":
+        open_continuation = _open_package_owned_continuation_payload(planning_report=planning_report)
+        if open_continuation.get("status") == "present":
+            owner_surfaces = [str(item) for item in _list_payload(open_continuation.get("owner_surfaces"))]
+            continuation_surface = owner_surfaces[0] if owner_surfaces else ".agentic-workspace/planning/"
+            return {
+                "status": "present",
+                "trust": "follow-up-required",
+                "reason": "no active planning record, but package-owned continuation surfaces remain open",
+                "required_for_broad_work": True,
+                "larger_intent": "",
+                "slice_completes_larger_intent": "unknown",
+                "required_follow_on": "yes",
+                "continuation_surface": continuation_surface,
+                "package_owned_continuation": open_continuation,
+                "rule": "Validation success is not enough; package-owned roadmap or decomposition continuation must be routed before closeout can claim larger intent satisfaction.",
+                "closure_scope": {
+                    "validation_proof": {
+                        "status": "separate-answer",
+                        "not_sufficient_for_closure": True,
+                        "rule": "Validation success proves implementation behavior, not intent closure by itself.",
+                    },
+                    "requested_slice": {"status": "unavailable"},
+                    "lane_or_system_intent": {
+                        "status": "follow-up-required",
+                        "required_follow_on": "yes",
+                        "continuation_surface": continuation_surface,
+                        "sources": [
+                            "planning.roadmap",
+                            "planning.decomposition",
+                        ],
+                    },
+                    "larger_intent_closure": {
+                        "status": "open",
+                        "closure_decision": "requires-package-owned-continuation",
+                        "evidence": "open package-owned roadmap or decomposition continuation",
+                        "source": "planning roadmap/decomposition state",
+                        "rule": "External tracker state is evidence only; package-owned continuation controls intent satisfaction.",
+                    },
+                    "non_substitution_rule": "Validation success alone is not closure evidence.",
+                },
+                "recommended_next_action": "Promote, continue, or explicitly close the package-owned continuation surface before treating broad closeout as satisfied.",
+            }
         return {
             "status": "unavailable",
             "reason": "no active planning record exposes intent-continuity evidence",

--- a/src/agentic_workspace/contracts/schemas/proof_route_hints.schema.json
+++ b/src/agentic_workspace/contracts/schemas/proof_route_hints.schema.json
@@ -42,20 +42,25 @@
       ],
       "properties": {
         "kind": {
-          "const": "setup-adopt-proof-route-learning-policy/v1"
+          "const": "setup-adopt-proof-route-learning-policy/v1",
+          "description": "Discriminator identifying the policy that governs setup/adopt-learned proof route hints."
         },
         "persistence": {
-          "const": "advisory-hints"
+          "const": "advisory-hints",
+          "description": "Declares that discovered proof routes are retained only as advisory hints, not authoritative proof policy."
         },
         "authoritative_selection": {
-          "const": "live-target-capabilities"
+          "const": "live-target-capabilities",
+          "description": "Declares that current target capabilities remain authoritative when selecting proof commands."
         },
         "configured_policy_role": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Explains how configured proof policy relates to learned advisory hints."
         },
         "route_map_decision": {
-          "const": "do-not-create-second-route-map-unless-live-discovery-proves-insufficient"
+          "const": "do-not-create-second-route-map-unless-live-discovery-proves-insufficient",
+          "description": "Prevents learned setup/adopt hints from becoming a parallel route map unless live discovery cannot select proof."
         }
       },
       "additionalProperties": false,

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -1303,8 +1303,9 @@ def test_report_closeout_trust_surfaces_package_workflow_evidence(tmp_path: Path
     assert cli.main(["report", "--target", str(target), "--verbose", "--format", "json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["closeout_trust"]["strict_closeout_gate"]["status"] == "allowed"
-    assert payload["closeout_trust"]["strict_closeout_gate"]["blocking"] is False
+    assert payload["closeout_trust"]["strict_closeout_gate"]["status"] == "blocked"
+    assert payload["closeout_trust"]["strict_closeout_gate"]["blocking"] is True
+    assert payload["closeout_trust"]["intent_satisfaction_lower_trust_count"] == 1
     evidence = payload["closeout_trust"]["package_workflow_evidence"]
     assert evidence["status"] == "present"
     assert evidence["trust"] == "normal"
@@ -1339,10 +1340,87 @@ def test_report_closeout_trust_surfaces_package_workflow_evidence(tmp_path: Path
     assert "future work goes to planning" in residue_action["destination_rule"]
     assert "rerun summary/reconcile" in residue_action["next_proof"]
     terminal_action = payload["closeout_trust"]["terminal_action"]
-    assert terminal_action["blocking"] is False
-    assert terminal_action["next_command"] == "none"
-    assert "No closeout trust blocker" in terminal_action["why"]
-    assert "proof, intent satisfaction, issue state" in terminal_action["changes_closure"]
+    assert terminal_action["blocking"] is True
+    assert terminal_action["next_command"] == "agentic-workspace report --target ./repo --section closeout_trust --format json"
+    assert "Lower-trust closeout signals" in terminal_action["why"]
+    assert "lower_trust_closeout_count is 0" in terminal_action["changes_closure"]
+
+
+def test_report_closeout_trust_lowers_trust_for_open_package_owned_continuation_without_active_plan(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write(
+        target / ".agentic-workspace" / "config.toml",
+        "schema_version = 1\n\n[assurance]\nstrict_closeout = true\n",
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "epic-continuation", maturity = "candidate", status = "next", priority = "P1", refs = "package-owned-only", title = "Continue epic", outcome = "Finish the original epic intent.", reason = "A completed lane did not satisfy the larger intent.", promotion_signal = "Promote before closeout.", suggested_first_slice = "Promote the next lane." },
+]
+""",
+    )
+    (target / ".agentic-workspace" / "planning" / "decompositions").mkdir(parents=True, exist_ok=True)
+    _write_json(
+        target / ".agentic-workspace" / "planning" / "decompositions" / "epic-continuation.decomposition.json",
+        {
+            "kind": "planning-decomposition/v1",
+            "title": "Epic continuation",
+            "outcome": "Finish the original epic intent.",
+            "status": "ready-for-lane-promotion",
+            "lanes": [
+                {
+                    "id": "next-lane",
+                    "title": "Next lane",
+                    "readiness": "ready",
+                    "owner_surface": ".agentic-workspace/planning/state.toml",
+                }
+            ],
+        },
+    )
+
+    assert cli.main(["report", "--target", str(target), "--verbose", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    closeout = payload["closeout_trust"]
+    assert closeout["trust"] == "lower-trust"
+    assert closeout["strict_closeout_gate"]["status"] == "blocked"
+    assert closeout["lower_trust_closeout_count"] == 1
+    assert closeout["planning_residue_lower_trust_count"] == 0
+    assert closeout["package_evidence_lower_trust_count"] == 0
+    assert closeout["acceptance_reconciliation_lower_trust_count"] == 0
+    assert closeout["intent_satisfaction_lower_trust_count"] == 1
+    intent_check = closeout["intent_satisfaction_check"]
+    assert intent_check["status"] == "present"
+    assert intent_check["trust"] == "follow-up-required"
+    assert intent_check["reason"] == "no active planning record, but package-owned continuation surfaces remain open"
+    continuation = intent_check["package_owned_continuation"]
+    assert continuation["status"] == "present"
+    assert continuation["surface_count"] >= 1
+    assert ".agentic-workspace/planning/state.toml" in continuation["owner_surfaces"]
+    assert intent_check["closure_scope"]["larger_intent_closure"]["status"] == "open"
+    assert "package-owned continuation" in intent_check["recommended_next_action"]
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+    section_payload = json.loads(capsys.readouterr().out)
+    answer = section_payload["answer"]
+    assert answer["trust"] == "lower-trust"
+    assert answer["lower_trust_closeout_count"] == 1
+    assert answer["checks"]["intent_satisfaction"]["status"] == "present"
+    assert answer["checks"]["intent_satisfaction"]["trust"] == "follow-up-required"
 
 
 def test_report_closeout_trust_lowers_trust_when_active_plan_has_no_package_evidence(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Adds a package-owned continuation check to closeout intent satisfaction when no active planning record exists.
- Counts `follow-up-required` or `needs-review` intent satisfaction as lower-trust closeout evidence.
- Adds a regression for the #892-style failure: quiet active state plus open package-owned roadmap/decomposition continuation cannot be treated as satisfied closeout.
- Records the pre-implementation planning review in `.agentic-workspace/planning/reviews/2026-05-12-epic-intent-satisfaction-915.review.json`.

## Proof
- `uv run pytest tests/test_workspace_report_cli.py -q`
- `uv run ruff check src/agentic_workspace/cli.py tests/test_workspace_report_cli.py`
- `uv run agentic-planning summary --target . --verbose --format json`
- `uv run agentic-workspace doctor --target . --modules planning --format json`
- `uv run agentic-workspace report --target . --section closeout_trust --format json`
- `uv run agentic-workspace proof --changed src/agentic_workspace/cli.py tests/test_workspace_report_cli.py .agentic-workspace/planning/reviews/2026-05-12-epic-intent-satisfaction-915.review.json --format json`
- `make test-workspace`
- `make lint-workspace`
- `uv run agentic-workspace defaults --section root_cli_authority --format json`
- `uv run pytest tests/test_workspace_cli.py -q`

Closes #915