### PR TITLE
[codex] Fix planning closeout summary routing

### DIFF
--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -1931,7 +1931,7 @@ def _run_planning_front_door(args: argparse.Namespace) -> int:
     buffer = io.StringIO()
     with contextlib.redirect_stdout(buffer):
         result = planning_main(_planning_module_argv(args))
-    print(buffer.getvalue().replace("agentic-planning ", "agentic-workspace planning "), end="")
+    print(_rewrite_module_cli_commands(buffer.getvalue()), end="")
     return result
 
 

--- a/tests/test_workspace_planning_help_cli.py
+++ b/tests/test_workspace_planning_help_cli.py
@@ -112,6 +112,65 @@ def test_planning_front_door_runs_package_operation(tmp_path, capsys) -> None:
     assert payload["lifecycle_plan"]["next_safe_command"].startswith("agentic-workspace planning new-plan")
 
 
+def test_planning_front_door_rewrites_closeout_summary_action_to_top_level(tmp_path, capsys) -> None:
+    assert (
+        cli.main(
+            [
+                "planning",
+                "new-plan",
+                "--id",
+                "closeout-command",
+                "--title",
+                "Closeout command",
+                "--target",
+                str(tmp_path),
+                "--activate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "closeout-command.plan.json"
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record["active_milestone"]["status"] = "completed"
+    record_path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+
+    assert (
+        cli.main(
+            [
+                "planning",
+                "closeout",
+                "closeout-command",
+                "--target",
+                str(tmp_path),
+                "--proof-from",
+                "front-door closeout proof passed",
+                "--what-happened",
+                "closed the front-door closeout command wording",
+                "--scope-touched",
+                "workspace planning front door",
+                "--changed-surfaces",
+                "planning closeout action output",
+                "--review-summary",
+                "scope respected",
+                "--outcome-summary",
+                "summary action points at the top-level workspace summary router",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    next_actions = [action["detail"] for action in payload["actions"] if action["kind"] == "next safe action"]
+
+    assert "agentic-workspace summary --target . --format json" in next_actions
+    assert all("agentic-workspace planning summary" not in detail for detail in next_actions)
+    assert all("agentic-planning summary" not in detail for detail in next_actions)
+
+
 def test_memory_front_door_runs_package_operation(tmp_path, capsys) -> None:
     assert cli.main(["memory", "route", "--target", str(tmp_path), "--files", "src/example.py", "--format", "json"]) == 0
     payload = json.loads(capsys.readouterr().out)


### PR DESCRIPTION
## Summary
- Reuse the workspace command rewriter for planning front-door output instead of blanket-mapping every `agentic-planning` command under `agentic-workspace planning`.
- Add a regression that closes a plan through `agentic-workspace planning closeout` and verifies the next safe action points to top-level `agentic-workspace summary`.

Closes #1218.

## Validation
- `uv run pytest tests/test_workspace_planning_help_cli.py::test_planning_front_door_rewrites_closeout_summary_action_to_top_level -q`
- `uv run pytest tests/test_workspace_planning_help_cli.py -q`
- `uv run agentic-workspace implement --changed src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_planning_help_cli.py --task "Implement GitHub #1218: closeout suggests invalid planning summary command" --format json`
- `make test-workspace`
- `make lint-workspace`
- `uv run agentic-workspace proof --verbose --changed src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_planning_help_cli.py --format json`
- Dogfooding checks: `uv run agentic-workspace report --target . --section workflow_obligations --format json`, `uv run agentic-workspace report --target . --section closeout_trust --format json`, `uv run agentic-workspace reconcile --format json`, `uv run agentic-workspace memory promotion-report --target . --mode remediation --format json`