### PR TITLE
Add Python completion blocker report

### DIFF
--- a/.agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json
@@ -144,9 +144,9 @@
     {
       "id": "tier-0-honest-gate",
       "title": "Stabilize the honest Python completion gate",
-      "readiness": "deferred",
+      "readiness": "promoted",
       "outcome": "False Python completion claims fail while generated commands import package runtime helpers, generated operation executors call package-owned runtime for generic deterministic behavior, package source still owns parser/dispatch/executable runtime envelopes, or the operation inventory has unresolved generic deterministic debt. The compact blockers report answers what blocks Python completion now.",
-      "owner_surface": "src/agentic_workspace/contracts/command_package_ir.json, src/agentic_workspace/contracts/python_operation_execution_inventory.json, scripts/check/check_generated_command_packages.py, tests/test_generated_command_package_proof_runner.py, and tests/test_contract_tooling.py",
+      "owner_surface": ".agentic-workspace/planning/execplans/tier-0-honest-gate.plan.json",
       "proof": "uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q",
       "depends_on": [],
       "parallel_with": []

--- a/.agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json
@@ -1,0 +1,364 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Stabilize the honest Python completion gate",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "lane",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "required_continuation",
+      "iterative_follow_through",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-0-honest-gate.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "False Python completion claims fail while generated commands import package runtime helpers, generated operation executors call package-owned runtime for generic deterministic behavior, package source still owns parser/dispatch/executable runtime envelopes, or the operation inventory has unresolved generic deterministic debt. The compact blockers report answers what blocks Python completion now.",
+    "proof_expectations": [
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q",
+      "uv run python scripts/check/run_generated_command_package_proof.py --all",
+      "make test-workspace",
+      "make lint-workspace",
+      "uv run agentic-workspace summary --target . --verbose --format json",
+      "uv run agentic-workspace doctor --target . --modules planning --format json"
+    ],
+    "touched_scope": [
+      "scripts/check/check_generated_command_packages.py",
+      "src/agentic_workspace/contracts/command_package_ir.json",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_contract_tooling.py",
+      "tests/test_generated_command_package_proof_runner.py",
+      "tests/test_workspace_defaults_cli.py",
+      ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json",
+      ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+      ".agentic-workspace/planning/mutation-provenance.json"
+    ],
+    "completion_criteria": [
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q",
+      "uv run python scripts/check/run_generated_command_package_proof.py --all",
+      "make test-workspace",
+      "make lint-workspace",
+      "uv run agentic-workspace summary --target . --verbose --format json",
+      "uv run agentic-workspace doctor --target . --modules planning --format json"
+    ],
+    "continuation_owner": "#892 / tier-1-primitive-taxonomy",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-0-honest-gate."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-0-honest-gate.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    },
+    "execution": {
+      "milestone": "tier-0-honest-gate",
+      "status": "completed",
+      "next_step": "False Python completion claims fail while generated commands import package runtime helpers, generated operation executors call package-owned runtime for generic deterministic behavior, package source still owns parser/dispatch/executable runtime envelopes, or the operation inventory has unresolved generic deterministic debt. The compact blockers report answers what blocks Python completion now.",
+      "proof": "uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q; uv run python scripts/check/run_generated_command_package_proof.py --all; make test-workspace; make lint-workspace; uv run agentic-workspace summary --target . --verbose --format json; uv run agentic-workspace doctor --target . --modules planning --format json"
+    },
+    "scope": {
+      "touched": [
+        "scripts/check/check_generated_command_packages.py",
+        "src/agentic_workspace/contracts/command_package_ir.json",
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_contract_tooling.py",
+        "tests/test_generated_command_package_proof_runner.py",
+        "tests/test_workspace_defaults_cli.py",
+        ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json",
+        ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+        ".agentic-workspace/planning/mutation-provenance.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "#892 Python generated CLI completion remains open beyond this Tier 0 checkpoint.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "#892 / tier-1-primitive-taxonomy"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "#892 / tier-1-primitive-taxonomy",
+    "activation trigger": "Promote tier-1-primitive-taxonomy when the next #892 primitive taxonomy slice is selected."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Tier 0 can now report why full Python generated CLI completion remains blocked while false full-completion claims still fail static proof.",
+    "intentionally deferred": "Primitive taxonomy, generated target layout, Memory-first migration, Workspace runtime reduction, and Planning runtime reduction remain in later #892 tiers.",
+    "discovered implications": "The current blockers are shipped module runtime/lifecycle ownership and generated runtime facade delegation to package-owned helpers.",
+    "proof achieved now": "yes",
+    "validation still needed": "none for Tier 0; future tiers need their own proof when promoted.",
+    "next likely slice": "tier-1-primitive-taxonomy"
+  },
+  "intent_interpretation": {
+    "literal request": "Stabilize the honest Python completion gate",
+    "inferred intended outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-0-honest-gate.",
+    "chosen concrete what": "False Python completion claims fail while generated commands import package runtime helpers, generated operation executors call package-owned runtime for generic deterministic behavior, package source still owns parser/dispatch/executable runtime envelopes, or the operation inventory has unresolved generic deterministic debt. The compact blockers report answers what blocks Python completion now.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "scripts/check/check_generated_command_packages.py; src/agentic_workspace/contracts/command_package_ir.json; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_contract_tooling.py; tests/test_generated_command_package_proof_runner.py; tests/test_workspace_defaults_cli.py; .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json; .agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json; .agentic-workspace/planning/mutation-provenance.json",
+    "max changed files": "9",
+    "required validation commands": "uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q; uv run python scripts/check/run_generated_command_package_proof.py --all; make test-workspace; make lint-workspace; uv run agentic-workspace summary --target . --verbose --format json; uv run agentic-workspace doctor --target . --modules planning --format json",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "False Python completion claims fail while generated commands import package runtime helpers, generated operation executors call package-owned runtime for generic deterministic behavior, package source still owns parser/dispatch/executable runtime envelopes, or the operation inventory has unresolved generic deterministic debt. The compact blockers report answers what blocks Python completion now.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-0-honest-gate.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "delegate-exploration",
+    "route skipped reason": "",
+    "decision command": "agentic-planning delegation-decision",
+    "recorded at": "2026-05-17T20:00:07+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json",
+      "label": "decomposition lane tier-0-honest-gate",
+      "role": "intake",
+      "locator": "candidate_lanes[10]"
+    }
+  ],
+  "active_milestone": {
+    "id": "tier-0-honest-gate",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "False Python completion claims fail while generated commands import package runtime helpers, generated operation executors call package-owned runtime for generic deterministic behavior, package source still owns parser/dispatch/executable runtime envelopes, or the operation inventory has unresolved generic deterministic debt. The compact blockers report answers what blocks Python completion now."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "scripts/check/check_generated_command_packages.py",
+    "src/agentic_workspace/contracts/command_package_ir.json",
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "tests/test_contract_tooling.py",
+    "tests/test_generated_command_package_proof_runner.py",
+    "tests/test_workspace_defaults_cli.py",
+    ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json",
+    ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+    ".agentic-workspace/planning/mutation-provenance.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q",
+    "uv run python scripts/check/run_generated_command_package_proof.py --all",
+    "make test-workspace",
+    "make lint-workspace",
+    "uv run agentic-workspace summary --target . --verbose --format json",
+    "uv run agentic-workspace doctor --target . --modules planning --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q",
+    "uv run python scripts/check/run_generated_command_package_proof.py --all",
+    "make test-workspace",
+    "make lint-workspace",
+    "uv run agentic-workspace summary --target . --verbose --format json",
+    "uv run agentic-workspace doctor --target . --modules planning --format json"
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning promote-to-plan decomposition lane",
+    "what happened": "Implemented a compact Python completion blocker report so Tier 0 can answer why full Python generated CLI completion remains blocked while false full-completion claims still fail static proof.",
+    "scope touched": "Tier 0 honest Python completion gate, generated-package checker, command_package_ir proof requirement, focused proof tests, planning metadata.",
+    "changed surfaces": "scripts/check/check_generated_command_packages.py; src/agentic_workspace/contracts/command_package_ir.json; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_contract_tooling.py; tests/test_generated_command_package_proof_runner.py; tests/test_workspace_defaults_cli.py; .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json; .agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json; .agentic-workspace/planning/mutation-provenance.json",
+    "validations run": "uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q; uv run python scripts/check/run_generated_command_package_proof.py --all; make test-workspace; make lint-workspace; uv run agentic-workspace summary --target . --verbose --format json; uv run agentic-workspace doctor --target . --modules planning --format json",
+    "result for continuation": "bounded closeout complete",
+    "next step": "continue #892 from tier-1-primitive-taxonomy when the next primitive taxonomy slice is selected"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within the promoted Tier 0 gate. Static proof already rejected false completion claims, but there was no compact blockers answer; the new report exposes the current blockers and keeps continuation on #892 Tier 1+ migration slices.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "#892 remains open; continue with tier-1-primitive-taxonomy"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "delegate-exploration",
+    "route skipped reason": "not skipped",
+    "expected savings": "unknown",
+    "actual friction": "pending",
+    "proof result": "passed",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q; uv run python scripts/check/run_generated_command_package_proof.py --all; make test-workspace; make lint-workspace; uv run agentic-workspace summary --target . --verbose --format json; uv run agentic-workspace doctor --target . --modules planning --format json",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q; uv run python scripts/check/run_generated_command_package_proof.py --all; make test-workspace; make lint-workspace; uv run agentic-workspace summary --target . --verbose --format json; uv run agentic-workspace doctor --target . --modules planning --format json"
+  },
+  "intent_satisfaction": {
+    "original intent": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-0-honest-gate.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "Tier 0 has a machine-readable blocker report and false completion claims fail; the larger #892 Python completion lane remains open.",
+    "unsolved intent passed to": "#892 / tier-1-primitive-taxonomy"
+  },
+  "execution_summary": {
+    "outcome delivered": "Tier 0 honest gate now has a machine-readable blockers report with completion_claim_allowed=false, false_completion_claim_would_fail=true, and explicit blocker messages for shipped runtime source plus generated facade package-runtime delegation.",
+    "validation confirmed": "uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q; uv run python scripts/check/run_generated_command_package_proof.py --all; make test-workspace; make lint-workspace; uv run agentic-workspace summary --target . --verbose --format json; uv run agentic-workspace doctor --target . --modules planning --format json",
+    "follow-on routed to": "#892 / tier-1-primitive-taxonomy",
+    "post-work posterity capture": "archive closeout distillation",
+    "knowledge promoted (memory/docs/config)": "none",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to #892 tier-1-primitive-taxonomy.",
+    "motivation worth preserving": "Future agents should continue from #892 tier-1-primitive-taxonomy rather than rediscover this closeout residue.",
+    "canonical owner now": "#892 tier-1-primitive-taxonomy",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "#892 tier-1-primitive-taxonomy",
+    "proposed durable intent": "Future agents should continue from #892 tier-1-primitive-taxonomy rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": "True",
+    "owner surface": "#892 / tier-1-primitive-taxonomy"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "Tier 0 is complete, but #892 Python generated CLI completion still has follow-on tiers; continuation is explicitly routed to tier-1-primitive-taxonomy.",
+    "evidence carried forward": "uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q; uv run python scripts/check/run_generated_command_package_proof.py --all; make test-workspace; make lint-workspace; uv run agentic-workspace summary --target . --verbose --format json; uv run agentic-workspace doctor --target . --modules planning --format json",
+    "reopen trigger": "Promote tier-1-primitive-taxonomy or another #892 follow-on tier when selected."
+  },
+  "improvement_signal_review": {
+    "status": "pending",
+    "guidance": "At closeout, separate acted-on, reported-only/routed, and dismissed incidental findings; keep this compact and evidence-backed.",
+    "source": "operating_posture",
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": ""
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "#892 Python generated CLI completion remains open; next owner is tier-1-primitive-taxonomy.",
+          "owner": "#892 / tier-1-primitive-taxonomy",
+          "source": "closure_check"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": [
+        {
+          "summary": "Keep #892 open for Tier 1+ follow-on work.",
+          "owner": "#892",
+          "source": "required_continuation"
+        }
+      ]
+    }
+  },
+  "drift_log": [
+    "2026-05-17: Scaffolded by agentic-planning promote-to-plan from decomposition lane tier-0-honest-gate.",
+    "2026-05-17: Recorded delegation decision route=delegate-exploration."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "#892 tier-1-primitive-taxonomy",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Tier 0 honest Python completion gate for #892.\nIntent satisfied: yes for Tier 0; no for the larger #892 Python completion lane.\nArchive decision: archive-but-keep-lane-open\nProof: uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q; uv run python scripts/check/run_generated_command_package_proof.py --all; make test-workspace; make lint-workspace; uv run agentic-workspace summary --target . --verbose --format json; uv run agentic-workspace doctor --target . --modules planning --format json\nChanged surfaces: scripts/check/check_generated_command_packages.py; src/agentic_workspace/contracts/command_package_ir.json; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_contract_tooling.py; tests/test_generated_command_package_proof_runner.py; tests/test_workspace_defaults_cli.py; .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json; .agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json; .agentic-workspace/planning/mutation-provenance.json\nDurable residue: planning (#892 / tier-1-primitive-taxonomy)\nMemory learning: route_to_planning\nFollow-up: #892 / tier-1-primitive-taxonomy"
+  }
+}

--- a/.agentic-workspace/planning/mutation-provenance.json
+++ b/.agentic-workspace/planning/mutation-provenance.json
@@ -2,78 +2,6 @@
   "kind": "planning-mutation-provenance/v1",
   "entries": [
     {
-      "path": ".agentic-workspace/planning/execplans/python-memory-doctor-runtime-reduction.plan.json",
-      "sha256": "127394595d8cb68d6fd7e4c6e681caa78014544e9ca5feda0d69a040047a84e8",
-      "command": "agentic-planning record-recovery",
-      "reason": "Closed memory.doctor runtime delegate reduction plan after green proof; no focused execplan closeout field command exists.",
-      "mode": "manual-recovery",
-      "recorded_at": "2026-05-16T14:31:58+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "8b634c0d006a9f3e3d3b89e6a2e70341a39d31709226206be26ce470c214eb8f",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-memory-doctor-runtime-reduction",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:31:58+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/archive/python-memory-doctor-runtime-reduction.plan.json",
-      "sha256": "127394595d8cb68d6fd7e4c6e681caa78014544e9ca5feda0d69a040047a84e8",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-memory-doctor-runtime-reduction",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:31:58+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json",
-      "sha256": "7b1db49ab3e7b7bf82c1a100db0a4f7a6b1355bde6403a112eedbb292c1e1a79",
-      "command": "agentic-planning record-recovery",
-      "reason": "Recorded memory.doctor portable-IR reduction in the epic decomposition.",
-      "mode": "manual-recovery",
-      "recorded_at": "2026-05-16T14:33:14+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-memory-report-runtime-reduction.plan.json",
-      "sha256": "ff00b01049b85dc910d9a8fb41ddb253ca03a0764177a93d419bd98d50602de1",
-      "command": "agentic-planning new-plan",
-      "reason": "create execplan scaffold python-memory-report-runtime-reduction",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:34:52+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "a7a3e77279b69543d5ebb1ae43dbd31b31f5b28768ae2d5b9377637301720dc4",
-      "command": "agentic-planning new-plan",
-      "reason": "create execplan scaffold python-memory-report-runtime-reduction",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:34:52+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/python-memory-report-runtime-reduction.plan.json",
-      "sha256": "8f5a7238d3655f612cee395290670e39714f3bdc0972568762a6c8b01d0c59ea",
-      "command": "agentic-planning delegation-decision",
-      "reason": "record delegation decision route=delegate-exploration",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:36:59+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/state.toml",
-      "sha256": "8b634c0d006a9f3e3d3b89e6a2e70341a39d31709226206be26ce470c214eb8f",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-memory-report-runtime-reduction",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:47:07+00:00"
-    },
-    {
-      "path": ".agentic-workspace/planning/execplans/archive/python-memory-report-runtime-reduction.plan.json",
-      "sha256": "526a26670954275dbbc95e1da597d26a11409094ff40c5932fd01344ee3ad59e",
-      "command": "agentic-planning archive-plan",
-      "reason": "archive execplan python-memory-report-runtime-reduction",
-      "mode": "cli-mutation",
-      "recorded_at": "2026-05-16T14:47:07+00:00"
-    },
-    {
       "path": ".agentic-workspace/planning/execplans/python-memory-verify-payload-runtime-audit.plan.json",
       "sha256": "c3c47ee7576637d6cae315aa81dd48322a4d6d6fc67a48943395691c99d71646",
       "command": "agentic-planning new-plan",
@@ -1600,6 +1528,86 @@
       "reason": "close out execplan startup-skills-recommended-reasons",
       "mode": "cli-mutation",
       "recorded_at": "2026-05-17T19:16:22+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/tier-0-honest-gate.plan.json",
+      "sha256": "d7fdd6fac081ef5be864d7ff6ae1a229452b48ab62830c3d80b2a8df4a4c7ce8",
+      "command": "agentic-planning promote-to-plan",
+      "reason": "promote decomposition lane tier-0-honest-gate",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T19:53:00+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "e38a8edd1fd25e4ab025ef364926ffefe7470f149758d14d2c36b81b652de718",
+      "command": "agentic-planning promote-to-plan",
+      "reason": "promote decomposition lane tier-0-honest-gate",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T19:53:00+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json",
+      "sha256": "21910576491654451290b3713b957ce29e413bdd60ac85eb81c8f38b53b7e30e",
+      "command": "agentic-planning promote-to-plan",
+      "reason": "promote decomposition lane tier-0-honest-gate",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T19:53:00+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/tier-0-honest-gate.plan.json",
+      "sha256": "3f76fefea7677a2be0a31a8a9f0c6a24ebc8351e10b1b11d3e2324c3deae34d6",
+      "command": "agentic-planning delegation-decision",
+      "reason": "record delegation decision route=delegate-exploration",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T20:00:07+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan tier-0-honest-gate",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T20:04:38+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+      "sha256": "47258bdeb0d9624eeffbc298cb27f7b34ae7da5b775714b4b6d47cd46390ba82",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan tier-0-honest-gate",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T20:04:38+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan tier-0-honest-gate",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T20:04:38+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+      "sha256": "47258bdeb0d9624eeffbc298cb27f7b34ae7da5b775714b4b6d47cd46390ba82",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan tier-0-honest-gate",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T20:04:38+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/mutation-provenance.json",
+      "sha256": "a3f940edfe528995e9e529a97e2ebca43fcef1fb0575c338b5d38c317fc5d2d2",
+      "command": "agentic-planning closeout",
+      "reason": "close out execplan tier-0-honest-gate",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T20:04:38+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+      "sha256": "728cfee6465ef4c613340cbeb1512fffcaf5b91f7069741a9a6698a8ba21feee",
+      "command": "agentic-planning record-recovery",
+      "reason": "Post-PR review cleanup: archive closeout fields were corrected to remove scaffold placeholders and honestly route #892 continuation to tier-1-primitive-taxonomy.",
+      "mode": "manual-recovery",
+      "recorded_at": "2026-05-17T20:19:39+00:00"
     }
   ]
 }

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import copy
 import importlib
 import io
 import json
@@ -2489,8 +2490,81 @@ def _run_primitive_conformance() -> int:
     return _run([_python_executable(), "packages/command-generation/tests/primitive_conformance.py"])
 
 
+def _python_completion_blockers_report(ir: dict[str, object]) -> dict[str, object]:
+    policy = ir.get("generation_policy", {}).get("python_cli_completion", {})
+    if not isinstance(policy, dict):
+        return {
+            "kind": "python-completion-blockers/v1",
+            "current_state": "missing",
+            "completion_gate_state": "missing",
+            "completion_claim_allowed": False,
+            "false_completion_claim_would_fail": True,
+            "blockers": ["command_package_ir.json generation_policy.python_cli_completion is missing or malformed"],
+            "blocker_count": 1,
+            "next_owner": "command_package_ir.json",
+        }
+
+    forced_full_ir = copy.deepcopy(ir)
+    forced_policy = forced_full_ir["generation_policy"]["python_cli_completion"]
+    forced_policy["current_state"] = "full-generated-cli-complete"
+    forced_policy.setdefault("completion_gate", {})["state"] = "satisfied"
+
+    blockers: list[str] = []
+    blockers.extend(_validate_python_cli_completion_policy(forced_policy))
+    blockers.extend(_validate_full_python_completion_runtime_ownership(forced_full_ir))
+    blockers.extend(_validate_full_python_completion_executable_ownership(forced_full_ir))
+    blockers.extend(_validate_python_runtime_projection_inventory(full_completion=True))
+    blockers.extend(_validate_python_operation_execution_inventory(forced_full_ir))
+
+    current_state = str(policy.get("current_state", ""))
+    gate = policy.get("completion_gate", {})
+    gate_state = str(gate.get("state", "")) if isinstance(gate, dict) else "malformed"
+    completion_claim_allowed = current_state == "full-generated-cli-complete" and gate_state == "satisfied" and not blockers
+    return {
+        "kind": "python-completion-blockers/v1",
+        "current_state": current_state,
+        "completion_gate_state": gate_state,
+        "completion_claim_allowed": completion_claim_allowed,
+        "false_completion_claim_would_fail": bool(blockers),
+        "blockers": blockers,
+        "blocker_count": len(blockers),
+        "next_owner": (
+            "promote the next #892 primitive/runtime migration slice"
+            if blockers
+            else "python_cli_completion may be promoted only with full proof rerun"
+        ),
+    }
+
+
+def _print_python_completion_blockers_report(report: dict[str, object], *, output_format: str) -> None:
+    if output_format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return
+
+    print(f"Python completion state: {report['current_state']} (gate: {report['completion_gate_state']})")
+    print(f"Completion claim allowed: {str(report['completion_claim_allowed']).lower()}")
+    blockers = report.get("blockers", [])
+    if not isinstance(blockers, list) or not blockers:
+        print("Blockers: none")
+        return
+    print("Blockers:")
+    for blocker in blockers:
+        print(f"- {blocker}")
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Check generated command package outputs.")
+    parser.add_argument(
+        "--python-completion-blockers",
+        action="store_true",
+        help="Print the compact blocker report for Python full generated CLI completion.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for report modes.",
+    )
     parser.add_argument(
         "--docker",
         action="store_true",
@@ -2556,6 +2630,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
+    if args.python_completion_blockers:
+        ir = load_workspace_command_package_ir(repo_root=REPO_ROOT)
+        _print_python_completion_blockers_report(
+            _python_completion_blockers_report(ir),
+            output_format=str(args.format),
+        )
+        return 0
+
     generator = REPO_ROOT / "scripts" / "generate" / "generate_command_packages.py"
     freshness = _run([_python_executable(), str(generator), "--check"])
     if freshness:

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -140,7 +140,8 @@
         "root console smoke proof executes at least one generated root command through the installed console path, not only through generated parser/help imports",
         "Full completion proof must distinguish generated-output placement from generated ownership; product-specific runtime files under generated/python must be produced by command-generation or explicitly inventoried as transitional generated-output debt.",
         "Full completion proof must distinguish portable codegen primitive execution from domain runtime primitives wrapped in IR.",
-        "Full completion proof must fail while shipped module source contains runtime primitive/projection modules that own generated CLI behavior."
+        "Full completion proof must fail while shipped module source contains runtime primitive/projection modules that own generated CLI behavior.",
+        "The compact Python completion blocker report must answer why current_state cannot honestly move to full-generated-cli-complete."
       ],
       "completion_gate": {
         "state": "pending",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -6218,6 +6218,7 @@ def _rewrite_module_cli_commands(value: Any) -> Any:
     if isinstance(value, str):
         value = value.replace("agentic-planning reconcile ", "agentic-workspace reconcile ")
         value = value.replace("agentic-planning summary ", "agentic-workspace summary ")
+        value = value.replace("agentic-planning doctor ", "agentic-workspace doctor ")
         value = value.replace("agentic-planning ", "agentic-workspace planning ")
         value = value.replace("agentic-memory ", "agentic-workspace memory ")
         return value

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -480,6 +480,7 @@ def test_command_package_ir_declares_python_and_typescript_targets() -> None:
     assert any("weak-agent-safe-adapter" in item for item in python_completion["proof_requirements"])
     assert any("generic deterministic operations" in item for item in python_completion["proof_requirements"])
     assert any("generated/python target output" in item for item in python_completion["proof_requirements"])
+    assert any("compact Python completion blocker report" in item for item in python_completion["proof_requirements"])
     assert runtime_binding["selected_model"] == "generated parser/help with process handoff to canonical Python CLI"
     assert "operation primitive implementation" in runtime_binding["runtime_owns"]
     assert "argv spelling and help rendering" in runtime_binding["target_projection_owns"]

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import copy
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -137,6 +138,34 @@ def test_current_python_completion_state_is_not_full_while_runtime_source_remain
 
     assert ir["generation_policy"]["python_cli_completion"]["current_state"] == "product-runtime-source-generation-incomplete"
     assert ir["generation_policy"]["python_cli_completion"]["completion_gate"]["state"] == "pending"
+
+
+def test_python_completion_blocker_report_names_current_false_claim_blockers() -> None:
+    checker = _load_checker()
+    ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
+
+    report = checker._python_completion_blockers_report(ir)
+
+    assert report["kind"] == "python-completion-blockers/v1"
+    assert report["current_state"] == "product-runtime-source-generation-incomplete"
+    assert report["completion_gate_state"] == "pending"
+    assert report["completion_claim_allowed"] is False
+    assert report["false_completion_claim_would_fail"] is True
+    blockers = "\n".join(report["blockers"])
+    assert "generated CLI runtime/lifecycle behavior" in blockers
+    assert "generated runtime facades still delegate to package-owned runtime helpers" in blockers
+
+
+def test_python_completion_blocker_report_has_json_cli_mode(capsys) -> None:
+    checker = _load_checker()
+
+    status = checker.main(["--python-completion-blockers", "--format", "json"])
+
+    assert status == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "python-completion-blockers/v1"
+    assert payload["completion_claim_allowed"] is False
+    assert payload["blocker_count"] == len(payload["blockers"])
 
 
 def test_memory_list_commands_are_direct_generated_python_projections() -> None:

--- a/tests/test_workspace_defaults_cli.py
+++ b/tests/test_workspace_defaults_cli.py
@@ -4,6 +4,26 @@ from __future__ import annotations
 from tests.workspace_cli_support import *
 
 
+def test_module_cli_command_rewrite_keeps_summary_and_doctor_on_workspace_front_door() -> None:
+    from agentic_workspace.workspace_runtime_primitives import _rewrite_module_cli_commands
+
+    payload = {
+        "proof": [
+            "agentic-planning summary --target . --format json",
+            "agentic-planning doctor --target . --modules planning --format json",
+            "agentic-planning promote-to-plan lane --target . --format json",
+        ]
+    }
+
+    assert _rewrite_module_cli_commands(payload) == {
+        "proof": [
+            "agentic-workspace summary --target . --format json",
+            "agentic-workspace doctor --target . --modules planning --format json",
+            "agentic-workspace planning promote-to-plan lane --target . --format json",
+        ]
+    }
+
+
 def test_defaults_command_reports_machine_readable_default_routes_as_json(capsys) -> None:
     assert cli.main(["defaults", "--verbose", "--format", "json"]) == 0
 


### PR DESCRIPTION
## Summary
- Promotes and archives the #892 Tier 0 honest-gate slice.
- Adds `--python-completion-blockers --format json|text` to `scripts/check/check_generated_command_packages.py` so the current Python completion gate can report why `full-generated-cli-complete` is not honest yet.
- Fixes dogfooding friction where rewritten planning follow-up commands incorrectly became `agentic-workspace planning summary/doctor` instead of the workspace front-door `summary` and `doctor` commands.

## Current blocker report
`uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json` reports:
- `completion_claim_allowed: false`
- `false_completion_claim_would_fail: true`
- blockers for shipped module runtime/lifecycle ownership and generated runtime facade delegation to package-owned helpers.

## Proof
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_generated_command_package_proof.py --all`
- `uv run agentic-workspace summary --target . --verbose --format json`
- `uv run agentic-workspace doctor --target . --modules planning --format json`

Refs #892.
Closes #1037.