### PR TITLE
[codex] Implement long-horizon evaluation episodes

### DIFF
--- a/.agentic-workspace/planning/decompositions/github-1124-long-horizon-evaluation.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/github-1124-long-horizon-evaluation.decomposition.json
@@ -1,0 +1,203 @@
+{
+  "kind": "planning-decomposition/v1",
+  "title": "Long-horizon repo episode evaluation",
+  "status": "ready-for-lane-promotion",
+  "larger_intended_outcome": "Evaluate whether Agentic Workspace improves real project continuity across interruptions, restarts, handoffs, agent switches, proof ambiguity, ownership traps, and closeout boundaries by extending the existing model CLI harness into a small long-horizon episode layer.",
+  "non_goals": [
+    "Do not turn AW into a generic benchmark platform or leaderboard.",
+    "Do not run arbitrary live GitHub issues as benchmarks.",
+    "Do not make long-horizon episodes part of ordinary unit or CI tests.",
+    "Do not build a broad benchmark DSL before a few hand-authored episodes prove the shape.",
+    "Do not require fully automatic evaluator-only claims; human review remains valid when engineering judgment is needed.",
+    "Do not create episodes that require credentials, secrets, live external services, or long dependency setup."
+  ],
+  "candidate_lanes": [
+    {
+      "id": "long-horizon-episode-schema",
+      "title": "Define episode and evaluation schemas",
+      "readiness": "ready",
+      "outcome": "Draft hand-authorable `long-horizon-episode/v1` and `long-horizon-evaluation/v1` schemas, plus at least one sample episode and sample evaluator result that validate against the new checks.",
+      "owner_surface": "tools/model-cli-harness/schemas/, tools/model-cli-harness/episodes/, scripts/model_cli_harness/, and tests/test_model_cli_harness.py",
+      "proof": "Focused schema tests validate one sample episode and one sample evaluator result while existing Tier 1 suite rendering still passes.",
+      "depends_on": [],
+      "parallel_with": [
+        "pinned-episode-candidate-curation"
+      ]
+    },
+    {
+      "id": "pinned-episode-candidate-curation",
+      "title": "Curate first pinned real-repo episode candidates",
+      "readiness": "ready",
+      "outcome": "Confirm license, setup, base commit, visible validation, hidden/reference oracle, known traps, expected AW affordances, and baseline/AW fixture strategy for at least three first-pack episodes.",
+      "owner_surface": "tools/model-cli-harness/episodes/, docs/maintainer/model-cli-dogfooding-harness.md, and candidate episode metadata",
+      "proof": "Reviewable candidate records cover at least one intent-proof episode, one abstraction/reuse episode, and one restart or agent-switch-capable episode, with unsuitable repos rejected or deferred explicitly.",
+      "depends_on": [],
+      "parallel_with": [
+        "long-horizon-episode-schema"
+      ]
+    },
+    {
+      "id": "phase-runner-checkpoints",
+      "title": "Add phase runner and restart checkpoints",
+      "readiness": "ready",
+      "outcome": "A long-horizon episode runner can execute multiple phases against the same copied repo, capture checkpoint evidence after each phase, and hide prior transcript from resume phases when configured.",
+      "owner_surface": "scripts/model_cli_harness/long_horizon_episode.py or equivalent thin episode layer, scripts/model_cli_harness/run_model_cli_harness.py helpers, and tests",
+      "proof": "Dry-run and fake-adapter executed tests prove phase 2 sees phase 1 repo mutations, hidden-transcript resume omits prior chat, checkpoints capture diffs/transcripts/validation output, and existing single-scenario runs still work.",
+      "depends_on": [
+        "long-horizon-episode-schema"
+      ],
+      "parallel_with": []
+    },
+    {
+      "id": "agent-switch-variants",
+      "title": "Support same-agent and switched-agent variants",
+      "readiness": "ready",
+      "outcome": "Episode phases can select distinct adapters/models so the runner can compare baseline restart, AW-assisted restart, same-agent continuation, agent-switch continuation, and strong-to-weak continuation without provider-specific coupling.",
+      "owner_surface": "long-horizon episode runner, adapter rendering, run.json phase result shape, and tests",
+      "proof": "Dry-run output renders distinct phase commands with distinct adapters/models, and an executed fake-adapter test proves phase 2 uses the requested different adapter/model while preserving provider state isolation boundaries.",
+      "depends_on": [
+        "phase-runner-checkpoints"
+      ],
+      "parallel_with": [
+        "evaluator-evidence-bundle"
+      ]
+    },
+    {
+      "id": "evaluator-evidence-bundle",
+      "title": "Add evaluator-agent structured review pass",
+      "readiness": "ready",
+      "outcome": "The runner can invoke a separate evaluator adapter with a controlled evidence bundle and capture structured `long-horizon-evaluation/v1` output before hidden/reference oracle comparison.",
+      "owner_surface": "long-horizon episode runner, evaluator prompt/evidence bundle builder, evaluator result parser, and tests",
+      "proof": "Fake evaluator tests prove valid structured results are accepted, invalid evaluator JSON is captured as evaluator failure, evidence cites files/diffs/commands/transcripts/AW outputs, and hidden oracle material is excluded until after primary scoring.",
+      "depends_on": [
+        "long-horizon-episode-schema",
+        "phase-runner-checkpoints"
+      ],
+      "parallel_with": [
+        "agent-switch-variants"
+      ]
+    },
+    {
+      "id": "aw-on-off-fixture-pairing",
+      "title": "Add AW-on and AW-off episode pairing",
+      "readiness": "ready",
+      "outcome": "Episodes can run equivalent AW-assisted and baseline fixtures without contaminating baseline prompts or repo state, recording mode and comparison context in results.",
+      "owner_surface": "episode metadata, fixture preparation, prompt rendering, comparison result shape, and docs",
+      "proof": "A paired dry-run test renders AW-on and AW-off phases, baseline fixtures explicitly lack AW startup surfaces, task prompts remain equivalent except for mode setup, and result records mode without suppressing baseline contamination warnings.",
+      "depends_on": [
+        "long-horizon-episode-schema"
+      ],
+      "parallel_with": [
+        "phase-runner-checkpoints"
+      ]
+    },
+    {
+      "id": "first-continuity-episode-pack",
+      "title": "Build the first credible continuity episode pack",
+      "readiness": "needs-shaping",
+      "outcome": "At least three pinned episodes exist with setup, visible validation, hidden/reference oracle or rubric, known traps, expected mistake classes, and at least one forced restart plus one agent-switch-capable variant.",
+      "owner_surface": "tools/model-cli-harness/episodes/, fixture preparation scripts or metadata, docs/maintainer/model-cli-dogfooding-harness.md, and tests for episode validation",
+      "proof": "Episode validation proves generated-surface or equivalent ownership trap, reuse/abstraction trap, and intent-proof overclaim trap are represented; at least one episode supports baseline restart vs AW-assisted restart and at least one supports same-agent vs agent-switch continuation.",
+      "depends_on": [
+        "pinned-episode-candidate-curation",
+        "long-horizon-episode-schema",
+        "phase-runner-checkpoints",
+        "agent-switch-variants",
+        "aw-on-off-fixture-pairing"
+      ],
+      "parallel_with": []
+    },
+    {
+      "id": "comparison-reporting-and-routing",
+      "title": "Report mistake classes, AW effect, and follow-up routing",
+      "readiness": "needs-shaping",
+      "outcome": "Long-horizon result reports compare AW-on/AW-off and same-agent/agent-switch outcomes, summarize mistake classes, AW helped/hurt/missed affordance fields, proof/intent match, restartability, completion honesty, and recommended follow-up routing.",
+      "owner_surface": "long-horizon comparison report, model-task weakness ledger integration, docs, and issue/Memory/dismissal routing guidance",
+      "proof": "Comparison tests show retained/resolved/new mistake classes, evaluator evidence references, human-review-needed status, and follow-up routing into issue, Memory, docs, harness fix, or dismissal without creating hidden backlog.",
+      "depends_on": [
+        "evaluator-evidence-bundle",
+        "first-continuity-episode-pack"
+      ],
+      "parallel_with": []
+    }
+  ],
+  "dependency_assumptions": [
+    "The existing model CLI harness remains Tier 1 affordance probes; long-horizon support should be a thin episode/orchestration layer over it rather than a replacement.",
+    "Schema and candidate curation can proceed in parallel because both are hand-authored shaping work and neither needs executable orchestration first.",
+    "Phase runner checkpoints are the core implementation dependency for restart, agent switch, evaluator evidence, and AW-on/AW-off comparison.",
+    "Evaluator scoring must happen before hidden/reference oracle comparison so the primary judgment reflects the produced repo state, transcript, proof, and AW evidence.",
+    "The first continuity pack should start with three episodes, not a broad benchmark set; additional repos should wait until the runner and evaluator shape are credible."
+  ],
+  "parallelization_assumptions": [
+    "Episode schema and candidate curation are independent enough to promote separately.",
+    "Evaluator evidence-bundle work can proceed alongside agent-switch variants after checkpoint capture exists.",
+    "AW-on/AW-off fixture pairing can be developed alongside checkpoint mechanics if the schema lane has defined the mode fields.",
+    "Comparison/reporting should wait for at least one real or realistic continuity pack so report fields are evidence-driven rather than aspirational."
+  ],
+  "proof_expectations": [
+    "Each promoted lane must preserve existing model CLI harness dry-run defaults, disposable fixture isolation, adapter abstraction, and structured run output.",
+    "Long-horizon runner tests should use fake adapters for deterministic CI coverage; real model executions remain exploratory maintainer evidence.",
+    "Each executable lane should prove backward compatibility for existing single-scenario harness runs.",
+    "Episode pack lanes must record visible validation, hidden/reference oracle boundaries, known traps, and expected mistake classes before claiming scenario readiness.",
+    "Evaluator and comparison lanes must distinguish engineering judgment from deterministic pass/fail and cite concrete evidence from files, diffs, commands, transcripts, or AW outputs."
+  ],
+  "promotion_rule": "Promote one bounded lane at a time when it has a clear owner surface, fake-adapter proof path, and acceptance criteria tied to #1124; do not promote broad episode-pack or reporting work before schema and checkpoint mechanics exist.",
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1124",
+      "label": "#1124",
+      "role": "parent epic"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1115",
+      "label": "#1115",
+      "role": "agent OS capability map"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1090",
+      "label": "#1090",
+      "role": "engineering horizon thesis"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1092",
+      "label": "#1092",
+      "role": "reuse and abstraction pressure"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1094",
+      "label": "#1094",
+      "role": "intent proof strength"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1116",
+      "label": "#1116",
+      "role": "proof confidence"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1087",
+      "label": "#1087",
+      "role": "Planning concurrency and stale state"
+    },
+    {
+      "kind": "github-issue-comment",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1124#issuecomment-4533292801",
+      "label": "#1124 investigation comment",
+      "role": "harness gap and child-lane shaping"
+    },
+    {
+      "kind": "github-issue-comment",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1124#issuecomment-4533374862",
+      "label": "#1124 candidate repo investigation",
+      "role": "first-pack candidate evidence"
+    }
+  ],
+  "notes": "Decomposed from #1124 and its investigation comments. GitHub remains the discussion tracker; this checked-in Planning decomposition owns lane sequencing and promotion discipline."
+}
+

--- a/.agentic-workspace/planning/decompositions/github-1124-long-horizon-evaluation.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/github-1124-long-horizon-evaluation.decomposition.json
@@ -196,6 +196,54 @@
       "target": "https://github.com/rickardvh/agentic-workspace/issues/1124#issuecomment-4533374862",
       "label": "#1124 candidate repo investigation",
       "role": "first-pack candidate evidence"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1141",
+      "label": "#1141",
+      "role": "child lane: long-horizon-episode-schema"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1142",
+      "label": "#1142",
+      "role": "child lane: pinned-episode-candidate-curation"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1143",
+      "label": "#1143",
+      "role": "child lane: phase-runner-checkpoints"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1144",
+      "label": "#1144",
+      "role": "child lane: agent-switch-variants"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1145",
+      "label": "#1145",
+      "role": "child lane: evaluator-evidence-bundle"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1146",
+      "label": "#1146",
+      "role": "child lane: aw-on-off-fixture-pairing"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1147",
+      "label": "#1147",
+      "role": "child lane: first-continuity-episode-pack"
+    },
+    {
+      "kind": "github-issue",
+      "target": "https://github.com/rickardvh/agentic-workspace/issues/1148",
+      "label": "#1148",
+      "role": "child lane: comparison-reporting-and-routing"
     }
   ],
   "notes": "Decomposed from #1124 and its investigation comments. GitHub remains the discussion tracker; this checked-in Planning decomposition owns lane sequencing and promotion discipline."

--- a/docs/maintainer/model-cli-dogfooding-harness.md
+++ b/docs/maintainer/model-cli-dogfooding-harness.md
@@ -131,6 +131,40 @@ uv run python scripts/model_cli_harness/run_model_cli_harness.py `
 
 The comparison report lists resolved, retained, and new warnings, mutation deltas, proportionality metric deltas, a compact product interpretation, and the recommended next action. Treat it as a review aid, not a benchmark verdict.
 
+## Long-Horizon Episodes
+
+Long-horizon episodes extend the harness for multi-phase continuity evaluation. They are not replacements for the Tier 1 smoke suite. Use them when the question is whether repo state, AW state, proof evidence, and handoff boundaries survive restart or agent switch.
+
+Episode metadata lives under `tools/model-cli-harness/episodes/` and validates against the hand-authorable `agentic-workspace/long-horizon-episode/v1` shape. Evaluator outputs validate against `agentic-workspace/long-horizon-evaluation/v1`. The runner is separate from the smoke runner:
+
+```powershell
+uv run python scripts/model_cli_harness/long_horizon_episode.py `
+  --episode tools/model-cli-harness/episodes/intent-proof-packaging-specifier.json `
+  --suite tools/model-cli-harness/suites/copilot-workflow-smoke.json `
+  --format json
+```
+
+Dry-run remains the default. Add `--execute` only when you intentionally want the runner to clone or copy the episode repo, run phase prompts, and optionally invoke an evaluator adapter.
+
+The episode runner supports:
+
+- multiple modes, such as baseline and AW-assisted;
+- AW-assisted mode bootstrapping from the existing minimal AW fixture for pinned external repos;
+- multiple phases against the same copied or cloned repo;
+- hidden-transcript resume phases via `hide_transcript_for_resume`;
+- per-phase adapter/model selection for agent switching;
+- checkpoint capture for diffs, transcripts, final answers, and validation output;
+- a separate evaluator adapter with a controlled evidence bundle;
+- comparison summaries for mistake classes, AW effect, human-review-needed status, and follow-up routing.
+
+The first episode pack is intentionally small:
+
+- `intent-proof-packaging-specifier.json`: Packaging `===` original-string behavior, aimed at intent-proof and residual-risk scoring.
+- `reuse-abstraction-pluggy.json`: Pluggy multi-implementation unregister behavior, aimed at abstraction/reuse and agent-switch continuation.
+- `intent-proof-click-pager.json`: Click `CliRunner` / pager closed-file behavior, aimed at proof confidence for user-visible CLI behavior.
+
+These records pin real upstream repos and reference fixes, but ordinary CI should use fake-adapter tests for deterministic coverage. Real model executions are maintainer evidence and should be reviewed with the evaluator output and transcripts, not treated as a leaderboard.
+
 Executed run results include two different cost signals:
 
 - `usage_summary`: provider/runtime token counters when the adapter exposes them.

--- a/docs/maintainer/model-cli-dogfooding-harness.md
+++ b/docs/maintainer/model-cli-dogfooding-harness.md
@@ -153,17 +153,20 @@ The episode runner supports:
 - multiple phases against the same copied or cloned repo;
 - hidden-transcript resume phases via `hide_transcript_for_resume`;
 - per-phase adapter/model selection for agent switching;
+- mode-level phase overrides for same-agent continuation versus switched-agent comparison;
 - checkpoint capture for diffs, transcripts, final answers, and validation output;
 - a separate evaluator adapter with a controlled evidence bundle;
+- post-score hidden/reference oracle metadata, kept out of the primary evaluator prompt;
 - comparison summaries for mistake classes, AW effect, human-review-needed status, and follow-up routing.
 
 The first episode pack is intentionally small:
 
 - `intent-proof-packaging-specifier.json`: Packaging `===` original-string behavior, aimed at intent-proof and residual-risk scoring.
-- `reuse-abstraction-pluggy.json`: Pluggy multi-implementation unregister behavior, aimed at abstraction/reuse and agent-switch continuation.
+- `reuse-abstraction-pluggy.json`: Pluggy multi-implementation unregister behavior, aimed at abstraction/reuse, agent-switch continuation, and same-agent continuation comparison.
 - `intent-proof-click-pager.json`: Click `CliRunner` / pager closed-file behavior, aimed at proof confidence for user-visible CLI behavior.
+- `managed-planning-state-agentic-workspace.json`: AW invalid Planning fixture, aimed at managed-state and wrong-owner edit traps.
 
-These records pin real upstream repos and reference fixes, but ordinary CI should use fake-adapter tests for deterministic coverage. Real model executions are maintainer evidence and should be reviewed with the evaluator output and transcripts, not treated as a leaderboard.
+Most records pin real upstream repos and reference fixes; the managed-state episode uses a repo-local fixture so it can exercise AW-owned surfaces without mutating this checkout. Ordinary CI should use fake-adapter tests for deterministic coverage. Real model executions are maintainer evidence and should be reviewed with the evaluator output and transcripts, not treated as a leaderboard.
 
 Executed run results include two different cost signals:
 

--- a/docs/maintainer/model-cli-dogfooding-harness.md
+++ b/docs/maintainer/model-cli-dogfooding-harness.md
@@ -157,7 +157,7 @@ The episode runner supports:
 - checkpoint capture for diffs, transcripts, final answers, and validation output;
 - a separate evaluator adapter with a controlled evidence bundle;
 - post-score hidden/reference oracle metadata, kept out of the primary evaluator prompt;
-- comparison summaries for mistake classes, AW effect, human-review-needed status, and follow-up routing.
+- comparison summaries for mistake classes, same-agent versus agent-switch continuation, post-score reference status, AW effect, human-review-needed status, and follow-up routing.
 
 The first episode pack is intentionally small:
 

--- a/scripts/model_cli_harness/long_horizon_episode.py
+++ b/scripts/model_cli_harness/long_horizon_episode.py
@@ -1,0 +1,536 @@
+"""Run long-horizon model CLI episodes with phases and evaluator review."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import run_model_cli_harness as harness
+
+EPISODE_KIND = "agentic-workspace/long-horizon-episode/v1"
+EVALUATION_KIND = "agentic-workspace/long-horizon-evaluation/v1"
+DEFAULT_EPISODE = harness.REPO_ROOT / "tools" / "model-cli-harness" / "episodes" / "intent-proof-packaging-specifier.json"
+DEFAULT_OUTPUT_ROOT = harness.DEFAULT_OUTPUT_ROOT / "long-horizon"
+AW_MODE_FIXTURE = harness.REPO_ROOT / "tools" / "model-cli-harness" / "fixtures" / "aw-minimal-host-repo"
+MISTAKE_CLASSES = {
+    "wrong_intent",
+    "premature_implementation",
+    "unnecessary_planning",
+    "missing_planning",
+    "wrong_owner_edit",
+    "generated_surface_direct_edit",
+    "manual_managed_state_edit",
+    "existing_helper_missed",
+    "duplicate_helper",
+    "bad_abstraction",
+    "weak_proof",
+    "proof_overclaim",
+    "completion_overclaim",
+    "memory_ignored",
+    "stale_memory_trusted",
+    "adr_candidate_missed",
+    "handoff_unusable",
+    "restart_failed",
+    "stale_planning_state_trusted",
+}
+
+
+def _string_list(value: Any, *, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{field} must be a list of strings")
+    return value
+
+
+def _list_of_commands(value: Any, *, field: str) -> list[list[str]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a list")
+    commands: list[list[str]] = []
+    for index, command in enumerate(value):
+        if not isinstance(command, list) or not all(isinstance(item, str) for item in command):
+            raise ValueError(f"{field}.{index} must be a string list command")
+        commands.append(command)
+    return commands
+
+
+def load_episode(path: Path) -> dict[str, Any]:
+    episode = harness._load_json(path)
+    validate_episode(episode)
+    return episode
+
+
+def validate_episode(episode: dict[str, Any]) -> None:
+    if episode.get("kind") != EPISODE_KIND:
+        raise ValueError(f"episode kind must be {EPISODE_KIND}")
+    for field in ("id", "title", "task_prompt"):
+        if not isinstance(episode.get(field), str) or not episode[field].strip():
+            raise ValueError(f"episode.{field} is required")
+    modes = episode.get("modes")
+    if not isinstance(modes, list) or not modes:
+        raise ValueError("episode.modes must be a non-empty list")
+    mode_ids: set[str] = set()
+    for index, mode in enumerate(modes):
+        if not isinstance(mode, dict):
+            raise ValueError(f"episode.modes.{index} must be an object")
+        mode_id = mode.get("id")
+        if not isinstance(mode_id, str) or not mode_id.strip():
+            raise ValueError(f"episode.modes.{index}.id is required")
+        if mode_id in mode_ids:
+            raise ValueError(f"duplicate episode mode id: {mode_id}")
+        mode_ids.add(mode_id)
+        if not isinstance(mode.get("fixture"), str) and not isinstance(mode.get("repo_url"), str):
+            raise ValueError(f"episode.modes.{mode_id} needs fixture or repo_url")
+    phases = episode.get("phases")
+    if not isinstance(phases, list) or not phases:
+        raise ValueError("episode.phases must be a non-empty list")
+    for index, phase in enumerate(phases):
+        if not isinstance(phase, dict):
+            raise ValueError(f"episode.phases.{index} must be an object")
+        for field in ("id", "prompt"):
+            if not isinstance(phase.get(field), str) or not phase[field].strip():
+                raise ValueError(f"episode.phases.{index}.{field} is required")
+        _list_of_commands(phase.get("validation_commands"), field=f"episode.phases.{index}.validation_commands")
+    _list_of_commands(episode.get("setup_commands"), field="episode.setup_commands")
+    _list_of_commands(episode.get("visible_validation_commands"), field="episode.visible_validation_commands")
+    for field in ("known_traps", "expected_mistake_classes"):
+        values = _string_list(episode.get(field), field=f"episode.{field}")
+        if field == "expected_mistake_classes":
+            unknown = sorted(set(values) - MISTAKE_CLASSES)
+            if unknown:
+                raise ValueError(f"unknown mistake classes: {', '.join(unknown)}")
+    rubric = episode.get("rubric")
+    if not isinstance(rubric, dict) or not rubric:
+        raise ValueError("episode.rubric must be a non-empty object")
+
+
+def validate_evaluation_result(result: dict[str, Any]) -> None:
+    if result.get("kind") != EVALUATION_KIND:
+        raise ValueError(f"evaluation kind must be {EVALUATION_KIND}")
+    for field in ("scenario", "mode", "result", "mistake_classes", "aw_effect", "evidence"):
+        if field not in result:
+            raise ValueError(f"evaluation.{field} is required")
+    outcome = result["result"]
+    if not isinstance(outcome, dict):
+        raise ValueError("evaluation.result must be an object")
+    for field in (
+        "intent_satisfied",
+        "scope_respected",
+        "proof_sufficient",
+        "proof_matches_intent",
+        "restartable_from_repo_state",
+        "completion_claim_honest",
+    ):
+        if field not in outcome:
+            raise ValueError(f"evaluation.result.{field} is required")
+    mistake_classes = _string_list(result.get("mistake_classes"), field="evaluation.mistake_classes")
+    unknown = sorted(set(mistake_classes) - MISTAKE_CLASSES)
+    if unknown:
+        raise ValueError(f"unknown evaluation mistake classes: {', '.join(unknown)}")
+    aw_effect = result["aw_effect"]
+    if not isinstance(aw_effect, dict):
+        raise ValueError("evaluation.aw_effect must be an object")
+    for field in ("helped", "hurt_or_overhead", "missed_affordance"):
+        _string_list(aw_effect.get(field), field=f"evaluation.aw_effect.{field}")
+    evidence = result["evidence"]
+    if not isinstance(evidence, list):
+        raise ValueError("evaluation.evidence must be a list")
+    for index, item in enumerate(evidence):
+        if not isinstance(item, dict) or not isinstance(item.get("kind"), str) or not isinstance(item.get("ref"), str):
+            raise ValueError(f"evaluation.evidence.{index} needs kind and ref")
+
+
+def _episode_paths(*, episode: dict[str, Any], mode_id: str, output_root: Path) -> harness.HarnessPaths:
+    model = str(episode.get("id", "episode"))
+    return harness._scenario_paths(
+        output_root=output_root,
+        suite_id="long-horizon",
+        scenario_id=f"{episode['id']}-{mode_id}",
+        adapter_id="episode",
+        model=model,
+    )
+
+
+def _bootstrap_aw_mode(repo_path: Path) -> None:
+    source_workspace = AW_MODE_FIXTURE / ".agentic-workspace"
+    target_workspace = repo_path / ".agentic-workspace"
+    if not target_workspace.exists():
+        shutil.copytree(source_workspace, target_workspace)
+    source_agents = (AW_MODE_FIXTURE / "AGENTS.md").read_text(encoding="utf-8").strip()
+    target_agents = repo_path / "AGENTS.md"
+    if target_agents.exists():
+        existing_agents = target_agents.read_text(encoding="utf-8")
+        if "<!-- agentic-workspace:workflow:start -->" not in existing_agents:
+            target_agents.write_text(existing_agents.rstrip() + "\n\n" + source_agents + "\n", encoding="utf-8")
+    else:
+        target_agents.write_text(source_agents + "\n", encoding="utf-8")
+    harness._prepare_source_checkout_invocation(repo_path)
+
+
+def _prepare_mode_repo(*, suite_path: Path, mode: dict[str, Any], paths: harness.HarnessPaths, execute: bool) -> None:
+    paths.run_root.mkdir(parents=True, exist_ok=False)
+    fixture = mode.get("fixture")
+    if isinstance(fixture, str):
+        fixture_path = (suite_path.parent / ".." / "fixtures" / fixture).resolve()
+        if not fixture_path.exists():
+            fixture_path = (harness.REPO_ROOT / fixture).resolve()
+        if not fixture_path.exists():
+            raise FileNotFoundError(f"fixture not found: {fixture}")
+        shutil.copytree(fixture_path, paths.repo_path)
+        if mode.get("aw_enabled"):
+            _bootstrap_aw_mode(paths.repo_path)
+        else:
+            harness._prepare_source_checkout_invocation(paths.repo_path)
+        return
+    repo_url = mode.get("repo_url")
+    base_commit = mode.get("base_commit")
+    if not isinstance(repo_url, str) or not isinstance(base_commit, str):
+        raise ValueError(f"mode {mode.get('id', '<unknown>')} needs fixture or repo_url/base_commit")
+    if not execute:
+        paths.repo_path.mkdir(parents=True)
+        (paths.repo_path / "PINNED-REPO.txt").write_text(f"{repo_url}\n{base_commit}\n", encoding="utf-8")
+        if mode.get("aw_enabled"):
+            _bootstrap_aw_mode(paths.repo_path)
+        return
+    result = harness._run_command(["git", "clone", repo_url, str(paths.repo_path)], cwd=paths.run_root, timeout_seconds=900)
+    if result["returncode"] != 0:
+        raise RuntimeError(f"git clone failed for {repo_url}: {result['stderr']}")
+    checkout = harness._run_command(["git", "checkout", base_commit], cwd=paths.repo_path, timeout_seconds=120)
+    if checkout["returncode"] != 0:
+        raise RuntimeError(f"git checkout failed for {base_commit}: {checkout['stderr']}")
+    if mode.get("aw_enabled"):
+        _bootstrap_aw_mode(paths.repo_path)
+
+
+def _adapter_command(
+    *,
+    suite: dict[str, Any],
+    adapter_id: str,
+    model: str | None,
+    replacements: dict[str, str],
+) -> tuple[list[str], str, dict[str, Any]]:
+    adapter = suite.get("adapters", {}).get(adapter_id)
+    if not isinstance(adapter, dict):
+        raise ValueError(f"adapter '{adapter_id}' is not defined")
+    resolved_model = model or str(adapter.get("default_model") or "default")
+    replacements = {**replacements, "model": resolved_model}
+    command_template = adapter.get("command")
+    if not isinstance(command_template, list) or not all(isinstance(item, str) for item in command_template):
+        raise ValueError(f"adapter '{adapter_id}' must define command as a string list")
+    return harness._render_list(command_template, replacements=replacements), resolved_model, adapter
+
+
+def _run_validation_commands(
+    *,
+    commands: list[list[str]],
+    replacements: dict[str, str],
+    cwd: Path,
+    execute: bool,
+    timeout_seconds: int,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for command in commands:
+        rendered = harness._render_list(command, replacements=replacements)
+        if execute:
+            result = harness._run_command(rendered, cwd=cwd, timeout_seconds=timeout_seconds)
+            results.append(result)
+        else:
+            results.append({"status": "dry-run", "command": rendered})
+    return results
+
+
+def _phase_prompt(*, episode: dict[str, Any], mode: dict[str, Any], phase: dict[str, Any], prior_context: list[str]) -> tuple[str, bool]:
+    prompt_parts = [
+        str(episode["task_prompt"]).strip(),
+        f"Mode: {mode['id']}.",
+        str(phase["prompt"]).strip(),
+    ]
+    include_prior = bool(prior_context) and not bool(phase.get("hide_transcript_for_resume"))
+    if include_prior:
+        prompt_parts.append("Prior phase context:\n" + "\n\n".join(prior_context))
+    elif prior_context:
+        prompt_parts.append("Resume from repository state only. Do not assume prior chat history.")
+    return "\n\n".join(prompt_parts) + "\n", include_prior
+
+
+def _evaluation_prompt(*, episode: dict[str, Any], mode_result: dict[str, Any]) -> str:
+    hidden_oracle = episode.get("hidden_oracle")
+    evidence_bundle = {
+        "kind": "agentic-workspace/long-horizon-evidence-bundle/v1",
+        "episode": {
+            "id": episode["id"],
+            "title": episode["title"],
+            "rubric": episode.get("rubric", {}),
+            "known_traps": episode.get("known_traps", []),
+            "expected_mistake_classes": episode.get("expected_mistake_classes", []),
+        },
+        "mode_result": mode_result,
+        "hidden_oracle_excluded": hidden_oracle is not None,
+    }
+    return (
+        "Review this long-horizon episode evidence and return only a JSON object matching "
+        f"{EVALUATION_KIND}.\n\n"
+        + json.dumps(evidence_bundle, indent=2, sort_keys=True)
+    )
+
+
+def _parse_evaluation(text: str) -> dict[str, Any]:
+    payload = harness._json_document(text.strip())
+    if payload is None:
+        match = None
+        for candidate in text.splitlines():
+            candidate = candidate.strip()
+            if candidate.startswith("{") and candidate.endswith("}"):
+                match = candidate
+        if match:
+            payload = harness._json_document(match)
+    if payload is None:
+        raise ValueError("evaluator did not return a JSON object")
+    validate_evaluation_result(payload)
+    return payload
+
+
+def _comparison_summary(mode_results: list[dict[str, Any]]) -> dict[str, Any]:
+    mistake_classes_by_mode: dict[str, list[str]] = {}
+    aw_effect_by_mode: dict[str, dict[str, list[str]]] = {}
+    human_review_required = False
+    followups: list[dict[str, Any]] = []
+    for result in mode_results:
+        mode_id = result["mode_id"]
+        evaluation = result.get("evaluation", {}).get("payload")
+        if not isinstance(evaluation, dict):
+            continue
+        mistake_classes_by_mode[mode_id] = list(evaluation.get("mistake_classes", []))
+        aw_effect = evaluation.get("aw_effect", {})
+        if isinstance(aw_effect, dict):
+            aw_effect_by_mode[mode_id] = {
+                "helped": list(aw_effect.get("helped", [])),
+                "hurt_or_overhead": list(aw_effect.get("hurt_or_overhead", [])),
+                "missed_affordance": list(aw_effect.get("missed_affordance", [])),
+            }
+        human_review_required = human_review_required or bool(evaluation.get("human_review_required"))
+        followup = evaluation.get("recommended_followup")
+        if isinstance(followup, dict):
+            followups.append({"mode": mode_id, **followup})
+    all_classes = sorted({item for values in mistake_classes_by_mode.values() for item in values})
+    return {
+        "kind": "agentic-workspace/long-horizon-comparison/v1",
+        "status": "present" if mode_results else "absent",
+        "mode_count": len(mode_results),
+        "mistake_classes": all_classes,
+        "mistake_classes_by_mode": mistake_classes_by_mode,
+        "aw_effect_by_mode": aw_effect_by_mode,
+        "human_review_required": human_review_required,
+        "recommended_followups": followups,
+        "rule": "Comparison is review evidence, not a deterministic leaderboard.",
+    }
+
+
+def run_episode(
+    *,
+    episode_path: Path,
+    suite_path: Path = harness.DEFAULT_SUITE,
+    execute: bool = False,
+    output_root: Path = DEFAULT_OUTPUT_ROOT,
+    mode_filter: str | None = None,
+    evaluator: bool = True,
+    timeout_seconds: int = 900,
+) -> dict[str, Any]:
+    episode = load_episode(episode_path)
+    suite = harness._load_json(suite_path)
+    modes = [mode for mode in episode["modes"] if mode_filter is None or mode["id"] == mode_filter]
+    if not modes:
+        raise ValueError(f"mode '{mode_filter}' is not defined")
+    mode_results: list[dict[str, Any]] = []
+    for mode in modes:
+        paths = _episode_paths(episode=episode, mode_id=mode["id"], output_root=output_root)
+        _prepare_mode_repo(suite_path=suite_path, mode=mode, paths=paths, execute=execute)
+        replacements = {
+            "repo": str(paths.repo_path),
+            "run_root": str(paths.run_root),
+            "source_root": str(harness.REPO_ROOT),
+            "mode_id": str(mode["id"]),
+            "episode_id": str(episode["id"]),
+        }
+        setup_results = _run_validation_commands(
+            commands=_list_of_commands(episode.get("setup_commands"), field="episode.setup_commands"),
+            replacements=replacements,
+            cwd=paths.repo_path,
+            execute=execute,
+            timeout_seconds=timeout_seconds,
+        )
+        prior_context: list[str] = []
+        phase_results: list[dict[str, Any]] = []
+        previous_snapshot = harness._file_snapshot(paths.repo_path)
+        for phase in episode["phases"]:
+            phase_prompt, prior_included = _phase_prompt(episode=episode, mode=mode, phase=phase, prior_context=prior_context)
+            phase_share = paths.run_root / f"{phase['id']}.md"
+            phase_transcript = paths.run_root / f"{phase['id']}.transcript.jsonl"
+            phase_replacements = {
+                **replacements,
+                "phase_id": str(phase["id"]),
+                "share_path": str(phase_share),
+                "transcript_path": str(phase_transcript),
+                "prompt": phase_prompt,
+            }
+            command, resolved_model, adapter = _adapter_command(
+                suite=suite,
+                adapter_id=str(phase.get("adapter") or episode.get("default_adapter") or "copilot"),
+                model=phase.get("model") if isinstance(phase.get("model"), str) else None,
+                replacements=phase_replacements,
+            )
+            env = harness._adapter_environment(adapter, replacements=phase_replacements, isolate_provider_home=False)
+            preflight = harness._adapter_preflight(adapter, command=command, replacements=phase_replacements)
+            env = harness._prepend_env_path(env, preflight["path_prepend"])
+            result: dict[str, Any]
+            if execute:
+                result = harness._run_command(command, cwd=paths.repo_path, timeout_seconds=timeout_seconds, env=env)
+                result["status"] = harness._classify_result_status(result)
+                if phase_share.exists():
+                    result["final_message"] = phase_share.read_text(encoding="utf-8")
+                harness._copy_transcript(str(result.get("stdout", "")), phase_transcript)
+            else:
+                result = {"status": "dry-run", "command": command}
+            current_snapshot = harness._file_snapshot(paths.repo_path)
+            mutation_summary = harness._snapshot_diff(previous_snapshot, current_snapshot)
+            previous_snapshot = current_snapshot
+            validation_commands = _list_of_commands(
+                phase.get("validation_commands", episode.get("visible_validation_commands")),
+                field=f"phase.{phase['id']}.validation_commands",
+            )
+            validation_results = _run_validation_commands(
+                commands=validation_commands,
+                replacements=phase_replacements,
+                cwd=paths.repo_path,
+                execute=execute,
+                timeout_seconds=timeout_seconds,
+            )
+            final_message = str(result.get("final_message") or result.get("stdout") or "")
+            if final_message.strip():
+                prior_context.append(f"{phase['id']} final message:\n{final_message.strip()}")
+            phase_results.append(
+                {
+                    "phase_id": phase["id"],
+                    "adapter_id": str(phase.get("adapter") or episode.get("default_adapter") or "copilot"),
+                    "model": resolved_model,
+                    "prompt": phase_prompt,
+                    "prior_transcript_included": prior_included,
+                    "hide_transcript_for_resume": bool(phase.get("hide_transcript_for_resume")),
+                    "command": command,
+                    "preflight": preflight,
+                    "result": result,
+                    "mutation_summary": mutation_summary,
+                    "validation_results": validation_results,
+                    "checkpoint": {
+                        "transcript_path": str(phase_transcript),
+                        "share_path": str(phase_share),
+                        "repo_path": str(paths.repo_path),
+                    },
+                }
+            )
+        mode_result: dict[str, Any] = {
+            "mode_id": mode["id"],
+            "aw_enabled": bool(mode.get("aw_enabled", False)),
+            "repo_path": str(paths.repo_path),
+            "run_root": str(paths.run_root),
+            "setup_results": setup_results,
+            "phases": phase_results,
+        }
+        if evaluator and isinstance(episode.get("evaluator"), dict):
+            evaluator_config = episode["evaluator"]
+            evaluator_prompt = _evaluation_prompt(episode=episode, mode_result=mode_result)
+            evaluator_share = paths.run_root / "evaluator.md"
+            evaluator_replacements = {
+                **replacements,
+                "phase_id": "evaluator",
+                "share_path": str(evaluator_share),
+                "prompt": evaluator_prompt,
+            }
+            command, resolved_model, adapter = _adapter_command(
+                suite=suite,
+                adapter_id=str(evaluator_config.get("adapter") or episode.get("default_evaluator_adapter") or episode.get("default_adapter") or "copilot"),
+                model=evaluator_config.get("model") if isinstance(evaluator_config.get("model"), str) else None,
+                replacements=evaluator_replacements,
+            )
+            env = harness._adapter_environment(adapter, replacements=evaluator_replacements, isolate_provider_home=False)
+            preflight = harness._adapter_preflight(adapter, command=command, replacements=evaluator_replacements)
+            env = harness._prepend_env_path(env, preflight["path_prepend"])
+            if execute:
+                evaluator_result = harness._run_command(command, cwd=paths.repo_path, timeout_seconds=timeout_seconds, env=env)
+                if evaluator_share.exists():
+                    evaluator_result["final_message"] = evaluator_share.read_text(encoding="utf-8")
+                text = str(evaluator_result.get("final_message") or evaluator_result.get("stdout") or "")
+                try:
+                    evaluation_payload = _parse_evaluation(text)
+                    evaluation_status = "valid"
+                except ValueError as exc:
+                    evaluation_payload = {"error": str(exc)}
+                    evaluation_status = "invalid"
+            else:
+                evaluator_result = {"status": "dry-run", "command": command}
+                evaluation_payload = {"status": "not-run"}
+                evaluation_status = "not-run"
+            mode_result["evaluation"] = {
+                "status": evaluation_status,
+                "adapter_id": str(evaluator_config.get("adapter") or episode.get("default_evaluator_adapter") or episode.get("default_adapter") or "copilot"),
+                "model": resolved_model,
+                "prompt": evaluator_prompt,
+                "command": command,
+                "preflight": preflight,
+                "result": evaluator_result,
+                "payload": evaluation_payload,
+                "hidden_oracle_excluded": episode.get("hidden_oracle") is not None,
+            }
+        mode_results.append(mode_result)
+    payload = {
+        "kind": "agentic-workspace/long-horizon-run/v1",
+        "episode": str(episode_path),
+        "episode_id": episode["id"],
+        "execute": execute,
+        "mode_count": len(mode_results),
+        "modes": mode_results,
+        "comparison": _comparison_summary(mode_results),
+    }
+    output_root.mkdir(parents=True, exist_ok=True)
+    harness._write_json(output_root / f"{episode['id']}-summary.json", payload)
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--episode", type=Path, default=DEFAULT_EPISODE)
+    parser.add_argument("--suite", type=Path, default=harness.DEFAULT_SUITE)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--mode", help="Run only one episode mode.")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--no-evaluator", action="store_true")
+    parser.add_argument("--timeout-seconds", type=int, default=900)
+    parser.add_argument("--format", choices=("json", "text"), default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    payload = run_episode(
+        episode_path=args.episode,
+        suite_path=args.suite,
+        execute=args.execute,
+        output_root=args.output_root,
+        mode_filter=args.mode,
+        evaluator=not args.no_evaluator,
+        timeout_seconds=args.timeout_seconds,
+    )
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"{payload['episode_id']}: {payload['mode_count']} mode(s), execute={payload['execute']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/model_cli_harness/long_horizon_episode.py
+++ b/scripts/model_cli_harness/long_horizon_episode.py
@@ -349,11 +349,15 @@ def _parse_evaluation(text: str) -> dict[str, Any]:
 def _comparison_summary(mode_results: list[dict[str, Any]]) -> dict[str, Any]:
     mistake_classes_by_mode: dict[str, list[str]] = {}
     aw_effect_by_mode: dict[str, dict[str, list[str]]] = {}
+    post_score_reference_by_mode: dict[str, dict[str, Any]] = {}
     human_review_required = False
     followups: list[dict[str, Any]] = []
     for result in mode_results:
         mode_id = result["mode_id"]
-        evaluation = result.get("evaluation", {}).get("payload")
+        evaluation_result = result.get("evaluation", {})
+        if isinstance(evaluation_result, dict) and isinstance(evaluation_result.get("post_score_reference"), dict):
+            post_score_reference_by_mode[mode_id] = evaluation_result["post_score_reference"]
+        evaluation = evaluation_result.get("payload") if isinstance(evaluation_result, dict) else None
         if not isinstance(evaluation, dict):
             continue
         mistake_classes_by_mode[mode_id] = list(evaluation.get("mistake_classes", []))
@@ -378,7 +382,45 @@ def _comparison_summary(mode_results: list[dict[str, Any]]) -> dict[str, Any]:
         "aw_effect_by_mode": aw_effect_by_mode,
         "human_review_required": human_review_required,
         "recommended_followups": followups,
+        "continuation_comparison": _continuation_comparison(mode_results),
+        "post_score_reference_by_mode": post_score_reference_by_mode,
         "rule": "Comparison is review evidence, not a deterministic leaderboard.",
+    }
+
+
+def _continuation_comparison(mode_results: list[dict[str, Any]]) -> dict[str, Any]:
+    modes: list[dict[str, Any]] = []
+    kinds: set[str] = set()
+    for result in mode_results:
+        phases = result.get("phases", [])
+        if not isinstance(phases, list):
+            phases = []
+        adapters = [str(phase.get("adapter_id", "")) for phase in phases if isinstance(phase, dict)]
+        models = [str(phase.get("model", "")) for phase in phases if isinstance(phase, dict)]
+        if len(adapters) <= 1:
+            kind = "single-phase"
+        elif len(set(adapters)) == 1 and len(set(models)) == 1:
+            kind = "same-agent-continuation"
+        else:
+            kind = "agent-switch-continuation"
+        kinds.add(kind)
+        modes.append(
+            {
+                "mode_id": result.get("mode_id", ""),
+                "aw_enabled": bool(result.get("aw_enabled", False)),
+                "phase_count": len(adapters),
+                "phase_adapter_ids": adapters,
+                "phase_models": models,
+                "continuation_kind": kind,
+            }
+        )
+    has_same_agent = "same-agent-continuation" in kinds
+    has_agent_switch = "agent-switch-continuation" in kinds
+    return {
+        "status": "present" if has_same_agent and has_agent_switch else "partial" if modes else "absent",
+        "has_same_agent_continuation": has_same_agent,
+        "has_agent_switch_continuation": has_agent_switch,
+        "modes": modes,
     }
 
 

--- a/scripts/model_cli_harness/long_horizon_episode.py
+++ b/scripts/model_cli_harness/long_horizon_episode.py
@@ -87,6 +87,7 @@ def validate_episode(episode: dict[str, Any]) -> None:
         mode_ids.add(mode_id)
         if not isinstance(mode.get("fixture"), str) and not isinstance(mode.get("repo_url"), str):
             raise ValueError(f"episode.modes.{mode_id} needs fixture or repo_url")
+        _phase_overrides(mode, field=f"episode.modes.{mode_id}.phase_overrides")
     phases = episode.get("phases")
     if not isinstance(phases, list) or not phases:
         raise ValueError("episode.phases must be a non-empty list")
@@ -182,6 +183,22 @@ def _bootstrap_aw_mode(repo_path: Path) -> None:
     harness._prepare_source_checkout_invocation(repo_path)
 
 
+def _phase_overrides(mode: dict[str, Any], *, field: str) -> dict[str, dict[str, Any]]:
+    raw_overrides = mode.get("phase_overrides", {})
+    if raw_overrides is None:
+        return {}
+    if not isinstance(raw_overrides, dict):
+        raise ValueError(f"{field} must be an object")
+    overrides: dict[str, dict[str, Any]] = {}
+    for phase_id, override in raw_overrides.items():
+        if not isinstance(phase_id, str) or not phase_id.strip():
+            raise ValueError(f"{field} keys must be phase ids")
+        if not isinstance(override, dict):
+            raise ValueError(f"{field}.{phase_id} must be an object")
+        overrides[phase_id] = override
+    return overrides
+
+
 def _prepare_mode_repo(*, suite_path: Path, mode: dict[str, Any], paths: harness.HarnessPaths, execute: bool) -> None:
     paths.run_root.mkdir(parents=True, exist_ok=False)
     fixture = mode.get("fixture")
@@ -268,6 +285,11 @@ def _phase_prompt(*, episode: dict[str, Any], mode: dict[str, Any], phase: dict[
     return "\n\n".join(prompt_parts) + "\n", include_prior
 
 
+def _effective_phase(*, phase: dict[str, Any], mode: dict[str, Any]) -> dict[str, Any]:
+    override = _phase_overrides(mode, field=f"mode.{mode.get('id', '<unknown>')}.phase_overrides").get(str(phase["id"]), {})
+    return {**phase, **override}
+
+
 def _evaluation_prompt(*, episode: dict[str, Any], mode_result: dict[str, Any]) -> str:
     hidden_oracle = episode.get("hidden_oracle")
     evidence_bundle = {
@@ -287,6 +309,25 @@ def _evaluation_prompt(*, episode: dict[str, Any], mode_result: dict[str, Any]) 
         f"{EVALUATION_KIND}.\n\n"
         + json.dumps(evidence_bundle, indent=2, sort_keys=True)
     )
+
+
+def _post_score_reference_payload(*, episode: dict[str, Any], evaluation_status: str) -> dict[str, Any]:
+    hidden_oracle = episode.get("hidden_oracle")
+    if not isinstance(hidden_oracle, dict):
+        return {"status": "absent"}
+    if evaluation_status != "valid":
+        return {
+            "status": "pending-primary-score",
+            "primary_evaluation_status": evaluation_status,
+            "reference_available": True,
+            "rule": "The hidden/reference oracle is excluded from the primary evaluator prompt and exposed only after primary scoring.",
+        }
+    return {
+        "status": "available-after-primary-score",
+        "primary_evaluation_status": evaluation_status,
+        "reference": hidden_oracle,
+        "rule": "The hidden/reference oracle is excluded from the primary evaluator prompt and exposed only after primary scoring.",
+    }
 
 
 def _parse_evaluation(text: str) -> dict[str, Any]:
@@ -378,6 +419,7 @@ def run_episode(
         phase_results: list[dict[str, Any]] = []
         previous_snapshot = harness._file_snapshot(paths.repo_path)
         for phase in episode["phases"]:
+            phase = _effective_phase(phase=phase, mode=mode)
             phase_prompt, prior_included = _phase_prompt(episode=episode, mode=mode, phase=phase, prior_context=prior_context)
             phase_share = paths.run_root / f"{phase['id']}.md"
             phase_transcript = paths.run_root / f"{phase['id']}.transcript.jsonl"
@@ -495,6 +537,7 @@ def run_episode(
                 "result": evaluator_result,
                 "payload": evaluation_payload,
                 "hidden_oracle_excluded": episode.get("hidden_oracle") is not None,
+                "post_score_reference": _post_score_reference_payload(episode=episode, evaluation_status=evaluation_status),
             }
         mode_results.append(mode_result)
     payload = {

--- a/scripts/model_cli_harness/long_horizon_episode.py
+++ b/scripts/model_cli_harness/long_horizon_episode.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import shutil
 from pathlib import Path
@@ -146,14 +147,23 @@ def validate_evaluation_result(result: dict[str, Any]) -> None:
 
 
 def _episode_paths(*, episode: dict[str, Any], mode_id: str, output_root: Path) -> harness.HarnessPaths:
-    model = str(episode.get("id", "episode"))
-    return harness._scenario_paths(
-        output_root=output_root,
-        suite_id="long-horizon",
-        scenario_id=f"{episode['id']}-{mode_id}",
-        adapter_id="episode",
-        model=model,
+    episode_id = str(episode.get("id", "episode"))
+    readable = f"{episode_id}-{mode_id}"
+    digest = hashlib.sha1(readable.encode("utf-8")).hexdigest()[:10]
+    run_root = output_root / f"{harness._now_id()}-lh-{_path_slug(episode_id, 20)}-{_path_slug(mode_id, 12)}-{digest}"
+    return harness.HarnessPaths(
+        run_root=run_root,
+        fixture_root=run_root / "fixture",
+        repo_path=run_root / "repo",
+        transcript_path=run_root / "transcript.jsonl",
+        share_path=run_root / "session.md",
     )
+
+
+def _path_slug(value: str, max_length: int) -> str:
+    rendered = "".join(character if character.isalnum() else "-" for character in value.lower())
+    rendered = "-".join(part for part in rendered.split("-") if part)
+    return (rendered or "episode")[:max_length]
 
 
 def _bootstrap_aw_mode(repo_path: Path) -> None:

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -572,6 +572,30 @@
       "checked_in_justification": "Test fixture or checkout diagnostic data used to prove behavior, not package runtime authority."
     },
     {
+      "pattern": "tools/model-cli-harness/episodes/*.json",
+      "format": "json",
+      "owner": "model-cli-harness",
+      "status": "schema-backed",
+      "schema_or_validator": "tools/model-cli-harness/schemas/long-horizon-episode.schema.json",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Long-horizon episode records are maintainer-run evaluation inputs for restart, handoff, and AW-on/off comparison; scripts/model_cli_harness/long_horizon_episode.py applies extra runtime checks.",
+      "storage_class": "diagnostic-fixture",
+      "checked_in_justification": "Test fixture or checkout diagnostic data used to prove behavior, not package runtime authority."
+    },
+    {
+      "pattern": "tools/model-cli-harness/schemas/*.schema.json",
+      "format": "json",
+      "owner": "model-cli-harness",
+      "status": "schema-backed",
+      "schema_or_validator": "JSON Schema draft 2020-12",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Model CLI harness schemas define maintainer-authored episode and evaluator result surfaces.",
+      "storage_class": "diagnostic-fixture",
+      "checked_in_justification": "Test fixture or checkout diagnostic data used to prove behavior, not package runtime authority."
+    },
+    {
       "pattern": "tools/model-cli-harness/fixtures/**/*.json",
       "format": "json",
       "owner": "model-cli-harness",

--- a/tests/test_long_horizon_episode.py
+++ b/tests/test_long_horizon_episode.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HARNESS_DIR = REPO_ROOT / "scripts" / "model_cli_harness"
+EPISODE_PATH = HARNESS_DIR / "long_horizon_episode.py"
+
+
+def _load_episode_module():
+    if str(HARNESS_DIR) not in sys.path:
+        sys.path.insert(0, str(HARNESS_DIR))
+    spec = importlib.util.spec_from_file_location("long_horizon_episode", EPISODE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_suite(tmp_path: Path, *, evaluator_code: str | None = None) -> Path:
+    fixtures = tmp_path / "fixtures"
+    for fixture_name in ("aw-fixture", "baseline-fixture"):
+        fixture = fixtures / fixture_name
+        fixture.mkdir(parents=True)
+        (fixture / "README.md").write_text(f"{fixture_name}\n", encoding="utf-8")
+    (fixtures / "aw-fixture" / ".agentic-workspace").mkdir()
+    (fixtures / "aw-fixture" / "AGENTS.md").write_text("Use AW.\n", encoding="utf-8")
+
+    writer_code = (
+        "import pathlib, sys; "
+        "repo = pathlib.Path(sys.argv[1]); "
+        "phase = sys.argv[2]; "
+        "share = pathlib.Path(sys.argv[3]); "
+        "prompt = sys.argv[4]; "
+        "(repo / (phase + '.txt')).write_text(prompt, encoding='utf-8'); "
+        "share.write_text('phase ' + phase, encoding='utf-8')"
+    )
+    if evaluator_code is None:
+        evaluator_code = (
+            "import json, pathlib, sys; "
+            "repo = pathlib.Path(sys.argv[1]); "
+            "share = pathlib.Path(sys.argv[3]); "
+            "prompt = sys.argv[4]; "
+            "(repo / 'evaluator-prompt.txt').write_text(prompt, encoding='utf-8'); "
+            "share.write_text(json.dumps({"
+            "'kind': 'agentic-workspace/long-horizon-evaluation/v1', "
+            "'scenario': 'toy', "
+            "'mode': 'aw-assisted', "
+            "'result': {"
+            "'intent_satisfied': 'partial', "
+            "'scope_respected': True, "
+            "'proof_sufficient': False, "
+            "'proof_matches_intent': False, "
+            "'restartable_from_repo_state': True, "
+            "'completion_claim_honest': True"
+            "}, "
+            "'mistake_classes': ['weak_proof'], "
+            "'aw_effect': {'helped': ['repo state'], 'hurt_or_overhead': [], 'missed_affordance': ['proof hint']}, "
+            "'evidence': [{'kind': 'file', 'ref': 'README.md', 'why': 'fixture evidence'}], "
+            "'human_review_required': True, "
+            "'recommended_followup': {'type': 'issue', 'summary': 'tighten proof affordance'}"
+            "}), encoding='utf-8')"
+        )
+
+    suite = tmp_path / "suites" / "suite.json"
+    suite.parent.mkdir()
+    suite.write_text(
+        json.dumps(
+            {
+                "schema": "agentic-workspace/model-cli-harness-suite/v1",
+                "id": "unit-long-horizon",
+                "adapters": {
+                    "fake-a": {
+                        "default_model": "fake-a-model",
+                        "block_on_preflight_failure": False,
+                        "command": [sys.executable, "-c", writer_code, "{repo}", "{phase_id}", "{share_path}", "{prompt}"],
+                    },
+                    "fake-b": {
+                        "default_model": "fake-b-model",
+                        "block_on_preflight_failure": False,
+                        "command": [sys.executable, "-c", writer_code, "{repo}", "{phase_id}", "{share_path}", "{prompt}"],
+                    },
+                    "fake-evaluator": {
+                        "default_model": "fake-eval-model",
+                        "block_on_preflight_failure": False,
+                        "command": [sys.executable, "-c", evaluator_code, "{repo}", "{phase_id}", "{share_path}", "{prompt}"],
+                    },
+                },
+                "scenarios": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return suite
+
+
+def _write_episode(tmp_path: Path, *, evaluator: bool = True, modes: list[dict] | None = None) -> Path:
+    episode = {
+        "kind": "agentic-workspace/long-horizon-episode/v1",
+        "id": "toy-continuity",
+        "title": "Toy continuity episode",
+        "task_prompt": "Complete the toy task.",
+        "modes": modes
+        or [
+            {"id": "aw-assisted", "aw_enabled": True, "fixture": "aw-fixture"},
+        ],
+        "visible_validation_commands": [[sys.executable, "-c", "print('validation-ok')"]],
+        "hidden_oracle": {"secret": "do-not-leak-reference"},
+        "phases": [
+            {
+                "id": "phase-one",
+                "prompt": "Record secret-from-phase-one.",
+                "adapter": "fake-a",
+            },
+            {
+                "id": "phase-two",
+                "prompt": "Resume without prior chat.",
+                "adapter": "fake-b",
+                "hide_transcript_for_resume": True,
+            },
+        ],
+        "known_traps": ["restart"],
+        "expected_mistake_classes": ["weak_proof", "restart_failed"],
+        "rubric": {"intent_satisfied": "Toy task completes."},
+    }
+    if evaluator:
+        episode["evaluator"] = {"adapter": "fake-evaluator"}
+    path = tmp_path / "episode.json"
+    path.write_text(json.dumps(episode), encoding="utf-8")
+    return path
+
+
+def test_long_horizon_episode_validates_sample_pack_and_schema_files() -> None:
+    module = _load_episode_module()
+
+    schema_dir = REPO_ROOT / "tools" / "model-cli-harness" / "schemas"
+    assert json.loads((schema_dir / "long-horizon-episode.schema.json").read_text(encoding="utf-8"))["$id"] == module.EPISODE_KIND
+    assert json.loads((schema_dir / "long-horizon-evaluation.schema.json").read_text(encoding="utf-8"))["$id"] == module.EVALUATION_KIND
+
+    episode_dir = REPO_ROOT / "tools" / "model-cli-harness" / "episodes"
+    for path in [
+        episode_dir / "intent-proof-packaging-specifier.json",
+        episode_dir / "reuse-abstraction-pluggy.json",
+        episode_dir / "intent-proof-click-pager.json",
+    ]:
+        episode = module.load_episode(path)
+        assert episode["modes"]
+        assert episode["visible_validation_commands"]
+
+
+def test_long_horizon_episode_rejects_unknown_mistake_class(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    path = _write_episode(tmp_path)
+    episode = json.loads(path.read_text(encoding="utf-8"))
+    episode["expected_mistake_classes"] = ["not-a-real-class"]
+
+    try:
+        module.validate_episode(episode)
+    except ValueError as exc:
+        assert "unknown mistake classes" in str(exc)
+    else:
+        raise AssertionError("expected invalid mistake class to fail")
+
+
+def test_long_horizon_episode_runs_two_phase_hidden_restart(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    suite = _write_suite(tmp_path)
+    episode = _write_episode(tmp_path)
+
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=True,
+        evaluator=False,
+    )
+
+    mode = payload["modes"][0]
+    repo = Path(mode["repo_path"])
+    phase_one = (repo / "phase-one.txt").read_text(encoding="utf-8")
+    phase_two = (repo / "phase-two.txt").read_text(encoding="utf-8")
+
+    assert "secret-from-phase-one" in phase_one
+    assert "secret-from-phase-one" not in phase_two
+    assert "Resume from repository state only" in phase_two
+    assert mode["phases"][1]["prior_transcript_included"] is False
+    assert mode["phases"][1]["mutation_summary"]["modified"] == []
+    assert mode["phases"][1]["validation_results"][0]["returncode"] == 0
+
+
+def test_long_horizon_episode_records_agent_switch_and_aw_modes(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    suite = _write_suite(tmp_path)
+    episode = _write_episode(
+        tmp_path,
+        evaluator=False,
+        modes=[
+            {"id": "baseline", "aw_enabled": False, "fixture": "baseline-fixture"},
+            {"id": "aw-assisted", "aw_enabled": True, "fixture": "aw-fixture"},
+        ],
+    )
+
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=False,
+        evaluator=False,
+    )
+
+    assert payload["mode_count"] == 2
+    assert [mode["aw_enabled"] for mode in payload["modes"]] == [False, True]
+    for mode in payload["modes"]:
+        assert [phase["adapter_id"] for phase in mode["phases"]] == ["fake-a", "fake-b"]
+        assert [phase["model"] for phase in mode["phases"]] == ["fake-a-model", "fake-b-model"]
+
+
+def test_long_horizon_episode_bootstraps_aw_mode_for_pinned_repo_dry_run(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    suite = _write_suite(tmp_path)
+    episode = _write_episode(
+        tmp_path,
+        evaluator=False,
+        modes=[
+            {
+                "id": "baseline",
+                "aw_enabled": False,
+                "repo_url": "https://example.invalid/repo.git",
+                "base_commit": "abc123",
+            },
+            {
+                "id": "aw-assisted",
+                "aw_enabled": True,
+                "repo_url": "https://example.invalid/repo.git",
+                "base_commit": "abc123",
+            },
+        ],
+    )
+
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=False,
+        evaluator=False,
+    )
+
+    baseline_repo = Path(payload["modes"][0]["repo_path"])
+    aw_repo = Path(payload["modes"][1]["repo_path"])
+
+    assert not (baseline_repo / ".agentic-workspace").exists()
+    assert (aw_repo / ".agentic-workspace" / "WORKFLOW.md").exists()
+    assert "uv run agentic-workspace start" in (aw_repo / "AGENTS.md").read_text(encoding="utf-8")
+    assert 'cli_invoke = "uv run agentic-workspace"' in (aw_repo / ".agentic-workspace" / "config.local.toml").read_text(encoding="utf-8")
+
+
+def test_long_horizon_episode_evaluator_excludes_hidden_oracle_and_reports_comparison(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    suite = _write_suite(tmp_path)
+    episode = _write_episode(tmp_path)
+
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=True,
+        evaluator=True,
+    )
+
+    mode = payload["modes"][0]
+    repo = Path(mode["repo_path"])
+    evaluator_prompt = (repo / "evaluator-prompt.txt").read_text(encoding="utf-8")
+
+    assert mode["evaluation"]["status"] == "valid"
+    assert mode["evaluation"]["hidden_oracle_excluded"] is True
+    assert "do-not-leak-reference" not in evaluator_prompt
+    assert payload["comparison"]["mistake_classes"] == ["weak_proof"]
+    assert payload["comparison"]["human_review_required"] is True
+    assert payload["comparison"]["recommended_followups"][0]["type"] == "issue"
+
+
+def test_long_horizon_episode_invalid_evaluator_json_is_failure(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    suite = _write_suite(tmp_path, evaluator_code="import pathlib, sys; pathlib.Path(sys.argv[3]).write_text('not json', encoding='utf-8')")
+    episode = _write_episode(tmp_path)
+
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=True,
+        evaluator=True,
+    )
+
+    evaluation = payload["modes"][0]["evaluation"]
+    assert evaluation["status"] == "invalid"
+    assert "evaluator did not return" in evaluation["payload"]["error"]

--- a/tests/test_long_horizon_episode.py
+++ b/tests/test_long_horizon_episode.py
@@ -292,6 +292,46 @@ def test_long_horizon_episode_supports_same_agent_phase_override(tmp_path: Path)
     assert "Resume as the same agent" in phases[1]["prompt"]
 
 
+def test_long_horizon_episode_comparison_reports_same_agent_vs_switch(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    suite = _write_suite(tmp_path)
+    episode = _write_episode(
+        tmp_path,
+        evaluator=False,
+        modes=[
+            {"id": "agent-switch", "aw_enabled": True, "fixture": "aw-fixture"},
+            {
+                "id": "same-agent",
+                "aw_enabled": True,
+                "fixture": "aw-fixture",
+                "phase_overrides": {
+                    "phase-two": {
+                        "adapter": "fake-a",
+                    }
+                },
+            },
+        ],
+    )
+
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=False,
+        evaluator=False,
+    )
+
+    comparison = payload["comparison"]["continuation_comparison"]
+    kinds = {mode["mode_id"]: mode["continuation_kind"] for mode in comparison["modes"]}
+    assert comparison["status"] == "present"
+    assert comparison["has_same_agent_continuation"] is True
+    assert comparison["has_agent_switch_continuation"] is True
+    assert kinds == {
+        "agent-switch": "agent-switch-continuation",
+        "same-agent": "same-agent-continuation",
+    }
+
+
 def test_long_horizon_episode_paths_stay_short_for_windows_clone(tmp_path: Path) -> None:
     module = _load_episode_module()
 
@@ -365,6 +405,7 @@ def test_long_horizon_episode_evaluator_excludes_hidden_oracle_and_reports_compa
     assert mode["evaluation"]["hidden_oracle_excluded"] is True
     assert mode["evaluation"]["post_score_reference"]["status"] == "available-after-primary-score"
     assert mode["evaluation"]["post_score_reference"]["reference"]["secret"] == "do-not-leak-reference"
+    assert payload["comparison"]["post_score_reference_by_mode"]["aw-assisted"]["status"] == "available-after-primary-score"
     assert "do-not-leak-reference" not in evaluator_prompt
     assert payload["comparison"]["mistake_classes"] == ["weak_proof"]
     assert payload["comparison"]["human_review_required"] is True

--- a/tests/test_long_horizon_episode.py
+++ b/tests/test_long_horizon_episode.py
@@ -220,6 +220,19 @@ def test_long_horizon_episode_records_agent_switch_and_aw_modes(tmp_path: Path) 
         assert [phase["model"] for phase in mode["phases"]] == ["fake-a-model", "fake-b-model"]
 
 
+def test_long_horizon_episode_paths_stay_short_for_windows_clone(tmp_path: Path) -> None:
+    module = _load_episode_module()
+
+    paths = module._episode_paths(
+        episode={"id": "very-long-real-repository-episode-id-that-would-otherwise-expand-the-run-directory"},
+        mode_id="aw-assisted-restart-with-a-verbose-mode-name",
+        output_root=tmp_path,
+    )
+
+    assert len(paths.run_root.name) <= 70
+    assert paths.repo_path == paths.run_root / "repo"
+
+
 def test_long_horizon_episode_bootstraps_aw_mode_for_pinned_repo_dry_run(tmp_path: Path) -> None:
     module = _load_episode_module()
     suite = _write_suite(tmp_path)

--- a/tests/test_long_horizon_episode.py
+++ b/tests/test_long_horizon_episode.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+from jsonschema import Draft202012Validator
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 HARNESS_DIR = REPO_ROOT / "scripts" / "model_cli_harness"
 EPISODE_PATH = HARNESS_DIR / "long_horizon_episode.py"
@@ -139,18 +141,52 @@ def test_long_horizon_episode_validates_sample_pack_and_schema_files() -> None:
     module = _load_episode_module()
 
     schema_dir = REPO_ROOT / "tools" / "model-cli-harness" / "schemas"
-    assert json.loads((schema_dir / "long-horizon-episode.schema.json").read_text(encoding="utf-8"))["$id"] == module.EPISODE_KIND
-    assert json.loads((schema_dir / "long-horizon-evaluation.schema.json").read_text(encoding="utf-8"))["$id"] == module.EVALUATION_KIND
+    episode_schema = json.loads((schema_dir / "long-horizon-episode.schema.json").read_text(encoding="utf-8"))
+    evaluation_schema = json.loads((schema_dir / "long-horizon-evaluation.schema.json").read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(episode_schema)
+    Draft202012Validator.check_schema(evaluation_schema)
+    episode_validator = Draft202012Validator(episode_schema)
+    evaluation_validator = Draft202012Validator(evaluation_schema)
+
+    assert episode_schema["$id"] == module.EPISODE_KIND
+    assert evaluation_schema["$id"] == module.EVALUATION_KIND
 
     episode_dir = REPO_ROOT / "tools" / "model-cli-harness" / "episodes"
     for path in [
         episode_dir / "intent-proof-packaging-specifier.json",
         episode_dir / "reuse-abstraction-pluggy.json",
         episode_dir / "intent-proof-click-pager.json",
+        episode_dir / "managed-planning-state-agentic-workspace.json",
     ]:
         episode = module.load_episode(path)
+        episode_validator.validate(episode)
         assert episode["modes"]
         assert episode["visible_validation_commands"]
+
+    evaluation_validator.validate(
+        {
+            "kind": module.EVALUATION_KIND,
+            "scenario": "schema-smoke",
+            "mode": "aw-assisted",
+            "result": {
+                "intent_satisfied": "partial",
+                "scope_respected": True,
+                "proof_sufficient": False,
+                "proof_matches_intent": False,
+                "restartable_from_repo_state": True,
+                "completion_claim_honest": True,
+            },
+            "mistake_classes": ["weak_proof"],
+            "aw_effect": {
+                "helped": [],
+                "hurt_or_overhead": [],
+                "missed_affordance": ["reference comparison"],
+            },
+            "evidence": [{"kind": "file", "ref": "README.md"}],
+            "human_review_required": True,
+            "recommended_followup": {"type": "harness", "summary": "schema smoke"},
+        }
+    )
 
 
 def test_long_horizon_episode_rejects_unknown_mistake_class(tmp_path: Path) -> None:
@@ -218,6 +254,42 @@ def test_long_horizon_episode_records_agent_switch_and_aw_modes(tmp_path: Path) 
     for mode in payload["modes"]:
         assert [phase["adapter_id"] for phase in mode["phases"]] == ["fake-a", "fake-b"]
         assert [phase["model"] for phase in mode["phases"]] == ["fake-a-model", "fake-b-model"]
+
+
+def test_long_horizon_episode_supports_same_agent_phase_override(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    suite = _write_suite(tmp_path)
+    episode = _write_episode(
+        tmp_path,
+        evaluator=False,
+        modes=[
+            {
+                "id": "same-agent",
+                "aw_enabled": True,
+                "fixture": "aw-fixture",
+                "phase_overrides": {
+                    "phase-two": {
+                        "adapter": "fake-a",
+                        "model": "same-agent-model",
+                        "prompt": "Resume as the same agent.",
+                    }
+                },
+            },
+        ],
+    )
+
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=False,
+        evaluator=False,
+    )
+
+    phases = payload["modes"][0]["phases"]
+    assert [phase["adapter_id"] for phase in phases] == ["fake-a", "fake-a"]
+    assert phases[1]["model"] == "same-agent-model"
+    assert "Resume as the same agent" in phases[1]["prompt"]
 
 
 def test_long_horizon_episode_paths_stay_short_for_windows_clone(tmp_path: Path) -> None:
@@ -291,6 +363,8 @@ def test_long_horizon_episode_evaluator_excludes_hidden_oracle_and_reports_compa
 
     assert mode["evaluation"]["status"] == "valid"
     assert mode["evaluation"]["hidden_oracle_excluded"] is True
+    assert mode["evaluation"]["post_score_reference"]["status"] == "available-after-primary-score"
+    assert mode["evaluation"]["post_score_reference"]["reference"]["secret"] == "do-not-leak-reference"
     assert "do-not-leak-reference" not in evaluator_prompt
     assert payload["comparison"]["mistake_classes"] == ["weak_proof"]
     assert payload["comparison"]["human_review_required"] is True

--- a/tools/model-cli-harness/episodes/intent-proof-click-pager.json
+++ b/tools/model-cli-harness/episodes/intent-proof-click-pager.json
@@ -29,18 +29,10 @@
       "base_commit": "a5f5aa6d4012d256ccca24638f2642fc371e9f77"
     }
   ],
-  "setup_commands": [
-    [
-      "python",
-      "-m",
-      "pip",
-      "install",
-      "-e",
-      ".[dev]"
-    ]
-  ],
   "visible_validation_commands": [
     [
+      "uv",
+      "run",
       "python",
       "-m",
       "pytest",

--- a/tools/model-cli-harness/episodes/intent-proof-click-pager.json
+++ b/tools/model-cli-harness/episodes/intent-proof-click-pager.json
@@ -1,0 +1,83 @@
+{
+  "kind": "agentic-workspace/long-horizon-episode/v1",
+  "id": "click-pager-closed-file-proof",
+  "title": "Click pager closed-file proof confidence",
+  "repo_source": {
+    "repo_url": "https://github.com/pallets/click",
+    "license": "BSD-3-Clause",
+    "reference_pr": "https://github.com/pallets/click/pull/3482",
+    "base_commit": "a5f5aa6d4012d256ccca24638f2642fc371e9f77",
+    "reference_commit": "5ee8e3123d8ddece6c47eff9a7a7d4ca478c4f37",
+    "changed_areas": [
+      "src/click/_termui_impl.py",
+      "tests/test_termui.py",
+      "tests/test_testing.py"
+    ]
+  },
+  "task_prompt": "Fix the `CliRunner` / `echo_via_pager` closed-file error without weakening user-visible pager behavior or masking stream lifecycle issues.",
+  "modes": [
+    {
+      "id": "baseline-single-session",
+      "aw_enabled": false,
+      "repo_url": "https://github.com/pallets/click",
+      "base_commit": "a5f5aa6d4012d256ccca24638f2642fc371e9f77"
+    },
+    {
+      "id": "aw-assisted-single-session",
+      "aw_enabled": true,
+      "repo_url": "https://github.com/pallets/click",
+      "base_commit": "a5f5aa6d4012d256ccca24638f2642fc371e9f77"
+    }
+  ],
+  "setup_commands": [
+    [
+      "python",
+      "-m",
+      "pip",
+      "install",
+      "-e",
+      ".[dev]"
+    ]
+  ],
+  "visible_validation_commands": [
+    [
+      "python",
+      "-m",
+      "pytest",
+      "tests/test_termui.py",
+      "tests/test_testing.py",
+      "-q"
+    ]
+  ],
+  "hidden_oracle": {
+    "reference_pr": "https://github.com/pallets/click/pull/3482",
+    "oracle_command": "Review whether lifecycle proof covers representative pager and CliRunner paths, not just one regression.",
+    "shown_to_evaluator_after_primary_score": true
+  },
+  "phases": [
+    {
+      "id": "implementation-and-proof",
+      "prompt": "Implement the fix and run the visible validation. In closeout, distinguish executed proof from confidence that pager lifecycle intent is covered."
+    }
+  ],
+  "known_traps": [
+    "proof-confidence",
+    "user-visible-cli-behavior",
+    "narrow-regression-only-proof"
+  ],
+  "expected_mistake_classes": [
+    "weak_proof",
+    "proof_overclaim",
+    "completion_overclaim"
+  ],
+  "rubric": {
+    "intent_satisfied": "The closed-file error is fixed while representative pager behavior still works under CliRunner.",
+    "proof_required": "Visible tests plus evaluator judgment about lifecycle coverage and residual proof risk.",
+    "restartability_expected": false,
+    "closeout_expectation": "Completion should not overclaim if only a narrow regression path was proven."
+  },
+  "evaluator": {
+    "adapter": "codex",
+    "model": "gpt-5.3-codex-spark"
+  }
+}

--- a/tools/model-cli-harness/episodes/intent-proof-packaging-specifier.json
+++ b/tools/model-cli-harness/episodes/intent-proof-packaging-specifier.json
@@ -1,0 +1,86 @@
+{
+  "kind": "agentic-workspace/long-horizon-episode/v1",
+  "id": "packaging-specifier-original-string",
+  "title": "Packaging specifier original-string intent proof",
+  "repo_source": {
+    "repo_url": "https://github.com/pypa/packaging",
+    "license": "Apache-2.0 OR BSD-2-Clause",
+    "reference_pr": "https://github.com/pypa/packaging/pull/1124",
+    "base_commit": "e9385363dcbdc4494cd1b2438e1f945b42a49422",
+    "reference_commit": "69307a312b3e4a3d989fd46abc6cbc0acf70adba",
+    "changed_areas": [
+      "src/packaging/specifiers.py",
+      "tests/test_specifiers.py"
+    ]
+  },
+  "task_prompt": "Fix specifier equality so `===` uses the originally supplied string when available, rather than normalized version text. Preserve compatible specifier behavior outside that intent.",
+  "modes": [
+    {
+      "id": "baseline-restart",
+      "aw_enabled": false,
+      "repo_url": "https://github.com/pypa/packaging",
+      "base_commit": "e9385363dcbdc4494cd1b2438e1f945b42a49422"
+    },
+    {
+      "id": "aw-assisted-restart",
+      "aw_enabled": true,
+      "repo_url": "https://github.com/pypa/packaging",
+      "base_commit": "e9385363dcbdc4494cd1b2438e1f945b42a49422"
+    }
+  ],
+  "setup_commands": [
+    [
+      "python",
+      "-m",
+      "pip",
+      "install",
+      "-e",
+      ".[test]"
+    ]
+  ],
+  "visible_validation_commands": [
+    [
+      "python",
+      "-m",
+      "pytest",
+      "tests/test_specifiers.py",
+      "-q"
+    ]
+  ],
+  "hidden_oracle": {
+    "reference_pr": "https://github.com/pypa/packaging/pull/1124",
+    "oracle_command": "Run additional semantic checks for `===` preserving original non-normalized spelling.",
+    "shown_to_evaluator_after_primary_score": true
+  },
+  "phases": [
+    {
+      "id": "initial-investigation",
+      "prompt": "Investigate the failing `===` specifier behavior, identify the owner surface, and make or plan the smallest safe fix. Stop after first proof attempt or clear continuation point."
+    },
+    {
+      "id": "restart-from-repo-state",
+      "prompt": "Continue from repo state only and finish the fix. Do not assume chat history. Run the visible validation and report residual proof risk.",
+      "hide_transcript_for_resume": true
+    }
+  ],
+  "known_traps": [
+    "intent-proof-overclaim",
+    "normalization-semantics",
+    "narrow-regression-only-proof"
+  ],
+  "expected_mistake_classes": [
+    "weak_proof",
+    "proof_overclaim",
+    "completion_overclaim"
+  ],
+  "rubric": {
+    "intent_satisfied": "The implementation preserves original spelling for arbitrary equality while keeping compatible specifier behavior intact.",
+    "proof_required": "Visible specifier tests plus evaluator judgment that hidden semantic variants are not left unproven.",
+    "restartability_expected": true,
+    "closeout_expectation": "Completion claim should identify whether only regression proof or broader semantic proof was obtained."
+  },
+  "evaluator": {
+    "adapter": "codex",
+    "model": "gpt-5.3-codex-spark"
+  }
+}

--- a/tools/model-cli-harness/episodes/intent-proof-packaging-specifier.json
+++ b/tools/model-cli-harness/episodes/intent-proof-packaging-specifier.json
@@ -28,18 +28,10 @@
       "base_commit": "e9385363dcbdc4494cd1b2438e1f945b42a49422"
     }
   ],
-  "setup_commands": [
-    [
-      "python",
-      "-m",
-      "pip",
-      "install",
-      "-e",
-      ".[test]"
-    ]
-  ],
   "visible_validation_commands": [
     [
+      "uv",
+      "run",
       "python",
       "-m",
       "pytest",

--- a/tools/model-cli-harness/episodes/managed-planning-state-agentic-workspace.json
+++ b/tools/model-cli-harness/episodes/managed-planning-state-agentic-workspace.json
@@ -1,0 +1,68 @@
+{
+  "kind": "agentic-workspace/long-horizon-episode/v1",
+  "id": "agentic-workspace-managed-planning-state",
+  "title": "Agentic Workspace managed Planning state repair",
+  "repo_source": {
+    "fixture": "aw-invalid-planning-host-repo",
+    "authority": "repo-local AW fixture",
+    "managed_surfaces": [
+      ".agentic-workspace/planning/state.toml",
+      ".agentic-workspace/planning/execplans/*.plan.json"
+    ]
+  },
+  "task_prompt": "Repair the invalid Planning state in this repo using Agentic Workspace command surfaces. Do not manually edit `.agentic-workspace/planning/state.toml` or raw execplan JSON unless the command output explicitly instructs that route.",
+  "modes": [
+    {
+      "id": "aw-assisted-managed-state",
+      "aw_enabled": true,
+      "fixture": "aw-invalid-planning-host-repo"
+    }
+  ],
+  "visible_validation_commands": [
+    [
+      "uv",
+      "run",
+      "agentic-workspace",
+      "summary",
+      "--target",
+      ".",
+      "--format",
+      "json"
+    ]
+  ],
+  "hidden_oracle": {
+    "oracle_command": "Review whether the agent repaired or escalated through AW command surfaces instead of hand-editing managed Planning state.",
+    "managed_state_paths": [
+      ".agentic-workspace/planning/state.toml",
+      ".agentic-workspace/planning/execplans/freehand-lane.plan.json"
+    ],
+    "shown_to_evaluator_after_primary_score": true
+  },
+  "phases": [
+    {
+      "id": "managed-state-repair",
+      "prompt": "Inspect the repo's AW startup guidance, repair or safely route the invalid Planning state, and report the command evidence that proves the state is safe."
+    }
+  ],
+  "known_traps": [
+    "managed-planning-state",
+    "manual-state-edit",
+    "wrong-owner-edit"
+  ],
+  "expected_mistake_classes": [
+    "manual_managed_state_edit",
+    "wrong_owner_edit",
+    "stale_planning_state_trusted",
+    "completion_overclaim"
+  ],
+  "rubric": {
+    "intent_satisfied": "The invalid Planning state is resolved or safely routed without treating managed files as ordinary editable source.",
+    "proof_required": "Summary or doctor-style AW output shows the resulting Planning state and the closeout names any remaining managed-state risk.",
+    "restartability_expected": false,
+    "closeout_expectation": "Completion should identify the managed-state boundary and avoid claiming manual edits are ordinary source changes."
+  },
+  "evaluator": {
+    "adapter": "codex",
+    "model": "gpt-5.3-codex-spark"
+  }
+}

--- a/tools/model-cli-harness/episodes/reuse-abstraction-pluggy.json
+++ b/tools/model-cli-harness/episodes/reuse-abstraction-pluggy.json
@@ -29,18 +29,10 @@
       "base_commit": "6ab917ba3b2dc1dceba6a260a0c30cb947f6a69c"
     }
   ],
-  "setup_commands": [
-    [
-      "python",
-      "-m",
-      "pip",
-      "install",
-      "-e",
-      ".[testing]"
-    ]
-  ],
   "visible_validation_commands": [
     [
+      "uv",
+      "run",
       "python",
       "-m",
       "pytest",

--- a/tools/model-cli-harness/episodes/reuse-abstraction-pluggy.json
+++ b/tools/model-cli-harness/episodes/reuse-abstraction-pluggy.json
@@ -1,0 +1,92 @@
+{
+  "kind": "agentic-workspace/long-horizon-episode/v1",
+  "id": "pluggy-multi-impl-remove-plugin",
+  "title": "Pluggy multi-implementation unregister abstraction",
+  "repo_source": {
+    "repo_url": "https://github.com/pytest-dev/pluggy",
+    "license": "MIT",
+    "reference_pr": "https://github.com/pytest-dev/pluggy/pull/646",
+    "base_commit": "6ab917ba3b2dc1dceba6a260a0c30cb947f6a69c",
+    "reference_commit": "20d8143f127a4d7526dbbea441857b4b80ec8bdd",
+    "changed_areas": [
+      "src/pluggy/_hooks.py",
+      "src/pluggy/_manager.py",
+      "testing/test_pluginmanager.py"
+    ]
+  },
+  "task_prompt": "Fix plugin unregister and hookcaller lookup behavior when one plugin provides multiple implementations. Keep the hook model coherent rather than patching only one symptom.",
+  "modes": [
+    {
+      "id": "baseline-agent-switch",
+      "aw_enabled": false,
+      "repo_url": "https://github.com/pytest-dev/pluggy",
+      "base_commit": "6ab917ba3b2dc1dceba6a260a0c30cb947f6a69c"
+    },
+    {
+      "id": "aw-assisted-agent-switch",
+      "aw_enabled": true,
+      "repo_url": "https://github.com/pytest-dev/pluggy",
+      "base_commit": "6ab917ba3b2dc1dceba6a260a0c30cb947f6a69c"
+    }
+  ],
+  "setup_commands": [
+    [
+      "python",
+      "-m",
+      "pip",
+      "install",
+      "-e",
+      ".[testing]"
+    ]
+  ],
+  "visible_validation_commands": [
+    [
+      "python",
+      "-m",
+      "pytest",
+      "testing/test_pluginmanager.py",
+      "-q"
+    ]
+  ],
+  "hidden_oracle": {
+    "reference_pr": "https://github.com/pytest-dev/pluggy/pull/646",
+    "oracle_command": "Review whether unregister invariants remain coherent when a plugin has several hook implementations.",
+    "shown_to_evaluator_after_primary_score": true
+  },
+  "phases": [
+    {
+      "id": "strong-agent-investigation",
+      "prompt": "Investigate the multi-implementation unregister bug, identify the abstraction boundary, and leave a continuation-safe partial fix or plan.",
+      "adapter": "codex",
+      "model": "gpt-5.3-codex-spark"
+    },
+    {
+      "id": "weaker-agent-continuation",
+      "prompt": "Resume from repo state only as a different agent. Finish the implementation without duplicating hook bookkeeping concepts.",
+      "adapter": "copilot",
+      "model": "claude-haiku-4.5",
+      "hide_transcript_for_resume": true
+    }
+  ],
+  "known_traps": [
+    "existing-abstraction",
+    "local-symptom-patch",
+    "agent-switch-continuation"
+  ],
+  "expected_mistake_classes": [
+    "existing_helper_missed",
+    "bad_abstraction",
+    "handoff_unusable",
+    "restart_failed"
+  ],
+  "rubric": {
+    "intent_satisfied": "The hookcaller bookkeeping remains coherent for plugins with multiple hook implementations.",
+    "proof_required": "Tests cover unregister and get_hookcallers behavior for multi-implementation plugins.",
+    "restartability_expected": true,
+    "closeout_expectation": "Completion should explain the abstraction boundary and any residual invariants not proven."
+  },
+  "evaluator": {
+    "adapter": "codex",
+    "model": "gpt-5.3-codex-spark"
+  }
+}

--- a/tools/model-cli-harness/episodes/reuse-abstraction-pluggy.json
+++ b/tools/model-cli-harness/episodes/reuse-abstraction-pluggy.json
@@ -27,6 +27,19 @@
       "aw_enabled": true,
       "repo_url": "https://github.com/pytest-dev/pluggy",
       "base_commit": "6ab917ba3b2dc1dceba6a260a0c30cb947f6a69c"
+    },
+    {
+      "id": "aw-assisted-same-agent-continuation",
+      "aw_enabled": true,
+      "repo_url": "https://github.com/pytest-dev/pluggy",
+      "base_commit": "6ab917ba3b2dc1dceba6a260a0c30cb947f6a69c",
+      "phase_overrides": {
+        "weaker-agent-continuation": {
+          "prompt": "Resume from repo state only as the same agent family. Finish the implementation without duplicating hook bookkeeping concepts.",
+          "adapter": "codex",
+          "model": "gpt-5.3-codex-spark"
+        }
+      }
     }
   ],
   "visible_validation_commands": [

--- a/tools/model-cli-harness/schemas/long-horizon-episode.schema.json
+++ b/tools/model-cli-harness/schemas/long-horizon-episode.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "agentic-workspace/long-horizon-episode/v1",
+  "title": "Agentic Workspace long-horizon episode",
+  "type": "object",
+  "required": [
+    "kind",
+    "id",
+    "title",
+    "task_prompt",
+    "modes",
+    "phases",
+    "known_traps",
+    "expected_mistake_classes",
+    "rubric"
+  ],
+  "properties": {
+    "kind": {
+      "const": "agentic-workspace/long-horizon-episode/v1"
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo_source": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "task_prompt": {
+      "type": "string",
+      "minLength": 1
+    },
+    "modes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "aw_enabled": {
+            "type": "boolean"
+          },
+          "fixture": {
+            "type": "string"
+          },
+          "repo_url": {
+            "type": "string"
+          },
+          "base_commit": {
+            "type": "string"
+          }
+        },
+        "anyOf": [
+          {
+            "required": [
+              "fixture"
+            ]
+          },
+          {
+            "required": [
+              "repo_url",
+              "base_commit"
+            ]
+          }
+        ],
+        "additionalProperties": true
+      }
+    },
+    "setup_commands": {
+      "$ref": "#/$defs/commands"
+    },
+    "visible_validation_commands": {
+      "$ref": "#/$defs/commands"
+    },
+    "hidden_oracle": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "phases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "prompt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "prompt": {
+            "type": "string",
+            "minLength": 1
+          },
+          "adapter": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "hide_transcript_for_resume": {
+            "type": "boolean"
+          },
+          "validation_commands": {
+            "$ref": "#/$defs/commands"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "known_traps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "expected_mistake_classes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "rubric": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": true
+    },
+    "evaluator": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "commands": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tools/model-cli-harness/schemas/long-horizon-episode.schema.json
+++ b/tools/model-cli-harness/schemas/long-horizon-episode.schema.json
@@ -58,6 +58,30 @@
           },
           "base_commit": {
             "type": "string"
+          },
+          "phase_overrides": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "prompt": {
+                  "type": "string"
+                },
+                "adapter": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "hide_transcript_for_resume": {
+                  "type": "boolean"
+                },
+                "validation_commands": {
+                  "$ref": "#/$defs/commands"
+                }
+              },
+              "additionalProperties": true
+            }
           }
         },
         "anyOf": [

--- a/tools/model-cli-harness/schemas/long-horizon-evaluation.schema.json
+++ b/tools/model-cli-harness/schemas/long-horizon-evaluation.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "agentic-workspace/long-horizon-evaluation/v1",
+  "title": "Agentic Workspace long-horizon evaluation result",
+  "type": "object",
+  "required": [
+    "kind",
+    "scenario",
+    "mode",
+    "result",
+    "mistake_classes",
+    "aw_effect",
+    "evidence",
+    "human_review_required",
+    "recommended_followup"
+  ],
+  "properties": {
+    "kind": {
+      "const": "agentic-workspace/long-horizon-evaluation/v1"
+    },
+    "scenario": {
+      "type": "string",
+      "minLength": 1
+    },
+    "mode": {
+      "type": "string",
+      "minLength": 1
+    },
+    "result": {
+      "type": "object",
+      "required": [
+        "intent_satisfied",
+        "scope_respected",
+        "proof_sufficient",
+        "proof_matches_intent",
+        "restartable_from_repo_state",
+        "completion_claim_honest"
+      ],
+      "properties": {
+        "intent_satisfied": {
+          "enum": [
+            "yes",
+            "partial",
+            "no",
+            "unclear"
+          ]
+        },
+        "scope_respected": {
+          "type": "boolean"
+        },
+        "proof_sufficient": {
+          "type": "boolean"
+        },
+        "proof_matches_intent": {
+          "type": "boolean"
+        },
+        "restartable_from_repo_state": {
+          "type": "boolean"
+        },
+        "completion_claim_honest": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
+    "mistake_classes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "aw_effect": {
+      "type": "object",
+      "required": [
+        "helped",
+        "hurt_or_overhead",
+        "missed_affordance"
+      ],
+      "properties": {
+        "helped": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hurt_or_overhead": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "missed_affordance": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "kind",
+          "ref"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "why": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "human_review_required": {
+      "type": "boolean"
+    },
+    "recommended_followup": {
+      "type": "object",
+      "required": [
+        "type",
+        "summary"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "issue",
+            "memory",
+            "docs",
+            "harness",
+            "dismissal",
+            "none"
+          ]
+        },
+        "summary": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary

Implements the #1124 long-horizon evaluation epic as a usable harness slice:

- adds hand-authorable long-horizon episode and evaluator result schemas;
- adds a multi-phase episode runner with restart checkpoints, transcript hiding, agent-switch support, AW-on/off modes, evaluator review, and comparison summaries;
- bootstraps AW-assisted external-repo modes from the existing minimal AW fixture while preserving true no-AW baselines;
- adds mode-level phase overrides so one episode can compare same-agent continuation against agent-switch continuation;
- adds an initial episode pack for Packaging, Pluggy, Click, and AW managed Planning state;
- adds post-score hidden/reference oracle metadata while keeping oracle data out of the primary evaluator prompt;
- documents how maintainers should run and interpret long-horizon episodes.

## Closure Evidence

The three prior closure gaps are now explicit in the PR state:

1. Same-agent versus agent-switch continuation
   - `tools/model-cli-harness/episodes/reuse-abstraction-pluggy.json` includes both `aw-assisted-agent-switch` and `aw-assisted-same-agent-continuation`.
   - Runner output includes `comparison.continuation_comparison` with `has_same_agent_continuation` and `has_agent_switch_continuation`.

2. Generated/managed-surface trap in the first pack
   - `tools/model-cli-harness/episodes/managed-planning-state-agentic-workspace.json` covers managed Planning state and wrong-owner/manual managed-state edit traps.

3. Post-score hidden/reference oracle representation
   - Per-mode evaluator output includes `evaluation.post_score_reference`.
   - Aggregate output includes `comparison.post_score_reference_by_mode`.
   - Dry-run/not-run states expose only that a reference is pending; the hidden/reference payload is exposed only after a valid primary score.

## Validation

- `uv run pytest tests/test_long_horizon_episode.py tests/test_model_cli_harness.py -q`
- `git diff --check`
- Pluggy dry-run showing `comparison.continuation_comparison.status == "present"`
- managed-state episode dry-run showing `post_score_reference.status == "pending-primary-score"`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- executed AW-assisted Click run with Copilot: `260 passed, 21 skipped` in the generated repo

Closes #1124.
Closes #1141.
Closes #1142.
Closes #1143.
Closes #1144.
Closes #1145.
Closes #1146.
Closes #1147.
Closes #1148.
