### PR TITLE
[codex] Implement eval dogfooding fixes

### DIFF
--- a/scripts/model_cli_harness/long_horizon_episode.py
+++ b/scripts/model_cli_harness/long_horizon_episode.py
@@ -199,8 +199,9 @@ def _phase_overrides(mode: dict[str, Any], *, field: str) -> dict[str, dict[str,
     return overrides
 
 
-def _prepare_mode_repo(*, suite_path: Path, mode: dict[str, Any], paths: harness.HarnessPaths, execute: bool) -> None:
+def _prepare_mode_repo(*, suite_path: Path, mode: dict[str, Any], paths: harness.HarnessPaths, execute: bool) -> dict[str, Any]:
     paths.run_root.mkdir(parents=True, exist_ok=False)
+    setup_before: dict[str, dict[str, Any]] | None = None
     fixture = mode.get("fixture")
     if isinstance(fixture, str):
         fixture_path = (suite_path.parent / ".." / "fixtures" / fixture).resolve()
@@ -210,10 +211,11 @@ def _prepare_mode_repo(*, suite_path: Path, mode: dict[str, Any], paths: harness
             raise FileNotFoundError(f"fixture not found: {fixture}")
         shutil.copytree(fixture_path, paths.repo_path)
         if mode.get("aw_enabled"):
+            setup_before = harness._file_snapshot(paths.repo_path, include_ignored=True)
             _bootstrap_aw_mode(paths.repo_path)
         else:
             harness._prepare_source_checkout_invocation(paths.repo_path)
-        return
+        return _setup_mutation_summary(setup_before=setup_before, repo_path=paths.repo_path)
     repo_url = mode.get("repo_url")
     base_commit = mode.get("base_commit")
     if not isinstance(repo_url, str) or not isinstance(base_commit, str):
@@ -222,8 +224,9 @@ def _prepare_mode_repo(*, suite_path: Path, mode: dict[str, Any], paths: harness
         paths.repo_path.mkdir(parents=True)
         (paths.repo_path / "PINNED-REPO.txt").write_text(f"{repo_url}\n{base_commit}\n", encoding="utf-8")
         if mode.get("aw_enabled"):
+            setup_before = harness._file_snapshot(paths.repo_path, include_ignored=True)
             _bootstrap_aw_mode(paths.repo_path)
-        return
+        return _setup_mutation_summary(setup_before=setup_before, repo_path=paths.repo_path)
     result = harness._run_command(["git", "clone", repo_url, str(paths.repo_path)], cwd=paths.run_root, timeout_seconds=900)
     if result["returncode"] != 0:
         raise RuntimeError(f"git clone failed for {repo_url}: {result['stderr']}")
@@ -231,7 +234,19 @@ def _prepare_mode_repo(*, suite_path: Path, mode: dict[str, Any], paths: harness
     if checkout["returncode"] != 0:
         raise RuntimeError(f"git checkout failed for {base_commit}: {checkout['stderr']}")
     if mode.get("aw_enabled"):
+        setup_before = harness._file_snapshot(paths.repo_path, include_ignored=True)
         _bootstrap_aw_mode(paths.repo_path)
+    return _setup_mutation_summary(setup_before=setup_before, repo_path=paths.repo_path)
+
+
+def _setup_mutation_summary(*, setup_before: dict[str, dict[str, Any]] | None, repo_path: Path) -> dict[str, Any]:
+    if setup_before is None:
+        return {"status": "not-applicable"}
+    return harness._snapshot_diff(
+        setup_before,
+        harness._file_snapshot(repo_path, include_ignored=True),
+        harness_setup_patterns=harness.HARNESS_SETUP_MUTATION_PATHS,
+    )
 
 
 def _adapter_command(
@@ -240,16 +255,20 @@ def _adapter_command(
     adapter_id: str,
     model: str | None,
     replacements: dict[str, str],
-) -> tuple[list[str], str, dict[str, Any]]:
+) -> tuple[list[str], str, dict[str, Any], dict[str, Any], dict[str, str]]:
     adapter = suite.get("adapters", {}).get(adapter_id)
     if not isinstance(adapter, dict):
         raise ValueError(f"adapter '{adapter_id}' is not defined")
     resolved_model = model or str(adapter.get("default_model") or "default")
-    replacements = {**replacements, "model": resolved_model}
-    command_template = adapter.get("command")
-    if not isinstance(command_template, list) or not all(isinstance(item, str) for item in command_template):
-        raise ValueError(f"adapter '{adapter_id}' must define command as a string list")
-    return harness._render_list(command_template, replacements=replacements), resolved_model, adapter
+    command, prompt_transport, command_replacements = harness._adapter_invocation_command(
+        adapter,
+        adapter_id=adapter_id,
+        model=resolved_model,
+        replacements={**replacements, "model": resolved_model},
+        run_root=Path(replacements["run_root"]),
+        prompt_id=f"{replacements.get('mode_id', 'mode')}-{replacements.get('phase_id', 'phase')}",
+    )
+    return command, resolved_model, adapter, prompt_transport, command_replacements
 
 
 def _run_validation_commands(
@@ -391,12 +410,18 @@ def _comparison_summary(mode_results: list[dict[str, Any]]) -> dict[str, Any]:
 def _continuation_comparison(mode_results: list[dict[str, Any]]) -> dict[str, Any]:
     modes: list[dict[str, Any]] = []
     kinds: set[str] = set()
+    continuation_contribution_by_mode: dict[str, str] = {}
     for result in mode_results:
         phases = result.get("phases", [])
         if not isinstance(phases, list):
             phases = []
         adapters = [str(phase.get("adapter_id", "")) for phase in phases if isinstance(phase, dict)]
         models = [str(phase.get("model", "")) for phase in phases if isinstance(phase, dict)]
+        contributions = [
+            str(phase.get("continuation_contribution", "unknown"))
+            for phase in phases
+            if isinstance(phase, dict)
+        ]
         if len(adapters) <= 1:
             kind = "single-phase"
         elif len(set(adapters)) == 1 and len(set(models)) == 1:
@@ -404,6 +429,7 @@ def _continuation_comparison(mode_results: list[dict[str, Any]]) -> dict[str, An
         else:
             kind = "agent-switch-continuation"
         kinds.add(kind)
+        continuation_contribution_by_mode[str(result.get("mode_id", ""))] = contributions[-1] if contributions else "unknown"
         modes.append(
             {
                 "mode_id": result.get("mode_id", ""),
@@ -411,6 +437,7 @@ def _continuation_comparison(mode_results: list[dict[str, Any]]) -> dict[str, An
                 "phase_count": len(adapters),
                 "phase_adapter_ids": adapters,
                 "phase_models": models,
+                "phase_contributions": contributions,
                 "continuation_kind": kind,
             }
         )
@@ -420,7 +447,42 @@ def _continuation_comparison(mode_results: list[dict[str, Any]]) -> dict[str, An
         "status": "present" if has_same_agent and has_agent_switch else "partial" if modes else "absent",
         "has_same_agent_continuation": has_same_agent,
         "has_agent_switch_continuation": has_agent_switch,
+        "continuation_contribution_by_mode": continuation_contribution_by_mode,
+        "substantive_continuation_count": sum(
+            1
+            for contribution in continuation_contribution_by_mode.values()
+            if contribution in {"changed-source", "changed-tests", "changed-non-source"}
+        ),
         "modes": modes,
+    }
+
+
+def _path_contribution_kind(paths: list[str]) -> str:
+    if any(path.startswith(("src/", "lib/", "packages/")) and not path.endswith((".md", ".txt")) for path in paths):
+        return "changed-source"
+    if any(path.startswith(("test/", "tests/", "testing/")) or path.endswith(("_test.py", "test.py")) or "/test_" in path for path in paths):
+        return "changed-tests"
+    if paths:
+        return "changed-non-source"
+    return "no-op"
+
+
+def _phase_contribution(mutation_summary: dict[str, Any]) -> dict[str, Any]:
+    paths = sorted(
+        set(mutation_summary.get("created", []))
+        | set(mutation_summary.get("modified", []))
+        | set(mutation_summary.get("deleted", []))
+    )
+    kind = _path_contribution_kind([str(path) for path in paths])
+    if kind == "no-op" and mutation_summary.get("raw_status") == "changed":
+        kind = "ignored-or-setup-only"
+    return {
+        "kind": kind,
+        "source_change_count": len(paths),
+        "raw_change_count": int(mutation_summary.get("raw_created_count", 0) or 0)
+        + int(mutation_summary.get("raw_modified_count", 0) or 0)
+        + int(mutation_summary.get("raw_deleted_count", 0) or 0),
+        "paths": paths[:20],
     }
 
 
@@ -442,7 +504,7 @@ def run_episode(
     mode_results: list[dict[str, Any]] = []
     for mode in modes:
         paths = _episode_paths(episode=episode, mode_id=mode["id"], output_root=output_root)
-        _prepare_mode_repo(suite_path=suite_path, mode=mode, paths=paths, execute=execute)
+        setup_mutation_summary = _prepare_mode_repo(suite_path=suite_path, mode=mode, paths=paths, execute=execute)
         replacements = {
             "repo": str(paths.repo_path),
             "run_root": str(paths.run_root),
@@ -459,7 +521,7 @@ def run_episode(
         )
         prior_context: list[str] = []
         phase_results: list[dict[str, Any]] = []
-        previous_snapshot = harness._file_snapshot(paths.repo_path)
+        previous_snapshot = harness._file_snapshot(paths.repo_path, include_ignored=True)
         for phase in episode["phases"]:
             phase = _effective_phase(phase=phase, mode=mode)
             phase_prompt, prior_included = _phase_prompt(episode=episode, mode=mode, phase=phase, prior_context=prior_context)
@@ -472,14 +534,14 @@ def run_episode(
                 "transcript_path": str(phase_transcript),
                 "prompt": phase_prompt,
             }
-            command, resolved_model, adapter = _adapter_command(
+            command, resolved_model, adapter, prompt_transport, command_replacements = _adapter_command(
                 suite=suite,
                 adapter_id=str(phase.get("adapter") or episode.get("default_adapter") or "copilot"),
                 model=phase.get("model") if isinstance(phase.get("model"), str) else None,
                 replacements=phase_replacements,
             )
-            env = harness._adapter_environment(adapter, replacements=phase_replacements, isolate_provider_home=False)
-            preflight = harness._adapter_preflight(adapter, command=command, replacements=phase_replacements)
+            env = harness._adapter_environment(adapter, replacements=command_replacements, isolate_provider_home=False)
+            preflight = harness._adapter_preflight(adapter, command=command, replacements=command_replacements)
             env = harness._prepend_env_path(env, preflight["path_prepend"])
             result: dict[str, Any]
             if execute:
@@ -490,9 +552,10 @@ def run_episode(
                 harness._copy_transcript(str(result.get("stdout", "")), phase_transcript)
             else:
                 result = {"status": "dry-run", "command": command}
-            current_snapshot = harness._file_snapshot(paths.repo_path)
+            current_snapshot = harness._file_snapshot(paths.repo_path, include_ignored=True)
             mutation_summary = harness._snapshot_diff(previous_snapshot, current_snapshot)
             previous_snapshot = current_snapshot
+            contribution = _phase_contribution(mutation_summary)
             validation_commands = _list_of_commands(
                 phase.get("validation_commands", episode.get("visible_validation_commands")),
                 field=f"phase.{phase['id']}.validation_commands",
@@ -513,12 +576,15 @@ def run_episode(
                     "adapter_id": str(phase.get("adapter") or episode.get("default_adapter") or "copilot"),
                     "model": resolved_model,
                     "prompt": phase_prompt,
+                    "prompt_transport": prompt_transport,
                     "prior_transcript_included": prior_included,
                     "hide_transcript_for_resume": bool(phase.get("hide_transcript_for_resume")),
                     "command": command,
                     "preflight": preflight,
                     "result": result,
                     "mutation_summary": mutation_summary,
+                    "continuation_contribution": contribution["kind"],
+                    "continuation_contribution_detail": contribution,
                     "validation_results": validation_results,
                     "checkpoint": {
                         "transcript_path": str(phase_transcript),
@@ -532,6 +598,7 @@ def run_episode(
             "aw_enabled": bool(mode.get("aw_enabled", False)),
             "repo_path": str(paths.repo_path),
             "run_root": str(paths.run_root),
+            "setup_mutation_summary": setup_mutation_summary,
             "setup_results": setup_results,
             "phases": phase_results,
         }
@@ -545,14 +612,14 @@ def run_episode(
                 "share_path": str(evaluator_share),
                 "prompt": evaluator_prompt,
             }
-            command, resolved_model, adapter = _adapter_command(
+            command, resolved_model, adapter, prompt_transport, command_replacements = _adapter_command(
                 suite=suite,
                 adapter_id=str(evaluator_config.get("adapter") or episode.get("default_evaluator_adapter") or episode.get("default_adapter") or "copilot"),
                 model=evaluator_config.get("model") if isinstance(evaluator_config.get("model"), str) else None,
                 replacements=evaluator_replacements,
             )
-            env = harness._adapter_environment(adapter, replacements=evaluator_replacements, isolate_provider_home=False)
-            preflight = harness._adapter_preflight(adapter, command=command, replacements=evaluator_replacements)
+            env = harness._adapter_environment(adapter, replacements=command_replacements, isolate_provider_home=False)
+            preflight = harness._adapter_preflight(adapter, command=command, replacements=command_replacements)
             env = harness._prepend_env_path(env, preflight["path_prepend"])
             if execute:
                 evaluator_result = harness._run_command(command, cwd=paths.repo_path, timeout_seconds=timeout_seconds, env=env)
@@ -574,6 +641,7 @@ def run_episode(
                 "adapter_id": str(evaluator_config.get("adapter") or episode.get("default_evaluator_adapter") or episode.get("default_adapter") or "copilot"),
                 "model": resolved_model,
                 "prompt": evaluator_prompt,
+                "prompt_transport": prompt_transport,
                 "command": command,
                 "preflight": preflight,
                 "result": evaluator_result,

--- a/scripts/model_cli_harness/run_model_cli_harness.py
+++ b/scripts/model_cli_harness/run_model_cli_harness.py
@@ -25,10 +25,30 @@ DEFAULT_SUITE = REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / WORKSPACE_LOCAL_SCRATCH_ROOT_PATH / "model-cli-harness"
 EPHEMERAL_MUTATION_PATHS = (
     ".git/",
+    ".coverage",
+    ".mypy_cache/",
     ".pytest_cache/",
+    ".ruff_cache/",
+    ".tox/",
     ".venv/",
     "__pycache__/",
+    "build/",
+    "dist/",
+    "env/",
+    "htmlcov/",
+    "node_modules/",
+    "site/",
     "uv.lock",
+    "venv/",
+)
+EPHEMERAL_MUTATION_GLOBS = (
+    "*.egg-info/*",
+    "*.egg-info",
+)
+HARNESS_SETUP_MUTATION_PATHS = (
+    ".agentic-workspace/",
+    "AGENTS.md",
+    "pyproject.toml",
 )
 
 
@@ -63,6 +83,142 @@ def _replace_placeholders(value: str, *, replacements: dict[str, str]) -> str:
 
 def _render_list(values: list[str], *, replacements: dict[str, str]) -> list[str]:
     return [_replace_placeholders(value, replacements=replacements) for value in values]
+
+
+def _string_list_config(value: Any, *, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{field} must be a string list")
+    return value
+
+
+def _adapter_model_args(adapter: dict[str, Any], *, model: str) -> list[str]:
+    args = _string_list_config(adapter.get("model_args"), field="adapter.model_args")
+    by_model = adapter.get("model_args_by_model", {})
+    if by_model is None:
+        return args
+    if not isinstance(by_model, dict):
+        raise ValueError("adapter.model_args_by_model must be an object")
+    if model not in by_model:
+        return args
+    return _string_list_config(by_model[model], field=f"adapter.model_args_by_model.{model}")
+
+
+def _safe_prompt_stem(value: str) -> str:
+    rendered = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-._")
+    return (rendered or "prompt")[:80]
+
+
+def _prompt_transport(
+    adapter: dict[str, Any],
+    *,
+    prompt: str,
+    run_root: Path,
+    prompt_id: str,
+    replacements: dict[str, str],
+) -> tuple[str, list[str], dict[str, Any]]:
+    config = adapter.get("prompt_transport")
+    prompt_length = len(prompt)
+    if config is None:
+        return prompt, [], {
+            "mode": "inline",
+            "prompt_length": prompt_length,
+            "threshold_chars": None,
+            "prompt_file": "",
+        }
+    if not isinstance(config, dict):
+        raise ValueError("adapter.prompt_transport must be an object")
+    threshold = int(config.get("threshold_chars", 8000))
+    if prompt_length <= threshold:
+        return prompt, [], {
+            "mode": "inline",
+            "prompt_length": prompt_length,
+            "threshold_chars": threshold,
+            "prompt_file": "",
+        }
+
+    prompt_dir = run_root / "prompts"
+    prompt_dir.mkdir(parents=True, exist_ok=True)
+    prompt_file = prompt_dir / f"{_safe_prompt_stem(prompt_id)}.txt"
+    prompt_file.write_text(prompt, encoding="utf-8")
+    transport_replacements = {
+        **replacements,
+        "prompt_file": str(prompt_file),
+        "prompt_length": str(prompt_length),
+    }
+    file_prompt_template = str(
+        config.get("file_prompt")
+        or "Read the attached prompt file and follow it exactly. Treat it as the complete task prompt."
+    )
+    inline_prompt = _replace_placeholders(file_prompt_template, replacements=transport_replacements)
+    file_args = _render_list(
+        _string_list_config(config.get("file_args"), field="adapter.prompt_transport.file_args"),
+        replacements=transport_replacements,
+    )
+    mode = str(config.get("mode") or "file")
+    return inline_prompt, file_args, {
+        "mode": mode,
+        "prompt_length": prompt_length,
+        "inline_prompt_length": len(inline_prompt),
+        "threshold_chars": threshold,
+        "prompt_file": str(prompt_file),
+    }
+
+
+def _render_command_template(
+    values: list[str],
+    *,
+    replacements: dict[str, str],
+    expansion_args: dict[str, list[str]] | None = None,
+) -> list[str]:
+    expansion_args = expansion_args or {}
+    rendered: list[str] = []
+    for value in values:
+        if value == "{model_args}":
+            rendered.extend(_render_list(expansion_args.get("model_args", []), replacements=replacements))
+            continue
+        if value == "{prompt_transport_args}":
+            rendered.extend(_render_list(expansion_args.get("prompt_transport_args", []), replacements=replacements))
+            continue
+        rendered.append(_replace_placeholders(value, replacements=replacements))
+    return rendered
+
+
+def _adapter_invocation_command(
+    adapter: dict[str, Any],
+    *,
+    adapter_id: str,
+    model: str,
+    replacements: dict[str, str],
+    run_root: Path,
+    prompt_id: str,
+    command_key: str = "command",
+) -> tuple[list[str], dict[str, Any], dict[str, str]]:
+    command_template = adapter.get(command_key)
+    if command_template is None and command_key != "command":
+        command_template = adapter.get("command")
+    if not isinstance(command_template, list) or not all(isinstance(item, str) for item in command_template):
+        raise ValueError(f"adapter '{adapter_id}' must define {command_key} as a string list")
+    prompt = str(replacements.get("prompt", ""))
+    model_args = _adapter_model_args(adapter, model=model)
+    command_prompt, prompt_transport_args, prompt_transport = _prompt_transport(
+        adapter,
+        prompt=prompt,
+        run_root=run_root,
+        prompt_id=prompt_id,
+        replacements={**replacements, "model": model},
+    )
+    command_replacements = {**replacements, "model": model, "prompt": command_prompt}
+    command = _render_command_template(
+        command_template,
+        replacements=command_replacements,
+        expansion_args={
+            "model_args": model_args,
+            "prompt_transport_args": prompt_transport_args,
+        },
+    )
+    return command, prompt_transport, command_replacements
 
 
 def _render_prompt(template: str, *, replacements: dict[str, str]) -> str:
@@ -273,9 +429,25 @@ def _has_usable_model_output(result: dict[str, Any]) -> bool:
     return bool(str(result.get("stdout") or "").strip() or str(result.get("final_message") or "").strip())
 
 
+def _adapter_configuration_rejected(result: dict[str, Any]) -> bool:
+    combined = f"{result.get('stdout') or ''}\n{result.get('stderr') or ''}\n{result.get('final_message') or ''}".lower()
+    markers = (
+        "does not support reasoning effort",
+        "unsupported reasoning effort",
+        "unsupported adapter option",
+        "unknown option",
+        "invalid option",
+        "unrecognized option",
+        "doesn't support reasoning effort",
+    )
+    return isinstance(result.get("returncode"), int) and result["returncode"] != 0 and any(marker in combined for marker in markers)
+
+
 def _classify_result_status(result: dict[str, Any]) -> str:
     if result.get("timed_out"):
         return "adapter_blocked"
+    if _adapter_configuration_rejected(result):
+        return "adapter_configuration_rejected"
     if isinstance(result.get("returncode"), int) and result["returncode"] != 0 and not _has_usable_model_output(result):
         return "runtime_failed"
     return str(result.get("status") or "completed")
@@ -292,18 +464,30 @@ def _with_git_ceiling(env: dict[str, str], *, run_root: Path) -> dict[str, str]:
 def _is_ephemeral_mutation_path(path: str) -> bool:
     normalized = path.replace("\\", "/")
     parts = normalized.split("/")
-    if any(part in {".git", ".pytest_cache", ".venv", "__pycache__"} for part in parts):
+    if any(part in {".git", ".mypy_cache", ".pytest_cache", ".ruff_cache", ".tox", ".venv", "__pycache__", "node_modules"} for part in parts):
         return True
-    return any(normalized.startswith(prefix) for prefix in EPHEMERAL_MUTATION_PATHS)
+    return any(normalized.startswith(prefix) or normalized == prefix.rstrip("/") for prefix in EPHEMERAL_MUTATION_PATHS) or any(
+        fnmatch.fnmatch(normalized, pattern) for pattern in EPHEMERAL_MUTATION_GLOBS
+    )
 
 
-def _file_snapshot(root: Path) -> dict[str, dict[str, Any]]:
+def _is_harness_setup_mutation_path(path: str, *, patterns: Iterable[str] | None = None) -> bool:
+    if patterns is None:
+        return False
+    normalized = path.replace("\\", "/")
+    candidates = tuple(patterns)
+    return any(normalized.startswith(pattern) or normalized == pattern.rstrip("/") or fnmatch.fnmatch(normalized, pattern) for pattern in candidates)
+
+
+def _file_snapshot(root: Path, *, include_ignored: bool = False) -> dict[str, dict[str, Any]]:
     snapshot: dict[str, dict[str, Any]] = {}
     if not root.exists():
         return snapshot
     for path in sorted(item for item in root.rglob("*") if item.is_file()):
         relative = path.relative_to(root).as_posix()
-        if _is_ephemeral_mutation_path(relative):
+        if relative.startswith(".git/"):
+            continue
+        if not include_ignored and _is_ephemeral_mutation_path(relative):
             continue
         data = path.read_bytes()
         snapshot[relative] = {
@@ -313,20 +497,67 @@ def _file_snapshot(root: Path) -> dict[str, dict[str, Any]]:
     return snapshot
 
 
-def _snapshot_diff(before: dict[str, dict[str, Any]], after: dict[str, dict[str, Any]]) -> dict[str, Any]:
+def _path_changes(
+    before: dict[str, dict[str, Any]],
+    after: dict[str, dict[str, Any]],
+    *,
+    paths: Iterable[str],
+) -> dict[str, list[str]]:
+    selected = set(paths)
+    before_paths = set(before) & selected
+    after_paths = set(after) & selected
+    return {
+        "created": sorted(after_paths - before_paths),
+        "deleted": sorted(before_paths - after_paths),
+        "modified": sorted(path for path in before_paths & after_paths if before[path] != after[path]),
+    }
+
+
+def _snapshot_diff(
+    before: dict[str, dict[str, Any]],
+    after: dict[str, dict[str, Any]],
+    *,
+    harness_setup_patterns: Iterable[str] | None = None,
+) -> dict[str, Any]:
     before_paths = set(before)
     after_paths = set(after)
-    created = sorted(after_paths - before_paths)
-    deleted = sorted(before_paths - after_paths)
-    modified = sorted(path for path in before_paths & after_paths if before[path] != after[path])
+    raw_created = sorted(after_paths - before_paths)
+    raw_deleted = sorted(before_paths - after_paths)
+    raw_modified = sorted(path for path in before_paths & after_paths if before[path] != after[path])
+    changed_paths = sorted(set(raw_created + raw_deleted + raw_modified))
+    ignored_paths = [path for path in changed_paths if _is_ephemeral_mutation_path(path)]
+    setup_paths = [path for path in changed_paths if path not in ignored_paths and _is_harness_setup_mutation_path(path, patterns=harness_setup_patterns)]
+    source_paths = [path for path in changed_paths if path not in set(ignored_paths) and path not in set(setup_paths)]
+    source_changes = _path_changes(before, after, paths=source_paths)
+    ignored_changes = _path_changes(before, after, paths=ignored_paths)
+    setup_changes = _path_changes(before, after, paths=setup_paths)
+    raw_status = "changed" if changed_paths else "clean"
     return {
-        "status": "changed" if created or modified or deleted else "clean",
-        "created_count": len(created),
-        "modified_count": len(modified),
-        "deleted_count": len(deleted),
-        "created": created,
-        "modified": modified,
-        "deleted": deleted,
+        "status": "changed" if source_paths else "clean",
+        "raw_status": raw_status,
+        "created_count": len(source_changes["created"]),
+        "modified_count": len(source_changes["modified"]),
+        "deleted_count": len(source_changes["deleted"]),
+        "created": source_changes["created"],
+        "modified": source_changes["modified"],
+        "deleted": source_changes["deleted"],
+        "source_created": source_changes["created"],
+        "source_modified": source_changes["modified"],
+        "source_deleted": source_changes["deleted"],
+        "raw_created_count": len(raw_created),
+        "raw_modified_count": len(raw_modified),
+        "raw_deleted_count": len(raw_deleted),
+        "raw_created": raw_created,
+        "raw_modified": raw_modified,
+        "raw_deleted": raw_deleted,
+        "ignored_noise_count": len(ignored_paths),
+        "ignored_created": ignored_changes["created"],
+        "ignored_modified": ignored_changes["modified"],
+        "ignored_deleted": ignored_changes["deleted"],
+        "harness_setup_count": len(setup_paths),
+        "harness_setup_created": setup_changes["created"],
+        "harness_setup_modified": setup_changes["modified"],
+        "harness_setup_deleted": setup_changes["deleted"],
     }
 
 
@@ -2057,6 +2288,13 @@ def _execution_warnings(*, result: dict[str, Any], repo_path: Path, mutation_sum
                 "message": "The model CLI process failed before producing usable model output.",
             }
         )
+    if result.get("status") == "adapter_configuration_rejected" or _adapter_configuration_rejected(result):
+        warnings.append(
+            {
+                "warning_class": "model_cli_adapter_configuration_rejected",
+                "message": "The model CLI rejected the configured adapter/model options.",
+            }
+        )
     if result.get("capture_warning"):
         warnings.append(
             {
@@ -2222,6 +2460,7 @@ def _finding_base_classes(warning_key: str) -> list[str]:
         "model_cli_runtime_failed",
         "model_cli_adapter_tooling_limitation",
         "model_cli_adapter_blocked",
+        "model_cli_adapter_configuration_rejected",
         "model_cli_permission_denied",
     }:
         return ["environment_or_provider"]
@@ -2478,7 +2717,12 @@ def _completion_loop_summary(
     final_validation_status = "not-run"
     if validation_results:
         final_validation_status = "passed" if all(result.get("returncode") == 0 for result in validation_results) else "failed"
-    blocking_warning_classes = {"model_cli_adapter_blocked", "model_cli_runtime_failed", "model_cli_model_not_found"}
+    blocking_warning_classes = {
+        "model_cli_adapter_blocked",
+        "model_cli_runtime_failed",
+        "model_cli_model_not_found",
+        "model_cli_adapter_configuration_rejected",
+    }
     blocked = any(warning.get("warning_class") in blocking_warning_classes for warning in first_warnings)
     first_pass_success = execute and not first_warnings and final_validation_status in {"not-run", "passed"}
     eventual_success = execute and not blocked and final_validation_status != "failed"
@@ -2563,14 +2807,18 @@ def run_suite(
             if bool(adapter.get("inject_repo_startup_instructions", False)):
                 prompt = _startup_instruction_prompt(repo_path=paths.repo_path, prompt=prompt)
             replacements["prompt"] = prompt
-            command_template = adapter.get("command")
-            if not isinstance(command_template, list) or not all(isinstance(item, str) for item in command_template):
-                raise ValueError(f"adapter '{adapter_id}' must define command as a string list")
-            command = _render_list(command_template, replacements=replacements)
-            preflight = _adapter_preflight(adapter, command=command, replacements=replacements)
+            command, prompt_transport, command_replacements = _adapter_invocation_command(
+                adapter,
+                adapter_id=adapter_id,
+                model=resolved_model,
+                replacements=replacements,
+                run_root=paths.run_root,
+                prompt_id=f"{scenario_id}-{prompt_variant_id}",
+            )
+            preflight = _adapter_preflight(adapter, command=command, replacements=command_replacements)
             adapter_env = _adapter_environment(
                 adapter,
-                replacements=replacements,
+                replacements=command_replacements,
                 isolate_provider_home=isolate_provider_home,
             )
             adapter_env = _prepend_env_path(adapter_env, preflight["path_prepend"])
@@ -2595,7 +2843,7 @@ def run_suite(
                             env=adapter_env,
                         )
                     )
-            baseline_snapshot = _file_snapshot(paths.repo_path)
+            baseline_snapshot = _file_snapshot(paths.repo_path, include_ignored=True)
 
             invocation: dict[str, Any] = {
                 "scenario_id": scenario_id,
@@ -2606,6 +2854,7 @@ def run_suite(
                 "repo_path": str(paths.repo_path),
                 "run_root": str(paths.run_root),
                 "prompt": prompt,
+                "prompt_transport": prompt_transport,
                 "command": command,
                 "preflight": preflight,
                 "git_ceiling_directories": adapter_env.get("GIT_CEILING_DIRECTORIES", ""),
@@ -2635,7 +2884,7 @@ def run_suite(
                     result["final_message"] = paths.share_path.read_text(encoding="utf-8")
                 result["status"] = _classify_result_status(result)
                 _copy_transcript(str(result.get("stdout", "")), paths.transcript_path)
-                mutation_summary = _snapshot_diff(baseline_snapshot, _file_snapshot(paths.repo_path))
+                mutation_summary = _snapshot_diff(baseline_snapshot, _file_snapshot(paths.repo_path, include_ignored=True))
                 invocation["usage_summary"] = _usage_summary_from_stdout(str(result.get("stdout", "")))
                 invocation["package_read_surface_summary"] = _package_read_surface_summary_from_stdout(str(result.get("stdout", "")))
                 invocation["result"] = result
@@ -2694,10 +2943,15 @@ def run_suite(
                             "share_path": str(paths.run_root / "postmortem.md"),
                             "postmortem_cwd": str(postmortem_cwd),
                         }
-                        postmortem_template = adapter.get("postmortem_command", command_template)
-                        if not isinstance(postmortem_template, list) or not all(isinstance(item, str) for item in postmortem_template):
-                            raise ValueError(f"adapter '{adapter_id}' postmortem_command must be a string list")
-                        postmortem_command = _render_list(postmortem_template, replacements=postmortem_replacements)
+                        postmortem_command, postmortem_prompt_transport, _ = _adapter_invocation_command(
+                            adapter,
+                            adapter_id=adapter_id,
+                            model=resolved_model,
+                            replacements=postmortem_replacements,
+                            run_root=paths.run_root,
+                            prompt_id=f"{scenario_id}-{prompt_variant_id}-postmortem",
+                            command_key="postmortem_command",
+                        )
                         postmortem_result = _run_command(
                             postmortem_command,
                             cwd=postmortem_cwd,
@@ -2709,6 +2963,7 @@ def run_suite(
                             postmortem_result["final_message"] = postmortem_share.read_text(encoding="utf-8")
                         invocation["postmortem_feedback"] = {
                             "prompt": postmortem_prompt,
+                            "prompt_transport": postmortem_prompt_transport,
                             "command": postmortem_command,
                             "result": postmortem_result,
                             "warnings": _postmortem_feedback_warnings(result=postmortem_result),
@@ -2736,7 +2991,14 @@ def run_suite(
                         "share_path": str(followup_share),
                         "transcript_path": str(followup_transcript),
                     }
-                    followup_command = _render_list(command_template, replacements=followup_replacements)
+                    followup_command, followup_prompt_transport, _ = _adapter_invocation_command(
+                        adapter,
+                        adapter_id=adapter_id,
+                        model=resolved_model,
+                        replacements=followup_replacements,
+                        run_root=paths.run_root,
+                        prompt_id=f"{scenario_id}-{prompt_variant_id}-turn-{index}",
+                    )
                     followup_result = _run_command(
                         followup_command,
                         cwd=paths.repo_path,
@@ -2750,6 +3012,7 @@ def run_suite(
                     followup_turn = {
                         "turn": index,
                         "prompt": followup_prompt,
+                        "prompt_transport": followup_prompt_transport,
                         "command": followup_command,
                         "result": followup_result,
                         "usage_summary": _usage_summary_from_stdout(str(followup_result.get("stdout", ""))),
@@ -2972,4 +3235,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tests/test_long_horizon_episode.py
+++ b/tests/test_long_horizon_episode.py
@@ -326,6 +326,7 @@ def test_long_horizon_episode_comparison_reports_same_agent_vs_switch(tmp_path: 
     assert comparison["status"] == "present"
     assert comparison["has_same_agent_continuation"] is True
     assert comparison["has_agent_switch_continuation"] is True
+    assert comparison["continuation_contribution_by_mode"]["agent-switch"] == "no-op"
     assert kinds == {
         "agent-switch": "agent-switch-continuation",
         "same-agent": "same-agent-continuation",
@@ -382,6 +383,10 @@ def test_long_horizon_episode_bootstraps_aw_mode_for_pinned_repo_dry_run(tmp_pat
     assert (aw_repo / ".agentic-workspace" / "WORKFLOW.md").exists()
     assert "uv run agentic-workspace start" in (aw_repo / "AGENTS.md").read_text(encoding="utf-8")
     assert 'cli_invoke = "uv run agentic-workspace"' in (aw_repo / ".agentic-workspace" / "config.local.toml").read_text(encoding="utf-8")
+    setup_summary = payload["modes"][1]["setup_mutation_summary"]
+    assert setup_summary["status"] == "clean"
+    assert setup_summary["raw_status"] == "changed"
+    assert setup_summary["harness_setup_count"] > 0
 
 
 def test_long_horizon_episode_evaluator_excludes_hidden_oracle_and_reports_comparison(tmp_path: Path) -> None:
@@ -428,3 +433,151 @@ def test_long_horizon_episode_invalid_evaluator_json_is_failure(tmp_path: Path) 
     evaluation = payload["modes"][0]["evaluation"]
     assert evaluation["status"] == "invalid"
     assert "evaluator did not return" in evaluation["payload"]["error"]
+
+
+def test_long_horizon_episode_uses_model_args_by_phase_model(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    fixtures = tmp_path / "fixtures"
+    fixture = fixtures / "repo"
+    fixture.mkdir(parents=True)
+    (fixture / "README.md").write_text("repo\n", encoding="utf-8")
+    suite = tmp_path / "suites" / "suite.json"
+    suite.parent.mkdir()
+    suite.write_text(
+        json.dumps(
+            {
+                "schema": "agentic-workspace/model-cli-harness-suite/v1",
+                "id": "unit",
+                "adapters": {
+                    "fake": {
+                        "default_model": "haiku",
+                        "model_args": ["--effort", "low"],
+                        "model_args_by_model": {"haiku": []},
+                        "command": ["fake", "--model", "{model}", "{model_args}", "-p", "{prompt}"],
+                    }
+                },
+                "scenarios": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    episode_payload = {
+        "kind": "agentic-workspace/long-horizon-episode/v1",
+        "id": "model-args",
+        "title": "Model args",
+        "task_prompt": "Run phases.",
+        "modes": [{"id": "mode", "aw_enabled": False, "fixture": "repo"}],
+        "visible_validation_commands": [[sys.executable, "-c", "print('ok')"]],
+        "phases": [
+            {"id": "phase-one", "prompt": "Use default.", "adapter": "fake"},
+            {"id": "phase-two", "prompt": "Use sonnet.", "adapter": "fake", "model": "sonnet"},
+        ],
+        "known_traps": ["model-options"],
+        "expected_mistake_classes": ["restart_failed"],
+        "rubric": {"intent_satisfied": "phases run"},
+    }
+    episode = tmp_path / "episode-model-args.json"
+    episode.write_text(json.dumps(episode_payload), encoding="utf-8")
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=False,
+        evaluator=False,
+    )
+
+    commands = [phase["command"] for phase in payload["modes"][0]["phases"]]
+    assert "--effort" not in commands[0]
+    assert commands[1][commands[1].index("--effort") + 1] == "low"
+
+
+def test_long_horizon_episode_evaluator_uses_prompt_file_transport(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    fixtures = tmp_path / "fixtures"
+    fixture = fixtures / "repo"
+    fixture.mkdir(parents=True)
+    (fixture / "README.md").write_text("repo\n", encoding="utf-8")
+    suite = tmp_path / "suites" / "suite.json"
+    suite.parent.mkdir()
+    suite.write_text(
+        json.dumps(
+            {
+                "schema": "agentic-workspace/model-cli-harness-suite/v1",
+                "id": "unit",
+                "adapters": {
+                    "fake": {
+                        "default_model": "fake-model",
+                        "block_on_preflight_failure": False,
+                        "command": [sys.executable, "-c", "import sys; sys.exit(0)", "{repo}", "{phase_id}", "{share_path}", "{prompt}"],
+                    },
+                    "fake-evaluator": {
+                        "default_model": "fake-eval-model",
+                        "block_on_preflight_failure": False,
+                        "prompt_transport": {
+                            "threshold_chars": 20,
+                            "mode": "file-attachment",
+                            "file_args": ["--attachment", "{prompt_file}"],
+                            "file_prompt": "Read {prompt_file}.",
+                        },
+                        "command": [
+                            sys.executable,
+                            "-c",
+                            "import sys; sys.exit(0)",
+                            "{repo}",
+                            "{phase_id}",
+                            "{share_path}",
+                            "{prompt}",
+                            "{prompt_transport_args}",
+                        ],
+                    },
+                },
+                "scenarios": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    episode_payload = {
+        "kind": "agentic-workspace/long-horizon-episode/v1",
+        "id": "transport",
+        "title": "Transport",
+        "task_prompt": "Run evaluator with a large prompt.",
+        "modes": [{"id": "mode", "aw_enabled": False, "fixture": "repo"}],
+        "visible_validation_commands": [[sys.executable, "-c", "print('ok')"]],
+        "phases": [{"id": "phase-one", "prompt": "Do work.", "adapter": "fake"}],
+        "known_traps": ["large-prompt"],
+        "expected_mistake_classes": ["weak_proof"],
+        "rubric": {"intent_satisfied": "prompt is transported"},
+        "evaluator": {"adapter": "fake-evaluator"},
+    }
+    episode = tmp_path / "episode-transport.json"
+    episode.write_text(json.dumps(episode_payload), encoding="utf-8")
+
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=False,
+        evaluator=True,
+    )
+
+    evaluation = payload["modes"][0]["evaluation"]
+    prompt_transport = evaluation["prompt_transport"]
+    prompt_file = Path(prompt_transport["prompt_file"])
+    assert prompt_transport["mode"] == "file-attachment"
+    assert prompt_file.exists()
+    assert "--attachment" in evaluation["command"]
+    assert str(prompt_file) in evaluation["command"]
+
+
+def test_long_horizon_episode_classifies_phase_contribution() -> None:
+    module = _load_episode_module()
+
+    assert module._phase_contribution({"created": ["src/pluggy/_manager.py"], "modified": [], "deleted": []})["kind"] == "changed-source"
+    assert (
+        module._phase_contribution({"created": ["testing/test_pluginmanager.py"], "modified": [], "deleted": []})["kind"] == "changed-tests"
+    )
+    assert (
+        module._phase_contribution({"created": [], "modified": [], "deleted": [], "raw_status": "changed"})["kind"]
+        == "ignored-or-setup-only"
+    )
+    assert module._phase_contribution({"created": [], "modified": [], "deleted": [], "raw_status": "clean"})["kind"] == "no-op"

--- a/tests/test_model_cli_harness.py
+++ b/tests/test_model_cli_harness.py
@@ -147,6 +147,30 @@ def test_model_cli_harness_ignores_uv_lock_runtime_byproduct(tmp_path: Path) -> 
     assert harness._snapshot_diff(before, harness._file_snapshot(repo))["status"] == "clean"
 
 
+def test_model_cli_harness_separates_source_changes_from_cache_noise(tmp_path: Path) -> None:
+    harness = _load_harness()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    before = harness._file_snapshot(repo, include_ignored=True)
+
+    (repo / ".mypy_cache" / "cache.json").parent.mkdir()
+    (repo / ".mypy_cache" / "cache.json").write_text("{}", encoding="utf-8")
+    (repo / ".ruff_cache" / "cache.bin").parent.mkdir()
+    (repo / ".ruff_cache" / "cache.bin").write_text("cache", encoding="utf-8")
+    (repo / "src" / "pluggy.egg-info").mkdir(parents=True)
+    (repo / "src" / "pluggy.egg-info" / "PKG-INFO").write_text("metadata", encoding="utf-8")
+    (repo / "src" / "pluggy" / "_manager.py").parent.mkdir(parents=True)
+    (repo / "src" / "pluggy" / "_manager.py").write_text("source", encoding="utf-8")
+
+    diff = harness._snapshot_diff(before, harness._file_snapshot(repo, include_ignored=True))
+
+    assert diff["status"] == "changed"
+    assert diff["created"] == ["src/pluggy/_manager.py"]
+    assert diff["ignored_noise_count"] == 3
+    assert "src/pluggy.egg-info/PKG-INFO" in diff["raw_created"]
+    assert "src/pluggy.egg-info/PKG-INFO" in diff["ignored_created"]
+
+
 def test_model_cli_harness_marks_mixed_package_commands_approximate() -> None:
     harness = _load_harness()
     stdout = json.dumps(
@@ -737,6 +761,85 @@ def test_model_cli_harness_suite_renders_copilot_adapter_with_explicit_cwd(tmp_p
     assert result["repo_path"] in command
 
 
+def test_model_cli_harness_copilot_uses_per_model_args(tmp_path: Path) -> None:
+    harness = _load_harness()
+
+    haiku_payload = harness.run_suite(
+        suite_path=REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json",
+        adapter_id="copilot",
+        model="claude-haiku-4.5",
+        scenario_filter="startup-orientation",
+        execute=False,
+        output_root=tmp_path / "haiku",
+        timeout_seconds=None,
+    )
+    sonnet_payload = harness.run_suite(
+        suite_path=REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json",
+        adapter_id="copilot",
+        model="claude-sonnet-4.6",
+        scenario_filter="startup-orientation",
+        execute=False,
+        output_root=tmp_path / "sonnet",
+        timeout_seconds=None,
+    )
+
+    assert "--effort" not in haiku_payload["results"][0]["command"]
+    sonnet_command = sonnet_payload["results"][0]["command"]
+    assert sonnet_command[sonnet_command.index("--effort") + 1] == "low"
+
+
+def test_model_cli_harness_prompt_transport_writes_large_prompt_to_file(tmp_path: Path) -> None:
+    fixture = tmp_path / "fixtures" / "repo"
+    fixture.mkdir(parents=True)
+    suite = tmp_path / "suites" / "suite.json"
+    suite.parent.mkdir()
+    suite.write_text(
+        json.dumps(
+            {
+                "schema": "agentic-workspace/model-cli-harness-suite/v1",
+                "id": "unit",
+                "adapters": {
+                    "fake": {
+                        "default_model": "fake-model",
+                        "block_on_preflight_failure": False,
+                        "prompt_transport": {
+                            "threshold_chars": 20,
+                            "mode": "file-attachment",
+                            "file_args": ["--attachment", "{prompt_file}"],
+                            "file_prompt": "Read {prompt_file}.",
+                        },
+                        "command": ["fake-cli", "-p", "{prompt}", "{prompt_transport_args}"],
+                    }
+                },
+                "scenarios": [{"id": "large", "fixture": "repo", "prompt": "x" * 80}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    harness = _load_harness()
+
+    payload = harness.run_suite(
+        suite_path=suite,
+        adapter_id="fake",
+        model=None,
+        scenario_filter="large",
+        execute=False,
+        output_root=tmp_path / "out",
+        timeout_seconds=None,
+    )
+
+    result = payload["results"][0]
+    prompt_transport = result["prompt_transport"]
+    command = result["command"]
+    prompt_file = Path(prompt_transport["prompt_file"])
+    assert prompt_transport["mode"] == "file-attachment"
+    assert prompt_file.exists()
+    assert prompt_file.read_text(encoding="utf-8") == "x" * 80
+    assert command[command.index("-p") + 1].startswith("Read ")
+    assert "--attachment" in command
+    assert str(prompt_file) in command
+
+
 def test_model_cli_harness_resolves_path_shims(tmp_path: Path, monkeypatch) -> None:
     harness = _load_harness()
     shim = tmp_path / "fake-cli.cmd"
@@ -780,6 +883,21 @@ def test_model_cli_harness_runtime_failure_gets_structured_status(tmp_path: Path
 
     assert result["status"] == "runtime_failed"
     assert "model_cli_runtime_failed" in {warning["warning_class"] for warning in warnings}
+
+
+def test_model_cli_harness_adapter_configuration_rejection_gets_structured_status(tmp_path: Path) -> None:
+    harness = _load_harness()
+
+    result = {
+        "returncode": 1,
+        "stdout": "",
+        "stderr": "model does not support reasoning effort configuration",
+    }
+    result["status"] = harness._classify_result_status(result)
+    warnings = harness._execution_warnings(result=result, repo_path=tmp_path, mutation_summary={"status": "clean"})
+
+    assert result["status"] == "adapter_configuration_rejected"
+    assert "model_cli_adapter_configuration_rejected" in {warning["warning_class"] for warning in warnings}
 
 
 def test_model_cli_harness_extracts_execution_warnings(tmp_path: Path) -> None:

--- a/tools/model-cli-harness/episodes/reuse-abstraction-pluggy.json
+++ b/tools/model-cli-harness/episodes/reuse-abstraction-pluggy.json
@@ -61,13 +61,13 @@
   "phases": [
     {
       "id": "strong-agent-investigation",
-      "prompt": "Investigate the multi-implementation unregister bug, identify the abstraction boundary, and leave a continuation-safe partial fix or plan.",
+      "prompt": "Investigate the multi-implementation unregister bug and identify the abstraction boundary, but do not edit implementation files under src/pluggy. Leave either focused failing tests or a continuation-safe plan that makes the next phase perform substantive implementation work.",
       "adapter": "codex",
       "model": "gpt-5.3-codex-spark"
     },
     {
       "id": "weaker-agent-continuation",
-      "prompt": "Resume from repo state only as a different agent. Finish the implementation without duplicating hook bookkeeping concepts.",
+      "prompt": "Resume from repo state only as a different agent. Perform the substantive source implementation now, without duplicating hook bookkeeping concepts.",
       "adapter": "copilot",
       "model": "claude-haiku-4.5",
       "hide_transcript_for_resume": true

--- a/tools/model-cli-harness/suites/copilot-workflow-smoke.json
+++ b/tools/model-cli-harness/suites/copilot-workflow-smoke.json
@@ -23,16 +23,34 @@
       "env": {
         "COPILOT_ALLOW_ALL": "true"
       },
+      "model_args": [
+        "--effort",
+        "low"
+      ],
+      "model_args_by_model": {
+        "claude-haiku-4.5": []
+      },
+      "prompt_transport": {
+        "threshold_chars": 8000,
+        "mode": "file-attachment",
+        "file_args": [
+          "--attachment",
+          "{prompt_file}"
+        ],
+        "file_prompt": "Read the attached prompt file and follow its instructions exactly. Treat it as the complete task prompt."
+      },
       "inject_repo_startup_instructions": true,
       "postmortem_feedback_supported": false,
       "command": [
         "copilot",
         "--model",
         "{model}",
+        "{model_args}",
         "-C",
         "{repo}",
         "-p",
         "{prompt}",
+        "{prompt_transport_args}",
         "--allow-all",
         "--allow-tool=write",
         "--no-ask-user",
@@ -53,8 +71,10 @@
         "copilot",
         "--model",
         "{model}",
+        "{model_args}",
         "-p",
         "{prompt}",
+        "{prompt_transport_args}",
         "--allow-all",
         "--no-ask-user",
         "--disable-builtin-mcps",
@@ -600,4 +620,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
## Summary

Implements the open eval dogfooding fixes from the Copilot long-horizon runs:

- adds per-model adapter arguments so Copilot can use `--effort low` for supported Claude models while Haiku opts out
- adds bounded prompt-file transport metadata so large evaluator/model prompts do not hit Windows command-line limits
- separates source/product mutation summaries from cache, build, egg-info, and AW setup residue while retaining raw inventories
- reports AW bootstrap residue as setup mutation evidence for AW-assisted long-horizon modes
- adds continuation contribution reporting and updates the Pluggy episode so phase two must perform substantive implementation work

Closes #1153.
Closes #1154.
Closes #1155.
Closes #1156.
Closes #1157.

## Validation

- `uv run python -m pytest tests/test_model_cli_harness.py tests/test_long_horizon_episode.py -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_model_cli_harness.py -q`
- commit hooks: `sync-all`, workspace/memory/planning/verification lint, memory markdownlint, absolute-path check
