### PR TITLE
[codex] Add reasons to startup skill recommendations

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/startup-skills-recommended-reasons.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/startup-skills-recommended-reasons.plan.json
@@ -1,0 +1,294 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Add reasons to startup skills recommendations",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for Add reasons to startup skills recommendations.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "Fill in the narrowest command that proves the promoted work."
+    ],
+    "touched_scope": [
+      "Fill in the concrete files before implementation starts."
+    ],
+    "completion_criteria": [
+      "Add reasons to startup skills recommendations is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "pending"
+  },
+  "goal": [
+    "Create a bounded plan for Add reasons to startup skills recommendations."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Add reasons to startup skills recommendations.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    },
+    "execution": {
+      "milestone": "startup-skills-recommended-reasons",
+      "status": "active",
+      "next_step": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+      "proof": "Fill in the narrowest command that proves the promoted work."
+    },
+    "scope": {
+      "touched": [
+        "Fill in the concrete files before implementation starts."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Add reasons to startup skills recommendations.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "pending",
+    "validation still needed": "current milestone validation remains pending",
+    "next likely slice": "continue the current milestone until the completion criteria are met"
+  },
+  "intent_interpretation": {
+    "literal request": "Add reasons to startup skills recommendations",
+    "inferred intended outcome": "Create a bounded plan for Add reasons to startup skills recommendations.",
+    "chosen concrete what": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "Fill in the concrete write scope before implementation starts.",
+    "max changed files": "Fill in an expected upper bound before implementation starts.",
+    "required validation commands": "Fill in the narrowest command that proves the promoted work.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Add reasons to startup skills recommendations.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "Narrow #1035 acceptance gap: add short reasons to startup skills recommendations and focused tests; no disjoint implementation scope.",
+    "decision command": "agentic-planning delegation-decision",
+    "recorded at": "2026-05-17T19:14:18+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "startup-skills-recommended-reasons",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Fill in execution bounds, touched paths, and validation before implementation starts."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "Fill in the concrete files before implementation starts."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "Fill in the narrowest command that proves the promoted work."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Add reasons to startup skills recommendations is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Backfilled startup skills.recommended entries from the full recommendation payload and skill catalog so compact startup recommendations always include path plus short reasons.",
+    "scope touched": "startup skills projection, focused startup tests, active planning record",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_start_preflight_cli.py; .agentic-workspace/planning/execplans/startup-skills-recommended-reasons.plan.json",
+    "validations run": "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_default_returns_selector_first_router tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection -q; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_start_preflight_cli.py",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within the updated #1035 acceptance gap for recommended skill reasons; #1034 and the rest of #1035 were already present in the branch base.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "Narrow #1035 acceptance gap: add short reasons to startup skills recommendations and focused tests; no disjoint implementation scope.",
+    "expected savings": "unknown",
+    "actual friction": "pending",
+    "proof result": "pending",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_default_returns_selector_first_router tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection -q; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_start_preflight_cli.py",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_default_returns_selector_first_router tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection -q; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_start_preflight_cli.py"
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Add reasons to startup skills recommendations.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_default_returns_selector_first_router tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection -q; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_start_preflight_cli.py",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "skills.recommended now includes reasons and paths in ordinary startup output, and focused tests enforce that contract.",
+    "validation confirmed": "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_default_returns_selector_first_router tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection -q; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_start_preflight_cli.py",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "knowledge promoted (memory/docs/config)": "none",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed issue residue to #1035 startup skills projection acceptance.",
+    "motivation worth preserving": "Future agents should continue from #1035 startup skills projection acceptance rather than rediscover this closeout residue.",
+    "canonical owner now": "#1035 startup skills projection acceptance",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "#1035 startup skills projection acceptance",
+    "proposed durable intent": "Future agents should continue from #1035 startup skills projection acceptance rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": "True",
+    "owner surface": "#1035 startup skills projection acceptance"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_default_returns_selector_first_router tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection -q; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_start_preflight_cli.py",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "pending",
+    "guidance": "At closeout, separate acted-on, reported-only/routed, and dismissed incidental findings; keep this compact and evidence-backed.",
+    "source": "operating_posture",
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": ""
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-05-17: Scaffolded by agentic-planning new-plan.",
+    "2026-05-17: Recorded delegation decision route=keep-local."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "#1035 startup skills projection acceptance",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Add reasons to startup skills recommendations.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_default_returns_selector_first_router tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection -q; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_start_preflight_cli.py\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_start_preflight_cli.py; .agentic-workspace/planning/execplans/startup-skills-recommended-reasons.plan.json\nDurable residue: planning (#1035 startup skills projection acceptance)\nMemory learning: route_to_planning\nFollow-up: none"
+  }
+}

--- a/.agentic-workspace/planning/mutation-provenance.json
+++ b/.agentic-workspace/planning/mutation-provenance.json
@@ -2,70 +2,6 @@
   "kind": "planning-mutation-provenance/v1",
   "entries": [
     {
-      "path": ".agentic-workspace/planning/execplans/python-next-runtime-delegate-candidate.plan.json",
-      "sha256": "5ed7549a2114dc2e24d87427f52538581ab60169caf6b368815cbc791398d152",
-      "command": "agentic-planning record-recovery",
-      "reason": "Closed memory.status runtime delegate reduction plan after green proof; no focused execplan closeout field command exists.",
-      "mode": "manual-recovery",
-      "recorded_at": "2026-05-16T14:25:18+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "8b634c0d006a9f3e3d3b89e6a2e70341a39d31709226206be26ce470c214eb8f",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-next-runtime-delegate-candidate",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:25:22+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/archive/python-next-runtime-delegate-candidate.plan.json",
-      "sha256": "5ed7549a2114dc2e24d87427f52538581ab60169caf6b368815cbc791398d152",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-next-runtime-delegate-candidate",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:25:22+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json",
-      "sha256": "94b25ae9a94a48f1d2993670a63e9df1339485e4433f7528cf33a9e515cfd3e5",
-      "command": "agentic-planning record-recovery",
-      "reason": "Recorded memory.status portable-IR reduction in the epic decomposition.",
-      "mode": "manual-recovery",
-      "recorded_at": "2026-05-16T14:26:33+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-memory-doctor-runtime-reduction.plan.json",
-      "sha256": "09d37d7a7a5c05a9f10ace663640ec3dbda19861fadcdf0737a9bdbeddf50dc2",
-      "command": "agentic-planning new-plan",
-      "reason": "create execplan scaffold python-memory-doctor-runtime-reduction",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:27:08+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "6aa629890c6ee1018c8d798ac4e660db302e293c91a2af7d6461834978f958d2",
-      "command": "agentic-planning new-plan",
-      "reason": "create execplan scaffold python-memory-doctor-runtime-reduction",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:27:08+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-memory-doctor-runtime-reduction.plan.json",
-      "sha256": "451bb8160674a675141c52eb4e40cd8c346b3c5fee615a6b5fa1caa60295f8c3",
-      "command": "agentic-planning delegation-decision",
-      "reason": "record delegation decision route=keep-local",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:27:18+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-memory-doctor-runtime-reduction.plan.json",
-      "sha256": "586bce31f27f982ab46ae506bd5c50349315af9b8a0865655d98c4da7aff9494",
-      "command": "agentic-planning record-recovery",
-      "reason": "Bound active #892 slice to memory.doctor runtime delegate reduction.",
-      "mode": "manual-recovery",
-      "recorded_at": "2026-05-16T14:27:38+00:00"
-    },
-    {
       "path": ".agentic-workspace/planning/execplans/python-memory-doctor-runtime-reduction.plan.json",
       "sha256": "127394595d8cb68d6fd7e4c6e681caa78014544e9ca5feda0d69a040047a84e8",
       "command": "agentic-planning record-recovery",
@@ -1600,6 +1536,70 @@
       "reason": "close out execplan ci-schema-reference-doc-refresh",
       "mode": "cli-mutation",
       "recorded_at": "2026-05-17T19:12:30+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/startup-skills-recommended-reasons.plan.json",
+      "sha256": "a5d505cc5e657e5f817167a0e294b254476b3d41ff4c052531f24e56348504ee",
+      "command": "agentic-planning new-plan",
+      "reason": "create execplan scaffold startup-skills-recommended-reasons",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T19:14:14+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "99e656cc4f15e26bf97538005c3182800a631bdb366389fa397a92e6721f3359",
+      "command": "agentic-planning new-plan",
+      "reason": "create execplan scaffold startup-skills-recommended-reasons",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T19:14:14+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/startup-skills-recommended-reasons.plan.json",
+      "sha256": "65981609ae8d14603f04dd7532860fdf6adcdab98a5b6ba2d7170b789d3ca517",
+      "command": "agentic-planning delegation-decision",
+      "reason": "record delegation decision route=keep-local",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T19:14:18+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan startup-skills-recommended-reasons",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T19:16:22+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/startup-skills-recommended-reasons.plan.json",
+      "sha256": "e58c14c8576b714250f705a56cb4750908bfbc7fa1651c3ede9bd497170b56d1",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan startup-skills-recommended-reasons",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T19:16:22+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan startup-skills-recommended-reasons",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T19:16:22+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/startup-skills-recommended-reasons.plan.json",
+      "sha256": "e58c14c8576b714250f705a56cb4750908bfbc7fa1651c3ede9bd497170b56d1",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan startup-skills-recommended-reasons",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T19:16:22+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/mutation-provenance.json",
+      "sha256": "811458ecda4295cb7b9650d1d10fa671f15be12dcbfa5b2f212d8db6e66970c7",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan startup-skills-recommended-reasons",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T19:16:22+00:00"
     }
   ]
 }

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -10404,6 +10404,9 @@ def _startup_skills_projection(
     skills_by_id = {
         str(skill.get("id", "")): skill for skill in skills_payload.get("skills", []) if isinstance(skill, dict) and skill.get("id")
     }
+    recommendations_by_id = {
+        str(item.get("id", "")): item for item in skills_payload.get("recommendations", []) if isinstance(item, dict) and item.get("id")
+    }
 
     required_id = str(next_safe_action.get("required_skill", "") or "")
     required: list[dict[str, Any]] = []
@@ -10426,13 +10429,16 @@ def _startup_skills_projection(
             skill_id = str(item.get("id", "") or "")
             if not skill_id or skill_id == required_id:
                 continue
+            skill = skills_by_id.get(skill_id, {})
+            recommendation = recommendations_by_id.get(skill_id, {})
+            reasons = _list_payload(item.get("reasons") or recommendation.get("reasons"))
+            reason = str(reasons[0]) if reasons else "task-match"
             recommended.append(
                 {
-                    key: item.get(key)
-                    for key in ("id", "path", "summary", "score")
-                    if item.get(key) not in ("", None)
+                    "id": skill_id,
+                    "path": str(item.get("path") or recommendation.get("path") or skill.get("path") or ""),
+                    "reasons": [reason[:40]],
                 }
-                | ({"reasons": item.get("reasons", [])[:2]} if item.get("reasons") else {})
             )
 
     catalog_command = _proof_command_for_target(
@@ -10446,7 +10452,7 @@ def _startup_skills_projection(
     return {
         "kind": "agentic-workspace/startup-skills-projection/v1",
         "status": "recommended" if (required or recommended) else "available",
-        "rule": "This is a compact startup projection over the skill registry; use the catalog command for the full skill list.",
+        "rule": "Compact skill projection; use catalog.command for the full list.",
         "required": required,
         "recommended": recommended,
         "catalog": {

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -477,9 +477,7 @@ def test_start_command_returns_minimum_safe_startup_context(tmp_path: Path, caps
     assert payload["skill_routing"]["query"].startswith('uv run agentic-workspace skills --target "')
     assert payload["skill_routing"]["query"].endswith('" --task "<task>" --format json')
     assert "planning-autopilot" not in {route["skill"] for route in payload["skill_routing"]["preferred_routes"]}
-    assert payload["skill_routing"]["available_advanced_route_command"].startswith(
-        'uv run agentic-workspace modules --target "'
-    )
+    assert payload["skill_routing"]["available_advanced_route_command"].startswith('uv run agentic-workspace modules --target "')
     assert payload["skill_routing"]["fallback_when_skills_unavailable_count"] == 3
     assert "compact CLI routers" in payload["skill_routing"]["fallback_detail"]
     assert payload["workflow_obligations"]["configured_count"] == 0
@@ -633,6 +631,9 @@ def test_start_default_returns_selector_first_router(tmp_path: Path, capsys) -> 
     assert "legacy=select/context" in profile
     assert _start_active_state(payload)["todo_active_count"] >= 0
     assert payload["skills"]["required"] or payload["skills"]["recommended"] or payload["skills"]["catalog"]["available"]
+    for recommendation in payload["skills"]["recommended"]:
+        assert recommendation["path"]
+        assert recommendation["reasons"]
     assert payload["skills"]["catalog"]["command"].startswith("agentic-workspace skills --target")
     assert "--target ./repo" not in payload["skills"]["catalog"]["command"]
     assert _start_task_context(payload)["implement_changed_command"] == (


### PR DESCRIPTION
## What changed

- Completes the remaining updated #1035 startup skill-projection acceptance gap on top of the already-landed #1034/#1035 startup output work.
- Ensures compact `skills.recommended` entries include an executable path and short reasons, while staying within ordinary startup size budgets.
- Tightens the startup regression test so recommended skill entries must carry both `path` and `reasons`.

## Why

The updated #1035 body explicitly requires `skills.recommended` to be capped optional guidance with short reasons and paths. The existing startup projection could preserve paths while dropping reasons when routing through the compact task recommendation surface.

## Validation

- `uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_default_returns_selector_first_router tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection tests/test_workspace_start_preflight_cli.py::test_start_tiny_routes_config_posture_questions_to_tiny_config -q`
- `uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_start_preflight_cli.py`
- `make lint-workspace`
- `make test-workspace`
- `uv run agentic-workspace doctor --target . --modules planning --format json`
