### PR TITLE
Add lazy report catalog and workflow compliance summary

### DIFF
--- a/docs/continuation-readiness-projections.md
+++ b/docs/continuation-readiness-projections.md
@@ -12,10 +12,12 @@ Use them when a compact report answer should make continuation cheaper without m
 | `repair_loop_residue` | Summarizes validation-driven repair residue: observed problem, inspection findings, focused change, validation evidence, remaining gap, continuation input, and stop reason. |
 | `structured_findings` | Provides a compact finding shape with owner and disposition fields so review, friction, Verification, and promotion residue can be routed or dismissed. |
 | `external_evidence_safety` | Summarizes external source freshness, local state, divergence, stale-after, closeout safety, and refresh route without making external systems authoritative. |
+| `workflow_compliance_summary` | Summarizes expected entrypoint, observed workflow use, satisfied or missing gates, skipped or unavailable steps, trust impact, and recovery action for takeover, recovery, review, and closeout. |
 | `continuation_next_actions` | Ranks next actions by available evidence, confidence, validation route, and stop condition. |
 | `migration_pilot_template` | Defines an optional migration-pilot decomposition pattern with inventory, target design, parity proof, validation, and rollout boundaries. |
 | `compact_output_criteria` | Names the fields compact outputs must preserve or point to: intent, evidence, next action, stop condition, changed surfaces, and unresolved risk. |
 | `automation_readiness` | Gives a provider-agnostic checklist for evaluating external workflows while keeping execution, secrets, and side effects outside AW. |
+| `section_catalog` | Lists lazy report selectors and their purpose without computing their full payloads. |
 
 ## Boundary
 
@@ -49,7 +51,9 @@ Use a projection only when the compact answer, task shape, or closeout question 
 ```bash
 agentic-workspace report --target ./repo --section completion_contract --format json
 agentic-workspace report --target ./repo --section external_evidence_safety --format json
+agentic-workspace report --target ./repo --section workflow_compliance_summary --format json
 agentic-workspace report --target ./repo --section continuation_next_actions --format json
+agentic-workspace report --target ./repo --section section_catalog --format json
 ```
 
 For closeout, preserve the completion boundary explicitly:

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -86,6 +86,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `repair_loop_residue` | object | yes |  | Derived validation-driven repair residue across Planning and Verification. |  |  |
 | `structured_findings` | object | yes |  | Structured finding residue shape for review and promotion routing. |  |  |
 | `external_evidence_safety` | object | yes |  | External evidence freshness, divergence, stale-after, and closeout-safety projection. |  |  |
+| `workflow_compliance_summary` | object | yes |  | Derived review and recovery summary of workflow entrypoint, satisfied or missing gates, trust impact, and recovery action. |  |  |
 | `continuation_next_actions` | object | yes |  | Evidence-ranked next actions for safe continuation. |  |  |
 | `migration_pilot_template` | object | yes |  | Optional migration-pilot decomposition template with parity and rollout boundaries. |  |  |
 | `compact_output_criteria` | object | yes |  | Criteria for compact CLI outputs to remain sufficient for cheap continuation. |  |  |

--- a/src/agentic_workspace/contracts/report_contract.json
+++ b/src/agentic_workspace/contracts/report_contract.json
@@ -40,6 +40,7 @@
     "repair_loop_residue",
     "structured_findings",
     "external_evidence_safety",
+    "workflow_compliance_summary",
     "continuation_next_actions",
     "migration_pilot_template",
     "compact_output_criteria",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -44,6 +44,7 @@
     "repair_loop_residue",
     "structured_findings",
     "external_evidence_safety",
+    "workflow_compliance_summary",
     "continuation_next_actions",
     "migration_pilot_template",
     "compact_output_criteria",
@@ -281,6 +282,10 @@
     "external_evidence_safety": {
       "type": "object",
       "description": "External evidence freshness, divergence, stale-after, and closeout-safety projection."
+    },
+    "workflow_compliance_summary": {
+      "type": "object",
+      "description": "Derived review and recovery summary of workflow entrypoint, satisfied or missing gates, trust impact, and recovery action."
     },
     "continuation_next_actions": {
       "type": "object",

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -602,6 +602,7 @@ def report_router_payload(
                 cli_invoke=cli_invoke,
                 target_arg=target_arg,
             ),
+            "lazy_section_catalog": "section_catalog",
             "high_volume_sections": profile_payload.get("high_volume_sections", []),
             "omitted_section_hint_count": max(0, len(section_hints) - len(compact_section_hints)),
         },
@@ -651,6 +652,7 @@ def report_router_payload(
                 "context.external_work_reconciliation",
                 "context.surface_value_guardrail",
                 "drill_down.section_hints",
+                "drill_down.deeper_detail.lazy_section_catalog",
                 "drill_down.deeper_detail",
             ],
         },
@@ -713,7 +715,7 @@ def _compact_report_section_hints(hints: list[dict[str, Any]]) -> list[dict[str,
     for item in ordered[:8]:
         compact.append(
             {key: item[key] for key in ("section", "why_now", "command", "volume", "advanced_feature") if key in item}
-            | ({"purpose_summary": str(item.get("purpose", ""))[:96]} if item.get("purpose") else {})
+            | ({"purpose_summary": str(item.get("purpose", ""))[:80]} if item.get("purpose") else {})
         )
     return compact
 
@@ -1036,6 +1038,7 @@ def report_section_hints(
         "completion_contract": "Planning completion-contract lens for what must become true, proof, constraints, and blocked stop",
         "repair_loop_residue": "validation-driven repair loop residue across Planning and Verification",
         "structured_findings": "shared structured finding shape for review and promotion routing",
+        "workflow_compliance_summary": "derived review/recovery summary of workflow entrypoint, gates, trust impact, and recovery action",
         "continuation_next_actions": "evidence-ranked next actions, validation, risks, and stop conditions for continuation",
         "migration_pilot_template": "optional migration-pilot decomposition shape with parity and rollout boundaries",
         "compact_output_criteria": "criteria for compact outputs to remain sufficient for cheap continuation",
@@ -1075,6 +1078,7 @@ def report_section_hints(
         "completion_contract": "inspect when deciding whether work is done, partial, blocked, or continuation-required",
         "repair_loop_residue": "inspect after failed validation, iterative repair, or partial proof to recover the next grounded action",
         "structured_findings": "inspect when review, friction, verification, or promotion residue needs one owner and disposition",
+        "workflow_compliance_summary": "inspect during takeover, recovery, review, or closeout when workflow use affects trust",
         "continuation_next_actions": "inspect when a future session needs ranked next actions with evidence and stop conditions",
         "migration_pilot_template": "inspect before turning broad migration or modernization into a bounded pilot",
         "compact_output_criteria": "inspect when changing compact CLI output contracts or reviewing restart sufficiency",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -7120,6 +7120,401 @@ def _automation_readiness_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> di
     }
 
 
+_LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
+    {
+        "section": "section_catalog",
+        "kind": "agentic-workspace/report-section-catalog/v1",
+        "purpose": "compact catalog of section selectors whose payloads stay behind explicit report --section requests",
+        "when_to_use": "when the router hints omit rare or high-context sections and the agent needs a selector index",
+    },
+    {
+        "section": "assurance_requirements",
+        "kind": "agentic-workspace/assurance-requirements/v1",
+        "purpose": "repo-declared assurance requirements, evidence obligations, proof profile, and claim-boundary facts",
+        "when_to_use": "when configured assurance may affect proof, review, or closeout claims",
+    },
+    {
+        "section": "verification",
+        "kind": "agentic-workspace/verification-report/v1",
+        "purpose": "Verification module protocols, routes, evidence bundles, and known gaps",
+        "when_to_use": "when evidence production or review provenance matters more than ordinary proof selection",
+    },
+    {
+        "section": "successful_completion_cost",
+        "kind": "agentic-workspace/successful-completion-cost/v1",
+        "purpose": "recent model CLI evaluation cost, package-read overhead, and first-pass versus rework evidence",
+        "when_to_use": "when deciding whether workflow surfaces should stay default, shrink, or move behind selectors",
+    },
+    {
+        "section": "operational_compression",
+        "kind": "workspace-operational-compression/v1",
+        "purpose": "advisory measures for whether AW surfaces reduce total operational cost",
+        "when_to_use": "when reviewing whether a surface lowers repeated work more than it adds product weight",
+    },
+    {
+        "section": "completion_contract",
+        "kind": "agentic-workspace/completion-contract/v1",
+        "purpose": "Planning completion-contract lens for done, partial, blocked, and continuation-required decisions",
+        "when_to_use": "when deciding whether a slice can honestly close or must route follow-up",
+    },
+    {
+        "section": "repair_loop_residue",
+        "kind": "agentic-workspace/repair-loop-residue/v1",
+        "purpose": "validation-driven repair residue across Planning and Verification",
+        "when_to_use": "after failed validation, partial proof, or interrupted repair loops",
+    },
+    {
+        "section": "structured_findings",
+        "kind": "agentic-workspace/structured-findings/v1",
+        "purpose": "shared finding shape for review, friction, Verification, and promotion residue",
+        "when_to_use": "when review or recovery needs owner-shaped findings instead of prose residue",
+    },
+    {
+        "section": "external_evidence_safety",
+        "kind": "agentic-workspace/external-evidence-safety/v1",
+        "purpose": "external freshness, divergence, and closeout-safety decision support",
+        "when_to_use": "before broad closeout when external issue, CI, scanner, or ticket evidence may be stale or divergent",
+    },
+    {
+        "section": "workflow_compliance_summary",
+        "kind": "agentic-workspace/workflow-compliance-summary/v1",
+        "purpose": ("review/recovery summary of expected entrypoint, observed workflow use, gates, trust impact, and recovery action"),
+        "when_to_use": "during takeover, recovery, review, or closeout when package workflow use may affect trust",
+    },
+    {
+        "section": "continuation_next_actions",
+        "kind": "agentic-workspace/continuation-next-actions/v1",
+        "purpose": "evidence-ranked next actions, validation, risks, and stop conditions for continuation",
+        "when_to_use": "when a future session needs ranked, restartable next actions",
+    },
+    {
+        "section": "migration_pilot_template",
+        "kind": "agentic-workspace/migration-pilot-template/v1",
+        "purpose": "optional migration-pilot decomposition shape with parity and rollout boundaries",
+        "when_to_use": "before turning broad migration or modernization into a bounded pilot",
+    },
+    {
+        "section": "compact_output_criteria",
+        "kind": "agentic-workspace/compact-output-criteria/v1",
+        "purpose": "criteria for compact outputs to remain sufficient for cheap continuation",
+        "when_to_use": "when changing compact CLI output contracts or reviewing restart sufficiency",
+    },
+    {
+        "section": "automation_readiness",
+        "kind": "agentic-workspace/automation-readiness/v1",
+        "purpose": "provider-agnostic automation-readiness checklist that keeps execution outside AW",
+        "when_to_use": "before adding external automation, bot, CI, ticket, or agent workflow integration",
+    },
+)
+
+
+def _lazy_report_section_names() -> set[str]:
+    return {str(item["section"]) for item in _LAZY_REPORT_SECTION_CATALOG}
+
+
+def _report_section_catalog_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
+    sections = [
+        {
+            **item,
+            "payload_is_lazy": True,
+            "command": _command_with_cli_invoke(
+                command=f"agentic-workspace report --target ./repo --section {item['section']} --format json",
+                cli_invoke=cli_invoke,
+            ),
+        }
+        for item in _LAZY_REPORT_SECTION_CATALOG
+    ]
+    return {
+        "kind": "agentic-workspace/report-section-catalog/v1",
+        "status": "available",
+        "section_count": len(sections),
+        "lazy_sections": sections,
+        "default_router_policy": {
+            "rule": "Default report output keeps only routing hints; rare, high-context, or recovery-only payloads stay behind selectors.",
+            "ordinary_entry": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "catalog_command": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section section_catalog --format json",
+                cli_invoke=cli_invoke,
+            ),
+        },
+        "boundary": [
+            "the catalog is a selector index, not a full report",
+            "listed section payloads must remain lazy unless an explicit selector or verbose report already has the needed inputs",
+            "adding a section here should not require ordinary report callers to compute that section",
+        ],
+    }
+
+
+def _workflow_entrypoint_observed(execution: dict[str, Any]) -> dict[str, Any]:
+    handoff_source = _first_boundary_text(
+        execution,
+        keys=("handoff source", "handoff_source", "entrypoint", "entry point", "workflow entrypoint"),
+    )
+    what_happened = _first_boundary_text(
+        execution,
+        keys=("what happened", "summary", "workflow evidence", "package workflow evidence"),
+    )
+    combined = f"{handoff_source} {what_happened}".lower()
+    observed_surfaces = [
+        surface
+        for surface in ("preflight", "start", "summary", "report", "implement", "proof", "closeout", "reconcile")
+        if f"agentic-workspace {surface}" in combined or f"agentic-workspace {surface.replace('_', '-')}" in combined
+    ]
+    observed = handoff_source or what_happened
+    return {
+        "status": "recorded" if observed else "not-recorded",
+        "observed_or_assumed_entrypoint": observed or "not recorded in active Planning execution_run",
+        "observed_surfaces": sorted(set(observed_surfaces)),
+        "source_fields": [
+            "planning.active.planning_record.execution_run.handoff source",
+            "planning.active.planning_record.execution_run.what happened",
+        ],
+    }
+
+
+def _workflow_gate(gate_id: str, summary: str, *, source: str = "", command: str = "") -> dict[str, str]:
+    payload = {"id": gate_id, "summary": summary}
+    if source:
+        payload["source"] = source
+    if command:
+        payload["command"] = command
+    return payload
+
+
+def _workflow_compliance_summary_payload(
+    *,
+    active_planning_record: dict[str, Any],
+    completion_contract: dict[str, Any],
+    repair_loop_residue: dict[str, Any],
+    structured_findings: dict[str, Any],
+    external_evidence_safety: dict[str, Any],
+    verification: dict[str, Any],
+    cli_invoke: str = DEFAULT_CLI_INVOKE,
+) -> dict[str, Any]:
+    active_planning_record = active_planning_record if isinstance(active_planning_record, dict) else {}
+    execution = active_planning_record.get("execution_run", {})
+    execution = execution if isinstance(execution, dict) else {}
+    active_plan_present = bool(active_planning_record) and str(active_planning_record.get("status", "")).strip().lower() != "absent"
+    observed = _workflow_entrypoint_observed(execution)
+    evidence_state = completion_contract.get("evidence_state", {})
+    evidence_state = evidence_state if isinstance(evidence_state, dict) else {}
+    proof_state = str(evidence_state.get("proof_state", "unknown")).strip().lower().replace("-", "_") or "unknown"
+    completion_decision = str(completion_contract.get("completion_decision", "unknown")).strip().lower()
+    closeout_safe = external_evidence_safety.get("closeout_safe", "unknown")
+    satisfied_gates: list[dict[str, str]] = []
+    missing_gates: list[dict[str, str]] = []
+    skipped_or_unavailable_steps: list[dict[str, str]] = []
+
+    if active_plan_present:
+        satisfied_gates.append(
+            _workflow_gate(
+                "active_planning_record",
+                "active Planning evidence is available",
+                source=".agentic-workspace/planning/state.toml or active execplan",
+            )
+        )
+    else:
+        skipped_or_unavailable_steps.append(
+            _workflow_gate(
+                "active_planning_record",
+                "no active Planning record is present; workflow compliance is guidance-only",
+                command=_command_with_cli_invoke(
+                    command="agentic-workspace start --target ./repo --format json",
+                    cli_invoke=cli_invoke,
+                ),
+            )
+        )
+
+    if observed["status"] == "recorded" and observed["observed_surfaces"]:
+        satisfied_gates.append(
+            _workflow_gate(
+                "workflow_entrypoint_recorded",
+                f"recorded entrypoint evidence: {observed['observed_or_assumed_entrypoint']}",
+                source="planning.active.planning_record.execution_run",
+            )
+        )
+    elif active_plan_present:
+        missing_gates.append(
+            _workflow_gate(
+                "workflow_entrypoint_record",
+                "active Planning exists but does not record an AW workflow entrypoint used",
+                command=_command_with_cli_invoke(
+                    command="agentic-workspace preflight --target ./repo --format json",
+                    cli_invoke=cli_invoke,
+                ),
+            )
+        )
+
+    if proof_state in {"passed", "representative", "sufficient_for_claim", "satisfied"}:
+        satisfied_gates.append(_workflow_gate("proof_state", f"proof state is {proof_state}", source="completion_contract"))
+    elif active_plan_present:
+        missing_gates.append(
+            _workflow_gate(
+                "proof_state",
+                f"proof state is {proof_state}",
+                command=_command_with_cli_invoke(
+                    command="agentic-workspace proof --target ./repo --changed <paths> --format json",
+                    cli_invoke=cli_invoke,
+                ),
+            )
+        )
+
+    if completion_decision in {"done", "continuation-required"}:
+        satisfied_gates.append(
+            _workflow_gate(
+                "completion_contract",
+                f"completion contract decision is {completion_decision}",
+                source="completion_contract",
+            )
+        )
+    elif active_plan_present:
+        missing_gates.append(
+            _workflow_gate(
+                "completion_contract",
+                f"completion contract decision is {completion_decision or 'unknown'}",
+                command=_command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section completion_contract --format json",
+                    cli_invoke=cli_invoke,
+                ),
+            )
+        )
+
+    if closeout_safe is True:
+        satisfied_gates.append(
+            _workflow_gate("external_evidence_safety", "external evidence does not block closeout", source="external_evidence_safety")
+        )
+    elif closeout_safe is False:
+        missing_gates.append(
+            _workflow_gate(
+                "external_evidence_safety",
+                "external evidence blocks broad closeout",
+                command=str(external_evidence_safety.get("refresh_command", "")),
+            )
+        )
+    else:
+        skipped_or_unavailable_steps.append(
+            _workflow_gate(
+                "external_evidence_safety",
+                "external evidence is absent or unavailable; Planning remains primary unless external work is in scope",
+                command=str(external_evidence_safety.get("refresh_command", "")),
+            )
+        )
+
+    if repair_loop_residue.get("status") == "active-evidence":
+        missing_gates.append(
+            _workflow_gate(
+                "repair_loop_residue",
+                "repair-loop residue remains active",
+                command=_command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section repair_loop_residue --format json",
+                    cli_invoke=cli_invoke,
+                ),
+            )
+        )
+    if _as_int(structured_findings.get("entry_count")):
+        missing_gates.append(
+            _workflow_gate(
+                "structured_findings",
+                f"{structured_findings.get('entry_count')} structured finding(s) need disposition",
+                command=_command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section structured_findings --format json",
+                    cli_invoke=cli_invoke,
+                ),
+            )
+        )
+    verification_status = str(verification.get("status", "")).strip()
+    if verification_status in {"attention", "blocked", "missing-evidence"}:
+        missing_gates.append(
+            _workflow_gate(
+                "verification",
+                f"Verification status is {verification_status}",
+                command=_command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section verification --format json",
+                    cli_invoke=cli_invoke,
+                ),
+            )
+        )
+
+    if any(gate["id"] in {"external_evidence_safety", "proof_state", "completion_contract"} for gate in missing_gates):
+        trust_impact = "lower-trust"
+    elif missing_gates:
+        trust_impact = "review-required"
+    else:
+        trust_impact = "normal"
+
+    if missing_gates:
+        first_missing = missing_gates[0]
+        recovery_action = {
+            "action": f"resolve-{first_missing['id']}",
+            "command": first_missing.get("command", ""),
+            "reason": first_missing["summary"],
+        }
+    elif skipped_or_unavailable_steps and not active_plan_present:
+        recovery_action = {
+            "action": "establish-workflow-entry",
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace start --target ./repo --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "reason": "no active Planning record is present",
+        }
+    else:
+        recovery_action = {
+            "action": "inspect-closeout-trust-before-broad-claims",
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section closeout_trust --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "reason": "workflow compliance summary is clear enough for review; closeout still owns claim honesty",
+        }
+
+    return {
+        "kind": "agentic-workspace/workflow-compliance-summary/v1",
+        "status": "attention" if missing_gates else "guidance-only" if not active_plan_present else "clear",
+        "authority": "derived-projection",
+        "expected_entrypoint": (
+            "Use AGENTS.md -> agentic-workspace start/preflight for first contact or takeover; "
+            "use implement/proof once changed paths are known; inspect closeout_trust before broad completion claims."
+        ),
+        "observed_or_assumed_entrypoint": observed["observed_or_assumed_entrypoint"],
+        "observed_surfaces": observed["observed_surfaces"],
+        "satisfied_gates": satisfied_gates,
+        "missing_gates": missing_gates,
+        "skipped_or_unavailable_steps": skipped_or_unavailable_steps,
+        "trust_impact": trust_impact,
+        "recovery_action": recovery_action,
+        "source_fields": [
+            *observed["source_fields"],
+            "completion_contract.evidence_state",
+            "external_evidence_safety.closeout_safe",
+            "repair_loop_residue.status",
+            "structured_findings.entry_count",
+            "verification.status",
+        ],
+        "boundary": (
+            "This summarizes existing Planning, Verification, proof, external-evidence, and closeout-related facts; "
+            "it does not run workflow steps or decide work classification for the agent."
+        ),
+        "detail_commands": {
+            "catalog": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section section_catalog --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "completion_contract": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section completion_contract --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "closeout_trust": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section closeout_trust --format json",
+                cli_invoke=cli_invoke,
+            ),
+        },
+    }
+
+
 def _derived_continuation_projection_payloads(
     *,
     target_root: Path,
@@ -7175,11 +7570,21 @@ def _derived_continuation_projection_payloads(
         external_evidence_safety=external_evidence_safety,
         cli_invoke=config.cli_invoke,
     )
+    workflow_compliance_summary = _workflow_compliance_summary_payload(
+        active_planning_record=active_planning_record,
+        completion_contract=completion_contract,
+        repair_loop_residue=repair_loop_residue,
+        structured_findings=structured_findings,
+        external_evidence_safety=external_evidence_safety,
+        verification=verification,
+        cli_invoke=config.cli_invoke,
+    )
     return {
         "completion_contract": completion_contract,
         "repair_loop_residue": repair_loop_residue,
         "structured_findings": structured_findings,
         "external_evidence_safety": external_evidence_safety,
+        "workflow_compliance_summary": workflow_compliance_summary,
         "continuation_next_actions": continuation_next_actions,
         "migration_pilot_template": _migration_pilot_template_payload(cli_invoke=config.cli_invoke),
         "compact_output_criteria": _compact_output_criteria_payload(cli_invoke=config.cli_invoke),
@@ -7198,20 +7603,7 @@ def _run_lazy_report_section_command(
     if section is None:
         return None
     normalized = section.strip()
-    if normalized not in {
-        "assurance_requirements",
-        "verification",
-        "successful_completion_cost",
-        "operational_compression",
-        "completion_contract",
-        "repair_loop_residue",
-        "structured_findings",
-        "external_evidence_safety",
-        "continuation_next_actions",
-        "migration_pilot_template",
-        "compact_output_criteria",
-        "automation_readiness",
-    }:
+    if normalized not in _lazy_report_section_names():
         return None
 
     payload = _report_section_base_payload(
@@ -7220,6 +7612,10 @@ def _run_lazy_report_section_command(
         resolved_preset=resolved_preset,
         config=config,
     )
+    if normalized == "section_catalog":
+        payload["section_catalog"] = _report_section_catalog_payload(cli_invoke=config.cli_invoke)
+        return _select_report_payload(payload, profile="router", section=normalized)
+
     active_planning_record = _active_planning_record_for_report_section(target_root=target_root)
 
     if normalized in {"assurance_requirements", "verification"}:
@@ -7245,6 +7641,7 @@ def _run_lazy_report_section_command(
         "repair_loop_residue",
         "structured_findings",
         "external_evidence_safety",
+        "workflow_compliance_summary",
         "continuation_next_actions",
         "migration_pilot_template",
         "compact_output_criteria",

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -286,6 +286,7 @@ def test_report_continuation_projection_sections_are_lazy(tmp_path: Path, capsys
         "repair_loop_residue": "agentic-workspace/repair-loop-residue/v1",
         "structured_findings": "agentic-workspace/structured-findings/v1",
         "continuation_next_actions": "agentic-workspace/continuation-next-actions/v1",
+        "workflow_compliance_summary": "agentic-workspace/workflow-compliance-summary/v1",
         "migration_pilot_template": "agentic-workspace/migration-pilot-template/v1",
         "compact_output_criteria": "agentic-workspace/compact-output-criteria/v1",
         "automation_readiness": "agentic-workspace/automation-readiness/v1",
@@ -296,6 +297,27 @@ def test_report_continuation_projection_sections_are_lazy(tmp_path: Path, capsys
         payload = json.loads(capsys.readouterr().out)
         assert payload["selector"] == {"section": section}
         assert payload["answer"]["kind"] == kind
+
+
+def test_report_section_catalog_lists_lazy_sections_without_full_report(tmp_path: Path, capsys, monkeypatch) -> None:
+    _init_git_repo(tmp_path)
+
+    def fail_full_report(**_kwargs: object) -> dict[str, object]:
+        raise AssertionError("section catalog should not build the full report")
+
+    monkeypatch.setattr(workspace_runtime_primitives, "_run_report_command", fail_full_report)
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "section_catalog", "--format", "json"]) == 0
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    assert answer["kind"] == "agentic-workspace/report-section-catalog/v1"
+    assert answer["section_count"] == len(answer["lazy_sections"])
+    sections = {item["section"]: item for item in answer["lazy_sections"]}
+    assert "workflow_compliance_summary" in sections
+    assert "automation_readiness" in sections
+    assert sections["workflow_compliance_summary"]["payload_is_lazy"] is True
+    assert "--section workflow_compliance_summary" in sections["workflow_compliance_summary"]["command"]
+    assert "--section section_catalog" in answer["default_router_policy"]["catalog_command"]
 
 
 def test_report_external_evidence_safety_surfaces_divergence(tmp_path: Path, capsys) -> None:
@@ -354,6 +376,39 @@ def test_report_external_evidence_safety_blocks_stable_open_external_work(tmp_pa
     assert answer["closeout_blockers"] == ["external_open_items"]
     assert answer["source_state"]["open_count"] == 1
     assert answer["source_state"]["changed_count"] == 0
+
+
+def test_report_workflow_compliance_summary_surfaces_recovery_gates(tmp_path: Path, capsys, monkeypatch) -> None:
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(
+        workspace_runtime_primitives,
+        "_active_planning_record_for_report_section",
+        lambda target_root: {
+            "status": "present",
+            "execution_run": {
+                "handoff source": "chat only",
+                "what happened": "Implemented without recording package workflow use.",
+            },
+            "closure_check": {"bounded_slice_complete": False},
+            "intent_continuity": {"larger_intent_complete": False},
+            "validation": {"status": "missing"},
+        },
+    )
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "workflow_compliance_summary", "--format", "json"]) == 0
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    assert answer["kind"] == "agentic-workspace/workflow-compliance-summary/v1"
+    assert answer["status"] == "attention"
+    assert "start/preflight" in answer["expected_entrypoint"]
+    assert answer["observed_or_assumed_entrypoint"] == "chat only"
+    missing = {gate["id"]: gate for gate in answer["missing_gates"]}
+    assert "workflow_entrypoint_record" in missing
+    assert "proof_state" in missing
+    assert "completion_contract" in missing
+    assert answer["trust_impact"] == "lower-trust"
+    assert answer["recovery_action"]["action"] == "resolve-workflow_entrypoint_record"
+    assert answer["skipped_or_unavailable_steps"][0]["id"] == "external_evidence_safety"
 
 
 def test_report_completion_contract_distinguishes_closure_states(tmp_path: Path, capsys, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Add a lazy `report --section section_catalog` answer listing low-frequency/lazy report selectors without building the full report.
- Add a derived `workflow_compliance_summary` projection for takeover/recovery/review/closeout checks over existing Planning, Verification, proof, and external-evidence facts.
- Document the new continuation-readiness projections and update the generated workspace report reference.

Closes #1184
Closes #1185

## Validation
- `make maintainer-surfaces`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `make lint-workspace`
- `make test-workspace`
- `make schema-reference-docs`
- `uv run python -m pytest tests/test_workspace_report_cli.py -q`
- `uv run python -m pytest tests/test_contract_tooling.py tests/test_maintainer_surfaces.py -q`