### PR TITLE
Fix stale planning candidate reconcile command

### DIFF
--- a/.agentic-workspace/planning/state.toml
+++ b/.agentic-workspace/planning/state.toml
@@ -18,5 +18,4 @@ queued_items = []
 [roadmap]
 lanes = []
 candidates = [
-  { id = "github-892-codegen-epic-implementation-independent-generate", maturity = "candidate", status = "next", priority = "P3", refs = "GitHub #892", title = "[Codegen Epic]: Implementation-independent generated command packages", outcome = "Coordinate the remaining codegen epic through bounded TypeScript-resource and extraction-readiness slices.", reason = "Parent issue remains the source of tier sequencing and completion rules, but should not outrank concrete child work.", promotion_signal = "Promote only as an umbrella lane when multiple child slices need parent-level coordination.", suggested_first_slice = "Promote #929 as the next concrete continuation; keep #892 open until TypeScript resource parity and extraction-readiness residue are explicitly routed or closed." },
 ]

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -9911,7 +9911,7 @@ def _stale_planning_candidate_reconciliation(
                 "id": str(candidate.get("id", "")),
                 "refs": sorted(refs),
                 "title": str(candidate.get("title", "")),
-                "reconcile_command": f"uv run agentic-workspace planning close-item --target . --item {candidate.get('id', '')} --issue '{', '.join(sorted(refs))}' --format json",
+                "reconcile_command": "uv run agentic-workspace external-intent refresh-github --target . --state closed --storage cache --apply-planning-candidates --format json",
             }
         )
     if not stale:

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -450,6 +450,31 @@ candidates = [
 
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
 
+    dry_run_exit_code = cli.main(
+        [
+            "external-intent",
+            "refresh-github",
+            "--target",
+            str(tmp_path),
+            "--state",
+            "all",
+            "--storage",
+            "cache",
+            "--dry-run",
+            "--format",
+            "json",
+        ]
+    )
+    dry_run_payload = json.loads(capsys.readouterr().out)
+
+    assert dry_run_exit_code == 0
+    stale_candidate = dry_run_payload["stale_planning_candidate_reconciliation"]["stale_candidates"][0]
+    assert stale_candidate["id"] == "github-10-stale"
+    assert stale_candidate["reconcile_command"] == (
+        "uv run agentic-workspace external-intent refresh-github --target . --state closed --storage cache "
+        "--apply-planning-candidates --format json"
+    )
+
     exit_code = cli.main(
         [
             "external-intent",


### PR DESCRIPTION
## Summary
- Replace the stale Planning candidate reconciliation hint with the executable `external-intent refresh-github --state closed --apply-planning-candidates` command.
- Add a dry-run regression that verifies the stale-candidate reconcile command without erasing the open-to-closed external-intent delta under test.
- Apply the command-owned cleanup that removes the stale #892 roadmap candidate from Planning state.

## Root Cause
The old reconcile hint suggested `planning close-item` for a `status = next` roadmap candidate, but that command refuses next candidates. The repair path now reuses the existing external-intent reconciliation flow that can safely apply closed GitHub issue state to Planning candidates.

## Validation
- `uv run pytest tests/test_workspace_summary_cli.py::test_external_intent_refresh_applies_stale_candidate_reconciliation_and_preserves_delta -q`
- `uv run agentic-workspace summary --target . --format json`
- `uv run agentic-workspace doctor --target . --modules planning --format json`
- `make test-workspace`
- `make lint-workspace`
- `git diff --check`

Closes #1138