### PR TITLE
[codex] Add proof confidence residual risk output

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -313,6 +313,8 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
         intent_check = intent_check if isinstance(intent_check, dict) else {}
         intent_proof_check = answer.get("intent_proof_check", {})
         intent_proof_check = intent_proof_check if isinstance(intent_proof_check, dict) else {}
+        proof_confidence = answer.get("proof_confidence", {})
+        proof_confidence = proof_confidence if isinstance(proof_confidence, dict) else {}
         architecture_decision = answer.get("architecture_decision_closeout", {})
         architecture_decision = architecture_decision if isinstance(architecture_decision, dict) else {}
         terminal_action = answer.get("terminal_action", {})
@@ -336,6 +338,11 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
             "summary": answer.get("summary", ""),
             "terminal_action": terminal_action,
             "completion_options": completion_options,
+            "proof_confidence": {
+                key: proof_confidence.get(key)
+                for key in ("status", "confidence", "claim_boundary", "proven_dimensions", "unproven_dimensions", "residual_risk")
+                if key in proof_confidence
+            },
             "checks": {
                 "package_workflow_evidence": compact_closeout_check(package_evidence),
                 "intent_satisfaction": compact_closeout_check(intent_check),

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -7737,6 +7737,7 @@ def _report_closeout_trust_payload(
             "intent_satisfaction_check": intent_check,
             "acceptance_criteria_reconciliation": acceptance_reconciliation,
             "intent_proof_check": intent_proof_check,
+            "proof_confidence": _proof_confidence_payload(intent_proof=intent_proof_check),
             "architecture_decision_closeout": architecture_decision_closeout,
             "historical_review_artifacts": _historical_review_artifacts_policy(
                 planning_report={}, intent_validation={}, target_root=target_root
@@ -7775,6 +7776,7 @@ def _report_closeout_trust_payload(
             "intent_satisfaction_check": intent_check,
             "acceptance_criteria_reconciliation": acceptance_reconciliation,
             "intent_proof_check": intent_proof_check,
+            "proof_confidence": _proof_confidence_payload(intent_proof=intent_proof_check),
             "architecture_decision_closeout": architecture_decision_closeout,
             "historical_review_artifacts": _historical_review_artifacts_policy(
                 planning_report=planning_report, intent_validation={}, target_root=target_root
@@ -7866,6 +7868,7 @@ def _report_closeout_trust_payload(
         "intent_satisfaction_check": intent_satisfaction_check,
         "acceptance_criteria_reconciliation": acceptance_reconciliation,
         "intent_proof_check": intent_proof_check,
+        "proof_confidence": _proof_confidence_payload(intent_proof=intent_proof_check),
         "architecture_decision_closeout": architecture_decision_closeout,
         "historical_review_artifacts": _historical_review_artifacts_policy(
             planning_report=planning_report, intent_validation=intent_validation, target_root=target_root
@@ -20845,6 +20848,62 @@ def _intent_proof_prompt_payload(
     }
 
 
+def _proof_confidence_payload(
+    *,
+    intent_proof: dict[str, Any],
+    proof_execution_evidence: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    intent_proof = intent_proof if isinstance(intent_proof, dict) else {}
+    proof_execution_evidence = proof_execution_evidence if isinstance(proof_execution_evidence, dict) else {}
+    status = str(intent_proof.get("status", "not_recorded")).strip().lower().replace("-", "_") or "not_recorded"
+    claim_boundary = str(intent_proof.get("claim_boundary", "slice")).strip() or "slice"
+    proven_dimensions = [str(item) for item in _list_payload(intent_proof.get("proof_dimensions")) if str(item).strip()][:5]
+    unproven_dimensions = [str(item) for item in _list_payload(intent_proof.get("unproven_after_tests")) if str(item).strip()][:5]
+    intended_behavior = [str(item) for item in _list_payload(intent_proof.get("intended_behavior")) if str(item).strip()][:5]
+    if status == "regression_only" and not proven_dimensions:
+        proven_dimensions = ["local regression behavior"]
+    if status in {"not_recorded", "needs_agent_judgment"} and not unproven_dimensions:
+        unproven_dimensions = intended_behavior or ["intended behavior has not been compared to proof"]
+    elif status == "regression_only" and not unproven_dimensions:
+        unproven_dimensions = [
+            "representative user path",
+            "negative or boundary case",
+            "integration or consumer behavior",
+        ]
+
+    confidence_by_status = {
+        "sufficient_for_claim": "high",
+        "representative": "medium",
+        "regression_only": "low",
+        "not_recorded": "low",
+        "needs_review": "needs-review",
+        "needs_agent_judgment": "needs-review",
+    }
+    residual_risk_by_status = {
+        "sufficient_for_claim": "Proof confidence supports the stated claim boundary; remaining risk is ordinary unlisted behavior.",
+        "representative": "Representative proof is present, but broader work or parent closure may still need closeout reconciliation.",
+        "regression_only": "Proof may cover the local patch while leaving representative user, boundary, or consumer behavior unproven.",
+        "not_recorded": "Proof execution may be recorded, but proof confidence was not recorded.",
+        "needs_review": "Human or domain review is required before treating proof as sufficient for the claim.",
+        "needs_agent_judgment": "Selected proof still needs agent judgment against the intended behavior before completion can be claimed.",
+    }
+    return {
+        "kind": "agentic-workspace/proof-confidence/v1",
+        "status": "present",
+        "source": "intent_proof",
+        "intent_proof_status": status,
+        "confidence": confidence_by_status.get(status, "needs-review"),
+        "claim_boundary": claim_boundary,
+        "proven_dimensions": proven_dimensions,
+        "unproven_dimensions": unproven_dimensions,
+        "residual_risk": residual_risk_by_status.get(
+            status, "Proof confidence cannot be classified from the available intent-proof evidence."
+        ),
+        "evidence_state": str(proof_execution_evidence.get("status", "")) or "unknown",
+        "rule": "Proof confidence interprets proof strength; it does not execute proof or score test quality automatically.",
+    }
+
+
 def _proof_completion_options(*, required_commands: list[str], manual_verification: dict[str, Any] | None) -> list[dict[str, Any]]:
     options: list[dict[str, Any]] = [
         _completion_option(
@@ -21335,6 +21394,7 @@ def _proof_selection_for_changed_paths(
         )
         for command in optional_commands
     ]
+    intent_proof = _intent_proof_prompt_payload(task_text=task_text, acceptance=acceptance, claim_boundary="slice")
     proof_selection = {
         "kind": "proof-selection/v1",
         "changed_paths": changed_paths,
@@ -21381,7 +21441,11 @@ def _proof_selection_for_changed_paths(
         "unavailable_commands": unavailable_commands,
         "host_policy_blocked_commands": host_policy_blocked_commands,
         "proof_execution_evidence": proof_execution_evidence,
-        "intent_proof": _intent_proof_prompt_payload(task_text=task_text, acceptance=acceptance, claim_boundary="slice"),
+        "intent_proof": intent_proof,
+        "proof_confidence": _proof_confidence_payload(
+            intent_proof=intent_proof,
+            proof_execution_evidence=proof_execution_evidence,
+        ),
         "proof_route_decision": proof_route_decision,
         "proof_route_explanation": proof_route_explanation,
         "proof_next_decision": proof_next_decision,

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -1275,6 +1275,30 @@ def test_proof_changed_surfaces_compact_intent_proof_prompt(capsys) -> None:
     assert "proof strength" not in json.dumps(answer["required_commands"]).lower()
 
 
+def test_proof_changed_verbose_surfaces_proof_confidence(capsys) -> None:
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--verbose",
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_primitives.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    proof_confidence = answer["proof_confidence"]
+    assert proof_confidence["confidence"] == "needs-review"
+    assert proof_confidence["claim_boundary"] == "slice"
+    assert proof_confidence["proven_dimensions"] == []
+    assert proof_confidence["unproven_dimensions"]
+    assert "Selected proof" in proof_confidence["residual_risk"]
+
+
 def test_proof_changed_selector_includes_planning_schema_reference_wrapper(capsys) -> None:
     assert (
         cli.main(

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -1869,6 +1869,96 @@ def test_report_closeout_trust_blocks_work_claim_for_regression_only_intent_proo
     assert "intent_proof" in options["claim-work-complete"]["blocking_fields"]
 
 
+def test_report_closeout_trust_allows_work_claim_for_sufficient_intent_proof(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    plan = target / ".agentic-workspace" / "planning" / "execplans" / "direct-proof.plan.json"
+    _write_json(
+        plan,
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Direct Proof",
+            "active_milestone": {"id": "direct-proof", "status": "complete"},
+            "delegated_judgment": {
+                "requested outcome": "Record proportionate proof for a small direct change.",
+                "hard constraints": "Do not require broad integration proof for this direct slice.",
+                "agent may decide locally": "Exact compact closeout wording.",
+                "escalate when": "Proof no longer covers the requested behavior.",
+            },
+            "immediate_next_action": ["Close when direct proof supports the claim."],
+            "completion_criteria": ["Direct proof supports the requested behavior."],
+            "validation_commands": ["uv run pytest tests/test_direct.py"],
+            "intent_continuity": {
+                "larger intended outcome": "Record proportionate direct proof.",
+                "this slice completes the larger intended outcome": "yes",
+                "continuation surface": "none",
+            },
+            "required_continuation": {
+                "required follow-on for the larger intended outcome": "no",
+                "owner surface": "none",
+                "activation trigger": "none",
+            },
+            "execution_run": {
+                "run status": "complete",
+                "executor": "test",
+                "handoff source": "uv run agentic-workspace preflight --format json",
+                "what happened": "Used agentic-workspace report --target . --format json and proof-selected validation.",
+                "scope touched": "test",
+                "changed surfaces": "test",
+                "validations run": "uv run agentic-workspace summary --format json; uv run agentic-workspace proof --format json; uv run pytest tests/test_direct.py",
+                "result for continuation": "close",
+                "next step": "close",
+            },
+            "proof_report": {
+                "validation proof": "uv run agentic-workspace proof passed; uv run pytest tests/test_direct.py passed",
+                "acceptance reconciliation": "requested direct proof -> delivered focused direct test -> proof passed",
+                "proof achieved now": "yes",
+                'evidence for "proof achieved" state': "focused direct test fixture",
+                "intent_proof": {
+                    "status": "sufficient_for_claim",
+                    "claim_boundary": "work",
+                    "intended_behavior": ["direct behavior"],
+                    "proof_dimensions": ["focused direct behavior"],
+                    "unproven_after_tests": [],
+                },
+            },
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": "closed",
+                "closure decision": "archive-and-close",
+                "why this decision is honest": "The focused direct proof is sufficient for the work claim.",
+                "evidence carried forward": "report closeout_trust",
+                "reopen trigger": "direct proof no longer covers requested behavior",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'direct-proof', title = 'Direct proof', surface = '.agentic-workspace/planning/execplans/direct-proof.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+
+    closeout = json.loads(capsys.readouterr().out)["answer"]
+    assert closeout["checks"]["intent_proof"]["status"] == "sufficient_for_claim"
+    assert closeout["proof_confidence"]["confidence"] == "high"
+    assert closeout["proof_confidence"]["claim_boundary"] == "work"
+    assert closeout["proof_confidence"]["proven_dimensions"] == ["focused direct behavior"]
+    assert closeout["proof_confidence"]["unproven_dimensions"] == []
+    assert closeout["proof_confidence"]["residual_risk"]
+    options = {option["id"]: option for option in closeout["completion_options"]}
+    assert options["claim-slice-complete"]["allowed"] is True
+    assert options["claim-work-complete"]["allowed"] is True
+
+
 def test_report_closeout_trust_requires_external_negative_invariant_reconciliation(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -1859,6 +1859,10 @@ def test_report_closeout_trust_blocks_work_claim_for_regression_only_intent_proo
 
     closeout = json.loads(capsys.readouterr().out)["answer"]
     assert closeout["checks"]["intent_proof"]["status"] == "regression_only"
+    assert closeout["proof_confidence"]["confidence"] == "low"
+    assert closeout["proof_confidence"]["proven_dimensions"] == ["local regression"]
+    assert closeout["proof_confidence"]["unproven_dimensions"] == ["representative user path"]
+    assert "local patch" in closeout["proof_confidence"]["residual_risk"]
     options = {option["id"]: option for option in closeout["completion_options"]}
     assert options["claim-slice-complete"]["allowed"] is True
     assert options["claim-work-complete"]["allowed"] is False
@@ -2001,6 +2005,8 @@ def test_report_closeout_trust_requires_external_negative_invariant_reconciliati
     assert options["claim-work-complete"]["allowed"] is True
     assert options["close-parent-lane"]["allowed"] is True
     assert options["route-residue"]["allowed"] is False
+    assert closeout["proof_confidence"]["confidence"] == "medium"
+    assert closeout["proof_confidence"]["proven_dimensions"] == ["negative invariant"]
 
 
 def test_report_closeout_trust_lowers_trust_for_open_package_owned_continuation_without_active_plan(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Implements #1116 by adding a compact `proof_confidence` payload derived from existing intent-proof evidence.

## What changed

- Adds `agentic-workspace/proof-confidence/v1` derived from `intent_proof` / `intent_proof_check`.
- Surfaces proof confidence in verbose proof selection output and closeout trust output.
- Keeps the tiny proof next-action payload within its existing size budget by leaving the new detail in verbose/selector and closeout surfaces.
- Adds tests for needs-review proof confidence, regression-only low confidence, and representative medium confidence.

## Validation

- `uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence tests/test_workspace_report_cli.py::test_report_closeout_trust_blocks_work_claim_for_regression_only_intent_proof tests/test_workspace_report_cli.py::test_report_closeout_trust_requires_external_negative_invariant_reconciliation`
- `make test-workspace`
- `make lint-workspace`

## Notes

This extends the existing proof / intent-proof / closeout surfaces rather than adding a new proof workflow or test-quality scoring mechanism.