### PR TITLE
Add compact task contract view

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/github-1118-task-contract-view.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1118-task-contract-view.plan.json
@@ -31,22 +31,11 @@
     "agent_may_decide": "Exact command/selector home, payload field names, compact-vs-verbose placement, and focused tests.",
     "escalate_when": "The implementation needs a new durable Planning artifact, provider-specific session state, a broad task manager, or a change that makes ordinary direct work heavier.",
     "next_action": "Inspect current start/implement/proof/closeout task-intent surfaces, choose the smallest existing command/selector home, implement the assembled view, and validate task-present, task-absent, and changed-path cases.",
-    "proof_expectations": [
-      "Focused tests prove the task-contract view names intent, acceptance, autonomy/escalation, proof expectations, stop conditions, source fields, and missing fields.",
-      "Workspace test and lint targets pass."
-    ],
-    "touched_scope": [
-      "src/agentic_workspace/workspace_runtime_primitives.py",
-      "tests/test_workspace_implement_cli.py",
-      "tests/test_workspace_start_preflight_cli.py",
-      "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
-      "docs/reference/implementer-context.md"
-    ],
-    "completion_criteria": [
-      "Assemble compact task contract view (#1118) is implemented, validated, and closed out honestly."
-    ],
+    "proof_expectations": "['Focused tests prove the task-contract view names intent, acceptance, autonomy/escalation, proof expectations, stop conditions, source fields, and missing fields.', 'Workspace test and lint targets pass.']",
+    "touched_scope": "['src/agentic_workspace/workspace_runtime_primitives.py', 'tests/test_workspace_implement_cli.py', 'tests/test_workspace_start_preflight_cli.py', 'src/agentic_workspace/contracts/schemas/implementer_context.schema.json', 'docs/reference/implementer-context.md']",
+    "completion_criteria": "['Assemble compact task contract view (#1118) is implemented, validated, and closed out honestly.']",
     "continuation_owner": "none",
-    "closeout_decision": "pending"
+    "closeout_decision": "archive-and-close"
   },
   "goal": [
     "GitHub #1118"
@@ -56,27 +45,14 @@
   ],
   "machine_readable_contract": {
     "intent": {
-    "outcome": "Assemble a compact task-contract view from existing task intent, acceptance, autonomy/escalation, proof expectations, and stop-condition surfaces.",
-    "constraints": "Do not add new durable task-contract state in this first slice; the view must be assembled from existing source surfaces and keep small direct work cheap.",
-    "latitude": "Exact command/selector home, payload field names, compact-vs-verbose placement, and focused tests.",
-    "escalation": "Escalate when the implementation needs a new durable Planning artifact, provider-specific session state, a broad task manager, or a change that makes ordinary direct work heavier."
+      "proof": "make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; make schema-reference-docs"
     },
     "execution": {
-      "milestone": "github-1118-task-contract-view",
-      "status": "active",
-    "next_step": "Inspect current start/implement/proof/closeout task-intent surfaces, choose the smallest existing command/selector home, implement the assembled view, and validate task-present, task-absent, and changed-path cases.",
-    "proof": "Focused task-contract tests plus make test-workspace and make lint-workspace."
+      "proof": "make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; make schema-reference-docs"
     },
     "scope": {
       "touched": [
-      "src/agentic_workspace/workspace_runtime_primitives.py",
-      "tests/test_workspace_implement_cli.py",
-      "tests/test_workspace_start_preflight_cli.py",
-      "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
-      "docs/reference/implementer-context.md"
-      ],
-      "invariants": [
-        "Preserve the planning contract and keep the work bounded to this plan."
+        "closeout scope recorded in closure_check and generated_closeout."
       ]
     }
   },
@@ -94,7 +70,7 @@
     "what this slice enabled": "none yet",
     "intentionally deferred": "none",
     "discovered implications": "none yet",
-    "proof achieved now": "pending",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
     "validation still needed": "current milestone validation remains pending",
     "next likely slice": "continue the current milestone until the completion criteria are met"
   },
@@ -156,7 +132,7 @@
   ],
   "active_milestone": {
     "id": "github-1118-task-contract-view",
-    "status": "active",
+    "status": "completed",
     "scope": "Keep this execution thread bounded to the promoted TODO item.",
     "ready": "ready",
     "blocked": "none",
@@ -190,79 +166,80 @@
     "Assemble compact task contract view (#1118) is implemented, validated, and closed out honestly."
   ],
   "execution_run": {
-    "run status": "not-run-yet",
-    "executor": "",
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
     "handoff source": "agentic-planning new-plan",
-    "what happened": "execution has not started",
-    "scope touched": "none yet",
-    "changed surfaces": "none yet; execution has not changed files",
-    "validations run": "pending",
-    "result for continuation": "continue from this scaffolded execplan",
-    "next step": "Inspect current start/implement/proof/closeout task-intent surfaces, choose the smallest existing command/selector home, implement the assembled view, and validate task-present, task-absent, and changed-path cases."
+    "what happened": "Implemented compact task_contract view for implement output as an assembled, non-authoritative projection over existing intent, acceptance, autonomy, proof, and stop-condition surfaces.",
+    "scope touched": "implement runtime payloads, implementer-context schema/reference docs, implement CLI tests",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_implement_cli.py; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; docs/reference/implementer-context.md",
+    "validations run": "make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; make schema-reference-docs",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
   },
   "finished_run_review": {
-    "review status": "pending",
-    "scope respected": "pending",
-    "proof status": "pending",
-    "intent served": "pending",
-    "config compliance": "pending",
-    "misinterpretation risk": "pending",
-    "follow-on decision": "pending"
+    "review status": "complete",
+    "scope respected": "Task contract is available through --select task_contract and verbose implement output; default tiny implement remains cheap and only advertises the selector.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
   },
   "delegation_outcome_feedback": {
-    "route chosen": "pending",
-    "route skipped reason": "pending",
-    "expected savings": "pending",
-    "actual friction": "pending",
-    "proof result": "pending",
-    "quality concern": "pending",
-    "decomposition adjustment": "pending"
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
   },
   "proof_report": {
-    "validation proof": "pending",
-    "proof achieved now": "pending",
-    "evidence for \"proof achieved\" state": ""
+    "validation proof": "make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; make schema-reference-docs",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; make schema-reference-docs"
   },
   "intent_satisfaction": {
     "original intent": "GitHub #1118",
-    "was original intent fully satisfied?": "pending",
-    "evidence of intent satisfaction": "",
-    "unsolved intent passed to": "none yet"
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; make schema-reference-docs",
+    "unsolved intent passed to": "none"
   },
   "execution_summary": {
-    "outcome delivered": "not completed yet",
-    "validation confirmed": "pending",
-    "follow-on routed to": "none yet",
-    "post-work posterity capture": "pending",
-    "knowledge promoted (Memory/Docs/Config)": "none",
-    "resume from": "current milestone"
+    "outcome delivered": "Closes #1118 by assembling task intent, acceptance, autonomy/escalation, proof expectations, and stop conditions from existing implement surfaces without adding durable task-contract state.",
+    "validation confirmed": "make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; make schema-reference-docs",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "knowledge promoted (memory/docs/config)": "none",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
   },
   "durable_residue": {
     "status": "none",
-    "learned constraint": "none yet",
-    "motivation worth preserving": "none yet",
-    "canonical owner now": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
     "promotion trigger": "none",
     "retention after promotion": "retain"
   },
   "task_intent_promotion": {
-    "decision": "pending",
+    "decision": "do-not-promote",
     "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
-    "evidence source": "",
-    "target scope": "",
-    "proposed durable intent": "",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
     "confidence": "low",
-    "needs review": true,
-    "owner surface": ""
+    "needs review": "True",
+    "owner surface": "archive"
   },
   "closure_check": {
-    "slice status": "pending",
-    "larger-intent status": "pending",
-    "closure decision": "pending",
-    "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
-    "why this decision is honest": "",
-    "evidence carried forward": "",
-    "reopen trigger": ""
+    "closeout scope": "lane",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a lane claim with intent-status satisfied.",
+    "evidence carried forward": "make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; make schema-reference-docs",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
   },
   "improvement_signal_review": {
     "status": "not_checked",
@@ -282,11 +259,17 @@
     "signals fixed": [],
     "signals routed": [],
     "signals dismissed": [],
-    "next owner": ""
+    "next owner": "agent closeout reflection"
   },
   "closeout_distillation": {
     "buckets": {
-      "discard": [],
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
       "continuation": [],
       "memory": [],
       "config_check": [],
@@ -296,5 +279,20 @@
   },
   "drift_log": [
     "2026-05-24: Scaffolded by agentic-planning new-plan."
-  ]
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: GitHub #1118\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; make schema-reference-docs\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_implement_cli.py; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; docs/reference/implementer-context.md\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
 }

--- a/.agentic-workspace/planning/execplans/archive/github-1118-task-contract-view.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1118-task-contract-view.plan.json
@@ -31,9 +31,20 @@
     "agent_may_decide": "Exact command/selector home, payload field names, compact-vs-verbose placement, and focused tests.",
     "escalate_when": "The implementation needs a new durable Planning artifact, provider-specific session state, a broad task manager, or a change that makes ordinary direct work heavier.",
     "next_action": "Inspect current start/implement/proof/closeout task-intent surfaces, choose the smallest existing command/selector home, implement the assembled view, and validate task-present, task-absent, and changed-path cases.",
-    "proof_expectations": "['Focused tests prove the task-contract view names intent, acceptance, autonomy/escalation, proof expectations, stop conditions, source fields, and missing fields.', 'Workspace test and lint targets pass.']",
-    "touched_scope": "['src/agentic_workspace/workspace_runtime_primitives.py', 'tests/test_workspace_implement_cli.py', 'tests/test_workspace_start_preflight_cli.py', 'src/agentic_workspace/contracts/schemas/implementer_context.schema.json', 'docs/reference/implementer-context.md']",
-    "completion_criteria": "['Assemble compact task contract view (#1118) is implemented, validated, and closed out honestly.']",
+    "proof_expectations": [
+      "Focused tests prove the task-contract view names intent, acceptance, autonomy/escalation, proof expectations, stop conditions, source fields, and missing fields.",
+      "Workspace test and lint targets pass."
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_workspace_implement_cli.py",
+      "tests/test_workspace_start_preflight_cli.py",
+      "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+      "docs/reference/implementer-context.md"
+    ],
+    "completion_criteria": [
+      "Assemble compact task contract view (#1118) is implemented, validated, and closed out honestly."
+    ],
     "continuation_owner": "none",
     "closeout_decision": "archive-and-close"
   },
@@ -45,14 +56,26 @@
   ],
   "machine_readable_contract": {
     "intent": {
-      "proof": "make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; make schema-reference-docs"
+      "outcome": "Assemble a compact task-contract view from existing task intent, acceptance, autonomy/escalation, proof expectations, and stop-condition surfaces.",
+      "constraints": "Do not add new durable task-contract state in this first slice; the view must be assembled from existing source surfaces and keep small direct work cheap.",
+      "latitude": "Exact command/selector home, payload field names, compact-vs-verbose placement, and focused tests.",
+      "escalation": "Escalate when the implementation needs a new durable Planning artifact, provider-specific session state, a broad task manager, or a change that makes ordinary direct work heavier."
     },
     "execution": {
+      "milestone": "github-1118-task-contract-view",
+      "status": "completed",
+      "next_step": "archive this execplan",
       "proof": "make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; make schema-reference-docs"
     },
     "scope": {
       "touched": [
-        "closeout scope recorded in closure_check and generated_closeout."
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_workspace_implement_cli.py",
+        "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+        "docs/reference/implementer-context.md"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
       ]
     }
   },
@@ -229,7 +252,7 @@
     "target scope": "archive",
     "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
     "confidence": "low",
-    "needs review": "True",
+    "needs review": true,
     "owner surface": "archive"
   },
   "closure_check": {

--- a/.agentic-workspace/planning/state.toml
+++ b/.agentic-workspace/planning/state.toml
@@ -12,9 +12,7 @@ work_items = []
 execplans = []
 
 [todo]
-active_items = [
-  { id = "github-1118-task-contract-view", title = "Assemble compact task contract view (#1118)", maturity = "active", status = "active", surface = ".agentic-workspace/planning/execplans/github-1118-task-contract-view.plan.json", why_now = "GitHub #1118", owner_role = "implementation", handoff_ready = true, refs = ["GitHub #1118"] },
-]
+active_items = []
 queued_items = []
 
 [roadmap]

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -27,6 +27,7 @@ Cheap implementer context for a bounded changed-path scope.
 | `path_boundaries` | array of ref `#/$defs/path_boundary` | yes |  | Path-specific ownership and locality constraints for the changed paths. |  |  |
 | `authority_markers` | array of ref `#/$defs/authority_marker` | yes |  | Authority markers relevant to the implementation scope. |  |  |
 | `change_impact` | object | yes |  | Changed-path ownership, generatedness, authority, related contract, and proof-impact projection. |  |  |
+| `task_contract` | object | yes |  | Compact assembled task contract view covering intent, acceptance, autonomy/escalation, proof expectations, and stop conditions. |  |  |
 | `task_intent` | object | yes |  | Task-intent carry-forward packet used to derive acceptance, proof guidance, objective-drift checks, and closeout prompts. |  |  |
 | `acceptance` | ref `#/$defs/task_acceptance` | yes |  | Definition-of-done expectations inferred from task intent. |  |  |
 | `acceptance.kind` | const `"agentic-workspace/task-acceptance/v1"` | yes |  | Discriminator for the task-intent acceptance payload. |  |  |

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -15,6 +15,7 @@
     "path_boundaries",
     "authority_markers",
     "change_impact",
+    "task_contract",
     "task_intent",
     "acceptance",
     "proof",
@@ -104,6 +105,11 @@
     "change_impact": {
       "type": "object",
       "description": "Changed-path ownership, generatedness, authority, related contract, and proof-impact projection.",
+      "additionalProperties": true
+    },
+    "task_contract": {
+      "type": "object",
+      "description": "Compact assembled task contract view covering intent, acceptance, autonomy/escalation, proof expectations, and stop conditions.",
       "additionalProperties": true
     },
     "task_intent": {

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -11617,6 +11617,7 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "acceptance_reconciliation",
         "objective_drift",
         "reuse_pressure",
+        "task_contract",
         "change_impact",
         "detail_commands",
         "path_boundaries",
@@ -13715,8 +13716,146 @@ def _change_impact_payload(*, target_root: Path, changed_paths: list[str], proof
     }
 
 
+def _task_contract_payload(
+    *,
+    changed_paths: list[str],
+    task_intent: dict[str, Any],
+    acceptance: dict[str, Any],
+    proof: dict[str, Any],
+    execution_posture: dict[str, Any],
+    planning_safety_gate: dict[str, Any],
+    intent_acknowledgement: dict[str, Any],
+    handoff_requirements: dict[str, Any],
+) -> dict[str, Any]:
+    task_present = bool(task_intent.get("task_text_available"))
+    acceptance_items = acceptance.get("items", []) if isinstance(acceptance.get("items"), list) else []
+    capability = execution_posture.get("capability_posture", {}) if isinstance(execution_posture, dict) else {}
+    runtime_resolution = execution_posture.get("runtime_resolution", {}) if isinstance(execution_posture, dict) else {}
+    delegation_decision = execution_posture.get("delegation_decision", {}) if isinstance(execution_posture, dict) else {}
+    acceptance_guidance = proof.get("acceptance_guidance", {}) if isinstance(proof, dict) else {}
+    intent_proof = proof.get("intent_proof", {}) if isinstance(proof, dict) else {}
+    work_shape_facts = planning_safety_gate.get("work_shape_facts", {}) if isinstance(planning_safety_gate, dict) else {}
+
+    stop_conditions: list[str] = []
+    for source in (
+        handoff_requirements.get("stop_when") if isinstance(handoff_requirements, dict) else [],
+        work_shape_facts.get("stop_conditions") if isinstance(work_shape_facts, dict) else [],
+        proof.get("escalate_when") if isinstance(proof, dict) else [],
+    ):
+        if isinstance(source, list):
+            for item in source:
+                text = str(item).strip()
+                if text and text not in stop_conditions:
+                    stop_conditions.append(text)
+
+    missing_fields = []
+    if not task_present:
+        missing_fields.append("task_intent.task_text")
+    if not changed_paths:
+        missing_fields.append("changed_paths")
+    if not acceptance_items:
+        missing_fields.append("acceptance.items")
+    if not proof.get("required_commands"):
+        missing_fields.append("proof.required_commands")
+
+    return {
+        "kind": "agentic-workspace/task-contract/v1",
+        "status": "present" if not missing_fields else "present-with-gaps",
+        "authority": "assembled-view",
+        "rule": (
+            "Task contract assembles existing implement surfaces for orientation and closeout; it does not create durable "
+            "Planning state or override source fields."
+        ),
+        "changed_paths": changed_paths,
+        "source_fields": [
+            "changed_paths",
+            "task_intent",
+            "acceptance",
+            "proof",
+            "execution_posture",
+            "planning_safety_gate",
+            "intent_acknowledgement",
+            "handoff_requirements",
+        ],
+        "missing_fields": missing_fields,
+        "intent": {
+            "status": "present" if task_present else "absent",
+            "task_text_available": task_present,
+            "task_excerpt": task_intent.get("task_excerpt"),
+            "requested_outcomes": task_intent.get("requested_outcomes", []),
+            "task_argument_mode": task_intent.get("task_argument_mode"),
+            "source_fields": ["task_intent.task_text_available", "task_intent.requested_outcomes", "task_intent.task_excerpt"],
+            "missing_fields": [] if task_present else ["task_intent.task_text"],
+        },
+        "acceptance": {
+            "status": acceptance.get("status", "unknown"),
+            "closeout_required": bool(acceptance.get("closeout_required")),
+            "item_count": len(acceptance_items),
+            "requested_outcomes": acceptance.get("requested_outcomes", []),
+            "closeout_rule": acceptance.get("closeout_rule", ""),
+            "source_fields": ["acceptance.status", "acceptance.items", "acceptance.closeout_required", "acceptance.closeout_rule"],
+            "missing_fields": [] if acceptance_items else ["acceptance.items"],
+        },
+        "autonomy_and_escalation": {
+            "delegation_decision": delegation_decision.get("decision"),
+            "delegation_mode": delegation_decision.get("mode"),
+            "work_shape": capability.get("work_shape"),
+            "proof_burden": capability.get("proof_burden"),
+            "runtime_recommendation": runtime_resolution.get("recommendation") if isinstance(runtime_resolution, dict) else None,
+            "planning_safety": planning_safety_gate.get("status") if isinstance(planning_safety_gate, dict) else None,
+            "intent_acknowledgement": intent_acknowledgement.get("decision"),
+            "ask_human_when": intent_acknowledgement.get("ask_human_when"),
+            "source_fields": [
+                "execution_posture.delegation_decision",
+                "execution_posture.capability_posture",
+                "execution_posture.runtime_resolution",
+                "planning_safety_gate.status",
+                "intent_acknowledgement",
+            ],
+            "missing_fields": [],
+        },
+        "proof_expectations": {
+            "status": "present" if proof.get("required_commands") else "missing-required-commands",
+            "required_commands": proof.get("required_commands", []),
+            "intent_proof_status": intent_proof.get("status") if isinstance(intent_proof, dict) else None,
+            "acceptance_guidance": {
+                "status": acceptance_guidance.get("status") if isinstance(acceptance_guidance, dict) else None,
+                "closeout_required": acceptance_guidance.get("closeout_required") if isinstance(acceptance_guidance, dict) else None,
+                "acceptance_item_count": acceptance_guidance.get("acceptance_item_count")
+                if isinstance(acceptance_guidance, dict)
+                else None,
+            },
+            "broaden_when": proof.get("broaden_when", []),
+            "escalate_when": proof.get("escalate_when", []),
+            "source_fields": [
+                "proof.required_commands",
+                "proof.intent_proof.status",
+                "proof.acceptance_guidance",
+                "proof.broaden_when",
+                "proof.escalate_when",
+            ],
+            "missing_fields": [] if proof.get("required_commands") else ["proof.required_commands"],
+        },
+        "stop_conditions": {
+            "status": "present" if stop_conditions else "not-recorded",
+            "items": stop_conditions,
+            "source_fields": [
+                "handoff_requirements.stop_when",
+                "planning_safety_gate.work_shape_facts.stop_conditions",
+                "proof.escalate_when",
+            ],
+            "missing_fields": [] if stop_conditions else ["handoff_requirements.stop_when"],
+        },
+    }
+
+
 def _implement_payload(
-    *, target_root: Path, changed_paths: list[str], task_text: str | None = None, include_change_impact: bool = True
+    *,
+    target_root: Path,
+    changed_paths: list[str],
+    task_text: str | None = None,
+    include_change_impact: bool = True,
+    include_task_contract: bool = True,
 ) -> dict[str, Any]:
     implementer_template = _CONTEXT_TEMPLATES["implementer_context"]
     normalized_paths = _normalize_changed_paths(changed_paths)
@@ -13890,6 +14029,17 @@ def _implement_payload(
             "planning safety gate requires active planning ownership",
             *payload["handoff_requirements"]["stop_when"],
         ]
+    if include_task_contract:
+        payload["task_contract"] = _task_contract_payload(
+            changed_paths=normalized_paths,
+            task_intent=task_intent,
+            acceptance=acceptance,
+            proof=proof,
+            execution_posture=execution_posture,
+            planning_safety_gate=planning_safety_gate,
+            intent_acknowledgement=payload["intent_acknowledgement"],
+            handoff_requirements=payload["handoff_requirements"],
+        )
     if include_change_impact:
         payload["change_impact"] = _change_impact_payload(
             target_root=target_root, changed_paths=normalized_paths, proof=proof, cli_invoke=config.cli_invoke
@@ -14035,6 +14185,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "context.acceptance_reconciliation",
                 "context.objective_drift",
                 "context.reuse_pressure",
+                "task_contract",
                 "change_impact",
                 "context.delegation_decision",
                 "context.routing",
@@ -19064,6 +19215,10 @@ def _selector_requests_change_impact(select: str | None) -> bool:
     return any(token == "change_impact" or token.startswith("change_impact.") for token in _selector_tokens(select))
 
 
+def _selector_requests_task_contract(select: str | None) -> bool:
+    return any(token == "task_contract" or token.startswith("task_contract.") for token in _selector_tokens(select))
+
+
 def _run_implement_context_adapter(args: argparse.Namespace) -> int:
     target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
     _validate_target_root(command_name="implement", target_root=target_root)
@@ -19073,16 +19228,21 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
     if not task_text:
         task_text = _read_task_text_from_file(target_root=target_root, task_file=getattr(args, "task_file", None))
     profile = _diagnostic_profile(args, default="tiny")
-    change_impact_selected = _selector_requests_change_impact(getattr(args, "select", None))
+    selected_fields = getattr(args, "select", None)
+    change_impact_selected = _selector_requests_change_impact(selected_fields)
+    task_contract_selected = _selector_requests_task_contract(selected_fields)
     full_payload = _implement_payload(
         target_root=target_root,
         changed_paths=list(getattr(args, "changed", []) or []),
         task_text=task_text,
         include_change_impact=(profile != "tiny" or change_impact_selected),
+        include_task_contract=(profile != "tiny" or task_contract_selected),
     )
     payload = full_payload
     if profile == "tiny":
         payload = _tiny_implement_payload(full_payload)
+        if task_contract_selected:
+            payload["task_contract"] = full_payload["task_contract"]
         if change_impact_selected:
             payload["change_impact"] = full_payload["change_impact"]
     if getattr(args, "select", None):

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -264,6 +264,88 @@ def test_implement_selector_surfaces_changed_path_impact_map(tmp_path: Path, cap
     assert impact["proof_impact"]["required_commands"]
 
 
+def test_implement_selector_surfaces_task_contract_view(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "Makefile", "test-workspace:\n\tpytest tests\n\nlint-workspace:\n\truff check src tests\n")
+    _write(tmp_path / "README.md", "hello\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "README.md",
+                "--task",
+                "Update README wording",
+                "--select",
+                "task_contract",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    contract = json.loads(capsys.readouterr().out)["values"]["task_contract"]
+    assert contract["kind"] == "agentic-workspace/task-contract/v1"
+    assert contract["status"] == "present"
+    assert contract["authority"] == "assembled-view"
+    assert contract["changed_paths"] == ["README.md"]
+    assert "task_intent" in contract["source_fields"]
+    assert contract["intent"]["status"] == "present"
+    assert contract["intent"]["missing_fields"] == []
+    assert contract["acceptance"]["closeout_required"] is True
+    assert contract["acceptance"]["item_count"] == 3
+    assert contract["autonomy_and_escalation"]["delegation_decision"] in {
+        "execute-locally",
+        "stay-local",
+        "suggest-delegation",
+        "manual-handoff",
+        "clarify-first",
+    }
+    assert contract["proof_expectations"]["status"] == "present"
+    assert contract["proof_expectations"]["required_commands"]
+    assert contract["proof_expectations"]["intent_proof_status"] in {"prompt-required", "needs-agent-judgment"}
+    assert contract["stop_conditions"]["status"] == "present"
+    assert "proof.escalate_when" in contract["stop_conditions"]["source_fields"]
+
+
+def test_implement_task_contract_names_missing_task_inputs(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "Makefile", "test-workspace:\n\tpytest tests\n\nlint-workspace:\n\truff check src tests\n")
+    _write(tmp_path / "README.md", "hello\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "README.md",
+                "--select",
+                "task_contract",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    contract = json.loads(capsys.readouterr().out)["values"]["task_contract"]
+    assert contract["status"] == "present-with-gaps"
+    assert contract["intent"]["status"] == "absent"
+    assert contract["intent"]["missing_fields"] == ["task_intent.task_text"]
+    assert "task_intent.task_text" in contract["missing_fields"]
+    assert "acceptance.items" in contract["missing_fields"]
+    assert contract["proof_expectations"]["status"] == "present"
+    assert contract["changed_paths"] == ["README.md"]
+
+
 def test_implement_tiny_profile_does_not_compute_change_impact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
@@ -293,6 +375,40 @@ def test_implement_tiny_profile_does_not_compute_change_impact(tmp_path: Path, m
     assert payload["kind"] == "implementer-context-tiny/v1"
     assert "change_impact" not in payload
     assert "change_impact" not in payload["context"]
+
+
+def test_implement_tiny_profile_does_not_compute_task_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "README.md", "hello\n")
+
+    def fail_task_contract(**_: object) -> dict[str, object]:
+        raise AssertionError("ordinary tiny implement output should not build task_contract")
+
+    monkeypatch.setattr(cli, "_task_contract_payload", fail_task_contract)
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "README.md",
+                "--task",
+                "Update README wording",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "implementer-context-tiny/v1"
+    assert "task_contract" not in payload
+    assert "task_contract" not in payload["context"]
+    assert "task_contract" in payload["drill_down"]["available_selectors"]
 
 
 def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Add `task_contract` as an assembled `implement` view for task intent, acceptance, autonomy/escalation, proof expectations, and stop conditions.
- Keep ordinary tiny `implement` output cheap; the new view is emitted for verbose output or explicit `--select task_contract`.
- Close out and archive the active #1118 Planning execplan through the Planning closeout writer.

Closes #1118

## Validation
- `uv run pytest tests/test_workspace_implement_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make maintainer-surfaces`
- `make schema-reference-docs`
- `uv run agentic-workspace summary --format json`
- `uv run agentic-workspace doctor --target . --modules planning --format json`

## Stacking
Base branch is `codex/reconcile-agent-os-planning-state` so this PR only shows the #1118 implementation and closeout on top of PR #1121.