### PR TITLE
[codex] Reframe AW routing as agent-owned guidance

### DIFF
--- a/.agentic-workspace/skills/REGISTRY.json
+++ b/.agentic-workspace/skills/REGISTRY.json
@@ -31,7 +31,7 @@
       "path": "workspace-work-shape/SKILL.md",
       "scope": "bundled",
       "stability": "package-managed",
-      "summary": "classify work shape and route direct, bounded, lane, or epic work before implementation",
+      "summary": "decide work shape from AW facts, hard blockers, proof needs, and user intent before implementation",
       "activation_hints": {
         "verbs": ["classify", "triage", "shape", "route", "decide", "infer", "resolve"],
         "nouns": [
@@ -51,7 +51,7 @@
           "satisfaction evidence"
         ],
         "phrases": [
-          "classify work shape",
+          "decide work shape",
           "shape this work",
           "infer intended outcome",
           "resolve intended outcome",

--- a/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
+++ b/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
@@ -43,7 +43,7 @@ Each gate is a compact SkillSpec-shaped record:
 
 - Trigger: changed paths are known or a completion claim is near.
 - Preferred CLI: `agentic-workspace implement --changed <paths> --format json` or `agentic-workspace proof --changed <paths> --format json`.
-- Interpreted fields: required commands, proof burden, acceptance guidance, completion-claim boundary.
+- Interpreted fields: required commands, proof factors, acceptance guidance, completion-claim boundary.
 - Allowed: run the selected narrow proof and classify gaps.
 - Forbidden: substitute passing commands for intent satisfaction.
 - Fallback: choose the narrowest existing test, lint, contract, or inspection route for the changed surface.

--- a/.agentic-workspace/skills/workspace-work-shape/SKILL.md
+++ b/.agentic-workspace/skills/workspace-work-shape/SKILL.md
@@ -8,7 +8,7 @@ description: Decide work shape from AW facts, hard blockers, proof needs, and us
 Use this skill before implementation when task size, proof cost, handoff needs, or the user's intended outcome are unclear.
 
 AW reports facts about AW-owned state; it does not own the final semantic judgment for soft cases. When `implement --changed`
-returns `work_shape_facts.agent_decision_required=true`, use those facts to decide whether the work is `direct`, `bounded`,
+returns `work_shape_guidance.agent_decision_required=true`, use those facts to decide whether the work is `direct`, `bounded`,
 `lane`, or `epic`. Treat hard blockers from AW as authoritative, but do not outsource ordinary intent interpretation to
 keyword matches.
 
@@ -17,17 +17,17 @@ keyword matches.
 1. Run `agentic-workspace start --target . --task "<task>" --format json`.
 2. If changed paths are known, run `agentic-workspace implement --target . --changed <paths> --format json`.
 3. Run `agentic-workspace preflight --target . --format json` only for takeover, recovery, or uncertain state.
-4. Read `planning_safety_gate.work_shape_facts` when present:
+4. Read `planning_safety_gate.work_shape_guidance` when present:
    - `hard_blockers` are AW-owned stop signs.
    - `scope_factors` are observable changed-path, issue, active-state, and proof facts.
-   - `suggested_shape` is advisory for soft cases.
+   - `direct_work_is_reasonable_when` and `planning_may_help_when` are guidelines, not package decisions.
    - `agent_decision_required=true` means you must choose and own the work shape.
    - `stop_conditions` name when to pause or promote Planning.
 5. For vague outcome prompts, resolve the intended outcome before naming a solution:
    - What user-visible failure or cost should be reduced?
    - What would count as satisfaction?
    - Which repo-visible surface should preserve that intent for the next pass?
-6. Classify the request as `direct`, `bounded`, `lane`, or `epic`.
+6. Decide whether the request is `direct`, `bounded`, `lane`, or `epic`; AW guidance can inform that decision but does not own it.
 7. For `direct` work, keep workspace overhead minimal and prove with the obvious narrow command.
 8. For `bounded` work, use compact planning or proof output when continuation, risk, or non-obvious validation matters.
 9. For `lane` or `epic` work, stop before coding and create or continue checked-in Planning state.

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -101,11 +101,11 @@ Cheap implementer context for a bounded changed-path scope.
 | `execution_posture.capability_posture` | ref `#/$defs/capability_posture` | yes |  | Task capability posture inferred from changed paths and optional task text. |  |  |
 | `execution_posture.capability_posture.status` | string | yes |  | Whether capability posture was inferred, configured, or unavailable. |  |  |
 | `execution_posture.capability_posture.posture` | object | yes |  | Human-readable posture details used for review. |  |  |
-| `execution_posture.capability_posture.work_shape` | string | yes |  | Inferred work shape such as direct, bounded, lane, or epic. |  |  |
-| `execution_posture.capability_posture.proof_burden` | string | yes |  | Expected proof burden for this task. |  |  |
+| `execution_posture.capability_posture.work_shape_guidance` | object | yes |  | Structural work-shape guidance; the agent owns final work-shape judgment. |  |  |
+| `execution_posture.capability_posture.proof_factors` | object | yes |  | Structural proof factors; the agent owns proof proportionality judgment. |  |  |
 | `execution_posture.capability_posture.risk_flags` | array of string | yes |  | Risk signals inferred from paths or task text. |  |  |
 | `execution_posture.capability_posture.inspection_evidence_required` | array of string | yes |  | Context required before trusting the posture. |  |  |
-| `execution_posture.capability_posture.classification_authority` | string | yes |  | Authority used to classify task capability needs. |  |  |
+| `execution_posture.capability_posture.guidance_authority` | string | yes |  | Authority used to provide structural guidance. |  |  |
 | `execution_posture.capability_posture.self_assessment_authority` | string | yes |  | Authority level of a model's own confidence or self-assessment. |  |  |
 | `execution_posture.runtime_resolution` | ref `#/$defs/runtime_resolution` | yes |  | Compact stay-local, stronger-reasoning, external-delegation, or manual-handoff recommendation. |  |  |
 | `execution_posture.runtime_resolution.recommendation` | string | yes |  | Recommended execution route. |  |  |

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -857,11 +857,11 @@
       "required": [
         "status",
         "posture",
-        "work_shape",
-        "proof_burden",
+        "work_shape_guidance",
+        "proof_factors",
         "risk_flags",
         "inspection_evidence_required",
-        "classification_authority",
+        "guidance_authority",
         "self_assessment_authority"
       ],
       "properties": {
@@ -873,13 +873,13 @@
           "type": "object",
           "description": "Human-readable posture details used for review."
         },
-        "work_shape": {
-          "type": "string",
-          "description": "Inferred work shape such as direct, bounded, lane, or epic."
+        "work_shape_guidance": {
+          "type": "object",
+          "description": "Structural work-shape guidance; the agent owns final work-shape judgment."
         },
-        "proof_burden": {
-          "type": "string",
-          "description": "Expected proof burden for this task."
+        "proof_factors": {
+          "type": "object",
+          "description": "Structural proof factors; the agent owns proof proportionality judgment."
         },
         "risk_flags": {
           "type": "array",
@@ -897,9 +897,9 @@
           },
           "description": "Context required before trusting the posture."
         },
-        "classification_authority": {
+        "guidance_authority": {
           "type": "string",
-          "description": "Authority used to classify task capability needs."
+          "description": "Authority used to provide structural guidance."
         },
         "self_assessment_authority": {
           "type": "string",
@@ -907,7 +907,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "Task capability classification for changed-path implementation."
+      "description": "Task capability guidance for changed-path implementation."
     },
     "runtime_resolution": {
       "type": "object",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -15929,7 +15929,6 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     if isinstance(planning_safety_gate, dict):
         compact_gate = _selector_first_planning_safety_gate(planning_safety_gate)
         compact_gate.pop("planning_revision", None)
-        compact_gate.pop("active_plan_reliance", None)
         compact_gate.pop("work_shape_guidance", None)
         projected["context"]["planning_safety_gate"] = compact_gate
     if isinstance(intent_acknowledgement, dict) and intent_acknowledgement.get("decision") == "proceed-with-stated-assumption":
@@ -16293,11 +16292,127 @@ def _command_with_expected_planning_revision(command: str, *, planning_revision:
     return f"{command}{addition}"
 
 
-def _active_plan_reliance_payload(
+def _file_mtime_iso(path: Path) -> str | None:
+    try:
+        if not path.exists():
+            return None
+        return datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat()
+    except OSError:
+        return None
+
+
+def _active_plan_record_for_reliance(*, target_root: Path, active_surface: str) -> dict[str, Any]:
+    if not active_surface:
+        return {}
+    plan_path = target_root / active_surface
+    if not plan_path.exists() or plan_path.suffix != ".json":
+        return {}
+    try:
+        record = json.loads(plan_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return record if isinstance(record, dict) else {}
+
+
+def _active_plan_freshness_evidence(
     *,
-    active_planning_present: bool,
+    target_root: Path,
+    active_summary: dict[str, Any],
     active_delegation_requirement: dict[str, Any],
     planning_revision: dict[str, Any],
+    cli_invoke: str,
+) -> dict[str, Any]:
+    active_surface = str(
+        active_summary.get("active_execplan") or planning_revision.get("active_execplan") or active_delegation_requirement.get("path") or ""
+    ).strip()
+    state_path_text = str(planning_revision.get("state_path") or ".agentic-workspace/planning/state.toml")
+    state_path = target_root / state_path_text
+    plan_path = target_root / active_surface if active_surface else None
+    record = _active_plan_record_for_reliance(target_root=target_root, active_surface=active_surface)
+    proof_report = record.get("proof_report", {}) if isinstance(record.get("proof_report"), dict) else {}
+    finished_review = record.get("finished_run_review", {}) if isinstance(record.get("finished_run_review"), dict) else {}
+    execution_run = record.get("execution_run", {}) if isinstance(record.get("execution_run"), dict) else {}
+    proof_values = [
+        str(proof_report.get("validation proof", "") or "").strip(),
+        str(proof_report.get("proof achieved now", "") or "").strip(),
+        str(proof_report.get('evidence for "proof achieved" state', "") or "").strip(),
+        str(finished_review.get("proof status", "") or "").strip(),
+    ]
+    proof_recorded = any(proof_values)
+    proof_status = str(finished_review.get("proof status") or proof_report.get("proof achieved now") or "").strip()
+    state_mtime = _file_mtime_iso(state_path)
+    plan_mtime = _file_mtime_iso(plan_path) if plan_path is not None else None
+    last_updated_candidates = [item for item in (state_mtime, plan_mtime) if item]
+    last_updated = max(last_updated_candidates) if last_updated_candidates else None
+    requirement_status = str(active_delegation_requirement.get("status", "") or "unknown")
+    stale_indicators: list[str] = []
+    if active_surface and not proof_recorded:
+        stale_indicators.append("proof-not-recorded")
+    if execution_run and not proof_recorded:
+        stale_indicators.append("execution-run-present-without-proof-report")
+    if active_delegation_requirement.get("required"):
+        stale_indicators.append("active-planning-gate-blocked")
+    if requirement_status == "delegation-decision-untrusted-shared-state":
+        stale_indicators.append("hand-edited-delegation-decision")
+    if requirement_status == "delegation-decision-recorded":
+        mutation_authority = "command-provenance-present"
+    elif requirement_status == "delegation-decision-untrusted-shared-state":
+        mutation_authority = "manual-edit-indicator"
+    elif active_surface:
+        mutation_authority = "active-state-requires-agent-review"
+    else:
+        mutation_authority = "not-applicable"
+    refresh_command = _command_with_cli_invoke(
+        command="agentic-workspace summary --target . --format json",
+        cli_invoke=cli_invoke,
+    )
+    closeout_command = _command_with_expected_planning_revision(
+        _command_with_cli_invoke(
+            command="agentic-workspace planning closeout --target . --proof-from last --format json",
+            cli_invoke=cli_invoke,
+        ),
+        planning_revision=planning_revision,
+    )
+    repair_command = str(active_delegation_requirement.get("command") or "")
+    return {
+        "authority": "assembled-from-planning-state",
+        "state_path": state_path_text,
+        "active_execplan": active_surface,
+        "state_last_modified": state_mtime,
+        "active_execplan_last_modified": plan_mtime,
+        "last_updated": last_updated,
+        "source_hashes": {
+            "state_hash": planning_revision.get("state_hash"),
+            "active_execplan_hash": planning_revision.get("active_execplan_hash"),
+            "revision_id": planning_revision.get("revision_id"),
+        },
+        "mutation_authority": mutation_authority,
+        "manual_edit_indicator": mutation_authority == "manual-edit-indicator",
+        "last_proof": {
+            "status": proof_status or ("recorded" if proof_recorded else "not-recorded"),
+            "recorded": proof_recorded,
+            "proof_report_present": bool(proof_report),
+            "finished_review_proof_status": str(finished_review.get("proof status", "") or "").strip(),
+        },
+        "stale_indicators": stale_indicators,
+        "current_enough_to_guide_work": bool(active_surface) and not stale_indicators,
+        "routes": {
+            "refresh": refresh_command,
+            "record_or_repair": repair_command or closeout_command,
+            "close_or_update_stale_state": closeout_command,
+        },
+        "rule": "Planning state can guide work only after the agent reviews freshness, provenance, proof state, and any stale indicators.",
+    }
+
+
+def _active_plan_reliance_payload(
+    *,
+    target_root: Path,
+    active_planning_present: bool,
+    active_summary: dict[str, Any],
+    active_delegation_requirement: dict[str, Any],
+    planning_revision: dict[str, Any],
+    cli_invoke: str,
 ) -> dict[str, Any]:
     revision_id = str(planning_revision.get("revision_id", "") or "")
     requirement_status = str(active_delegation_requirement.get("status", "") or "unknown")
@@ -16326,7 +16441,7 @@ def _active_plan_reliance_payload(
         permission_claim = "continue-active-plan-after-normal-review"
         integrity = "not-required-by-current-facts"
         reliance = "allowed-after-current-state-review"
-    return {
+    payload = {
         "kind": "agentic-workspace/active-plan-reliance/v1",
         "status": status,
         "permission_claim": permission_claim,
@@ -16338,6 +16453,15 @@ def _active_plan_reliance_payload(
         "reliance": reliance,
         "requirement_status": requirement_status,
     }
+    if active_planning_present:
+        payload["authority_evidence"] = _active_plan_freshness_evidence(
+            target_root=target_root,
+            active_summary=active_summary,
+            active_delegation_requirement=active_delegation_requirement,
+            planning_revision=planning_revision,
+            cli_invoke=cli_invoke,
+        )
+    return payload
 
 
 def _planning_safety_promotion_command(
@@ -16610,9 +16734,12 @@ def _planning_safety_gate_payload(
         active_summary=active_summary,
     )
     active_plan_reliance = _active_plan_reliance_payload(
+        target_root=target_root,
         active_planning_present=active_planning_present,
+        active_summary=active_summary,
         active_delegation_requirement=active_delegation_requirement,
         planning_revision=planning_revision,
+        cli_invoke=config.cli_invoke,
     )
     if active_planning_present and active_delegation_requirement.get("required"):
         status = "blocked"

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -12198,16 +12198,26 @@ def _compact_start_delegation_decision(value: Any) -> dict[str, Any]:
         "mode",
         "clarification_mode",
         "decision",
-        "work_shape",
-        "proof_burden",
-        "quality_risk",
-        "token_savings_expected",
+        "quality_factors",
+        "token_savings_guidance",
         "required_next_action",
-        "effort_recommendation",
+        "effort_guidance",
     )
     compact = {key: value.get(key) for key in common_keys if key in value}
-    if isinstance(compact.get("effort_recommendation"), dict):
-        compact["effort_recommendation"] = _compact_effort_recommendation(compact["effort_recommendation"])
+    if isinstance(compact.get("quality_factors"), dict):
+        factors = compact["quality_factors"]
+        compact["quality_factors"] = {
+            key: factors.get(key)
+            for key in ("tier", "proof_factor_hint", "work_shape_hint", "agent_judgment_required")
+            if factors.get(key) not in (None, "")
+        }
+    if isinstance(compact.get("token_savings_guidance"), dict):
+        savings = compact["token_savings_guidance"]
+        compact["token_savings_guidance"] = {
+            key: savings.get(key) for key in ("signal", "agent_judgment_required") if savings.get(key) not in (None, "")
+        }
+    if isinstance(compact.get("effort_guidance"), dict):
+        compact["effort_guidance"] = _compact_effort_guidance(compact["effort_guidance"])
     decision = str(value.get("decision", ""))
     config_effect = value.get("config_effect")
     manual_external_relay = value.get("manual_external_relay")
@@ -12335,7 +12345,7 @@ def _compact_start_delegation_decision(value: Any) -> dict[str, Any]:
     return compact
 
 
-def _compact_effort_recommendation(value: dict[str, Any]) -> dict[str, Any]:
+def _compact_effort_guidance(value: dict[str, Any]) -> dict[str, Any]:
     return {
         key: value.get(key)
         for key in ("orchestrator", "planner", "implementer", "validator", "cost_posture")
@@ -12810,7 +12820,7 @@ def _start_payload(
     execution_posture = _execution_posture_payload(
         config=config, changed_paths=_normalize_changed_paths(changed_paths), task_text=task_text, target_root=target_root
     )
-    payload["delegation_decision"] = execution_posture["delegation_decision"]
+    payload["delegation_decision"] = _compact_start_delegation_decision(execution_posture["delegation_decision"])
     planning_safety_gate = _planning_safety_gate_payload(
         target_root=target_root,
         config=config,
@@ -13115,7 +13125,7 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "context.delegation_decision",
         "context.intent_acknowledgement",
         "context.workflow_sufficiency",
-        "context.routing",
+        "context.guidance",
         "context.acceptance_reconciliation",
         "context.objective_drift",
         "context.reuse_pressure",
@@ -13238,8 +13248,6 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         "reason": gate.get("reason"),
         "required_next_action": gate.get("required_next_action"),
         "active_planning_present": gate.get("active_planning_present"),
-        "work_shape": gate.get("work_shape"),
-        "proof_burden": gate.get("proof_burden"),
         "issue_refs": gate.get("issue_refs", []),
         "promotion_command": gate.get("promotion_command"),
         "delegation_decision_command": gate.get("delegation_decision_command"),
@@ -13254,7 +13262,7 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         "active_delegation_requirement",
         "active_parent_decomposition_requirement",
         "repair_route",
-        "work_shape_facts",
+        "work_shape_guidance",
     ):
         if key in gate:
             compact[key] = gate[key]
@@ -13554,7 +13562,7 @@ def _start_tiny_payload_fast(
     execution_posture = _execution_posture_payload(
         config=config, changed_paths=_normalize_changed_paths(changed_paths), task_text=task_text, target_root=target_root
     )
-    payload["delegation_decision"] = execution_posture["delegation_decision"]
+    payload["delegation_decision"] = _compact_start_delegation_decision(execution_posture["delegation_decision"])
     planning_safety_gate = _planning_safety_gate_payload(
         target_root=target_root,
         config=config,
@@ -14331,8 +14339,6 @@ def _intent_acknowledgement_payload(
     *, task_text: str | None, execution_posture: dict[str, Any], vague_orientation: dict[str, Any] | None = None
 ) -> dict[str, Any]:
     task = str(task_text or "").strip()
-    capability = execution_posture.get("capability_posture", {}) if isinstance(execution_posture, dict) else {}
-    work_shape = capability.get("work_shape") if isinstance(capability, dict) else None
     task_lower = " ".join(task.lower().split())
     if not task:
         return {
@@ -14370,15 +14376,12 @@ def _intent_acknowledgement_payload(
     direct_only = any((marker in task_lower for marker in direct_markers)) and (
         not any((marker in task_lower for marker in non_direct_markers))
     )
-    should_state = (
-        vague_applies or has_issue_ref or work_shape in {"lane", "epic"} or any((marker in task_lower for marker in non_direct_markers))
-    )
+    should_state = vague_applies or has_issue_ref or any((marker in task_lower for marker in non_direct_markers))
     if direct_only or not should_state:
         return {
             "kind": "agentic-workspace/intent-acknowledgement/v1",
             "status": "available",
             "decision": "silent-ok",
-            "work_shape": work_shape or "unknown",
             "reason": "Task appears direct enough that a separate stated-assumption preface is optional.",
             "use_stated_assumption_when": "Use the middle path if the edit stops being obvious, proof becomes non-obvious, or scope starts to widen.",
         }
@@ -14386,8 +14389,7 @@ def _intent_acknowledgement_payload(
         "kind": "agentic-workspace/intent-acknowledgement/v1",
         "status": "recommended",
         "decision": "proceed-with-stated-assumption",
-        "work_shape": work_shape or "unknown",
-        "rule": "Before editing non-direct, vague-outcome, bounded, lane, or epic work, briefly state the inferred intent and first slice, then proceed unless corrected.",
+        "rule": "Before editing non-direct or vague-outcome work, briefly state the inferred intent and first slice, then proceed unless corrected.",
         "before_editing": ["inferred_intent", "concrete_first_slice", "non_goals_or_deferred_scope", "correction_point"],
         "correction_point": "Say that you will proceed on the stated interpretation unless the user corrects it.",
         "silent_inference_ok_when": "The change is direct, local, low-risk, and validation is obvious.",
@@ -14519,10 +14521,10 @@ def _objective_drift_payload(*, target_root: Path, changed_paths: list[str], tas
 
 def _reuse_pressure_taxonomy() -> list[dict[str, str]]:
     return [
-        {"state": "none_found", "meaning": "cheap repo facts did not find nearby reuse or abstraction pressure"},
+        {"state": "none_found", "meaning": "cheap repo facts did not find nearby reuse evidence"},
         {"state": "existing_helper_candidate", "meaning": "a named helper or primitive already appears to exist"},
         {"state": "similar_pattern_candidate", "meaning": "nearby files or similarly named surfaces suggest an existing pattern"},
-        {"state": "abstraction_pressure", "meaning": "the same helper or pattern appears in multiple places"},
+        {"state": "abstraction_pressure", "meaning": "a named helper or semantic concept appears in multiple places"},
         {"state": "duplication_accepted_with_reason", "meaning": "duplication may proceed when the agent records why it is acceptable"},
         {"state": "extraction_deferred_with_owner", "meaning": "extraction is routed to a durable owner instead of hidden in chat"},
     ]
@@ -14534,7 +14536,7 @@ def _reuse_pressure_payload(
     normalized_paths = _normalize_changed_paths(changed_paths or [])
     base: dict[str, Any] = {
         "kind": "agentic-workspace/reuse-pressure/v1",
-        "rule": "AW exposes cheap reuse and abstraction facts; the agent owns the engineering decision.",
+        "rule": "AW exposes cheap reuse evidence and confidence; the agent owns the engineering decision.",
         "taxonomy": _reuse_pressure_taxonomy(),
         "changed_paths": normalized_paths,
         "allowed_outcomes": [
@@ -14693,6 +14695,7 @@ def _reuse_pressure_python_findings(*, target_root: Path, changed_path: str, pat
                 "state": state,
                 "changed_path": changed_path,
                 "symbol": name,
+                "evidence_confidence": "high" if state == "abstraction_pressure" else "medium",
                 "candidate_paths": matches[:5],
                 "why": f"{name} is already defined elsewhere in the repository.",
             }
@@ -14713,6 +14716,7 @@ def _reuse_pressure_python_findings(*, target_root: Path, changed_path: str, pat
                 "changed_path": changed_path,
                 "kind": "sibling_helper_hint",
                 "prominence": "normal" if has_token_overlap else "weak",
+                "evidence_confidence": "medium" if has_token_overlap else "low",
                 "candidate_paths": candidate_paths[:5],
                 "matched_tokens": sorted({token for candidate in sibling_candidates for token in candidate.get("matched_tokens", [])})[:8],
                 "why": "Nearby module files share changed-path tokens and may express the same local pattern."
@@ -14729,15 +14733,15 @@ def _repeated_special_case_findings(*, target_root: Path, changed_path: str, pat
         matches = _find_special_case_matches(target_root=target_root, marker=marker, exclude=path)
         if not matches:
             continue
-        state = "abstraction_pressure" if len(matches) >= 2 else "similar_pattern_candidate"
         findings.append(
             {
-                "state": state,
+                "state": "similar_pattern_candidate",
                 "changed_path": changed_path,
                 "kind": "repeated_special_case",
                 "pattern": marker,
+                "evidence_confidence": "medium",
                 "candidate_paths": matches[:5],
-                "why": "The same conditional special case appears elsewhere; consider reusing or extracting the policy.",
+                "why": "The same conditional special case appears elsewhere; inspect whether it is a real shared policy before adding another local branch.",
             }
         )
     return findings
@@ -14793,6 +14797,7 @@ def _reuse_pressure_surface_findings(*, target_root: Path, changed_path: str, pa
         {
             "state": "similar_pattern_candidate",
             "changed_path": changed_path,
+            "evidence_confidence": "low",
             "candidate_paths": matches,
             "why": f"Other surfaces share the filename {path.name!r}.",
         }
@@ -14827,6 +14832,7 @@ def _reuse_pressure_inventory_findings(*, target_root: Path, changed_path: str, 
             "state": "existing_helper_candidate",
             "changed_path": changed_path,
             "kind": "contract_or_inventory_candidate",
+            "evidence_confidence": "medium",
             "candidate_paths": matches[:5],
             "why": "Generated command, primitive, schema, or contract inventories mention related names; check ownership before adding a parallel surface.",
         }
@@ -15006,7 +15012,9 @@ def _compact_reuse_pressure_payload(payload: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(finding, dict):
             continue
         compact_finding = {
-            key: finding[key] for key in ("state", "changed_path", "kind", "symbol", "pattern", "matched_tokens", "why") if key in finding
+            key: finding[key]
+            for key in ("state", "changed_path", "kind", "symbol", "pattern", "matched_tokens", "evidence_confidence", "why")
+            if key in finding
         }
         candidate_paths = finding.get("candidate_paths")
         if isinstance(candidate_paths, list):
@@ -15181,9 +15189,9 @@ def _reuse_pressure_state(findings: list[dict[str, Any]]) -> str:
 def _reuse_pressure_summary(*, state: str, finding_count: int, weak_hint_count: int = 0) -> str:
     if state == "none_found":
         if weak_hint_count:
-            return f"No actionable reuse pressure found; {weak_hint_count} weak sibling hint(s) available for optional context."
-        return "No cheap reuse or abstraction pressure found for the changed paths."
-    return f"{finding_count} reuse-pressure finding(s) surfaced; inspect before adding another local implementation."
+            return f"No actionable reuse evidence found; {weak_hint_count} weak sibling hint(s) available for optional context."
+        return "No cheap reuse evidence found for the changed paths."
+    return f"{finding_count} reuse evidence finding(s) surfaced; inspect before adding another local implementation."
 
 
 def _change_impact_owner_guess(*, path: str, ownership_answer: dict[str, Any], authority_marker: dict[str, Any]) -> str:
@@ -15390,17 +15398,15 @@ def _task_contract_payload(
 ) -> dict[str, Any]:
     task_present = bool(task_intent.get("task_text_available"))
     acceptance_items = acceptance.get("items", []) if isinstance(acceptance.get("items"), list) else []
-    capability = execution_posture.get("capability_posture", {}) if isinstance(execution_posture, dict) else {}
-    runtime_resolution = execution_posture.get("runtime_resolution", {}) if isinstance(execution_posture, dict) else {}
     delegation_decision = execution_posture.get("delegation_decision", {}) if isinstance(execution_posture, dict) else {}
     acceptance_guidance = proof.get("acceptance_guidance", {}) if isinstance(proof, dict) else {}
     intent_proof = proof.get("intent_proof", {}) if isinstance(proof, dict) else {}
-    work_shape_facts = planning_safety_gate.get("work_shape_facts", {}) if isinstance(planning_safety_gate, dict) else {}
+    work_shape_guidance = planning_safety_gate.get("work_shape_guidance", {}) if isinstance(planning_safety_gate, dict) else {}
 
     stop_conditions: list[str] = []
     for source in (
         handoff_requirements.get("stop_when") if isinstance(handoff_requirements, dict) else [],
-        work_shape_facts.get("stop_conditions") if isinstance(work_shape_facts, dict) else [],
+        work_shape_guidance.get("stop_conditions") if isinstance(work_shape_guidance, dict) else [],
         proof.get("escalate_when") if isinstance(proof, dict) else [],
     ):
         if isinstance(source, list):
@@ -15460,16 +15466,30 @@ def _task_contract_payload(
         "autonomy_and_escalation": {
             "delegation_decision": delegation_decision.get("decision"),
             "delegation_mode": delegation_decision.get("mode"),
-            "work_shape": capability.get("work_shape"),
-            "proof_burden": capability.get("proof_burden"),
-            "runtime_recommendation": runtime_resolution.get("recommendation") if isinstance(runtime_resolution, dict) else None,
+            "work_shape_guidance": {
+                key: work_shape_guidance.get(key)
+                for key in (
+                    "hard_blockers",
+                    "scope_factors",
+                    "proof_factors",
+                    "direct_work_is_reasonable_when",
+                    "planning_may_help_when",
+                    "agent_decision_required",
+                    "judgment_boundary",
+                )
+                if key in work_shape_guidance
+            },
+            "delegation_guidance": {
+                "mode": delegation_decision.get("mode"),
+                "decision": delegation_decision.get("decision"),
+                "rule": "Delegation posture is a control/guidance surface; the agent owns whether delegation fits the current engineering task unless a hard blocker applies.",
+            },
             "planning_safety": planning_safety_gate.get("status") if isinstance(planning_safety_gate, dict) else None,
             "intent_acknowledgement": intent_acknowledgement.get("decision"),
             "ask_human_when": intent_acknowledgement.get("ask_human_when"),
             "source_fields": [
                 "execution_posture.delegation_decision",
-                "execution_posture.capability_posture",
-                "execution_posture.runtime_resolution",
+                "planning_safety_gate.work_shape_guidance",
                 "planning_safety_gate.status",
                 "intent_acknowledgement",
             ],
@@ -15502,7 +15522,7 @@ def _task_contract_payload(
             "items": stop_conditions,
             "source_fields": [
                 "handoff_requirements.stop_when",
-                "planning_safety_gate.work_shape_facts.stop_conditions",
+                "planning_safety_gate.work_shape_guidance.stop_conditions",
                 "proof.escalate_when",
             ],
             "missing_fields": [] if stop_conditions else ["handoff_requirements.stop_when"],
@@ -15766,8 +15786,6 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     proof_commands = payload.get("required_validation_commands", [])
     primary_command = proof_commands[0] if isinstance(proof_commands, list) and proof_commands else None
     execution_posture = payload.get("execution_posture", {})
-    capability = execution_posture.get("capability_posture", {}) if isinstance(execution_posture, dict) else {}
-    runtime_resolution = execution_posture.get("runtime_resolution", {}) if isinstance(execution_posture, dict) else {}
     intent_acknowledgement = payload.get("intent_acknowledgement", {})
     reuse_pressure = (
         _reuse_pressure_payload(
@@ -15864,11 +15882,12 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "objective_drift": _tiny_objective_drift(payload.get("objective_drift", {})),
             "reuse_pressure": context_reuse_pressure,
             "durable_intent_promotion": _tiny_task_intent_promotion_guidance(payload.get("durable_intent_promotion", {})),
-            "routing": {
-                "work_shape": capability.get("work_shape"),
-                "proof_burden": capability.get("proof_burden"),
-                "delegation_recommendation": runtime_resolution.get("recommendation"),
+            "guidance": {
+                "work_shape_guidance": _tiny_work_shape_guidance(planning_safety_gate.get("work_shape_guidance"))
+                if isinstance(planning_safety_gate, dict)
+                else None,
                 "planning_safety": planning_safety_gate.get("status") if isinstance(planning_safety_gate, dict) else None,
+                "rule": "AW exposes facts, blockers, and guidelines; the agent owns work-shape and proof proportionality judgment.",
             },
             "delegation_decision": _compact_start_delegation_decision(execution_posture.get("delegation_decision", {})),
         },
@@ -15891,7 +15910,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "verification",
                 "routine_work_context",
                 "context.delegation_decision",
-                "context.routing",
+                "context.guidance",
             ],
         },
     }
@@ -15911,6 +15930,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
         compact_gate = _selector_first_planning_safety_gate(planning_safety_gate)
         compact_gate.pop("planning_revision", None)
         compact_gate.pop("active_plan_reliance", None)
+        compact_gate.pop("work_shape_guidance", None)
         projected["context"]["planning_safety_gate"] = compact_gate
     if isinstance(intent_acknowledgement, dict) and intent_acknowledgement.get("decision") == "proceed-with-stated-assumption":
         projected["context"]["intent_acknowledgement"] = {
@@ -16009,6 +16029,37 @@ def _tiny_objective_drift(value: Any) -> dict[str, Any]:
         "removed_or_retired_outcomes": value.get("removed_or_retired_outcomes", []),
         "missing_from_changed_surface": value.get("missing_from_changed_surface", []),
         "recommended_next_action": value.get("recommended_next_action", ""),
+    }
+
+
+def _tiny_work_shape_guidance(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"status": "unavailable"}
+    scope = value.get("scope_factors", {}) if isinstance(value.get("scope_factors"), dict) else {}
+    return {
+        "hard_blockers": value.get("hard_blockers", []),
+        "scope_factors": {
+            key: scope.get(key)
+            for key in (
+                "dirty_shape",
+                "changed_roots",
+                "surface_root_count",
+                "scope_growth_detected",
+                "scope_growth_reasons",
+                "active_planning_present",
+                "issue_refs",
+            )
+            if key in scope
+        },
+        "proof_factors": value.get("proof_factors", []),
+        "direct_work_is_reasonable_when": value.get("direct_work_is_reasonable_when", [])[:2]
+        if isinstance(value.get("direct_work_is_reasonable_when"), list)
+        else [],
+        "planning_may_help_when": value.get("planning_may_help_when", [])[:2]
+        if isinstance(value.get("planning_may_help_when"), list)
+        else [],
+        "agent_decision_required": bool(value.get("agent_decision_required")),
+        "rule": value.get("rule", "AW exposes facts and guidelines; the agent owns work-shape judgment."),
     }
 
 
@@ -16112,7 +16163,7 @@ def _allow_issue_scoped_planning_state_reconciliation(path_classification: dict[
     }
 
 
-def _work_shape_facts_payload(
+def _work_shape_guidance_payload(
     *,
     path_classification: dict[str, Any],
     issue_refs: list[str],
@@ -16128,16 +16179,25 @@ def _work_shape_facts_payload(
     hard_blockers: list[str] = []
     if not workflow_sufficient:
         hard_blockers.append(decision)
-    suggested_shape = work_shape or "unknown"
     implementation_paths = path_classification.get("implementation_paths", [])
-    if not hard_blockers:
-        if active_planning_present:
-            suggested_shape = "bounded"
-        elif implementation_paths and not path_classification.get("scope_growth_detected"):
-            suggested_shape = "direct"
-        elif path_classification.get("dirty_shape") == "planning-only":
-            suggested_shape = "direct"
-    confidence = "high" if hard_blockers else "medium"
+    direct_reasons = []
+    planning_reasons = []
+    if implementation_paths and not path_classification.get("scope_growth_detected"):
+        direct_reasons.append("changed implementation paths are within a narrow top-level surface")
+    if path_classification.get("dirty_shape") == "planning-only":
+        direct_reasons.append("only Planning surfaces are named; validate Planning state before treating this as implementation")
+    if path_classification.get("scope_growth_detected"):
+        planning_reasons.extend(str(reason) for reason in path_classification.get("scope_growth_reasons", []) if str(reason))
+    if active_planning_present:
+        planning_reasons.append("active Planning state is present and should be reviewed before relying on it")
+    if issue_refs:
+        planning_reasons.append("task text references external issue(s); preserve intent/proof mapping explicitly")
+    proof_factors = [
+        "selected proof commands",
+        "changed path categories",
+        "active planning state" if active_planning_present else "",
+        "scope growth reasons" if path_classification.get("scope_growth_detected") else "",
+    ]
     return {
         "hard_blockers": hard_blockers,
         "scope_factors": {
@@ -16149,10 +16209,17 @@ def _work_shape_facts_payload(
             "ancillary_paths": path_classification.get("ancillary_paths", []),
             "active_planning_present": active_planning_present,
             "issue_refs": issue_refs,
-            "proof_burden": proof_burden or "unknown",
         },
-        "suggested_shape": suggested_shape,
-        "confidence": confidence,
+        "proof_factors": [item for item in proof_factors if item],
+        "structural_signals": {
+            "work_shape_hint": work_shape or "unknown",
+            "proof_factor_hint": proof_burden or "unknown",
+            "authority": "structural path/task heuristic only",
+        },
+        "direct_work_is_reasonable_when": direct_reasons
+        or ["no AW-owned hard blocker is present and the agent judges intent, scope, and proof to be bounded"],
+        "planning_may_help_when": planning_reasons
+        or ["changed paths, proof surfaces, or user intent widen beyond the agent's current bounded understanding"],
         "agent_decision_required": workflow_sufficient,
         "judgment_boundary": {
             "aw_owns": ["hard blockers", "changed-path facts", "active planning state", "proof candidates"],
@@ -16172,8 +16239,31 @@ def _work_shape_facts_payload(
         "status": status,
         "decision": decision,
         "required_next_action": required_next_action,
-        "rule": "AW reports hard blockers and work-shape facts; the agent owns soft semantic work-shape judgment when no hard blocker applies.",
+        "rule": "AW reports hard blockers, facts, and decision guidelines; the agent owns soft semantic work-shape judgment when no hard blocker applies.",
     }
+
+
+def _capability_structural_hints(capability: Any) -> tuple[str, str]:
+    if not isinstance(capability, dict):
+        return "", ""
+    posture = capability.get("posture", {}) if isinstance(capability.get("posture"), dict) else {}
+    work_shape_guidance = capability.get("work_shape_guidance", {}) if isinstance(capability.get("work_shape_guidance"), dict) else {}
+    proof_factors = capability.get("proof_factors", {}) if isinstance(capability.get("proof_factors"), dict) else {}
+    work_shape = (
+        work_shape_guidance.get("structural_hint")
+        or posture.get("structural work-shape hint")
+        or posture.get("work shape")
+        or capability.get("work_shape")
+        or ""
+    )
+    proof_burden = (
+        proof_factors.get("structural_hint")
+        or posture.get("proof factor hint")
+        or posture.get("proof burden")
+        or capability.get("proof_burden")
+        or ""
+    )
+    return str(work_shape), str(proof_burden)
 
 
 def _planning_revision_payload(*, target_root: Path) -> dict[str, Any]:
@@ -16308,9 +16398,7 @@ def _active_plan_delegation_requirement(
     status = str(delegation.get("status", "")).strip().lower()
     normalized_task = " ".join((task_text or "").lower().split())
     capability = execution_posture.get("capability_posture", {}) if isinstance(execution_posture, dict) else {}
-    posture = capability.get("posture", {}) if isinstance(capability.get("posture"), dict) else {}
-    work_shape = str(capability.get("work_shape") or posture.get("work shape") or "")
-    proof_burden = str(capability.get("proof_burden") or posture.get("proof burden") or "")
+    work_shape, proof_burden = _capability_structural_hints(capability)
     trigger_terms = ("decomposed", "decomposition", "delegate", "delegation", "mechanical", "lane", "epic", "high-assurance")
     active_plan_continuation = _task_appears_to_continue_active_plan(
         active_surface=active_surface,
@@ -16500,9 +16588,7 @@ def _planning_safety_gate_payload(
     active_summary = _fast_planning_active_summary(target_root=target_root)
     active_planning_present = bool(active_summary.get("todo_active_count") or active_summary.get("active_execplan"))
     capability = execution_posture.get("capability_posture", {}) if isinstance(execution_posture, dict) else {}
-    posture = capability.get("posture", {}) if isinstance(capability.get("posture"), dict) else {}
-    work_shape = str(capability.get("work_shape") or posture.get("work shape") or "")
-    proof_burden = str(capability.get("proof_burden") or posture.get("proof burden") or "")
+    work_shape, proof_burden = _capability_structural_hints(capability)
     decomposition_delegation = execution_posture.get("decomposition_delegation", {}) if isinstance(execution_posture, dict) else {}
     decomposition_status = str(decomposition_delegation.get("status", "")) if isinstance(decomposition_delegation, dict) else ""
     path_classification = _planning_safety_path_classification(changed_paths)
@@ -16568,7 +16654,7 @@ def _planning_safety_gate_payload(
         status = "attention"
         decision = "agent-work-shape-decision-required"
         reason = (
-            "Changed paths cross implementation boundaries; AW reports the scope facts and proof burden, and the agent owns "
+            "Changed paths cross implementation boundaries; AW reports the scope facts and proof factors, and the agent owns "
             "whether to continue direct or create planning."
         )
         required_next_action = "decide-work-shape-from-scope-facts"
@@ -16595,18 +16681,16 @@ def _planning_safety_gate_payload(
         "planning_revision": planning_revision,
         "active_plan_reliance": active_plan_reliance,
         "active_state_summary": active_summary,
-        "work_shape": work_shape or "unknown",
-        "proof_burden": proof_burden or "unknown",
         "issue_refs": issue_refs,
         "repair_route": {
             "status": "retired",
             "fit_criteria": [
-                "use work_shape_facts instead of prompt phrase exceptions",
+                "use work_shape_guidance instead of prompt phrase exceptions",
                 "agent decides whether a repair is small enough when hard_blockers is empty",
             ],
-            "rule": "Narrow repair is no longer a prompt-text gate; work_shape_facts reports hard blockers, factors, proof, and stop conditions.",
+            "rule": "Narrow repair is no longer a prompt-text gate; work-shape guidance reports hard blockers, factors, proof, and stop conditions.",
         },
-        "work_shape_facts": _work_shape_facts_payload(
+        "work_shape_guidance": _work_shape_guidance_payload(
             path_classification=path_classification,
             issue_refs=issue_refs,
             work_shape=work_shape or "unknown",
@@ -16695,21 +16779,30 @@ def _capability_posture_for_implementation(*, changed_paths: list[str], task_tex
             inspection_evidence.append("active planning state")
         enriched_posture = {
             **posture,
-            "work shape": work_shape,
-            "proof burden": proof_burden,
+            "structural work-shape hint": work_shape,
+            "proof factor hint": proof_burden,
             "risk flags": risk_flags,
             "inspection evidence required": inspection_evidence,
-            "classification authority": "structural task/path signals",
+            "guidance authority": "structural task/path signals",
             "self-assessment authority": "advisory-only",
         }
         return {
             "status": "inferred",
             "posture": enriched_posture,
-            "work_shape": work_shape,
-            "proof_burden": proof_burden,
+            "work_shape_guidance": {
+                "structural_hint": work_shape,
+                "authority": "path/task heuristic only",
+                "agent_decision_required": True,
+            },
+            "proof_factors": {
+                "structural_hint": proof_burden,
+                "risk_flags": risk_flags,
+                "inspection_evidence_required": inspection_evidence,
+                "authority": "path/task heuristic only",
+            },
             "risk_flags": risk_flags,
             "inspection_evidence_required": inspection_evidence,
-            "classification_authority": "structural task/path signals",
+            "guidance_authority": "structural task/path signals",
             "self_assessment_authority": "advisory-only",
             "reason": reason,
         }
@@ -16825,9 +16918,7 @@ def _delegation_next_action_decision(
     target_location = str(selected_target.get("location", "")) if isinstance(selected_target, dict) else ""
     target_strength = str(selected_target.get("strength", "")) if isinstance(selected_target, dict) else ""
     capability_status = str(capability.get("status", "unknown")) if isinstance(capability, dict) else "unknown"
-    posture = capability.get("posture", {}) if isinstance(capability, dict) else {}
-    work_shape = capability.get("work_shape") or (posture.get("work shape") if isinstance(posture, dict) else None)
-    proof_burden = capability.get("proof_burden") or (posture.get("proof burden") if isinstance(posture, dict) else None)
+    work_shape, proof_burden = _capability_structural_hints(capability)
     reasons = list(runtime_resolution.get("reasons", [])) if isinstance(runtime_resolution.get("reasons", []), list) else []
     if not reasons:
         reasons = [str(runtime_resolution.get("guidance", "Local posture did not produce a specific reason."))]
@@ -17048,9 +17139,9 @@ def _delegation_next_action_decision(
     if decision != "delegate-bounded-slice":
         auto_skip_reasons.append(f"delegation decision is {decision}, not delegate-bounded-slice")
     if proof_burden == "high":
-        auto_skip_reasons.append("proof burden is high")
+        auto_skip_reasons.append("proof factor hint is high")
     if work_shape not in {"direct", "bounded"}:
-        auto_skip_reasons.append(f"work shape is {work_shape or 'unknown'}")
+        auto_skip_reasons.append(f"work-shape hint is {work_shape or 'unknown'}")
     auto_audit_applies = bool(
         configured_auto_targets
         and decision not in {"delegate-bounded-slice", "suggest-delegation"}
@@ -17076,8 +17167,8 @@ def _delegation_next_action_decision(
         else [],
         "reporting_rule": "When auto-capable configured targets are not used, report the skip reason so the orchestrator can distinguish human-control gating, proof risk, and ordinary stay-local execution.",
     }
-    quality_risk = "high" if proof_burden == "high" else "medium" if proof_burden == "non-obvious" else "low"
-    token_savings_expected = (
+    quality_tier = "high" if proof_burden == "high" else "medium" if proof_burden == "non-obvious" else "low"
+    token_savings_signal = (
         "likely"
         if decision in {"suggest-downroute", "delegate-bounded-slice"}
         else "possible"
@@ -17091,18 +17182,27 @@ def _delegation_next_action_decision(
         "clarification_mode": clarification_mode,
         "decision": decision,
         "target": target_name if decision != "stay-local" else None,
-        "work_shape": work_shape,
-        "proof_burden": proof_burden,
-        "quality_risk": quality_risk,
-        "token_savings_expected": token_savings_expected,
+        "quality_factors": {
+            "tier": quality_tier,
+            "proof_factor_hint": proof_burden or "unknown",
+            "work_shape_hint": work_shape or "unknown",
+            "risk_flags": capability.get("risk_flags", []) if isinstance(capability, dict) else [],
+            "agent_judgment_required": True,
+            "rule": "AW exposes structural factors for delegation posture; the agent owns whether the factors justify delegation.",
+        },
+        "token_savings_guidance": {
+            "signal": token_savings_signal,
+            "authority": "configured-target and route fit only",
+            "agent_judgment_required": True,
+        },
         "required_next_action": required_next_action,
-        "effort_recommendation": _effort_recommendation_payload(
+        "effort_guidance": _effort_guidance_payload(
             work_shape=str(work_shape or "unknown"),
             proof_burden=str(proof_burden or "unknown"),
-            quality_risk=quality_risk,
+            quality_tier=quality_tier,
             decision=decision,
             required_next_action=required_next_action,
-            token_savings_expected=token_savings_expected,
+            token_savings_signal=token_savings_signal,
             target_name=target_name if decision != "stay-local" else None,
             target_strength=target_strength,
             manual_external_relay=manual_external_relay,
@@ -17123,26 +17223,30 @@ def _delegation_next_action_decision(
     }
 
 
-def _effort_recommendation_payload(
+def _effort_guidance_payload(
     *,
     work_shape: str,
     proof_burden: str,
-    quality_risk: str,
+    quality_tier: str,
     decision: str,
     required_next_action: str,
-    token_savings_expected: str,
+    token_savings_signal: str,
     target_name: str | None,
     target_strength: str,
     manual_external_relay: dict[str, Any],
 ) -> dict[str, Any]:
-    """Recommend cost/effort posture from already-computed routing signals."""
+    """Expose cost/effort guidance from already-computed routing signals."""
     orchestrator = "medium"
     planner = "none"
     implementer = "medium"
     validator = "medium"
     cost_posture = "balanced"
     escalation_trigger = "escalate only if inspection reveals broader uncertainty, high risk, or proof gaps"
-    rationale: list[str] = [f"work_shape={work_shape}", f"proof_burden={proof_burden}", f"quality_risk={quality_risk}"]
+    rationale: list[str] = [
+        f"work_shape_hint={work_shape}",
+        f"proof_factor_hint={proof_burden}",
+        f"quality_factor_tier={quality_tier}",
+    ]
     if work_shape == "direct" and proof_burden == "obvious":
         implementer = "low"
         validator = "low"
@@ -17152,7 +17256,7 @@ def _effort_recommendation_payload(
         implementer = "medium"
         validator = "medium" if proof_burden == "non-obvious" else "low"
         cost_posture = "bounded-medium"
-    elif work_shape in {"lane", "epic"} or proof_burden == "high" or quality_risk == "high":
+    elif work_shape in {"lane", "epic"} or proof_burden == "high" or quality_tier == "high":
         planner = "high" if work_shape != "epic" else "xhigh"
         implementer = "medium-after-plan" if work_shape in {"lane", "epic"} else "medium"
         validator = "high"
@@ -17161,7 +17265,7 @@ def _effort_recommendation_payload(
     if decision in {"suggest-downroute", "delegate-bounded-slice"} and target_name:
         implementer = f"{target_strength or 'configured'} delegate"
         cost_posture = "save-tokens-where-safe"
-        rationale.append(f"token_savings_expected={token_savings_expected}")
+        rationale.append(f"token_savings_signal={token_savings_signal}")
     elif decision in {"suggest-escalation", "manual-handoff"}:
         planner = "high"
         cost_posture = "buy-quality-before-coding"
@@ -17175,9 +17279,9 @@ def _effort_recommendation_payload(
         escalation_trigger = "prepare the manual relay prompt early, before code-local work consumes the question"
         rationale.append("manual_external_relay=appropriate")
     return {
-        "kind": "agentic-workspace/effort-recommendation/v1",
+        "kind": "agentic-workspace/effort-guidance/v1",
         "status": "evaluated",
-        "principle": "Start with cheap routing, then spend higher reasoning effort only where it improves quality or safely saves tokens.",
+        "principle": "Start with cheap routing, then spend higher reasoning effort only where the agent judges it improves quality or safely saves tokens.",
         "orchestrator": orchestrator,
         "planner": planner,
         "implementer": implementer,
@@ -17185,7 +17289,8 @@ def _effort_recommendation_payload(
         "cost_posture": cost_posture,
         "escalation_trigger": escalation_trigger,
         "target": target_name,
-        "reason": "; ".join(rationale),
+        "factor_summary": "; ".join(rationale),
+        "agent_decision_required": True,
     }
 
 
@@ -17289,8 +17394,8 @@ def _manual_external_relay_payload(
             ],
             "return_to": "Paste the answer back into the current coding-agent session; the coding agent remains responsible for repo implementation and proof.",
             "source_reason": reason,
-            "proof_burden": proof_burden,
-            "work_shape": work_shape,
+            "proof_factors": {"structural_hint": proof_burden},
+            "work_shape_guidance": {"structural_hint": work_shape, "agent_decision_required": True},
         },
     }
 
@@ -25099,7 +25204,10 @@ def _capability_resolution_for_profile(*, profile: DelegationTargetProfile, capa
         elif profile_reasoning_rank and required_rank and (profile_reasoning_rank > required_rank):
             score += 1
             reasons.append("target reasoning profile exceeds the recommended strength")
-    if profile.context_capacity == "small" and str(capability_posture.get("work shape", "")).strip() in ("lane", "epic"):
+    if profile.context_capacity == "small" and str(capability_posture.get("structural work-shape hint", "")).strip() in (
+        "lane",
+        "epic",
+    ):
         capability_mismatch = True
         score -= 2
         reasons.append("target context capacity is too small for lane or epic shaped work")
@@ -25515,16 +25623,19 @@ def _ready_capability_handoff_packet(
 ) -> dict[str, Any]:
     templates = _capability_handoff_packet_templates()
     packet_template = templates["packet_types"].get(packet_type, {})
+    posture_detail = posture.get("posture", {}) if isinstance(posture.get("posture"), dict) else {}
+    proof_factors = posture.get("proof_factors", {}) if isinstance(posture.get("proof_factors"), dict) else {}
+    work_shape_guidance = posture.get("work_shape_guidance", {}) if isinstance(posture.get("work_shape_guidance"), dict) else {}
     return {
         "kind": "agentic-workspace/capability-handoff-packet/v1",
         "packet_type": packet_type,
         "mode": mode,
         "target": target,
         "template": packet_template,
-        "task_shape": posture.get("work_shape") or posture.get("posture", {}).get("work shape"),
+        "task_shape": work_shape_guidance.get("structural_hint") or posture_detail.get("structural work-shape hint"),
         "route_reason": runtime_resolution.get("guidance"),
         "inspected_context": posture.get("inspection_evidence_required", []),
-        "proof_expectations": posture.get("proof_burden"),
+        "proof_expectations": proof_factors.get("structural_hint") or posture_detail.get("proof factor hint"),
         "allowed_write_scope": "Use the active plan or implementer-context path boundaries; do not infer broader ownership.",
         "stop_conditions": [
             "capability mismatch remains unresolved",

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -104,7 +104,7 @@ def test_implement_command_returns_bounded_context_and_boundary_warnings(tmp_pat
     assert payload["planning_safety_gate"]["status"] == "attention"
     assert payload["planning_safety_gate"]["decision"] == "agent-work-shape-decision-required"
     assert payload["planning_safety_gate"]["implementation_allowed"] is True
-    assert payload["planning_safety_gate"]["work_shape_facts"]["hard_blockers"] == []
+    assert payload["planning_safety_gate"]["work_shape_guidance"]["hard_blockers"] == []
 
 
 def test_implement_selects_active_assurance_requirements_from_changed_paths(tmp_path: Path, capsys) -> None:
@@ -740,7 +740,9 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert "make test-workspace" in payload["proof"]["required_commands"]
     assert "uv run python scripts/check/check_generated_command_packages.py" in payload["proof"]["required_commands"]
     assert payload["proof"]["acceptance_guidance"]["status"] == "present"
-    assert context["routing"]["work_shape"] == "bounded"
+    guidance = context["guidance"]
+    assert guidance["rule"].startswith("AW exposes facts")
+    assert guidance["work_shape_guidance"]["agent_decision_required"] is True
     acknowledgement = context["intent_acknowledgement"]
     assert acknowledgement["decision"] == "proceed-with-stated-assumption"
     assert acknowledgement["fields"] == [
@@ -955,7 +957,7 @@ def test_implement_task_text_does_not_route_broad_issue_ingestion_to_planning(tm
     payload = json.loads(capsys.readouterr().out)
     assert "task_routing" not in payload
     assert payload["planning_safety_gate"]["status"] == "clear"
-    assert payload["planning_safety_gate"]["work_shape_facts"]["agent_decision_required"] is True
+    assert payload["planning_safety_gate"]["work_shape_guidance"]["agent_decision_required"] is True
     assert payload["next_allowed_action"] == "Provide --changed paths or use start/preflight before broad implementation."
     assert payload["handoff_requirements"]["stop_when"][0] != "task routing status is needs-planning for broad external-work ingestion"
 
@@ -969,8 +971,8 @@ def test_implement_task_allows_narrow_single_issue_context(tmp_path: Path, capsy
     payload = json.loads(capsys.readouterr().out)
     assert "task_routing" not in payload
     assert payload["planning_safety_gate"]["status"] == "clear"
-    assert payload["planning_safety_gate"]["work_shape_facts"]["scope_factors"]["issue_refs"] == ["#424"]
-    assert payload["planning_safety_gate"]["work_shape_facts"]["agent_decision_required"] is True
+    assert payload["planning_safety_gate"]["work_shape_guidance"]["scope_factors"]["issue_refs"] == ["#424"]
+    assert payload["planning_safety_gate"]["work_shape_guidance"]["agent_decision_required"] is True
     assert payload["next_allowed_action"] == "Provide --changed paths or use start/preflight before broad implementation."
 
 
@@ -1162,8 +1164,8 @@ def test_implement_command_surfaces_reasoning_heavy_execution_posture(tmp_path: 
     payload = json.loads(capsys.readouterr().out)
     posture = payload["execution_posture"]
     assert posture["capability_posture"]["posture"]["execution class"] == "boundary-shaping"
-    assert posture["capability_posture"]["work_shape"] == "bounded"
-    assert posture["capability_posture"]["proof_burden"] == "high"
+    assert posture["capability_posture"]["work_shape_guidance"]["structural_hint"] == "bounded"
+    assert posture["capability_posture"]["proof_factors"]["structural_hint"] == "high"
     assert "schema" in posture["capability_posture"]["risk_flags"]
     assert "proof route" in posture["capability_posture"]["inspection_evidence_required"]
     assert posture["capability_posture"]["self_assessment_authority"] == "advisory-only"
@@ -1250,8 +1252,8 @@ def test_implement_auto_delegation_exposes_bounded_slice_handoff(tmp_path: Path,
     assert decision["decision"] == "delegate-bounded-slice"
     assert decision["target"] == "mini"
     assert decision["required_next_action"] == "execute-when-safe"
-    assert decision["token_savings_expected"] == "likely"
-    effort = decision["effort_recommendation"]
+    assert decision["token_savings_guidance"]["signal"] == "likely"
+    effort = decision["effort_guidance"]
     assert effort["cost_posture"] == "save-tokens-where-safe"
     assert effort["orchestrator"] == "medium"
     assert effort["implementer"] == "medium delegate"
@@ -1341,7 +1343,7 @@ def test_implement_epic_decomposition_prefers_reusable_worker_over_manual_relay(
     assert decision["decision"] == "suggest-delegation"
     assert decision["target"] == "reusable-worker"
     assert decision["required_next_action"] == "select-or-promote-bounded-lane"
-    assert decision["token_savings_expected"] == "possible"
+    assert decision["token_savings_guidance"]["signal"] == "possible"
     assert decision["config_effect"]["execution_authority"] == "auto-execution-permitted"
     assert "handoff_command" not in decision
     assert decision["delegation_next_step"]["status"] == "prepare-or-report"
@@ -1401,11 +1403,11 @@ def test_implement_suppresses_manual_external_relay_for_code_local_changed_paths
     decision = _implement_context(payload)["delegation_decision"]
     assert decision["decision"] == "stay-local"
     assert decision["required_next_action"] == "continue-local"
-    assert decision["effort_recommendation"]["orchestrator"] == "medium"
-    assert decision["effort_recommendation"]["implementer"] == "medium"
-    assert decision["effort_recommendation"]["validator"] == "high"
-    assert decision["effort_recommendation"]["cost_posture"] == "quality-first"
-    assert "target" not in decision["effort_recommendation"]
+    assert decision["effort_guidance"]["orchestrator"] == "medium"
+    assert decision["effort_guidance"]["implementer"] == "medium"
+    assert decision["effort_guidance"]["validator"] == "high"
+    assert decision["effort_guidance"]["cost_posture"] == "quality-first"
+    assert "target" not in decision["effort_guidance"]
     assert "manual_external_relay" not in decision
     assert "config_effect" not in decision
     assert "manual_prompt" not in decision
@@ -1447,7 +1449,7 @@ def test_implement_supports_selector_drilldown(tmp_path: Path, capsys) -> None:
                 "--task",
                 "Implement bounded text helper behavior",
                 "--select",
-                "context.delegation_decision.required_next_action,context.delegation_decision.delegation_next_step.must_report_if_not_run,context.delegation_decision.effort_recommendation.cost_posture",
+                "context.delegation_decision.required_next_action,context.delegation_decision.delegation_next_step.must_report_if_not_run,context.delegation_decision.effort_guidance.cost_posture",
                 "--format",
                 "json",
             ]
@@ -1461,7 +1463,7 @@ def test_implement_supports_selector_drilldown(tmp_path: Path, capsys) -> None:
     assert "available_selectors" not in payload
     assert payload["values"]["context.delegation_decision.required_next_action"] == "execute-when-safe"
     assert payload["values"]["context.delegation_decision.delegation_next_step.must_report_if_not_run"] is True
-    assert payload["values"]["context.delegation_decision.effort_recommendation.cost_posture"] == "save-tokens-where-safe"
+    assert payload["values"]["context.delegation_decision.effort_guidance.cost_posture"] == "save-tokens-where-safe"
 
 
 def test_implement_selector_surfaces_reuse_pressure_without_blocking_direct_work(tmp_path: Path, capsys) -> None:
@@ -1569,8 +1571,9 @@ def test_implement_reuse_pressure_surfaces_repeated_special_case(tmp_path: Path,
     )
 
     reuse_pressure = json.loads(capsys.readouterr().out)["values"]["reuse_pressure"]
-    assert reuse_pressure["state"] == "abstraction_pressure"
-    finding = reuse_pressure["findings"][0]
+    assert reuse_pressure["state"] == "similar_pattern_candidate"
+    finding = next(item for item in reuse_pressure["findings"] if item["kind"] == "repeated_special_case")
+    assert finding["evidence_confidence"] == "medium"
     assert finding["kind"] == "repeated_special_case"
     assert finding["candidate_paths"] == ["src/sample_app/legacy_a.py", "src/sample_app/legacy_b.py"]
 

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -1936,6 +1936,12 @@ queued_items = []
                     "decision command": "agentic-planning delegation-decision",
                     "recorded at": "2026-05-21T15:04:09+00:00",
                 },
+                "proof_report": {
+                    "validation proof": "uv run pytest tests/test_workspace_start_preflight_cli.py -q passed",
+                    "proof achieved now": "yes",
+                    'evidence for "proof achieved" state': "focused active-plan reliance test",
+                },
+                "finished_run_review": {"proof status": "passed"},
             }
         ),
     )
@@ -1960,6 +1966,17 @@ queued_items = []
     assert recorded_payload["active_plan_reliance"]["status"] == "command-written-state-observed"
     assert recorded_payload["active_plan_reliance"]["permission_claim"] == "review-before-continuing-active-plan"
     assert recorded_payload["planning_revision"]["revision_id"]
+    authority = recorded_payload["active_plan_reliance"]["authority_evidence"]
+    assert authority["active_execplan"] == ".agentic-workspace/planning/execplans/mechanical-lane.plan.json"
+    assert authority["state_last_modified"]
+    assert authority["active_execplan_last_modified"]
+    assert authority["last_updated"]
+    assert authority["mutation_authority"] == "command-provenance-present"
+    assert authority["manual_edit_indicator"] is False
+    assert authority["last_proof"]["recorded"] is True
+    assert authority["last_proof"]["status"] == "passed"
+    assert authority["current_enough_to_guide_work"] is True
+    assert "--expect-planning-revision" in authority["routes"]["close_or_update_stale_state"]
 
 
 def test_implement_does_not_promote_unmatched_decomposition_candidate(tmp_path: Path, capsys) -> None:
@@ -2050,10 +2067,18 @@ queued_items = []
         == 0
     )
 
-    gate = _start_planning_safety_gate(json.loads(capsys.readouterr().out))
+    payload = json.loads(capsys.readouterr().out)
+    gate = _start_planning_safety_gate(payload)
     assert gate["status"] == "blocked"
     assert gate["decision"] == "delegation-decision-required"
     assert gate["active_delegation_requirement"]["status"] == "delegation-decision-untrusted-shared-state"
+    reliance = gate["active_plan_reliance"]
+    assert reliance["status"] == "blocked"
+    authority = reliance["authority_evidence"]
+    assert authority["mutation_authority"] == "manual-edit-indicator"
+    assert authority["manual_edit_indicator"] is True
+    assert "hand-edited-delegation-decision" in authority["stale_indicators"]
+    assert "planning delegation-decision" in authority["routes"]["record_or_repair"]
 
 
 def test_implement_blocks_stale_parent_decomposition_for_active_epic_plan(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -1330,7 +1330,7 @@ def test_start_tiny_prepares_manual_external_relay_for_early_epic_shaping(tmp_pa
 
     decision = _start_context_value(json.loads(capsys.readouterr().out), "delegation_decision")
     assert decision["required_next_action"] == "prepare-manual-handoff"
-    effort = decision["effort_recommendation"]
+    effort = decision["effort_guidance"]
     assert effort["orchestrator"] == "medium"
     assert effort["planner"] == "external-high-judgment"
     assert effort["cost_posture"] == "human-interrupt-only-if-worth-it"
@@ -1639,7 +1639,8 @@ def test_implement_flags_scope_growth_without_active_execplan(tmp_path: Path, ca
     assert gate["status"] == "attention"
     assert gate["decision"] == "agent-work-shape-decision-required"
     assert gate["implementation_allowed"] is True
-    assert gate["work_shape_facts"]["hard_blockers"] == []
+    guidance = payload["context"]["guidance"]["work_shape_guidance"]
+    assert guidance["hard_blockers"] == []
     assert gate["changed_path_classification"]["dirty_shape"] == "implementation-only"
     assert "generated artifacts changed with source or tests" in gate["changed_path_classification"]["scope_growth_reasons"]
     assert _start_workflow_sufficiency(payload)["decision"] == "enough-for-bounded-implementation"
@@ -1674,16 +1675,11 @@ def test_implement_allows_routine_pr_comment_repair_without_plan_scaffold(tmp_pa
     assert gate["decision"] == "direct-work-allowed"
     assert gate["implementation_allowed"] is True
     assert gate["repair_route"]["status"] == "retired"
-    assert gate["work_shape_facts"]["hard_blockers"] == []
-    assert gate["work_shape_facts"]["agent_decision_required"] is True
-    assert gate["work_shape_facts"]["suggested_shape"] == "direct"
-    assert gate["work_shape_facts"]["judgment_boundary"]["aw_owns"] == [
-        "hard blockers",
-        "changed-path facts",
-        "active planning state",
-        "proof candidates",
-    ]
-    assert "semantic work shape" in gate["work_shape_facts"]["judgment_boundary"]["agent_owns"]
+    guidance = payload["context"]["guidance"]["work_shape_guidance"]
+    assert guidance["hard_blockers"] == []
+    assert guidance["agent_decision_required"] is True
+    assert "changed implementation paths are within a narrow top-level surface" in guidance["direct_work_is_reasonable_when"]
+    assert payload["context"]["guidance"]["rule"].startswith("AW exposes facts")
     assert gate["changed_path_classification"]["scope_growth_detected"] is False
     assert gate["changed_path_classification"]["ancillary_paths"] == [".agentic-workspace/memory/repo/current/routing-feedback.md"]
     assert _start_workflow_sufficiency(payload)["decision"] == "enough-for-bounded-implementation"
@@ -1718,10 +1714,11 @@ def test_implement_allows_single_issue_followthrough_with_memory_feedback_note(t
     assert gate["decision"] == "direct-work-allowed"
     assert gate["implementation_allowed"] is True
     assert gate["repair_route"]["status"] == "retired"
-    assert gate["work_shape_facts"]["hard_blockers"] == []
-    assert gate["work_shape_facts"]["agent_decision_required"] is True
-    assert gate["work_shape_facts"]["suggested_shape"] == "direct"
-    assert gate["work_shape_facts"]["scope_factors"]["issue_refs"] == ["#1058"]
+    guidance = payload["context"]["guidance"]["work_shape_guidance"]
+    assert guidance["hard_blockers"] == []
+    assert guidance["agent_decision_required"] is True
+    assert "changed implementation paths are within a narrow top-level surface" in guidance["direct_work_is_reasonable_when"]
+    assert guidance["scope_factors"]["issue_refs"] == ["#1058"]
     assert gate["changed_path_classification"]["ancillary_paths"] == [".agentic-workspace/memory/repo/current/routing-feedback.md"]
     assert _start_workflow_sufficiency(payload)["decision"] == "enough-for-bounded-implementation"
 


### PR DESCRIPTION
## Summary

- Reframes implement/start work-shape output from package-owned classification to agent-owned guidance and structural factors.
- Deliberately renames the selector/contract language from package routing/classification terms to guidance terms, including `context.routing` -> `context.guidance`, `work_shape_facts` -> `work_shape_guidance`, and proof/delegation posture fields becoming guidance/factor surfaces.
- Demotes generic reuse pressure into confidence-marked evidence and updates the active work-shape skills/reference schema.
- Adds active Planning freshness and authority evidence wherever active-plan reliance is surfaced: state/execplan timestamps, command-vs-manual provenance, last proof status, stale indicators, current-enough guidance, and refresh/repair/closeout routes.

Closes #1168

## Validation

- `uv run pytest tests/test_workspace_start_preflight_cli.py tests/test_workspace_implement_cli.py -q`
- `uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_start_preflight_cli.py`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`