### PR TITLE
Implement #892 Python completion tiers 1 and 2

### DIFF
--- a/.agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json
@@ -154,9 +154,9 @@
     {
       "id": "tier-1-primitive-taxonomy",
       "title": "Freeze portable primitive taxonomy",
-      "readiness": "deferred",
+      "readiness": "promoted",
       "outcome": "All operation steps are classified as Tier 1 portable codegen primitives, Tier 2 package-domain primitives or explicit debt, or Tier 3 deferred/out of completion scope. operation_primitives.json declares the taxonomy, schema backing, and Tier 2 owner/reason/conformance/migration/generic-behavior audit.",
-      "owner_surface": "src/agentic_workspace/contracts/operation_primitives.json, operation primitive schemas, src/agentic_workspace/contracts/python_operation_execution_inventory.json, packages/command-generation/tests/primitive_conformance.py, and scripts/check/check_generated_command_packages.py",
+      "owner_surface": ".agentic-workspace/planning/execplans/tier-1-primitive-taxonomy.plan.json",
       "proof": "uv run python scripts/check/check_generated_command_packages.py; uv run python packages/command-generation/tests/primitive_conformance.py",
       "depends_on": [
         "tier-0-honest-gate"
@@ -166,9 +166,9 @@
     {
       "id": "tier-2-generated-target-layout",
       "title": "Lock generated target layout",
-      "readiness": "deferred",
+      "readiness": "promoted",
       "outcome": "generated/<package>/python is the only visible generated Python target output with cli.py, commands/, primitives/, operations/, and resources or contracts where needed; legacy generated/python/*-cli/generated_cli_package output is removed or explicitly transitional.",
-      "owner_surface": "scripts/generate/generate_command_packages.py, generated/<package>/python, package force-include configuration, scripts/check/check_structured_file_inventory.py, and packaging tests",
+      "owner_surface": ".agentic-workspace/planning/execplans/tier-2-generated-target-layout.plan.json",
       "proof": "uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q",
       "depends_on": [
         "tier-0-honest-gate",

--- a/.agentic-workspace/planning/execplans/archive/fix-pr-1045-ci.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/fix-pr-1045-ci.plan.json
@@ -1,0 +1,288 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Fix PR 1045 CI checks",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Fix the failing PR #1045 planning CI check.",
+    "hard_constraints": "Keep scope bounded to schema reference documentation failures reported by CI; do not start the next #892 tier.",
+    "agent_may_decide": "Add missing schema descriptions, regenerate reference docs, and run the failing planning check plus focused schema validation.",
+    "escalate_when": "CI logs reveal an unrelated failure outside schema reference docs or the fix requires changing operation primitive semantics.",
+    "next_action": "Add missing operation primitive taxonomy schema descriptions and regenerate schema reference docs.",
+    "proof_expectations": [
+      "make schema-reference-docs",
+      "make check-planning"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/contracts/schemas/operation_primitives.schema.json",
+      "docs/reference/operation-primitives.md"
+    ],
+    "completion_criteria": [
+      "PR #1045 planning CI no longer fails schema reference docs.",
+      "Operation primitive taxonomy schema fields have descriptions.",
+      "Generated reference docs are current."
+    ],
+    "continuation_owner": "#892 / tier-3-memory-first",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Fix PR 1045 CI checks."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Fix the failing PR #1045 planning CI check.",
+      "constraints": "Keep scope bounded to schema reference documentation failures reported by CI; do not start the next #892 tier.",
+      "latitude": "Add missing schema descriptions, regenerate reference docs, and run the failing planning check plus focused schema validation.",
+      "escalation": "Escalate when CI logs reveal an unrelated failure outside schema reference docs or the fix requires changing operation primitive semantics."
+    },
+    "execution": {
+      "milestone": "fix-pr-1045-ci",
+      "status": "active",
+      "next_step": "Add missing operation primitive taxonomy schema descriptions and regenerate schema reference docs.",
+      "proof": "make schema-reference-docs; make check-planning"
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/contracts/schemas/operation_primitives.schema.json",
+        "docs/reference/operation-primitives.md"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Land PR #1045 with CI passing while #892 remains routed to tier-3-memory-first.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "#892 / tier-3-memory-first"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "#892 / tier-3-memory-first",
+    "activation trigger": "After PR #1045 lands."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "PR #1045 planning CI can pass schema reference docs.",
+    "intentionally deferred": "The larger #892 Python completion lane remains routed to tier-3-memory-first.",
+    "discovered implications": "CI enforces descriptions for newly exposed schema reference fields.",
+    "proof achieved now": "make schema-reference-docs, make check-planning, contract tooling, structured inventory, ruff, and maintainer surfaces pass.",
+    "validation still needed": "Push the fix and let GitHub Actions rerun.",
+    "next likely slice": "#892 / tier-3-memory-first after PR #1045 lands"
+  },
+  "intent_interpretation": {
+    "literal request": "Fix CI checks",
+    "inferred intended outcome": "Fix failing PR #1045 GitHub Actions checks.",
+    "chosen concrete what": "Resolve schema reference documentation failures for operation primitive taxonomy fields.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace/contracts/schemas/operation_primitives.schema.json; docs/reference/operation-primitives.md; planning closeout files.",
+    "max changed files": "5",
+    "required validation commands": "make schema-reference-docs; make check-planning; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue by adding missing schema descriptions, regenerating docs, and rerunning make check-planning.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Fix the failing PR #1045 planning CI check.",
+    "hard constraints": "Keep scope bounded to schema reference documentation failures reported by CI; do not start the next #892 tier.",
+    "agent may decide locally": "Add missing schema descriptions, regenerate reference docs, and run the failing planning check plus focused schema validation.",
+    "escalate when": "CI logs reveal an unrelated failure outside schema reference docs or the fix requires changing operation primitive semantics."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "CI failure is a narrow schema-reference docs repair with two implementation files; delegation would add handoff overhead.",
+    "decision command": "agentic-planning delegation-decision",
+    "recorded at": "2026-05-18T09:57:31+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "fix-pr-1045-ci",
+    "status": "completed",
+    "scope": "Fix schema reference documentation CI failure for PR #1045.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Add missing schema descriptions and regenerate schema reference docs."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/contracts/schemas/operation_primitives.schema.json",
+    "docs/reference/operation-primitives.md"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "make schema-reference-docs",
+    "make check-planning",
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "PR #1045 planning CI no longer fails schema reference docs.",
+    "Operation primitive taxonomy schema fields have descriptions.",
+    "Generated reference docs are current."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added missing primitive_taxonomy schema field descriptions and regenerated docs/reference/operation-primitives.md.",
+    "scope touched": "src/agentic_workspace/contracts/schemas/operation_primitives.schema.json; docs/reference/operation-primitives.md",
+    "changed surfaces": "Schema reference docs and operation primitives schema metadata.",
+    "validations run": "make schema-reference-docs; make check-planning; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces",
+    "result for continuation": "Commit and push the CI fix to PR #1045; #892 remains routed to tier-3-memory-first.",
+    "next step": "Push and recheck PR checks."
+  },
+  "finished_run_review": {
+    "review status": "completed",
+    "scope respected": "yes",
+    "proof status": "passed locally",
+    "intent served": "yes for CI fix; larger #892 remains open",
+    "config compliance": "used planning-backed workflow and CI log evidence",
+    "misinterpretation risk": "low",
+    "follow-on decision": "#892 / tier-3-memory-first"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "CI failure is a narrow schema-reference docs repair with two implementation files; delegation would add handoff overhead.",
+    "expected savings": "low",
+    "actual friction": "none",
+    "proof result": "passed",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "make schema-reference-docs; make check-planning; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces",
+    "proof achieved now": "yes",
+    "evidence for \"proof achieved\" state": "All listed local validation commands passed."
+  },
+  "intent_satisfaction": {
+    "original intent": "Fix failing CI checks for PR #1045.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "The exact failed CI target make check-planning passes locally after schema descriptions and regenerated docs.",
+    "unsolved intent passed to": "#892 / tier-3-memory-first"
+  },
+  "execution_summary": {
+    "outcome delivered": "Schema reference docs CI failure fixed for PR #1045.",
+    "validation confirmed": "local failing CI command and supporting checks pass",
+    "follow-on routed to": "#892 / tier-3-memory-first",
+    "post-work posterity capture": "archive closeout",
+    "knowledge promoted (Memory/Docs/Config)": "none",
+    "resume from": "No work remains in this CI-fix slice after push; wait for PR #1045 checks."
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "CI fix closeout",
+    "target scope": "none",
+    "proposed durable intent": "none",
+    "confidence": "low",
+    "needs review": false,
+    "owner surface": "none"
+  },
+  "closure_check": {
+    "slice status": "complete",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
+    "why this decision is honest": "The CI-fix slice is complete locally, while #892 remains open for tier-3-memory-first.",
+    "evidence carried forward": "The exact failed CI target make check-planning passes locally; schema reference docs are current.",
+    "reopen trigger": "PR #1045 GitHub Actions reports a remaining or new failure."
+  },
+  "improvement_signal_review": {
+    "status": "completed",
+    "guidance": "At closeout, separate acted-on, reported-only/routed, and dismissed incidental findings; keep this compact and evidence-backed.",
+    "source": "operating_posture",
+    "signals found": [
+      "CI reported missing descriptions for primitive_taxonomy schema reference fields."
+    ],
+    "signals fixed": [
+      "Added descriptions and regenerated docs/reference/operation-primitives.md."
+    ],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "#892 / tier-3-memory-first"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [
+        "docs/reference/operation-primitives.md regenerated from schema."
+      ],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-05-18: Scaffolded by agentic-planning new-plan.",
+    "2026-05-18: Recorded delegation decision route=keep-local."
+  ]
+}

--- a/.agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json
@@ -258,9 +258,9 @@
     "decomposition adjustment": "none"
   },
   "proof_report": {
-    "validation proof": "uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q; uv run python scripts/check/run_generated_command_package_proof.py --all; make test-workspace; make lint-workspace; uv run agentic-workspace summary --target . --verbose --format json; uv run agentic-workspace doctor --target . --modules planning --format json",
+    "validation proof": "generated package proof; focused tests; full proof runner; workspace tests/lint; planning summary and doctor",
     "proof achieved now": "yes; planning closeout recorded explicit proof input.",
-    "evidence for \"proof achieved\" state": "uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q; uv run python scripts/check/run_generated_command_package_proof.py --all; make test-workspace; make lint-workspace; uv run agentic-workspace summary --target . --verbose --format json; uv run agentic-workspace doctor --target . --modules planning --format json"
+    "evidence for \"proof achieved\" state": "Tier 0 proof commands passed; exact command list is retained in validation_commands."
   },
   "intent_satisfaction": {
     "original intent": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-0-honest-gate.",
@@ -305,14 +305,14 @@
     "reopen trigger": "Promote tier-1-primitive-taxonomy or another #892 follow-on tier when selected."
   },
   "improvement_signal_review": {
-    "status": "pending",
+    "status": "completed",
     "guidance": "At closeout, separate acted-on, reported-only/routed, and dismissed incidental findings; keep this compact and evidence-backed.",
     "source": "operating_posture",
     "signals found": [],
     "signals fixed": [],
     "signals routed": [],
     "signals dismissed": [],
-    "next owner": ""
+    "next owner": "#892 / tier-1-primitive-taxonomy"
   },
   "closeout_distillation": {
     "buckets": {
@@ -359,6 +359,6 @@
     "status": "generated",
     "source": "archive-plan --prepare-closeout",
     "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
-    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Tier 0 honest Python completion gate for #892.\nIntent satisfied: yes for Tier 0; no for the larger #892 Python completion lane.\nArchive decision: archive-but-keep-lane-open\nProof: uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q; uv run python scripts/check/run_generated_command_package_proof.py --all; make test-workspace; make lint-workspace; uv run agentic-workspace summary --target . --verbose --format json; uv run agentic-workspace doctor --target . --modules planning --format json\nChanged surfaces: scripts/check/check_generated_command_packages.py; src/agentic_workspace/contracts/command_package_ir.json; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_contract_tooling.py; tests/test_generated_command_package_proof_runner.py; tests/test_workspace_defaults_cli.py; .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json; .agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json; .agentic-workspace/planning/mutation-provenance.json\nDurable residue: planning (#892 / tier-1-primitive-taxonomy)\nMemory learning: route_to_planning\nFollow-up: #892 / tier-1-primitive-taxonomy"
+    "text": "Intent: Tier 0 honest Python completion gate for #892.\nTier 0 satisfied: yes.\nLarger #892 lane satisfied: no; archive-but-keep-lane-open.\nProof: generated package proof, focused tests, full proof runner, workspace tests/lint, planning summary, planning doctor.\nChanged surfaces: checker, command package IR, workspace runtime rewrite, focused tests, decomposition, archive/provenance.\nDurable residue and follow-up: #892 / tier-1-primitive-taxonomy."
   }
 }

--- a/.agentic-workspace/planning/execplans/archive/tier-1-primitive-taxonomy.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/tier-1-primitive-taxonomy.plan.json
@@ -1,0 +1,339 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Freeze portable primitive taxonomy",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "lane",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "required_continuation",
+      "iterative_follow_through",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-1-primitive-taxonomy.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "All operation steps are classified as Tier 1 portable codegen primitives, Tier 2 package-domain primitives or explicit debt, or Tier 3 deferred/out of completion scope. operation_primitives.json declares the taxonomy, schema backing, and Tier 2 owner/reason/conformance/migration/generic-behavior audit.",
+    "proof_expectations": [
+      "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+      "uv run pytest tests/test_contract_tooling.py -q",
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run python packages/command-generation/tests/primitive_conformance.py"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/contracts/operation_primitives.json",
+      "src/agentic_workspace/contracts/schemas/operation_primitives.schema.json",
+      "scripts/check/check_contract_tooling_surfaces.py",
+      "tests/test_contract_tooling.py",
+      "packages/command-generation/src/command_generation/generated_package_loader.py",
+      ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json"
+    ],
+    "completion_criteria": [
+      "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+      "uv run pytest tests/test_contract_tooling.py -q",
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run python packages/command-generation/tests/primitive_conformance.py"
+    ],
+    "continuation_owner": "#892 / tier-2-generated-target-layout",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-1-primitive-taxonomy."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-1-primitive-taxonomy.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    },
+    "execution": {
+      "milestone": "tier-1-primitive-taxonomy",
+      "status": "completed",
+      "next_step": "All operation steps are classified as Tier 1 portable codegen primitives, Tier 2 package-domain primitives or explicit debt, or Tier 3 deferred/out of completion scope. operation_primitives.json declares the taxonomy, schema backing, and Tier 2 owner/reason/conformance/migration/generic-behavior audit.",
+      "proof": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run pytest tests/test_contract_tooling.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run python packages/command-generation/tests/primitive_conformance.py"
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/contracts/operation_primitives.json",
+        "src/agentic_workspace/contracts/schemas/operation_primitives.schema.json",
+        "scripts/check/check_contract_tooling_surfaces.py",
+        "tests/test_contract_tooling.py",
+        "packages/command-generation/src/command_generation/generated_package_loader.py",
+        ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "#892 Python generated CLI completion remains open beyond Tier 1.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "#892 / tier-2-generated-target-layout"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "#892 / tier-2-generated-target-layout",
+    "activation trigger": "Promote tier-2-generated-target-layout."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Operation primitive refs now have schema-backed Tier 1/Tier 2/Tier 3 classification and Tier 2 audit fields.",
+    "intentionally deferred": "Generated target layout and later runtime-reduction tiers remain in #892.",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes",
+    "validation still needed": "Tier 2 and later #892 proof.",
+    "next likely slice": "tier-2-generated-target-layout"
+  },
+  "intent_interpretation": {
+    "literal request": "Freeze portable primitive taxonomy",
+    "inferred intended outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-1-primitive-taxonomy.",
+    "chosen concrete what": "All operation steps are classified as Tier 1 portable codegen primitives, Tier 2 package-domain primitives or explicit debt, or Tier 3 deferred/out of completion scope. operation_primitives.json declares the taxonomy, schema backing, and Tier 2 owner/reason/conformance/migration/generic-behavior audit.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace/contracts/operation_primitives.json; src/agentic_workspace/contracts/schemas/operation_primitives.schema.json; scripts/check/check_contract_tooling_surfaces.py; tests/test_contract_tooling.py; packages/command-generation/src/command_generation/generated_package_loader.py; .agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+    "max changed files": "6 plus planning metadata",
+    "required validation commands": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run pytest tests/test_contract_tooling.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run python packages/command-generation/tests/primitive_conformance.py",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "All operation steps are classified as Tier 1 portable codegen primitives, Tier 2 package-domain primitives or explicit debt, or Tier 3 deferred/out of completion scope. operation_primitives.json declares the taxonomy, schema backing, and Tier 2 owner/reason/conformance/migration/generic-behavior audit.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-1-primitive-taxonomy.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "delegate-exploration",
+    "route skipped reason": "",
+    "decision command": "agentic-planning delegation-decision",
+    "recorded at": "2026-05-17T20:58:04+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json",
+      "label": "decomposition lane tier-1-primitive-taxonomy",
+      "role": "intake",
+      "locator": "candidate_lanes[11]"
+    }
+  ],
+  "active_milestone": {
+    "id": "tier-1-primitive-taxonomy",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "All operation steps are classified as Tier 1 portable codegen primitives, Tier 2 package-domain primitives or explicit debt, or Tier 3 deferred/out of completion scope. operation_primitives.json declares the taxonomy, schema backing, and Tier 2 owner/reason/conformance/migration/generic-behavior audit."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/contracts/operation_primitives.json",
+    "src/agentic_workspace/contracts/schemas/operation_primitives.schema.json",
+    "scripts/check/check_contract_tooling_surfaces.py",
+    "tests/test_contract_tooling.py",
+    "packages/command-generation/src/command_generation/generated_package_loader.py",
+    ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run pytest tests/test_contract_tooling.py -q",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run python packages/command-generation/tests/primitive_conformance.py"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run pytest tests/test_contract_tooling.py -q",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run python packages/command-generation/tests/primitive_conformance.py"
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "",
+    "handoff source": "agentic-planning promote-to-plan decomposition lane",
+    "what happened": "Added primitive taxonomy contract/schema/check/test coverage and fixed a crash-prone generated package loader glob path found during validation.",
+    "scope touched": "Tier 1 primitive taxonomy, contract tooling proof, generated package loader crash fix, archive size guardrail cleanup.",
+    "changed surfaces": "src/agentic_workspace/contracts/operation_primitives.json; src/agentic_workspace/contracts/schemas/operation_primitives.schema.json; scripts/check/check_contract_tooling_surfaces.py; tests/test_contract_tooling.py; packages/command-generation/src/command_generation/generated_package_loader.py; .agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+    "validations run": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run pytest tests/test_contract_tooling.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run python packages/command-generation/tests/primitive_conformance.py",
+    "result for continuation": "Tier 1 complete; continue #892 with Tier 2.",
+    "next step": "Promote tier-2-generated-target-layout."
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "yes",
+    "proof status": "passed",
+    "intent served": "yes for Tier 1; larger #892 remains open",
+    "config compliance": "used planning-backed workflow and compact summary",
+    "misinterpretation risk": "low",
+    "follow-on decision": "#892 / tier-2-generated-target-layout"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "delegate-exploration",
+    "route skipped reason": "not skipped",
+    "expected savings": "Spark explorers inspect Tier 1 contract and Tier 2 layout surfaces while implementation remains local for cross-file consistency.",
+    "actual friction": "Delegated exploration was interrupted by crashes; local implementation carried the narrow cross-file contract change.",
+    "proof result": "passed",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run pytest tests/test_contract_tooling.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run python packages/command-generation/tests/primitive_conformance.py",
+    "proof achieved now": "yes",
+    "evidence for \"proof achieved\" state": "Tier 1 validation commands passed."
+  },
+  "intent_satisfaction": {
+    "original intent": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-1-primitive-taxonomy.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "Tier 1 primitive taxonomy is implemented: operation_primitives.json classifies operation step primitives into Tier 1 portable codegen and Tier 2 package-domain debt with schema/check/test coverage; full #892 remains open.",
+    "unsolved intent passed to": "#892 / tier-2-generated-target-layout"
+  },
+  "execution_summary": {
+    "outcome delivered": "Tier 1 primitive taxonomy implemented with schema/check/test proof; loader crash found during validation fixed.",
+    "validation confirmed": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run pytest tests/test_contract_tooling.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run python packages/command-generation/tests/primitive_conformance.py",
+    "follow-on routed to": "#892 / tier-2-generated-target-layout",
+    "post-work posterity capture": "archive closeout distillation",
+    "knowledge promoted (Memory/Docs/Config)": "none",
+    "resume from": "tier-2-generated-target-layout"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "none",
+    "proposed durable intent": "none yet",
+    "confidence": "low",
+    "needs review": "True",
+    "owner surface": "none"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "Tier 1 is complete, but the larger #892 Python generated CLI lane still requires Tier 2 generated target layout and later runtime-reduction tiers.",
+    "evidence carried forward": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run pytest tests/test_contract_tooling.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run python packages/command-generation/tests/primitive_conformance.py",
+    "reopen trigger": "Promote tier-2-generated-target-layout for the next #892 continuation slice."
+  },
+  "improvement_signal_review": {
+    "status": "completed",
+    "guidance": "At closeout, separate acted-on, reported-only/routed, and dismissed incidental findings; keep this compact and evidence-backed.",
+    "source": "operating_posture",
+    "signals found": [],
+    "signals fixed": [
+      "Loader crash finding fixed and filed as #1043."
+    ],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "#892 / tier-2-generated-target-layout"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "Continue #892 with tier-2-generated-target-layout.",
+          "owner": "#892 / tier-2-generated-target-layout",
+          "source": "closure_check"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-05-17: Scaffolded by agentic-planning promote-to-plan from decomposition lane tier-1-primitive-taxonomy.",
+    "2026-05-17: Recorded delegation decision route=delegate-exploration.",
+    "2026-05-17: Tier 1 completed and routed continuation to tier-2-generated-target-layout."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-1-primitive-taxonomy.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run pytest tests/test_contract_tooling.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run python packages/command-generation/tests/primitive_conformance.py\nChanged surfaces: src/agentic_workspace/contracts/operation_primitives.json; src/agentic_workspace/contracts/schemas/operation_primitives.schema.json; scripts/check/check_contract_tooling_surfaces.py; tests/test_contract_tooling.py; packages/command-generation/src/command_generation/generated_package_loader.py; .agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json\nDurable residue: none (none)\nMemory learning: none\nFollow-up: #892 / tier-2-generated-target-layout"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/tier-2-generated-target-layout.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/tier-2-generated-target-layout.plan.json
@@ -1,0 +1,329 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Lock generated target layout",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "lane",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "required_continuation",
+      "iterative_follow_through",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-2-generated-target-layout.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "generated/<package>/python is the only visible generated Python target output with cli.py, commands/, primitives/, operations/, and resources or contracts where needed; legacy generated/python/*-cli/generated_cli_package output is removed or explicitly transitional.",
+    "proof_expectations": [
+      "uv run python scripts/generate/generate_command_packages.py --check",
+      "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+      "uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q",
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q"
+    ],
+    "touched_scope": [
+      "scripts/check/check_generated_command_packages.py",
+      "tests/test_generated_command_package_proof_runner.py",
+      ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json"
+    ],
+    "completion_criteria": [
+      "uv run python scripts/generate/generate_command_packages.py --check",
+      "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+      "uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q",
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q"
+    ],
+    "continuation_owner": "#892 / tier-3-memory-first",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-2-generated-target-layout."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-2-generated-target-layout.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    },
+    "execution": {
+      "milestone": "tier-2-generated-target-layout",
+      "status": "completed",
+      "next_step": "generated/<package>/python is the only visible generated Python target output with cli.py, commands/, primitives/, operations/, and resources or contracts where needed; legacy generated/python/*-cli/generated_cli_package output is removed or explicitly transitional.",
+      "proof": "uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q"
+    },
+    "scope": {
+      "touched": [
+        "scripts/check/check_generated_command_packages.py",
+        "tests/test_generated_command_package_proof_runner.py",
+        ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "#892 Python generated CLI completion remains open beyond Tier 2.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "#892 / tier-3-memory-first"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "#892 / tier-3-memory-first",
+    "activation trigger": "Promote tier-3-memory-first."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Generated Python target layout is locked by static proof: package outputs live under generated/<package>/python and legacy generated/python package directories are rejected.",
+    "intentionally deferred": "Memory-first runtime reduction and later Workspace/Planning tiers remain in #892.",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes",
+    "validation still needed": "Tier 3 and later #892 proof.",
+    "next likely slice": "tier-3-memory-first"
+  },
+  "intent_interpretation": {
+    "literal request": "Lock generated target layout",
+    "inferred intended outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-2-generated-target-layout.",
+    "chosen concrete what": "generated/<package>/python is the only visible generated Python target output with cli.py, commands/, primitives/, operations/, and resources or contracts where needed; legacy generated/python/*-cli/generated_cli_package output is removed or explicitly transitional.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "scripts/check/check_generated_command_packages.py; tests/test_generated_command_package_proof_runner.py; .agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+    "max changed files": "3 plus planning metadata",
+    "required validation commands": "uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "generated/<package>/python is the only visible generated Python target output with cli.py, commands/, primitives/, operations/, and resources or contracts where needed; legacy generated/python/*-cli/generated_cli_package output is removed or explicitly transitional.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-2-generated-target-layout.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "delegate-exploration",
+    "route skipped reason": "",
+    "decision command": "agentic-planning delegation-decision",
+    "recorded at": "2026-05-17T21:24:19+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json",
+      "label": "decomposition lane tier-2-generated-target-layout",
+      "role": "intake",
+      "locator": "candidate_lanes[12]"
+    }
+  ],
+  "active_milestone": {
+    "id": "tier-2-generated-target-layout",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "generated/<package>/python is the only visible generated Python target output with cli.py, commands/, primitives/, operations/, and resources or contracts where needed; legacy generated/python/*-cli/generated_cli_package output is removed or explicitly transitional."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "scripts/check/check_generated_command_packages.py",
+    "tests/test_generated_command_package_proof_runner.py",
+    ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run python scripts/generate/generate_command_packages.py --check",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "uv run python scripts/generate/generate_command_packages.py --check",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q"
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "",
+    "handoff source": "agentic-planning promote-to-plan decomposition lane",
+    "what happened": "Added static generated Python target layout guard and regression test; compacted oversized Tier 0 archive evidence so structured inventory proof passes.",
+    "scope touched": "Tier 2 generated target layout proof and planning archive guardrail cleanup.",
+    "changed surfaces": "scripts/check/check_generated_command_packages.py; tests/test_generated_command_package_proof_runner.py; .agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+    "validations run": "uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q",
+    "result for continuation": "Tier 2 complete; continue #892 with Tier 3.",
+    "next step": "Promote tier-3-memory-first when selected."
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "yes",
+    "proof status": "passed",
+    "intent served": "yes for Tier 2; larger #892 remains open",
+    "config compliance": "used planning-backed workflow and compact summary",
+    "misinterpretation risk": "low",
+    "follow-on decision": "#892 / tier-3-memory-first"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "delegate-exploration",
+    "route skipped reason": "not skipped",
+    "expected savings": "Spark explorer inspected generated target layout before crash; implementation remains local for proof and planning closeout.",
+    "actual friction": "Delegated exploration was interrupted by crashes; local implementation carried the narrow checker/test change.",
+    "proof result": "passed",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q",
+    "proof achieved now": "yes",
+    "evidence for \"proof achieved\" state": "Tier 2 validation commands passed."
+  },
+  "intent_satisfaction": {
+    "original intent": "Promoted from .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json lane tier-2-generated-target-layout.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "Tier 2 generated target layout is locked: generated package check rejects legacy generated/python package directories, generation --check passes, structured inventory passes, and packaging tests pass.",
+    "unsolved intent passed to": "#892 / tier-3-memory-first"
+  },
+  "execution_summary": {
+    "outcome delivered": "Tier 2 generated target layout locked with static proof and regression test; structured inventory guardrail passes.",
+    "validation confirmed": "uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q",
+    "follow-on routed to": "#892 / tier-3-memory-first",
+    "post-work posterity capture": "archive closeout distillation",
+    "knowledge promoted (Memory/Docs/Config)": "none",
+    "resume from": "tier-3-memory-first"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive closeout",
+    "target scope": "none",
+    "proposed durable intent": "none",
+    "confidence": "low",
+    "needs review": false,
+    "owner surface": "none"
+  },
+  "closure_check": {
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
+    "why this decision is honest": "Tier 2 is complete, but #892 still requires Tier 3 Memory-first and later runtime-reduction tiers.",
+    "evidence carried forward": "uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q",
+    "reopen trigger": "Promote tier-3-memory-first."
+  },
+  "improvement_signal_review": {
+    "status": "routed",
+    "guidance": "At closeout, separate acted-on, reported-only/routed, and dismissed incidental findings; keep this compact and evidence-backed.",
+    "source": "operating_posture",
+    "signals found": [
+      {
+        "summary": "Windows interpreter access violation during generated package discovery glob in validation."
+      }
+    ],
+    "signals fixed": [
+      {
+        "summary": "Replaced wildcard Path.glob discovery with bounded iterdir scans."
+      }
+    ],
+    "signals routed": [
+      {
+        "summary": "Filed #1043 for dogfooding traceability; PR will close it."
+      }
+    ],
+    "signals dismissed": [],
+    "next owner": "#1043"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [],
+      "continuation": [
+        {
+          "summary": "Continue #892 with tier-3-memory-first.",
+          "owner": "#892 / tier-3-memory-first",
+          "source": "closure_check"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": [
+        {
+          "summary": "Dogfooding crash finding fixed in this PR and tracked by #1043.",
+          "owner": "#1043",
+          "source": "improvement_signal_review"
+        }
+      ]
+    }
+  },
+  "drift_log": [
+    "2026-05-17: Scaffolded by agentic-planning promote-to-plan from decomposition lane tier-2-generated-target-layout.",
+    "2026-05-17: Recorded delegation decision route=delegate-exploration.",
+    "2026-05-17: Tier 2 completed and routed continuation to tier-3-memory-first; #1043 filed for fixed validation crash."
+  ]
+}

--- a/.agentic-workspace/planning/execplans/archive/tiny-start-payload-budget.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/tiny-start-payload-budget.plan.json
@@ -1,0 +1,283 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Restore tiny start payload budget",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Restore the selector-first start payload budget without weakening planning safety semantics.",
+    "hard_constraints": "Keep scope bounded to the default start payload projection and its focused tests; do not start Tier 3 work.",
+    "agent_may_decide": "Compact redundant projection detail when drill-down selectors or direct fields preserve the underlying safety information.",
+    "escalate_when": "The fix requires changing planning decisions, active execplan semantics, or unrelated startup routing behavior.",
+    "next_action": "Compact planning safety gate detail in the selector-first start context and validate the workspace tests.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection tests/test_workspace_start_preflight_cli.py::test_start_tiny_routes_config_posture_questions_to_tiny_config tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q",
+      "make test-workspace"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_workspace_start_preflight_cli.py"
+    ],
+    "completion_criteria": [
+      "Default selector-first start payload remains under the existing size budgets.",
+      "Planning safety gate context still exposes actionable status, decision, proof, and ownership fields.",
+      "The Tier 1/2 PR validation completes without carrying this blocker as hidden residue."
+    ],
+    "continuation_owner": "#892 / tier-3-memory-first",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Restore tiny start payload budget."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Restore the selector-first start payload budget without weakening planning safety semantics.",
+      "constraints": "Keep scope bounded to the default start payload projection and its focused tests; do not start Tier 3 work.",
+      "latitude": "Compact redundant projection detail when drill-down selectors or direct fields preserve the underlying safety information.",
+      "escalation": "Escalate when the fix requires changing planning decisions, active execplan semantics, or unrelated startup routing behavior."
+    },
+    "execution": {
+      "milestone": "tiny-start-payload-budget",
+      "status": "active",
+      "next_step": "Compact planning safety gate detail in the selector-first start context and validate the workspace tests.",
+      "proof": "Focused start payload budget tests and make test-workspace pass."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_workspace_start_preflight_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Finish the Tier 1/2 #892 branch with honest validation and no hidden startup payload regression.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "#892 / tier-3-memory-first"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "#892 / tier-3-memory-first",
+    "activation trigger": "After Tier 1/2 PR lands and the next #892 slice is intentionally promoted."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Tier 1/2 #892 branch validation can complete without oversized tiny startup or implementer payloads.",
+    "intentionally deferred": "The larger #892 Python completion lane remains routed to tier-3-memory-first.",
+    "discovered implications": "Dogfooding issue #1044 tracks the fixed payload-budget regression.",
+    "proof achieved now": "Focused payload tests and make test-workspace pass.",
+    "validation still needed": "Full PR validation remains to be rerun after closeout.",
+    "next likely slice": "#892 / tier-3-memory-first"
+  },
+  "intent_interpretation": {
+    "literal request": "Restore tiny start payload budget",
+    "inferred intended outcome": "Remove the validation blocker discovered while finishing the Tier 1/2 #892 branch.",
+    "chosen concrete what": "Compact selector-first planning safety gate projection while preserving actionable fields.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_start_preflight_cli.py or tests/test_workspace_implement_cli.py only if a focused assertion is needed.",
+    "max changed files": "3",
+    "required validation commands": "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection tests/test_workspace_start_preflight_cli.py::test_start_tiny_routes_config_posture_questions_to_tiny_config tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q; make test-workspace",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue by compacting selector-first planning safety gate detail, then rerun the two focused budget tests and make test-workspace.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Restore the selector-first start payload budget without weakening planning safety semantics.",
+    "hard constraints": "Keep scope bounded to the default start payload projection and its focused tests; do not start Tier 3 work.",
+    "agent may decide locally": "Compact redundant projection detail when drill-down selectors or direct fields preserve the underlying safety information.",
+    "escalate when": "The fix requires changing planning decisions, active execplan semantics, or unrelated startup routing behavior."
+  },
+  "post_decomposition_delegation": {
+    "status": "not-needed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "tiny-start-payload-budget",
+    "status": "completed",
+    "scope": "Compact selector-first start payload planning safety detail and validate the budget regression.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Compact selector-first planning safety gate detail in src/agentic_workspace/workspace_runtime_primitives.py."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "tests/test_workspace_start_preflight_cli.py",
+    "tests/test_workspace_implement_cli.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection tests/test_workspace_start_preflight_cli.py::test_start_tiny_routes_config_posture_questions_to_tiny_config tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_workspace_start_preflight_cli.py::test_implement_requires_delegation_decision_for_active_decomposed_lane -q",
+    "make test-workspace"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Default selector-first start payload remains under the existing size budgets.",
+    "Planning safety gate context still exposes actionable status, decision, proof, and ownership fields.",
+    "The Tier 1/2 PR validation completes without carrying this blocker as hidden residue."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Compacted blocked planning safety gate projection for selector-first start and tiny implementer payloads, preserving actionable fields while summarizing decomposition candidates.",
+    "scope touched": "src/agentic_workspace/workspace_runtime_primitives.py",
+    "changed surfaces": "Workspace startup and implementer context projections.",
+    "validations run": "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection tests/test_workspace_start_preflight_cli.py::test_start_tiny_routes_config_posture_questions_to_tiny_config tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q; uv run pytest tests/test_workspace_start_preflight_cli.py::test_implement_requires_delegation_decision_for_active_decomposed_lane ... -q; make test-workspace",
+    "result for continuation": "Return to Tier 1/2 PR validation; #892 remains open for tier-3-memory-first.",
+    "next step": "Run full PR validation, commit, push, and open the PR."
+  },
+  "finished_run_review": {
+    "review status": "completed",
+    "scope respected": "yes",
+    "proof status": "focused and workspace proof passed",
+    "intent served": "yes",
+    "config compliance": "yes",
+    "misinterpretation risk": "low",
+    "follow-on decision": "#892 / tier-3-memory-first remains open"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "Small validation blocker with single-file implementation; delegation would add handoff overhead.",
+    "expected savings": "low",
+    "actual friction": "none",
+    "proof result": "focused and workspace tests passed",
+    "quality concern": "none after preserving delegation_decision_command in the compact gate",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection tests/test_workspace_start_preflight_cli.py::test_start_tiny_routes_config_posture_questions_to_tiny_config tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q; focused delegation command guard test; make test-workspace",
+    "proof achieved now": "yes",
+    "evidence for \"proof achieved\" state": "Focused tests passed; make test-workspace reported [ok] workspace tests."
+  },
+  "intent_satisfaction": {
+    "original intent": "Restore the selector-first start payload budget without weakening planning safety semantics.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "Tiny start and implementer budget tests pass while blocked planning gate action fields remain present.",
+    "unsolved intent passed to": "#892 / tier-3-memory-first"
+  },
+  "execution_summary": {
+    "outcome delivered": "Selector-first and tiny implementer planning safety gate projections are compact enough for existing budgets.",
+    "validation confirmed": "focused tests and make test-workspace pass",
+    "follow-on routed to": "#892 / tier-3-memory-first",
+    "post-work posterity capture": "Issue #1044 filed and fixed in this PR.",
+    "knowledge promoted (Memory/Docs/Config)": "none",
+    "resume from": "No work remains in this recovery slice; resume #892 at tier-3-memory-first after this PR lands."
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive closeout",
+    "target scope": "none",
+    "proposed durable intent": "none",
+    "confidence": "low",
+    "needs review": false,
+    "owner surface": "none"
+  },
+  "closure_check": {
+    "slice status": "complete",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
+    "why this decision is honest": "The validation blocker slice is complete, but the larger #892 Python completion lane still continues at tier-3-memory-first.",
+    "evidence carried forward": "Focused payload and delegation guard tests pass; make test-workspace passes; issue #1044 documents the fixed dogfooding finding.",
+    "reopen trigger": "A future tiny start or implementer payload reintroduces full decomposition candidate detail by default."
+  },
+  "improvement_signal_review": {
+    "status": "completed",
+    "guidance": "At closeout, separate acted-on, reported-only/routed, and dismissed incidental findings; keep this compact and evidence-backed.",
+    "source": "operating_posture",
+    "signals found": [
+      "#1044: Tiny startup and implementer projections embedded bulky planning gate decomposition details."
+    ],
+    "signals fixed": [
+      "#1044 fixed by compacting blocked planning gate projection while preserving actionable command fields."
+    ],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "#892 / tier-3-memory-first"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": [
+        "#1044 is filed and fixed by this branch; close via PR."
+      ]
+    }
+  },
+  "drift_log": [
+    "2026-05-17: Scaffolded by agentic-planning new-plan."
+  ]
+}

--- a/.agentic-workspace/planning/mutation-provenance.json
+++ b/.agentic-workspace/planning/mutation-provenance.json
@@ -1608,6 +1608,174 @@
       "reason": "Post-PR review cleanup: archive closeout fields were corrected to remove scaffold placeholders and honestly route #892 continuation to tier-1-primitive-taxonomy.",
       "mode": "manual-recovery",
       "recorded_at": "2026-05-17T20:19:39+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/tier-1-primitive-taxonomy.plan.json",
+      "sha256": "57f31d6c506b91ee7dbe43f07b61af59a1ec6728ecec35c198770b3434d37666",
+      "command": "agentic-planning promote-to-plan",
+      "reason": "promote decomposition lane tier-1-primitive-taxonomy",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T20:41:21+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "039d24e0fd7fd233a42e6c96e46c13318c914aaa620a47195cc1570c303168d1",
+      "command": "agentic-planning promote-to-plan",
+      "reason": "promote decomposition lane tier-1-primitive-taxonomy",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T20:41:21+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json",
+      "sha256": "20924bd5cf110df66c502f580af77146bcabf922c1352f199862a6e8eea89aa4",
+      "command": "agentic-planning promote-to-plan",
+      "reason": "promote decomposition lane tier-1-primitive-taxonomy",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T20:41:21+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/tier-1-primitive-taxonomy.plan.json",
+      "sha256": "926a15be9cd89c16a8dc6a3a2f9d5a36392a6a00ebfedb25edd75c12dded3997",
+      "command": "agentic-planning delegation-decision",
+      "reason": "record delegation decision route=delegate-exploration",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T20:58:04+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan tier-1-primitive-taxonomy",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:24:05+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/tier-1-primitive-taxonomy.plan.json",
+      "sha256": "f265d8a9fd99b6b5ca6eb305afb615c53e458c9450093133a0907d2f5607bce9",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan tier-1-primitive-taxonomy",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:24:05+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/tier-2-generated-target-layout.plan.json",
+      "sha256": "80ed4782342cd194233825898575f61774ec187586bb09e6e5418a3a2b3bd238",
+      "command": "agentic-planning promote-to-plan",
+      "reason": "promote decomposition lane tier-2-generated-target-layout",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:24:11+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "fd285b4d6f81e0a180fea65193a273645f8fc163282c1be326a479370ec561f9",
+      "command": "agentic-planning promote-to-plan",
+      "reason": "promote decomposition lane tier-2-generated-target-layout",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:24:11+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json",
+      "sha256": "60ea117f49f5353875505b56951ea071678d4b895ceed4416851d02158614623",
+      "command": "agentic-planning promote-to-plan",
+      "reason": "promote decomposition lane tier-2-generated-target-layout",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:24:11+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/tier-2-generated-target-layout.plan.json",
+      "sha256": "9f51dc593168502aacd3ffc6bf9402bc6206f2d69a2d3013409cfee6e6b3dba1",
+      "command": "agentic-planning delegation-decision",
+      "reason": "record delegation decision route=delegate-exploration",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:24:19+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan tier-2-generated-target-layout",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:31:46+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/tier-2-generated-target-layout.plan.json",
+      "sha256": "a1041591ef4144918acaaa09a652f31af206502bd801bef09bd2eaf31de83733",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan tier-2-generated-target-layout",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:31:46+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+      "sha256": "aa1952d3d6c4f6ed43eb880565fabc5ec209ef686cd4b86e0602e918464aa55f",
+      "command": "agentic-planning record-recovery",
+      "reason": "Tier 2 proof required compacting oversized Tier 0 archive generated_closeout/proof prose so structured file inventory guardrails pass.",
+      "mode": "manual-recovery",
+      "recorded_at": "2026-05-17T21:33:23+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/tiny-start-payload-budget.plan.json",
+      "sha256": "7ac98aaeb53e07e0efa9853dbb5a92441a3557da149b6b00889e5090733ad874",
+      "command": "agentic-planning new-plan",
+      "reason": "create execplan scaffold tiny-start-payload-budget",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:36:23+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "bd3592e911b45012c78cb97a612f4935e60ee667a6c768b163738eb24e97b84d",
+      "command": "agentic-planning new-plan",
+      "reason": "create execplan scaffold tiny-start-payload-budget",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:36:23+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan tiny-start-payload-budget",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:45:05+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/tiny-start-payload-budget.plan.json",
+      "sha256": "e8d84a2f77c2abc53693d97b480cc46d8d853207252d9621dca4fce8aa0b9d35",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan tiny-start-payload-budget",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-17T21:45:05+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/tier-1-primitive-taxonomy.plan.json",
+      "sha256": "b0989f9341f25adc0beb6f1c16cea6897d4754bfbcf3c63f55094aa465f829d2",
+      "command": "agentic-planning record-recovery",
+      "reason": "Post-archive cleanup: replace residual pending delegation/improvement fields with completed proof and #1043 routing.",
+      "mode": "manual-recovery",
+      "recorded_at": "2026-05-17T21:48:53+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/tier-2-generated-target-layout.plan.json",
+      "sha256": "95b80834f0e99ca55b6c67d91fe24e724b7f7a0b19218eadd9cd8abb21f6aafa",
+      "command": "agentic-planning record-recovery",
+      "reason": "Post-archive cleanup: replace residual pending delegation/task-intent fields with completed proof and no-promotion decision.",
+      "mode": "manual-recovery",
+      "recorded_at": "2026-05-17T21:48:57+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/tiny-start-payload-budget.plan.json",
+      "sha256": "d5880050f1f3087f478f47fc367c69d3f7c19e20e7bd9fe58c903df9856b45db",
+      "command": "agentic-planning record-recovery",
+      "reason": "Post-archive cleanup: mark delegation not needed, record no-promotion decision, and add focused delegation guard proof command.",
+      "mode": "manual-recovery",
+      "recorded_at": "2026-05-17T21:49:01+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/tier-0-honest-gate.plan.json",
+      "sha256": "1c65c192c5d68414f047924aa664bd2dd9b516fbc785bab57144194d30f426df",
+      "command": "agentic-planning record-recovery",
+      "reason": "Post-archive cleanup: mark improvement review complete and route next owner to #892 / tier-1-primitive-taxonomy.",
+      "mode": "manual-recovery",
+      "recorded_at": "2026-05-17T21:49:40+00:00"
     }
   ]
 }

--- a/.agentic-workspace/planning/mutation-provenance.json
+++ b/.agentic-workspace/planning/mutation-provenance.json
@@ -1776,6 +1776,46 @@
       "reason": "Post-archive cleanup: mark improvement review complete and route next owner to #892 / tier-1-primitive-taxonomy.",
       "mode": "manual-recovery",
       "recorded_at": "2026-05-17T21:49:40+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/fix-pr-1045-ci.plan.json",
+      "sha256": "e7e60b7a68e76a1d05429c8918a84b1e63123140c6a7a8dd53a6d15ef7fb2c6c",
+      "command": "agentic-planning new-plan",
+      "reason": "create execplan scaffold fix-pr-1045-ci",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-18T09:55:07+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "db61af3b2bc3d75ca74c77deeecd83f08352b9fb9261d40233f51ad2ebcb2dce",
+      "command": "agentic-planning new-plan",
+      "reason": "create execplan scaffold fix-pr-1045-ci",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-18T09:55:07+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/fix-pr-1045-ci.plan.json",
+      "sha256": "c694d0e51e3f6d3c584276065ae31c1c3715c22cef29d6f05e97e8aa0d97795d",
+      "command": "agentic-planning delegation-decision",
+      "reason": "record delegation decision route=keep-local",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-18T09:57:31+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/state.toml",
+      "sha256": "2825a103bb66f149fb0a5df4c54a27542a980a4b8f789ea801637c26cd080901",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan fix-pr-1045-ci",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-18T09:58:49+00:00"
+    },
+    {
+      "path": ".agentic-workspace/planning/execplans/archive/fix-pr-1045-ci.plan.json",
+      "sha256": "27fae3a655704ec6c18f2b9fae72121ad3c2a740de46cfe26f97777ea69e38e4",
+      "command": "agentic-planning archive-plan",
+      "reason": "archive execplan fix-pr-1045-ci",
+      "mode": "cli-mutation",
+      "recorded_at": "2026-05-18T09:58:49+00:00"
     }
   ]
 }

--- a/docs/reference/operation-primitives.md
+++ b/docs/reference/operation-primitives.md
@@ -25,4 +25,9 @@ Registry of implementation primitives referenced by operation contracts.
 | `primitive_extension_boundary.module_extension_rule` | string | yes |  | Rule for keeping module-specific primitives explicit as domain-runtime extensions. |  |  |
 | `primitive_extension_boundary.target_support_rule` | string | yes |  | Rule requiring each generated target to implement shared primitives or visibly report unsupported/deferred behavior. |  |  |
 | `primitive_extension_boundary.target_support_matrix` | array of object | yes |  | Target support or explicit unsupported reporting for shared primitives and module/domain-runtime extensions. |  |  |
+| `primitive_taxonomy` | object | no |  | Completion-tier taxonomy for primitive references used by operation contracts. |  |  |
+| `primitive_taxonomy.classification_rule` | string | yes |  | Rule used to classify each primitive into a completion tier. |  |  |
+| `primitive_taxonomy.tier_definitions` | array of object | yes |  | Completion tiers that separate portable codegen primitives, package-domain primitives, and deferred or out-of-scope debt. |  |  |
+| `primitive_taxonomy.tier_2_required_audit_fields` | array of string | yes |  | Audit fields that every Tier 2 package-domain primitive must carry. |  |  |
+| `primitive_taxonomy.generic_behavior_rule` | string | yes |  | Rule preventing generic deterministic behavior from being hidden behind package-domain primitive classification. |  |  |
 | `primitives` | array of object | yes |  | Ordered primitives entries used by this contract. |  |  |

--- a/packages/command-generation/src/command_generation/generated_package_loader.py
+++ b/packages/command-generation/src/command_generation/generated_package_loader.py
@@ -143,15 +143,26 @@ def _candidate_generated_package_dirs() -> list[Path]:
     for parent in Path(__file__).resolve().parents:
         generated_root = parent / "generated"
         if generated_root.is_dir():
-            candidates.extend(sorted(generated_root.glob("*/python")))
-            candidates.extend(sorted((generated_root / "python").glob("*/generated_cli_package")))
+            for child in sorted(generated_root.iterdir()):
+                python_dir = child / "python"
+                if python_dir.is_dir():
+                    candidates.append(python_dir)
+            legacy_root = generated_root / "python"
+            if legacy_root.is_dir():
+                for child in sorted(legacy_root.iterdir()):
+                    legacy_package = child / "generated_cli_package"
+                    if legacy_package.is_dir():
+                        candidates.append(legacy_package)
     for path_entry in sys.path:
         if not path_entry:
             continue
         root = Path(path_entry)
         if not root.is_dir():
             continue
-        candidates.extend(sorted(root.glob("*/_generated_cli_package_impl")))
+        for child in sorted(root.iterdir()):
+            generated_impl = child / "_generated_cli_package_impl"
+            if generated_impl.is_dir():
+                candidates.append(generated_impl)
     seen: set[Path] = set()
     unique: list[Path] = []
     for candidate in candidates:

--- a/scripts/check/check_contract_tooling_surfaces.py
+++ b/scripts/check/check_contract_tooling_surfaces.py
@@ -377,6 +377,35 @@ def _validate_operation_primitives(payload: dict[str, object]) -> list[str]:
             for required_target in ("python", "typescript", "bash", "powershell"):
                 if required_target not in support_targets:
                     errors.append(f"operation_primitives.json target_support_matrix missing target {required_target}")
+    taxonomy = payload.get("primitive_taxonomy")
+    tier_2_required_fields = {
+        "tier_owner",
+        "tier_reason",
+        "conformance_ref",
+        "migration_path",
+        "generic_behavior_audit",
+    }
+    if not isinstance(taxonomy, dict):
+        errors.append("operation_primitives.json must declare primitive_taxonomy")
+    else:
+        definitions = taxonomy.get("tier_definitions")
+        if not isinstance(definitions, list):
+            errors.append("operation_primitives.json primitive_taxonomy must declare tier_definitions")
+        else:
+            defined_tiers = {str(item.get("id")) for item in definitions if isinstance(item, dict)}
+            missing_tiers = {
+                "tier-1-portable-codegen",
+                "tier-2-package-domain",
+                "tier-3-deferred-or-out-of-scope",
+            } - defined_tiers
+            if missing_tiers:
+                errors.append("operation_primitives.json primitive_taxonomy missing tier(s): " + ", ".join(sorted(missing_tiers)))
+        required_fields = taxonomy.get("tier_2_required_audit_fields")
+        if set(required_fields or []) != tier_2_required_fields:
+            errors.append(
+                "operation_primitives.json primitive_taxonomy tier_2_required_audit_fields must be: "
+                + ", ".join(sorted(tier_2_required_fields))
+            )
     primitives = payload.get("primitives")
     if not isinstance(primitives, list) or not primitives:
         errors.append("operation_primitives.json must contain at least one primitive")
@@ -402,6 +431,19 @@ def _validate_operation_primitives(payload: dict[str, object]) -> list[str]:
                 target_executor_kinds.add(kind)
             if not isinstance(primitive.get("semantics"), str) or not str(primitive.get("semantics")).strip():
                 errors.append(f"target-executor primitive {primitive_id} must declare semantics")
+        taxonomy_tier = primitive.get("taxonomy_tier")
+        if taxonomy_tier not in {
+            "tier-1-portable-codegen",
+            "tier-2-package-domain",
+            "tier-3-deferred-or-out-of-scope",
+        }:
+            errors.append(f"primitive {primitive_id} missing valid taxonomy_tier")
+        if primitive.get("portability") == "target-executor" and taxonomy_tier != "tier-1-portable-codegen":
+            errors.append(f"target-executor primitive {primitive_id} must be classified tier-1-portable-codegen")
+        if taxonomy_tier == "tier-2-package-domain":
+            missing_audit = sorted(field for field in tier_2_required_fields if not str(primitive.get(field, "")).strip())
+            if missing_audit:
+                errors.append(f"tier-2 primitive {primitive_id} missing audit field(s): " + ", ".join(missing_audit))
     required_target_executor_kinds = {
         "filesystem",
         "structured-data",
@@ -435,6 +477,37 @@ def _validate_operation_primitives(payload: dict[str, object]) -> list[str]:
             missing_support = sorted(schema_backed_primitives - implemented_target_primitives)
             if missing_support:
                 errors.append("operation_primitives.json schema-backed primitives missing implemented target support: " + ", ".join(missing_support))
+    operation_step_primitives: set[str] = set()
+    for operation_ref in operation_contracts_manifest()["operations"]:
+        try:
+            operation = operation_manifest(str(operation_ref.get("path", "")))
+        except Exception as exc:  # pragma: no cover - checker reports the loaded path
+            errors.append(f"operation {operation_ref.get('id')} failed primitive taxonomy load: {exc}")
+            continue
+        for step in operation.get("steps", []):
+            if isinstance(step, dict) and isinstance(step.get("uses"), str):
+                operation_step_primitives.add(step["uses"])
+        ir_plan = operation.get("ir_plan", {})
+        if isinstance(ir_plan, dict):
+            for step in ir_plan.get("steps", []):
+                if isinstance(step, dict) and isinstance(step.get("uses"), str):
+                    operation_step_primitives.add(step["uses"])
+    missing_classification = sorted(primitive for primitive in operation_step_primitives if primitive not in seen_ids)
+    if missing_classification:
+        errors.append("operation steps reference primitives missing from operation_primitives.json: " + ", ".join(missing_classification))
+    tiered_primitives = {
+        str(primitive["id"]): str(primitive.get("taxonomy_tier"))
+        for primitive in primitives
+        if isinstance(primitive, dict) and isinstance(primitive.get("id"), str)
+    }
+    unclassified_steps = sorted(
+        primitive
+        for primitive in operation_step_primitives
+        if tiered_primitives.get(primitive)
+        not in {"tier-1-portable-codegen", "tier-2-package-domain", "tier-3-deferred-or-out-of-scope"}
+    )
+    if unclassified_steps:
+        errors.append("operation step primitives missing valid taxonomy_tier: " + ", ".join(unclassified_steps))
     return errors
 
 
@@ -2073,7 +2146,6 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-
 
 
 

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -1875,6 +1875,30 @@ def _validate_no_legacy_generated_adapter_runtime_import(*, relative_path: str, 
     return errors
 
 
+def _validate_generated_python_target_layout() -> list[str]:
+    errors: list[str] = []
+    generated_python_root = REPO_ROOT / "generated" / "python"
+    if generated_python_root.is_dir():
+        legacy_dirs = sorted(path.name for path in generated_python_root.iterdir() if path.is_dir())
+        if legacy_dirs:
+            errors.append(
+                "generated/python must contain only shared Python proof support files; legacy generated Python "
+                "package directories must live under generated/<package>/python: "
+                + ", ".join(legacy_dirs)
+            )
+    for package_name in ("workspace", "planning", "memory"):
+        package_root = REPO_ROOT / "generated" / package_name / "python"
+        if not package_root.is_dir():
+            errors.append(f"generated/{package_name}/python is missing")
+            continue
+        for directory_name in ("commands", "operations", "primitives"):
+            if not (package_root / directory_name).is_dir():
+                errors.append(f"generated/{package_name}/python/{directory_name} is missing")
+        if not (package_root / "cli.py").is_file():
+            errors.append(f"generated/{package_name}/python/cli.py is missing")
+    return errors
+
+
 def _validate_generated_python_commands_absent_from_handwritten_parsers() -> list[str]:
     errors: list[str] = []
     for package_id in ("root-workspace", "planning-bootstrap", "memory-bootstrap"):
@@ -2347,6 +2371,7 @@ def _validate_static_surfaces() -> list[str]:
                 errors.append(f"{relative_path} does not route generated Python adapters through generated command modules")
         errors.extend(_validate_python_shipped_source_executable_retirement())
         errors.extend(_validate_python_runtime_handler_boundary())
+        errors.extend(_validate_generated_python_target_layout())
         errors.extend(_validate_direct_generated_python_command_projection())
         errors.extend(_validate_generated_python_commands_absent_from_handwritten_parsers())
         errors.extend(_validate_generated_cli_compatibility_vocabulary())

--- a/src/agentic_workspace/contracts/operation_primitives.json
+++ b/src/agentic_workspace/contracts/operation_primitives.json
@@ -131,34 +131,66 @@
       "summary": "Run an explicitly allowed validation command.",
       "kind": "check",
       "portability": "target-executor",
-      "semantics": "Execute only a command declared by the operation or proof route and report structured exit/output data."
+      "semantics": "Execute only a command declared by the operation or proof route and report structured exit/output data.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "delegation.outcome.append",
-      "summary": "Append a local-only delegation outcome record for future target-profile tuning."
+      "summary": "Append a local-only delegation outcome record for future target-profile tuning.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "command operation contract owner",
+      "tier_reason": "The primitive is named in operation IR but its portable executor semantics are not schema-backed yet.",
+      "conformance_ref": "contract tooling and generated command package checks",
+      "migration_path": "Add schema-backed semantics and executor conformance before promoting to Tier 1.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "external_intent.evidence.normalize",
-      "summary": "Normalize provider-specific issue data into provider-agnostic external intent evidence records."
+      "summary": "Normalize provider-specific issue data into provider-agnostic external intent evidence records.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "external provider adapter boundary",
+      "tier_reason": "Provider integration or checked callable adapter behavior is not portable target-executor logic.",
+      "conformance_ref": "operation inventory and generated command package checks",
+      "migration_path": "Split deterministic normalization or file writes into Tier 1 primitives only after provider-specific behavior has a stable contract.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "external_intent.evidence.write",
-      "summary": "Write provider-agnostic external intent evidence under the planning evidence surface."
+      "summary": "Write provider-agnostic external intent evidence under the planning evidence surface.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "external provider adapter boundary",
+      "tier_reason": "Provider integration or checked callable adapter behavior is not portable target-executor logic.",
+      "conformance_ref": "operation inventory and generated command package checks",
+      "migration_path": "Split deterministic normalization or file writes into Tier 1 primitives only after provider-specific behavior has a stable contract.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "external_intent.github.issues.list",
-      "summary": "Read GitHub issues through the optional gh CLI adapter."
+      "summary": "Read GitHub issues through the optional gh CLI adapter.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "external provider adapter boundary",
+      "tier_reason": "Provider integration or checked callable adapter behavior is not portable target-executor logic.",
+      "conformance_ref": "operation inventory and generated command package checks",
+      "migration_path": "Split deterministic normalization or file writes into Tier 1 primitives only after provider-specific behavior has a stable contract.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "external_intent.github.repo.resolve",
-      "summary": "Resolve a GitHub repository for optional external intent refresh from an explicit repo or local gh context."
+      "summary": "Resolve a GitHub repository for optional external intent refresh from an explicit repo or local gh context.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "external provider adapter boundary",
+      "tier_reason": "Provider integration or checked callable adapter behavior is not portable target-executor logic.",
+      "conformance_ref": "operation inventory and generated command package checks",
+      "migration_path": "Split deterministic normalization or file writes into Tier 1 primitives only after provider-specific behavior has a stable contract.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "filesystem.copy",
       "summary": "Copy a package resource or root-contained file to a root-contained destination.",
       "kind": "filesystem",
       "portability": "target-executor",
-      "semantics": "Copy bytes between declared roots without allowing path escape."
+      "semantics": "Copy bytes between declared roots without allowing path escape.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "filesystem.exists",
@@ -167,7 +199,8 @@
       "portability": "target-executor",
       "semantics": "Return a boolean for a normalized path without escaping the operation root.",
       "input_schema_ref": "schemas/primitives/filesystem_exists.input.schema.json",
-      "output_schema_ref": "schemas/primitives/filesystem_exists.output.schema.json"
+      "output_schema_ref": "schemas/primitives/filesystem_exists.output.schema.json",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "filesystem.glob",
@@ -176,7 +209,8 @@
       "portability": "target-executor",
       "semantics": "Return sorted relative paths that match a non-escaping glob expression.",
       "input_schema_ref": "schemas/primitives/filesystem_glob.input.schema.json",
-      "output_schema_ref": "schemas/primitives/filesystem_glob.output.schema.json"
+      "output_schema_ref": "schemas/primitives/filesystem_glob.output.schema.json",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "filesystem.read",
@@ -185,25 +219,34 @@
       "portability": "target-executor",
       "semantics": "Read text from a normalized path after root containment checks.",
       "input_schema_ref": "schemas/primitives/filesystem_read.input.schema.json",
-      "output_schema_ref": "schemas/primitives/filesystem_read.output.schema.json"
+      "output_schema_ref": "schemas/primitives/filesystem_read.output.schema.json",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "filesystem.remove",
       "summary": "Remove a root-contained file when the operation allows the mutation.",
       "kind": "filesystem",
       "portability": "target-executor",
-      "semantics": "Remove a normalized root-contained path only when operation effects and guards permit removal."
+      "semantics": "Remove a normalized root-contained path only when operation effects and guards permit removal.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "filesystem.write",
       "summary": "Write a UTF-8 text file within the operation root.",
       "kind": "filesystem",
       "portability": "target-executor",
-      "semantics": "Write text to a normalized path after root containment and operation effect checks."
+      "semantics": "Write text to a normalized path after root containment and operation effect checks.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "implementer.context.assemble",
-      "summary": "Assemble bounded implementer context from changed paths, boundary markers, and proof selection."
+      "summary": "Assemble bounded implementer context from changed paths, boundary markers, and proof selection.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "json.parse",
@@ -212,147 +255,288 @@
       "portability": "target-executor",
       "semantics": "Parse JSON using the target runtime's standard parser and fail the operation on invalid JSON.",
       "input_schema_ref": "schemas/primitives/json_parse.input.schema.json",
-      "output_schema_ref": "schemas/primitives/json_parse.output.schema.json"
+      "output_schema_ref": "schemas/primitives/json_parse.output.schema.json",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "json.write",
       "summary": "Serialize a structured value as stable JSON text.",
       "kind": "structured-data",
       "portability": "target-executor",
-      "semantics": "Emit deterministic UTF-8 JSON using the contract-selected formatting policy."
+      "semantics": "Emit deterministic UTF-8 JSON using the contract-selected formatting policy.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "markdown.sections.parse",
       "summary": "Parse Markdown into heading-addressable sections.",
       "kind": "structured-data",
       "portability": "target-executor",
-      "semantics": "Build a conservative section map from Markdown headings without interpreting arbitrary Markdown syntax."
+      "semantics": "Build a conservative section map from Markdown headings without interpreting arbitrary Markdown syntax.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "memory.bootstrap.doctor.load",
-      "summary": "Load package-local memory doctor diagnostics for a target repository."
+      "summary": "Load package-local memory doctor diagnostics for a target repository.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.bootstrap.files.list",
-      "summary": "List packaged memory bootstrap files without mutating a target repository."
+      "summary": "List packaged memory bootstrap files without mutating a target repository.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.bootstrap.skills.list",
-      "summary": "List packaged memory bootstrap lifecycle skills."
+      "summary": "List packaged memory bootstrap lifecycle skills.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.bootstrap.status.load",
-      "summary": "Load package-local memory bootstrap status for a target repository."
+      "summary": "Load package-local memory bootstrap status for a target repository.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.bootstrap.cleanup",
       "summary": "Remove package-local temporary Memory bootstrap workspace files.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.capture_note.load",
       "summary": "Load package-local Memory capture recommendations.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.current.load",
       "summary": "Load package-local legacy current-memory show or check result.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.front_door.dispatch",
       "summary": "Dispatch generated workspace memory front-door argv to the Memory module runtime boundary.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.install.apply",
       "summary": "Install or initialize package-local Memory bootstrap surfaces.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.init.apply",
       "summary": "Initialize package-local Memory bootstrap surfaces using install semantics.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.adopt.apply",
       "summary": "Adopt package-local Memory bootstrap surfaces in an existing repository.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.upgrade.apply",
       "summary": "Upgrade package-local Memory bootstrap surfaces.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.migrate_layout.apply",
       "summary": "Migrate package-local Memory bootstrap legacy layout surfaces.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.uninstall.apply",
       "summary": "Remove package-local Memory bootstrap surfaces conservatively.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.note.create",
       "summary": "Create or dry-run a package-local Memory note and manifest entry.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.prompt.render",
       "summary": "Render package-local Memory bootstrap prompt guidance.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.report.load",
-      "summary": "Load package-local memory report state for a target repository."
+      "summary": "Load package-local memory report state for a target repository.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.route.load",
       "summary": "Load package-local Memory note routing recommendations.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.route_report.load",
-      "summary": "Load package-local memory routing aggregate report state."
+      "summary": "Load package-local memory routing aggregate report state.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.route_review.load",
       "summary": "Load package-local Memory routing feedback review results.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.search.load",
       "summary": "Load package-local Memory note search results.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.verify-payload.load",
       "summary": "Load package-local Memory payload verification results.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "memory.sync_memory.load",
       "summary": "Load package-local Memory synchronization suggestions.",
       "kind": "memory-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "memory package runtime boundary",
+      "tier_reason": "Memory bootstrap policy, note routing, lifecycle behavior, or compatibility formatting remains package-domain behavior.",
+      "conformance_ref": "memory package tests plus generated command package checks",
+      "migration_path": "Move deterministic payload, TOML, file, or output portions to Tier 1 primitives as contracts stabilize.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "output.emit",
@@ -361,19 +545,38 @@
       "portability": "target-executor",
       "semantics": "Emit either stable JSON or declared text from an already assembled structured payload.",
       "input_schema_ref": "schemas/primitives/output_emit.input.schema.json",
-      "output_schema_ref": "schemas/primitives/output_emit.output.schema.json"
+      "output_schema_ref": "schemas/primitives/output_emit.output.schema.json",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "output.fields.select",
-      "summary": "Select exact top-level or dotted JSON fields before rendering output."
+      "summary": "Select exact top-level or dotted JSON fields before rendering output.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "command operation contract owner",
+      "tier_reason": "The primitive is named in operation IR but its portable executor semantics are not schema-backed yet.",
+      "conformance_ref": "contract tooling and generated command package checks",
+      "migration_path": "Add schema-backed semantics and executor conformance before promoting to Tier 1.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "output.profile.select",
-      "summary": "Select the smallest requested output projection that preserves the operation's next decision."
+      "summary": "Select the smallest requested output projection that preserves the operation's next decision.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "command operation contract owner",
+      "tier_reason": "The primitive is named in operation IR but its portable executor semantics are not schema-backed yet.",
+      "conformance_ref": "contract tooling and generated command package checks",
+      "migration_path": "Add schema-backed semantics and executor conformance before promoting to Tier 1.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "ownership.answer.resolve",
-      "summary": "Resolve ownership, authority, concern, or path-specific boundary answers."
+      "summary": "Resolve ownership, authority, concern, or path-specific boundary answers.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "path.target_root.resolve",
@@ -382,7 +585,8 @@
       "portability": "target-executor",
       "semantics": "Resolve the target input or current working directory into a normalized target root and reject path escape.",
       "input_schema_ref": "schemas/primitives/path_target_root_resolve.input.schema.json",
-      "output_schema_ref": "schemas/primitives/path_target_root_resolve.output.schema.json"
+      "output_schema_ref": "schemas/primitives/path_target_root_resolve.output.schema.json",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "payload.assemble",
@@ -391,7 +595,8 @@
       "portability": "target-executor",
       "semantics": "Build a JSON-serializable payload from declared step outputs and constants.",
       "input_schema_ref": "schemas/primitives/payload_assemble.input.schema.json",
-      "output_schema_ref": "schemas/primitives/payload_assemble.output.schema.json"
+      "output_schema_ref": "schemas/primitives/payload_assemble.output.schema.json",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "payload.verify",
@@ -400,255 +605,481 @@
       "portability": "target-executor",
       "semantics": "Read a schema-backed payload verification policy and inspect rooted payload files for declared version markers, required files, forbidden paths, manifest validity, upgrade-source metadata, and guidance fragments without package-specific executable policy.",
       "input_schema_ref": "schemas/primitives/payload_verify.input.schema.json",
-      "output_schema_ref": "schemas/primitives/payload_verify.output.schema.json"
+      "output_schema_ref": "schemas/primitives/payload_verify.output.schema.json",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "planning.adopt.apply",
       "summary": "Conservatively add planning bootstrap files to an existing repository.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.archive-plan.apply",
       "summary": "Close a completed execplan or parent lane after distillation.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.bootstrap.doctor.load",
-      "summary": "Load package-local planning doctor diagnostics for a target repository."
+      "summary": "Load package-local planning doctor diagnostics for a target repository.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.bootstrap.status.load",
-      "summary": "Load package-local planning bootstrap status for a target repository."
+      "summary": "Load package-local planning bootstrap status for a target repository.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.closeout.apply",
       "summary": "Close out a completed execplan through one command-owned Planning writer.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.close-item.apply",
       "summary": "Apply package-local planning close-item lifecycle mutation for a target repository.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.create-review.apply",
       "summary": "Apply package-local planning create-review lifecycle mutation for a target repository.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.delegation-decision.apply",
       "summary": "Record the delegation route chosen for the active execplan.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.front_door.dispatch",
       "summary": "Dispatch generated workspace planning front-door argv to the Planning module runtime boundary.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.handoff.load",
       "summary": "Load package-local planning handoff payload for a target repository.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.help.build",
-      "summary": "Build planning orientation guidance and lifecycle command affordances without mutating planning state."
+      "summary": "Build planning orientation guidance and lifecycle command affordances without mutating planning state.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.init.apply",
       "summary": "Initialise planning bootstrap files in a repository.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.install.apply",
       "summary": "Install planning bootstrap files into a repository.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.intake-artifact.apply",
       "summary": "Route a freehand planning artifact into a canonical Planning surface.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.list-files.load",
       "summary": "Load package-local planning payload file inventory.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.new-plan.apply",
       "summary": "Create a schema-valid execplan scaffold and optionally register it.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.promote-to-plan.apply",
       "summary": "Promote a direct TODO item into an execplan scaffold.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.prompt.render",
       "summary": "Render package-local planning prompt guidance for a selected bootstrap command.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.reconcile.load",
-      "summary": "Load provider-agnostic planning reconciliation state when the planning module is installed."
+      "summary": "Load provider-agnostic planning reconciliation state when the planning module is installed.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.record-recovery.apply",
       "summary": "Bless an emergency manual repair to managed planning surfaces with explicit provenance.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.report.load",
-      "summary": "Load package-local planning report state for a target repository."
+      "summary": "Load package-local planning report state for a target repository.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.summary.load",
-      "summary": "Load compact active planning summary when the planning module is installed."
+      "summary": "Load compact active planning summary when the planning module is installed.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.uninstall.apply",
       "summary": "Remove managed planning bootstrap files when they still match package content.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.upgrade.apply",
       "summary": "Refresh package-managed planning helper surfaces.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "planning.verify-payload.load",
       "summary": "Load package-local planning payload verification result.",
       "kind": "planning-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "planning package runtime boundary",
+      "tier_reason": "Planning policy, lifecycle state mutation, closeout, or installed-surface interpretation remains package-domain behavior.",
+      "conformance_ref": "planning package tests plus generated command package checks",
+      "migration_path": "Extract deterministic record/file/template portions into schema-backed Tier 1 primitives when the planning policy boundary is explicit.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "preflight.context.assemble",
-      "summary": "Assemble startup defaults, resolved config, and active planning state into takeover-safe context."
+      "summary": "Assemble startup defaults, resolved config, and active planning state into takeover-safe context.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "preflight.token.create",
-      "summary": "Create a fresh preflight token using the configured token policy."
+      "summary": "Create a fresh preflight token using the configured token policy.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "command operation contract owner",
+      "tier_reason": "The primitive is named in operation IR but its portable executor semantics are not schema-backed yet.",
+      "conformance_ref": "contract tooling and generated command package checks",
+      "migration_path": "Add schema-backed semantics and executor conformance before promoting to Tier 1.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "python.function.call",
       "summary": "Call a checked-in Python runtime function declared by operation IR.",
       "kind": "external-runtime",
       "portability": "external-adapter",
-      "semantics": "Resolve import module, function name, and keyword bindings only from checked-in operation artifacts; user input may supply values but never the callable target."
+      "semantics": "Resolve import module, function name, and keyword bindings only from checked-in operation artifacts; user input may supply values but never the callable target.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "external provider adapter boundary",
+      "tier_reason": "Provider integration or checked callable adapter behavior is not portable target-executor logic.",
+      "conformance_ref": "operation inventory and generated command package checks",
+      "migration_path": "Split deterministic normalization or file writes into Tier 1 primitives only after provider-specific behavior has a stable contract.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "prompt.render",
-      "summary": "Render a ready-to-paste lifecycle handoff prompt without mutating repo state."
+      "summary": "Render a ready-to-paste lifecycle handoff prompt without mutating repo state.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "command operation contract owner",
+      "tier_reason": "The primitive is named in operation IR but its portable executor semantics are not schema-backed yet.",
+      "conformance_ref": "contract tooling and generated command package checks",
+      "migration_path": "Add schema-backed semantics and executor conformance before promoting to Tier 1.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "proof.routes.resolve",
-      "summary": "Resolve canonical proof routes, current proof state, or changed-path proof recommendations."
+      "summary": "Resolve canonical proof routes, current proof state, or changed-path proof recommendations.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "record.append",
       "summary": "Append an item to a structured record list.",
       "kind": "record",
       "portability": "target-executor",
-      "semantics": "Append one item to a declared list path after schema validation."
+      "semantics": "Append one item to a declared list path after schema validation.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "record.delete",
       "summary": "Delete a field or list item from a structured record.",
       "kind": "record",
       "portability": "target-executor",
-      "semantics": "Remove only the declared path or matched item and return the updated record."
+      "semantics": "Remove only the declared path or matched item and return the updated record.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "record.merge",
       "summary": "Merge structured records using a declared shallow merge policy.",
       "kind": "record",
       "portability": "target-executor",
-      "semantics": "Apply an operation-declared merge policy without target-specific conflict heuristics."
+      "semantics": "Apply an operation-declared merge policy without target-specific conflict heuristics.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "record.normalize",
       "summary": "Normalize a structured record into its canonical contract shape.",
       "kind": "record",
       "portability": "target-executor",
-      "semantics": "Apply schema-backed defaults, sorting, and field projection declared by the operation."
+      "semantics": "Apply schema-backed defaults, sorting, and field projection declared by the operation.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "record.select",
       "summary": "Select a field or dotted path from a structured record.",
       "kind": "record",
       "portability": "target-executor",
-      "semantics": "Return the value at a declared path or a missing-value signal according to operation policy."
+      "semantics": "Return the value at a declared path or a missing-value signal according to operation policy.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "record.set",
       "summary": "Set a field or dotted path in a structured record.",
       "kind": "record",
       "portability": "target-executor",
-      "semantics": "Return an updated record with the declared path set to a contract-valid value."
+      "semantics": "Return an updated record with the declared path set to a contract-valid value.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "schema.validate",
       "summary": "Validate a structured value against a JSON Schema.",
       "kind": "validation",
       "portability": "target-executor",
-      "semantics": "Evaluate the declared JSON Schema and surface validation errors as operation failures."
+      "semantics": "Evaluate the declared JSON Schema and surface validation errors as operation failures.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "skills.registry.inspect",
-      "summary": "Inspect installed and repo-owned skill registries and optionally rank them for a task."
+      "summary": "Inspect installed and repo-owned skill registries and optionally rank them for a task.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "startup.context.assemble",
-      "summary": "Assemble bounded startup context from preflight state, authority markers, and optional changed paths."
+      "summary": "Assemble bounded startup context from preflight state, authority markers, and optional changed paths.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "system_intent.config.resolve",
-      "summary": "Resolve configured or autodetected system-intent source hints from workspace config."
+      "summary": "Resolve configured or autodetected system-intent source hints from workspace config.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "command operation contract owner",
+      "tier_reason": "The primitive is named in operation IR but its portable executor semantics are not schema-backed yet.",
+      "conformance_ref": "contract tooling and generated command package checks",
+      "migration_path": "Add schema-backed semantics and executor conformance before promoting to Tier 1.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "system_intent.mirror.read_or_create",
-      "summary": "Read the compiled system-intent declaration or create a conservative missing declaration shell."
+      "summary": "Read the compiled system-intent declaration or create a conservative missing declaration shell.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "command operation contract owner",
+      "tier_reason": "The primitive is named in operation IR but its portable executor semantics are not schema-backed yet.",
+      "conformance_ref": "contract tooling and generated command package checks",
+      "migration_path": "Add schema-backed semantics and executor conformance before promoting to Tier 1.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "system_intent.result.emit",
-      "summary": "Emit compiled system-intent declaration status and metadata in the requested format."
+      "summary": "Emit compiled system-intent declaration status and metadata in the requested format.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "command operation contract owner",
+      "tier_reason": "The primitive is named in operation IR but its portable executor semantics are not schema-backed yet.",
+      "conformance_ref": "contract tooling and generated command package checks",
+      "migration_path": "Add schema-backed semantics and executor conformance before promoting to Tier 1.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "system_intent.source_metadata.refresh",
-      "summary": "Refresh metadata for configured system-intent source hints without interpreting source prose."
+      "summary": "Refresh metadata for configured system-intent source hints without interpreting source prose.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "command operation contract owner",
+      "tier_reason": "The primitive is named in operation IR but its portable executor semantics are not schema-backed yet.",
+      "conformance_ref": "contract tooling and generated command package checks",
+      "migration_path": "Add schema-backed semantics and executor conformance before promoting to Tier 1.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "template.render",
       "summary": "Render a declared template from a structured value.",
       "kind": "rendering",
       "portability": "target-executor",
-      "semantics": "Render only named templates with structured inputs; do not execute arbitrary template code."
+      "semantics": "Render only named templates with structured inputs; do not execute arbitrary template code.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "toml.parse",
       "summary": "Parse TOML text into a structured value.",
       "kind": "structured-data",
       "portability": "target-executor",
-      "semantics": "Parse TOML using the target runtime's declared TOML library and fail the operation on invalid TOML."
+      "semantics": "Parse TOML using the target runtime's declared TOML library and fail the operation on invalid TOML.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "toml.table.counts",
@@ -657,64 +1088,166 @@
       "portability": "target-executor",
       "semantics": "Read one rooted TOML file, count records in a named table, and return deterministic category counts without interpreting package policy.",
       "input_schema_ref": "schemas/primitives/toml_table_counts.input.schema.json",
-      "output_schema_ref": "schemas/primitives/toml_table_counts.output.schema.json"
+      "output_schema_ref": "schemas/primitives/toml_table_counts.output.schema.json",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "toml.write",
       "summary": "Serialize a structured value as TOML text.",
       "kind": "structured-data",
       "portability": "target-executor",
-      "semantics": "Write deterministic TOML for the limited record shapes owned by package contracts."
+      "semantics": "Write deterministic TOML for the limited record shapes owned by package contracts.",
+      "taxonomy_tier": "tier-1-portable-codegen"
     },
     {
       "id": "usage.error",
-      "summary": "Stop with a user-facing usage error when operation preconditions are violated."
+      "summary": "Stop with a user-facing usage error when operation preconditions are violated.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "command operation contract owner",
+      "tier_reason": "The primitive is named in operation IR but its portable executor semantics are not schema-backed yet.",
+      "conformance_ref": "contract tooling and generated command package checks",
+      "migration_path": "Add schema-backed semantics and executor conformance before promoting to Tier 1.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "workspace.config.emit",
-      "summary": "Emit the resolved workspace config payload in the requested output format."
+      "summary": "Emit the resolved workspace config payload in the requested output format.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "workspace.config.load",
-      "summary": "Load resolved workspace config layered over product defaults and local override state."
+      "summary": "Load resolved workspace config layered over product defaults and local override state.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "workspace.defaults.load",
-      "summary": "Load compact startup defaults, route contracts, and generated policy answers."
+      "summary": "Load compact startup defaults, route contracts, and generated policy answers.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "workspace.defaults.select",
-      "summary": "Select a requested defaults section when the operation supports compact section filtering."
+      "summary": "Select a requested defaults section when the operation supports compact section filtering.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "workspace.lifecycle.apply",
-      "summary": "Apply lifecycle mutations for selected modules when the operation is not a dry run."
+      "summary": "Apply lifecycle mutations for selected modules when the operation is not a dry run.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "workspace.lifecycle.plan",
-      "summary": "Plan lifecycle changes for selected modules without applying file mutations."
+      "summary": "Plan lifecycle changes for selected modules without applying file mutations.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "workspace.modules.inspect",
-      "summary": "Inspect module descriptors and installed-module signals for the target repository."
+      "summary": "Inspect module descriptors and installed-module signals for the target repository.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "workspace.report.assemble",
-      "summary": "Assemble combined workspace status, doctor, setup, or report payloads from module and workspace surfaces."
+      "summary": "Assemble combined workspace status, doctor, setup, or report payloads from module and workspace surfaces.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "workspace.report.select",
-      "summary": "Select the compact report router profile, the full report profile, or one top-level report section."
+      "summary": "Select the compact report router profile, the full report profile, or one top-level report section.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "workspace.root.resolve",
       "summary": "Resolve the effective workspace root from a target path or current working directory.",
       "kind": "workspace-runtime",
-      "portability": "domain-runtime"
+      "portability": "domain-runtime",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     },
     {
       "id": "workspace.selection.resolve",
-      "summary": "Resolve module selection options, presets, and configured defaults."
+      "summary": "Resolve module selection options, presets, and configured defaults.",
+      "taxonomy_tier": "tier-2-package-domain",
+      "tier_owner": "workspace package runtime boundary",
+      "tier_reason": "Workspace routing, live inspection, policy assembly, or agent-facing judgment remains package-domain behavior.",
+      "conformance_ref": "workspace tests plus generated command package checks",
+      "migration_path": "Extract deterministic file/data/schema/template/output portions into Tier 1 primitives after the package judgment boundary is separated.",
+      "generic_behavior_audit": "Not counted as portable codegen completion; any deterministic file/data/schema/template/output sub-behavior must be migrated to Tier 1 before full Python completion is claimed."
     }
-  ]
+  ],
+  "primitive_taxonomy": {
+    "classification_rule": "Every primitive referenced by operation contract steps must declare a completion tier. Tier 1 is portable codegen-owned target executor behavior, Tier 2 is explicit package-domain or external adapter debt, and Tier 3 is deferred or out of Python completion scope.",
+    "tier_definitions": [
+      {
+        "id": "tier-1-portable-codegen",
+        "summary": "Portable target-executor primitive implemented by command-generation-owned executors with schema-backed semantics before it counts as Python completion coverage.",
+        "blocks_full_python_completion": false
+      },
+      {
+        "id": "tier-2-package-domain",
+        "summary": "Package-domain, live inspection, mutation orchestration, provider integration, or external adapter primitive that may be invoked from operation IR but does not count as portable codegen completion.",
+        "blocks_full_python_completion": true
+      },
+      {
+        "id": "tier-3-deferred-or-out-of-scope",
+        "summary": "Primitive target or capability intentionally deferred or outside the current Python completion lane.",
+        "blocks_full_python_completion": false
+      }
+    ],
+    "tier_2_required_audit_fields": [
+      "tier_owner",
+      "tier_reason",
+      "conformance_ref",
+      "migration_path",
+      "generic_behavior_audit"
+    ],
+    "generic_behavior_rule": "A Tier 2 primitive may not hide deterministic file/data/schema/template/output behavior that belongs in Tier 1; generic_behavior_audit must say why the boundary is not portable yet."
+  }
 }

--- a/src/agentic_workspace/contracts/schemas/operation_primitives.schema.json
+++ b/src/agentic_workspace/contracts/schemas/operation_primitives.schema.json
@@ -179,6 +179,64 @@
       "additionalProperties": false,
       "description": "Rules that separate shared codegen primitives from module-specific primitive extensions."
     },
+    "primitive_taxonomy": {
+      "type": "object",
+      "required": [
+        "classification_rule",
+        "tier_definitions",
+        "tier_2_required_audit_fields",
+        "generic_behavior_rule"
+      ],
+      "properties": {
+        "classification_rule": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tier_definitions": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "summary",
+              "blocks_full_python_completion"
+            ],
+            "properties": {
+              "id": {
+                "enum": [
+                  "tier-1-portable-codegen",
+                  "tier-2-package-domain",
+                  "tier-3-deferred-or-out-of-scope"
+                ]
+              },
+              "summary": {
+                "type": "string",
+                "minLength": 1
+              },
+              "blocks_full_python_completion": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "tier_2_required_audit_fields": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "generic_behavior_rule": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "description": "Completion-tier taxonomy for primitive references used by operation contracts."
+    },
     "primitives": {
       "type": "array",
       "minItems": 1,
@@ -239,6 +297,34 @@
             "type": "string",
             "pattern": "^schemas/primitives/[a-z0-9_.-]+\\.schema\\.json$",
             "description": "Primitive-specific output schema for target-executor implementations."
+          },
+          "taxonomy_tier": {
+            "enum": [
+              "tier-1-portable-codegen",
+              "tier-2-package-domain",
+              "tier-3-deferred-or-out-of-scope"
+            ],
+            "description": "Completion-tier classification for operation-step references."
+          },
+          "tier_owner": {
+            "type": "string",
+            "minLength": 1
+          },
+          "tier_reason": {
+            "type": "string",
+            "minLength": 1
+          },
+          "conformance_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "migration_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "generic_behavior_audit": {
+            "type": "string",
+            "minLength": 1
           }
         },
         "additionalProperties": false,

--- a/src/agentic_workspace/contracts/schemas/operation_primitives.schema.json
+++ b/src/agentic_workspace/contracts/schemas/operation_primitives.schema.json
@@ -190,7 +190,8 @@
       "properties": {
         "classification_rule": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Rule used to classify each primitive into a completion tier."
         },
         "tier_definitions": {
           "type": "array",
@@ -219,7 +220,8 @@
               }
             },
             "additionalProperties": false
-          }
+          },
+          "description": "Completion tiers that separate portable codegen primitives, package-domain primitives, and deferred or out-of-scope debt."
         },
         "tier_2_required_audit_fields": {
           "type": "array",
@@ -227,11 +229,13 @@
           "items": {
             "type": "string",
             "minLength": 1
-          }
+          },
+          "description": "Audit fields that every Tier 2 package-domain primitive must carry."
         },
         "generic_behavior_rule": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Rule preventing generic deterministic behavior from being hidden behind package-domain primitive classification."
         }
       },
       "additionalProperties": false,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -10463,6 +10463,51 @@ def _startup_skills_projection(
     }
 
 
+def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
+    if not isinstance(gate, dict):
+        return {}
+    compact: dict[str, Any] = {
+        "kind": gate.get("kind"),
+        "status": gate.get("status"),
+        "decision": gate.get("decision"),
+        "workflow_sufficient": gate.get("workflow_sufficient"),
+        "reason": gate.get("reason"),
+        "required_next_action": gate.get("required_next_action"),
+        "active_planning_present": gate.get("active_planning_present"),
+        "work_shape": gate.get("work_shape"),
+        "proof_burden": gate.get("proof_burden"),
+        "issue_refs": gate.get("issue_refs", []),
+        "promotion_command": gate.get("promotion_command"),
+        "delegation_decision_command": gate.get("delegation_decision_command"),
+        "new_plan_command": gate.get("new_plan_command"),
+        "implementation_allowed": gate.get("implementation_allowed"),
+        "delegation_decision_required": gate.get("delegation_decision_required"),
+    }
+    for key in (
+        "changed_path_classification",
+        "active_delegation_requirement",
+        "active_parent_decomposition_requirement",
+    ):
+        if key in gate:
+            compact[key] = gate[key]
+    decomposition = gate.get("decomposition")
+    if isinstance(decomposition, dict):
+        candidates = decomposition.get("candidates", [])
+        top_candidate = candidates[0] if isinstance(candidates, list) and candidates else {}
+        compact["decomposition"] = {
+            "status": decomposition.get("status"),
+            "candidate_count": decomposition.get("candidate_count", len(candidates) if isinstance(candidates, list) else 0),
+            "top_candidate": {
+                "lane_id": top_candidate.get("lane_id"),
+                "title": top_candidate.get("title"),
+                "route_candidate": top_candidate.get("route_candidate"),
+            }
+            if isinstance(top_candidate, dict) and top_candidate
+            else {},
+        }
+    return {key: value for key, value in compact.items() if value is not None}
+
+
 def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, target_root: Path | None = None) -> dict[str, Any]:
     skill_routing = payload.get("skill_routing", {}) if isinstance(payload.get("skill_routing"), dict) else {}
     next_safe_action = _next_safe_action_packet(
@@ -10488,7 +10533,11 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                     reason="Use the next action and selectors; no raw workspace files are needed yet.",
                 ),
             ),
-            **({"planning_safety_gate": payload["planning_safety_gate"]} if "planning_safety_gate" in payload else {}),
+            **(
+                {"planning_safety_gate": _selector_first_planning_safety_gate(payload["planning_safety_gate"])}
+                if "planning_safety_gate" in payload
+                else {}
+            ),
         },
         "memory": payload.get("memory_consult", {}),
     }
@@ -11772,21 +11821,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "detail_commands": detail_commands,
     }
     if isinstance(planning_safety_gate, dict):
-        projected["planning_safety_gate"] = (
-            planning_safety_gate
-            if planning_safety_gate.get("workflow_sufficient") is False
-            else {
-                "kind": planning_safety_gate.get("kind"),
-                "status": planning_safety_gate.get("status"),
-                "decision": planning_safety_gate.get("decision"),
-                "workflow_sufficient": planning_safety_gate.get("workflow_sufficient"),
-                "required_next_action": planning_safety_gate.get("required_next_action"),
-                "active_planning_present": planning_safety_gate.get("active_planning_present"),
-                "active_parent_decomposition_requirement": planning_safety_gate.get("active_parent_decomposition_requirement", {}),
-                "implementation_allowed": planning_safety_gate.get("implementation_allowed"),
-                "changed_path_classification": planning_safety_gate.get("changed_path_classification", {}),
-            }
-        )
+        projected["planning_safety_gate"] = _selector_first_planning_safety_gate(planning_safety_gate)
     if isinstance(intent_acknowledgement, dict) and intent_acknowledgement.get("decision") == "proceed-with-stated-assumption":
         projected["intent_acknowledgement"] = {
             "decision": intent_acknowledgement.get("decision"),

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -956,6 +956,30 @@ def test_operation_primitives_require_target_support_matrix(monkeypatch: pytest.
     assert any("schema-backed primitives missing implemented target support" in error for error in errors)
 
 
+def test_operation_primitives_classify_operation_step_tiers(monkeypatch: pytest.MonkeyPatch) -> None:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "check" / "check_contract_tooling_surfaces.py"
+    spec = importlib.util.spec_from_file_location("check_contract_tooling_surfaces", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    registry = copy.deepcopy(module.operation_primitives_manifest())
+    by_id = {primitive["id"]: primitive for primitive in registry["primitives"]}
+
+    assert module._validate_operation_primitives(registry) == []
+    assert by_id["filesystem.glob"]["taxonomy_tier"] == "tier-1-portable-codegen"
+    assert by_id["workspace.root.resolve"]["taxonomy_tier"] == "tier-2-package-domain"
+    assert by_id["workspace.root.resolve"]["tier_owner"]
+    assert by_id["workspace.root.resolve"]["generic_behavior_audit"]
+
+    by_id["workspace.root.resolve"].pop("generic_behavior_audit")
+    monkeypatch.setattr(module, "operation_primitives_manifest", lambda: registry)
+
+    errors = module._validate_operation_primitives(registry)
+
+    assert any("tier-2 primitive workspace.root.resolve missing audit field" in error for error in errors)
+
+
 def test_python_operation_execution_inventory_tracks_direct_generated_memory_commands() -> None:
     inventory = contract_tooling.load_contract_json("python_operation_execution_inventory.json")
     entries = {entry["operation_id"]: entry for entry in inventory["entries"]}

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -666,6 +666,23 @@ def test_static_generated_package_proof_rejects_missing_runtime_projection_inven
     assert any("missing runtime projection entries" in error for error in errors)
 
 
+def test_static_generated_package_proof_rejects_legacy_generated_python_package_dirs(monkeypatch, tmp_path: Path) -> None:
+    checker = _load_checker()
+    generated_python = tmp_path / "generated" / "python" / "workspace-cli" / "legacy_package"
+    generated_python.mkdir(parents=True)
+    for package in ("workspace", "planning", "memory"):
+        package_root = tmp_path / "generated" / package / "python"
+        package_root.mkdir(parents=True)
+        (package_root / "cli.py").write_text("", encoding="utf-8")
+        for directory in ("commands", "operations", "primitives"):
+            (package_root / directory).mkdir()
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+
+    errors = checker._validate_generated_python_target_layout()
+
+    assert any("legacy generated Python package directories" in error for error in errors)
+
+
 def test_static_generated_package_proof_rejects_full_completion_with_transitional_runtime_projection_debt(monkeypatch) -> None:
     checker = _load_checker()
     original_manifest = checker.python_runtime_projection_inventory_manifest


### PR DESCRIPTION
## Summary

Implements the next #892 Tier 1 and Tier 2 slices on `codex/tier-1-2-python-completion-892`.

- Tier 1: adds an explicit primitive taxonomy to `operation_primitives.json`, extends the schema, and teaches contract tooling to reject unclassified or unaudited operation primitives.
- Tier 2: locks the generated Python target layout by rejecting legacy package directories under `generated/python` and requiring `generated/{workspace,planning,memory}/python` target surfaces.
- Dogfooding fixes: avoids crash-prone generated package discovery globs on Windows and compacts blocked planning-gate projections in tiny startup/implementer payloads.
- Planning: archives Tier 1, Tier 2, and the payload-budget recovery slice; #892 remains open and continues at `tier-3-memory-first`.

Closes #1043
Closes #1044
Refs #892

## Validation

- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run pytest tests/test_contract_tooling.py -q`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python packages/command-generation/tests/primitive_conformance.py`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run pytest tests/test_workspace_packaging.py packages/memory/tests/test_packaging.py packages/planning/tests/test_packaging.py -q`
- `uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -q`
- `uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_tiny_profile_returns_first_contact_projection tests/test_workspace_start_preflight_cli.py::test_start_tiny_routes_config_posture_questions_to_tiny_config tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_workspace_start_preflight_cli.py::test_implement_requires_delegation_decision_for_active_decomposed_lane -q`
- `make test-workspace`
- `uv run ruff check scripts/check/check_generated_command_packages.py scripts/check/check_contract_tooling_surfaces.py packages/command-generation/src/command_generation/generated_package_loader.py src/agentic_workspace/workspace_runtime_primitives.py tests/test_contract_tooling.py tests/test_generated_command_package_proof_runner.py`
- `make lint-workspace`
- `uv run agentic-workspace summary --target . --format json`
- `uv run agentic-workspace doctor --target . --modules planning --format json`
- `git diff --check`