### PR TITLE
Add Planning closeout writer

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/github-1024-planning-closeout-writer.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1024-planning-closeout-writer.plan.json
@@ -1,0 +1,304 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Make Planning closeout a command-owned writer",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1024 by making ordinary Planning closeout a command-owned writer affordance.",
+    "hard_constraints": "Keep #1021 parent lane open; do not select deferred codegen backlog; preserve archive validation as the honesty gate.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Archive this completed #1024 slice with planning closeout.",
+    "proof_expectations": [
+      "Focused closeout tests; test_contract_tooling; make test-planning; make test-workspace; make lint-planning; make lint-workspace; make maintainer-surfaces; generated package static/conformance checks; structured inventory."
+    ],
+    "touched_scope": [
+      "Planning closeout runtime and contracts; generated Planning/workspace command outputs; focused Planning/workspace/contract tests."
+    ],
+    "completion_criteria": [
+      "planning closeout command exists and owns common closeout state mutation",
+      "lane/epic proxy closure is blocked or routed as continuation",
+      "residue and proof inputs are structured and validated",
+      "workspace front door forwards closeout positionally"
+    ],
+    "continuation_owner": "#1021",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Implement #1024 as a narrow source-boundary slice: `planning closeout` writes structured closeout fields, routes residue/proof inputs, runs archive validation, and emits the next safe action."
+  ],
+  "non_goals": [
+    "Do not solve every external tracker integration.",
+    "Do not force Planning closeout for unplanned direct edits.",
+    "Do not reopen deferred codegen work."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Make Planning closeout a command-owned writer.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    },
+    "execution": {
+      "milestone": "github-1024-planning-closeout-writer",
+      "status": "active",
+      "next_step": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+      "proof": "Fill in the narrowest command that proves the promoted work."
+    },
+    "scope": {
+      "touched": [
+        "Fill in the concrete files before implementation starts."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "#1021 source-boundary lane: subtract compensating machinery by enforcing write boundaries at the source.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "#1021"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "#1021",
+    "activation trigger": "after #1024 lands and the next source-boundary compensating machinery is selected"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Agents can close ordinary planned work through `agentic-workspace planning closeout` instead of hand-editing closeout fields.",
+    "intentionally deferred": "Remaining #1021 source-boundary slices after #1024.",
+    "discovered implications": "New lifecycle operations must be registered in operation, conformance, adapter, inventory, payload-classification, and generated command surfaces.",
+    "proof achieved now": "yes",
+    "validation still needed": "CI on PR",
+    "next likely slice": "Select the next non-codegen #1021 child or close parent if no compensating machinery remains."
+  },
+  "intent_interpretation": {
+    "literal request": "Make Planning closeout a command-owned writer",
+    "inferred intended outcome": "Create a bounded plan for Make Planning closeout a command-owned writer.",
+    "chosen concrete what": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "Planning closeout runtime and contracts; generated Planning/workspace command outputs; focused Planning/workspace/contract tests.",
+    "max changed files": "Broad generated-output fanout is allowed only as regeneration from command_package_ir and command_adapter_generation sources.",
+    "required validation commands": "Focused closeout tests; test_contract_tooling; make test-planning; make test-workspace; make lint-planning; make lint-workspace; make maintainer-surfaces; generated package static/conformance checks; structured inventory.",
+    "ask-before-refactor threshold": "Any change outside the closeout writer/front-door/contract fanout.",
+    "stop before touching": "Deferred codegen backlog or unrelated Planning lifecycle commands."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "Closeout writer runtime, operation contracts, generated command outputs, and focused tests.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archive complete; #1021 remains continuation owner.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Make Planning closeout a command-owned writer.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "completed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "Closeout writer changes are tightly coupled across Planning runtime, operation contracts, generated command surfaces, and focused tests; local execution keeps the source-boundary validation coherent.",
+    "decision command": "agentic-planning delegation-decision",
+    "recorded at": "2026-05-17T13:44:26+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1024-planning-closeout-writer",
+    "status": "completed",
+    "scope": "#1024 Planning closeout writer slice",
+    "ready": "complete",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run planning closeout for this completed slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "Planning closeout runtime and contracts; generated Planning/workspace command outputs; focused Planning/workspace/contract tests."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "Focused closeout tests; test_contract_tooling; make test-planning; make test-workspace; make lint-planning; make lint-workspace; make maintainer-surfaces; generated package static/conformance checks; structured inventory."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Make Planning closeout a command-owned writer is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "local",
+    "handoff source": "active execplan github-1024-planning-closeout-writer",
+    "what happened": "Added planning closeout as the primary command-owned writer for ordinary planned-work closeout; it records residue/proof inputs, uses archive validation, blocks dishonest proxy closure, and is exposed through the workspace front door.",
+    "scope touched": "Planning closeout runtime and contracts; generated Planning/workspace command outputs; focused Planning/workspace/contract tests.",
+    "changed surfaces": "Planning closeout runtime and contracts; generated Planning/workspace command outputs; focused Planning/workspace/contract tests.",
+    "validations run": "Focused closeout tests; test_contract_tooling; make test-planning; make test-workspace; make lint-planning; make lint-workspace; make maintainer-surfaces; generated package static/conformance checks; structured inventory.",
+    "result for continuation": "#1024 is complete; #1021 remains open for the next source-boundary slice.",
+    "next step": "Create PR linked to #1024 and #1021."
+  },
+  "finished_run_review": {
+    "review status": "completed",
+    "scope respected": "yes",
+    "proof status": "satisfied",
+    "intent served": "yes for #1024; parent #1021 remains open",
+    "config compliance": "used AW start, active execplan, delegation decision, implement/proof routing, and package-owned Planning mutations",
+    "misinterpretation risk": "low",
+    "follow-on decision": "archive-but-keep-lane-open"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "Closeout writer changes are tightly coupled across Planning runtime, operation contracts, generated command surfaces, and focused tests.",
+    "expected savings": "low after implementation context is loaded",
+    "actual friction": "none beyond generated contract regeneration",
+    "proof result": "passed",
+    "quality concern": "generated and registry drift was caught and fixed",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Focused closeout tests; test_contract_tooling; make test-planning; make test-workspace; make lint-planning; make lint-workspace; make maintainer-surfaces; generated package static/conformance checks; structured inventory.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "Focused closeout tests; test_contract_tooling; make test-planning; make test-workspace; make lint-planning; make lint-workspace; make maintainer-surfaces; generated package static/conformance checks; structured inventory."
+  },
+  "intent_satisfaction": {
+    "original intent": "Continue with the #1021 lane starting with #1024.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "#1024 now has a single command-owned closeout path with tests for direct closeout, partial lane continuation, proxy closeout blocking, residue routing, and workspace front-door forwarding.",
+    "unsolved intent passed to": "#1021"
+  },
+  "execution_summary": {
+    "outcome delivered": "Implemented Planning closeout writer and exposed it through generated Planning/workspace command surfaces.",
+    "validation confirmed": "Focused closeout tests; test_contract_tooling; make test-planning; make test-workspace; make lint-planning; make lint-workspace; make maintainer-surfaces; generated package static/conformance checks; structured inventory.",
+    "follow-on routed to": "#1021",
+    "post-work posterity capture": "archived execplan plus PR links to #1024/#1021",
+    "knowledge promoted (Memory/Docs/Config)": "none",
+    "resume from": "#1021 next slice after this PR"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to #1021.",
+    "motivation worth preserving": "Future agents should continue from #1021 rather than rediscover this closeout residue.",
+    "canonical owner now": "#1021",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "#1021",
+    "proposed durable intent": "Future agents should continue from #1021 rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": "True",
+    "owner surface": "#1021"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "bounded slice complete",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status partial.",
+    "evidence carried forward": "planning closeout wrote structured closeout fields and archive validation accepted the result.",
+    "reopen trigger": "Reopen when #1021 activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "pending",
+    "guidance": "At closeout, separate acted-on, reported-only/routed, and dismissed incidental findings; keep this compact and evidence-backed.",
+    "source": "operating_posture",
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": ""
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "#1021",
+          "owner": "#1021",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-05-17: Scaffolded by agentic-planning new-plan.",
+    "2026-05-17: Implemented and validated #1024; closeout distilled for archive-size guardrail."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "#1021",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Continue with the #1021 lane starting with #1024.\nIntent satisfied: yes\nArchive decision: archive-but-keep-lane-open\nProof: Focused closeout tests; test_contract_tooling; make test-planning; make test-workspace; make lint-planning; make lint-workspace; make maintainer-surfaces; generated package static/conformance checks; structured inventory.\nChanged surfaces: Planning closeout runtime and contracts; generated Planning/workspace command outputs; focused Planning/workspace/contract tests.\nDurable residue: planning (#1021)\nMemory learning: route_to_planning\nFollow-up: #1021"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/github-1028-intent-status-review-fix.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1028-intent-status-review-fix.plan.json
@@ -1,0 +1,307 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Fix closeout intent status review comment",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for Fix closeout intent status review comment.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Archive this completed PR-comment fix after validation.",
+    "proof_expectations": [
+      "Focused closeout regression tests, make test-planning, make lint-planning, workspace summary, Planning doctor, and git diff --check pass."
+    ],
+    "touched_scope": [
+      "packages/planning/src/repo_planning_bootstrap/installer.py",
+      "packages/planning/tests/test_archive.py"
+    ],
+    "completion_criteria": [
+      "Fix closeout intent status review comment is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Fix closeout intent status review comment."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Fix closeout intent status review comment.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    },
+    "execution": {
+      "milestone": "github-1028-intent-status-review-fix",
+      "status": "completed",
+      "next_step": "Archive this completed PR-comment fix after validation.",
+      "proof": "Focused closeout regression tests, make test-planning, make lint-planning, workspace summary, Planning doctor, and git diff --check pass."
+    },
+    "scope": {
+      "touched": [
+        "packages/planning/src/repo_planning_bootstrap/installer.py",
+        "packages/planning/tests/test_archive.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Fix closeout intent status review comment.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "pending",
+    "validation still needed": "current milestone validation remains pending",
+    "next likely slice": "continue the current milestone until the completion criteria are met"
+  },
+  "intent_interpretation": {
+    "literal request": "Fix closeout intent status review comment",
+    "inferred intended outcome": "Create a bounded plan for Fix closeout intent status review comment.",
+    "chosen concrete what": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "Fill in the concrete write scope before implementation starts.",
+    "max changed files": "Fill in an expected upper bound before implementation starts.",
+    "required validation commands": "Fill in the narrowest command that proves the promoted work.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Fix closeout intent status review comment.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "PR review fix is a narrow semantic correction in the closeout writer plus focused regression tests; delegating would add coordination overhead without reducing proof risk.",
+    "decision command": "agentic-planning delegation-decision",
+    "recorded at": "2026-05-17T14:59:10+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1028-intent-status-review-fix",
+    "status": "completed",
+    "scope": "Address the PR review comment on closeout intent status mapping.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Archive this completed PR-comment fix after validation."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "packages/planning/src/repo_planning_bootstrap/installer.py",
+    "packages/planning/tests/test_archive.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest packages/planning/tests/test_archive.py::test_planning_closeout_routes_partial_lane_residue_to_continuation packages/planning/tests/test_archive.py::test_planning_closeout_routes_deferred_owner_without_full_intent_satisfaction packages/planning/tests/test_archive.py::test_planning_closeout_archives_direct_slice_without_manual_closeout_edits -q",
+    "make test-planning",
+    "make lint-planning",
+    "uv run agentic-workspace summary --target . --verbose --format json",
+    "uv run agentic-workspace doctor --target . --modules planning --format json",
+    "git diff --check"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Fix closeout intent status review comment is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Fixed closeout intent satisfaction mapping so only intent-status=satisfied records full original intent satisfaction.",
+    "scope touched": "Planning closeout writer and closeout regression tests.",
+    "changed surfaces": "packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_archive.py",
+    "validations run": "Focused closeout regression tests; make test-planning; make lint-planning; agentic-workspace summary; agentic-workspace doctor --modules planning; git diff --check",
+    "result for continuation": "PR review comment addressed on the existing #1024 branch.",
+    "next step": "Push the PR update and let CI re-run."
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "yes; fix stayed within the closeout writer and closeout tests.",
+    "proof status": "passed",
+    "intent served": "yes; partial and deferred-with-owner no longer record full intent satisfaction.",
+    "config compliance": "used workspace start, implement, summary, doctor, and Planning closeout commands.",
+    "misinterpretation risk": "low",
+    "follow-on decision": "push PR update"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "PR review fix is a narrow semantic correction in the closeout writer plus focused regression tests; delegating would add coordination overhead without reducing proof risk.",
+    "expected savings": "unknown",
+    "actual friction": "low",
+    "proof result": "passed",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Focused closeout regression tests; make test-planning; make lint-planning; agentic-workspace summary; agentic-workspace doctor --modules planning; git diff --check",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "Focused closeout regression tests; make test-planning; make lint-planning; agentic-workspace summary; agentic-workspace doctor --modules planning; git diff --check"
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Fix closeout intent status review comment.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "The PR review comment requested partial/deferred intent mapping fixes and tests; both are present and validated.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "PR review comment addressed.",
+    "validation confirmed": "Focused regression tests, make test-planning, make lint-planning, workspace summary, Planning doctor, and git diff --check passed.",
+    "follow-on routed to": "PR #1028 CI/review",
+    "post-work posterity capture": "archived execplan",
+    "knowledge promoted (Memory/Docs/Config)": "none",
+    "resume from": "PR #1028"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": "True",
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "planning closeout wrote structured closeout fields and archive validation accepted the result.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "pending",
+    "guidance": "At closeout, separate acted-on, reported-only/routed, and dismissed incidental findings; keep this compact and evidence-backed.",
+    "source": "operating_posture",
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": ""
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "PR #1028 CI/review",
+          "owner": "none",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-05-17: Scaffolded by agentic-planning new-plan.",
+    "2026-05-17: Recorded delegation decision route=keep-local."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Fix closeout intent status review comment.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Focused closeout regression tests; make test-planning; make lint-planning; agentic-workspace summary; agentic-workspace doctor --modules planning; git diff --check\nChanged surfaces: packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_archive.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: PR #1028 CI/review"
+  }
+}

--- a/.agentic-workspace/planning/mutation-provenance.json
+++ b/.agentic-workspace/planning/mutation-provenance.json
@@ -3,110 +3,6 @@
   "entries": [
     {
       "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "d0dd1302538b83c81abf7ddc3a53a7c2a889565142b2d350ae7a0f82678e622c",
-      "command": "agentic-planning new-plan",
-      "reason": "create execplan scaffold python-planning-runtime-facade",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:10:14+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-planning-runtime-facade.plan.json",
-      "sha256": "214d78fbd780fa9d67d5044a59115d460823a038ab2c27031b35d37d4e4d18a1",
-      "command": "agentic-planning delegation-decision",
-      "reason": "record delegation decision route=delegate-exploration",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:14:02+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "8b634c0d006a9f3e3d3b89e6a2e70341a39d31709226206be26ce470c214eb8f",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-planning-runtime-facade",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:19:44+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/archive/python-planning-runtime-facade.plan.json",
-      "sha256": "ea14c15106cb4b78d417ab224be0499491215c677fa206e03d577ffef9c2827b",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-planning-runtime-facade",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:19:44+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-prune-planning-list-files-runtime.plan.json",
-      "sha256": "39e3a6d5ae987d274d5b1366f8eccc555849503dc82f1ebaeb1734b97af59e2f",
-      "command": "agentic-planning new-plan",
-      "reason": "create execplan scaffold python-prune-planning-list-files-runtime",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:20:34+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "eff3f253bf4543d69d8740cb1d7afa38efd96fab261d339c6bb05ad8d675cc07",
-      "command": "agentic-planning new-plan",
-      "reason": "create execplan scaffold python-prune-planning-list-files-runtime",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:20:34+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-prune-planning-list-files-runtime.plan.json",
-      "sha256": "0cd44e23a1f336fe07238f641a4b9c174d555acb1ccb3fc8c220d7ba138ee412",
-      "command": "agentic-planning delegation-decision",
-      "reason": "record delegation decision route=keep-local",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:20:39+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-prune-planning-list-files-runtime.plan.json",
-      "sha256": "8613fecf6408058ef0865de15698f656414b28c9d70aa2652d54cd911afe50ee",
-      "command": "agentic-planning record-recovery",
-      "reason": "Filled bounded execplan fields before implementation for #892 dead planning list-files runtime delegate pruning.",
-      "mode": "manual-recovery",
-      "recorded_at": "2026-05-16T12:22:28+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-prune-planning-list-files-runtime.plan.json",
-      "sha256": "0e244778cc2a8fe15ad9cb8e69f27f5e6ef65e0e1d12c3672310a86767de05d5",
-      "command": "agentic-planning record-recovery",
-      "reason": "Filled closeout fields after #892 dead planning list-files runtime delegate proof passed.",
-      "mode": "manual-recovery",
-      "recorded_at": "2026-05-16T12:24:17+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-prune-planning-list-files-runtime.plan.json",
-      "sha256": "33a4fd4198d0d898fe814dbbc25a58ff4dc8109368527339097b594fac1fb0d3",
-      "command": "agentic-planning record-recovery",
-      "reason": "Added stale-reference sweep validation command required by archive gate for #892 dead planning list-files delegate pruning.",
-      "mode": "manual-recovery",
-      "recorded_at": "2026-05-16T12:24:51+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "8b634c0d006a9f3e3d3b89e6a2e70341a39d31709226206be26ce470c214eb8f",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-prune-planning-list-files-runtime",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:24:55+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/archive/python-prune-planning-list-files-runtime.plan.json",
-      "sha256": "33a4fd4198d0d898fe814dbbc25a58ff4dc8109368527339097b594fac1fb0d3",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-prune-planning-list-files-runtime",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:24:55+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-memory-json-output-primitive.plan.json",
-      "sha256": "0a6aa25a4b57b36523539decc74b94dd9c01788ec375eff254ffbcef34457054",
-      "command": "agentic-planning new-plan",
-      "reason": "create execplan scaffold python-memory-json-output-primitive",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:25:51+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/state.toml",
       "sha256": "526ff7330e1b29ddfff24abf9eaf38f93cbfbf3251a5277722c29a0da94d4da1",
       "command": "agentic-planning new-plan",
       "reason": "create execplan scaffold python-memory-json-output-primitive",
@@ -1616,6 +1512,94 @@
       "reason": "Integrated user-provided #892 tiered remaining-work plan into schema-valid Python generated CLI decomposition lanes.",
       "mode": "manual-recovery",
       "recorded_at": "2026-05-17T11:23:17+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/github-1024-planning-closeout-writer.plan.json",
+      "sha256": "7f597b0fd06bea16f1f8299055cbf566bb7d0be9276bcbe0e8bec0430d493d86",
+      "command": "agentic-planning new-plan",
+      "reason": "create execplan scaffold github-1024-planning-closeout-writer",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T13:32:41+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "b8d14bbc5e190702c27935b4867413be07386877c31b4aa8b4fcb2e2c3e821f7",
+      "command": "agentic-planning new-plan",
+      "reason": "create execplan scaffold github-1024-planning-closeout-writer",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T13:32:41+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/github-1024-planning-closeout-writer.plan.json",
+      "sha256": "5c62907b1ba9ce217a2ebaf3a3b47360e41ce57ea9c16573ac2b5f9c0a66eaee",
+      "command": "agentic-planning delegation-decision",
+      "reason": "record delegation decision route=keep-local",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T13:44:26+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/github-1024-planning-closeout-writer.plan.json",
+      "sha256": "922b6c41bfd7ad52d81fdc5082f5305efb63cee82ca92be3b1bdd78eb1e81311",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan github-1024-planning-closeout-writer",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T13:52:40+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/github-1024-planning-closeout-writer.plan.json",
+      "sha256": "922b6c41bfd7ad52d81fdc5082f5305efb63cee82ca92be3b1bdd78eb1e81311",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan github-1024-planning-closeout-writer",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T13:52:40+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "b8d14bbc5e190702c27935b4867413be07386877c31b4aa8b4fcb2e2c3e821f7",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan github-1024-planning-closeout-writer",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T13:52:40+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan github-1024-planning-closeout-writer",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T13:53:02+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/github-1024-planning-closeout-writer.plan.json",
+      "sha256": "15b82e509de24653deef4dd17e7cb858b969b75bc76d12e3fce5eb86e541ae12",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan github-1024-planning-closeout-writer",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T13:53:02+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan github-1024-planning-closeout-writer",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T13:53:02+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/github-1024-planning-closeout-writer.plan.json",
+      "sha256": "15b82e509de24653deef4dd17e7cb858b969b75bc76d12e3fce5eb86e541ae12",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan github-1024-planning-closeout-writer",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T13:53:02+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/mutation-provenance.json",
+      "sha256": "064200f521238e978e2b7b0e8eca406b71e2d61b7a665681fe2810c90e9a8aaf",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan github-1024-planning-closeout-writer",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T13:53:02+00:00"
     }
   ]
 }

--- a/.agentic-workspace/planning/mutation-provenance.json
+++ b/.agentic-workspace/planning/mutation-provenance.json
@@ -2,78 +2,6 @@
   "kind": "planning-mutation-provenance/v1",
   "entries": [
     {
-      "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "526ff7330e1b29ddfff24abf9eaf38f93cbfbf3251a5277722c29a0da94d4da1",
-      "command": "agentic-planning new-plan",
-      "reason": "create execplan scaffold python-memory-json-output-primitive",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:25:51+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-memory-json-output-primitive.plan.json",
-      "sha256": "be51da018acd4d2263d205ca46137a20c5678c07f0a3ad4e0776f79d400902bd",
-      "command": "agentic-planning delegation-decision",
-      "reason": "record delegation decision route=keep-local",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:25:55+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-memory-json-output-primitive.plan.json",
-      "sha256": "038e072ac69749dcf6927622e586371ed42658e73c89aaca94780484d0069c24",
-      "command": "agentic-planning record-recovery",
-      "reason": "Filled bounded execplan and proof fields for #892 memory generated JSON output primitive slice.",
-      "mode": "manual-recovery",
-      "recorded_at": "2026-05-16T12:27:47+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-memory-json-output-primitive.plan.json",
-      "sha256": "ca82f1213fb189e013f5bd0663f678843dea39473c48138f3504aac59bff06c5",
-      "command": "agentic-planning record-recovery",
-      "reason": "Filled closeout fields after #892 memory generated JSON output primitive proof passed.",
-      "mode": "manual-recovery",
-      "recorded_at": "2026-05-16T12:28:18+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "8b634c0d006a9f3e3d3b89e6a2e70341a39d31709226206be26ce470c214eb8f",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-memory-json-output-primitive",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:28:31+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/archive/python-memory-json-output-primitive.plan.json",
-      "sha256": "a0a14e131a11cf4570b5c997a06cbac61de39e8aa0961d9cf0906acb06bfe4cc",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-memory-json-output-primitive",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:28:31+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-planning-json-output-primitive.plan.json",
-      "sha256": "1e39aa89facd36868038de7bbe6c0f86f8ca1550e048ac8929fe9cea83a3f6db",
-      "command": "agentic-planning new-plan",
-      "reason": "create execplan scaffold python-planning-json-output-primitive",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:29:08+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "02228b696697acdb4e1765fb246f7f618675835d1dc2bc780ca1f6159113c37c",
-      "command": "agentic-planning new-plan",
-      "reason": "create execplan scaffold python-planning-json-output-primitive",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:29:08+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-planning-json-output-primitive.plan.json",
-      "sha256": "7fbd1f8f6f897cadab8a517d360348b805f476a3834f8a090dee860b66a85155",
-      "command": "agentic-planning delegation-decision",
-      "reason": "record delegation decision route=keep-local",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T12:29:12+00:00"
-    },
-    {
       "path": ".agentic-workspace/planning/execplans/python-planning-json-output-primitive.plan.json",
       "sha256": "f9b676e05b093b41301887780eacf48136dea33aec1120540465f2250ca2401f",
       "command": "agentic-planning record-recovery",
@@ -1600,6 +1528,78 @@
       "reason": "close out execplan github-1024-planning-closeout-writer",
       "mode": "cli-mutation",
       "recorded_at": "2026-05-17T13:53:02+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/github-1028-intent-status-review-fix.plan.json",
+      "sha256": "2285bac1ffdfd838a6bd4acf36d7cb171878affdfd3c4bb92cd3f9e7904c2b1d",
+      "command": "agentic-planning new-plan",
+      "reason": "create execplan scaffold github-1028-intent-status-review-fix",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T14:56:37+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "1c712b25b0bb8926f23c0713679e01ee7f4f5598901510992c0b42672e094128",
+      "command": "agentic-planning new-plan",
+      "reason": "create execplan scaffold github-1028-intent-status-review-fix",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T14:56:37+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/github-1028-intent-status-review-fix.plan.json",
+      "sha256": "b93f48a54166dde8a66aad477bce6e2fd0734f46111f0b0dbb4bcad361f4acb2",
+      "command": "agentic-planning delegation-decision",
+      "reason": "record delegation decision route=keep-local",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T14:59:10+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/github-1028-intent-status-review-fix.plan.json",
+      "sha256": "78181de6b8709e983504ae015617fb006e1f861deceb2ec8741d7884b248b728",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan github-1028-intent-status-review-fix",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T14:59:41+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan github-1028-intent-status-review-fix",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T15:01:13+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/github-1028-intent-status-review-fix.plan.json",
+      "sha256": "44c05c74b5d72acbd0217615774cf210cbb7ef2da44b38c6bf23e9c921b140bb",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan github-1028-intent-status-review-fix",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T15:01:13+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan github-1028-intent-status-review-fix",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T15:01:13+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/github-1028-intent-status-review-fix.plan.json",
+      "sha256": "44c05c74b5d72acbd0217615774cf210cbb7ef2da44b38c6bf23e9c921b140bb",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan github-1028-intent-status-review-fix",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T15:01:13+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/mutation-provenance.json",
+      "sha256": "27e39249977317ea0a8546827e96ec74f9ca497f7aaef1a55bae4957eb0d9042",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan github-1028-intent-status-review-fix",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T15:01:13+00:00"
     }
   ]
 }

--- a/generated/planning/python/adapter_commands.json
+++ b/generated/planning/python/adapter_commands.json
@@ -195,6 +195,119 @@
     "operation_path": "operations/planning.archive-plan.lifecycle.json"
   },
   {
+    "adapter_id": "planning.closeout.cli",
+    "interface": {
+      "arguments": [
+        {
+          "help": "Execplan path, slug, or id to close out.",
+          "name": "plan",
+          "nargs": "?"
+        }
+      ],
+      "help": "Close out a completed execplan through one command-owned writer.",
+      "name": "closeout",
+      "options": [
+        {
+          "flags": [
+            "--target"
+          ],
+          "help": "Optional repository path.",
+          "name": "target"
+        },
+        {
+          "choices": [
+            "slice",
+            "lane",
+            "epic"
+          ],
+          "default": "slice",
+          "flags": [
+            "--claim-level"
+          ],
+          "help": "Scope claimed by this closeout.",
+          "name": "claim_level"
+        },
+        {
+          "choices": [
+            "satisfied",
+            "partial",
+            "unsatisfied",
+            "deferred-with-owner"
+          ],
+          "default": "satisfied",
+          "flags": [
+            "--intent-status"
+          ],
+          "help": "Intent result for the closeout claim.",
+          "name": "intent_status"
+        },
+        {
+          "choices": [
+            "none",
+            "memory",
+            "planning",
+            "docs",
+            "tests",
+            "contracts",
+            "issue",
+            "dismissed"
+          ],
+          "default": "none",
+          "flags": [
+            "--residue"
+          ],
+          "help": "Durable residue route for follow-up or learning.",
+          "name": "residue"
+        },
+        {
+          "default": "last",
+          "flags": [
+            "--proof-from"
+          ],
+          "help": "Use existing proof with 'last' or record the supplied proof command/text.",
+          "name": "proof_from"
+        },
+        {
+          "flags": [
+            "--residue-owner"
+          ],
+          "help": "Canonical owner for non-empty residue or deferred intent.",
+          "name": "residue_owner"
+        },
+        {
+          "action": "store_true",
+          "flags": [
+            "--dry-run"
+          ],
+          "help": "Show closeout actions without mutating files.",
+          "name": "dry_run"
+        },
+        {
+          "action": "store_true",
+          "flags": [
+            "--discard-archive"
+          ],
+          "help": "Do not retain the archived execplan record after cleanup.",
+          "name": "discard_archive"
+        },
+        {
+          "choices": [
+            "text",
+            "json"
+          ],
+          "default": "text",
+          "flags": [
+            "--format"
+          ],
+          "help": "Output format.",
+          "name": "format"
+        }
+      ]
+    },
+    "operation_id": "planning.closeout.lifecycle",
+    "operation_path": "operations/planning.closeout.lifecycle.json"
+  },
+  {
     "adapter_id": "planning.close-item.cli",
     "interface": {
       "arguments": [

--- a/generated/planning/python/command_package.json
+++ b/generated/planning/python/command_package.json
@@ -292,6 +292,167 @@
       "status": "generated"
     },
     {
+      "adapter_id": "planning.closeout.cli",
+      "command": {
+        "manifest_ref": "package:planning:cli",
+        "name": "closeout"
+      },
+      "conformance_refs": [
+        "planning.closeout.lifecycle.dry-run.process"
+      ],
+      "effect_hints": {
+        "destructive": false,
+        "idempotent": false,
+        "read_only": false,
+        "requires_preflight_gate": false,
+        "writes_repo_state": true
+      },
+      "interface": {
+        "arguments": [
+          {
+            "help": "Execplan path, slug, or id to close out.",
+            "name": "plan",
+            "nargs": "?"
+          }
+        ],
+        "help": "Close out a completed execplan through one command-owned writer.",
+        "name": "closeout",
+        "options": [
+          {
+            "flags": [
+              "--target"
+            ],
+            "help": "Optional repository path.",
+            "name": "target"
+          },
+          {
+            "choices": [
+              "slice",
+              "lane",
+              "epic"
+            ],
+            "default": "slice",
+            "flags": [
+              "--claim-level"
+            ],
+            "help": "Scope claimed by this closeout.",
+            "name": "claim_level"
+          },
+          {
+            "choices": [
+              "satisfied",
+              "partial",
+              "unsatisfied",
+              "deferred-with-owner"
+            ],
+            "default": "satisfied",
+            "flags": [
+              "--intent-status"
+            ],
+            "help": "Intent result for the closeout claim.",
+            "name": "intent_status"
+          },
+          {
+            "choices": [
+              "none",
+              "memory",
+              "planning",
+              "docs",
+              "tests",
+              "contracts",
+              "issue",
+              "dismissed"
+            ],
+            "default": "none",
+            "flags": [
+              "--residue"
+            ],
+            "help": "Durable residue route for follow-up or learning.",
+            "name": "residue"
+          },
+          {
+            "default": "last",
+            "flags": [
+              "--proof-from"
+            ],
+            "help": "Use existing proof with 'last' or record the supplied proof command/text.",
+            "name": "proof_from"
+          },
+          {
+            "flags": [
+              "--residue-owner"
+            ],
+            "help": "Canonical owner for non-empty residue or deferred intent.",
+            "name": "residue_owner"
+          },
+          {
+            "action": "store_true",
+            "flags": [
+              "--dry-run"
+            ],
+            "help": "Show closeout actions without mutating files.",
+            "name": "dry_run"
+          },
+          {
+            "action": "store_true",
+            "flags": [
+              "--discard-archive"
+            ],
+            "help": "Do not retain the archived execplan record after cleanup.",
+            "name": "discard_archive"
+          },
+          {
+            "choices": [
+              "text",
+              "json"
+            ],
+            "default": "text",
+            "flags": [
+              "--format"
+            ],
+            "help": "Output format.",
+            "name": "format"
+          }
+        ]
+      },
+      "operation_ref": {
+        "id": "planning.closeout.lifecycle",
+        "path": "operations/planning.closeout.lifecycle.json"
+      },
+      "projection_boundary": {
+        "runtime_owned": [
+          "planning closeout policy",
+          "managed planning payload mutation",
+          "module result assembly"
+        ],
+        "target_specific": [
+          "parser library",
+          "package entrypoint wiring",
+          "help text layout",
+          "test container image"
+        ],
+        "universal": [
+          "command identity",
+          "operation reference",
+          "runtime primitive reference",
+          "effect hints",
+          "conformance refs"
+        ]
+      },
+      "runtime_binding": {
+        "kind": "operation-primitive-sequence",
+        "primitive_refs": [
+          "planning.closeout.apply",
+          "output.emit"
+        ]
+      },
+      "schemas": {
+        "input": [],
+        "output": []
+      },
+      "status": "generated"
+    },
+    {
       "adapter_id": "planning.close-item.cli",
       "command": {
         "manifest_ref": "package:planning:cli",
@@ -2272,6 +2433,12 @@
           "primitive": "planning.archive-plan.apply"
         },
         {
+          "function": "apply_planning_closeout_operation",
+          "handler": "runtime_handler",
+          "import_module": "repo_planning_bootstrap.runtime_projection",
+          "primitive": "planning.closeout.apply"
+        },
+        {
           "function": "apply_planning_delegation_decision_operation",
           "handler": "runtime_handler",
           "import_module": "repo_planning_bootstrap.runtime_projection",
@@ -2496,6 +2663,36 @@
           "name": "continuation_summary"
         },
         {
+          "arg": "claim_level",
+          "default": "slice",
+          "name": "claim_level"
+        },
+        {
+          "arg": "intent_status",
+          "default": "satisfied",
+          "name": "intent_status"
+        },
+        {
+          "arg": "residue",
+          "default": "none",
+          "name": "residue"
+        },
+        {
+          "arg": "proof_from",
+          "default": "last",
+          "name": "proof_from"
+        },
+        {
+          "arg": "residue_owner",
+          "default": null,
+          "name": "residue_owner"
+        },
+        {
+          "arg": "discard_archive",
+          "default": false,
+          "name": "discard_archive"
+        },
+        {
           "arg": "route",
           "default": "",
           "name": "route"
@@ -2540,6 +2737,7 @@
       "supported_operation_ids": [
         "planning.adopt.lifecycle",
         "planning.archive-plan.lifecycle",
+        "planning.closeout.lifecycle",
         "planning.close-item.lifecycle",
         "planning.create-review.lifecycle",
         "planning.delegation-decision.lifecycle",

--- a/generated/planning/python/commands/__init__.py
+++ b/generated/planning/python/commands/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from . import planning_adopt_lifecycle as _command_planning_adopt_lifecycle
 from . import planning_archive_plan_lifecycle as _command_planning_archive_plan_lifecycle
 from . import planning_close_item_lifecycle as _command_planning_close_item_lifecycle
+from . import planning_closeout_lifecycle as _command_planning_closeout_lifecycle
 from . import planning_create_review_lifecycle as _command_planning_create_review_lifecycle
 from . import planning_delegation_decision_lifecycle as _command_planning_delegation_decision_lifecycle
 from . import planning_doctor_report as _command_planning_doctor_report
@@ -38,6 +39,7 @@ GENERATED_COMMAND_HANDLERS = {
     'planning.adopt.lifecycle': _command_planning_adopt_lifecycle.run,
     'planning.archive-plan.lifecycle': _command_planning_archive_plan_lifecycle.run,
     'planning.close-item.lifecycle': _command_planning_close_item_lifecycle.run,
+    'planning.closeout.lifecycle': _command_planning_closeout_lifecycle.run,
     'planning.create-review.lifecycle': _command_planning_create_review_lifecycle.run,
     'planning.delegation-decision.lifecycle': _command_planning_delegation_decision_lifecycle.run,
     'planning.doctor.report': _command_planning_doctor_report.run,

--- a/generated/planning/python/commands/planning_closeout_lifecycle.py
+++ b/generated/planning/python/commands/planning_closeout_lifecycle.py
@@ -1,0 +1,22 @@
+"""Generated executable command projection.
+
+Source: src/agentic_workspace/contracts/command_package_ir.json
+Program: agentic-planning
+Operation: planning.closeout.lifecycle
+Regenerate with: uv run python scripts/generate/generate_command_packages.py
+"""
+
+from __future__ import annotations
+
+import argparse
+
+# DO NOT EDIT DIRECTLY.
+# Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
+# Regenerate with: uv run python scripts/generate/generate_command_packages.py
+
+from ..cli import generated_operation_contract
+from ..primitives.operation_executor import run_operation_ir
+
+
+def run(args: argparse.Namespace) -> int:
+    return run_operation_ir(generated_operation_contract('planning.closeout.lifecycle'), args)

--- a/generated/planning/python/generated_command_adapters.json
+++ b/generated/planning/python/generated_command_adapters.json
@@ -96,6 +96,38 @@
       },
       "status": "generated"
     },
+    "closeout": {
+      "command": {
+        "command_manifest": "package:planning:cli",
+        "name": "closeout",
+        "option_group_manifest": "cli_option_groups.json",
+        "program": "agentic-planning"
+      },
+      "conformance_refs": [
+        "planning.closeout.lifecycle.dry-run.process"
+      ],
+      "effect_hints": {
+        "destructive": false,
+        "idempotent": false,
+        "read_only": false,
+        "requires_preflight_gate": false,
+        "writes_repo_state": true
+      },
+      "id": "planning.closeout.cli",
+      "operation_id": "planning.closeout.lifecycle",
+      "runtime_binding": {
+        "kind": "operation-primitive-sequence",
+        "primitive_refs": [
+          "planning.closeout.apply",
+          "output.emit"
+        ]
+      },
+      "schemas": {
+        "input": [],
+        "output": []
+      },
+      "status": "generated"
+    },
     "create-review": {
       "command": {
         "command_manifest": "package:planning:cli",

--- a/generated/planning/python/operations/planning.closeout.lifecycle.json
+++ b/generated/planning/python/operations/planning.closeout.lifecycle.json
@@ -1,0 +1,139 @@
+{
+  "classification": "lifecycle-mutation",
+  "command_surface": {
+    "command": "closeout",
+    "format_option": "format",
+    "program": "agentic-planning"
+  },
+  "effects": {
+    "destructive": false,
+    "idempotent": false,
+    "read_only": false,
+    "requires_preflight_gate": false,
+    "writes_repo_state": true
+  },
+  "guards": [
+    "Respect dry-run mode by avoiding writes.",
+    "Use planning closeout as the primary closeout writer instead of hand-editing closeout fields.",
+    "Lane or epic closeout must preserve unresolved parent intent as an explicit continuation."
+  ],
+  "id": "planning.closeout.lifecycle",
+  "inputs": [
+    {
+      "name": "plan",
+      "required": true,
+      "source": "cli-option"
+    },
+    {
+      "name": "target",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "claim_level",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "intent_status",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "residue",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "proof_from",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "residue_owner",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "dry_run",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "discard_archive",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "format",
+      "required": false,
+      "source": "cli-option"
+    }
+  ],
+  "ir_plan": {
+    "status": "representative",
+    "steps": [
+      {
+        "arguments": {},
+        "description": "Write structured closeout fields and run archive validation.",
+        "id": "apply_lifecycle_operation",
+        "on_error": "emit_usage_error",
+        "outputs": [
+          "result"
+        ],
+        "uses": "planning.closeout.apply"
+      },
+      {
+        "arguments": {},
+        "description": "Emit planning lifecycle result in the requested format.",
+        "id": "emit_output",
+        "on_error": "emit_usage_error",
+        "outputs": [
+          "emitted"
+        ],
+        "uses": "output.emit"
+      }
+    ],
+    "summary": "Planning closeout executes generated operation IR through codegen-owned dataflow while the planning module owns closeout policy."
+  },
+  "locality": {
+    "network": "forbidden",
+    "outside_repo_writes": "forbidden",
+    "requires_repo": false
+  },
+  "migration_status": "runtime-consumed",
+  "output": {
+    "kind": "module-result"
+  },
+  "proof": [
+    "operation contract validates against operation.schema.json",
+    "generated closeout dry-run process conformance passes"
+  ],
+  "reads": [
+    {
+      "required": true,
+      "surface": "target repository Planning execplan and state"
+    }
+  ],
+  "schema_version": "agentic-workspace/operation/v1",
+  "steps": [
+    {
+      "description": "Write structured closeout fields and run archive validation.",
+      "id": "apply_lifecycle_operation",
+      "uses": "planning.closeout.apply"
+    },
+    {
+      "description": "Emit planning lifecycle result in the requested format.",
+      "id": "emit_output",
+      "uses": "output.emit"
+    }
+  ],
+  "summary": "Close out a completed execplan through one command-owned writer.",
+  "writes": [
+    {
+      "required": false,
+      "surface": ".agentic-workspace/planning/",
+      "when": "not a dry run"
+    }
+  ]
+}

--- a/generated/planning/python/primitives/operation_executor.py
+++ b/generated/planning/python/primitives/operation_executor.py
@@ -31,6 +31,7 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
         'planning.adopt.lifecycle',
         'planning.archive-plan.lifecycle',
         'planning.close-item.lifecycle',
+        'planning.closeout.lifecycle',
         'planning.create-review.lifecycle',
         'planning.delegation-decision.lifecycle',
         'planning.doctor.report',
@@ -100,6 +101,12 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'reopen_trigger': getattr(args, 'reopen_trigger', None),
                 'discard_summary': getattr(args, 'discard_summary', None),
                 'continuation_summary': getattr(args, 'continuation_summary', None),
+                'claim_level': getattr(args, 'claim_level', 'slice'),
+                'intent_status': getattr(args, 'intent_status', 'satisfied'),
+                'residue': getattr(args, 'residue', 'none'),
+                'proof_from': getattr(args, 'proof_from', 'last'),
+                'residue_owner': getattr(args, 'residue_owner', None),
+                'discard_archive': getattr(args, 'discard_archive', False),
                 'route': getattr(args, 'route', ''),
                 'skipped_reason': getattr(args, 'skipped_reason', ''),
                 'expected_savings': getattr(args, 'expected_savings', ''),
@@ -119,6 +126,7 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'planning.new-plan.apply': _handle_planning_new_plan_apply,
                 'planning.promote-to-plan.apply': _handle_planning_promote_to_plan_apply,
                 'planning.archive-plan.apply': _handle_planning_archive_plan_apply,
+                'planning.closeout.apply': _handle_planning_closeout_apply,
                 'planning.delegation-decision.apply': _handle_planning_delegation_decision_apply,
                 'planning.record-recovery.apply': _handle_planning_record_recovery_apply,
             },
@@ -181,6 +189,12 @@ def _handle_planning_archive_plan_apply(values: dict[str, Any], arguments: dict[
     from .planning_runtime import apply_planning_archive_plan_operation
 
     return apply_planning_archive_plan_operation(values, arguments, context)
+
+
+def _handle_planning_closeout_apply(values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> Any:
+    from .planning_runtime import apply_planning_closeout_operation
+
+    return apply_planning_closeout_operation(values, arguments, context)
 
 
 def _handle_planning_delegation_decision_apply(values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> Any:

--- a/generated/planning/python/primitives/planning_runtime.py
+++ b/generated/planning/python/primitives/planning_runtime.py
@@ -119,6 +119,12 @@ def apply_planning_archive_plan_operation(*args: Any, **kwargs: Any) -> Any:
     return source_function(*args, **kwargs)
 
 
+def apply_planning_closeout_operation(*args: Any, **kwargs: Any) -> Any:
+    from repo_planning_bootstrap.runtime_projection import apply_planning_closeout_operation as source_function
+
+    return source_function(*args, **kwargs)
+
+
 def apply_planning_delegation_decision_operation(*args: Any, **kwargs: Any) -> Any:
     from repo_planning_bootstrap.runtime_projection import apply_planning_delegation_decision_operation as source_function
 
@@ -173,6 +179,7 @@ def render_planning_prompt_operation(*args: Any, **kwargs: Any) -> Any:
 
 __all__ = [
     'apply_planning_archive_plan_operation',
+    'apply_planning_closeout_operation',
     'apply_planning_delegation_decision_operation',
     'apply_planning_new_plan_operation',
     'apply_planning_promote_to_plan_operation',

--- a/generated/typescript/planning-cli/src/cli.mjs
+++ b/generated/typescript/planning-cli/src/cli.mjs
@@ -8,7 +8,7 @@
 import { spawnSync } from 'node:child_process';
 import { writeSync } from 'node:fs';
 
-const supportedCommands = new Set(["adopt", "archive-plan", "close-item", "create-review", "delegation-decision", "doctor", "handoff", "init", "install", "list-files", "new-plan", "promote-to-plan", "prompt", "reconcile", "record-recovery", "report", "status", "summary", "uninstall", "upgrade", "verify-payload"]);
+const supportedCommands = new Set(["adopt", "archive-plan", "close-item", "closeout", "create-review", "delegation-decision", "doctor", "handoff", "init", "install", "list-files", "new-plan", "promote-to-plan", "prompt", "reconcile", "record-recovery", "report", "status", "summary", "uninstall", "upgrade", "verify-payload"]);
 const argv = process.argv.slice(2);
 const command = argv[0];
 

--- a/generated/typescript/planning-cli/src/commandPackage.ts
+++ b/generated/typescript/planning-cli/src/commandPackage.ts
@@ -298,6 +298,167 @@ export const generatedCommandPackage = {
       "status": "generated"
     },
     {
+      "adapter_id": "planning.closeout.cli",
+      "command": {
+        "manifest_ref": "package:planning:cli",
+        "name": "closeout"
+      },
+      "conformance_refs": [
+        "planning.closeout.lifecycle.dry-run.process"
+      ],
+      "effect_hints": {
+        "destructive": false,
+        "idempotent": false,
+        "read_only": false,
+        "requires_preflight_gate": false,
+        "writes_repo_state": true
+      },
+      "interface": {
+        "arguments": [
+          {
+            "help": "Execplan path, slug, or id to close out.",
+            "name": "plan",
+            "nargs": "?"
+          }
+        ],
+        "help": "Close out a completed execplan through one command-owned writer.",
+        "name": "closeout",
+        "options": [
+          {
+            "flags": [
+              "--target"
+            ],
+            "help": "Optional repository path.",
+            "name": "target"
+          },
+          {
+            "choices": [
+              "slice",
+              "lane",
+              "epic"
+            ],
+            "default": "slice",
+            "flags": [
+              "--claim-level"
+            ],
+            "help": "Scope claimed by this closeout.",
+            "name": "claim_level"
+          },
+          {
+            "choices": [
+              "satisfied",
+              "partial",
+              "unsatisfied",
+              "deferred-with-owner"
+            ],
+            "default": "satisfied",
+            "flags": [
+              "--intent-status"
+            ],
+            "help": "Intent result for the closeout claim.",
+            "name": "intent_status"
+          },
+          {
+            "choices": [
+              "none",
+              "memory",
+              "planning",
+              "docs",
+              "tests",
+              "contracts",
+              "issue",
+              "dismissed"
+            ],
+            "default": "none",
+            "flags": [
+              "--residue"
+            ],
+            "help": "Durable residue route for follow-up or learning.",
+            "name": "residue"
+          },
+          {
+            "default": "last",
+            "flags": [
+              "--proof-from"
+            ],
+            "help": "Use existing proof with 'last' or record the supplied proof command/text.",
+            "name": "proof_from"
+          },
+          {
+            "flags": [
+              "--residue-owner"
+            ],
+            "help": "Canonical owner for non-empty residue or deferred intent.",
+            "name": "residue_owner"
+          },
+          {
+            "action": "store_true",
+            "flags": [
+              "--dry-run"
+            ],
+            "help": "Show closeout actions without mutating files.",
+            "name": "dry_run"
+          },
+          {
+            "action": "store_true",
+            "flags": [
+              "--discard-archive"
+            ],
+            "help": "Do not retain the archived execplan record after cleanup.",
+            "name": "discard_archive"
+          },
+          {
+            "choices": [
+              "text",
+              "json"
+            ],
+            "default": "text",
+            "flags": [
+              "--format"
+            ],
+            "help": "Output format.",
+            "name": "format"
+          }
+        ]
+      },
+      "operation_ref": {
+        "id": "planning.closeout.lifecycle",
+        "path": "operations/planning.closeout.lifecycle.json"
+      },
+      "projection_boundary": {
+        "runtime_owned": [
+          "planning closeout policy",
+          "managed planning payload mutation",
+          "module result assembly"
+        ],
+        "target_specific": [
+          "parser library",
+          "package entrypoint wiring",
+          "help text layout",
+          "test container image"
+        ],
+        "universal": [
+          "command identity",
+          "operation reference",
+          "runtime primitive reference",
+          "effect hints",
+          "conformance refs"
+        ]
+      },
+      "runtime_binding": {
+        "kind": "operation-primitive-sequence",
+        "primitive_refs": [
+          "planning.closeout.apply",
+          "output.emit"
+        ]
+      },
+      "schemas": {
+        "input": [],
+        "output": []
+      },
+      "status": "generated"
+    },
+    {
       "adapter_id": "planning.close-item.cli",
       "command": {
         "manifest_ref": "package:planning:cli",
@@ -2278,6 +2439,12 @@ export const generatedCommandPackage = {
           "primitive": "planning.archive-plan.apply"
         },
         {
+          "function": "apply_planning_closeout_operation",
+          "handler": "runtime_handler",
+          "import_module": "repo_planning_bootstrap.runtime_projection",
+          "primitive": "planning.closeout.apply"
+        },
+        {
           "function": "apply_planning_delegation_decision_operation",
           "handler": "runtime_handler",
           "import_module": "repo_planning_bootstrap.runtime_projection",
@@ -2502,6 +2669,36 @@ export const generatedCommandPackage = {
           "name": "continuation_summary"
         },
         {
+          "arg": "claim_level",
+          "default": "slice",
+          "name": "claim_level"
+        },
+        {
+          "arg": "intent_status",
+          "default": "satisfied",
+          "name": "intent_status"
+        },
+        {
+          "arg": "residue",
+          "default": "none",
+          "name": "residue"
+        },
+        {
+          "arg": "proof_from",
+          "default": "last",
+          "name": "proof_from"
+        },
+        {
+          "arg": "residue_owner",
+          "default": null,
+          "name": "residue_owner"
+        },
+        {
+          "arg": "discard_archive",
+          "default": false,
+          "name": "discard_archive"
+        },
+        {
           "arg": "route",
           "default": "",
           "name": "route"
@@ -2546,6 +2743,7 @@ export const generatedCommandPackage = {
       "supported_operation_ids": [
         "planning.adopt.lifecycle",
         "planning.archive-plan.lifecycle",
+        "planning.closeout.lifecycle",
         "planning.close-item.lifecycle",
         "planning.create-review.lifecycle",
         "planning.delegation-decision.lifecycle",

--- a/generated/typescript/planning-cli/test/command-package.test.mjs
+++ b/generated/typescript/planning-cli/test/command-package.test.mjs
@@ -8,7 +8,7 @@ const source = readFileSync(new URL('../src/commandPackage.ts', import.meta.url)
 const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 
 test('generated package metadata exposes expected commands', () => {
-  const expected = ["adopt", "archive-plan", "close-item", "create-review", "delegation-decision", "doctor", "handoff", "init", "install", "list-files", "new-plan", "promote-to-plan", "prompt", "reconcile", "record-recovery", "report", "status", "summary", "uninstall", "upgrade", "verify-payload"];
+  const expected = ["adopt", "archive-plan", "close-item", "closeout", "create-review", "delegation-decision", "doctor", "handoff", "init", "install", "list-files", "new-plan", "promote-to-plan", "prompt", "reconcile", "record-recovery", "report", "status", "summary", "uninstall", "upgrade", "verify-payload"];
   for (const command of expected) {
     assert.match(source, new RegExp(`\"name\": \\"${command}\\"`));
   }

--- a/generated/typescript/workspace-cli/src/commandPackage.ts
+++ b/generated/typescript/workspace-cli/src/commandPackage.ts
@@ -540,6 +540,114 @@ export const generatedCommandPackage = {
             ]
           },
           {
+            "arguments": [
+              {
+                "help": "Execplan path, slug, or id to close out.",
+                "name": "plan",
+                "nargs": "?"
+              }
+            ],
+            "help": "Close out a completed execplan through one command-owned writer.",
+            "name": "closeout",
+            "options": [
+              {
+                "flags": [
+                  "--target"
+                ],
+                "help": "Optional repository path.",
+                "name": "target"
+              },
+              {
+                "choices": [
+                  "slice",
+                  "lane",
+                  "epic"
+                ],
+                "default": "slice",
+                "flags": [
+                  "--claim-level"
+                ],
+                "help": "Scope claimed by this closeout.",
+                "name": "claim_level"
+              },
+              {
+                "choices": [
+                  "satisfied",
+                  "partial",
+                  "unsatisfied",
+                  "deferred-with-owner"
+                ],
+                "default": "satisfied",
+                "flags": [
+                  "--intent-status"
+                ],
+                "help": "Intent result for the closeout claim.",
+                "name": "intent_status"
+              },
+              {
+                "choices": [
+                  "none",
+                  "memory",
+                  "planning",
+                  "docs",
+                  "tests",
+                  "contracts",
+                  "issue",
+                  "dismissed"
+                ],
+                "default": "none",
+                "flags": [
+                  "--residue"
+                ],
+                "help": "Durable residue route for follow-up or learning.",
+                "name": "residue"
+              },
+              {
+                "default": "last",
+                "flags": [
+                  "--proof-from"
+                ],
+                "help": "Use existing proof with 'last' or record the supplied proof command/text.",
+                "name": "proof_from"
+              },
+              {
+                "flags": [
+                  "--residue-owner"
+                ],
+                "help": "Canonical owner for non-empty residue or deferred intent.",
+                "name": "residue_owner"
+              },
+              {
+                "action": "store_true",
+                "flags": [
+                  "--dry-run"
+                ],
+                "help": "Show closeout actions without mutating files.",
+                "name": "dry_run"
+              },
+              {
+                "action": "store_true",
+                "flags": [
+                  "--discard-archive"
+                ],
+                "help": "Do not retain the archived execplan record after cleanup.",
+                "name": "discard_archive"
+              },
+              {
+                "choices": [
+                  "text",
+                  "json"
+                ],
+                "default": "text",
+                "flags": [
+                  "--format"
+                ],
+                "help": "Output format.",
+                "name": "format"
+              }
+            ]
+          },
+          {
             "help": "Close completed planning residue by id without hand-editing checked-in state.",
             "name": "close-item",
             "options": [

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -416,6 +416,114 @@
           ]
         },
         {
+          "arguments": [
+            {
+              "help": "Execplan path, slug, or id to close out.",
+              "name": "plan",
+              "nargs": "?"
+            }
+          ],
+          "help": "Close out a completed execplan through one command-owned writer.",
+          "name": "closeout",
+          "options": [
+            {
+              "flags": [
+                "--target"
+              ],
+              "help": "Optional repository path.",
+              "name": "target"
+            },
+            {
+              "choices": [
+                "slice",
+                "lane",
+                "epic"
+              ],
+              "default": "slice",
+              "flags": [
+                "--claim-level"
+              ],
+              "help": "Scope claimed by this closeout.",
+              "name": "claim_level"
+            },
+            {
+              "choices": [
+                "satisfied",
+                "partial",
+                "unsatisfied",
+                "deferred-with-owner"
+              ],
+              "default": "satisfied",
+              "flags": [
+                "--intent-status"
+              ],
+              "help": "Intent result for the closeout claim.",
+              "name": "intent_status"
+            },
+            {
+              "choices": [
+                "none",
+                "memory",
+                "planning",
+                "docs",
+                "tests",
+                "contracts",
+                "issue",
+                "dismissed"
+              ],
+              "default": "none",
+              "flags": [
+                "--residue"
+              ],
+              "help": "Durable residue route for follow-up or learning.",
+              "name": "residue"
+            },
+            {
+              "default": "last",
+              "flags": [
+                "--proof-from"
+              ],
+              "help": "Use existing proof with 'last' or record the supplied proof command/text.",
+              "name": "proof_from"
+            },
+            {
+              "flags": [
+                "--residue-owner"
+              ],
+              "help": "Canonical owner for non-empty residue or deferred intent.",
+              "name": "residue_owner"
+            },
+            {
+              "action": "store_true",
+              "flags": [
+                "--dry-run"
+              ],
+              "help": "Show closeout actions without mutating files.",
+              "name": "dry_run"
+            },
+            {
+              "action": "store_true",
+              "flags": [
+                "--discard-archive"
+              ],
+              "help": "Do not retain the archived execplan record after cleanup.",
+              "name": "discard_archive"
+            },
+            {
+              "choices": [
+                "text",
+                "json"
+              ],
+              "default": "text",
+              "flags": [
+                "--format"
+              ],
+              "help": "Output format.",
+              "name": "format"
+            }
+          ]
+        },
+        {
           "help": "Close completed planning residue by id without hand-editing checked-in state.",
           "name": "close-item",
           "options": [

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -534,6 +534,114 @@
             ]
           },
           {
+            "arguments": [
+              {
+                "help": "Execplan path, slug, or id to close out.",
+                "name": "plan",
+                "nargs": "?"
+              }
+            ],
+            "help": "Close out a completed execplan through one command-owned writer.",
+            "name": "closeout",
+            "options": [
+              {
+                "flags": [
+                  "--target"
+                ],
+                "help": "Optional repository path.",
+                "name": "target"
+              },
+              {
+                "choices": [
+                  "slice",
+                  "lane",
+                  "epic"
+                ],
+                "default": "slice",
+                "flags": [
+                  "--claim-level"
+                ],
+                "help": "Scope claimed by this closeout.",
+                "name": "claim_level"
+              },
+              {
+                "choices": [
+                  "satisfied",
+                  "partial",
+                  "unsatisfied",
+                  "deferred-with-owner"
+                ],
+                "default": "satisfied",
+                "flags": [
+                  "--intent-status"
+                ],
+                "help": "Intent result for the closeout claim.",
+                "name": "intent_status"
+              },
+              {
+                "choices": [
+                  "none",
+                  "memory",
+                  "planning",
+                  "docs",
+                  "tests",
+                  "contracts",
+                  "issue",
+                  "dismissed"
+                ],
+                "default": "none",
+                "flags": [
+                  "--residue"
+                ],
+                "help": "Durable residue route for follow-up or learning.",
+                "name": "residue"
+              },
+              {
+                "default": "last",
+                "flags": [
+                  "--proof-from"
+                ],
+                "help": "Use existing proof with 'last' or record the supplied proof command/text.",
+                "name": "proof_from"
+              },
+              {
+                "flags": [
+                  "--residue-owner"
+                ],
+                "help": "Canonical owner for non-empty residue or deferred intent.",
+                "name": "residue_owner"
+              },
+              {
+                "action": "store_true",
+                "flags": [
+                  "--dry-run"
+                ],
+                "help": "Show closeout actions without mutating files.",
+                "name": "dry_run"
+              },
+              {
+                "action": "store_true",
+                "flags": [
+                  "--discard-archive"
+                ],
+                "help": "Do not retain the archived execplan record after cleanup.",
+                "name": "discard_archive"
+              },
+              {
+                "choices": [
+                  "text",
+                  "json"
+                ],
+                "default": "text",
+                "flags": [
+                  "--format"
+                ],
+                "help": "Output format.",
+                "name": "format"
+              }
+            ]
+          },
+          {
             "help": "Close completed planning residue by id without hand-editing checked-in state.",
             "name": "close-item",
             "options": [

--- a/packages/planning/payload-surface-classification.json
+++ b/packages/planning/payload-surface-classification.json
@@ -126,6 +126,20 @@
       "rationale": "The planning wheel force-includes generated operation resource data as private runtime import data; the canonical source remains the operation contract and generator."
     },
     {
+      "source_path": "generated/planning/python/operations/planning.closeout.lifecycle.json",
+      "installed_path": "repo_planning_bootstrap/_generated_cli_package_impl/operations/planning.closeout.lifecycle.json",
+      "classification": "maintainer/development only",
+      "owner": "generated operation projection",
+      "rationale": "The planning wheel force-includes generated operation resource data as private runtime import data; the canonical source remains the operation contract and generator."
+    },
+    {
+      "source_path": "generated/planning/python/commands/planning_closeout_lifecycle.py",
+      "installed_path": "repo_planning_bootstrap/_generated_cli_package_impl/commands/planning_closeout_lifecycle.py",
+      "classification": "maintainer/development only",
+      "owner": "generated command projection",
+      "rationale": "The planning wheel force-includes generated command dispatch modules as private runtime import data; the canonical source remains command-package IR and generator."
+    },
+    {
       "source_path": "generated/planning/python/operations/planning.close-item.lifecycle.json",
       "installed_path": "repo_planning_bootstrap/_generated_cli_package_impl/operations/planning.close-item.lifecycle.json",
       "classification": "maintainer/development only",

--- a/packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.closeout.lifecycle.json
+++ b/packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.closeout.lifecycle.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": "agentic-workspace/operation/v1",
+  "id": "planning.closeout.lifecycle",
+  "command_surface": {
+    "program": "agentic-planning",
+    "command": "closeout",
+    "format_option": "format"
+  },
+  "summary": "Close out a completed execplan through one command-owned writer.",
+  "classification": "lifecycle-mutation",
+  "inputs": [
+    {
+      "name": "plan",
+      "source": "cli-option",
+      "required": true
+    },
+    {
+      "name": "target",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "claim_level",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "intent_status",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "residue",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "proof_from",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "residue_owner",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "dry_run",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "discard_archive",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "format",
+      "source": "cli-option",
+      "required": false
+    }
+  ],
+  "output": {
+    "kind": "module-result"
+  },
+  "effects": {
+    "read_only": false,
+    "destructive": false,
+    "idempotent": false,
+    "writes_repo_state": true,
+    "requires_preflight_gate": false
+  },
+  "locality": {
+    "requires_repo": false,
+    "network": "forbidden",
+    "outside_repo_writes": "forbidden"
+  },
+  "reads": [
+    {
+      "surface": "target repository Planning execplan and state",
+      "required": true
+    }
+  ],
+  "writes": [
+    {
+      "surface": ".agentic-workspace/planning/",
+      "required": false,
+      "when": "not a dry run"
+    }
+  ],
+  "steps": [
+    {
+      "id": "apply_lifecycle_operation",
+      "uses": "planning.closeout.apply",
+      "description": "Write structured closeout fields and run archive validation."
+    },
+    {
+      "id": "emit_output",
+      "uses": "output.emit",
+      "description": "Emit planning lifecycle result in the requested format."
+    }
+  ],
+  "guards": [
+    "Respect dry-run mode by avoiding writes.",
+    "Use planning closeout as the primary closeout writer instead of hand-editing closeout fields.",
+    "Lane or epic closeout must preserve unresolved parent intent as an explicit continuation."
+  ],
+  "proof": [
+    "operation contract validates against operation.schema.json",
+    "generated closeout dry-run process conformance passes"
+  ],
+  "migration_status": "runtime-consumed",
+  "ir_plan": {
+    "status": "representative",
+    "summary": "Planning closeout executes generated operation IR through codegen-owned dataflow while the planning module owns closeout policy.",
+    "steps": [
+      {
+        "id": "apply_lifecycle_operation",
+        "uses": "planning.closeout.apply",
+        "description": "Write structured closeout fields and run archive validation.",
+        "arguments": {},
+        "outputs": [
+          "result"
+        ],
+        "on_error": "emit_usage_error"
+      },
+      {
+        "id": "emit_output",
+        "uses": "output.emit",
+        "description": "Emit planning lifecycle result in the requested format.",
+        "arguments": {},
+        "outputs": [
+          "emitted"
+        ],
+        "on_error": "emit_usage_error"
+      }
+    ]
+  }
+}

--- a/packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.front-door.json
+++ b/packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.front-door.json
@@ -6,6 +6,7 @@
     "format_option": "format",
     "subcommands": [
       "archive-plan",
+      "closeout",
       "close-item",
       "create-review",
       "delegation-decision",

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -74,6 +74,19 @@ ARCHIVE_CLOSEOUT_VALUE_HINT = (
     "for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. "
     "Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields."
 )
+PLANNING_CLOSEOUT_CLAIM_LEVELS = {"slice", "lane", "epic"}
+PLANNING_CLOSEOUT_INTENT_STATUSES = {"satisfied", "partial", "unsatisfied", "deferred-with-owner"}
+PLANNING_CLOSEOUT_RESIDUE_STATUSES = {"none", "memory", "planning", "docs", "tests", "contracts", "issue", "dismissed"}
+PLANNING_CLOSEOUT_RESIDUE_MAP = {
+    "none": ("none", "archive"),
+    "dismissed": ("evidence_only", "archive"),
+    "memory": ("memory", "Memory"),
+    "planning": ("planning", PLANNING_STATE_PATH.as_posix()),
+    "docs": ("docs", "docs"),
+    "tests": ("check", "tests"),
+    "contracts": ("contract", "contracts"),
+    "issue": ("planning", "issue follow-up"),
+}
 PLANNING_STATE_ROLE_FIELDS = (
     "decision_owner",
     "strategy_role",
@@ -9966,7 +9979,7 @@ def _prepare_execplan_closeout(
         )
         return False
     slice_status = existing_slice_status or "completed"
-    larger_status = existing_larger_status or ("open" if normalized_closure == "archive-but-keep-lane-open" else "closed")
+    larger_status = "open" if normalized_closure == "archive-but-keep-lane-open" else (existing_larger_status or "closed")
     routed_unsolved_intent = continuation_owner if normalized_closure == "archive-but-keep-lane-open" else "none"
     original_intent = (
         existing_intent_satisfaction.get("original intent")
@@ -10305,6 +10318,131 @@ def archive_parent_lane_closeout(
         command="agentic-planning archive-plan --parent-lane-closeout",
         reason=f"close parent lane {parent_id}",
     )
+    return result
+
+
+def closeout_execplan(
+    plan: str,
+    *,
+    target: str | Path | None = None,
+    dry_run: bool = False,
+    claim_level: str = "slice",
+    intent_status: str = "satisfied",
+    residue: str = "none",
+    proof_from: str = "last",
+    residue_owner: str | None = None,
+    retain_archive: bool = True,
+) -> InstallResult:
+    target_root = resolve_target_root(target)
+    result = InstallResult(target_root=target_root, message=f"Close out execplan '{plan}'", dry_run=dry_run)
+    normalized_claim = claim_level.strip().lower()
+    normalized_intent = intent_status.strip().lower()
+    normalized_residue = residue.strip().lower()
+    if normalized_claim not in PLANNING_CLOSEOUT_CLAIM_LEVELS:
+        result.add("manual review", target_root / PLANNING_STATE_PATH, "--claim-level must be one of slice, lane, or epic")
+        return result
+    if normalized_intent not in PLANNING_CLOSEOUT_INTENT_STATUSES:
+        result.add(
+            "manual review",
+            target_root / PLANNING_STATE_PATH,
+            "--intent-status must be one of satisfied, partial, unsatisfied, or deferred-with-owner",
+        )
+        return result
+    if normalized_residue not in PLANNING_CLOSEOUT_RESIDUE_STATUSES:
+        result.add(
+            "manual review",
+            target_root / PLANNING_STATE_PATH,
+            "--residue must be one of none, memory, planning, docs, tests, contracts, issue, or dismissed",
+        )
+        return result
+
+    plan_path = _resolve_execplan_path(target_root, plan)
+    if plan_path is None:
+        result.add("manual review", target_root / PLANNING_STATE_PATH, f"execplan '{plan}' was not found")
+        return result
+    record_path = _canonical_execplan_record_path(plan_path)
+    record = _load_execplan_record(plan_path)
+    if record is None:
+        result.add("manual review", record_path, "planning closeout requires a canonical .plan.json record")
+        return result
+
+    closure_decision = "archive-and-close" if normalized_intent == "satisfied" else "archive-but-keep-lane-open"
+    intent_satisfied = "no" if normalized_intent == "unsatisfied" else "yes"
+    continuation_owner = residue_owner or ""
+    if closure_decision == "archive-but-keep-lane-open" and not continuation_owner:
+        continuation_owner = PLANNING_STATE_PATH.as_posix()
+
+    if not dry_run:
+        status, default_owner = PLANNING_CLOSEOUT_RESIDUE_MAP[normalized_residue]
+        owner = residue_owner or default_owner
+        record["durable_residue"] = {
+            "status": status,
+            "learned constraint": (
+                "No future-relevant learning was identified beyond the closeout evidence."
+                if status in EXECPLAN_DURABLE_RESIDUE_OWNERLESS_STATUSES
+                else f"Closeout routed {normalized_residue} residue to {owner}."
+            ),
+            "motivation worth preserving": (
+                "Closeout reviewed durable residue and found no live follow-up."
+                if status in EXECPLAN_DURABLE_RESIDUE_OWNERLESS_STATUSES
+                else f"Future agents should continue from {owner} rather than rediscover this closeout residue."
+            ),
+            "canonical owner now": owner,
+            "promotion trigger": "none"
+            if status in EXECPLAN_DURABLE_RESIDUE_OWNERLESS_STATUSES
+            else "when the routed closeout residue is acted on",
+            "retention after promotion": "retain",
+        }
+        if proof_from.strip() and proof_from.strip().lower() != "last":
+            proof = proof_from.strip()
+            record["proof_report"] = {
+                "validation proof": proof,
+                "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+                'evidence for "proof achieved" state': proof,
+            }
+            execution_run = _record_section_dict(record, "execution_run") or {}
+            execution_run["validations run"] = proof
+            record["execution_run"] = execution_run
+        if closure_decision == "archive-but-keep-lane-open":
+            intent_continuity = _record_section_dict(record, "intent_continuity") or {}
+            intent_continuity["this slice completes the larger intended outcome"] = "no"
+            intent_continuity["continuation surface"] = continuation_owner
+            record["intent_continuity"] = intent_continuity
+            required_continuation = _record_section_dict(record, "required_continuation") or {}
+            required_continuation["required follow-on for the larger intended outcome"] = "yes"
+            required_continuation["owner surface"] = continuation_owner
+            required_continuation.setdefault("activation trigger", "when the continuation owner promotes the next slice")
+            record["required_continuation"] = required_continuation
+        _write_execplan_record(record_path=record_path, record=record, render_markdown=plan_path != record_path)
+        result.add("updated", record_path, "recorded closeout residue and proof inputs")
+
+    archive_result = archive_execplan(
+        plan,
+        target=target_root,
+        dry_run=dry_run,
+        apply_cleanup=True,
+        prepare_closeout=True,
+        closure_decision=closure_decision,
+        intent_satisfied=intent_satisfied,
+        unsolved_intent=continuation_owner if closure_decision == "archive-but-keep-lane-open" else None,
+        closure_reason=f"planning closeout accepted a {normalized_claim} claim with intent-status {normalized_intent}.",
+        closure_evidence="planning closeout wrote structured closeout fields and archive validation accepted the result.",
+        reopen_trigger=(
+            f"Reopen when {continuation_owner} activates a fresh bounded slice."
+            if closure_decision == "archive-but-keep-lane-open"
+            else "None unless new evidence shows the closeout was incomplete."
+        ),
+        retain_archive=retain_archive,
+    )
+    result.actions.extend(archive_result.actions)
+    result.warnings.extend(archive_result.warnings)
+    blocked = bool(result.warnings) or any(action.kind == "manual review" for action in result.actions)
+    if blocked:
+        result.add("next safe action", record_path, "resolve the reported closeout blocker, then rerun planning closeout")
+    else:
+        result.add("next safe action", target_root / PLANNING_STATE_PATH, "agentic-planning summary --target . --format json")
+    if not dry_run:
+        _stamp_result_action_mutations(result, command="agentic-planning closeout", reason=f"close out execplan {plan}")
     return result
 
 

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -10367,7 +10367,7 @@ def closeout_execplan(
         return result
 
     closure_decision = "archive-and-close" if normalized_intent == "satisfied" else "archive-but-keep-lane-open"
-    intent_satisfied = "no" if normalized_intent == "unsatisfied" else "yes"
+    intent_satisfied = "yes" if normalized_intent == "satisfied" else "no"
     continuation_owner = residue_owner or ""
     if closure_decision == "archive-but-keep-lane-open" and not continuation_owner:
         continuation_owner = PLANNING_STATE_PATH.as_posix()
@@ -10411,7 +10411,9 @@ def closeout_execplan(
             required_continuation = _record_section_dict(record, "required_continuation") or {}
             required_continuation["required follow-on for the larger intended outcome"] = "yes"
             required_continuation["owner surface"] = continuation_owner
-            required_continuation.setdefault("activation trigger", "when the continuation owner promotes the next slice")
+            existing_activation_trigger = str(required_continuation.get("activation trigger", "")).strip().lower()
+            if existing_activation_trigger in {"", "none", "n/a"}:
+                required_continuation["activation trigger"] = "when the continuation owner promotes the next slice"
             record["required_continuation"] = required_continuation
         _write_execplan_record(record_path=record_path, record=record, render_markdown=plan_path != record_path)
         result.add("updated", record_path, "recorded closeout residue and proof inputs")

--- a/packages/planning/src/repo_planning_bootstrap/runtime_projection.py
+++ b/packages/planning/src/repo_planning_bootstrap/runtime_projection.py
@@ -7,6 +7,7 @@ from repo_planning_bootstrap._source import UpgradeSource, resolve_upgrade_sourc
 from repo_planning_bootstrap.installer import (
     archive_execplan,
     archive_parent_lane_closeout,
+    closeout_execplan,
     create_execplan_scaffold,
     format_actions,
     format_result_json,
@@ -109,6 +110,20 @@ def apply_planning_archive_plan_operation(values: dict, _arguments: dict, _conte
         discard_summary=values.get("discard_summary"),
         continuation_summary=values.get("continuation_summary"),
         retain_archive=bool(values.get("retain_archive")),
+    )
+
+
+def apply_planning_closeout_operation(values: dict, _arguments: dict, _context):
+    return closeout_execplan(
+        str(values.get("plan") or ""),
+        target=values.get("target"),
+        dry_run=bool(values.get("dry_run")),
+        claim_level=str(values.get("claim_level") or "slice"),
+        intent_status=str(values.get("intent_status") or "satisfied"),
+        residue=str(values.get("residue") or "none"),
+        proof_from=str(values.get("proof_from") or "last"),
+        residue_owner=values.get("residue_owner"),
+        retain_archive=not bool(values.get("discard_archive")),
     )
 
 

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -623,9 +623,53 @@ def test_planning_closeout_routes_partial_lane_residue_to_continuation(tmp_path:
     assert payload["warnings"] == []
     assert archived["closure_check"]["closeout scope"] == "lane"
     assert archived["closure_check"]["closure decision"] == "archive-but-keep-lane-open"
+    assert archived["intent_satisfaction"]["was original intent fully satisfied?"] == "no"
     assert archived["intent_satisfaction"]["unsolved intent passed to"] == ".agentic-workspace/planning/state.toml"
     assert archived["durable_residue"]["status"] == "planning"
     assert archived["closeout_distillation"]["buckets"]["continuation"][0]["owner"] == ".agentic-workspace/planning/state.toml"
+
+
+def test_planning_closeout_routes_deferred_owner_without_full_intent_satisfaction(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="completed")
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record["intent_continuity"]["this slice completes the larger intended outcome"] = "no"
+    installer_mod._write_execplan_record(record_path=record_path, record=record)
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--claim-level",
+                "lane",
+                "--intent-status",
+                "deferred-with-owner",
+                "--residue",
+                "planning",
+                "--residue-owner",
+                "GitHub #1021",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    archived = json.loads(
+        (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json").read_text(encoding="utf-8")
+    )
+
+    assert payload["warnings"] == []
+    assert archived["closure_check"]["closeout scope"] == "lane"
+    assert archived["closure_check"]["closure decision"] == "archive-but-keep-lane-open"
+    assert archived["intent_satisfaction"]["was original intent fully satisfied?"] == "no"
+    assert archived["intent_satisfaction"]["unsolved intent passed to"] == "GitHub #1021"
+    assert archived["required_continuation"]["owner surface"] == "GitHub #1021"
+    assert archived["closeout_distillation"]["buckets"]["continuation"][0]["owner"] == "GitHub #1021"
 
 
 def test_planning_closeout_blocks_proxy_lane_archive_and_close(tmp_path: Path, capsys) -> None:

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -545,6 +545,160 @@ def test_archive_plan_prepare_closeout_handles_open_parent_lane(tmp_path: Path, 
     assert archived["closeout_distillation"]["buckets"]["continuation"][0]["owner"] == ".agentic-workspace/planning/state.toml"
 
 
+def test_planning_closeout_archives_direct_slice_without_manual_closeout_edits(tmp_path: Path, capsys) -> None:
+    _write(
+        tmp_path / ".agentic-workspace/planning/state.toml",
+        """
+[todo]
+active_items = [
+  { id = "plan-alpha", status = "completed", surface = ".agentic-workspace/planning/execplans/plan-alpha.plan.json" },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="completed")
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record.pop("intent_satisfaction")
+    record.pop("closure_check")
+    record.pop("closeout_distillation", None)
+    installer_mod._write_execplan_record(record_path=record_path, record=record)
+
+    assert planning_cli.main(["closeout", "plan-alpha", "--target", str(tmp_path), "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    archived_record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json"
+    archived = json.loads(archived_record_path.read_text(encoding="utf-8"))
+
+    assert payload["warnings"] == []
+    assert any(action["kind"] == "updated" and "recorded closeout residue" in action["detail"] for action in payload["actions"])
+    assert any(action["kind"] == "archived" for action in payload["actions"])
+    assert any(action["kind"] == "next safe action" and "summary" in action["detail"] for action in payload["actions"])
+    assert not record_path.exists()
+    assert archived["closure_check"]["closure decision"] == "archive-and-close"
+    assert archived["intent_satisfaction"]["was original intent fully satisfied?"] == "yes"
+    assert archived["durable_residue"]["status"] == "none"
+
+
+def test_planning_closeout_routes_partial_lane_residue_to_continuation(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="completed")
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record["intent_continuity"]["this slice completes the larger intended outcome"] = "no"
+    record["required_continuation"] = {
+        "required follow-on for the larger intended outcome": "yes",
+        "owner surface": ".agentic-workspace/planning/state.toml",
+        "activation trigger": "next lane slice",
+    }
+    installer_mod._write_execplan_record(record_path=record_path, record=record)
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--claim-level",
+                "lane",
+                "--intent-status",
+                "partial",
+                "--residue",
+                "planning",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    archived = json.loads(
+        (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json").read_text(encoding="utf-8")
+    )
+
+    assert payload["warnings"] == []
+    assert archived["closure_check"]["closeout scope"] == "lane"
+    assert archived["closure_check"]["closure decision"] == "archive-but-keep-lane-open"
+    assert archived["intent_satisfaction"]["unsolved intent passed to"] == ".agentic-workspace/planning/state.toml"
+    assert archived["durable_residue"]["status"] == "planning"
+    assert archived["closeout_distillation"]["buckets"]["continuation"][0]["owner"] == ".agentic-workspace/planning/state.toml"
+
+
+def test_planning_closeout_blocks_proxy_lane_archive_and_close(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="completed")
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record["intent_continuity"]["this slice completes the larger intended outcome"] = "no"
+    record["required_continuation"] = {
+        "required follow-on for the larger intended outcome": "yes",
+        "owner surface": ".agentic-workspace/planning/state.toml",
+        "activation trigger": "next lane slice",
+    }
+    installer_mod._write_execplan_record(record_path=record_path, record=record)
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--claim-level",
+                "lane",
+                "--intent-status",
+                "satisfied",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert any(warning["warning_class"] == "archive_larger_intent_proxy_closeout_blocked" for warning in payload["warnings"])
+    assert any(action["kind"] == "manual review" for action in payload["actions"])
+    assert record_path.exists()
+
+
+def test_planning_closeout_records_explicit_proof_and_issue_residue(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="completed")
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--proof-from",
+                "uv run pytest packages/planning/tests/test_archive.py -q",
+                "--residue",
+                "issue",
+                "--residue-owner",
+                "GitHub #1021",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    archived = json.loads(
+        (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json").read_text(encoding="utf-8")
+    )
+
+    assert archived["proof_report"]["validation proof"] == "uv run pytest packages/planning/tests/test_archive.py -q"
+    assert archived["durable_residue"]["status"] == "planning"
+    assert archived["durable_residue"]["canonical owner now"] == "GitHub #1021"
+
+
 def test_archive_plan_parent_lane_closeout_creates_schema_valid_record_without_active_plan(tmp_path: Path, capsys) -> None:
     _write(
         tmp_path / ".agentic-workspace/planning/state.toml",

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -175,6 +175,9 @@ GENERATED_CLI_COMPATIBILITY_VOCABULARY_ALLOWLIST = {
     "packages/planning/pyproject.toml": "installed private bridge compatibility",
     "packages/memory/pyproject.toml": "installed private bridge compatibility",
     "packages/planning/payload-surface-classification.json": "installed private bridge compatibility inventory",
+    ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json": (
+        "historical generated target-layout migration context"
+    ),
     ".agentic-workspace/planning/mutation-provenance.json": "historical planning mutation provenance",
     "packages/command-generation/src/command_generation/generated_package_loader.py": "legacy loader compatibility wrappers and legacy layout fallback",
     "src/agentic_workspace/workspace_runtime_primitives.py": "legacy parser helper compatibility wrapper",

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -375,6 +375,114 @@
           "mutates_state": true
         },
         {
+          "name": "closeout",
+          "help": "Close out a completed execplan through one command-owned writer.",
+          "options": [
+            {
+              "name": "target",
+              "flags": [
+                "--target"
+              ],
+              "help": "Optional repository path."
+            },
+            {
+              "name": "claim_level",
+              "flags": [
+                "--claim-level"
+              ],
+              "choices": [
+                "slice",
+                "lane",
+                "epic"
+              ],
+              "default": "slice",
+              "help": "Scope claimed by this closeout."
+            },
+            {
+              "name": "intent_status",
+              "flags": [
+                "--intent-status"
+              ],
+              "choices": [
+                "satisfied",
+                "partial",
+                "unsatisfied",
+                "deferred-with-owner"
+              ],
+              "default": "satisfied",
+              "help": "Intent result for the closeout claim."
+            },
+            {
+              "name": "residue",
+              "flags": [
+                "--residue"
+              ],
+              "choices": [
+                "none",
+                "memory",
+                "planning",
+                "docs",
+                "tests",
+                "contracts",
+                "issue",
+                "dismissed"
+              ],
+              "default": "none",
+              "help": "Durable residue route for follow-up or learning."
+            },
+            {
+              "name": "proof_from",
+              "flags": [
+                "--proof-from"
+              ],
+              "default": "last",
+              "help": "Use existing proof with 'last' or record the supplied proof command/text."
+            },
+            {
+              "name": "residue_owner",
+              "flags": [
+                "--residue-owner"
+              ],
+              "help": "Canonical owner for non-empty residue or deferred intent."
+            },
+            {
+              "name": "dry_run",
+              "flags": [
+                "--dry-run"
+              ],
+              "action": "store_true",
+              "help": "Show closeout actions without mutating files."
+            },
+            {
+              "name": "discard_archive",
+              "flags": [
+                "--discard-archive"
+              ],
+              "action": "store_true",
+              "help": "Do not retain the archived execplan record after cleanup."
+            },
+            {
+              "name": "format",
+              "flags": [
+                "--format"
+              ],
+              "choices": [
+                "text",
+                "json"
+              ],
+              "default": "text",
+              "help": "Output format."
+            }
+          ],
+          "uses_option_groups": [
+            "format"
+          ],
+          "role": "core_context_router",
+          "audience": "ordinary_host_repo",
+          "classification_note": "Planning command-owned closeout writer",
+          "mutates_state": true
+        },
+        {
           "name": "close-item",
           "help": "Close completed planning residue by id without hand-editing checked-in state.",
           "uses_option_groups": [

--- a/src/agentic_workspace/contracts/command_adapter_generation.json
+++ b/src/agentic_workspace/contracts/command_adapter_generation.json
@@ -2914,6 +2914,84 @@
       ]
     },
     {
+      "id": "planning.closeout.cli",
+      "status": "generated",
+      "command": {
+        "program": "agentic-planning",
+        "name": "closeout",
+        "command_manifest": "package:planning:cli",
+        "option_group_manifest": "cli_option_groups.json"
+      },
+      "operation_ref": {
+        "id": "planning.closeout.lifecycle",
+        "registry": "operation_contracts.json",
+        "path": "operations/planning.closeout.lifecycle.json"
+      },
+      "runtime_binding": {
+        "kind": "operation-primitive-sequence",
+        "primitive_refs": [
+          "planning.closeout.apply",
+          "output.emit"
+        ]
+      },
+      "schemas": {
+        "input": [],
+        "output": []
+      },
+      "effect_hints": {
+        "read_only": false,
+        "destructive": false,
+        "idempotent": false,
+        "writes_repo_state": true,
+        "requires_preflight_gate": false
+      },
+      "projection_hints": {
+        "universal_fields": [
+          "command.name",
+          "command.options",
+          "command.arguments",
+          "operation_ref.id",
+          "runtime_binding.primitive_refs",
+          "effect_hints",
+          "conformance_refs"
+        ],
+        "adapter_specific_fields": [
+          {
+            "kind": "process-cli",
+            "fields": [
+              "program",
+              "argument rendering",
+              "help rendering",
+              "exit-code rendering"
+            ]
+          }
+        ]
+      },
+      "generation_boundary": {
+        "contract_owns": [
+          "visible command name",
+          "argument and option shape",
+          "help and usage text source",
+          "operation id",
+          "effect/read/write hints",
+          "conformance refs"
+        ],
+        "generated_adapter_owns": [
+          "parser and usage wiring",
+          "argument normalization into the operation input shape",
+          "dispatch wiring from command id to runtime binding"
+        ],
+        "runtime_owns": [
+          "planning state mutation policy",
+          "planning provenance updates",
+          "module result assembly"
+        ]
+      },
+      "conformance_refs": [
+        "planning.closeout.lifecycle.dry-run.process"
+      ]
+    },
+    {
       "id": "planning.close-item.cli",
       "status": "generated",
       "command": {

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -1144,6 +1144,114 @@
                 ]
               },
               {
+                "name": "closeout",
+                "help": "Close out a completed execplan through one command-owned writer.",
+                "options": [
+                  {
+                    "name": "target",
+                    "flags": [
+                      "--target"
+                    ],
+                    "help": "Optional repository path."
+                  },
+                  {
+                    "name": "claim_level",
+                    "flags": [
+                      "--claim-level"
+                    ],
+                    "choices": [
+                      "slice",
+                      "lane",
+                      "epic"
+                    ],
+                    "default": "slice",
+                    "help": "Scope claimed by this closeout."
+                  },
+                  {
+                    "name": "intent_status",
+                    "flags": [
+                      "--intent-status"
+                    ],
+                    "choices": [
+                      "satisfied",
+                      "partial",
+                      "unsatisfied",
+                      "deferred-with-owner"
+                    ],
+                    "default": "satisfied",
+                    "help": "Intent result for the closeout claim."
+                  },
+                  {
+                    "name": "residue",
+                    "flags": [
+                      "--residue"
+                    ],
+                    "choices": [
+                      "none",
+                      "memory",
+                      "planning",
+                      "docs",
+                      "tests",
+                      "contracts",
+                      "issue",
+                      "dismissed"
+                    ],
+                    "default": "none",
+                    "help": "Durable residue route for follow-up or learning."
+                  },
+                  {
+                    "name": "proof_from",
+                    "flags": [
+                      "--proof-from"
+                    ],
+                    "default": "last",
+                    "help": "Use existing proof with 'last' or record the supplied proof command/text."
+                  },
+                  {
+                    "name": "residue_owner",
+                    "flags": [
+                      "--residue-owner"
+                    ],
+                    "help": "Canonical owner for non-empty residue or deferred intent."
+                  },
+                  {
+                    "name": "dry_run",
+                    "flags": [
+                      "--dry-run"
+                    ],
+                    "action": "store_true",
+                    "help": "Show closeout actions without mutating files."
+                  },
+                  {
+                    "name": "discard_archive",
+                    "flags": [
+                      "--discard-archive"
+                    ],
+                    "action": "store_true",
+                    "help": "Do not retain the archived execplan record after cleanup."
+                  },
+                  {
+                    "name": "format",
+                    "flags": [
+                      "--format"
+                    ],
+                    "choices": [
+                      "text",
+                      "json"
+                    ],
+                    "default": "text",
+                    "help": "Output format."
+                  }
+                ],
+                "arguments": [
+                  {
+                    "name": "plan",
+                    "nargs": "?",
+                    "help": "Execplan path, slug, or id to close out."
+                  }
+                ]
+              },
+              {
                 "name": "close-item",
                 "help": "Close completed planning residue by id without hand-editing checked-in state.",
                 "options": [
@@ -4589,6 +4697,7 @@
           "supported_operation_ids": [
             "planning.adopt.lifecycle",
             "planning.archive-plan.lifecycle",
+            "planning.closeout.lifecycle",
             "planning.close-item.lifecycle",
             "planning.create-review.lifecycle",
             "planning.delegation-decision.lifecycle",
@@ -4820,6 +4929,36 @@
               "default": null
             },
             {
+              "name": "claim_level",
+              "arg": "claim_level",
+              "default": "slice"
+            },
+            {
+              "name": "intent_status",
+              "arg": "intent_status",
+              "default": "satisfied"
+            },
+            {
+              "name": "residue",
+              "arg": "residue",
+              "default": "none"
+            },
+            {
+              "name": "proof_from",
+              "arg": "proof_from",
+              "default": "last"
+            },
+            {
+              "name": "residue_owner",
+              "arg": "residue_owner",
+              "default": null
+            },
+            {
+              "name": "discard_archive",
+              "arg": "discard_archive",
+              "default": false
+            },
+            {
               "name": "route",
               "arg": "route",
               "default": ""
@@ -4924,6 +5063,12 @@
               "primitive": "planning.archive-plan.apply",
               "handler": "runtime_handler",
               "function": "apply_planning_archive_plan_operation",
+              "import_module": "repo_planning_bootstrap.runtime_projection"
+            },
+            {
+              "primitive": "planning.closeout.apply",
+              "function": "apply_planning_closeout_operation",
+              "handler": "runtime_handler",
               "import_module": "repo_planning_bootstrap.runtime_projection"
             },
             {
@@ -5255,6 +5400,167 @@
           },
           "conformance_refs": [
             "planning.archive-plan.lifecycle.dry-run.process"
+          ]
+        },
+        {
+          "adapter_id": "planning.closeout.cli",
+          "status": "generated",
+          "command": {
+            "manifest_ref": "package:planning:cli",
+            "name": "closeout"
+          },
+          "operation_ref": {
+            "id": "planning.closeout.lifecycle",
+            "path": "operations/planning.closeout.lifecycle.json"
+          },
+          "runtime_binding": {
+            "kind": "operation-primitive-sequence",
+            "primitive_refs": [
+              "planning.closeout.apply",
+              "output.emit"
+            ]
+          },
+          "schemas": {
+            "input": [],
+            "output": []
+          },
+          "effect_hints": {
+            "read_only": false,
+            "destructive": false,
+            "idempotent": false,
+            "writes_repo_state": true,
+            "requires_preflight_gate": false
+          },
+          "interface": {
+            "name": "closeout",
+            "help": "Close out a completed execplan through one command-owned writer.",
+            "options": [
+              {
+                "name": "target",
+                "flags": [
+                  "--target"
+                ],
+                "help": "Optional repository path."
+              },
+              {
+                "name": "claim_level",
+                "flags": [
+                  "--claim-level"
+                ],
+                "choices": [
+                  "slice",
+                  "lane",
+                  "epic"
+                ],
+                "default": "slice",
+                "help": "Scope claimed by this closeout."
+              },
+              {
+                "name": "intent_status",
+                "flags": [
+                  "--intent-status"
+                ],
+                "choices": [
+                  "satisfied",
+                  "partial",
+                  "unsatisfied",
+                  "deferred-with-owner"
+                ],
+                "default": "satisfied",
+                "help": "Intent result for the closeout claim."
+              },
+              {
+                "name": "residue",
+                "flags": [
+                  "--residue"
+                ],
+                "choices": [
+                  "none",
+                  "memory",
+                  "planning",
+                  "docs",
+                  "tests",
+                  "contracts",
+                  "issue",
+                  "dismissed"
+                ],
+                "default": "none",
+                "help": "Durable residue route for follow-up or learning."
+              },
+              {
+                "name": "proof_from",
+                "flags": [
+                  "--proof-from"
+                ],
+                "default": "last",
+                "help": "Use existing proof with 'last' or record the supplied proof command/text."
+              },
+              {
+                "name": "residue_owner",
+                "flags": [
+                  "--residue-owner"
+                ],
+                "help": "Canonical owner for non-empty residue or deferred intent."
+              },
+              {
+                "name": "dry_run",
+                "flags": [
+                  "--dry-run"
+                ],
+                "action": "store_true",
+                "help": "Show closeout actions without mutating files."
+              },
+              {
+                "name": "discard_archive",
+                "flags": [
+                  "--discard-archive"
+                ],
+                "action": "store_true",
+                "help": "Do not retain the archived execplan record after cleanup."
+              },
+              {
+                "name": "format",
+                "flags": [
+                  "--format"
+                ],
+                "choices": [
+                  "text",
+                  "json"
+                ],
+                "default": "text",
+                "help": "Output format."
+              }
+            ],
+            "arguments": [
+              {
+                "name": "plan",
+                "nargs": "?",
+                "help": "Execplan path, slug, or id to close out."
+              }
+            ]
+          },
+          "projection_boundary": {
+            "universal": [
+              "command identity",
+              "operation reference",
+              "runtime primitive reference",
+              "effect hints",
+              "conformance refs"
+            ],
+            "target_specific": [
+              "parser library",
+              "package entrypoint wiring",
+              "help text layout",
+              "test container image"
+            ],
+            "runtime_owned": [
+              "planning closeout policy",
+              "managed planning payload mutation",
+              "module result assembly"
+            ]
+          },
+          "conformance_refs": [
+            "planning.closeout.lifecycle.dry-run.process"
           ]
         },
         {

--- a/src/agentic_workspace/contracts/conformance/planning.closeout.lifecycle.dry-run.process.json
+++ b/src/agentic_workspace/contracts/conformance/planning.closeout.lifecycle.dry-run.process.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "agentic-workspace/conformance/v1",
+  "id": "planning.closeout.lifecycle.dry-run.process",
+  "operation_id": "planning.closeout.lifecycle",
+  "adapter": {
+    "kind": "process",
+    "command_template": [
+      "{agentic_planning_cli}",
+      "closeout",
+      "missing-plan",
+      "--target",
+      ".",
+      "--dry-run",
+      "--format",
+      "json"
+    ],
+    "cwd": "fixture_root"
+  },
+  "fixtures": [
+    {
+      "id": "minimal-planning-repo",
+      "files": {
+        ".git/.keep": "",
+        "README.md": "# Fixture\n"
+      }
+    }
+  ],
+  "expectations": {
+    "exit": {
+      "code": 0
+    },
+    "stdout": {
+      "format": "json",
+      "field_assertions": [
+        {
+          "path": [
+            "dry_run"
+          ],
+          "equals": true
+        },
+        {
+          "path": [
+            "message"
+          ],
+          "equals": "Close out execplan 'missing-plan'"
+        }
+      ]
+    },
+    "stderr": {
+      "allow_non_empty": false
+    },
+    "filesystem": {
+      "allowed_write_paths": [],
+      "required_paths": [
+        ".git/.keep",
+        "README.md"
+      ],
+      "forbidden_paths": [
+        ".agentic-workspace"
+      ]
+    },
+    "idempotency": {
+      "run_twice": true
+    },
+    "safety": {
+      "no_writes_outside_repo_root": true
+    }
+  }
+}

--- a/src/agentic_workspace/contracts/conformance_contracts.json
+++ b/src/agentic_workspace/contracts/conformance_contracts.json
@@ -226,6 +226,12 @@
       "adapter_kind": "process"
     },
     {
+      "id": "planning.closeout.lifecycle.dry-run.process",
+      "operation_id": "planning.closeout.lifecycle",
+      "path": "conformance/planning.closeout.lifecycle.dry-run.process.json",
+      "adapter_kind": "process"
+    },
+    {
       "id": "planning.close-item.process",
       "operation_id": "planning.close-item.lifecycle",
       "path": "conformance/planning.close-item.process.json",

--- a/src/agentic_workspace/contracts/operation_contracts.json
+++ b/src/agentic_workspace/contracts/operation_contracts.json
@@ -233,6 +233,12 @@
       "migration_status": "runtime-consumed"
     },
     {
+      "id": "planning.closeout.lifecycle",
+      "path": "operations/planning.closeout.lifecycle.json",
+      "command": "closeout",
+      "migration_status": "runtime-consumed"
+    },
+    {
       "id": "planning.close-item.lifecycle",
       "path": "operations/planning.close-item.lifecycle.json",
       "command": "close-item",

--- a/src/agentic_workspace/contracts/operation_primitives.json
+++ b/src/agentic_workspace/contracts/operation_primitives.json
@@ -423,6 +423,12 @@
       "summary": "Load package-local planning bootstrap status for a target repository."
     },
     {
+      "id": "planning.closeout.apply",
+      "summary": "Close out a completed execplan through one command-owned Planning writer.",
+      "kind": "planning-runtime",
+      "portability": "domain-runtime"
+    },
+    {
       "id": "planning.close-item.apply",
       "summary": "Apply package-local planning close-item lifecycle mutation for a target repository.",
       "kind": "planning-runtime",

--- a/src/agentic_workspace/contracts/python_operation_execution_inventory.json
+++ b/src/agentic_workspace/contracts/python_operation_execution_inventory.json
@@ -779,6 +779,27 @@
       "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.archive-plan.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
     },
     {
+      "operation_id": "planning.closeout.lifecycle",
+      "program": "agentic-planning",
+      "command": "closeout",
+      "generated_transport": "generated/planning/python/cli.py",
+      "operation_contract": "operations/planning.closeout.lifecycle.json",
+      "primitive_executor": "packages/command-generation/src/command_generation/primitive_executor.py",
+      "hand_owned_runtime_code": [
+        "planning.closeout.apply",
+        "module-result text/json compatibility formatting"
+      ],
+      "status": "domain-runtime-primitive-via-ir",
+      "conformance_ref": "planning.closeout.lifecycle.dry-run.process",
+      "domain_runtime_primitive_refs": [
+        "planning.closeout.apply"
+      ],
+      "runtime_boundary_class": "mutation-orchestration",
+      "runtime_boundary_reason": "Operation dataflow is generated and executed by codegen-owned run_operation_steps, but Planning closeout policy, archive validation, residue routing, and provenance updates remain package-specific runtime behavior.",
+      "what_would_make_portable_later": "Replace the package-domain closeout primitive with schema-backed codegen-owned primitives once closeout policy is deterministic file/data/template/schema/output work rather than Planning lifecycle judgment.",
+      "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.closeout.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+    },
+    {
       "operation_id": "planning.close-item.lifecycle",
       "program": "agentic-planning",
       "command": "close-item",
@@ -1516,4 +1537,3 @@
   ],
   "completion_rule": "Python completion can be claimed only when every generated Python operation is inventoried as portable-codegen-primitive-executed, domain-runtime-primitive-via-ir, or accepted-hand-owned-runtime-primitive; domain-runtime-primitive-via-ir and accepted-hand-owned-runtime-primitive entries are transitional unless their audit proves they do not hide generic deterministic runtime debt."
 }
-

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -1344,7 +1344,7 @@ def _planning_module_argv(args: argparse.Namespace) -> list[str]:
     argv = [command]
     if command == "promote-to-plan":
         argv.append(str(args.item_id))
-    elif command == "archive-plan" and getattr(args, "plan", None):
+    elif command in {"archive-plan", "closeout"} and getattr(args, "plan", None):
         argv.append(str(args.plan))
     elif command == "close-item" and getattr(args, "item", None):
         argv.append(str(args.item))
@@ -1377,6 +1377,11 @@ def _planning_module_argv(args: argparse.Namespace) -> list[str]:
         ("--reopen-trigger", "reopen_trigger"),
         ("--discard-summary", "discard_summary"),
         ("--continuation-summary", "continuation_summary"),
+        ("--claim-level", "claim_level"),
+        ("--intent-status", "intent_status"),
+        ("--residue", "residue"),
+        ("--proof-from", "proof_from"),
+        ("--residue-owner", "residue_owner"),
     ):
         _append_option(argv, option, getattr(args, attr, None))
     if command == "delegation-decision":
@@ -1392,6 +1397,7 @@ def _planning_module_argv(args: argparse.Namespace) -> list[str]:
         ("--apply-cleanup", "apply_cleanup"),
         ("--prepare-closeout", "prepare_closeout"),
         ("--retain-archive", "retain_archive"),
+        ("--discard-archive", "discard_archive"),
         ("--verbose", "verbose"),
     ):
         _append_flag(argv, option, bool(getattr(args, attr, False)))

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -531,6 +531,7 @@ def test_command_package_ir_reuses_generated_adapter_truth() -> None:
         "doctor.report.cli",
         "planning.adopt.cli",
         "planning.archive-plan.cli",
+        "planning.closeout.cli",
         "planning.close-item.cli",
         "planning.create-review.cli",
         "planning.delegation-decision.cli",
@@ -1646,6 +1647,7 @@ def test_contract_tooling_check_reports_generated_adapter_status() -> None:
     assert commands_by_program["agentic-planning"] == [
         "adopt",
         "archive-plan",
+        "closeout",
         "close-item",
         "create-review",
         "delegation-decision",

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -1594,6 +1594,31 @@ def test_planning_delegation_decision_front_door_keeps_plan_option() -> None:
     assert argv[argv.index("--plan") + 1] == "plan-alpha"
 
 
+def test_planning_closeout_front_door_forwards_plan_positionally() -> None:
+    args = argparse.Namespace(
+        planning_command="closeout",
+        plan="plan-alpha",
+        target=".",
+        claim_level="lane",
+        intent_status="partial",
+        residue="planning",
+        proof_from="last",
+        residue_owner=".agentic-workspace/planning/state.toml",
+        dry_run=True,
+        discard_archive=False,
+        format="json",
+    )
+
+    argv = cli._planning_module_argv(args)
+
+    assert argv[:2] == ["closeout", "plan-alpha"]
+    assert "--plan" not in argv
+    assert argv[argv.index("--claim-level") + 1] == "lane"
+    assert argv[argv.index("--intent-status") + 1] == "partial"
+    assert argv[argv.index("--residue") + 1] == "planning"
+    assert argv[argv.index("--residue-owner") + 1] == ".agentic-workspace/planning/state.toml"
+
+
 def test_planning_close_item_front_door_forwards_item_positionally() -> None:
     args = argparse.Namespace(
         planning_command="close-item",


### PR DESCRIPTION
## Summary

- Add `agentic-workspace planning closeout` / `agentic-planning closeout` as the primary command-owned writer for ordinary planned-work closeout.
- Route closeout claim level, intent status, proof input, and durable residue into structured execplan fields before archive validation runs.
- Generate Planning/workspace command surfaces and register the new lifecycle operation across operation, adapter, conformance, inventory, and payload-classification contracts.
- Add focused coverage for direct closeout, partial lane continuation, proxy closeout blocking, residue/proof routing, and workspace front-door forwarding.

## Validation

- `uv run pytest packages/planning/tests/test_archive.py::test_planning_closeout_archives_direct_slice_without_manual_closeout_edits packages/planning/tests/test_archive.py::test_planning_closeout_routes_partial_lane_residue_to_continuation packages/planning/tests/test_archive.py::test_planning_closeout_blocks_proxy_lane_archive_and_close packages/planning/tests/test_archive.py::test_planning_closeout_records_explicit_proof_and_issue_residue tests/test_workspace_start_preflight_cli.py::test_planning_closeout_front_door_forwards_plan_positionally -q`
- `uv run pytest tests/test_contract_tooling.py::test_contract_tooling_check_passes -q`
- `make test-planning`
- `make test-workspace`
- `make lint-planning`
- `make lint-workspace`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/check_generated_command_packages.py --conformance --require-node`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`

## Scope notes

- Completes the #1024 child slice.
- Leaves parent lane #1021 open for the next source-boundary reduction.

Refs #1021
Closes #1024