### PR TITLE
Add small-work proportionality guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Sync workspace dependencies
         run: make sync-all
@@ -44,15 +44,15 @@ jobs:
         python-version: ["3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Sync package-scoped dependencies (memory)
         if: matrix.package == 'memory'

--- a/docs/maintainer/model-cli-dogfooding-harness.md
+++ b/docs/maintainer/model-cli-dogfooding-harness.md
@@ -193,6 +193,7 @@ Treat one-off capability failures cautiously. Give more weight to repeated ambig
 - Dry-run is the default.
 - Scenario repository mutations should happen only in copied fixtures under `.agentic-workspace/local/scratch/`.
 - Provider CLIs may still maintain their own local state outside the fixture. For Copilot, the harness routes logs to the run directory, but authenticated session/config state may still use `COPILOT_HOME` unless the operator provides an isolated authenticated home.
+- The Copilot adapter passes both `-C {repo}` and `--add-dir {repo}` so Copilot roots its session in the copied fixture before invoking edit or PowerShell tools. It also sets `COPILOT_ALLOW_ALL=true` and passes Copilot's explicit `--allow-tool=write` grant because `--allow-all` alone has not reliably unlocked edits in non-interactive harness runs.
 - The Copilot adapter denies `git push`.
 - The Copilot adapter requires `pwsh` before execution because its shell tool uses PowerShell 7 on Windows. The suite includes standard PowerShell install paths and prepends the discovered parent directory to the model CLI `PATH`.
 - The Gemini adapter runs `gemini --prompt` in headless mode and records JSON output. It uses `--approval-mode yolo` only when the operator explicitly passes `--execute`; dry-run remains the default.

--- a/docs/maintainer/model-cli-dogfooding-harness.md
+++ b/docs/maintainer/model-cli-dogfooding-harness.md
@@ -105,6 +105,8 @@ The current suite evaluates these semi-realistic workflow pressure points. The p
 - `local-delegation-posture`: whether agents distinguish checked-in repo policy from local-only delegation controls and avoid auto-delegation when local safety disables it.
 - `config-output-posture`: whether agents use config to shape reporting style without turning output posture into execution-method authority.
 
+`direct-task-minimal-overhead`, `next-decision-output-profile`, and `config-closeout-obligation` are proportionality guardrails for small bounded work. Their `run.json` entries include `proportionality_metrics` for command count, package output size, changed-file count, Planning/Memory residue, raw workspace reads, verbose/full diagnostics, requests to completion, and final-answer length. The harness emits proportionality warning classes for over-planning, over-reading, over-proofing, Memory ceremony, and closeout ceremony. Treat those warnings as review signals: compact AW routing is allowed when it prevents wrong action, but tiny work should not become a broad diagnostic or Planning exercise.
+
 Use these as optimisation probes rather than regular regression tests. A good run matrix samples a few scenarios across weaker, cheaper, and stronger agents, then turns repeated weak points into package changes, clearer CLI output, docs, fixtures, or new scorer warnings. Do not expect a single deterministic pass/fail result to settle a workflow question.
 
 ## Adaptive Optimisation Loop
@@ -127,7 +129,7 @@ uv run python scripts/model_cli_harness/run_model_cli_harness.py `
   --format json
 ```
 
-The comparison report lists resolved, retained, and new warnings, mutation deltas, a compact product interpretation, and the recommended next action. Treat it as a review aid, not a benchmark verdict.
+The comparison report lists resolved, retained, and new warnings, mutation deltas, proportionality metric deltas, a compact product interpretation, and the recommended next action. Treat it as a review aid, not a benchmark verdict.
 
 Executed run results include two different cost signals:
 

--- a/docs/maintainer/model-cli-dogfooding-harness.md
+++ b/docs/maintainer/model-cli-dogfooding-harness.md
@@ -31,7 +31,7 @@ uv run python scripts/model_cli_harness/run_model_cli_harness.py `
   --scenario startup-orientation
 ```
 
-The runner defaults to dry-run. It copies the scenario fixture into `scratch/model-cli-harness`, renders the prompt, writes `run.json`, and prints the exact CLI command it would execute. Add `--execute` only when you intentionally want to spend model calls and allow the configured CLI to operate in the copied fixture.
+The runner defaults to dry-run. It copies the scenario fixture into the configured local scratch root under `.agentic-workspace/local/scratch/model-cli-harness`, renders the prompt, writes `run.json`, and prints the exact CLI command it would execute. Add `--execute` only when you intentionally want to spend model calls and allow the configured CLI to operate in the copied fixture.
 
 Scenarios may define `prompt_variants` for non-deterministic probing. By default the runner uses the first/default prompt. Use `--prompt-variant all` to run every variant, or `--prompt-variant <id>` for a single one:
 
@@ -124,8 +124,8 @@ Use comparison mode after product or harness changes to check whether a targeted
 
 ```powershell
 uv run python scripts/model_cli_harness/run_model_cli_harness.py `
-  --compare-baseline scratch/model-cli-harness/baseline/run.json `
-  --compare-current scratch/model-cli-harness/current/run.json `
+  --compare-baseline .agentic-workspace/local/scratch/model-cli-harness/baseline/run.json `
+  --compare-current .agentic-workspace/local/scratch/model-cli-harness/current/run.json `
   --format json
 ```
 
@@ -191,7 +191,7 @@ Treat one-off capability failures cautiously. Give more weight to repeated ambig
 ## Safety Defaults
 
 - Dry-run is the default.
-- Scenario repository mutations should happen only in copied fixtures under `scratch/`.
+- Scenario repository mutations should happen only in copied fixtures under `.agentic-workspace/local/scratch/`.
 - Provider CLIs may still maintain their own local state outside the fixture. For Copilot, the harness routes logs to the run directory, but authenticated session/config state may still use `COPILOT_HOME` unless the operator provides an isolated authenticated home.
 - The Copilot adapter denies `git push`.
 - The Copilot adapter requires `pwsh` before execution because its shell tool uses PowerShell 7 on Windows. The suite includes standard PowerShell install paths and prepends the discovered parent directory to the model CLI `PATH`.

--- a/scripts/model_cli_harness/run_model_cli_harness.py
+++ b/scripts/model_cli_harness/run_model_cli_harness.py
@@ -617,6 +617,204 @@ def _aggregate_package_read_surface_summaries(results: list[dict[str, Any]]) -> 
     }
 
 
+PROPORTIONALITY_GUARDRAIL_SCENARIOS = {
+    "direct-task-minimal-overhead",
+    "next-decision-output-profile",
+    "config-closeout-obligation",
+}
+
+
+def _is_proportionality_guardrail_scenario(scenario: dict[str, Any]) -> bool:
+    return bool(scenario.get("proportionality_guardrail")) or str(scenario.get("id", "")) in PROPORTIONALITY_GUARDRAIL_SCENARIOS
+
+
+def _command_contains_any(command_text: str, markers: list[str]) -> bool:
+    normalized = _normalized_command_text(command_text)
+    return any(_normalized_command_text(marker) in normalized for marker in markers)
+
+
+def _proportionality_metrics(
+    *,
+    scenario: dict[str, Any],
+    result: dict[str, Any],
+    mutation_summary: dict[str, Any] | None,
+    package_read_surface_summary: dict[str, Any] | None,
+    completion_loop: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not _is_proportionality_guardrail_scenario(scenario):
+        return {"kind": "agentic-workspace/model-cli-proportionality-metrics/v1", "status": "not-applicable"}
+    changed_paths = _changed_paths(mutation_summary)
+    created = [path.replace("\\", "/") for path in (mutation_summary or {}).get("created", []) if isinstance(path, str)]
+    executed_command_text = _normalized_command_text(_executed_command_text(result))
+    scored_response_text = _scored_agent_response_text(result)
+    mentioned_paths = sorted(dict.fromkeys([*_mentioned_workspace_paths(scored_response_text), *_mentioned_workspace_paths(executed_command_text)]))
+    scored_text = _normalized_command_text(scored_response_text)
+    combined_agent_text = f"{executed_command_text}\n{scored_text}"
+    workspace_mentions = [path for path in mentioned_paths if path.startswith(".agentic-workspace/")]
+    memory_mentions = [path for path in workspace_mentions if path.startswith(".agentic-workspace/memory/")]
+    planning_created = [path for path in created if path.startswith(".agentic-workspace/planning/")]
+    memory_created = [path for path in created if path.startswith(".agentic-workspace/memory/")]
+    diagnostic_markers = (
+        "--verbose",
+        "agentic-workspace report",
+        "agentic-workspace doctor",
+        "agentic-workspace preflight",
+        "agentic-workspace summary --verbose",
+        "agentic-workspace implement --verbose",
+        "agentic-workspace proof --verbose",
+    )
+    broad_diagnostic_markers = (
+        "agentic-workspace report",
+        "agentic-workspace doctor",
+        "agentic-workspace preflight",
+        "agentic-workspace summary",
+    )
+    raw_workspace_read_patterns = (
+        r"\b(get-content|cat|type|read_file|open)\b[^\n;|&]*\.agentic-workspace/",
+        r"\.agentic-workspace/[^\s`'\"),;]+[^\n.]*\b(read|opened|inspected)\b",
+    )
+    raw_workspace_read_count = sum(
+        1 for pattern in raw_workspace_read_patterns for _match in re.finditer(pattern, combined_agent_text, flags=re.IGNORECASE)
+    )
+    package_summary = package_read_surface_summary if isinstance(package_read_surface_summary, dict) else {}
+    return {
+        "kind": "agentic-workspace/model-cli-proportionality-metrics/v1",
+        "status": "present",
+        "scenario_id": str(scenario.get("id", "")),
+        "package_command_count": int(package_summary.get("command_count", 0) or 0),
+        "package_output_bytes": int(package_summary.get("output_bytes", 0) or 0),
+        "package_output_lines": int(package_summary.get("output_lines", 0) or 0),
+        "workspace_command_count": int(package_summary.get("command_count", 0) or 0),
+        "raw_workspace_file_mentions": len(workspace_mentions),
+        "raw_workspace_read_count": raw_workspace_read_count,
+        "files_read_or_mentioned_count": len(mentioned_paths),
+        "files_read_or_mentioned": mentioned_paths[:20],
+        "changed_files_count": len(changed_paths),
+        "planning_files_created": len(planning_created),
+        "memory_files_created": len(memory_created),
+        "memory_files_read_or_mentioned": len(memory_mentions),
+        "verbose_or_full_diagnostic_count": sum(combined_agent_text.count(marker) for marker in diagnostic_markers),
+        "broad_workspace_diagnostic_count": sum(combined_agent_text.count(marker) for marker in broad_diagnostic_markers),
+        "requests_to_completion": int((completion_loop or {}).get("requests_to_completion", 0) or 0),
+        "final_answer_length": len(_scored_agent_response_text(result)),
+    }
+
+
+def _proportionality_warnings(
+    *,
+    scenario: dict[str, Any],
+    result: dict[str, Any],
+    metrics: dict[str, Any],
+) -> list[dict[str, str]]:
+    if metrics.get("status") != "present":
+        return []
+    limits = scenario.get("proportionality_limits", {})
+    if not isinstance(limits, dict):
+        limits = {}
+    warnings: list[dict[str, str]] = []
+
+    def add(warning_class: str, message: str, *, evidence: str = "", mistake_class: str = "") -> None:
+        warning: dict[str, str] = {"warning_class": warning_class, "message": message}
+        if evidence:
+            warning["evidence"] = evidence
+        if mistake_class:
+            warning["mistake_class"] = mistake_class
+        warnings.append(warning)
+
+    if metrics["planning_files_created"]:
+        add(
+            "model_cli_proportionality_over_planning",
+            "Tiny bounded work created Planning residue without scenario justification.",
+            evidence=f"planning_files_created={metrics['planning_files_created']}",
+            mistake_class="over_planning",
+        )
+    if metrics["memory_files_created"] or metrics["memory_files_read_or_mentioned"]:
+        add(
+            "model_cli_proportionality_memory_ceremony",
+            "Tiny bounded work used Memory despite no durable anti-rediscovery need in the scenario.",
+            evidence=(
+                f"memory_files_created={metrics['memory_files_created']}; "
+                f"memory_files_read_or_mentioned={metrics['memory_files_read_or_mentioned']}"
+            ),
+            mistake_class="memory_ceremony",
+        )
+    max_workspace_commands = limits.get("workspace_command_count")
+    if isinstance(max_workspace_commands, int) and metrics["workspace_command_count"] > max_workspace_commands:
+        add(
+            "model_cli_proportionality_over_reading",
+            "Tiny bounded work used more Agentic Workspace commands than the scenario budget allows.",
+            evidence=f"workspace_command_count={metrics['workspace_command_count']}; limit={max_workspace_commands}",
+            mistake_class="over_reading",
+        )
+    max_verbose = limits.get("verbose_or_full_diagnostic_count", 0)
+    if isinstance(max_verbose, int) and metrics["verbose_or_full_diagnostic_count"] > max_verbose:
+        add(
+            "model_cli_proportionality_over_reading",
+            "Tiny bounded work used verbose or full diagnostics where compact output should suffice.",
+            evidence=f"verbose_or_full_diagnostic_count={metrics['verbose_or_full_diagnostic_count']}; limit={max_verbose}",
+            mistake_class="verbose_diagnostics_for_tiny_task",
+        )
+    if metrics["raw_workspace_read_count"]:
+        add(
+            "model_cli_proportionality_over_reading",
+            "Tiny bounded work appears to read raw `.agentic-workspace` files instead of compact command surfaces.",
+            evidence=f"raw_workspace_read_count={metrics['raw_workspace_read_count']}",
+            mistake_class="raw_workspace_spelunking",
+        )
+    avoid_broad_proof = scenario.get("proportionality_avoid_broad_proof_commands", [])
+    if isinstance(avoid_broad_proof, list) and all(isinstance(item, str) for item in avoid_broad_proof):
+        command_text = _executed_command_text(result)
+        broad_proof = [marker for marker in avoid_broad_proof if _command_contains_any(command_text, [marker])]
+        if broad_proof:
+            add(
+                "model_cli_proportionality_over_proofing",
+                "Tiny bounded work used broad proof where the scenario expects narrow local proof.",
+                evidence=", ".join(broad_proof[:8]),
+                mistake_class="over_proofing",
+            )
+    max_final = limits.get("final_answer_length")
+    if isinstance(max_final, int) and metrics["final_answer_length"] > max_final:
+        add(
+            "model_cli_proportionality_closeout_ceremony",
+            "Tiny bounded work produced a longer closeout than the scenario budget allows.",
+            evidence=f"final_answer_length={metrics['final_answer_length']}; limit={max_final}",
+            mistake_class="closeout_ceremony",
+        )
+    return warnings
+
+
+def _aggregate_proportionality_metrics(results: list[dict[str, Any]]) -> dict[str, Any]:
+    present = [
+        result.get("proportionality_metrics")
+        for result in results
+        if isinstance(result.get("proportionality_metrics"), dict) and result["proportionality_metrics"].get("status") == "present"
+    ]
+    numeric_fields = (
+        "package_command_count",
+        "package_output_bytes",
+        "package_output_lines",
+        "workspace_command_count",
+        "raw_workspace_file_mentions",
+        "raw_workspace_read_count",
+        "changed_files_count",
+        "planning_files_created",
+        "memory_files_created",
+        "memory_files_read_or_mentioned",
+        "verbose_or_full_diagnostic_count",
+        "broad_workspace_diagnostic_count",
+        "requests_to_completion",
+        "final_answer_length",
+    )
+    totals = {field: sum(int(metrics.get(field, 0) or 0) for metrics in present) for field in numeric_fields}
+    return {
+        "kind": "agentic-workspace/model-cli-proportionality-summary/v1",
+        "status": "present" if present else "absent",
+        "result_count": len(present),
+        "scenario_ids": sorted({str(metrics.get("scenario_id", "")) for metrics in present if metrics.get("scenario_id")}),
+        "totals": totals,
+    }
+
+
 def _aggregate_usage_summaries(results: list[dict[str, Any]]) -> dict[str, Any]:
     totals = {
         "input_tokens": 0,
@@ -2177,6 +2375,16 @@ def compare_results(*, baseline_path: Path, current_path: Path) -> dict[str, Any
         "baseline_changed_results": sum(1 for result in baseline_results if result.get("mutation_summary", {}).get("status") == "changed"),
         "current_changed_results": sum(1 for result in current_results if result.get("mutation_summary", {}).get("status") == "changed"),
     }
+    baseline_proportionality = _aggregate_proportionality_metrics(baseline_results)
+    current_proportionality = _aggregate_proportionality_metrics(current_results)
+    proportionality_delta = {
+        key: int(current_proportionality.get("totals", {}).get(key, 0) or 0)
+        - int(baseline_proportionality.get("totals", {}).get(key, 0) or 0)
+        for key in sorted(
+            set(baseline_proportionality.get("totals", {}))
+            | set(current_proportionality.get("totals", {}))
+        )
+    }
     if introduced:
         interpretation = "regressed"
     elif resolved:
@@ -2195,6 +2403,9 @@ def compare_results(*, baseline_path: Path, current_path: Path) -> dict[str, Any
         "new_warnings": [current_warnings[key] for key in introduced],
         "retained_warnings": [current_warnings[key] for key in retained],
         "mutation_delta": mutation_delta,
+        "baseline_proportionality_summary": baseline_proportionality,
+        "current_proportionality_summary": current_proportionality,
+        "proportionality_delta": proportionality_delta,
         "product_interpretation": interpretation,
         "recommended_action": (
             "Promote the fix if resolved warnings match the intended product change."
@@ -2388,6 +2599,7 @@ def run_suite(
                 ]
                 invocation["usage_summary"] = {"status": "not-run"}
                 invocation["package_read_surface_summary"] = {"status": "not-run"}
+                invocation["proportionality_metrics"] = {"status": "not-run"}
             elif execute:
                 result = _run_command(command, cwd=paths.repo_path, timeout_seconds=effective_timeout, env=adapter_env)
                 if paths.share_path.exists():
@@ -2416,6 +2628,19 @@ def run_suite(
                         result=result,
                         mutation_summary=mutation_summary,
                         repo_path=paths.repo_path,
+                    )
+                )
+                invocation["proportionality_metrics"] = _proportionality_metrics(
+                    scenario=scenario,
+                    result=result,
+                    mutation_summary=mutation_summary,
+                    package_read_surface_summary=invocation["package_read_surface_summary"],
+                )
+                invocation["warnings"].extend(
+                    _proportionality_warnings(
+                        scenario=scenario,
+                        result=result,
+                        metrics=invocation["proportionality_metrics"],
                     )
                 )
                 if postmortem_feedback:
@@ -2539,6 +2764,13 @@ def run_suite(
                         *followup_turns,
                     ]
                 )
+                invocation["proportionality_metrics"] = _proportionality_metrics(
+                    scenario=scenario,
+                    result=result,
+                    mutation_summary=mutation_summary,
+                    package_read_surface_summary=invocation["package_read_surface_summary"],
+                    completion_loop=invocation["completion_loop"],
+                )
             else:
                 invocation["result"] = {
                     "status": "dry-run",
@@ -2547,6 +2779,7 @@ def run_suite(
                 invocation["mutation_summary"] = {"status": "not-run"}
                 invocation["usage_summary"] = {"status": "not-run"}
                 invocation["package_read_surface_summary"] = {"status": "not-run"}
+                invocation["proportionality_metrics"] = {"status": "not-run"}
                 invocation["warnings"] = []
                 invocation["completion_loop"] = _completion_loop_summary(
                     execute=False,
@@ -2579,6 +2812,7 @@ def run_suite(
     }
     payload["usage_summary"] = _aggregate_usage_summaries(run_results)
     payload["package_read_surface_summary"] = _aggregate_package_read_surface_summaries(run_results)
+    payload["proportionality_summary"] = _aggregate_proportionality_metrics(run_results)
     payload["finding_classification"] = _classify_suite_findings(run_results)
     payload["capability_routing_evaluation"] = _aggregate_capability_routing_evaluations(run_results)
     completion_loops = [result.get("completion_loop") for result in run_results if isinstance(result.get("completion_loop"), dict)]

--- a/scripts/model_cli_harness/run_model_cli_harness.py
+++ b/scripts/model_cli_harness/run_model_cli_harness.py
@@ -18,9 +18,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Iterable
 
+from agentic_workspace.config import WORKSPACE_LOCAL_SCRATCH_ROOT_PATH
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SUITE = REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json"
-DEFAULT_OUTPUT_ROOT = REPO_ROOT / "scratch" / "model-cli-harness"
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / WORKSPACE_LOCAL_SCRATCH_ROOT_PATH / "model-cli-harness"
 EPHEMERAL_MUTATION_PATHS = (
     ".git/",
     ".pytest_cache/",

--- a/scripts/model_cli_harness/run_model_cli_harness.py
+++ b/scripts/model_cli_harness/run_model_cli_harness.py
@@ -1251,6 +1251,7 @@ def _executed_command_text(result: dict[str, Any]) -> str:
         if not isinstance(source, str):
             continue
         command_fragments.extend(_copilot_markdown_shell_commands(source))
+        command_fragments.extend(_copilot_plain_shell_commands(source))
         for event in _json_objects_from_lines(source):
                 command = event.get("command")
                 if isinstance(command, str):
@@ -1275,6 +1276,32 @@ def _executed_command_text(result: dict[str, Any]) -> str:
                         if "run_shell_command" in by_name and isinstance(response, str):
                             command_fragments.append(response)
     return "\n".join(command_fragments)
+
+
+def _copilot_plain_shell_commands(text: str) -> list[str]:
+    commands: list[str] = []
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not re.match(r"^[●✗]\s+.*\((?:shell|powershell|bash|cmd)\)\s*$", line):
+            index += 1
+            continue
+        index += 1
+        command_parts: list[str] = []
+        while index < len(lines):
+            body_line = lines[index]
+            if re.match(r"^[●✗]\s+", body_line) or re.match(r"^\s*└", body_line):
+                break
+            command_match = re.match(r"^\s*│\s?(?P<part>.*)$", body_line)
+            if command_match:
+                part = command_match.group("part").strip()
+                if part:
+                    command_parts.append(part)
+            index += 1
+        if command_parts:
+            commands.append(" ".join(command_parts))
+    return commands
 
 
 def _copilot_markdown_shell_commands(text: str) -> list[str]:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -6546,7 +6546,8 @@ def _final_report_budget_payload() -> dict[str, Any]:
 
 
 def _successful_completion_cost_payload(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
-    summary_dir = target_root / "scratch" / "model-cli-harness"
+    summary_dir_relative = WORKSPACE_LOCAL_SCRATCH_ROOT_PATH / "model-cli-harness"
+    summary_dir = target_root / summary_dir_relative
     summary_files = sorted(
         summary_dir.glob("*summary.json") if summary_dir.exists() else [], key=lambda path: (path.stat().st_mtime, path.name), reverse=True
     )
@@ -6601,7 +6602,7 @@ def _successful_completion_cost_payload(*, target_root: Path, cli_invoke: str) -
         "advisory_only": True,
         "rule": "Use this as maintainer evidence for surface-cost tradeoffs. It is not a formal benchmark, CI gate, or model leaderboard.",
         "evidence": {
-            "summary_dir": "scratch/model-cli-harness",
+            "summary_dir": summary_dir_relative.as_posix(),
             "summary_count": evidence_count,
             "skipped_summary_count": skipped_count,
             "included_recent_limit": 8,

--- a/tests/test_model_cli_harness.py
+++ b/tests/test_model_cli_harness.py
@@ -1752,6 +1752,131 @@ def test_model_cli_harness_quality_signals_flag_read_surface_over_read() -> None
     assert any(signal["id"] == "read_surface_over_read" and signal["status"] == "weak" for signal in signals)
 
 
+def test_model_cli_harness_reports_small_work_proportionality_metrics() -> None:
+    harness = _load_harness()
+    stdout = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "command_execution",
+                        "command": "uv run agentic-workspace implement --changed README.md --format json",
+                        "aggregated_output": '{"kind":"implementer-context-tiny/v1"}\n',
+                        "exit_code": 0,
+                        "status": "completed",
+                    },
+                }
+            )
+        ]
+    )
+    result = {"stdout": stdout, "final_message": "Changed README.md and inspected the diff."}
+    package_summary = harness._package_read_surface_summary_from_stdout(stdout)
+
+    metrics = harness._proportionality_metrics(
+        scenario={"id": "direct-task-minimal-overhead", "proportionality_guardrail": True},
+        result=result,
+        mutation_summary={"status": "changed", "modified": ["README.md"]},
+        package_read_surface_summary=package_summary,
+        completion_loop={"requests_to_completion": 1},
+    )
+
+    assert metrics["status"] == "present"
+    assert metrics["package_command_count"] == 1
+    assert metrics["workspace_command_count"] == 1
+    assert metrics["changed_files_count"] == 1
+    assert metrics["planning_files_created"] == 0
+    assert metrics["requests_to_completion"] == 1
+
+
+def test_model_cli_harness_warns_on_small_work_ceremony() -> None:
+    harness = _load_harness()
+    long_closeout = "Done. " * 80
+    result = {
+        "stdout": "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "command_execution",
+                            "command": "uv run agentic-workspace summary --verbose",
+                            "aggregated_output": "{}\n",
+                            "exit_code": 0,
+                            "status": "completed",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "command_execution",
+                            "command": "Get-Content .agentic-workspace/memory/repo/index.md",
+                            "aggregated_output": "# memory\n",
+                            "exit_code": 0,
+                            "status": "completed",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "command_execution",
+                            "command": "pytest",
+                            "aggregated_output": "1 passed\n",
+                            "exit_code": 0,
+                            "status": "completed",
+                        },
+                    }
+                ),
+            ]
+        ),
+        "final_message": f"I read .agentic-workspace/memory/repo/index.md. {long_closeout}",
+    }
+    scenario = {
+        "id": "direct-task-minimal-overhead",
+        "proportionality_guardrail": True,
+        "proportionality_limits": {
+            "workspace_command_count": 1,
+            "verbose_or_full_diagnostic_count": 0,
+            "final_answer_length": 40,
+        },
+        "proportionality_avoid_broad_proof_commands": ["pytest"],
+    }
+    metrics = harness._proportionality_metrics(
+        scenario=scenario,
+        result=result,
+        mutation_summary={
+            "status": "changed",
+            "created": [
+                ".agentic-workspace/planning/execplans/readme.plan.json",
+                ".agentic-workspace/memory/repo/readme.md",
+            ],
+            "modified": ["README.md"],
+        },
+        package_read_surface_summary=harness._package_read_surface_summary_from_stdout(result["stdout"]),
+    )
+    warnings = harness._proportionality_warnings(scenario=scenario, result=result, metrics=metrics)
+    classes = {warning["warning_class"] for warning in warnings}
+    mistakes = {warning["mistake_class"] for warning in warnings}
+
+    assert "model_cli_proportionality_over_planning" in classes
+    assert "model_cli_proportionality_memory_ceremony" in classes
+    assert "model_cli_proportionality_over_reading" in classes
+    assert "model_cli_proportionality_over_proofing" in classes
+    assert "model_cli_proportionality_closeout_ceremony" in classes
+    assert {
+        "over_planning",
+        "memory_ceremony",
+        "verbose_diagnostics_for_tiny_task",
+        "raw_workspace_spelunking",
+        "over_proofing",
+        "closeout_ceremony",
+    }.issubset(mistakes)
+
+
 def test_model_cli_harness_postmortem_prompt_keeps_feedback_compact_and_actionable() -> None:
     harness = _load_harness()
 
@@ -2777,6 +2902,11 @@ def test_model_cli_harness_compares_before_after_runs(tmp_path: Path) -> None:
                             {"warning_class": "model_cli_semantic_workflow_failure", "message": "still here"},
                         ],
                         "mutation_summary": {"status": "changed"},
+                        "proportionality_metrics": {
+                            "status": "present",
+                            "workspace_command_count": 1,
+                            "package_output_bytes": 100,
+                        },
                     }
                 ]
             }
@@ -2793,6 +2923,11 @@ def test_model_cli_harness_compares_before_after_runs(tmp_path: Path) -> None:
                             {"warning_class": "model_cli_metadata_scoring_failure", "message": "new problem"},
                         ],
                         "mutation_summary": {"status": "clean"},
+                        "proportionality_metrics": {
+                            "status": "present",
+                            "workspace_command_count": 3,
+                            "package_output_bytes": 260,
+                        },
                     }
                 ]
             }
@@ -2806,3 +2941,5 @@ def test_model_cli_harness_compares_before_after_runs(tmp_path: Path) -> None:
     assert [warning["message"] for warning in comparison["resolved_warnings"]] == ["old problem"]
     assert [warning["message"] for warning in comparison["new_warnings"]] == ["new problem"]
     assert comparison["mutation_delta"] == {"baseline_changed_results": 1, "current_changed_results": 0}
+    assert comparison["proportionality_delta"]["workspace_command_count"] == 2
+    assert comparison["proportionality_delta"]["package_output_bytes"] == 160

--- a/tests/test_model_cli_harness.py
+++ b/tests/test_model_cli_harness.py
@@ -505,6 +505,7 @@ def test_copilot_postmortem_feedback_is_marked_unsupported() -> None:
 
     adapter = suite["adapters"]["copilot"]
     command = adapter["postmortem_command"]
+    assert adapter["env"] == {"COPILOT_ALLOW_ALL": "true"}
     assert adapter["postmortem_feedback_supported"] is False
     assert "--available-tools=" in command
     assert "--no-custom-instructions" in command
@@ -707,6 +708,33 @@ def test_model_cli_harness_suite_renders_codex_adapter(tmp_path: Path) -> None:
     assert result["repo_path"] in result["command"]
     assert "--json" in result["command"]
     assert "Repository startup instruction from AGENTS.md" in result["prompt"]
+
+
+def test_model_cli_harness_suite_renders_copilot_adapter_with_explicit_cwd(tmp_path: Path) -> None:
+    harness = _load_harness()
+
+    payload = harness.run_suite(
+        suite_path=REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json",
+        adapter_id="copilot",
+        model=None,
+        scenario_filter="startup-orientation",
+        execute=False,
+        output_root=tmp_path / "out",
+        timeout_seconds=None,
+    )
+
+    result = payload["results"][0]
+    command = result["command"]
+    cwd_index = command.index("-C")
+    assert payload["adapter"] == "copilot"
+    assert payload["model"] == "claude-haiku-4.5"
+    assert result["result"]["status"] == "dry-run"
+    assert command[0:3] == ["copilot", "--model", "claude-haiku-4.5"]
+    assert command[cwd_index + 1] == result["repo_path"]
+    assert "--allow-all" in command
+    assert "--allow-tool=write" in command
+    assert "--add-dir" in command
+    assert result["repo_path"] in command
 
 
 def test_model_cli_harness_resolves_path_shims(tmp_path: Path, monkeypatch) -> None:
@@ -1542,6 +1570,32 @@ def test_model_cli_harness_counts_copilot_powershell_markdown_as_executed_comman
 ```
 """,
             "stdout": "",
+            "stderr": "",
+        },
+        mutation_summary={"status": "clean"},
+        repo_path=repo,
+    )
+
+    assert warnings == []
+
+
+def test_model_cli_harness_counts_copilot_plain_shell_block_as_executed_command(tmp_path: Path) -> None:
+    harness = _load_harness()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    warnings = harness._metadata_workflow_warnings(
+        scenario={
+            "id": "next-decision-output-profile",
+            "required_executed_commands": ["uv run agentic-workspace implement --changed"],
+        },
+        result={
+            "stdout": """
+● Get implementation guidance for README.md changes (shell)
+  │ uv run agentic-workspace implement --changed README.md --task "make a narrow
+  │ README.md edit" --format json
+  └ 411 lines...
+""",
             "stderr": "",
         },
         mutation_summary={"status": "clean"},

--- a/tests/test_model_cli_harness.py
+++ b/tests/test_model_cli_harness.py
@@ -53,6 +53,12 @@ def test_model_cli_harness_extracts_token_usage_summary() -> None:
     }
 
 
+def test_model_cli_harness_default_output_root_uses_workspace_local_scratch() -> None:
+    harness = _load_harness()
+
+    assert harness.DEFAULT_OUTPUT_ROOT == REPO_ROOT / ".agentic-workspace" / "local" / "scratch" / "model-cli-harness"
+
+
 def test_model_cli_harness_tolerates_gemini_string_events_and_stats() -> None:
     harness = _load_harness()
     stdout = "\n".join(

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -1162,7 +1162,7 @@ def test_report_section_selector_returns_successful_completion_cost_summary(tmp_
     assert cli.main(["init", "--target", str(target)]) == 0
     capsys.readouterr()
     _write_json(
-        target / "scratch" / "model-cli-harness" / "20260508T220836Z-suite-codex-summary.json",
+        target / ".agentic-workspace" / "local" / "scratch" / "model-cli-harness" / "20260508T220836Z-suite-codex-summary.json",
         {
             "adapter": "codex",
             "model": "gpt-5.3-codex-spark",
@@ -1219,6 +1219,7 @@ def test_report_section_selector_returns_successful_completion_cost_summary(tmp_
     assert answer["kind"] == "workspace-successful-completion-cost/v1"
     assert answer["advisory_only"] is True
     assert "not a formal benchmark" in answer["rule"]
+    assert answer["evidence"]["summary_dir"] == ".agentic-workspace/local/scratch/model-cli-harness"
     assert answer["evidence"]["summary_count"] == 1
     assert answer["evidence"]["weakness_ledger"]["active_high_priority_count"] == 1
     totals = answer["totals"]

--- a/tools/model-cli-harness/suites/copilot-workflow-smoke.json
+++ b/tools/model-cli-harness/suites/copilot-workflow-smoke.json
@@ -20,15 +20,21 @@
       "block_on_preflight_failure": true,
       "provider_home_env": "COPILOT_HOME",
       "provider_home_path": "{run_root}/copilot-home",
+      "env": {
+        "COPILOT_ALLOW_ALL": "true"
+      },
       "inject_repo_startup_instructions": true,
       "postmortem_feedback_supported": false,
       "command": [
         "copilot",
         "--model",
         "{model}",
+        "-C",
+        "{repo}",
         "-p",
         "{prompt}",
         "--allow-all",
+        "--allow-tool=write",
         "--no-ask-user",
         "--disable-builtin-mcps",
         "--no-remote",

--- a/tools/model-cli-harness/suites/copilot-workflow-smoke.json
+++ b/tools/model-cli-harness/suites/copilot-workflow-smoke.json
@@ -152,6 +152,18 @@
     {
       "id": "direct-task-minimal-overhead",
       "fixture": "aw-minimal-host-repo",
+      "proportionality_guardrail": true,
+      "proportionality_limits": {
+        "workspace_command_count": 2,
+        "verbose_or_full_diagnostic_count": 0,
+        "final_answer_length": 1200
+      },
+      "proportionality_avoid_broad_proof_commands": [
+        "make test",
+        "pytest",
+        "npm test",
+        "cargo test"
+      ],
       "prompt": "Make a tiny wording-only README improvement in this repo: change the first sentence so it says this fixture is for external model CLI dogfooding. Keep setup overhead proportional to this direct edit. Final answer should name the file changed and the proof command, if any.",
       "allowed_write_patterns": [
         "README.md"
@@ -182,6 +194,12 @@
     {
       "id": "next-decision-output-profile",
       "fixture": "aw-minimal-host-repo",
+      "proportionality_guardrail": true,
+      "proportionality_limits": {
+        "workspace_command_count": 1,
+        "verbose_or_full_diagnostic_count": 0,
+        "final_answer_length": 1200
+      },
       "prompt": "You are about to make a narrow README edit, but do not edit files yet. Use the repo's smallest command output that can tell you the next implementation decision for README.md. Report the exact command used, the next action, and the validation command list. Avoid reading raw .agentic-workspace files unless the command output tells you to.",
       "required_executed_commands": [
         "uv run agentic-workspace implement --changed"
@@ -420,6 +438,18 @@
     {
       "id": "config-closeout-obligation",
       "fixture": "aw-configured-host-repo",
+      "proportionality_guardrail": true,
+      "proportionality_limits": {
+        "workspace_command_count": 2,
+        "verbose_or_full_diagnostic_count": 0,
+        "final_answer_length": 1400
+      },
+      "proportionality_avoid_broad_proof_commands": [
+        "make test",
+        "pytest",
+        "npm test",
+        "cargo test"
+      ],
       "prompt": "Make a tiny wording-only README improvement in this repo: clarify that this fixture is for checking whether agents follow configured operating settings. Keep the edit direct. Before you finish, make sure any repository-specific closeout and reporting settings that affect this task are respected.",
       "allowed_write_patterns": [
         "README.md"


### PR DESCRIPTION
## Summary
- Add `proportionality_metrics` for guarded small-work harness scenarios, covering command count, package output size, changed-file count, Planning/Memory residue, raw workspace reads, verbose/full diagnostics, requests to completion, and final-answer length.
- Emit scenario-budgeted proportionality warning classes for over-planning, over-reading, over-proofing, Memory ceremony, and closeout ceremony.
- Mark the first three small-work scenarios as proportionality guardrails and document the new metrics plus comparison deltas.

## Why
#1125 asks for the small bounded-work side of the long-horizon evaluation story: AW should help serious restartable work without making tiny direct work ceremonial. This keeps the implementation inside the existing model CLI harness and existing smoke suite.

## Validation
- `uv run pytest tests/test_model_cli_harness.py -q`
- `uv run ruff check scripts/model_cli_harness/run_model_cli_harness.py tests/test_model_cli_harness.py`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `git diff --check`
- dry-runed `direct-task-minimal-overhead`, `next-decision-output-profile`, and `config-closeout-obligation`

Closes #1125