### PR TITLE
[codex] Make repository scans gitignore-aware

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/gitignore-aware-repo-scanning.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/gitignore-aware-repo-scanning.plan.json
@@ -1,0 +1,327 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Gitignore-aware repository scanning",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "GitHub #1214",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Add a central repository file scanner, migrate reuse-pressure and repo-friction/report scanners to it, and prove gitignored files are skipped while managed .agentic-workspace files remain visible.",
+    "proof_expectations": [
+      "uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py -q",
+      "make test-workspace",
+      "make lint-workspace"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/repository_scanning.py",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "src/agentic_workspace/reporting_support.py",
+      "tests/test_repository_scanning.py",
+      "tests/test_workspace_implement_cli.py",
+      "tests/test_workspace_report_cli.py"
+    ],
+    "completion_criteria": [
+      "Gitignore-aware repository scanning is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "GitHub #1214"
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "GitHub #1214",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py tests/test_workspace_summary_cli.py::test_external_intent_refresh_applies_stale_candidate_reconciliation_and_preserves_delta -q; uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; make test-workspace; make lint-workspace"
+    },
+    "execution": {
+      "milestone": "gitignore-aware-repo-scanning",
+      "status": "active",
+      "next_step": "Add a central repository file scanner, migrate reuse-pressure and repo-friction/report scanners to it, and prove gitignored files are skipped while managed .agentic-workspace files remain visible.",
+      "proof": "uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py -q"
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/repository_scanning.py",
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/reporting_support.py",
+        "tests/test_repository_scanning.py",
+        "tests/test_workspace_implement_cli.py",
+        "tests/test_workspace_report_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "GitHub #1214",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "current milestone validation remains pending",
+    "next likely slice": "continue the current milestone until the completion criteria are met"
+  },
+  "intent_interpretation": {
+    "literal request": "Gitignore-aware repository scanning",
+    "inferred intended outcome": "GitHub #1214",
+    "chosen concrete what": "Centralize ordinary repository file enumeration and migrate the known affected reuse-pressure and repo-friction/report scanners.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "Repository scanning helper, workspace runtime scanner call sites, reporting-support scanner call sites, focused tests, and this active execplan.",
+    "max changed files": "7 implementation/test files plus this active execplan and closeout archive.",
+    "required validation commands": "Focused pytest for repository scanning/reuse-pressure/repo-friction, then workspace test/lint proof.",
+    "ask-before-refactor threshold": "Ask or create a follow-up before migrating unrelated raw traversals that are not ordinary command repository scans.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Implement shared gitignore-aware file enumeration and migrate reuse-pressure plus repo-friction/report scans.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "GitHub #1214",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "keep-local",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "Bounded scanner migration is small enough to keep local; delegation would add handoff overhead while the proof burden remains focused on repository-scan behavior."
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": "GitHub #1214",
+      "label": "GitHub #1214",
+      "role": "intake",
+      "locator": ""
+    }
+  ],
+  "active_milestone": {
+    "id": "gitignore-aware-repo-scanning",
+    "status": "completed",
+    "scope": "Central repository file scanning plus the known affected reuse-pressure and repo-friction/report command scanners.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Add a central repository file scanner, migrate reuse-pressure and repo-friction/report scanners to it, and prove gitignored files are skipped while managed .agentic-workspace files remain visible."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/repository_scanning.py",
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "src/agentic_workspace/reporting_support.py",
+    "tests/test_repository_scanning.py",
+    "tests/test_workspace_implement_cli.py",
+    "tests/test_workspace_report_cli.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py -q",
+    "make test-workspace",
+    "make lint-workspace"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Gitignore-aware repository scanning is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added a central gitignore-aware repository scanner, migrated reuse-pressure and repo-friction/report scans, and optimized reuse-pressure to enumerate once per payload.",
+    "scope touched": "Repository file enumeration, reuse-pressure scanning, repo-friction/report scanning, artifact footprint scanning, and focused regression tests.",
+    "changed surfaces": "src/agentic_workspace/repository_scanning.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; tests/test_repository_scanning.py; tests/test_workspace_implement_cli.py; tests/test_workspace_report_cli.py",
+    "validations run": "uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py tests/test_workspace_summary_cli.py::test_external_intent_refresh_applies_stale_candidate_reconciliation_and_preserves_delta -q; uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; make test-workspace; make lint-workspace",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed bounded to GitHub #1214; dogfooding found and fixed local scratch false-positive reuse evidence and repeated scan overhead.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py tests/test_workspace_summary_cli.py::test_external_intent_refresh_applies_stale_candidate_reconciliation_and_preserves_delta -q; uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; make test-workspace; make lint-workspace",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py tests/test_workspace_summary_cli.py::test_external_intent_refresh_applies_stale_candidate_reconciliation_and_preserves_delta -q; uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; make test-workspace; make lint-workspace"
+  },
+  "intent_satisfaction": {
+    "original intent": "GitHub #1214",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py tests/test_workspace_summary_cli.py::test_external_intent_refresh_applies_stale_candidate_reconciliation_and_preserves_delta -q; uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; make test-workspace; make lint-workspace",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Ordinary repository scans now use Git ignore semantics in real Git repos, keep unignored untracked files, preserve managed .agentic-workspace visibility, and retain conservative non-Git fallback pruning.",
+    "validation confirmed": "uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py tests/test_workspace_summary_cli.py::test_external_intent_refresh_applies_stale_candidate_reconciliation_and_preserves_delta -q; uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; make test-workspace; make lint-workspace",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "knowledge promoted (memory/docs/config)": "none",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py tests/test_workspace_summary_cli.py::test_external_intent_refresh_applies_stale_candidate_reconciliation_and_preserves_delta -q; uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; make test-workspace; make lint-workspace",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-05-29: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: GitHub #1214\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py tests/test_workspace_summary_cli.py::test_external_intent_refresh_applies_stale_candidate_reconciliation_and_preserves_delta -q; uv run agentic-workspace summary --target . --format json; uv run agentic-workspace doctor --target . --modules planning --format json; make test-workspace; make lint-workspace\nChanged surfaces: src/agentic_workspace/repository_scanning.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; tests/test_repository_scanning.py; tests/test_workspace_implement_cli.py; tests/test_workspace_report_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from agentic_workspace.config import DEFAULT_CLI_INVOKE, WorkspaceUsageError
+from agentic_workspace.repository_scanning import repository_scan_files
 
 REPO_FRICTION_LARGE_FILE_THRESHOLD = 400
 REPO_FRICTION_CONCEPT_SURFACE_THRESHOLD = 200
@@ -21,19 +22,6 @@ REPO_FRICTION_SCAN_SUFFIXES = {
     ".yaml",
     ".yml",
     ".txt",
-}
-REPO_FRICTION_SKIP_DIRS = {
-    ".git",
-    ".hg",
-    ".svn",
-    "__pycache__",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".venv",
-    "node_modules",
-    "dist",
-    "build",
 }
 REPO_FRICTION_REGENERABLE_CACHE_PREFIXES = (".agentic-workspace/local/cache/", "scratch/")
 
@@ -2099,13 +2087,12 @@ def _repo_friction_hotspot_payload(
 
 def _repo_friction_hotspots(*, target_root: Path, cli_invoke: str = DEFAULT_CLI_INVOKE) -> list[dict[str, Any]]:
     hotspots: list[dict[str, Any]] = []
-    for path in sorted(target_root.rglob("*")):
-        if not path.is_file():
-            continue
-        if any(part in REPO_FRICTION_SKIP_DIRS or part.startswith(".uv-cache") for part in path.parts):
-            continue
-        if path.suffix.lower() not in REPO_FRICTION_SCAN_SUFFIXES:
-            continue
+    for path in repository_scan_files(
+        target_root,
+        include_untracked=True,
+        include_managed_workspace=True,
+        suffixes=REPO_FRICTION_SCAN_SUFFIXES,
+    ):
         try:
             line_count = sum(1 for _ in path.open("r", encoding="utf-8"))
         except (UnicodeDecodeError, OSError):
@@ -2122,22 +2109,20 @@ def _repo_friction_hotspots(*, target_root: Path, cli_invoke: str = DEFAULT_CLI_
 
 def _repo_friction_regenerable_cache_hotspots(*, target_root: Path, cli_invoke: str = DEFAULT_CLI_INVOKE) -> list[dict[str, Any]]:
     hotspots: list[dict[str, Any]] = []
-    for prefix in REPO_FRICTION_REGENERABLE_CACHE_PREFIXES:
-        cache_root = target_root / prefix.rstrip("/")
-        if not cache_root.exists():
+    for path in repository_scan_files(
+        target_root,
+        relative_roots=[prefix.rstrip("/") for prefix in REPO_FRICTION_REGENERABLE_CACHE_PREFIXES],
+        include_untracked=True,
+        include_managed_workspace=True,
+        suffixes=REPO_FRICTION_SCAN_SUFFIXES,
+    ):
+        try:
+            line_count = sum(1 for _ in path.open("r", encoding="utf-8"))
+        except (UnicodeDecodeError, OSError):
             continue
-        for path in sorted(cache_root.rglob("*")):
-            if not path.is_file() or path.suffix.lower() not in REPO_FRICTION_SCAN_SUFFIXES:
-                continue
-            try:
-                line_count = sum(1 for _ in path.open("r", encoding="utf-8"))
-            except (UnicodeDecodeError, OSError):
-                continue
-            if line_count < REPO_FRICTION_LARGE_FILE_THRESHOLD:
-                continue
-            hotspots.append(
-                _repo_friction_hotspot_payload(path=path, target_root=target_root, line_count=line_count, cli_invoke=cli_invoke)
-            )
+        if line_count < REPO_FRICTION_LARGE_FILE_THRESHOLD:
+            continue
+        hotspots.append(_repo_friction_hotspot_payload(path=path, target_root=target_root, line_count=line_count, cli_invoke=cli_invoke))
     hotspots.sort(key=lambda item: (-int(item["line_count"]), str(item["path"])))
     return hotspots[:REPO_FRICTION_MAX_HOTSPOTS]
 

--- a/src/agentic_workspace/repository_scanning.py
+++ b/src/agentic_workspace/repository_scanning.py
@@ -1,0 +1,259 @@
+"""Repository file enumeration with Git ignore semantics when available."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Iterable
+from pathlib import Path
+
+REPOSITORY_SCAN_FALLBACK_SKIP_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "node_modules",
+    "dist",
+    "build",
+}
+
+_MANAGED_WORKSPACE_ROOT = ".agentic-workspace"
+_GIT_TIMEOUT_SECONDS = 10
+
+
+def repository_scan_files(
+    target_root: Path,
+    *,
+    relative_roots: Iterable[str | Path] | None = None,
+    exclude_relative_roots: Iterable[str | Path] | None = None,
+    include_untracked: bool = True,
+    include_managed_workspace: bool = True,
+    suffixes: Iterable[str] | None = None,
+    max_files: int | None = None,
+) -> list[Path]:
+    """Return repository files using Git ignore semantics when possible.
+
+    In real Git repositories this lists tracked files and, by default, untracked
+    non-ignored files. The managed ``.agentic-workspace`` tree is included
+    explicitly when requested because AW command surfaces intentionally read
+    checked-in and local workflow state there even when a host repo ignores it.
+    Non-Git targets fall back to conservative directory pruning.
+    """
+
+    root = Path(target_root).resolve(strict=False)
+    if not root.exists():
+        return []
+
+    normalized_roots = _normalize_relative_roots(relative_roots)
+    excluded_roots = _normalize_excluded_relative_roots(exclude_relative_roots)
+    suffix_filter = _normalize_suffixes(suffixes)
+    git_files = _git_repository_files(
+        target_root=root,
+        relative_roots=normalized_roots,
+        include_untracked=include_untracked,
+    )
+    if git_files is None:
+        files = _fallback_repository_files(target_root=root, relative_roots=normalized_roots)
+    else:
+        files = git_files
+        if include_managed_workspace:
+            for managed_root in _managed_exception_roots(normalized_roots):
+                files.extend(_walk_files(target_root=root, scan_root=root / managed_root))
+
+    return _dedupe_sort_filter(
+        files,
+        target_root=root,
+        exclude_relative_roots=excluded_roots,
+        suffixes=suffix_filter,
+        max_files=max_files,
+    )
+
+
+def _normalize_relative_roots(relative_roots: Iterable[str | Path] | None) -> list[str]:
+    if relative_roots is None:
+        return ["."]
+    normalized: list[str] = []
+    for raw_root in relative_roots:
+        text = Path(raw_root).as_posix().strip()
+        if not text or text == ".":
+            normalized.append(".")
+            continue
+        normalized.append(text.strip("/"))
+    return normalized or ["."]
+
+
+def _normalize_suffixes(suffixes: Iterable[str] | None) -> set[str]:
+    normalized: set[str] = set()
+    for suffix in suffixes or ():
+        text = str(suffix).strip().lower()
+        if not text:
+            continue
+        normalized.add(text if text.startswith(".") else f".{text}")
+    return normalized
+
+
+def _normalize_excluded_relative_roots(exclude_relative_roots: Iterable[str | Path] | None) -> list[str]:
+    normalized = [root for root in _normalize_relative_roots(exclude_relative_roots) if root != "."]
+    return sorted(set(normalized), key=lambda value: (len(value), value))
+
+
+def _git_repository_files(
+    *,
+    target_root: Path,
+    relative_roots: list[str],
+    include_untracked: bool,
+) -> list[Path] | None:
+    git_root = _git_root_for(target_root)
+    if git_root is None:
+        return None
+    pathspecs = _git_pathspecs(git_root=git_root, target_root=target_root, relative_roots=relative_roots)
+    if not pathspecs:
+        return []
+    command = ["git", "-C", str(git_root), "ls-files", "-z", "--cached"]
+    if include_untracked:
+        command.extend(["--others", "--exclude-standard"])
+    command.extend(["--", *pathspecs])
+    try:
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired, TypeError):
+        return None
+    if result.returncode != 0:
+        return None
+    files: list[Path] = []
+    for raw_path in result.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        relative = raw_path.decode("utf-8", errors="replace")
+        path = git_root / relative
+        if _is_within(path, target_root) and path.is_file():
+            files.append(path)
+    return files
+
+
+def _git_root_for(target_root: Path) -> Path | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(target_root), "rev-parse", "--show-toplevel"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired, TypeError):
+        return None
+    if result.returncode != 0:
+        return None
+    text = result.stdout.strip()
+    if not text:
+        return None
+    return Path(text)
+
+
+def _git_pathspecs(*, git_root: Path, target_root: Path, relative_roots: list[str]) -> list[str]:
+    try:
+        target_prefix = target_root.resolve().relative_to(git_root.resolve()).as_posix()
+    except ValueError:
+        return []
+    pathspecs: list[str] = []
+    for relative_root in relative_roots:
+        if relative_root == ".":
+            pathspec = target_prefix or "."
+        elif target_prefix:
+            pathspec = f"{target_prefix.rstrip('/')}/{relative_root}"
+        else:
+            pathspec = relative_root
+        pathspecs.append(pathspec)
+    return pathspecs
+
+
+def _managed_exception_roots(relative_roots: list[str]) -> list[str]:
+    roots: set[str] = set()
+    for relative_root in relative_roots:
+        if relative_root == ".":
+            roots.add(_MANAGED_WORKSPACE_ROOT)
+        elif relative_root == _MANAGED_WORKSPACE_ROOT or relative_root.startswith(f"{_MANAGED_WORKSPACE_ROOT}/"):
+            roots.add(relative_root)
+    return sorted(roots)
+
+
+def _fallback_repository_files(*, target_root: Path, relative_roots: list[str]) -> list[Path]:
+    files: list[Path] = []
+    for relative_root in relative_roots:
+        scan_root = target_root if relative_root == "." else target_root / relative_root
+        files.extend(_walk_files(target_root=target_root, scan_root=scan_root))
+    return files
+
+
+def _walk_files(*, target_root: Path, scan_root: Path) -> list[Path]:
+    if not scan_root.exists():
+        return []
+    files: list[Path] = []
+    for root, dirnames, filenames in os.walk(scan_root):
+        dirnames[:] = sorted(
+            dirname for dirname in dirnames if dirname not in REPOSITORY_SCAN_FALLBACK_SKIP_DIRS and not dirname.startswith(".uv-cache")
+        )
+        root_path = Path(root)
+        for filename in sorted(filenames):
+            path = root_path / filename
+            if not _is_within(path, target_root) or not path.is_file():
+                continue
+            files.append(path)
+    return files
+
+
+def _dedupe_sort_filter(
+    files: Iterable[Path],
+    *,
+    target_root: Path,
+    exclude_relative_roots: list[str],
+    suffixes: set[str],
+    max_files: int | None,
+) -> list[Path]:
+    unique: dict[str, Path] = {}
+    for path in files:
+        if _is_excluded(path=path, target_root=target_root, exclude_relative_roots=exclude_relative_roots):
+            continue
+        if suffixes and path.suffix.lower() not in suffixes:
+            continue
+        key = str(path.resolve(strict=False)).casefold()
+        unique[key] = path
+    sorted_files = sorted(unique.values(), key=lambda path: _relative_sort_key(path=path, target_root=target_root))
+    if max_files is not None:
+        return sorted_files[:max_files]
+    return sorted_files
+
+
+def _relative_sort_key(*, path: Path, target_root: Path) -> str:
+    try:
+        return path.relative_to(target_root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _is_excluded(*, path: Path, target_root: Path, exclude_relative_roots: list[str]) -> bool:
+    if not exclude_relative_roots:
+        return False
+    relative = _relative_sort_key(path=path, target_root=target_root)
+    for excluded_root in exclude_relative_roots:
+        if relative == excluded_root or relative.startswith(f"{excluded_root.rstrip('/')}/"):
+            return True
+    return False
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(root.resolve(strict=False))
+    except ValueError:
+        return False
+    return True

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -130,6 +130,7 @@ from agentic_workspace.reporting_support import (
     setup_discovery_payload,
     standing_intent_payload,
 )
+from agentic_workspace.repository_scanning import repository_scan_files
 from agentic_workspace.result_adapter import adapt_module_result, serialise_value
 from agentic_workspace.workspace_output import (
     _display_path,
@@ -9317,7 +9318,16 @@ def _artifact_footprint_by_class(*, target: Any) -> dict[str, Any]:
         root = target_root / relative
         if not root.exists():
             return (0, [])
-        files = sorted((path for path in root.rglob(pattern) if path.is_file()))
+        files = [
+            path
+            for path in repository_scan_files(
+                target_root,
+                relative_roots=[relative],
+                include_untracked=True,
+                include_managed_workspace=True,
+            )
+            if fnmatch.fnmatch(path.name, pattern)
+        ]
         return (len(files), [_relative_posix(path, target_root) for path in files[:5]])
 
     def _top_level_plan_count() -> tuple[int, list[str]]:
@@ -9331,13 +9341,17 @@ def _artifact_footprint_by_class(*, target: Any) -> dict[str, Any]:
         root = target_root / ".agentic-workspace" / "memory" / "repo"
         if not root.exists():
             return (0, [])
-        files = sorted(
-            (
-                path
-                for path in root.rglob("*.md")
-                if path.is_file() and ".agentic-workspace/memory/repo/current/" not in _relative_posix(path, target_root)
+        files = [
+            path
+            for path in repository_scan_files(
+                target_root,
+                relative_roots=[".agentic-workspace/memory/repo"],
+                include_untracked=True,
+                include_managed_workspace=True,
+                suffixes={".md"},
             )
-        )
+            if ".agentic-workspace/memory/repo/current/" not in _relative_posix(path, target_root)
+        ]
         return (len(files), [_relative_posix(path, target_root) for path in files[:5]])
 
     def _large_docs() -> tuple[int, list[str]]:
@@ -9455,9 +9469,16 @@ def _artifact_class(*, class_id: str, role: str, count: int, sample: list[str], 
 
 
 def _generated_output_files(*, target_root: Path) -> list[Path]:
-    candidates: list[Path] = []
-    for pattern in ("generated/**/*",):
-        candidates.extend((path for path in target_root.glob(pattern) if path.is_file() and (not _is_runtime_cache_file(path))))
+    candidates = [
+        path
+        for path in repository_scan_files(
+            target_root,
+            relative_roots=["generated"],
+            include_untracked=True,
+            include_managed_workspace=False,
+        )
+        if not _is_runtime_cache_file(path)
+    ]
     return sorted({path.resolve(): path for path in candidates}.values(), key=lambda path: path.as_posix())
 
 
@@ -16193,9 +16214,10 @@ def _reuse_pressure_payload(
             ),
         }
 
+    scan_files = _iter_reuse_scan_files(target_root)
     raw_findings: list[dict[str, Any]] = []
     for changed_path in normalized_paths:
-        raw_findings.extend(_reuse_pressure_findings_for_path(target_root=target_root, changed_path=changed_path))
+        raw_findings.extend(_reuse_pressure_findings_for_path(target_root=target_root, changed_path=changed_path, scan_files=scan_files))
     generated_aggregation = _generated_reuse_pressure_aggregation(changed_paths=normalized_paths)
     if generated_aggregation.get("status") == "present":
         generated_paths = set(generated_aggregation.get("changed_generated_paths", []))
@@ -16295,22 +16317,24 @@ def _generated_reuse_pressure_aggregation(*, changed_paths: list[str]) -> dict[s
     }
 
 
-def _reuse_pressure_findings_for_path(*, target_root: Path, changed_path: str) -> list[dict[str, Any]]:
+def _reuse_pressure_findings_for_path(*, target_root: Path, changed_path: str, scan_files: Sequence[Path]) -> list[dict[str, Any]]:
     path = target_root / changed_path
     if not path.is_file():
         return []
     if path.suffix == ".py":
         return [
-            *_reuse_pressure_python_findings(target_root=target_root, changed_path=changed_path, path=path),
+            *_reuse_pressure_python_findings(target_root=target_root, changed_path=changed_path, path=path, scan_files=scan_files),
             *_reuse_pressure_inventory_findings(target_root=target_root, changed_path=changed_path, path=path),
         ]
     return [
-        *_reuse_pressure_surface_findings(target_root=target_root, changed_path=changed_path, path=path),
+        *_reuse_pressure_surface_findings(target_root=target_root, changed_path=changed_path, path=path, scan_files=scan_files),
         *_reuse_pressure_inventory_findings(target_root=target_root, changed_path=changed_path, path=path),
     ]
 
 
-def _reuse_pressure_python_findings(*, target_root: Path, changed_path: str, path: Path) -> list[dict[str, Any]]:
+def _reuse_pressure_python_findings(
+    *, target_root: Path, changed_path: str, path: Path, scan_files: Sequence[Path]
+) -> list[dict[str, Any]]:
     try:
         text = path.read_text(encoding="utf-8")
     except UnicodeDecodeError:
@@ -16322,7 +16346,7 @@ def _reuse_pressure_python_findings(*, target_root: Path, changed_path: str, pat
     )
     findings: list[dict[str, Any]] = []
     for name in definitions[:12]:
-        matches = _find_definition_matches(target_root=target_root, name=name, exclude=path)
+        matches = _find_definition_matches(target_root=target_root, name=name, exclude=path, scan_files=scan_files)
         if not matches:
             continue
         state = "abstraction_pressure" if len(matches) >= 2 else "existing_helper_candidate"
@@ -16336,12 +16360,14 @@ def _reuse_pressure_python_findings(*, target_root: Path, changed_path: str, pat
                 "why": f"{name} is already defined elsewhere in the repository.",
             }
         )
-    special_case_findings = _repeated_special_case_findings(target_root=target_root, changed_path=changed_path, path=path, text=text)
+    special_case_findings = _repeated_special_case_findings(
+        target_root=target_root, changed_path=changed_path, path=path, text=text, scan_files=scan_files
+    )
     findings.extend(special_case_findings)
     if findings:
         return findings
     sibling_candidates = _sibling_helper_candidates(
-        path=path, target_root=target_root, changed_tokens=_reuse_pressure_tokens(path=path, text=text)
+        path=path, target_root=target_root, changed_tokens=_reuse_pressure_tokens(path=path, text=text), scan_files=scan_files
     )
     if sibling_candidates:
         candidate_paths = [candidate["path"] for candidate in sibling_candidates]
@@ -16363,10 +16389,12 @@ def _reuse_pressure_python_findings(*, target_root: Path, changed_path: str, pat
     return findings
 
 
-def _repeated_special_case_findings(*, target_root: Path, changed_path: str, path: Path, text: str) -> list[dict[str, Any]]:
+def _repeated_special_case_findings(
+    *, target_root: Path, changed_path: str, path: Path, text: str, scan_files: Sequence[Path]
+) -> list[dict[str, Any]]:
     findings: list[dict[str, Any]] = []
     for marker in _special_case_markers(text)[:8]:
-        matches = _find_special_case_matches(target_root=target_root, marker=marker, exclude=path)
+        matches = _find_special_case_matches(target_root=target_root, marker=marker, exclude=path, scan_files=scan_files)
         if not matches:
             continue
         findings.append(
@@ -16400,10 +16428,10 @@ def _special_case_markers(text: str) -> list[str]:
     return markers
 
 
-def _find_special_case_matches(*, target_root: Path, marker: str, exclude: Path) -> list[str]:
+def _find_special_case_matches(*, target_root: Path, marker: str, exclude: Path, scan_files: Sequence[Path]) -> list[str]:
     matches: list[str] = []
     marker_pattern = re.compile(rf"^\s*{re.escape(marker)}\s*$", flags=re.MULTILINE)
-    for candidate in _iter_reuse_scan_files(target_root):
+    for candidate in scan_files:
         if candidate == exclude or candidate.suffix != ".py":
             continue
         try:
@@ -16418,10 +16446,12 @@ def _find_special_case_matches(*, target_root: Path, marker: str, exclude: Path)
     return matches
 
 
-def _reuse_pressure_surface_findings(*, target_root: Path, changed_path: str, path: Path) -> list[dict[str, Any]]:
+def _reuse_pressure_surface_findings(
+    *, target_root: Path, changed_path: str, path: Path, scan_files: Sequence[Path]
+) -> list[dict[str, Any]]:
     basename = path.name.lower()
     matches: list[str] = []
-    for candidate in _iter_reuse_scan_files(target_root):
+    for candidate in scan_files:
         if candidate == path or candidate.name.lower() != basename:
             continue
         matches.append(candidate.relative_to(target_root).as_posix())
@@ -16475,10 +16505,10 @@ def _reuse_pressure_inventory_findings(*, target_root: Path, changed_path: str, 
     ]
 
 
-def _find_definition_matches(*, target_root: Path, name: str, exclude: Path) -> list[str]:
+def _find_definition_matches(*, target_root: Path, name: str, exclude: Path, scan_files: Sequence[Path]) -> list[str]:
     pattern = re.compile(rf"^\s*(?:def|class)\s+{re.escape(name)}\b", flags=re.MULTILINE)
     matches: list[str] = []
-    for candidate in _iter_reuse_scan_files(target_root):
+    for candidate in scan_files:
         if candidate == exclude or candidate.suffix != ".py":
             continue
         try:
@@ -16492,9 +16522,11 @@ def _find_definition_matches(*, target_root: Path, name: str, exclude: Path) -> 
     return matches
 
 
-def _sibling_helper_candidates(*, path: Path, target_root: Path, changed_tokens: set[str]) -> list[dict[str, Any]]:
+def _sibling_helper_candidates(
+    *, path: Path, target_root: Path, changed_tokens: set[str], scan_files: Sequence[Path]
+) -> list[dict[str, Any]]:
     candidates: list[dict[str, Any]] = []
-    for sibling in sorted(path.parent.glob("*.py")):
+    for sibling in sorted(candidate for candidate in scan_files if candidate.parent == path.parent and candidate.suffix == ".py"):
         if sibling == path:
             continue
         try:
@@ -16543,30 +16575,15 @@ def _reuse_pressure_tokens(*, path: Path, text: str) -> set[str]:
 
 
 def _iter_reuse_scan_files(target_root: Path) -> list[Path]:
-    skip_dirs = {".git", ".hg", ".svn", ".venv", "__pycache__", ".pytest_cache", ".ruff_cache", "dist", "build", "node_modules"}
     suffixes = {".py", ".json", ".toml", ".yaml", ".yml", ".md"}
-    files: list[Path] = []
-    for root, dirnames, filenames in os.walk(target_root):
-        dirnames[:] = sorted(dirname for dirname in dirnames if dirname not in skip_dirs and not dirname.startswith(".uv-cache"))
-        root_path = Path(root)
-        for filename in sorted(filenames):
-            if len(files) >= 800:
-                break
-            path = root_path / filename
-            if path.suffix not in suffixes:
-                continue
-            try:
-                relative_parts = path.relative_to(target_root).parts
-            except ValueError:
-                relative_parts = path.parts
-            if any(part in skip_dirs or part.startswith(".uv-cache") for part in relative_parts):
-                continue
-            if not path.is_file():
-                continue
-            files.append(path)
-        if len(files) >= 800:
-            break
-    return sorted(files)
+    return repository_scan_files(
+        target_root,
+        exclude_relative_roots=[WORKSPACE_LOCAL_SCRATCH_ROOT_PATH.as_posix()],
+        include_untracked=True,
+        include_managed_workspace=True,
+        suffixes=suffixes,
+        max_files=800,
+    )
 
 
 def _changed_path_command_argument(*, changed_paths: list[str], compact: bool) -> str:

--- a/tests/test_repository_scanning.py
+++ b/tests/test_repository_scanning.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from agentic_workspace.repository_scanning import repository_scan_files
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _relatives(root: Path, paths: list[Path]) -> list[str]:
+    return [path.relative_to(root).as_posix() for path in paths]
+
+
+def test_repository_scan_uses_gitignore_and_keeps_managed_workspace_exception(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    _write(tmp_path / ".gitignore", "ignored/\n.agentic-workspace/\n")
+    _write(tmp_path / "tracked.py", "TRACKED = True\n")
+    _write(tmp_path / "untracked.py", "UNTRACKED = True\n")
+    _write(tmp_path / "ignored" / "hidden.py", "HIDDEN = True\n")
+    _write(tmp_path / ".agentic-workspace" / "local" / "managed.md", "managed\n")
+    _write(tmp_path / ".agentic-workspace" / "local" / "scratch" / "transient.py", "TRANSIENT = True\n")
+    _git(tmp_path, "add", ".gitignore", "tracked.py")
+
+    paths = _relatives(tmp_path, repository_scan_files(tmp_path, suffixes={".py", ".md"}))
+    filtered_paths = _relatives(
+        tmp_path,
+        repository_scan_files(
+            tmp_path,
+            exclude_relative_roots=[".agentic-workspace/local/scratch"],
+            suffixes={".py", ".md"},
+        ),
+    )
+
+    assert "tracked.py" in paths
+    assert "untracked.py" in paths
+    assert "ignored/hidden.py" not in paths
+    assert ".agentic-workspace/local/managed.md" in paths
+    assert ".agentic-workspace/local/scratch/transient.py" in paths
+    assert ".agentic-workspace/local/scratch/transient.py" not in filtered_paths
+
+
+def test_repository_scan_fallback_prunes_dependency_caches(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "app.py", "APP = True\n")
+    _write(tmp_path / ".venv" / "Lib" / "site-packages" / "dependency.py", "DEP = True\n")
+    _write(tmp_path / "node_modules" / "dependency" / "index.py", "DEP = True\n")
+    _write(tmp_path / ".agentic-workspace" / "config.toml", "schema_version = 1\n")
+
+    paths = _relatives(tmp_path, repository_scan_files(tmp_path, suffixes={".py", ".toml"}))
+
+    assert "src/app.py" in paths
+    assert ".venv/Lib/site-packages/dependency.py" not in paths
+    assert "node_modules/dependency/index.py" not in paths
+    assert ".agentic-workspace/config.toml" in paths

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1606,6 +1606,74 @@ def test_implement_reuse_pressure_ignores_dependency_cache_definitions(tmp_path:
     assert reuse_pressure["findings"] == []
 
 
+def test_implement_reuse_pressure_honors_gitignore_for_ordinary_scan(tmp_path: Path, capsys) -> None:
+    subprocess.run(["git", "-C", str(tmp_path), "init"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    _write(tmp_path / ".gitignore", "src/sample_app/ignored_helper.py\n")
+    _write(
+        tmp_path / "src" / "sample_app" / "text.py",
+        "def normalize_text(value):\n    return ' '.join(value.split())\n",
+    )
+    _write(
+        tmp_path / "src" / "sample_app" / "ignored_helper.py",
+        "def normalize_text(value):\n    return value\n",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/sample_app/text.py",
+                "--select",
+                "reuse_pressure",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    reuse_pressure = json.loads(capsys.readouterr().out)["values"]["reuse_pressure"]
+    assert reuse_pressure["state"] == "none_found"
+    assert reuse_pressure["findings"] == []
+    assert reuse_pressure["weak_hints"] == []
+
+
+def test_implement_reuse_pressure_skips_workspace_local_scratch(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / "src" / "sample_app" / "text.py",
+        "def normalize_text(value):\n    return ' '.join(value.split())\n",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "local" / "scratch" / "external-repo" / "helpers.py",
+        "def normalize_text(value):\n    return value\n",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/sample_app/text.py",
+                "--select",
+                "reuse_pressure",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    reuse_pressure = json.loads(capsys.readouterr().out)["values"]["reuse_pressure"]
+    assert reuse_pressure["state"] == "none_found"
+    assert reuse_pressure["findings"] == []
+
+
 def test_implement_reuse_pressure_surfaces_repeated_special_case(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -4816,6 +4816,28 @@ def test_report_surfaces_large_file_hotspots_as_repo_friction_evidence(tmp_path:
     assert signal["primary_next_action"]["action"] == "inspect-symbols-before-refactor"
 
 
+def test_report_repo_friction_honors_gitignore_with_managed_workspace_exception(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    subprocess.run(["git", "-C", str(target), "init"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    _write(target / ".gitignore", "ignored/\n.agentic-workspace/\n")
+    _write(
+        target / ".agentic-workspace" / "config.toml",
+        'schema_version = 1\n\n[workspace]\nimprovement_latitude = "balanced"\n',
+    )
+    _write(target / "src" / "big_module.py", "\n".join(f"line_{index}" for index in range(450)) + "\n")
+    _write(target / "ignored" / "hidden_big.py", "\n".join(f"line_{index}" for index in range(900)) + "\n")
+    _write(target / ".agentic-workspace" / "docs" / "managed.md", "\n".join(f"line_{index}" for index in range(450)) + "\n")
+
+    assert cli.main(["report", "--target", str(target), "--verbose", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    large_paths = {item["path"] for item in payload["repo_friction"]["large_file_hotspots"]["items"]}
+    assert "src/big_module.py" in large_paths
+    assert "ignored/hidden_big.py" not in large_paths
+    assert ".agentic-workspace/docs/managed.md" in large_paths
+
+
 def test_report_does_not_promote_regenerable_cache_as_large_file_friction(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()


### PR DESCRIPTION
## Summary
- add a central repository_scan_files helper that uses git ls-files with --exclude-standard when available
- migrate reuse-pressure, repo-friction, and artifact-footprint scans to the shared helper
- keep untracked non-ignored files visible, keep managed .agentic-workspace files visible, and skip .agentic-workspace/local/scratch for reuse-pressure

Closes #1214.

## Validation
- uv run pytest tests/test_repository_scanning.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py tests/test_workspace_summary_cli.py::test_external_intent_refresh_applies_stale_candidate_reconciliation_and_preserves_delta -q
- uv run agentic-workspace summary --target . --format json
- uv run agentic-workspace doctor --target . --modules planning --format json
- make test-workspace
- make lint-workspace

## Stack
- stacked on #1219 / codex/1212-windows-static-proof-stability so the Windows static-proof stability fix is present while validating this branch.