### PR TITLE
[Assurance]: Implement assurance requirements

### DIFF
--- a/.agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json
@@ -22,7 +22,7 @@
     {
       "id": "assurance-requirement-fact-model",
       "title": "Add minimal assurance requirement config and report projection",
-      "readiness": "ready",
+      "readiness": "promoted",
       "outcome": "Config/schema accepts a minimal [assurance.requirements.<id>] shape, including explicit waiver/dismissal facts, and config/report output projects configured requirements for agents to inspect.",
       "owner_surface": "src/agentic_workspace/config.py and workspace config schema",
       "proof": "Focused config/report tests cover valid requirement, invalid force/level/blocking_claims fields, missing activation signal, waiver/dismissal shape, configured requirement projection, and unchanged low-assurance config.",
@@ -34,7 +34,7 @@
     {
       "id": "assurance-requirement-projection",
       "title": "Project applicable assurance requirements",
-      "readiness": "deferred",
+      "readiness": "promoted",
       "outcome": "start, implement, and report expose matched requirements from changed paths, task markers, proof profiles, active Planning, and configured refs while unrelated small work stays quiet.",
       "owner_surface": "src/agentic_workspace/workspace_runtime_primitives.py and report/start/implement tests",
       "proof": "Fixtures cover high-assurance path/task matches and a tiny unrelated edit with no ceremony.",
@@ -46,7 +46,7 @@
     {
       "id": "assurance-evidence-closeout-gates",
       "title": "Integrate evidence status with closeout and completion options",
-      "readiness": "deferred",
+      "readiness": "promoted",
       "outcome": "closeout_trust and completion options distinguish proof passed from required assurance evidence satisfied, blocking broad claims when required evidence is missing.",
       "owner_surface": "closeout_trust and completion option payloads",
       "proof": "Focused tests show missing evidence blocks claim-work-complete and close-parent-lane, while honest stop/status and review routes remain available.",
@@ -58,7 +58,7 @@
     {
       "id": "assurance-proof-profile-integration",
       "title": "Wire requirement-linked proof profiles into proof output",
-      "readiness": "deferred",
+      "readiness": "promoted",
       "outcome": "proof selects requirement-linked proof profile commands, review aids, blocked commands, and residual evidence gaps without replacing agent judgment.",
       "owner_surface": "proof selection and active planning assurance payloads",
       "proof": "Proof tests cover configured proof profile selection, missing configured profile, review aids, and host-policy blocked commands.",
@@ -72,7 +72,7 @@
     {
       "id": "assurance-dogfood-fixtures",
       "title": "Add high-assurance and non-code dogfood fixtures",
-      "readiness": "deferred",
+      "readiness": "promoted",
       "outcome": "A host fixture proves code and non-code assurance requirements, evidence recording, claim gates, and proportionality for unrelated work.",
       "owner_surface": "tests and fixture host repos",
       "proof": "Fixture tests cover relevant high-assurance work, evidence recorded, unrelated quiet edit, and non-code policy/runbook surface.",
@@ -86,7 +86,8 @@
   "dependency_assumptions": [
     "#1131 should close before implementation lanes start so the fact model does not fork away from existing assurance/proof/Planning/closeout surfaces.",
     "Closeout and proof integration should reuse active Planning assurance fields before adding any new evidence store.",
-    "#1132 is the first implementation child and intentionally includes a read projection so schema does not land without agent-visible behavior."
+    "#1132 is the first implementation child and intentionally includes a read projection so schema does not land without agent-visible behavior.",
+    "#1133-#1136 were created as follow-on child slices for projection, closeout gates, proof integration, and dogfood fixtures."
   ],
   "parallelization_assumptions": [
     "Proof profile integration can proceed alongside closeout gate design after the projection shape is stable.",
@@ -115,6 +116,30 @@
       "target": "https://github.com/rickardvh/agentic-workspace/issues/1132",
       "label": "#1132",
       "role": "first implementation child"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1133",
+      "label": "#1133",
+      "role": "projection child"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1134",
+      "label": "#1134",
+      "role": "closeout gates child"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1135",
+      "label": "#1135",
+      "role": "proof integration child"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1136",
+      "label": "#1136",
+      "role": "dogfood fixtures child"
     }
   ],
   "notes": "Ingested from GitHub #1130 as parent lane context. The upstream issue remains a tracker reference; checked-in Planning owns execution sequencing."

--- a/.agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json
@@ -21,11 +21,11 @@
     },
     {
       "id": "assurance-requirement-fact-model",
-      "title": "Define repo-declared assurance requirement facts",
+      "title": "Add minimal assurance requirement config and report projection",
       "readiness": "ready",
-      "outcome": "Config/schema accepts a minimal [assurance.requirements.<id>] shape and reports invalid or unsupported fields clearly.",
+      "outcome": "Config/schema accepts a minimal [assurance.requirements.<id>] shape, including explicit waiver/dismissal facts, and config/report output projects configured requirements for agents to inspect.",
       "owner_surface": "src/agentic_workspace/config.py and workspace config schema",
-      "proof": "Focused config/schema tests cover valid requirement, invalid force/level/evidence fields, and unchanged low-assurance config.",
+      "proof": "Focused config/report tests cover valid requirement, invalid force/level/blocking_claims fields, missing activation signal, waiver/dismissal shape, configured requirement projection, and unchanged low-assurance config.",
       "depends_on": [
         "github-1131-model-investigation"
       ],
@@ -85,7 +85,8 @@
   ],
   "dependency_assumptions": [
     "#1131 should close before implementation lanes start so the fact model does not fork away from existing assurance/proof/Planning/closeout surfaces.",
-    "Closeout and proof integration should reuse active Planning assurance fields before adding any new evidence store."
+    "Closeout and proof integration should reuse active Planning assurance fields before adding any new evidence store.",
+    "#1132 is the first implementation child and intentionally includes a read projection so schema does not land without agent-visible behavior."
   ],
   "parallelization_assumptions": [
     "Proof profile integration can proceed alongside closeout gate design after the projection shape is stable.",
@@ -108,6 +109,12 @@
       "target": "https://github.com/rickardvh/agentic-workspace/issues/1131",
       "label": "#1131",
       "role": "first promoted investigation"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1132",
+      "label": "#1132",
+      "role": "first implementation child"
     }
   ],
   "notes": "Ingested from GitHub #1130 as parent lane context. The upstream issue remains a tracker reference; checked-in Planning owns execution sequencing."

--- a/.agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json
@@ -1,0 +1,114 @@
+{
+  "kind": "planning-decomposition/v1",
+  "title": "Repo-defined assurance requirements and evidence gates",
+  "status": "ready-for-lane-promotion",
+  "larger_intended_outcome": "Let host repos declare domain-generic assurance requirements, authority refs, evidence expectations, proof/review obligations, and completion claim boundaries without creating a parallel compliance subsystem.",
+  "non_goals": [
+    "Do not make AW understand legal, regulatory, privacy, security, accessibility, financial, medical, or other domain compliance semantics.",
+    "Do not create a separate compliance workflow engine.",
+    "Do not make low-assurance direct work pay high-assurance ceremony when no requirement matches."
+  ],
+  "candidate_lanes": [
+    {
+      "id": "github-1131-model-investigation",
+      "title": "Map existing assurance building blocks into one evidence-gate model",
+      "readiness": "promoted",
+      "outcome": "A compact design investigation identifies the v1 model, evidence ownership, surface integration, closeout behavior, proportionality guardrails, and follow-up implementation slices.",
+      "owner_surface": ".agentic-workspace/planning/execplans/github-1131-assurance-evidence-gate-investigation.plan.json",
+      "proof": "Review artifact answers #1131 acceptance questions and planning doctor validates the active plan.",
+      "depends_on": [],
+      "parallel_with": []
+    },
+    {
+      "id": "assurance-requirement-fact-model",
+      "title": "Define repo-declared assurance requirement facts",
+      "readiness": "ready",
+      "outcome": "Config/schema accepts a minimal [assurance.requirements.<id>] shape and reports invalid or unsupported fields clearly.",
+      "owner_surface": "src/agentic_workspace/config.py and workspace config schema",
+      "proof": "Focused config/schema tests cover valid requirement, invalid force/level/evidence fields, and unchanged low-assurance config.",
+      "depends_on": [
+        "github-1131-model-investigation"
+      ],
+      "parallel_with": []
+    },
+    {
+      "id": "assurance-requirement-projection",
+      "title": "Project applicable assurance requirements",
+      "readiness": "deferred",
+      "outcome": "start, implement, and report expose matched requirements from changed paths, task markers, proof profiles, active Planning, and configured refs while unrelated small work stays quiet.",
+      "owner_surface": "src/agentic_workspace/workspace_runtime_primitives.py and report/start/implement tests",
+      "proof": "Fixtures cover high-assurance path/task matches and a tiny unrelated edit with no ceremony.",
+      "depends_on": [
+        "assurance-requirement-fact-model"
+      ],
+      "parallel_with": []
+    },
+    {
+      "id": "assurance-evidence-closeout-gates",
+      "title": "Integrate evidence status with closeout and completion options",
+      "readiness": "deferred",
+      "outcome": "closeout_trust and completion options distinguish proof passed from required assurance evidence satisfied, blocking broad claims when required evidence is missing.",
+      "owner_surface": "closeout_trust and completion option payloads",
+      "proof": "Focused tests show missing evidence blocks claim-work-complete and close-parent-lane, while honest stop/status and review routes remain available.",
+      "depends_on": [
+        "assurance-requirement-projection"
+      ],
+      "parallel_with": []
+    },
+    {
+      "id": "assurance-proof-profile-integration",
+      "title": "Wire requirement-linked proof profiles into proof output",
+      "readiness": "deferred",
+      "outcome": "proof selects requirement-linked proof profile commands, review aids, blocked commands, and residual evidence gaps without replacing agent judgment.",
+      "owner_surface": "proof selection and active planning assurance payloads",
+      "proof": "Proof tests cover configured proof profile selection, missing configured profile, review aids, and host-policy blocked commands.",
+      "depends_on": [
+        "assurance-requirement-projection"
+      ],
+      "parallel_with": [
+        "assurance-evidence-closeout-gates"
+      ]
+    },
+    {
+      "id": "assurance-dogfood-fixtures",
+      "title": "Add high-assurance and non-code dogfood fixtures",
+      "readiness": "deferred",
+      "outcome": "A host fixture proves code and non-code assurance requirements, evidence recording, claim gates, and proportionality for unrelated work.",
+      "owner_surface": "tests and fixture host repos",
+      "proof": "Fixture tests cover relevant high-assurance work, evidence recorded, unrelated quiet edit, and non-code policy/runbook surface.",
+      "depends_on": [
+        "assurance-evidence-closeout-gates",
+        "assurance-proof-profile-integration"
+      ],
+      "parallel_with": []
+    }
+  ],
+  "dependency_assumptions": [
+    "#1131 should close before implementation lanes start so the fact model does not fork away from existing assurance/proof/Planning/closeout surfaces.",
+    "Closeout and proof integration should reuse active Planning assurance fields before adding any new evidence store."
+  ],
+  "parallelization_assumptions": [
+    "Proof profile integration can proceed alongside closeout gate design after the projection shape is stable.",
+    "Dogfood fixtures should wait until at least one implementation path exists so they validate real behavior rather than aspirational schema."
+  ],
+  "proof_expectations": [
+    "Each promoted implementation lane must prove both a matched high-assurance case and an unrelated low-assurance quiet case.",
+    "Implementation lanes must show that AW remains domain-generic and only routes repo-declared authority/evidence requirements."
+  ],
+  "promotion_rule": "Promote only one implementation slice at a time after #1131 records the v1 model and the slice has a bounded owner surface, proof expectation, and proportionality check.",
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1130",
+      "label": "#1130",
+      "role": "parent lane"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1131",
+      "label": "#1131",
+      "role": "first promoted investigation"
+    }
+  ],
+  "notes": "Ingested from GitHub #1130 as parent lane context. The upstream issue remains a tracker reference; checked-in Planning owns execution sequencing."
+}

--- a/.agentic-workspace/planning/execplans/archive/github-1130-assurance-requirements-implementation.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1130-assurance-requirements-implementation.plan.json
@@ -1,0 +1,341 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement assurance requirements and evidence gates",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement the remaining #1130 assurance requirements lane: config fact model, projection, proof integration, closeout gates, and dogfood coverage.",
+    "hard_constraints": "Reuse existing AW config/report/start/implement/proof/closeout machinery; keep AW domain-generic; do not add a parallel compliance subsystem or evidence store.",
+    "agent_may_decide": "Exact payload shape, tests, schema wiring, issue routing, and proportionality guardrails within the #1130 child issue boundaries.",
+    "escalate_when": "A correct implementation requires domain-specific compliance semantics, a new evidence store, a new top-level command, or broad workflow machinery beyond #1130.",
+    "next_action": "Validate the implemented assurance surfaces, then close out and open the PR.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_config_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_start_preflight_cli.py tests/test_workspace_proof_cli.py tests/test_workspace_report_cli.py -q",
+      "uv run agentic-workspace summary --target . --format json",
+      "uv run agentic-workspace doctor --target . --modules planning --format json"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/config.py",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "src/agentic_workspace/reporting_support.py",
+      "src/agentic_workspace/contracts/report_contract.json",
+      "src/agentic_workspace/contracts/schemas/workspace_config.schema.json",
+      "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+      "tests/test_workspace_config_cli.py",
+      "tests/test_workspace_implement_cli.py",
+      "tests/test_workspace_start_preflight_cli.py",
+      "tests/test_workspace_proof_cli.py",
+      "tests/test_workspace_report_cli.py",
+      ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json"
+    ],
+    "completion_criteria": [
+      "Host repos can configure assurance.requirements with activation signals, evidence labels, proof profiles, blocking claims, and waiver/dismissal records.",
+      "Report/start/implement/proof/closeout surfaces project active requirements without noisy unrelated tiny output.",
+      "closeout_trust blocks unsupported broad claims when required assurance evidence is missing while review/status routes remain available.",
+      "Tests cover high-assurance path/task matches, proof-profile integration, closeout gates, quiet unrelated work, and non-code requirements."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Implement assurance requirements and evidence gates."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement the remaining #1130 assurance requirements lane.",
+      "constraints": "Reuse existing AW machinery and keep the feature domain-generic.",
+      "latitude": "Choose compact payload and test shape within the child issue boundaries.",
+      "escalation": "Escalate if the work requires a new compliance subsystem, evidence store, or domain semantics.",
+      "proof": "make test-workspace; make lint-workspace; make schema-reference-docs; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success"
+    },
+    "execution": {
+      "milestone": "github-1130-assurance-requirements-implementation",
+      "status": "active",
+      "next_step": "Validate the implemented assurance surfaces, then close out and open the PR.",
+      "proof": "Focused workspace CLI assurance tests plus AW summary/doctor."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/config.py",
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/reporting_support.py",
+        "src/agentic_workspace/contracts/",
+        "tests/test_workspace_*_cli.py",
+        ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Complete the #1130 repo-defined assurance requirements lane.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "current milestone validation remains pending",
+    "next likely slice": "continue the current milestone until the completion criteria are met"
+  },
+  "intent_interpretation": {
+    "literal request": "Implement the remainder of #1130, creating new issues along the way",
+    "inferred intended outcome": "Finish the remaining #1130 implementation slices and create child issues for the concrete lanes.",
+    "chosen concrete what": "Implement requirement config, projection, proof, closeout, and fixture coverage in one bounded branch.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace config/runtime/reporting/contracts, focused workspace CLI tests, and #1130 planning decomposition.",
+    "max changed files": "About a dozen source, contract, test, and planning files.",
+    "required validation commands": "uv run pytest tests/test_workspace_config_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_start_preflight_cli.py tests/test_workspace_proof_cli.py tests/test_workspace_report_cli.py -q; uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Assurance requirements implementation is in branch codex/assurance-requirements-1130; validate focused workspace CLI tests and close out.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement the remaining #1130 assurance requirements lane.",
+    "hard constraints": "Reuse existing AW machinery, keep domain semantics repo-owned, and avoid a parallel compliance/evidence subsystem.",
+    "agent may decide locally": "Payload details, tests, and PR issue closure wording.",
+    "escalate when": "A correct fix requires a new evidence store, new top-level workflow, or domain-specific compliance logic."
+  },
+  "post_decomposition_delegation": {
+    "status": "pending",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    "#1130",
+    "#1132",
+    "#1133",
+    "#1134",
+    "#1135",
+    "#1136"
+  ],
+  "active_milestone": {
+    "id": "github-1130-assurance-requirements-implementation",
+    "status": "completed",
+    "scope": "Implement the remaining #1130 child slices in the workspace config/runtime/report/proof/closeout surfaces.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Validate the assurance implementation and open the PR."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/config.py",
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "src/agentic_workspace/reporting_support.py",
+    "src/agentic_workspace/contracts/report_contract.json",
+    "src/agentic_workspace/contracts/schemas/workspace_config.schema.json",
+    "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+    "tests/test_workspace_config_cli.py",
+    "tests/test_workspace_implement_cli.py",
+    "tests/test_workspace_start_preflight_cli.py",
+    "tests/test_workspace_proof_cli.py",
+    "tests/test_workspace_report_cli.py",
+    ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_config_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_start_preflight_cli.py tests/test_workspace_proof_cli.py tests/test_workspace_report_cli.py -q",
+    "uv run agentic-workspace summary --target . --format json",
+    "uv run agentic-workspace doctor --target . --modules planning --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement assurance requirements and evidence gates is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented repo-defined assurance requirements from #1130: config/schema parsing, config/report/start/implement/proof projections, closeout trust gates, waiver/dismissal metadata, proof-profile integration, and high-assurance/non-code fixtures.",
+    "scope touched": "Workspace config, runtime projections, report support, contracts, generated reference docs, tests, and Planning lane decomposition.",
+    "changed surfaces": "src/agentic_workspace/config.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; src/agentic_workspace/contracts; docs/reference; tests; .agentic-workspace/planning",
+    "validations run": "make test-workspace; make lint-workspace; make schema-reference-docs; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Remainder of #1130 is implemented as repo-native assurance requirements and evidence gates, with follow-up child issues #1133-#1136 created and linked in the decomposition.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "make test-workspace; make lint-workspace; make schema-reference-docs; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "make test-workspace; make lint-workspace; make schema-reference-docs; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success"
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement assurance requirements and evidence gates.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "make test-workspace; make lint-workspace; make schema-reference-docs; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Configured assurance requirements are inspectable, matchable, proof-affecting, and claim-gating without creating a separate evidence store.",
+    "validation confirmed": "make test-workspace; make lint-workspace; make schema-reference-docs; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "knowledge promoted (memory/docs/config)": "none",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a lane claim with intent-status satisfied.",
+    "evidence carried forward": "make test-workspace; make lint-workspace; make schema-reference-docs; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-05-26: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement assurance requirements and evidence gates.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: make test-workspace; make lint-workspace; make schema-reference-docs; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success\nChanged surfaces: src/agentic_workspace/config.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; src/agentic_workspace/contracts; docs/reference; tests; .agentic-workspace/planning\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/github-1131-assurance-evidence-gate-investigation.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1131-assurance-evidence-gate-investigation.plan.json
@@ -1,0 +1,370 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Investigate assurance evidence gate model",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Ingest the #1130 assurance parent lane into checked-in Planning and complete the #1131 design investigation.",
+    "hard_constraints": "Design-only slice; do not implement new config schema, commands, proof behavior, closeout gates, or fixtures. Keep GitHub as intake/reference and checked-in Planning as execution authority.",
+    "agent_may_decide": "Choose the compact planning artifact shape, investigation structure, follow-up slice recommendations, and issue-comment wording.",
+    "escalate_when": "The investigation would require committing implementation behavior or creating a parallel compliance subsystem.",
+    "next_action": "Validate the planning artifacts and post the compact investigation result to GitHub #1131.",
+    "proof_expectations": [
+      "uv run agentic-workspace summary --target . --format json",
+      "uv run agentic-workspace doctor --target . --modules planning --format json",
+      "uv run python scripts/check/check_planning_surfaces.py"
+    ],
+    "touched_scope": [
+      ".agentic-workspace/planning/state.toml",
+      ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+      ".agentic-workspace/planning/execplans/github-1131-assurance-evidence-gate-investigation.plan.json",
+      ".agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.review.json",
+      ".agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.md"
+    ],
+    "completion_criteria": [
+      "#1130 is represented as parent lane/decomposition context in checked-in Planning.",
+      "#1131 has a compact design investigation artifact answering inventory, v1 model, evidence ownership, integration points, closeout behavior, proportionality, non-goals, and follow-up issues.",
+      "The investigation is posted or summarized back to GitHub #1131.",
+      "Planning validation passes."
+    ],
+    "continuation_owner": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Ingest GitHub #1130 as the parent assurance lane in checked-in Planning.",
+    "Complete GitHub #1131 as a bounded design investigation, not an implementation."
+  ],
+  "non_goals": [
+    "Do not implement assurance requirements, evidence gates, proof integration, closeout gates, or fixtures in this slice.",
+    "Do not add domain-specific compliance semantics to AW.",
+    "Do not make GitHub issues the execution authority after intake."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Checked-in parent lane context for #1130 plus a completed #1131 investigation artifact.",
+      "constraints": "Design-only; no product behavior changes.",
+      "latitude": "Artifact format, summary wording, and follow-up slice recommendations.",
+      "escalation": "Escalate if investigation cannot stay design-only or if existing surfaces are insufficient to avoid a parallel subsystem.",
+      "proof": "uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_planning_surfaces.py"
+    },
+    "execution": {
+      "milestone": "github-1131-assurance-evidence-gate-investigation",
+      "status": "active",
+      "next_step": "Validate planning artifacts and post the investigation summary to #1131.",
+      "proof": "Planning summary, planning doctor, and planning surface check pass."
+    },
+    "scope": {
+      "touched": [
+        ".agentic-workspace/planning/state.toml",
+        ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+        ".agentic-workspace/planning/execplans/github-1131-assurance-evidence-gate-investigation.plan.json",
+        ".agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.review.json",
+        ".agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.md"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "GitHub #1130: repo-defined assurance requirements and evidence gates.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+    "parent lane": "GitHub #1130"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+    "activation trigger": "Promote the first implementation child issue after #1131 is accepted."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Follow-up implementation issues can start from a concrete v1 assurance requirement/evidence-gate model.",
+    "intentionally deferred": "Config/schema implementation, projection, proof integration, closeout gates, and dogfood fixtures.",
+    "discovered implications": "Most of the required assurance loop already exists; the missing piece is a small repo-declared requirement fact model plus evidence-status projection.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "current milestone validation remains pending",
+    "next likely slice": "Create/promote the minimal assurance requirement fact model child issue."
+  },
+  "intent_interpretation": {
+    "literal request": "Ingest the #1130 lane on a new branch and do the #1131 investigation.",
+    "inferred intended outcome": "Create checked-in planning context for the parent assurance lane and produce a design investigation that can seed implementation child issues.",
+    "chosen concrete what": "Parent decomposition plus active execplan plus planning review/design artifact and GitHub #1131 comment.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the investigation avoids implementation and avoids inventing a parallel compliance subsystem."
+  },
+  "execution_bounds": {
+    "allowed paths": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json; .agentic-workspace/planning/execplans/github-1131-assurance-evidence-gate-investigation.plan.json; .agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.review.json; .agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.md",
+    "max changed files": "5 planning files plus optional generated formatting changes from planning commands.",
+    "required validation commands": "uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_planning_surfaces.py",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Implementation code, schemas, generated contracts, tests, Memory notes, or docs outside the planning investigation artifacts."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "GitHub #1130, GitHub #1131, this execplan, the parent decomposition, and the review artifact.",
+    "recoverable later": "Detailed issue bodies, historical reviews, source search output, and deferred implementation lanes.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Complete the #1131 design artifact and post a compact issue comment; do not implement behavior.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Checked-in #1130 lane context and #1131 investigation result.",
+    "hard constraints": "No product behavior implementation; no domain compliance semantics; no parallel compliance subsystem.",
+    "agent may decide locally": "Investigation wording, follow-up issue breakdown, and whether to comment on #1131.",
+    "escalate when": "The next step would require implementing schema/command/proof/closeout behavior."
+  },
+  "post_decomposition_delegation": {
+    "status": "pending",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1131",
+      "label": "GitHub #1131",
+      "role": "intake",
+      "locator": ""
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1130",
+      "label": "GitHub #1130",
+      "role": "parent lane",
+      "locator": ""
+    },
+    {
+      "kind": "planning-decomposition",
+      "target": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+      "label": "#1130 lane decomposition",
+      "role": "parent context",
+      "locator": ""
+    },
+    {
+      "kind": "planning-review",
+      "target": ".agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.review.json",
+      "label": "#1131 investigation artifact",
+      "role": "design result",
+      "locator": ""
+    }
+  ],
+  "active_milestone": {
+    "id": "github-1131-assurance-evidence-gate-investigation",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Validate planning artifacts and post the compact design result to GitHub #1131."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    ".agentic-workspace/planning/state.toml",
+    ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+    ".agentic-workspace/planning/execplans/github-1131-assurance-evidence-gate-investigation.plan.json",
+    ".agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.review.json",
+    ".agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.md"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run agentic-workspace summary --target . --format json",
+    "uv run agentic-workspace doctor --target . --modules planning --format json",
+    "uv run python scripts/check/check_planning_surfaces.py"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Investigate assurance evidence gate model is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Ingested GitHub #1130 as parent assurance lane context, completed the #1131 design investigation, and prepared follow-up implementation lane recommendations.",
+    "scope touched": "Checked-in Planning intake, decomposition, execplan, and review surfaces.",
+    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json; .agentic-workspace/planning/execplans/github-1131-assurance-evidence-gate-investigation.plan.json; .agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.review.json; .agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.md",
+    "validations run": "uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_planning_surfaces.py",
+    "result for continuation": "continue from .agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed design-only; no config/schema/proof/closeout behavior was implemented. Parent #1130 remains open with follow-up lanes.",
+    "proof status": "passed",
+    "intent served": "no; intent-status=deferred-with-owner keeps continuation explicit.",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "Design investigation is bounded and directly tied to active Planning; external delegation would not reduce proof burden.",
+    "expected savings": "none",
+    "actual friction": "none yet",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_planning_surfaces.py",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_planning_surfaces.py"
+  },
+  "intent_satisfaction": {
+    "original intent": "Ingest the #1130 lane on a new branch and do the #1131 investigation.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_planning_surfaces.py",
+    "unsolved intent passed to": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1131 investigation recommends a repo-declared assurance requirement fact model, evidence-status projection, closeout completion-option gates, proof-profile integration, and dogfood fixtures while avoiding a parallel compliance subsystem.",
+    "validation confirmed": "uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_planning_surfaces.py",
+    "follow-on routed to": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "knowledge promoted (memory/docs/config)": "none",
+    "resume from": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "planning",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "GitHub #1130/#1131 and planning review artifact",
+    "target scope": "Parent lane decomposition and follow-up issues",
+    "proposed durable intent": "Assurance requirements should stay repo-defined, domain-generic, evidence-oriented, and integrated with existing proof/closeout claim gates.",
+    "confidence": "medium",
+    "needs review": false,
+    "owner surface": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status deferred-with-owner.",
+    "evidence carried forward": "uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_planning_surfaces.py",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "Promote child issues for the minimal fact model, matching/projection, evidence closeout gates, proof integration, and dogfood fixtures.",
+          "owner": "GitHub #1130",
+          "source": ""
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": [
+        {
+          "summary": "GitHub #1131",
+          "owner": "github-issue",
+          "source": "https://github.com/rickardvh/agentic-workspace/issues/1131"
+        },
+        {
+          "summary": "GitHub #1130",
+          "owner": "github-issue",
+          "source": "https://github.com/rickardvh/agentic-workspace/issues/1130"
+        }
+      ]
+    }
+  },
+  "drift_log": [
+    "2026-05-26: Scaffolded by agentic-planning new-plan.",
+    "2026-05-26: Tightened for #1131 investigation and linked #1130 parent decomposition plus review artifact."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Ingest the #1130 lane on a new branch and do the #1131 investigation.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; uv run python scripts/check/check_planning_surfaces.py\nChanged surfaces: .agentic-workspace/planning/state.toml; .agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json; .agentic-workspace/planning/execplans/github-1131-assurance-evidence-gate-investigation.plan.json; .agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.review.json; .agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.md\nDurable residue: planning (.agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json)\nMemory learning: route_to_planning\nFollow-up: .agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json"
+  }
+}

--- a/.agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.md
+++ b/.agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.md
@@ -1,0 +1,97 @@
+# Assurance Evidence Gate Model Investigation
+
+## Intent
+
+GitHub #1131 asks for a design investigation under parent lane #1130. The answer is: reuse the existing assurance/proof/Planning/Memory/closeout machinery, add only a small repo-declared requirement fact model, and make evidence status a projection before adding any new store.
+
+## Inventory
+
+- Config already owns assurance posture: `assurance.default_level`, `agent_may_escalate`, `agent_may_deescalate`, `strict_closeout`, `proof_profiles`, `test_data_policy`, `decision_record_target`, `invariant_registry`, and `risk_registry`.
+- Config also owns `workflow_obligations` with `summary`, `stage`, `force`, `scope_tags`, `commands`, and `review_hint`.
+- Planning execplans already carry `adaptive_assurance`, `traceability_refs`, `control_gates`, `risk_registry_refs`, `invariant_refs`, `test_data_policy`, `proof_report`, `intent_proof`, `durable_residue`, and closeout fields.
+- Proof already reads active Planning assurance and configured proof profiles, reports missing proof profiles, review aids, blocked commands, and proof confidence.
+- `closeout_trust` already reconciles proof, intent, acceptance, package evidence, durable residue, strict closeout, and completion options.
+- Memory is the anti-rediscovery layer and should not become the canonical store for active evidence.
+
+## Minimal V1 Requirement Shape
+
+Requirements should live under `assurance.requirements.<id>` unless implementation finds a schema blocker.
+
+Stable fields:
+
+- `level`: `low`, `medium`, `high`, or `critical`.
+- `applies_to_paths`: path globs.
+- `applies_to_task_markers`: repo-owned terms.
+- `authority_refs`: docs, runbooks, registries, policies, or decision records to consult.
+- `required_evidence`: free-form repo vocabulary, not AW domain semantics.
+- `proof_profile`: existing `assurance.proof_profiles.<id>`.
+- `workflow_obligation_refs`: existing or synthesized workflow obligations.
+- `review_owner`: repo-local owner label.
+- `force`: `informational`, `recommended`, `required-before-closeout`, or `blocking`.
+- `blocking_claims`: completion option ids such as `claim-work-complete` and `close-parent-lane`.
+
+The implementation should require at least one matching signal and should validate known enum fields, but leave evidence labels free-form.
+
+## Evidence Status
+
+Start with a projection, not a new evidence store:
+
+```json
+{
+  "requirement_id": "privacy_data",
+  "state": "matched|satisfied|missing-evidence|review-required|waived",
+  "level": "high",
+  "applies_because": ["changed path matched db/migrations/**"],
+  "authority_refs": ["docs/compliance/privacy.md"],
+  "required_evidence": ["authority_consulted", "risk_assessment"],
+  "evidence_present": [],
+  "missing_evidence": ["authority_consulted", "risk_assessment"],
+  "proof_profile": "privacy",
+  "workflow_obligation_refs": ["privacy_review"],
+  "review_owner": "privacy-review",
+  "blocking_claims": ["claim-work-complete", "close-parent-lane"],
+  "next_action": {}
+}
+```
+
+Evidence should be read from existing Planning/proof/closeout fields first. Add a command-owned writer only if direct-work evidence cannot be represented cleanly.
+
+## Surface Integration
+
+- `start`: report task-marker requirements and authority refs only when the task activates a requirement.
+- `implement`: match changed paths plus task markers; expose detail behind selector/verbose and keep tiny output quiet unless a required action changes the next step.
+- `proof`: include requirement-linked proof profile commands, review aids, disallowed commands, and residual missing evidence.
+- `report --section closeout_trust`: summarize evidence status and add blockers to existing completion options.
+- `report --section workflow_obligations`: let requirements reference or synthesize obligations rather than duplicate commands/reviews.
+- `planning`: carry requirement refs, evidence status, proof profile, review owner, and claim boundary in existing execplan fields.
+- `memory`: capture only durable lessons or unresolved assurance residue that future agents would rediscover.
+
+## Completion Behavior
+
+Missing high/critical required evidence should block `claim-work-complete` and `close-parent-lane` by default. `claim-slice-complete` can remain allowed only when the slice explicitly excludes that evidence or routes the continuation honestly. `request-review`, `route-residue`, and `stop-with-status` must remain available.
+
+## Proportionality
+
+A requirement should activate only from explicit evidence: path glob match, task marker match, active Planning requirement ref, proof profile ref, or risk/invariant ref. Configuring high-assurance requirements must not make unrelated small edits noisy.
+
+## Follow-Up Issues
+
+1. Minimal `assurance.requirements.<id>` fact model in config/schema/defaults/config output.
+2. Requirement matching/projection into `start`, `implement`, and `report`.
+3. Evidence status and `closeout_trust` completion-option gates.
+4. Requirement-linked proof profile integration.
+5. High-assurance and non-code dogfood fixtures after the first implementation slices exist.
+
+## Non-Goals
+
+- Domain compliance interpretation.
+- A parallel `[compliance]` tree.
+- A new evidence store by default.
+- A new top-level command by default.
+- Blocking all work in repos with assurance config.
+
+## Validation
+
+- `uv run agentic-workspace summary --target . --format json`
+- `uv run agentic-workspace doctor --target . --modules planning --format json`
+- `uv run python scripts/check/check_planning_surfaces.py`

--- a/.agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.md
+++ b/.agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.md
@@ -29,8 +29,9 @@ Stable fields:
 - `review_owner`: repo-local owner label.
 - `force`: `informational`, `recommended`, `required-before-closeout`, or `blocking`.
 - `blocking_claims`: completion option ids such as `claim-work-complete` and `close-parent-lane`.
+- `waiver` / `dismissal`: explicit recorded reason and owner when a matched requirement is waived, dismissed, or found not applicable after inspection.
 
-The implementation should require at least one matching signal and should validate known enum fields, but leave evidence labels free-form.
+The implementation should require at least one matching signal and should validate known enum fields, but leave evidence labels free-form. Waiver/dismissal must be first-class enough that agents do not work around gates by deleting or ignoring matched requirements.
 
 ## Evidence Status
 
@@ -46,6 +47,11 @@ Start with a projection, not a new evidence store:
   "required_evidence": ["authority_consulted", "risk_assessment"],
   "evidence_present": [],
   "missing_evidence": ["authority_consulted", "risk_assessment"],
+  "waiver": {
+    "status": "none|waived|dismissed",
+    "reason": "",
+    "owner": ""
+  },
   "proof_profile": "privacy",
   "workflow_obligation_refs": ["privacy_review"],
   "review_owner": "privacy-review",
@@ -76,7 +82,7 @@ A requirement should activate only from explicit evidence: path glob match, task
 
 ## Follow-Up Issues
 
-1. Minimal `assurance.requirements.<id>` fact model in config/schema/defaults/config output.
+1. #1132: Minimal `assurance.requirements.<id>` fact model plus config/report read projection, including explicit waiver/dismissal shape and no closeout gates yet.
 2. Requirement matching/projection into `start`, `implement`, and `report`.
 3. Evidence status and `closeout_trust` completion-option gates.
 4. Requirement-linked proof profile integration.

--- a/.agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.review.json
+++ b/.agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.review.json
@@ -1,0 +1,229 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Assurance Evidence Gate Model Investigation",
+  "date": "2026-05-26",
+  "scope": [
+    "GitHub #1131 investigation for parent lane #1130"
+  ],
+  "classification": "design-investigation",
+  "goal": [
+    "Answer GitHub #1131 by mapping existing AW assurance, proof, Planning, Memory, report, and closeout building blocks into one repo-defined evidence-gate model."
+  ],
+  "non_goals": [
+    "Do not implement new config schema, commands, proof behavior, closeout gates, or fixtures in this investigation slice.",
+    "Do not encode domain-specific compliance knowledge in AW.",
+    "Do not create a parallel compliance subsystem."
+  ],
+  "review_mode": {
+    "mode": "design-investigation",
+    "review question": "How should repo-defined assurance requirements compose with existing AW surfaces without becoming a separate compliance product?",
+    "default finding cap": "bounded",
+    "inputs inspected first": "compact planning and task-specific surfaces"
+  },
+  "review_method": {
+    "commands used": "uv run agentic-workspace start --task \"Ingest the #1130 lane on a new branch and do the #1131 investigation\" --format json; gh issue view 1130 --json number,title,state,body,labels,assignees,comments,url; gh issue view 1131 --json number,title,state,body,labels,assignees,comments,url; uv run agentic-workspace planning new-plan --id github-1131-assurance-evidence-gate-investigation --title \"Investigate assurance evidence gate model\" --source \"GitHub #1131; parent lane GitHub #1130\" --target . --activate --format json; rg assurance/proof/workflow/closeout surfaces; targeted source reads of config, workflow obligations, proof assurance, closeout, and config-effect review.",
+    "evidence sources": [
+      "GitHub #1130 parent lane",
+      "GitHub #1131 investigation slice",
+      "src/agentic_workspace/config.py",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "src/agentic_workspace/reporting_support.py",
+      "src/agentic_workspace/contracts/schemas/workspace_config.schema.json",
+      "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+      ".agentic-workspace/planning/schemas/planning-execplan.schema.json",
+      "docs/reviews/config-effect-review-2026-05-05.md",
+      "tests/test_workspace_report_cli.py",
+      "tests/test_workspace_proof_cli.py",
+      "packages/planning/tests/test_summary.py"
+    ]
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1130",
+      "label": "#1130",
+      "role": "parent lane"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1131",
+      "label": "#1131",
+      "role": "investigation"
+    },
+    {
+      "kind": "planning-decomposition",
+      "target": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
+      "label": "ingested #1130 lane",
+      "role": "parent decomposition"
+    }
+  ],
+  "findings": [
+    {
+      "title": "Existing surfaces already form most of the assurance loop",
+      "summary": "AW already has repo assurance config, workflow obligations, Planning assurance fields, proof-profile integration, closeout completion options, Memory residue routing, and ADR authority routing. The first implementation should compose these rather than add a compliance subsystem.",
+      "evidence": "config.py parses assurance.default_level, strict_closeout, proof_profiles, test_data_policy, invariant_registry, risk_registry, and workflow_obligations; planning-execplan.schema.json includes adaptive_assurance, traceability_refs, control_gates, test_data_policy, risk_registry_refs, invariant_refs; proof selection reads active planning assurance; closeout_trust already emits completion_options.",
+      "risk if unchanged": "A broad new subsystem would duplicate existing surfaces, increase ordinary-work cost, and weaken the repo-native boundary #1130 is trying to preserve.",
+      "suggested action": "Add a small requirement fact model under [assurance.requirements.<id>] and project it into existing assurance/proof/Planning/closeout surfaces.",
+      "confidence": "high",
+      "source": "#1131 investigation",
+      "promotion target": "follow-up issue: assurance requirement fact model",
+      "promotion trigger": "Before implementation starts",
+      "post-remediation note shape": "Keep as review evidence until child issues exist; no Memory note needed."
+    },
+    {
+      "title": "Minimal v1 requirement shape should be declarative and domain-generic",
+      "summary": "The smallest stable v1 shape should capture matching, authority refs, required evidence, proof/review linkage, force, and claim blockers. Domain meaning stays in repo-owned authority refs and free-form evidence labels.",
+      "evidence": "#1130 proposed id, level, applies_to_paths, applies_to_task_markers, authority_refs, required_evidence, proof_profile, workflow_obligation_refs, review_owner, force, blocking_claims; config.py already supports assurance levels and proof profiles; workflow obligations already support force/stage/commands/review_hint.",
+      "risk if unchanged": "Over-typing evidence or domain semantics would make AW appear to certify compliance; under-typing would leave agents unable to gate claims.",
+      "suggested action": "Use required fields id/level/at least one applies_to selector/force plus optional authority_refs, required_evidence, proof_profile, workflow_obligation_refs, review_owner, blocking_claims, notes.",
+      "confidence": "medium-high",
+      "source": "#1131 investigation",
+      "promotion target": "follow-up issue: assurance requirement fact model",
+      "promotion trigger": "When adding config/schema support",
+      "post-remediation note shape": "Retain in child issue acceptance, then shrink review."
+    },
+    {
+      "title": "Evidence status should be a projection first, not a new evidence store",
+      "summary": "Active evidence should live in Planning/proof/closeout fields for planned work and in explicit proof/closeout records for direct work. Memory is only for durable lessons or unresolved reusable residue.",
+      "evidence": "Planning records already carry proof_report, intent_proof, control_gates evidence, traceability_refs, durable_residue, closeout_distillation, and task_intent_promotion. closeout_trust already reconciles proof, intent, acceptance, package evidence, and residue. Memory index says Memory is anti-rediscovery, not active task state.",
+      "risk if unchanged": "A new evidence store would compete with Planning/proof ownership and create another state surface agents must reconcile.",
+      "suggested action": "Define an assurance_evidence_status projection with requirement_id, state, evidence_present, missing_evidence, sources, blocking_claims, and next_action. Read from existing fields first; add a command-owned writer only if direct-work evidence cannot be represented cleanly.",
+      "confidence": "high",
+      "source": "#1131 investigation",
+      "promotion target": "follow-up issue: evidence status and closeout gates",
+      "promotion trigger": "After requirement matching exists",
+      "post-remediation note shape": "No Memory note; active evidence ownership belongs to Planning/proof/closeout."
+    },
+    {
+      "title": "Closeout should block broad claims, not all progress",
+      "summary": "Missing high/critical assurance evidence should block claim-work-complete and close-parent-lane by default; claim-slice-complete can remain allowed only when the slice explicitly excludes the missing evidence or routes continuation honestly.",
+      "evidence": "_closeout_completion_options already distinguishes claim-slice-complete, claim-work-complete, close-parent-lane, route-residue, request-review, and stop-with-status. Tests already verify work-claim blocking for weak intent proof and closeout residue.",
+      "risk if unchanged": "Agents may treat passing tests as compliance/evidence satisfaction, or the product may overcorrect by blocking honest partial progress.",
+      "suggested action": "Feed assurance_evidence_status into existing completion option blockers: high/critical missing required evidence blocks work/parent claims; blocking force can also block slice claim unless explicitly scoped out; request-review and stop-with-status remain available.",
+      "confidence": "high",
+      "source": "#1131 investigation",
+      "promotion target": "follow-up issue: closeout evidence gates",
+      "promotion trigger": "After evidence status projection exists",
+      "post-remediation note shape": "Child issue acceptance should require both blocked broad claims and allowed honest status stops."
+    },
+    {
+      "title": "Proportionality depends on strict matching and quiet defaults",
+      "summary": "Configured high-assurance rules must not make unrelated work noisy. A requirement should activate only from explicit path glob match, task marker match, active Planning reference, proof profile reference, or risk/invariant reference.",
+      "evidence": "workflow_obligations currently matches from scope tags derived from active planning, task text, and changed paths; proof selection only enriches with configured assurance profiles when active planning assurance declares them.",
+      "risk if unchanged": "Repos with assurance config could make every small typo or README edit feel like regulated work, undermining AW's small-work ergonomics.",
+      "suggested action": "Require match evidence per active requirement and emit quiet status for non-matches. Tests must include a high-assurance matched task and an unrelated small edit that does not emit active requirements.",
+      "confidence": "high",
+      "source": "#1131 investigation",
+      "promotion target": "follow-up issue: requirement matching/projection",
+      "promotion trigger": "When implementing start/implement/report projection",
+      "post-remediation note shape": "Keep proportionality as a guardrail in every child issue."
+    }
+  ],
+  "recommendation": {
+    "promote": [
+      "Create a child issue for the minimal [assurance.requirements.<id>] fact model in config/schema/defaults/config output.",
+      "Create a child issue for matching/projection into start, implement, and report with high-assurance and quiet-low-assurance tests.",
+      "Create a child issue for evidence status and closeout completion-option gates.",
+      "Create a child issue for proof-profile integration from matched requirements.",
+      "Create a child issue for high-assurance and non-code dogfood fixtures after the first implementation slices exist."
+    ],
+    "defer": [
+      "Any new evidence store until Planning/proof/closeout projection proves insufficient.",
+      "Any domain-specific compliance vocabulary.",
+      "Any new top-level command until selectors/report sections prove too weak."
+    ],
+    "dismiss": [
+      "A separate [compliance] config tree.",
+      "AW-owned legal/regulatory interpretation.",
+      "Blocking all work in a repo merely because assurance requirements are configured."
+    ]
+  },
+  "retention": {
+    "closeout shape": "shrink",
+    "trigger": "findings promoted, dismissed, or superseded",
+    "proof surface": "routed issues, planning state, docs, checks, Memory, or a compact retained review stub"
+  },
+  "prose_templates": {
+    "review_finding": {
+      "sections": [
+        "Finding",
+        "Evidence",
+        "Impact",
+        "Recommendation",
+        "Owner",
+        "Status"
+      ],
+      "field_map": {
+        "Finding": "findings[].title + findings[].summary",
+        "Evidence": "findings[].evidence + findings[].source",
+        "Impact": "findings[].risk if unchanged",
+        "Recommendation": "findings[].suggested action + findings[].promotion target",
+        "Owner": "findings[].promotion target",
+        "Status": "recommendation/promote|defer|dismiss"
+      },
+      "rule": "Use only these headings when a prose finding is needed; keep the canonical fields structured."
+    },
+    "handoff_or_closeout": {
+      "sections": [
+        "Intent",
+        "What changed",
+        "Proof",
+        "Remaining risk",
+        "Durable residue",
+        "Next owner"
+      ],
+      "field_map": {
+        "Intent": "intent/outcome or requested_outcome",
+        "What changed": "execution_summary/outcome delivered",
+        "Proof": "proof_report/validation proof",
+        "Remaining risk": "finished_run_review/misinterpretation risk or follow-on decision",
+        "Durable residue": "durable_residue + closeout_distillation",
+        "Next owner": "execution_summary/follow-on routed to or required_continuation/owner surface"
+      },
+      "rule": "Prefer structured fields; use this shape only for short human-readable summaries."
+    }
+  },
+  "summary": {
+    "recommended_model": "Repo declares assurance requirements under [assurance.requirements.<id>]. AW matches requirements by explicit repo-owned signals, projects authority/evidence/proof/review facts into existing surfaces, and feeds missing evidence into existing completion options.",
+    "evidence_status_shape": {
+      "requirement_id": "stable id",
+      "state": "not-applicable|matched|satisfied|missing-evidence|review-required|waived",
+      "level": "low|medium|high|critical",
+      "applies_because": [],
+      "authority_refs": [],
+      "required_evidence": [],
+      "evidence_present": [],
+      "missing_evidence": [],
+      "proof_profile": "",
+      "workflow_obligation_refs": [],
+      "review_owner": "",
+      "blocking_claims": [],
+      "next_action": {}
+    },
+    "surface_integration": {
+      "start": "compactly report matched task-marker requirements and authority refs only when task text activates a requirement",
+      "implement": "match changed paths plus task markers; expose active requirements behind selector/verbose and keep tiny output quiet unless required action changes",
+      "proof": "include requirement-linked proof profiles, review aids, blocked commands, and residual missing evidence",
+      "closeout_trust": "summarize evidence status and add blockers to existing completion options",
+      "workflow_obligations": "allow requirements to reference or synthesize obligations rather than duplicate staged commands/reviews",
+      "planning": "carry requirement refs, evidence status, proof profile, review owner, and claim boundary in existing execplan fields",
+      "memory": "capture only durable lessons or unresolved assurance residue, not active evidence"
+    },
+    "non_goals": [
+      "domain compliance interpretation",
+      "parallel compliance subsystem",
+      "new evidence store by default",
+      "new top-level command by default",
+      "high-assurance ceremony for unrelated low-assurance work"
+    ]
+  },
+  "validation_commands": [
+    "uv run agentic-workspace summary --target . --format json",
+    "uv run agentic-workspace doctor --target . --modules planning --format json",
+    "uv run python scripts/check/check_planning_surfaces.py"
+  ],
+  "drift_log": [
+    "2026-05-26: Review record created by create-review.",
+    "2026-05-26: Filled with #1131 assurance evidence-gate investigation and follow-up slice recommendations."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.review.json
+++ b/.agentic-workspace/planning/reviews/2026-05-26-assurance-evidence-gate-model.review.json
@@ -51,6 +51,12 @@
       "role": "investigation"
     },
     {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1132",
+      "label": "#1132",
+      "role": "first implementation child"
+    },
+    {
       "kind": "planning-decomposition",
       "target": ".agentic-workspace/planning/decompositions/github-1130-assurance-requirements.decomposition.json",
       "label": "ingested #1130 lane",
@@ -72,10 +78,10 @@
     },
     {
       "title": "Minimal v1 requirement shape should be declarative and domain-generic",
-      "summary": "The smallest stable v1 shape should capture matching, authority refs, required evidence, proof/review linkage, force, and claim blockers. Domain meaning stays in repo-owned authority refs and free-form evidence labels.",
+      "summary": "The smallest stable v1 shape should capture matching, authority refs, required evidence, proof/review linkage, force, claim blockers, and explicit waiver/dismissal facts. Domain meaning stays in repo-owned authority refs and free-form evidence labels.",
       "evidence": "#1130 proposed id, level, applies_to_paths, applies_to_task_markers, authority_refs, required_evidence, proof_profile, workflow_obligation_refs, review_owner, force, blocking_claims; config.py already supports assurance levels and proof profiles; workflow obligations already support force/stage/commands/review_hint.",
       "risk if unchanged": "Over-typing evidence or domain semantics would make AW appear to certify compliance; under-typing would leave agents unable to gate claims.",
-      "suggested action": "Use required fields id/level/at least one applies_to selector/force plus optional authority_refs, required_evidence, proof_profile, workflow_obligation_refs, review_owner, blocking_claims, notes.",
+      "suggested action": "Use required fields id/level/at least one applies_to selector/force plus optional authority_refs, required_evidence, proof_profile, workflow_obligation_refs, review_owner, blocking_claims, waiver, dismissal, notes. Waiver/dismissal must include reason and owner when present.",
       "confidence": "medium-high",
       "source": "#1131 investigation",
       "promotion target": "follow-up issue: assurance requirement fact model",
@@ -121,7 +127,7 @@
   ],
   "recommendation": {
     "promote": [
-      "Create a child issue for the minimal [assurance.requirements.<id>] fact model in config/schema/defaults/config output.",
+      "Create #1132 for the minimal [assurance.requirements.<id>] fact model plus config/report read projection.",
       "Create a child issue for matching/projection into start, implement, and report with high-assurance and quiet-low-assurance tests.",
       "Create a child issue for evidence status and closeout completion-option gates.",
       "Create a child issue for proof-profile integration from matched requirements.",
@@ -194,6 +200,11 @@
       "required_evidence": [],
       "evidence_present": [],
       "missing_evidence": [],
+      "waiver": {
+        "status": "none|waived|dismissed",
+        "reason": "",
+        "owner": ""
+      },
       "proof_profile": "",
       "workflow_obligation_refs": [],
       "review_owner": "",
@@ -224,6 +235,7 @@
   ],
   "drift_log": [
     "2026-05-26: Review record created by create-review.",
-    "2026-05-26: Filled with #1131 assurance evidence-gate investigation and follow-up slice recommendations."
+    "2026-05-26: Filled with #1131 assurance evidence-gate investigation and follow-up slice recommendations.",
+    "2026-05-26: Added explicit waiver/dismissal refinement and promoted #1132 as the first config plus read-projection child issue."
   ]
 }

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -71,6 +71,7 @@ Cheap implementer context for a bounded changed-path scope.
 | `acceptance_reconciliation.task_carry_forward_hint` | string | yes |  | Short reminder to preserve task text across start and implement calls. |  |  |
 | `intent_acknowledgement` | object | yes |  | Guidance for stating inferred intent, first slice, non-goals, and correction point before non-direct implementation. |  |  |
 | `reuse_pressure` | object | yes |  | Changed-path reuse and abstraction-pressure facts that help the agent decide whether to reuse, accept duplication, or route extraction follow-up. |  |  |
+| `assurance_requirements` | object | yes |  | Repo-declared assurance requirements matched to the task or changed paths, with evidence status and claim-boundary facts. |  |  |
 | `objective_drift` | object | yes |  | Heuristic warning when changed files do not mention explicit requested outcomes. |  |  |
 | `objective_drift.kind` | const `"agentic-workspace/objective-drift/v1"` | yes |  | Discriminator for the lightweight objective-drift heuristic. |  |  |
 | `objective_drift.status` | string | yes |  | Whether requested task terms appear missing from changed surfaces. |  |  |

--- a/docs/reference/workspace-config.md
+++ b/docs/reference/workspace-config.md
@@ -69,7 +69,7 @@ Repo-owned Agentic Workspace configuration stored in .agentic-workspace/config.t
 | `assurance.proof_profiles.<name>.disallowed_commands` | array of string | no | `[]` | Commands that this proof profile disallows for the matched assurance concern. |  |  |
 | `assurance.requirements` | object | no | `{}` | Repo-declared assurance requirements that map work signals to authority refs, required evidence, proof profiles, review owners, and completion claim boundaries. |  |  |
 | `assurance.requirements.<name>` | object | no |  | One repo-defined assurance requirement. Domain meaning stays in repo-owned authority refs and free-form evidence labels. |  | x-agentic-workspace-unknown-properties: "warn" |
-| `assurance.requirements.<name>.level` | enum `"low"`, `"medium"`, `"high"`, `"critical"` | no | `"low"` | Repo-interpreted assurance level for the matched requirement. |  |  |
+| `assurance.requirements.<name>.level` | enum `"low"`, `"medium"`, `"high"`, `"critical"` | yes |  | Repo-interpreted assurance level for the matched requirement. |  |  |
 | `assurance.requirements.<name>.applies_to_paths` | array of string | no | `[]` | Path globs that activate this requirement when changed paths match. |  |  |
 | `assurance.requirements.<name>.applies_to_task_markers` | array of string | no | `[]` | Task-text markers that activate this requirement. |  |  |
 | `assurance.requirements.<name>.applies_to_planning_refs` | array of string | no | `[]` | Planning refs or requirement ids that activate this requirement from active planning state. |  |  |
@@ -81,7 +81,7 @@ Repo-owned Agentic Workspace configuration stored in .agentic-workspace/config.t
 | `assurance.requirements.<name>.proof_profile` | string | no |  | Optional assurance.proof_profiles id to add when this requirement is active. |  |  |
 | `assurance.requirements.<name>.workflow_obligation_refs` | array of string | no | `[]` | Workflow obligation ids related to this requirement. |  |  |
 | `assurance.requirements.<name>.review_owner` | string | no |  | Repo-local owner label for review or waiver decisions. |  |  |
-| `assurance.requirements.<name>.force` | enum `"informational"`, `"recommended"`, `"required-before-closeout"`, `"blocking"` | no | `"recommended"` | How strongly this requirement affects guidance and closeout claim gates. |  |  |
+| `assurance.requirements.<name>.force` | enum `"informational"`, `"recommended"`, `"required-before-closeout"`, `"blocking"` | yes |  | How strongly this requirement affects guidance and closeout claim gates. |  |  |
 | `assurance.requirements.<name>.blocking_claims` | array of enum `"claim-slice-complete"`, `"claim-work-complete"`, `"close-parent-lane"` | no | `[]` | Completion option ids blocked while required evidence for this requirement is missing. |  |  |
 | `assurance.requirements.<name>.waiver` | ref `#/$defs/assurance_requirement_disposition` | no |  | Recorded waiver with reason and owner for this requirement. |  |  |
 | `assurance.requirements.<name>.waiver.reason` | string | yes |  | Why the requirement was waived, dismissed, or found not applicable. |  |  |

--- a/docs/reference/workspace-config.md
+++ b/docs/reference/workspace-config.md
@@ -66,6 +66,30 @@ Repo-owned Agentic Workspace configuration stored in .agentic-workspace/config.t
 | `assurance.proof_profiles.<name>.required_commands` | array of string | no | `[]` | Commands that must pass for this proof profile. |  |  |
 | `assurance.proof_profiles.<name>.optional_commands` | array of string | no | `[]` | Commands that are useful but not required for this proof profile. |  |  |
 | `assurance.proof_profiles.<name>.review_aids` | array of string | no | `[]` | Manual review aids or checklists associated with this proof profile. |  |  |
+| `assurance.proof_profiles.<name>.disallowed_commands` | array of string | no | `[]` | Commands that this proof profile disallows for the matched assurance concern. |  |  |
+| `assurance.requirements` | object | no | `{}` | Repo-declared assurance requirements that map work signals to authority refs, required evidence, proof profiles, review owners, and completion claim boundaries. |  |  |
+| `assurance.requirements.<name>` | object | no |  | One repo-defined assurance requirement. Domain meaning stays in repo-owned authority refs and free-form evidence labels. |  | x-agentic-workspace-unknown-properties: "warn" |
+| `assurance.requirements.<name>.level` | enum `"low"`, `"medium"`, `"high"`, `"critical"` | no | `"low"` | Repo-interpreted assurance level for the matched requirement. |  |  |
+| `assurance.requirements.<name>.applies_to_paths` | array of string | no | `[]` | Path globs that activate this requirement when changed paths match. |  |  |
+| `assurance.requirements.<name>.applies_to_task_markers` | array of string | no | `[]` | Task-text markers that activate this requirement. |  |  |
+| `assurance.requirements.<name>.applies_to_planning_refs` | array of string | no | `[]` | Planning refs or requirement ids that activate this requirement from active planning state. |  |  |
+| `assurance.requirements.<name>.applies_to_proof_profiles` | array of string | no | `[]` | Active planning proof profile ids that activate this requirement. |  |  |
+| `assurance.requirements.<name>.applies_to_risk_refs` | array of string | no | `[]` | Risk registry refs that activate this requirement from active planning state. |  |  |
+| `assurance.requirements.<name>.applies_to_invariant_refs` | array of string | no | `[]` | Invariant refs that activate this requirement from active planning state. |  |  |
+| `assurance.requirements.<name>.authority_refs` | array of string | no | `[]` | Repo-owned docs, policies, runbooks, registries, or decision records agents should consult. |  |  |
+| `assurance.requirements.<name>.required_evidence` | array of string | no | `[]` | Free-form repo vocabulary naming evidence expected before supported completion claims. |  |  |
+| `assurance.requirements.<name>.proof_profile` | string | no |  | Optional assurance.proof_profiles id to add when this requirement is active. |  |  |
+| `assurance.requirements.<name>.workflow_obligation_refs` | array of string | no | `[]` | Workflow obligation ids related to this requirement. |  |  |
+| `assurance.requirements.<name>.review_owner` | string | no |  | Repo-local owner label for review or waiver decisions. |  |  |
+| `assurance.requirements.<name>.force` | enum `"informational"`, `"recommended"`, `"required-before-closeout"`, `"blocking"` | no | `"recommended"` | How strongly this requirement affects guidance and closeout claim gates. |  |  |
+| `assurance.requirements.<name>.blocking_claims` | array of enum `"claim-slice-complete"`, `"claim-work-complete"`, `"close-parent-lane"` | no | `[]` | Completion option ids blocked while required evidence for this requirement is missing. |  |  |
+| `assurance.requirements.<name>.waiver` | ref `#/$defs/assurance_requirement_disposition` | no |  | Recorded waiver with reason and owner for this requirement. |  |  |
+| `assurance.requirements.<name>.waiver.reason` | string | yes |  | Why the requirement was waived, dismissed, or found not applicable. |  |  |
+| `assurance.requirements.<name>.waiver.owner` | string | yes |  | Repo-local owner or role accountable for the waiver or dismissal. |  |  |
+| `assurance.requirements.<name>.dismissal` | ref `#/$defs/assurance_requirement_disposition` | no |  | Recorded dismissal or not-applicable decision with reason and owner for this requirement. |  |  |
+| `assurance.requirements.<name>.dismissal.reason` | string | yes |  | Why the requirement was waived, dismissed, or found not applicable. |  |  |
+| `assurance.requirements.<name>.dismissal.owner` | string | yes |  | Repo-local owner or role accountable for the waiver or dismissal. |  |  |
+| `assurance.requirements.<name>.notes` | string | no |  | Optional repo-local note about this requirement. |  |  |
 | `assurance.test_data_policy` | object | no | `{}` | Repo-specific policy for test data, privacy, fixtures, or generated samples. |  | x-agentic-workspace-unknown-properties: "warn" |
 | `cli_compatibility` | object | no | `{}` | Expected CLI identity and posture for commands executed in this repo. |  | x-agentic-workspace-doc-role: "maintainer"<br>x-agentic-workspace-unknown-properties: "warn" |
 | `cli_compatibility.enforcement` | enum `"off"`, `"advisory"`, `"blocking"` | no | `"off"` | How strictly CLI compatibility expectations should be enforced. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -69,6 +69,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `system_intent_mirror` | object | no |  | Compiled system-intent mirror status and source metadata. |  |  |
 | `durable_intent` | object | yes |  | Compact decision projection for durable task, subsystem, and system intent pressure. |  |  |
 | `workflow_obligations` | object | yes |  | Repo-configured workflow obligations surfaced for report consumers. |  |  |
+| `assurance_requirements` | object | yes |  | Repo-declared assurance requirements, active matches, and evidence status projection. |  |  |
 | `authority_hierarchy` | object | no |  | Authority and promotion-path guidance for deciding which repo surfaces are current instruction, durable memory, future work, or historical audit. |  |  |
 | `continuation_state` | object | no |  | Compact continuation-state contract for preserving only unfinished or handoff-relevant work, not historical residue. |  |  |
 | `compliance_economics` | object | no |  | Boundary statement for what Agentic Workspace can enforce directly and where it instead makes noncompliance visible or costly. |  |  |

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -104,6 +104,11 @@ SUPPORTED_WORKFLOW_OBLIGATION_FORCES = (
     "required-before-closeout",
     "blocking",
 )
+SUPPORTED_ASSURANCE_REQUIREMENT_BLOCKING_CLAIMS = (
+    "claim-slice-complete",
+    "claim-work-complete",
+    "close-parent-lane",
+)
 SUPPORTED_DELEGATION_TARGET_STRENGTHS = (
     "strong",
     "medium",
@@ -303,6 +308,34 @@ class AssuranceProofProfile:
 
 
 @dataclass(frozen=True)
+class AssuranceRequirementDisposition:
+    reason: str
+    owner: str
+
+
+@dataclass(frozen=True)
+class AssuranceRequirement:
+    id: str
+    level: str
+    applies_to_paths: tuple[str, ...]
+    applies_to_task_markers: tuple[str, ...]
+    applies_to_planning_refs: tuple[str, ...]
+    applies_to_proof_profiles: tuple[str, ...]
+    applies_to_risk_refs: tuple[str, ...]
+    applies_to_invariant_refs: tuple[str, ...]
+    authority_refs: tuple[str, ...]
+    required_evidence: tuple[str, ...]
+    proof_profile: str | None
+    workflow_obligation_refs: tuple[str, ...]
+    review_owner: str | None
+    force: str
+    blocking_claims: tuple[str, ...]
+    waiver: AssuranceRequirementDisposition | None
+    dismissal: AssuranceRequirementDisposition | None
+    notes: str | None
+
+
+@dataclass(frozen=True)
 class AssuranceConfig:
     default_level: str
     default_level_source: str
@@ -310,6 +343,7 @@ class AssuranceConfig:
     agent_may_deescalate: bool
     strict_closeout: bool
     proof_profiles: tuple[AssuranceProofProfile, ...]
+    requirements: tuple[AssuranceRequirement, ...]
     test_data_policy: dict[str, Any]
     decision_record_target: str | None
     decision_record_format: str | None
@@ -611,6 +645,125 @@ def _require_bool(*, payload: dict[str, Any], key: str, default: bool, config_pa
     return value
 
 
+def _require_disposition(
+    *,
+    payload: dict[str, Any],
+    key: str,
+    config_path: Path,
+) -> AssuranceRequirementDisposition | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if not isinstance(value, dict):
+        raise WorkspaceUsageError(f"{config_path.as_posix()} {key} must be a table with reason and owner.")
+    unknown = sorted(set(value) - {"reason", "owner"})
+    if unknown:
+        allowed = ", ".join(("reason", "owner"))
+        raise WorkspaceUsageError(f"{config_path.as_posix()} {key} contains unsupported field(s): {', '.join(unknown)}; use {allowed}.")
+    reason = require_optional_string(payload=value, key="reason", config_path=Path(f"{config_path.as_posix()} {key}"))
+    owner = require_optional_string(payload=value, key="owner", config_path=Path(f"{config_path.as_posix()} {key}"))
+    if reason is None or owner is None:
+        raise WorkspaceUsageError(f"{config_path.as_posix()} {key} requires non-empty reason and owner.")
+    return AssuranceRequirementDisposition(reason=reason, owner=owner)
+
+
+def _load_assurance_requirements(
+    *,
+    raw_requirements: Any,
+    config_path: Path,
+) -> tuple[tuple[AssuranceRequirement, ...], list[str]]:
+    warnings: list[str] = []
+    if raw_requirements is None:
+        raw_requirements = {}
+    if not isinstance(raw_requirements, dict):
+        raise WorkspaceUsageError(f"{config_path.as_posix()} [assurance.requirements] section must be a table.")
+    requirements: list[AssuranceRequirement] = []
+    supported_fields = {
+        "level",
+        "applies_to_paths",
+        "applies_to_task_markers",
+        "applies_to_planning_refs",
+        "applies_to_proof_profiles",
+        "applies_to_risk_refs",
+        "applies_to_invariant_refs",
+        "authority_refs",
+        "required_evidence",
+        "proof_profile",
+        "workflow_obligation_refs",
+        "review_owner",
+        "force",
+        "blocking_claims",
+        "waiver",
+        "dismissal",
+        "notes",
+    }
+    activation_fields = {
+        "applies_to_paths",
+        "applies_to_task_markers",
+        "applies_to_planning_refs",
+        "applies_to_proof_profiles",
+        "applies_to_risk_refs",
+        "applies_to_invariant_refs",
+    }
+    for requirement_id, raw_requirement in sorted(raw_requirements.items()):
+        requirement_path = Path(f"{config_path.as_posix()} assurance.requirements.{requirement_id}")
+        if not isinstance(raw_requirement, dict):
+            raise WorkspaceUsageError(f"{requirement_path.as_posix()} must be a table.")
+        unknown_requirement = sorted(set(raw_requirement) - supported_fields)
+        if unknown_requirement:
+            warnings.append(f"{requirement_path.as_posix()} contains unsupported field(s): {', '.join(unknown_requirement)}.")
+        activation_values = {
+            key: require_optional_string_list(payload=raw_requirement, key=key, config_path=requirement_path) for key in activation_fields
+        }
+        if not any(activation_values.values()):
+            allowed = ", ".join(sorted(activation_fields))
+            raise WorkspaceUsageError(f"{requirement_path.as_posix()} requires at least one activation signal: {allowed}.")
+        requirements.append(
+            AssuranceRequirement(
+                id=str(requirement_id).strip(),
+                level=require_optional_enum(
+                    payload=raw_requirement,
+                    key="level",
+                    config_path=requirement_path,
+                    allowed=SUPPORTED_ASSURANCE_LEVELS,
+                    default=DEFAULT_ASSURANCE_LEVEL,
+                ),
+                applies_to_paths=activation_values["applies_to_paths"],
+                applies_to_task_markers=activation_values["applies_to_task_markers"],
+                applies_to_planning_refs=activation_values["applies_to_planning_refs"],
+                applies_to_proof_profiles=activation_values["applies_to_proof_profiles"],
+                applies_to_risk_refs=activation_values["applies_to_risk_refs"],
+                applies_to_invariant_refs=activation_values["applies_to_invariant_refs"],
+                authority_refs=require_optional_string_list(payload=raw_requirement, key="authority_refs", config_path=requirement_path),
+                required_evidence=require_optional_string_list(
+                    payload=raw_requirement, key="required_evidence", config_path=requirement_path
+                ),
+                proof_profile=require_optional_string(payload=raw_requirement, key="proof_profile", config_path=requirement_path),
+                workflow_obligation_refs=require_optional_string_list(
+                    payload=raw_requirement, key="workflow_obligation_refs", config_path=requirement_path
+                ),
+                review_owner=require_optional_string(payload=raw_requirement, key="review_owner", config_path=requirement_path),
+                force=require_optional_enum(
+                    payload=raw_requirement,
+                    key="force",
+                    config_path=requirement_path,
+                    allowed=SUPPORTED_WORKFLOW_OBLIGATION_FORCES,
+                    default="recommended",
+                ),
+                blocking_claims=require_optional_string_list(
+                    payload=raw_requirement,
+                    key="blocking_claims",
+                    config_path=requirement_path,
+                    allowed=SUPPORTED_ASSURANCE_REQUIREMENT_BLOCKING_CLAIMS,
+                ),
+                waiver=_require_disposition(payload=raw_requirement, key="waiver", config_path=requirement_path),
+                dismissal=_require_disposition(payload=raw_requirement, key="dismissal", config_path=requirement_path),
+                notes=require_optional_string(payload=raw_requirement, key="notes", config_path=requirement_path),
+            )
+        )
+    return (tuple(requirement for requirement in requirements if requirement.id), warnings)
+
+
 def _load_assurance_config(*, raw_assurance: Any, config_path: Path) -> tuple[AssuranceConfig, list[str]]:
     warnings: list[str] = []
     if raw_assurance is None:
@@ -623,6 +776,7 @@ def _load_assurance_config(*, raw_assurance: Any, config_path: Path) -> tuple[As
         "agent_may_deescalate",
         "strict_closeout",
         "proof_profiles",
+        "requirements",
         "test_data_policy",
         "decision_record_target",
         "decision_record_format",
@@ -671,6 +825,11 @@ def _load_assurance_config(*, raw_assurance: Any, config_path: Path) -> tuple[As
     decision_record_template = raw_assurance.get("decision_record_template")
     invariant_registry = raw_assurance.get("invariant_registry")
     risk_registry = raw_assurance.get("risk_registry")
+    requirements, requirement_warnings = _load_assurance_requirements(
+        raw_requirements=raw_assurance.get("requirements", {}),
+        config_path=config_path,
+    )
+    warnings.extend(requirement_warnings)
     return (
         AssuranceConfig(
             default_level=default_level,
@@ -679,6 +838,7 @@ def _load_assurance_config(*, raw_assurance: Any, config_path: Path) -> tuple[As
             agent_may_deescalate=_require_bool(payload=raw_assurance, key="agent_may_deescalate", default=False, config_path=config_path),
             strict_closeout=_require_bool(payload=raw_assurance, key="strict_closeout", default=False, config_path=config_path),
             proof_profiles=tuple(profile for profile in profiles if profile.id),
+            requirements=requirements,
             test_data_policy={str(key): value for key, value in raw_test_data_policy.items()},
             decision_record_target=str(decision_record_target).strip() if decision_record_target is not None else None,
             decision_record_format=str(decision_record_format).strip() if decision_record_format is not None else None,

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -519,6 +519,17 @@ def require_optional_enum(
     return value
 
 
+def require_required_enum(*, payload: dict[str, Any], key: str, config_path: Path, allowed: tuple[str, ...]) -> str:
+    if key not in payload:
+        allowed_text = ", ".join(allowed)
+        raise WorkspaceUsageError(f"{config_path.as_posix()} {key} is required and must be one of: {allowed_text}.")
+    value = payload[key]
+    if not isinstance(value, str) or value not in allowed:
+        allowed_text = ", ".join(allowed)
+        raise WorkspaceUsageError(f"{config_path.as_posix()} {key} must be one of: {allowed_text}.")
+    return value
+
+
 def validate_agent_instructions_filename(filename: str) -> str:
     normalized = filename.strip()
     if not normalized:
@@ -721,12 +732,11 @@ def _load_assurance_requirements(
         requirements.append(
             AssuranceRequirement(
                 id=str(requirement_id).strip(),
-                level=require_optional_enum(
+                level=require_required_enum(
                     payload=raw_requirement,
                     key="level",
                     config_path=requirement_path,
                     allowed=SUPPORTED_ASSURANCE_LEVELS,
-                    default=DEFAULT_ASSURANCE_LEVEL,
                 ),
                 applies_to_paths=activation_values["applies_to_paths"],
                 applies_to_task_markers=activation_values["applies_to_task_markers"],
@@ -743,12 +753,11 @@ def _load_assurance_requirements(
                     payload=raw_requirement, key="workflow_obligation_refs", config_path=requirement_path
                 ),
                 review_owner=require_optional_string(payload=raw_requirement, key="review_owner", config_path=requirement_path),
-                force=require_optional_enum(
+                force=require_required_enum(
                     payload=raw_requirement,
                     key="force",
                     config_path=requirement_path,
                     allowed=SUPPORTED_WORKFLOW_OBLIGATION_FORCES,
-                    default="recommended",
                 ),
                 blocking_claims=require_optional_string_list(
                     payload=raw_requirement,

--- a/src/agentic_workspace/contracts/report_contract.json
+++ b/src/agentic_workspace/contracts/report_contract.json
@@ -26,6 +26,7 @@
     "system_intent_mirror",
     "durable_intent",
     "workflow_obligations",
+    "assurance_requirements",
     "product_managed_enclave",
     "ownership_diagnostics",
     "surface_value_guardrail",

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -24,6 +24,7 @@
     "intent_acknowledgement",
     "objective_drift",
     "reuse_pressure",
+    "assurance_requirements",
     "orientation",
     "inference_limits",
     "execution_posture",
@@ -145,6 +146,11 @@
     "reuse_pressure": {
       "type": "object",
       "description": "Changed-path reuse and abstraction-pressure facts that help the agent decide whether to reuse, accept duplication, or route extraction follow-up.",
+      "additionalProperties": true
+    },
+    "assurance_requirements": {
+      "type": "object",
+      "description": "Repo-declared assurance requirements matched to the task or changed paths, with evidence status and claim-boundary facts.",
       "additionalProperties": true
     },
     "objective_drift": {

--- a/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
@@ -338,6 +338,10 @@
             "type": "object",
             "description": "One repo-defined assurance requirement. Domain meaning stays in repo-owned authority refs and free-form evidence labels.",
             "x-agentic-workspace-unknown-properties": "warn",
+            "required": [
+              "level",
+              "force"
+            ],
             "properties": {
               "level": {
                 "description": "Repo-interpreted assurance level for the matched requirement.",
@@ -346,8 +350,7 @@
                   "medium",
                   "high",
                   "critical"
-                ],
-                "default": "low"
+                ]
               },
               "applies_to_paths": {
                 "description": "Path globs that activate this requirement when changed paths match.",
@@ -456,8 +459,7 @@
                   "recommended",
                   "required-before-closeout",
                   "blocking"
-                ],
-                "default": "recommended"
+                ]
               },
               "blocking_claims": {
                 "description": "Completion option ids blocked while required evidence for this requirement is missing.",

--- a/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
@@ -314,6 +314,176 @@
                 },
                 "uniqueItems": true,
                 "default": []
+              },
+              "disallowed_commands": {
+                "description": "Commands that this proof profile disallows for the matched assurance concern.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "One entry in the disallowed commands list."
+                },
+                "uniqueItems": true,
+                "default": []
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "requirements": {
+          "description": "Repo-declared assurance requirements that map work signals to authority refs, required evidence, proof profiles, review owners, and completion claim boundaries.",
+          "type": "object",
+          "default": {},
+          "additionalProperties": {
+            "type": "object",
+            "description": "One repo-defined assurance requirement. Domain meaning stays in repo-owned authority refs and free-form evidence labels.",
+            "x-agentic-workspace-unknown-properties": "warn",
+            "properties": {
+              "level": {
+                "description": "Repo-interpreted assurance level for the matched requirement.",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high",
+                  "critical"
+                ],
+                "default": "low"
+              },
+              "applies_to_paths": {
+                "description": "Path globs that activate this requirement when changed paths match.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "applies_to_task_markers": {
+                "description": "Task-text markers that activate this requirement.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "applies_to_planning_refs": {
+                "description": "Planning refs or requirement ids that activate this requirement from active planning state.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "applies_to_proof_profiles": {
+                "description": "Active planning proof profile ids that activate this requirement.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "applies_to_risk_refs": {
+                "description": "Risk registry refs that activate this requirement from active planning state.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "applies_to_invariant_refs": {
+                "description": "Invariant refs that activate this requirement from active planning state.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "authority_refs": {
+                "description": "Repo-owned docs, policies, runbooks, registries, or decision records agents should consult.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "required_evidence": {
+                "description": "Free-form repo vocabulary naming evidence expected before supported completion claims.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "proof_profile": {
+                "description": "Optional assurance.proof_profiles id to add when this requirement is active.",
+                "type": "string",
+                "minLength": 1
+              },
+              "workflow_obligation_refs": {
+                "description": "Workflow obligation ids related to this requirement.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "review_owner": {
+                "description": "Repo-local owner label for review or waiver decisions.",
+                "type": "string",
+                "minLength": 1
+              },
+              "force": {
+                "description": "How strongly this requirement affects guidance and closeout claim gates.",
+                "enum": [
+                  "informational",
+                  "recommended",
+                  "required-before-closeout",
+                  "blocking"
+                ],
+                "default": "recommended"
+              },
+              "blocking_claims": {
+                "description": "Completion option ids blocked while required evidence for this requirement is missing.",
+                "type": "array",
+                "items": {
+                  "enum": [
+                    "claim-slice-complete",
+                    "claim-work-complete",
+                    "close-parent-lane"
+                  ]
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "waiver": {
+                "description": "Recorded waiver with reason and owner for this requirement.",
+                "$ref": "#/$defs/assurance_requirement_disposition"
+              },
+              "dismissal": {
+                "description": "Recorded dismissal or not-applicable decision with reason and owner for this requirement.",
+                "$ref": "#/$defs/assurance_requirement_disposition"
+              },
+              "notes": {
+                "description": "Optional repo-local note about this requirement.",
+                "type": "string",
+                "minLength": 1
               }
             },
             "additionalProperties": true
@@ -515,6 +685,27 @@
       },
       "x-agentic-workspace-unknown-properties": "warn",
       "additionalProperties": true
+    },
+    "assurance_requirement_disposition": {
+      "description": "Recorded waiver or dismissal for a repo-declared assurance requirement.",
+      "type": "object",
+      "required": [
+        "reason",
+        "owner"
+      ],
+      "properties": {
+        "reason": {
+          "description": "Why the requirement was waived, dismissed, or found not applicable.",
+          "type": "string",
+          "minLength": 1
+        },
+        "owner": {
+          "description": "Repo-local owner or role accountable for the waiver or dismissal.",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -29,6 +29,7 @@
     "agent_configuration_system",
     "agent_configuration_queries",
     "workflow_obligations",
+    "assurance_requirements",
     "durable_intent",
     "product_managed_enclave",
     "ownership_diagnostics",
@@ -202,6 +203,10 @@
     "workflow_obligations": {
       "type": "object",
       "description": "Repo-configured workflow obligations surfaced for report consumers."
+    },
+    "assurance_requirements": {
+      "type": "object",
+      "description": "Repo-declared assurance requirements, active matches, and evidence status projection."
     },
     "authority_hierarchy": {
       "type": "object",

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -315,6 +315,8 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
         intent_proof_check = intent_proof_check if isinstance(intent_proof_check, dict) else {}
         proof_confidence = answer.get("proof_confidence", {})
         proof_confidence = proof_confidence if isinstance(proof_confidence, dict) else {}
+        assurance_requirements = answer.get("assurance_requirements", {})
+        assurance_requirements = assurance_requirements if isinstance(assurance_requirements, dict) else {}
         architecture_decision = answer.get("architecture_decision_closeout", {})
         architecture_decision = architecture_decision if isinstance(architecture_decision, dict) else {}
         architecture_candidate = architecture_decision.get("architecture_decision_candidate", {})
@@ -340,6 +342,13 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
             "summary": answer.get("summary", ""),
             "terminal_action": terminal_action,
             "completion_options": completion_options,
+            "assurance_requirements": {
+                "status": assurance_requirements.get("status", "absent"),
+                "configured_count": assurance_requirements.get("configured_count", 0),
+                "active_count": assurance_requirements.get("active_count", 0),
+                "missing_required_evidence_count": assurance_requirements.get("missing_required_evidence_count", 0),
+                "evidence_status": assurance_requirements.get("evidence_status", []),
+            },
             "proof_confidence": {
                 key: proof_confidence.get(key)
                 for key in ("status", "confidence", "claim_boundary", "proven_dimensions", "unproven_dimensions", "residual_risk")
@@ -973,6 +982,7 @@ def report_section_hints(
         "module_reports": "deep planning and memory module reports",
         "reports": "workspace lifecycle report detail",
         "surface_value_guardrail": "surface growth review pressure",
+        "assurance_requirements": "repo-declared assurance authority, evidence, proof profile, and claim-boundary facts",
         "closeout_trust": "closeout trust and lower-trust residue signals",
         "external_work_reconciliation": "one provider-agnostic external-work route for evidence freshness, closeout reconciliation, and landed-open checks",
         "external_work_delta": "provider-agnostic external-work snapshot or delta from prior evidence when available",
@@ -1003,6 +1013,7 @@ def report_section_hints(
         "module_reports": "deep detail; inspect only when a compact router field points to planning or memory internals",
         "reports": "deep lifecycle detail; inspect only for report/debug work",
         "surface_value_guardrail": "inspect before adding or expanding a visible surface",
+        "assurance_requirements": "inspect when repo-declared assurance requirements may affect authority lookup, proof, review, or closeout claims",
         "closeout_trust": "inspect before closing broad work or auditing package-use evidence",
         "external_work_reconciliation": "inspect when deciding whether checked-in planning, external work state, and landed evidence agree",
         "external_work_delta": "inspect when external-work intake or closure state is part of the task",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -14611,6 +14611,7 @@ def _implement_payload(
     task_text: str | None = None,
     include_change_impact: bool = True,
     include_task_contract: bool = True,
+    include_assurance_requirements: bool = True,
 ) -> dict[str, Any]:
     implementer_template = _CONTEXT_TEMPLATES["implementer_context"]
     normalized_paths = _normalize_changed_paths(changed_paths)
@@ -14622,6 +14623,7 @@ def _implement_payload(
             include_durable_intent=False,
             task_text=task_text,
             acceptance=_task_acceptance_payload(task_text=task_text, requested_outcomes=_extract_requested_outcomes(task_text)),
+            include_assurance_requirements=include_assurance_requirements,
         )
         if normalized_paths
         else copy.deepcopy(implementer_template["unknown_scope_proof"])
@@ -14737,12 +14739,6 @@ def _implement_payload(
         "reuse_pressure": _reuse_pressure_payload(
             target_root=target_root, changed_paths=normalized_paths, cli_invoke=config.cli_invoke, compact=False
         ),
-        "assurance_requirements": _assurance_requirements_report_payload(
-            config=config,
-            active_planning_record=None,
-            task_text=task_text,
-            changed_paths=normalized_paths,
-        ),
         "orientation": {
             "status": "changed-path-context" if normalized_paths else "unknown-scope",
             "minimum_before_editing": "Inspect the listed files, path boundaries, workflow obligations, and selected proof before editing."
@@ -14806,6 +14802,13 @@ def _implement_payload(
     if include_change_impact:
         payload["change_impact"] = _change_impact_payload(
             target_root=target_root, changed_paths=normalized_paths, proof=proof, cli_invoke=config.cli_invoke
+        )
+    if include_assurance_requirements:
+        payload["assurance_requirements"] = _assurance_requirements_report_payload(
+            config=config,
+            active_planning_record=None,
+            task_text=task_text,
+            changed_paths=normalized_paths,
         )
     return payload
 
@@ -20041,6 +20044,7 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
         task_text=task_text,
         include_change_impact=(profile != "tiny" or change_impact_selected),
         include_task_contract=(profile != "tiny" or task_contract_selected),
+        include_assurance_requirements=(profile != "tiny" or assurance_requirements_selected),
     )
     payload = full_payload
     if profile == "tiny":
@@ -22293,6 +22297,7 @@ def _proof_selection_for_changed_paths(
     include_durable_intent: bool = True,
     task_text: str | None = None,
     acceptance: dict[str, Any] | None = None,
+    include_assurance_requirements: bool = True,
 ) -> dict[str, Any]:
     defaults = _defaults_payload()
     cli_invoke = DEFAULT_CLI_INVOKE
@@ -22423,11 +22428,15 @@ def _proof_selection_for_changed_paths(
                     "disallowed_commands": list(profile.disallowed_commands),
                 }
             )
-    active_assurance_requirements = _assurance_requirements_report_payload(
-        config=config,
-        active_planning_record=planning_assurance if planning_assurance.get("status") == "present" else None,
-        task_text=task_text,
-        changed_paths=changed_paths,
+    active_assurance_requirements = (
+        _assurance_requirements_report_payload(
+            config=config,
+            active_planning_record=planning_assurance if planning_assurance.get("status") == "present" else None,
+            task_text=task_text,
+            changed_paths=changed_paths,
+        )
+        if include_assurance_requirements
+        else {}
     )
     requirement_lanes: list[dict[str, Any]] = []
     existing_concern_profiles = {str(lane.get("proof_profile", "")) for lane in concern_lanes}
@@ -22716,7 +22725,6 @@ def _proof_selection_for_changed_paths(
         "learned_route_hints": learned_route_hints,
         "proof_intents": proof_intents,
         "configured_policy": configured_policy,
-        "assurance_requirements": active_assurance_requirements,
         "selected_commands": selected_commands,
         "unavailable_commands": unavailable_commands,
         "host_policy_blocked_commands": host_policy_blocked_commands,
@@ -22862,6 +22870,8 @@ def _proof_selection_for_changed_paths(
             },
             "rule": "Path lanes stay package-defined; concern profiles are host-configured and activated from active planning assurance fields.",
         }
+    if include_assurance_requirements:
+        proof_selection["assurance_requirements"] = active_assurance_requirements
     surface_value_review = _surface_value_review_for_changed_paths(changed_paths=changed_paths, target_root=target_root)
     if surface_value_review["durable_surface_count"]:
         proof_selection["surface_value_review"] = surface_value_review

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -47,6 +47,7 @@ from agentic_workspace.config import (
     SUPPORTED_ADVANCED_FEATURES,
     SUPPORTED_AGENT_INSTRUCTIONS_FILES,
     SUPPORTED_ASSURANCE_LEVELS,
+    SUPPORTED_ASSURANCE_REQUIREMENT_BLOCKING_CLAIMS,
     SUPPORTED_CAPABILITY_EXECUTION_CLASSES,
     SUPPORTED_CAPABILITY_LOCATIONS,
     SUPPORTED_CLARIFICATION_CONTROL_MODES,
@@ -561,6 +562,7 @@ def _assurance_onboarding_payload(*, assurance: AssuranceConfig | None = None) -
     has_test_policy = bool(assurance.test_data_policy) if assurance is not None else False
     any_configured = bool(
         configured_profiles
+        or (assurance is not None and assurance.requirements)
         or host_refs
         or has_test_policy
         or (assurance is not None and assurance.default_level_source != "product-default")
@@ -592,6 +594,299 @@ def _assurance_onboarding_payload(*, assurance: AssuranceConfig | None = None) -
             "partial": "some assurance fields exist, but add at least one proof profile plus a host-owned ref or test-data policy",
             "usable": "at least one proof profile and one host-owned authority or test-data policy are configured",
         },
+    }
+
+
+def _assurance_disposition_payload(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {"status": "none"}
+    return {
+        "status": "recorded",
+        "reason": str(getattr(value, "reason", "")),
+        "owner": str(getattr(value, "owner", "")),
+    }
+
+
+def _assurance_requirement_payloads(config: WorkspaceConfig | None) -> list[dict[str, Any]]:
+    requirements = list(config.assurance.requirements) if config is not None else []
+    payloads: list[dict[str, Any]] = []
+    for requirement in requirements:
+        payloads.append(
+            {
+                "id": requirement.id,
+                "level": requirement.level,
+                "applies_to_paths": list(requirement.applies_to_paths),
+                "applies_to_task_markers": list(requirement.applies_to_task_markers),
+                "applies_to_planning_refs": list(requirement.applies_to_planning_refs),
+                "applies_to_proof_profiles": list(requirement.applies_to_proof_profiles),
+                "applies_to_risk_refs": list(requirement.applies_to_risk_refs),
+                "applies_to_invariant_refs": list(requirement.applies_to_invariant_refs),
+                "authority_refs": list(requirement.authority_refs),
+                "required_evidence": list(requirement.required_evidence),
+                "proof_profile": requirement.proof_profile,
+                "workflow_obligation_refs": list(requirement.workflow_obligation_refs),
+                "review_owner": requirement.review_owner,
+                "force": requirement.force,
+                "blocking_claims": list(requirement.blocking_claims),
+                "waiver": _assurance_disposition_payload(requirement.waiver),
+                "dismissal": _assurance_disposition_payload(requirement.dismissal),
+                "notes": requirement.notes,
+            }
+        )
+    return payloads
+
+
+def _assurance_requirement_planning_facts(active_planning_record: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(active_planning_record, dict):
+        return {
+            "refs": [],
+            "proof_profiles": [],
+            "risk_refs": [],
+            "invariant_refs": [],
+            "evidence_by_requirement": {},
+        }
+    adaptive = active_planning_record.get("adaptive_assurance", {})
+    adaptive = adaptive if isinstance(adaptive, dict) else {}
+    refs: list[str] = []
+    for raw in (
+        active_planning_record.get("id"),
+        active_planning_record.get("title"),
+        active_planning_record.get("surface"),
+        active_planning_record.get("next_action"),
+    ):
+        if str(raw).strip():
+            refs.append(str(raw).strip())
+    refs.extend(str(item).strip() for item in _list_payload(active_planning_record.get("minimal_refs")) if str(item).strip())
+    refs.extend(str(item).strip() for item in _list_payload(active_planning_record.get("traceability_refs")) if str(item).strip())
+    refs.extend(str(item).strip() for item in _list_payload(adaptive.get("requirement_refs")) if str(item).strip())
+    refs.extend(str(item).strip() for item in _list_payload(active_planning_record.get("assurance_requirement_refs")) if str(item).strip())
+    proof_profiles = [str(item).strip() for item in _list_payload(adaptive.get("proof_profiles")) if str(item).strip()]
+    risk_refs = [str(item).strip() for item in _list_payload(active_planning_record.get("risk_registry_refs")) if str(item).strip()]
+    invariant_refs = [str(item).strip() for item in _list_payload(active_planning_record.get("invariant_refs")) if str(item).strip()]
+    raw_evidence = active_planning_record.get("assurance_evidence", {})
+    evidence_by_requirement: dict[str, list[str]] = {}
+    if isinstance(raw_evidence, dict):
+        for requirement_id, evidence in raw_evidence.items():
+            if isinstance(evidence, dict):
+                values = evidence.get("evidence_present", evidence.get("present", evidence.get("evidence", [])))
+            else:
+                values = evidence
+            evidence_by_requirement[str(requirement_id)] = [str(item).strip() for item in _list_payload(values) if str(item).strip()]
+    if isinstance(raw_evidence, list):
+        for item in raw_evidence:
+            if not isinstance(item, dict):
+                continue
+            requirement_id = str(item.get("requirement_id", "")).strip()
+            if not requirement_id:
+                continue
+            values = item.get("evidence_present", item.get("present", item.get("evidence", [])))
+            evidence_by_requirement[requirement_id] = [str(value).strip() for value in _list_payload(values) if str(value).strip()]
+    return {
+        "refs": _dedupe(refs),
+        "proof_profiles": _dedupe(proof_profiles),
+        "risk_refs": _dedupe(risk_refs),
+        "invariant_refs": _dedupe(invariant_refs),
+        "evidence_by_requirement": evidence_by_requirement,
+    }
+
+
+def _assurance_requirement_match(
+    *,
+    requirement: dict[str, Any],
+    changed_paths: list[str] | None,
+    task_text: str | None,
+    planning_facts: dict[str, Any],
+) -> tuple[bool, list[str]]:
+    applies_because: list[str] = []
+    normalized_paths = _normalize_changed_paths(changed_paths or [])
+    for path in normalized_paths:
+        for pattern in _list_payload(requirement.get("applies_to_paths")):
+            pattern_text = str(pattern).strip()
+            if pattern_text and fnmatch.fnmatch(path, pattern_text):
+                applies_because.append(f"changed path matched {pattern_text}")
+    normalized_task = (task_text or "").lower()
+    for marker in _list_payload(requirement.get("applies_to_task_markers")):
+        marker_text = str(marker).strip()
+        if marker_text and marker_text.lower() in normalized_task:
+            applies_because.append(f"task marker matched {marker_text}")
+    for field_name, fact_name, label in (
+        ("applies_to_planning_refs", "refs", "planning ref"),
+        ("applies_to_proof_profiles", "proof_profiles", "proof profile"),
+        ("applies_to_risk_refs", "risk_refs", "risk ref"),
+        ("applies_to_invariant_refs", "invariant_refs", "invariant ref"),
+    ):
+        configured = {str(item).strip() for item in _list_payload(requirement.get(field_name)) if str(item).strip()}
+        facts = {str(item).strip() for item in _list_payload(planning_facts.get(fact_name)) if str(item).strip()}
+        for matched in sorted(configured & facts):
+            applies_because.append(f"{label} matched {matched}")
+    applies_because = _dedupe(applies_because)
+    return (bool(applies_because), applies_because)
+
+
+def _assurance_status_for_requirement(
+    *, requirement: dict[str, Any], applies_because: list[str], planning_facts: dict[str, Any]
+) -> dict[str, Any]:
+    required_evidence = [str(item).strip() for item in _list_payload(requirement.get("required_evidence")) if str(item).strip()]
+    evidence_by_requirement = planning_facts.get("evidence_by_requirement", {})
+    evidence_present = []
+    if isinstance(evidence_by_requirement, dict):
+        evidence_present = [
+            str(item).strip()
+            for item in _list_payload(evidence_by_requirement.get(str(requirement.get("id", "")), []))
+            if str(item).strip()
+        ]
+    missing_evidence = [item for item in required_evidence if item not in evidence_present]
+    waiver = requirement.get("waiver", {}) if isinstance(requirement.get("waiver"), dict) else {}
+    dismissal = requirement.get("dismissal", {}) if isinstance(requirement.get("dismissal"), dict) else {}
+    state = "satisfied" if not missing_evidence else "missing-evidence"
+    if dismissal.get("status") == "recorded":
+        state = "dismissed"
+        missing_evidence = []
+    elif waiver.get("status") == "recorded":
+        state = "waived"
+        missing_evidence = []
+    elif missing_evidence and requirement.get("review_owner"):
+        state = "review-required"
+    return {
+        "requirement_id": str(requirement.get("id", "")),
+        "state": state,
+        "level": str(requirement.get("level", DEFAULT_ASSURANCE_LEVEL)),
+        "applies_because": applies_because,
+        "authority_refs": _list_payload(requirement.get("authority_refs")),
+        "required_evidence": required_evidence,
+        "evidence_present": evidence_present,
+        "missing_evidence": missing_evidence,
+        "waiver": waiver if waiver else {"status": "none"},
+        "dismissal": dismissal if dismissal else {"status": "none"},
+        "proof_profile": requirement.get("proof_profile"),
+        "workflow_obligation_refs": _list_payload(requirement.get("workflow_obligation_refs")),
+        "review_owner": requirement.get("review_owner"),
+        "force": str(requirement.get("force", "recommended")),
+        "blocking_claims": _list_payload(requirement.get("blocking_claims")),
+        "next_action": {
+            "id": "record-assurance-evidence" if missing_evidence else "none",
+            "why": "Required assurance evidence is missing before broad completion claims."
+            if missing_evidence
+            else "No missing assurance evidence is currently projected.",
+        },
+    }
+
+
+def _assurance_requirements_report_payload(
+    *,
+    config: WorkspaceConfig | None,
+    active_planning_record: dict[str, Any] | None = None,
+    task_text: str | None = None,
+    changed_paths: list[str] | None = None,
+) -> dict[str, Any]:
+    configured = _assurance_requirement_payloads(config)
+    planning_facts = _assurance_requirement_planning_facts(active_planning_record)
+    matching: list[dict[str, Any]] = []
+    active: list[dict[str, Any]] = []
+    evidence_status: list[dict[str, Any]] = []
+    for requirement in configured:
+        matched, applies_because = _assurance_requirement_match(
+            requirement=requirement,
+            changed_paths=changed_paths,
+            task_text=task_text,
+            planning_facts=planning_facts,
+        )
+        status = _assurance_status_for_requirement(
+            requirement=requirement,
+            applies_because=applies_because,
+            planning_facts=planning_facts,
+        )
+        matching.append(
+            {
+                "id": requirement["id"],
+                "matched": matched,
+                "applies_because": applies_because,
+                "non_match_reason": "" if matched else "no configured activation signal matched current work",
+                "level": requirement["level"],
+                "force": requirement["force"],
+                "blocking_claims": requirement["blocking_claims"],
+            }
+        )
+        if matched:
+            active.append({**requirement, "applies_because": applies_because})
+            evidence_status.append(status)
+    required_missing = [
+        item
+        for item in evidence_status
+        if item.get("state") in {"missing-evidence", "review-required"}
+        and str(item.get("force", "recommended")) in {"required-before-closeout", "blocking"}
+    ]
+    return {
+        "kind": "agentic-workspace/assurance-requirements/v1",
+        "status": "attention" if required_missing else "matched" if active else "configured" if configured else "absent",
+        "rule": "Repo-declared assurance requirements are domain-generic routing and claim-boundary facts; AW does not certify compliance.",
+        "configured_count": len(configured),
+        "active_count": len(active),
+        "missing_required_evidence_count": len(required_missing),
+        "configured": configured,
+        "active": active,
+        "evidence_status": evidence_status,
+        "match_evidence": {
+            "observed_scope_source": ", ".join(
+                source
+                for source, present in (
+                    ("changed paths", bool(changed_paths)),
+                    ("task text", bool(task_text)),
+                    ("active planning", bool(active_planning_record)),
+                )
+                if present
+            )
+            or "no active planning record, task text, or changed paths",
+            "match_count": len(active),
+            "matching": matching,
+        },
+        "supported_blocking_claims": list(SUPPORTED_ASSURANCE_REQUIREMENT_BLOCKING_CLAIMS),
+    }
+
+
+def _compact_assurance_requirements(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"status": "absent", "active_count": 0}
+    active = value.get("active", [])
+    active = active if isinstance(active, list) else []
+    evidence_status = value.get("evidence_status", [])
+    evidence_status = evidence_status if isinstance(evidence_status, list) else []
+    required_missing = [
+        item for item in evidence_status if isinstance(item, dict) and item.get("state") in {"missing-evidence", "review-required"}
+    ]
+    return {
+        "status": value.get("status", "absent"),
+        "configured_count": value.get("configured_count", 0),
+        "active_count": value.get("active_count", 0),
+        "missing_required_evidence_count": value.get("missing_required_evidence_count", 0),
+        "active": [
+            {
+                key: item.get(key)
+                for key in (
+                    "id",
+                    "level",
+                    "applies_because",
+                    "authority_refs",
+                    "required_evidence",
+                    "proof_profile",
+                    "review_owner",
+                    "force",
+                    "blocking_claims",
+                )
+                if isinstance(item, dict) and key in item
+            }
+            for item in active[:3]
+            if isinstance(item, dict)
+        ],
+        "evidence_status": [
+            {
+                key: item.get(key)
+                for key in ("requirement_id", "state", "missing_evidence", "waiver", "dismissal", "next_action")
+                if key in item
+            }
+            for item in required_missing[:3]
+        ],
+        "detail_command": "agentic-workspace report --target ./repo --section assurance_requirements --format json",
     }
 
 
@@ -5650,6 +5945,16 @@ def _run_report_command(
         module_reports=module_reports, external_work_delta=external_work_delta, cli_invoke=config.cli_invoke
     )
     ownership_payload = _ownership_payload(target_root=target_root, descriptors=descriptors)
+    active_planning_record = _active_planning_record(module_reports=module_reports)
+    raw_active_planning_record = (
+        _raw_active_planning_record_for_closeout(planning_record=active_planning_record, target_root=target_root)
+        if isinstance(active_planning_record, dict)
+        else None
+    )
+    assurance_requirements = _assurance_requirements_report_payload(
+        config=config,
+        active_planning_record=raw_active_planning_record or active_planning_record,
+    )
     payload = {
         "kind": "workspace-report/v1",
         "schema": _reporting_schema_payload(),
@@ -5686,9 +5991,8 @@ def _run_report_command(
             installed_modules=installed_modules, active_direction=_effective_active_direction_payload(module_reports=module_reports)
         ),
         "system_intent_mirror": _system_intent_report_payload(target_root=target_root, config=config),
-        "workflow_obligations": _workflow_obligations_report_payload(
-            config=config, active_planning_record=_active_planning_record(module_reports=module_reports)
-        ),
+        "workflow_obligations": _workflow_obligations_report_payload(config=config, active_planning_record=active_planning_record),
+        "assurance_requirements": assurance_requirements,
         "product_managed_enclave": _product_managed_enclave_payload(target_root=target_root, ownership_payload=ownership_payload),
         "ownership_diagnostics": ownership_payload["diagnostics"],
         "surface_value_guardrail": surface_value_guardrail,
@@ -7707,6 +8011,7 @@ def _closeout_completion_options(
     intent_check: dict[str, Any],
     acceptance_reconciliation: dict[str, Any],
     intent_proof_check: dict[str, Any] | None = None,
+    assurance_requirements: dict[str, Any] | None = None,
     durable_residue_action: dict[str, Any],
     lower_trust_closeout_count: int,
     cli_invoke: str,
@@ -7779,25 +8084,42 @@ def _closeout_completion_options(
         completion_blockers.append("continuation_owner")
     if not intent_proof_supports_work:
         completion_blockers.append("intent_proof")
+    assurance_claim_blockers = _assurance_claim_blockers(assurance_requirements)
 
     slice_blockers = [
         field
         for field in completion_blockers
         if field not in {"intent_satisfaction", "intent_proof"} or intent_proof_status == "needs_review"
     ]
+    slice_blockers.extend(assurance_claim_blockers.get("claim-slice-complete", []))
+    work_blockers = [*completion_blockers, *assurance_claim_blockers.get("claim-work-complete", [])]
+    parent_blockers = [*completion_blockers, *assurance_claim_blockers.get("close-parent-lane", [])]
     claim_slice_allowed = (
-        proof_achieved and (not strict_blocking) and acceptance_ok and not residue_required and not intent_proof_needs_review
+        proof_achieved
+        and (not strict_blocking)
+        and acceptance_ok
+        and not residue_required
+        and not intent_proof_needs_review
+        and not assurance_claim_blockers.get("claim-slice-complete")
     )
-    claim_work_allowed = claim_slice_allowed and intent_satisfied and (not larger_intent_open) and intent_proof_supports_work
-    close_parent_allowed = claim_work_allowed and close_evidence
+    claim_work_allowed = (
+        claim_slice_allowed
+        and intent_satisfied
+        and (not larger_intent_open)
+        and intent_proof_supports_work
+        and not assurance_claim_blockers.get("claim-work-complete")
+    )
+    close_parent_allowed = claim_work_allowed and close_evidence and not assurance_claim_blockers.get("close-parent-lane")
     route_residue_command = str(durable_residue_action.get("command", "")) or _command_with_cli_invoke(
         command="agentic-workspace report --target ./repo --section closeout_trust --format json", cli_invoke=cli_invoke
     )
+    assurance_review_required = any(assurance_claim_blockers.values())
     request_review_allowed = (
         status in {"unavailable", "invalid"}
         or intent_trust == "needs-review"
         or intent_proof_needs_review
         or str(strict_gate.get("status", "")) == "requires-review"
+        or assurance_review_required
     )
     return [
         _completion_option(
@@ -7822,7 +8144,7 @@ def _closeout_completion_options(
             if claim_work_allowed
             else "work completion is blocked until proof, intent, residue, continuation, and closeout evidence support it",
             owner=continuation_owner if larger_intent_open else None,
-            blocking_fields=completion_blockers or None,
+            blocking_fields=work_blockers or None,
         ),
         _completion_option(
             "keep-parent-open",
@@ -7840,7 +8162,7 @@ def _closeout_completion_options(
             if close_parent_allowed
             else "parent lane closure requires satisfied larger intent and explicit closure evidence",
             owner=continuation_owner if larger_intent_open else None,
-            blocking_fields=completion_blockers if completion_blockers else ["intent_satisfaction.closure_scope.larger_intent_closure"],
+            blocking_fields=parent_blockers if parent_blockers else ["intent_satisfaction.closure_scope.larger_intent_closure"],
         ),
         _completion_option(
             "route-residue",
@@ -7856,7 +8178,11 @@ def _closeout_completion_options(
             why="intent satisfaction or strict closeout evidence requires human/domain review"
             if request_review_allowed
             else "a concrete closeout action is available without requiring review",
-            blocking_fields=["intent_satisfaction"] if intent_trust == "needs-review" else None,
+            blocking_fields=["intent_satisfaction"]
+            if intent_trust == "needs-review"
+            else ["assurance_requirements"]
+            if assurance_review_required
+            else None,
         ),
         _completion_option(
             "stop-with-status",
@@ -7867,6 +8193,35 @@ def _closeout_completion_options(
             ),
         ),
     ]
+
+
+def _assurance_claim_blockers(assurance_requirements: dict[str, Any] | None) -> dict[str, list[str]]:
+    blockers: dict[str, list[str]] = {
+        "claim-slice-complete": [],
+        "claim-work-complete": [],
+        "close-parent-lane": [],
+    }
+    if not isinstance(assurance_requirements, dict):
+        return blockers
+    evidence_status = assurance_requirements.get("evidence_status", [])
+    if not isinstance(evidence_status, list):
+        return blockers
+    for status in evidence_status:
+        if not isinstance(status, dict):
+            continue
+        if status.get("state") not in {"missing-evidence", "review-required"}:
+            continue
+        force = str(status.get("force", "recommended"))
+        if force not in {"required-before-closeout", "blocking"}:
+            continue
+        requirement_id = str(status.get("requirement_id", "")).strip() or "unknown"
+        blocking_claims = [str(item).strip() for item in _list_payload(status.get("blocking_claims")) if str(item).strip()]
+        if not blocking_claims and force in {"required-before-closeout", "blocking"}:
+            blocking_claims = ["claim-work-complete", "close-parent-lane"]
+        for claim in blocking_claims:
+            if claim in blockers:
+                blockers[claim].append(f"assurance_evidence:{requirement_id}")
+    return {claim: _dedupe(values) for claim, values in blockers.items()}
 
 
 def _report_closeout_trust_payload(
@@ -7956,6 +8311,7 @@ def _report_closeout_trust_payload(
         acceptance_reconciliation = _acceptance_criteria_reconciliation_payload(planning_report={})
         intent_proof_check = _intent_proof_check_payload(planning_report={}, target_root=target_root)
         architecture_decision_closeout = _architecture_decision_closeout_payload(planning_report={}, target_root=target_root, config=config)
+        assurance_requirements = _assurance_requirements_report_payload(config=config)
         residue_action = durable_residue_action(trust="unavailable")
         return {
             "status": "unavailable",
@@ -7966,6 +8322,7 @@ def _report_closeout_trust_payload(
             "acceptance_criteria_reconciliation": acceptance_reconciliation,
             "intent_proof_check": intent_proof_check,
             "proof_confidence": _proof_confidence_payload(intent_proof=intent_proof_check),
+            "assurance_requirements": assurance_requirements,
             "architecture_decision_closeout": architecture_decision_closeout,
             "historical_review_artifacts": _historical_review_artifacts_policy(
                 planning_report={}, intent_validation={}, target_root=target_root
@@ -7981,6 +8338,7 @@ def _report_closeout_trust_payload(
                 intent_check=intent_check,
                 acceptance_reconciliation=acceptance_reconciliation,
                 intent_proof_check=intent_proof_check,
+                assurance_requirements=assurance_requirements,
                 durable_residue_action=residue_action,
                 lower_trust_closeout_count=1,
                 cli_invoke=cli_invoke,
@@ -7995,6 +8353,7 @@ def _report_closeout_trust_payload(
         architecture_decision_closeout = _architecture_decision_closeout_payload(
             planning_report=planning_report, target_root=target_root, config=config
         )
+        assurance_requirements = _assurance_requirements_report_payload(config=config)
         residue_action = durable_residue_action(trust="unavailable")
         return {
             "status": "unavailable",
@@ -8005,6 +8364,7 @@ def _report_closeout_trust_payload(
             "acceptance_criteria_reconciliation": acceptance_reconciliation,
             "intent_proof_check": intent_proof_check,
             "proof_confidence": _proof_confidence_payload(intent_proof=intent_proof_check),
+            "assurance_requirements": assurance_requirements,
             "architecture_decision_closeout": architecture_decision_closeout,
             "historical_review_artifacts": _historical_review_artifacts_policy(
                 planning_report=planning_report, intent_validation={}, target_root=target_root
@@ -8020,6 +8380,7 @@ def _report_closeout_trust_payload(
                 intent_check=intent_check,
                 acceptance_reconciliation=acceptance_reconciliation,
                 intent_proof_check=intent_proof_check,
+                assurance_requirements=assurance_requirements,
                 durable_residue_action=residue_action,
                 lower_trust_closeout_count=1,
                 cli_invoke=cli_invoke,
@@ -8042,6 +8403,16 @@ def _report_closeout_trust_payload(
     intent_proof_check = _intent_proof_check_payload(planning_report=planning_report, target_root=target_root)
     architecture_decision_closeout = _architecture_decision_closeout_payload(
         planning_report=planning_report, target_root=target_root, config=config
+    )
+    raw_active_planning_record = _raw_active_planning_record_for_closeout(
+        planning_record=planning_report.get("active", {}).get("planning_record", {})
+        if isinstance(planning_report.get("active"), dict)
+        else {},
+        target_root=target_root,
+    )
+    assurance_requirements = _assurance_requirements_report_payload(
+        config=config,
+        active_planning_record=raw_active_planning_record,
     )
     active_planning_record = package_workflow_evidence.get("status") == "present"
     package_absence_signals: list[str] = []
@@ -8097,6 +8468,7 @@ def _report_closeout_trust_payload(
         "acceptance_criteria_reconciliation": acceptance_reconciliation,
         "intent_proof_check": intent_proof_check,
         "proof_confidence": _proof_confidence_payload(intent_proof=intent_proof_check),
+        "assurance_requirements": assurance_requirements,
         "architecture_decision_closeout": architecture_decision_closeout,
         "historical_review_artifacts": _historical_review_artifacts_policy(
             planning_report=planning_report, intent_validation=intent_validation, target_root=target_root
@@ -8110,6 +8482,7 @@ def _report_closeout_trust_payload(
             intent_check=intent_satisfaction_check,
             acceptance_reconciliation=acceptance_reconciliation,
             intent_proof_check=intent_proof_check,
+            assurance_requirements=assurance_requirements,
             durable_residue_action=residue_action,
             lower_trust_closeout_count=effective_lower_trust_count,
             cli_invoke=cli_invoke,
@@ -10808,6 +11181,9 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
             **({"task_search": skill_routing["task_search"]} if isinstance(skill_routing, dict) and "task_search" in skill_routing else {}),
         },
     }
+    assurance_requirements = payload.get("assurance_requirements", {})
+    if isinstance(assurance_requirements, dict) and int(assurance_requirements.get("active_count", 0) or 0) > 0:
+        projected["assurance_requirements"] = _compact_assurance_requirements(assurance_requirements)
     proof = payload.get("proof", {})
     if isinstance(proof, dict) and proof.get("kind") == "proof-selection/v1":
         projected["proof"] = _compact_start_proof_payload(proof)
@@ -11445,6 +11821,12 @@ def _start_payload(
     )
     workflow_obligations = preflight.get("workflow_obligations", {})
     compact_workflow_obligations = _compact_start_workflow_obligations(workflow_obligations)
+    assurance_requirements = _assurance_requirements_report_payload(
+        config=config,
+        active_planning_record=planning_record if isinstance(planning_record, dict) else None,
+        task_text=task_text,
+        changed_paths=changed_paths,
+    )
     current_need = "continue-active-planning" if active_planning_present else "first-contact-routing"
     if changed_paths:
         current_need = "changed-path-startup"
@@ -11526,6 +11908,8 @@ def _start_payload(
             cli_invoke=config.cli_invoke,
         ),
     }
+    if int(assurance_requirements.get("configured_count", 0) or 0) > 0:
+        payload["assurance_requirements"] = assurance_requirements
     startup_review = _workspace_absence_startup_review(target_root=target_root, config=config)
     if startup_review["status"] == "attention":
         payload["startup_review"] = startup_review
@@ -14353,6 +14737,12 @@ def _implement_payload(
         "reuse_pressure": _reuse_pressure_payload(
             target_root=target_root, changed_paths=normalized_paths, cli_invoke=config.cli_invoke, compact=False
         ),
+        "assurance_requirements": _assurance_requirements_report_payload(
+            config=config,
+            active_planning_record=None,
+            task_text=task_text,
+            changed_paths=normalized_paths,
+        ),
         "orientation": {
             "status": "changed-path-context" if normalized_paths else "unknown-scope",
             "minimum_before_editing": "Inspect the listed files, path boundaries, workflow obligations, and selected proof before editing."
@@ -14560,11 +14950,15 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "context.reuse_pressure",
                 "task_contract",
                 "change_impact",
+                "assurance_requirements",
                 "context.delegation_decision",
                 "context.routing",
             ],
         },
     }
+    assurance_requirements = payload.get("assurance_requirements", {})
+    if isinstance(assurance_requirements, dict) and int(assurance_requirements.get("active_count", 0) or 0) > 0:
+        projected["assurance_requirements"] = _compact_assurance_requirements(assurance_requirements)
     compatibility_review = projected["proof"].get("tiny_surface_compatibility_review", {})
     if not (isinstance(compatibility_review, dict) and compatibility_review.get("status") == "required"):
         projected["proof"].pop("tiny_surface_compatibility_review", None)
@@ -19621,6 +20015,10 @@ def _selector_requests_task_contract(select: str | None) -> bool:
     return any(token == "task_contract" or token.startswith("task_contract.") for token in _selector_tokens(select))
 
 
+def _selector_requests_assurance_requirements(select: str | None) -> bool:
+    return any(token == "assurance_requirements" or token.startswith("assurance_requirements.") for token in _selector_tokens(select))
+
+
 def _run_implement_context_adapter(args: argparse.Namespace) -> int:
     target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
     _validate_target_root(command_name="implement", target_root=target_root)
@@ -19633,6 +20031,7 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
     selected_fields = getattr(args, "select", None)
     change_impact_selected = _selector_requests_change_impact(selected_fields)
     task_contract_selected = _selector_requests_task_contract(selected_fields)
+    assurance_requirements_selected = _selector_requests_assurance_requirements(selected_fields)
     full_payload = _implement_payload(
         target_root=target_root,
         changed_paths=list(getattr(args, "changed", []) or []),
@@ -19647,6 +20046,8 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
             payload["task_contract"] = full_payload["task_contract"]
         if change_impact_selected:
             payload["change_impact"] = full_payload["change_impact"]
+        if assurance_requirements_selected:
+            payload["assurance_requirements"] = full_payload["assurance_requirements"]
     if getattr(args, "select", None):
         payload = _select_payload_fields(payload, select=getattr(args, "select"), source_command="implement")
     _emit_payload(payload=payload, format_name=args.format)
@@ -22019,7 +22420,43 @@ def _proof_selection_for_changed_paths(
                     "disallowed_commands": list(profile.disallowed_commands),
                 }
             )
+    active_assurance_requirements = _assurance_requirements_report_payload(
+        config=config,
+        task_text=task_text,
+        changed_paths=changed_paths,
+    )
+    requirement_lanes: list[dict[str, Any]] = []
+    existing_concern_profiles = {str(lane.get("proof_profile", "")) for lane in concern_lanes}
+    for requirement in active_assurance_requirements.get("active", []):
+        if not isinstance(requirement, dict):
+            continue
+        profile_id = str(requirement.get("proof_profile") or "").strip()
+        if not profile_id:
+            continue
+        profile = configured_profiles.get(profile_id)
+        if profile is None:
+            if profile_id not in missing_concern_profiles:
+                missing_concern_profiles.append(profile_id)
+            continue
+        if profile_id in existing_concern_profiles:
+            continue
+        requirement_lanes.append(
+            {
+                "id": f"assurance-requirement:{requirement.get('id')}",
+                "when": "matched repo-declared assurance requirement selects this proof profile",
+                "enough_proof": list(profile.required_commands),
+                "recovery_signal": "missing or failing requirement proof should block broad assurance closeout until resolved or explicitly waived",
+                "proof_profile": profile.id,
+                "optional_commands": list(profile.optional_commands),
+                "review_aids": list(profile.review_aids),
+                "disallowed_commands": list(profile.disallowed_commands),
+                "requirement_id": str(requirement.get("id", "")),
+                "applies_because": _list_payload(requirement.get("applies_because")),
+            }
+        )
+        existing_concern_profiles.add(profile_id)
     selected_lanes.extend(concern_lanes)
+    selected_lanes.extend(requirement_lanes)
     make_targets = _makefile_targets(target_root)
     package_scripts = _package_json_scripts(target_root)
     project_roots = _project_roots_for_changed_paths(target_root=target_root, changed_paths=changed_paths)
@@ -22030,7 +22467,7 @@ def _proof_selection_for_changed_paths(
     proof_command_adjustments: list[dict[str, str]] = []
     unavailable_proof_commands: list[dict[str, str]] = []
     host_policy_disallowed_commands: dict[str, dict[str, str]] = {}
-    for lane in concern_lanes:
+    for lane in [*concern_lanes, *requirement_lanes]:
         for raw_command in lane.get("disallowed_commands", []):
             raw_command_text = str(raw_command).strip()
             if not raw_command_text:
@@ -22190,7 +22627,7 @@ def _proof_selection_for_changed_paths(
                 for command in lane.get("disallowed_commands", [])
             ],
         }
-        for lane in concern_lanes
+        for lane in [*concern_lanes, *requirement_lanes]
         if lane.get("proof_profile")
     ]
     proof_next_decision = _proof_next_decision_payload(
@@ -22220,7 +22657,7 @@ def _proof_selection_for_changed_paths(
         proof_execution_evidence=proof_execution_evidence,
     )
     optional_commands = ["agentic-workspace proof --target ./repo --current --format json", "agentic-workspace summary --format json"]
-    for concern_lane in concern_lanes:
+    for concern_lane in [*concern_lanes, *requirement_lanes]:
         for command in concern_lane.get("optional_commands", []):
             if command not in optional_commands:
                 optional_commands.append(str(command))
@@ -22275,6 +22712,7 @@ def _proof_selection_for_changed_paths(
         "learned_route_hints": learned_route_hints,
         "proof_intents": proof_intents,
         "configured_policy": configured_policy,
+        "assurance_requirements": active_assurance_requirements,
         "selected_commands": selected_commands,
         "unavailable_commands": unavailable_commands,
         "host_policy_blocked_commands": host_policy_blocked_commands,
@@ -22301,6 +22739,8 @@ def _proof_selection_for_changed_paths(
                 "ci_relationship": lane.get("ci_relationship", ""),
                 "recovery_signal": lane.get("recovery_signal", ""),
                 **({"proof_profile": lane["proof_profile"]} if lane.get("proof_profile") else {}),
+                **({"requirement_id": lane["requirement_id"]} if lane.get("requirement_id") else {}),
+                **({"applies_because": lane["applies_because"]} if lane.get("applies_because") else {}),
                 **({"review_aids": lane["review_aids"]} if lane.get("review_aids") else {}),
                 **({"matched_paths": lane["matched_paths"]} if lane.get("matched_paths") else {}),
                 **({"subsystem": lane["subsystem"]} if lane.get("subsystem") else {}),
@@ -24345,9 +24785,11 @@ def _config_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
                     "required_commands": list(profile.required_commands),
                     "optional_commands": list(profile.optional_commands),
                     "review_aids": list(profile.review_aids),
+                    "disallowed_commands": list(profile.disallowed_commands),
                 }
                 for profile in assurance.proof_profiles
             ],
+            "requirements": _assurance_requirement_payloads(config),
             "test_data_policy": dict(assurance.test_data_policy),
             "decision_record_target": assurance.decision_record_target,
             "invariant_registry": assurance.invariant_registry,
@@ -24424,6 +24866,7 @@ def _compact_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "agent_may_escalate": assurance["agent_may_escalate"],
             "agent_may_deescalate": assurance["agent_may_deescalate"],
             "configured_proof_profile_count": len(assurance["proof_profiles"]),
+            "configured_requirement_count": len(assurance.get("requirements", [])),
         },
         "local_runtime": {
             "local_override_path": local_override["path"],

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -19730,7 +19730,10 @@ def _select_proof_payload(
             surface="proof", selector={"route": route}, answer=answer, refs=refs, matched=matched, target=payload["target"]
         )
     if current_only:
-        answer = payload["current"]
+        current_selection = _proof_selection_for_changed_paths(changed_paths=[], target_root=target_root)
+        planning_present = current_selection.get("planning_assurance", {}).get("status") == "present"
+        active_requirements = current_selection.get("assurance_requirements", {}).get("active_count", 0)
+        answer = {**current_selection, "current": payload["current"]} if planning_present or active_requirements else payload["current"]
         refs = [compact_contract_manifest()["canonical_doc"], payload["command"], payload["canonical_doc"]]
         return _compact_contract_answer(surface="proof", selector={"current": True}, answer=answer, refs=refs, target=payload["target"])
     return payload
@@ -22422,6 +22425,7 @@ def _proof_selection_for_changed_paths(
             )
     active_assurance_requirements = _assurance_requirements_report_payload(
         config=config,
+        active_planning_record=planning_assurance if planning_assurance.get("status") == "present" else None,
         task_text=task_text,
         changed_paths=changed_paths,
     )

--- a/tests/test_workspace_config_cli.py
+++ b/tests/test_workspace_config_cli.py
@@ -434,6 +434,81 @@ review_aids = []
     assert usable["assurance"]["onboarding"]["host_ref_count"] == 1
 
 
+def test_config_command_reports_assurance_requirements(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.privacy_data]
+level = "high"
+applies_to_paths = ["db/migrations/**"]
+applies_to_task_markers = ["privacy"]
+authority_refs = ["docs/compliance/privacy.md"]
+required_evidence = ["authority_consulted", "risk_assessment"]
+proof_profile = "privacy"
+workflow_obligation_refs = ["privacy_review"]
+review_owner = "privacy-review"
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+
+[assurance.requirements.privacy_data.waiver]
+reason = "Covered by existing privacy review for this migration class."
+owner = "privacy-review"
+""",
+    )
+
+    assert cli.main(["config", "--verbose", "--target", str(tmp_path), "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    requirement = payload["assurance"]["requirements"][0]
+    assert requirement["id"] == "privacy_data"
+    assert requirement["level"] == "high"
+    assert requirement["applies_to_paths"] == ["db/migrations/**"]
+    assert requirement["required_evidence"] == ["authority_consulted", "risk_assessment"]
+    assert requirement["force"] == "required-before-closeout"
+    assert requirement["blocking_claims"] == ["claim-work-complete", "close-parent-lane"]
+    assert requirement["waiver"]["status"] == "recorded"
+    assert requirement["waiver"]["owner"] == "privacy-review"
+
+
+def test_config_command_rejects_assurance_requirement_without_activation_signal(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.no_signal]
+level = "high"
+required_evidence = ["authority_consulted"]
+""",
+    )
+
+    with pytest.raises(SystemExit):
+        cli.main(["config", "--verbose", "--target", str(tmp_path), "--format", "json"])
+    assert "requires at least one activation signal" in capsys.readouterr().err
+
+
+def test_config_command_rejects_invalid_assurance_requirement_claim(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.bad_claim]
+applies_to_paths = ["docs/**"]
+blocking_claims = ["certify-compliant"]
+""",
+    )
+
+    with pytest.raises(SystemExit):
+        cli.main(["config", "--verbose", "--target", str(tmp_path), "--format", "json"])
+    assert "blocking_claims entries must be one of" in capsys.readouterr().err
+
+
 def test_config_command_reports_enabled_advanced_features(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     (tmp_path / ".agentic-workspace/config.toml").write_text(

--- a/tests/test_workspace_config_cli.py
+++ b/tests/test_workspace_config_cli.py
@@ -482,6 +482,7 @@ schema_version = 1
 
 [assurance.requirements.no_signal]
 level = "high"
+force = "required-before-closeout"
 required_evidence = ["authority_consulted"]
 """,
     )
@@ -489,6 +490,43 @@ required_evidence = ["authority_consulted"]
     with pytest.raises(SystemExit):
         cli.main(["config", "--verbose", "--target", str(tmp_path), "--format", "json"])
     assert "requires at least one activation signal" in capsys.readouterr().err
+
+
+def test_config_command_requires_assurance_requirement_level_and_force(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.missing_level]
+applies_to_paths = ["docs/**"]
+force = "required-before-closeout"
+
+[assurance.requirements.missing_force]
+level = "high"
+applies_to_paths = ["src/**"]
+""",
+    )
+
+    with pytest.raises(SystemExit):
+        cli.main(["config", "--verbose", "--target", str(tmp_path), "--format", "json"])
+    assert "missing_force force is required" in capsys.readouterr().err
+
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.missing_level]
+applies_to_paths = ["docs/**"]
+force = "required-before-closeout"
+""",
+    )
+
+    with pytest.raises(SystemExit):
+        cli.main(["config", "--verbose", "--target", str(tmp_path), "--format", "json"])
+    assert "missing_level level is required" in capsys.readouterr().err
 
 
 def test_config_command_rejects_invalid_assurance_requirement_claim(tmp_path: Path, capsys) -> None:
@@ -499,7 +537,9 @@ def test_config_command_rejects_invalid_assurance_requirement_claim(tmp_path: Pa
 schema_version = 1
 
 [assurance.requirements.bad_claim]
+level = "high"
 applies_to_paths = ["docs/**"]
+force = "required-before-closeout"
 blocking_claims = ["certify-compliant"]
 """,
     )

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -517,6 +517,53 @@ def test_implement_tiny_profile_does_not_compute_task_contract(tmp_path: Path, m
     assert "task_contract" in payload["drill_down"]["available_selectors"]
 
 
+def test_implement_tiny_profile_does_not_compute_assurance_requirements(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.docs_review]
+level = "high"
+applies_to_paths = ["docs/**"]
+required_evidence = ["review_recorded"]
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete"]
+""",
+    )
+    _write(tmp_path / "README.md", "hello\n")
+
+    def fail_assurance_requirements(**_: object) -> dict[str, object]:
+        raise AssertionError("ordinary tiny implement output should not build assurance_requirements")
+
+    monkeypatch.setattr(cli, "_assurance_requirements_report_payload", fail_assurance_requirements)
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "README.md",
+                "--task",
+                "Update README wording",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "implementer-context-tiny/v1"
+    assert "assurance_requirements" not in payload
+    assert "assurance_requirements" not in payload["context"]
+    assert "assurance_requirements" in payload["drill_down"]["available_selectors"]
+
+
 def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -107,6 +107,112 @@ def test_implement_command_returns_bounded_context_and_boundary_warnings(tmp_pat
     assert payload["planning_safety_gate"]["work_shape_facts"]["hard_blockers"] == []
 
 
+def test_implement_selects_active_assurance_requirements_from_changed_paths(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.privacy_data]
+level = "high"
+applies_to_paths = ["db/migrations/**"]
+authority_refs = ["docs/compliance/privacy.md"]
+required_evidence = ["authority_consulted"]
+proof_profile = "privacy"
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "db/migrations/001_privacy.sql",
+                "--select",
+                "assurance_requirements",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    selected = json.loads(capsys.readouterr().out)
+    requirements = selected["values"]["assurance_requirements"]
+    assert requirements["status"] == "attention"
+    assert requirements["active"][0]["id"] == "privacy_data"
+    assert requirements["active"][0]["applies_because"] == ["changed path matched db/migrations/**"]
+    assert requirements["evidence_status"][0]["missing_evidence"] == ["authority_consulted"]
+
+
+def test_implement_keeps_unmatched_assurance_requirements_out_of_tiny_output(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.privacy_data]
+level = "high"
+applies_to_paths = ["db/migrations/**"]
+required_evidence = ["authority_consulted"]
+force = "required-before-closeout"
+""",
+    )
+
+    assert cli.main(["implement", "--target", str(tmp_path), "--changed", "README.md", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert "assurance_requirements" not in payload
+
+
+def test_implement_matches_non_code_assurance_requirement(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.runbook_change]
+level = "medium"
+applies_to_paths = ["docs/runbooks/**"]
+authority_refs = ["docs/ops/runbook-authority.md"]
+required_evidence = ["operator_review"]
+force = "recommended"
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "docs/runbooks/restart-service.md",
+                "--select",
+                "assurance_requirements",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    requirements = json.loads(capsys.readouterr().out)["values"]["assurance_requirements"]
+    assert requirements["active"][0]["id"] == "runbook_change"
+    assert requirements["active"][0]["authority_refs"] == ["docs/ops/runbook-authority.md"]
+    assert requirements["evidence_status"][0]["missing_evidence"] == ["operator_review"]
+
+
 def test_implement_planning_source_includes_typecheck_ci_parity(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -903,6 +903,69 @@ blocking_claims = ["claim-work-complete", "close-parent-lane"]
     assert lane["applies_because"] == ["changed path matched db/migrations/**"]
 
 
+def test_proof_current_includes_active_planning_assurance_requirement_profile(tmp_path: Path, capsys) -> None:
+    from repo_planning_bootstrap import installer as planning_installer
+
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance.proof_profiles.privacy]
+required_commands = ["uv run pytest tests/privacy -q"]
+optional_commands = ["uv run pytest tests/privacy_integration -q"]
+review_aids = ["docs/compliance/privacy.md"]
+
+[assurance.requirements.privacy_data]
+level = "high"
+applies_to_planning_refs = ["privacy_data"]
+authority_refs = ["docs/compliance/privacy.md"]
+required_evidence = ["authority_consulted"]
+proof_profile = "privacy"
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+[todo]
+active_items = [
+  { id = "privacy-plan", status = "in-progress", surface = ".agentic-workspace/planning/execplans/privacy-plan.plan.json", why_now = "prove privacy requirement." },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    record = planning_installer._build_execplan_record_from_todo_item(
+        title="Privacy Plan",
+        item_id="privacy-plan",
+        status="in-progress",
+        why_now="prove privacy requirement.",
+        next_action="run proof selection.",
+        done_when="privacy proof appears.",
+    )
+    record["adaptive_assurance"] = {
+        "level": "high",
+        "requirement_refs": ["privacy_data"],
+        "strict_closeout": True,
+    }
+    _write_json(tmp_path / ".agentic-workspace" / "planning" / "execplans" / "privacy-plan.plan.json", record)
+
+    assert cli.main(["proof", "--verbose", "--target", str(tmp_path), "--current", "--format", "json"]) == 0
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    assert "uv run pytest tests/privacy -q" in answer["required_commands"]
+    assert "uv run pytest tests/privacy_integration -q" in answer["optional_commands"]
+    assert answer["assurance_requirements"]["active"][0]["id"] == "privacy_data"
+    lane = [item for item in answer["selected_lanes"] if item.get("requirement_id") == "privacy_data"][0]
+    assert lane["proof_profile"] == "privacy"
+    assert lane["applies_because"] == ["planning ref matched privacy_data"]
+
+
 def test_proof_changed_reports_compact_proof_execution_evidence_states(tmp_path: Path, capsys) -> None:
     from repo_planning_bootstrap import installer as planning_installer
 

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -856,6 +856,53 @@ candidates = []
     assert answer["selected_lanes"][-1]["review_aids"] == [".agentic-workspace/agent-aids/access-control.md"]
 
 
+def test_proof_changed_includes_matched_assurance_requirement_profile(tmp_path: Path, capsys) -> None:
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance.proof_profiles.privacy]
+required_commands = ["uv run pytest tests/privacy -q"]
+optional_commands = ["uv run pytest tests/privacy_integration -q"]
+review_aids = ["docs/compliance/privacy.md"]
+
+[assurance.requirements.privacy_data]
+level = "high"
+applies_to_paths = ["db/migrations/**"]
+authority_refs = ["docs/compliance/privacy.md"]
+required_evidence = ["authority_consulted"]
+proof_profile = "privacy"
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--verbose",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "db/migrations/001_privacy.sql",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    assert "uv run pytest tests/privacy -q" in answer["required_commands"]
+    assert "uv run pytest tests/privacy_integration -q" in answer["optional_commands"]
+    assert answer["assurance_requirements"]["active"][0]["id"] == "privacy_data"
+    lane = [item for item in answer["selected_lanes"] if item.get("requirement_id") == "privacy_data"][0]
+    assert lane["proof_profile"] == "privacy"
+    assert lane["applies_because"] == ["changed path matched db/migrations/**"]
+
+
 def test_proof_changed_reports_compact_proof_execution_evidence_states(tmp_path: Path, capsys) -> None:
     from repo_planning_bootstrap import installer as planning_installer
 

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -2245,6 +2245,109 @@ review_owner = "privacy-review"
     assert options["stop-with-status"]["allowed"] is True
 
 
+def test_report_closeout_trust_waiver_clears_assurance_evidence_claim_gate(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write(
+        target / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.privacy_data]
+level = "high"
+applies_to_planning_refs = ["privacy_data"]
+required_evidence = ["authority_consulted"]
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+review_owner = "privacy-review"
+
+[assurance.requirements.privacy_data.waiver]
+reason = "Existing privacy review covers this class of change."
+owner = "privacy-review"
+""",
+    )
+    plan = target / ".agentic-workspace" / "planning" / "execplans" / "assurance-proof.plan.json"
+    _write_json(
+        plan,
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Assurance Proof",
+            "active_milestone": {"id": "assurance-proof", "status": "complete"},
+            "adaptive_assurance": {"level": "high", "requirement_refs": ["privacy_data"]},
+            "delegated_judgment": {
+                "requested outcome": "Record proof while assurance evidence is waived.",
+                "hard constraints": "Do not claim work complete before assurance evidence or waiver is recorded.",
+                "agent may decide locally": "Exact compact closeout wording.",
+                "escalate when": "Assurance evidence and waiver are unavailable.",
+            },
+            "immediate_next_action": ["Close only after assurance evidence or waiver is present."],
+            "completion_criteria": ["Direct proof and assurance evidence or waiver support the claim."],
+            "validation_commands": ["uv run pytest tests/test_direct.py"],
+            "intent_continuity": {
+                "larger intended outcome": "Record assurance-gated proof.",
+                "this slice completes the larger intended outcome": "yes",
+                "continuation surface": "none",
+            },
+            "required_continuation": {
+                "required follow-on for the larger intended outcome": "no",
+                "owner surface": "none",
+                "activation trigger": "none",
+            },
+            "execution_run": {
+                "run status": "complete",
+                "executor": "test",
+                "handoff source": "uv run agentic-workspace preflight --format json",
+                "what happened": "Proof passed and assurance evidence was waived.",
+                "scope touched": "test",
+                "changed surfaces": "test",
+                "validations run": "uv run pytest tests/test_direct.py",
+                "result for continuation": "close",
+                "next step": "close",
+            },
+            "proof_report": {
+                "validation proof": "uv run pytest tests/test_direct.py passed",
+                "acceptance reconciliation": "requested direct proof -> delivered focused direct test -> proof passed",
+                "proof achieved now": "yes",
+                "intent_proof": {
+                    "status": "sufficient_for_claim",
+                    "claim_boundary": "work",
+                    "intended_behavior": ["direct behavior"],
+                    "proof_dimensions": ["focused direct behavior"],
+                    "unproven_after_tests": [],
+                },
+            },
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": "closed",
+                "closure decision": "archive-and-close",
+                "why this decision is honest": "The focused direct proof is sufficient and assurance waiver is recorded.",
+                "evidence carried forward": "report closeout_trust",
+                "reopen trigger": "waiver becomes invalid",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'assurance-proof', title = 'Assurance proof', surface = '.agentic-workspace/planning/execplans/assurance-proof.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+
+    closeout = json.loads(capsys.readouterr().out)["answer"]
+    assert closeout["assurance_requirements"]["evidence_status"][0]["state"] == "waived"
+    options = {option["id"]: option for option in closeout["completion_options"]}
+    assert "assurance_evidence:privacy_data" not in options["claim-work-complete"].get("blocking_fields", [])
+    assert "assurance_evidence:privacy_data" not in options["close-parent-lane"].get("blocking_fields", [])
+
+
 def test_report_closeout_trust_requires_external_negative_invariant_reconciliation(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -104,6 +104,33 @@ def test_report_decision_pressure_shows_unconfigured_repo(tmp_path: Path, capsys
     assert answer["actions"]["scaffold"]["available"] is False
 
 
+def test_report_assurance_requirements_section_projects_configured_requirements(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.privacy_data]
+level = "high"
+applies_to_paths = ["db/migrations/**"]
+authority_refs = ["docs/compliance/privacy.md"]
+required_evidence = ["authority_consulted"]
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+""",
+    )
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "assurance_requirements", "--format", "json"]) == 0
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    assert answer["status"] == "configured"
+    assert answer["configured_count"] == 1
+    assert answer["configured"][0]["id"] == "privacy_data"
+    assert answer["configured"][0]["authority_refs"] == ["docs/compliance/privacy.md"]
+    assert answer["match_evidence"]["match_count"] == 0
+
+
 def test_decision_pressure_scaffolds_configured_decision_record(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
@@ -426,6 +453,8 @@ def test_report_real_init_summarizes_combined_workspace_state(tmp_path: Path, ca
     assert payload["workflow_obligations"]["configured_count"] == 0
     assert payload["workflow_obligations"]["match_evidence"]["match_count"] == 0
     assert payload["workflow_obligations"]["relevant_to_current_work"] == []
+    assert payload["assurance_requirements"]["configured_count"] == 0
+    assert "assurance_requirements" in payload["schema"]["shared_fields"]
     assert "product_managed_enclave" in payload["schema"]["shared_fields"]
     enclave = payload["product_managed_enclave"]
     assert enclave["managed_root"] == ".agentic-workspace/"
@@ -2112,6 +2141,108 @@ def test_report_closeout_trust_allows_work_claim_for_sufficient_intent_proof(tmp
     options = {option["id"]: option for option in closeout["completion_options"]}
     assert options["claim-slice-complete"]["allowed"] is True
     assert options["claim-work-complete"]["allowed"] is True
+
+
+def test_report_closeout_trust_blocks_broad_claim_for_missing_assurance_evidence(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write(
+        target / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.privacy_data]
+level = "high"
+applies_to_planning_refs = ["privacy_data"]
+required_evidence = ["authority_consulted"]
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+review_owner = "privacy-review"
+""",
+    )
+    plan = target / ".agentic-workspace" / "planning" / "execplans" / "assurance-proof.plan.json"
+    _write_json(
+        plan,
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Assurance Proof",
+            "active_milestone": {"id": "assurance-proof", "status": "complete"},
+            "adaptive_assurance": {"level": "high", "requirement_refs": ["privacy_data"]},
+            "delegated_judgment": {
+                "requested outcome": "Record proof while assurance evidence remains missing.",
+                "hard constraints": "Do not claim work complete before assurance evidence is recorded.",
+                "agent may decide locally": "Exact compact closeout wording.",
+                "escalate when": "Assurance evidence is unavailable.",
+            },
+            "immediate_next_action": ["Close only after assurance evidence is present."],
+            "completion_criteria": ["Direct proof and assurance evidence support the claim."],
+            "validation_commands": ["uv run pytest tests/test_direct.py"],
+            "intent_continuity": {
+                "larger intended outcome": "Record assurance-gated proof.",
+                "this slice completes the larger intended outcome": "yes",
+                "continuation surface": "none",
+            },
+            "required_continuation": {
+                "required follow-on for the larger intended outcome": "no",
+                "owner surface": "none",
+                "activation trigger": "none",
+            },
+            "execution_run": {
+                "run status": "complete",
+                "executor": "test",
+                "handoff source": "uv run agentic-workspace preflight --format json",
+                "what happened": "Proof passed but assurance evidence was not recorded.",
+                "scope touched": "test",
+                "changed surfaces": "test",
+                "validations run": "uv run pytest tests/test_direct.py",
+                "result for continuation": "close",
+                "next step": "close",
+            },
+            "proof_report": {
+                "validation proof": "uv run pytest tests/test_direct.py passed",
+                "acceptance reconciliation": "requested direct proof -> delivered focused direct test -> proof passed",
+                "proof achieved now": "yes",
+                "intent_proof": {
+                    "status": "sufficient_for_claim",
+                    "claim_boundary": "work",
+                    "intended_behavior": ["direct behavior"],
+                    "proof_dimensions": ["focused direct behavior"],
+                    "unproven_after_tests": [],
+                },
+            },
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": "closed",
+                "closure decision": "archive-and-close",
+                "why this decision is honest": "The focused direct proof is sufficient but assurance evidence is separate.",
+                "evidence carried forward": "report closeout_trust",
+                "reopen trigger": "assurance evidence remains missing",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'assurance-proof', title = 'Assurance proof', surface = '.agentic-workspace/planning/execplans/assurance-proof.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+
+    closeout = json.loads(capsys.readouterr().out)["answer"]
+    assert closeout["assurance_requirements"]["evidence_status"][0]["state"] == "review-required"
+    options = {option["id"]: option for option in closeout["completion_options"]}
+    assert options["claim-work-complete"]["allowed"] is False
+    assert "assurance_evidence:privacy_data" in options["claim-work-complete"]["blocking_fields"]
+    assert "assurance_evidence:privacy_data" in options["close-parent-lane"]["blocking_fields"]
+    assert options["request-review"]["allowed"] is True
+    assert options["stop-with-status"]["allowed"] is True
 
 
 def test_report_closeout_trust_requires_external_negative_invariant_reconciliation(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -372,6 +372,49 @@ def test_preflight_matches_planless_workflow_obligations_from_task_text(tmp_path
     assert payload["closeout_obligations"]["status"] == "present"
 
 
+def test_start_surfaces_active_assurance_requirement_from_task_marker(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    _write(
+        target / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.privacy_data]
+level = "high"
+applies_to_task_markers = ["privacy"]
+authority_refs = ["docs/compliance/privacy.md"]
+required_evidence = ["authority_consulted"]
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(target),
+                "--task",
+                "Update privacy policy handling",
+                "--select",
+                "assurance_requirements",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    requirements = payload["values"]["assurance_requirements"]
+    assert requirements["status"] == "attention"
+    assert requirements["active"][0]["id"] == "privacy_data"
+    assert requirements["active"][0]["applies_because"] == ["task marker matched privacy"]
+
+
 def test_preflight_active_only_includes_active_todo_without_execplan(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()


### PR DESCRIPTION
## Summary

Implements the remainder of the #1130 assurance lane on top of the #1131 investigation. This adds repo-defined assurance requirements as config-backed, inspectable, matchable, proof-affecting, and closeout-gating facts without introducing a separate evidence store.

Changes include:
- `[assurance.requirements.<id>]` parsing, validation, waiver/dismissal metadata, schemas, and config/report projection.
- Active assurance requirement projection into `start`, `implement`, `report`, proof selection, and closeout trust.
- Missing-evidence claim gates for configured blocking claims while preserving honest review/status completion routes.
- Proof profile integration for matched requirements and high-assurance/non-code fixture coverage.
- Planning decomposition updates plus archived implementation closeout.

## Issues

Closes #1130
Closes #1131
Closes #1132
Closes #1133
Closes #1134
Closes #1135
Closes #1136

## Validation

- `uv run pytest tests/test_workspace_config_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_start_preflight_cli.py tests/test_workspace_proof_cli.py tests/test_workspace_report_cli.py -q`
- `uv run ruff check src/agentic_workspace/config.py src/agentic_workspace/workspace_runtime_primitives.py src/agentic_workspace/reporting_support.py tests/test_workspace_config_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_proof_cli.py tests/test_workspace_report_cli.py tests/test_workspace_start_preflight_cli.py`
- `make test-workspace`
- `make lint-workspace`
- `make schema-reference-docs`
- `uv run agentic-workspace doctor --target . --modules planning --format json`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/check/check_planning_surfaces.py`