### PR TITLE
[codex] Add open issue grounding reviews

### DIFF
--- a/.agentic-workspace/planning/reviews/2026-06-03-open-issue-1240-closeout-adoption-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-03-open-issue-1240-closeout-adoption-grounding.review.json
@@ -1,0 +1,171 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1240 closeout adoption",
+  "date": "2026-06-03",
+  "classification": "review-promotion",
+  "goal": [
+    "Evaluate the shipped closeout-reporting surfaces against the human-control questions in #1240.",
+    "Decide whether the existing #1238/#1239 work is enough substrate or whether narrower follow-up issues are needed."
+  ],
+  "scope": [
+    "Open issue #1240 as an investigation lane, not an implementation lane.",
+    "Current closeout_report, final_response_rendering, profile policy, authority boundary, and traceability rows.",
+    "Recent closeout and authority-boundary PRs #1233 and #1244 as representative broad/system-shaping work."
+  ],
+  "non_goals": [
+    "Do not implement another closeout renderer in this review.",
+    "Do not add a dashboard or new mutable closeout state.",
+    "Do not close #1240 from this bounded review because the issue says partial review artifacts may not close it.",
+    "Do not require verbose final answers for ordinary minimal work."
+  ],
+  "review_mode": {
+    "mode": "review-promotion",
+    "review question": "Should #1240 promote more closeout UX implementation now, or first use shipped closeout outputs against representative examples?",
+    "default finding cap": "3 findings",
+    "inputs inspected first": [
+      "gh issue view 1240",
+      "gh pr view 1233",
+      "gh pr view 1244",
+      "report --section closeout_report",
+      ".agentic-workspace/docs/reporting-contract.md",
+      "tests/test_workspace_report_cli.py closeout rendering tests"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "uv run python scripts/run_agentic_workspace.py start --task \"Create a new branch for deeper investigation of open issues and make grounding reviews\" --format json",
+      "gh issue view 1240 --json number,title,url,state,body,comments,labels,createdAt,updatedAt",
+      "gh pr view 1233 --json number,title,state,mergedAt,url,body,files,commits",
+      "gh pr view 1244 --json number,title,state,mergedAt,url,body,files,commits",
+      "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      "rg -n \"closeout_report|final_response_rendering|rendered_summary|authority_boundary|traceability\" .agentic-workspace/docs/reporting-contract.md docs/reference/workspace-report.md tests/test_workspace_report_cli.py src/agentic_workspace/workspace_runtime_primitives.py"
+    ],
+    "evidence sources": [
+      "#1240 issue body",
+      "PR #1233 merged body, files, commits, and validation list",
+      "PR #1244 merged body, files, commits, dogfooding note, and validation list",
+      "current closeout_report JSON in this repo",
+      "reporting contract closeout and authority-boundary sections",
+      "closeout_report regression tests"
+    ],
+    "representative examples": [
+      "PR #1233 operator-facing closeout reporting lane",
+      "PR #1244 authority-boundary and deep rename lane",
+      "current repo closeout_report output selected audit profile from archived evidence"
+    ],
+    "limitation": "This review grounded product behavior in contract, test, PR, and current report evidence. It did not collect external human usability feedback."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1240",
+      "label": "Draft operator-facing closeout adoption review",
+      "role": "review owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1240"
+    },
+    {
+      "kind": "github-pr",
+      "target": "#1233",
+      "label": "Add operator-facing closeout reporting",
+      "role": "representative closeout implementation evidence",
+      "locator": "https://github.com/rickardvh/agentic-workspace/pull/1233"
+    },
+    {
+      "kind": "github-pr",
+      "target": "#1244",
+      "label": "Clarify AW authority boundaries",
+      "role": "representative system-shaping and authority UX evidence",
+      "locator": "https://github.com/rickardvh/agentic-workspace/pull/1244"
+    },
+    {
+      "kind": "local-doc",
+      "target": ".agentic-workspace/docs/reporting-contract.md",
+      "label": "Closeout report and final response rendering contract",
+      "role": "canonical behavior contract"
+    },
+    {
+      "kind": "local-test",
+      "target": "tests/test_workspace_report_cli.py",
+      "label": "closeout_report rendering regression tests",
+      "role": "mechanical behavior proof"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      "label": "current closeout report output",
+      "role": "dogfooding evidence"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1240",
+      "kind": "review-only investigation",
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": ".agentic-workspace/planning/reviews/",
+      "implementation_allowed_now": false,
+      "reason": "The issue explicitly asks for review and enrichment first, with implementation out of scope."
+    }
+  ],
+  "findings": [
+    {
+      "title": "Closeout rendering is real substrate, so #1240 should not reopen generic renderer work",
+      "summary": "PR #1233 already added a derived closeout_report with profile selection, traceability rows, completeness checks, and final_response_rendering. PR #1244 added authority boundaries so final reports can distinguish AW evidence/gates from agent-owned completion judgment.",
+      "evidence": "PR #1233 merged and closed #1238/#1239; the reporting contract states that final_response_rendering.rendered_summary is final-response-ready and must not dump raw JSON; tests assert terse Done output for minimal guidance-only closeout and evidence-backed rendered text for audit closeout; current report --section closeout_report emits rendered_summary plus required fact coverage.",
+      "risk if unchanged": "A follow-up implementation lane could duplicate shipped closeout machinery instead of measuring whether the shipped machinery answers the human-control questions.",
+      "suggested action": "Treat #1238/#1239 as implemented substrate. Keep #1240 focused on adoption review, example comparison, and acceptance criteria.",
+      "confidence": "high",
+      "source class": "merged PR plus contract plus regression tests plus current report output",
+      "promotion target": "#1240 issue comment or a narrow child issue only after an example reveals a concrete UX gap",
+      "promotion trigger": "A representative final response fails a human-control question even though closeout_report contains the required fact."
+    },
+    {
+      "title": "The remaining closeout gap is acceptance criteria by work shape, not more report fields",
+      "summary": "The current report has fields for interpreted intent, changed surfaces, validation, residual risk, closure boundary, traceability, completeness, and rendered summary. What is not yet explicit is the human-facing quality bar for each work shape.",
+      "evidence": "#1240 asks what a good closeout experience looks like for small edits, planned slices, broad PRs, system-shaping changes, partial closeouts, and lower-trust work. The contract defines minimal, compact, balanced, explanatory, and audit profiles, but does not yet turn that into an adoption rubric against example final answers.",
+      "risk if unchanged": "Tests can keep proving that the renderer emits required facts while the in-chat UX still fails to make non-trivial work understandable to the human.",
+      "suggested action": "Draft #1240 acceptance criteria from examples: small edit may stay terse; planned or broad work should show intent, changed surfaces, proof, closure boundary, and residue; lower-trust work must show the caveat and owner; system-shaping work should also show decision facts from #1241.",
+      "confidence": "high",
+      "source class": "issue acceptance text plus reporting contract comparison",
+      "promotion target": "#1240 refinement or issue comment",
+      "promotion trigger": "When #1240 needs to decide whether current final responses are acceptable across representative work shapes."
+    },
+    {
+      "title": "Authority wording is correct but may still need operator-language rendering",
+      "summary": "The current rendered audit line can say that AW reports evidence and gates while the agent owns completion judgment. That is internally correct and addresses the overstatement problem, but #1240 is about what the human notices and understands at closeout.",
+      "evidence": "The reporting contract gives before/after examples that avoid saying AW classified or routed advisory work. Current closeout_report final_response_rendering includes an authority fact, and #1244 dogfooding notes canonical field names. The issue asks whether closeout reports make intent, proof, closure boundaries, and residual risk understandable enough for supervision.",
+      "risk if unchanged": "The final answer can be correct about authority boundaries but still feel like AW jargon instead of a clear statement of what I judged, what AW observed, and what the human still owns.",
+      "suggested action": "Add an adoption criterion that rendered closeout text should prefer operator language such as 'I judged this complete because...' and 'AW observed these gates/caveats...' over unexplained authority-boundary terminology.",
+      "confidence": "medium",
+      "source class": "dogfooding interpretation grounded in contract and current output",
+      "promotion target": "#1240 issue comment, with possible later wording-only follow-up",
+      "promotion trigger": "When a representative final response includes authority facts but the user-facing meaning is still unclear."
+    }
+  ],
+  "recommendation": {
+    "promote": "Do not promote implementation yet.",
+    "defer": "Keep #1240 open as the owner for adoption criteria and representative final-response comparison.",
+    "dismiss": "Do not dismiss; the review shows the mechanics exist, but adoption quality remains an unresolved UX question.",
+    "next_review_slice": "Compare rendered summaries from #1233/#1244-style work against the six human-control questions in #1240.",
+    "draft_acceptance_criteria": [
+      "Small direct work may close with terse text only when there is no residue, lower trust, or material proof caveat.",
+      "Planned, broad, partial, lower-trust, or system-shaping work must show intended outcome, changed surfaces, proof, closure boundary, residual risk, and follow-up owner when present.",
+      "System-shaping closeout should include decision facts or explicitly say decision traceability is absent and routed.",
+      "The final answer should use operator language and avoid raw JSON or unexplained internal field names."
+    ]
+  },
+  "retention": {
+    "closeout shape": "keep until #1240 findings are promoted, dismissed, or superseded",
+    "trigger": "After #1240 has an issue comment or child issues that capture adoption criteria and representative examples.",
+    "proof surface": "This review artifact plus any issue comment promoted from it."
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-03-open-issue-1240-closeout-adoption-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-03: Review record created by create-review.",
+    "2026-06-03: Populated grounding review after inspecting #1240, PR #1233, PR #1244, current closeout_report output, reporting contract, and closeout tests."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-03-open-issue-1241-decision-traceability-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-03-open-issue-1241-decision-traceability-grounding.review.json
@@ -1,0 +1,178 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1241 decision traceability",
+  "date": "2026-06-03",
+  "classification": "contract-integrity",
+  "goal": [
+    "Map current AW decision-related surfaces before proposing implementation.",
+    "Separate AW-supported routing and evidence from agent-owned architecture or product decisions."
+  ],
+  "scope": [
+    "Open issue #1241 as an investigation lane.",
+    "decision_pressure, durable intent, closeout_report traceability, authority_boundary, Planning closeout, and architecture-decision routing.",
+    "Recent system-shaping evidence from PR #1244 and closeout substrate from PR #1233."
+  ],
+  "non_goals": [
+    "Do not implement a new ADR system in this review.",
+    "Do not require formal decision records for every small change.",
+    "Do not add another durable state store for decision prose.",
+    "Do not describe AW as making semantic decisions on the agent's behalf."
+  ],
+  "review_mode": {
+    "mode": "contract-integrity",
+    "review question": "Do current AW decision surfaces honestly expose agent-made system decisions, or only route/prove surrounding evidence?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1241",
+      "report --section decision_pressure",
+      "report --section closeout_report",
+      ".agentic-workspace/docs/reporting-contract.md",
+      "docs/reference/workspace-report.md",
+      "PR #1244 authority boundary evidence"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "gh issue view 1241 --json number,title,url,state,body,comments,labels,createdAt,updatedAt",
+      "gh pr view 1244 --json number,title,state,mergedAt,url,body,files,commits",
+      "uv run python scripts/run_agentic_workspace.py report --section decision_pressure --format json",
+      "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      "rg -n \"decision_pressure|traceability|authority_boundary|completion_contract|task_contract\" src/agentic_workspace/workspace_runtime_primitives.py .agentic-workspace/docs/reporting-contract.md docs/reference/workspace-report.md tests/test_workspace_report_cli.py"
+    ],
+    "evidence sources": [
+      "#1241 issue body",
+      "current decision_pressure output",
+      "current closeout_report output",
+      "reporting contract authority-boundary and closeout sections",
+      "workspace-report reference rows",
+      "PR #1244 summary, dogfooding note, and changed files"
+    ],
+    "limitation": "This review inspected available AW surfaces and recent PR evidence. It does not claim to identify every system decision made in #1244 from code diff alone."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1241",
+      "label": "Draft decision traceability review for system-shaping agent work",
+      "role": "review owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1241"
+    },
+    {
+      "kind": "github-pr",
+      "target": "#1244",
+      "label": "Clarify AW authority boundaries",
+      "role": "system-shaping example",
+      "locator": "https://github.com/rickardvh/agentic-workspace/pull/1244"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py report --section decision_pressure --format json",
+      "label": "decision_pressure current output",
+      "role": "decision routing evidence"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      "label": "closeout_report current output",
+      "role": "traceability evidence"
+    },
+    {
+      "kind": "local-doc",
+      "target": ".agentic-workspace/docs/reporting-contract.md",
+      "label": "Reporting contract",
+      "role": "authority and closeout contract"
+    },
+    {
+      "kind": "local-doc",
+      "target": "docs/reference/workspace-report.md",
+      "label": "Workspace report reference",
+      "role": "schema-facing field inventory"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1241",
+      "kind": "review-only investigation",
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": ".agentic-workspace/planning/reviews/",
+      "implementation_allowed_now": false,
+      "reason": "The issue asks to map current surfaces and propose follow-ups before implementation."
+    }
+  ],
+  "findings": [
+    {
+      "title": "decision_pressure is a routing and promotion surface, not a decision trace",
+      "summary": "The current repo has decision_pressure status not-configured. It can report configuration, existing decision records, planning or Memory promotion pressure, and scaffold/promote actions, but it does not infer what architecture decision the agent made.",
+      "evidence": "Current report --section decision_pressure returns status not-configured, existing_decisions unavailable, planning_pressure candidate_count 0, closeout_decision_state no_decision, and rule: 'Agent owns architecture judgment; AW preserves and routes decision records without forcing every task to create one.'",
+      "risk if unchanged": "A later implementation could accidentally turn AW into a semantic decision classifier, repeating the authority-boundary problem #1243/#1244 just corrected.",
+      "suggested action": "Frame #1241 around agent-authored decision facts and AW-owned routing/provenance. AW can expose where a decision should live and whether evidence exists; the agent must state the decision and rationale.",
+      "confidence": "high",
+      "source class": "current command output plus reporting contract",
+      "promotion target": "#1241 issue refinement or child issue for a derived decision-review packet",
+      "promotion trigger": "When system-shaping closeout needs a compact decision row that is not present in Planning, closeout_report, or decision_pressure."
+    },
+    {
+      "title": "closeout_report traceability covers intent, work, proof, and closure but not decision rationale",
+      "summary": "The closeout traceability rows are useful review evidence, but they are not enough for the decision facts #1241 names: decision made, why, rejected alternatives, trade-offs, affected contract, validation, and durable owner.",
+      "evidence": "Current closeout_report traceability rows include intent-boundary, work-completed, changed-surfaces, validation, closure-boundary, and assurance-verification. The reporting contract says traceability rows connect intent or requirement to evidence surface and residual risk. It does not define rows for rejected alternatives or decision rationale.",
+      "risk if unchanged": "For PRs like #1244, a human can see what changed and what proof ran, but still must reconstruct why deep renaming was chosen and which alternatives were rejected from PR prose, chat context, or diff inspection.",
+      "suggested action": "Define a minimal decision-review shape for system-shaping work: decision, rationale, meaningful alternatives or trade-offs, affected subsystem/contract, proof, durable owner, and promotion status.",
+      "confidence": "high",
+      "source class": "current report output plus contract comparison",
+      "promotion target": "#1241 refined acceptance criteria or a narrow child issue",
+      "promotion trigger": "When a system-shaping closeout has changed contracts/docs/runtime behavior but no explicit decision rationale row."
+    },
+    {
+      "title": "Authority boundaries are necessary but do not name the concrete decisions",
+      "summary": "PR #1244 correctly prevents agents from saying AW classified, routed, or decided advisory work. That solves authority attribution, but it does not by itself tell the human which architecture/product decision the agent made.",
+      "evidence": "PR #1244 added authority_boundary packets across startup, implement, proof, and closeout/report surfaces and deep-renamed advisory fields. Current closeout_report authority_boundary says AW reports evidence and gates while the agent owns final wording, proof/acceptance judgment, and material caveat selection.",
+      "risk if unchanged": "The UX can become honest but still incomplete: the human knows who owns the judgment, but not what judgment shaped the system.",
+      "suggested action": "Keep authority_boundary as framing, and add decision facts only when the agent has actually made a material system/product choice. Do not overload authority_boundary with decision prose.",
+      "confidence": "high",
+      "source class": "merged PR plus current report output",
+      "promotion target": "#1241 decision-review model",
+      "promotion trigger": "When authority_boundary appears in closeout but the actual system decision remains implicit."
+    },
+    {
+      "title": "The durable owner is a combination of Planning, decision_pressure, and host-owned docs or Memory",
+      "summary": "No single current surface should own all decision traceability. Planning can capture active decision facts, closeout_report can render review facts, decision_pressure can route promotion, and repo-owned ADR/docs/Memory/config/checks can hold durable outcomes when needed.",
+      "evidence": "#1241 explicitly lists Planning, durable intent, closeout reporting, decision pressure, structured findings, and architecture-decision routing. Current decision_pressure exposes scaffold/promote actions but reports no configured target in this repo. closeout_report declares itself a derived presentation surface and not execution state.",
+      "risk if unchanged": "A new decision-trace store could duplicate Planning or repo-owned architecture docs and create more surfaces for the human to reconcile.",
+      "suggested action": "Recommend a combination model: agent records material decision facts in Planning or closeout evidence; closeout_report renders them for review; decision_pressure decides only promotion pressure and command-owned scaffolding; durable accepted decisions land in repo docs/ADR/Memory/config/checks as appropriate.",
+      "confidence": "medium-high",
+      "source class": "issue scope plus contract and current routing output",
+      "promotion target": "#1241 issue comment",
+      "promotion trigger": "When choosing owner surfaces for any follow-up implementation."
+    }
+  ],
+  "recommendation": {
+    "promote": "Do not promote implementation until #1241 records the minimal decision-review shape and owner split.",
+    "defer": "Keep #1241 as the owner for decision-traceability investigation.",
+    "dismiss": "Do not dismiss; current surfaces cover routing and closeout evidence but not concrete decision rationale or rejected alternatives.",
+    "minimal_decision_review_shape": [
+      "decision made",
+      "why it was made",
+      "meaningful rejected alternatives or trade-offs",
+      "affected subsystem, contract, or public surface",
+      "proof or validation supporting the decision",
+      "durable owner: Planning, ADR/docs, Memory, config/checks, or issue follow-up",
+      "promotion status: none, candidate, promoted, dismissed"
+    ],
+    "owner_model": "Planning captures active decision facts; closeout_report renders review facts; decision_pressure routes durable promotion; host-owned docs/ADR/Memory/config/checks hold accepted durable outcomes."
+  },
+  "retention": {
+    "closeout shape": "keep until #1241 findings are promoted, dismissed, or superseded",
+    "trigger": "After #1241 has an issue comment or child issues that capture decision fact shape and owner model.",
+    "proof surface": "This review artifact plus promoted issue refinement."
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-03-open-issue-1241-decision-traceability-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-03: Review record created by create-review.",
+    "2026-06-03: Populated grounding review after inspecting #1241, PR #1244, decision_pressure output, closeout_report output, reporting contract, and workspace report reference."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-03-open-issue-1242-review-compression-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-03-open-issue-1242-review-compression-grounding.review.json
@@ -1,0 +1,209 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1242 review compression",
+  "date": "2026-06-03",
+  "classification": "context-cost",
+  "goal": [
+    "Map existing AW review inputs before proposing a review-compression model.",
+    "Define draft review modes that preserve human judgment while reducing line-by-line reconstruction work."
+  ],
+  "scope": [
+    "Open issue #1242 as an investigation lane.",
+    "startup/report/summary/proof outputs, closeout_report, completion_contract, closeout_trust, authority_boundary, decision_pressure, Planning reviews, and PR evidence.",
+    "Representative broad/system-shaping examples from PR #1233 and PR #1244."
+  ],
+  "non_goals": [
+    "Do not implement a review dashboard in this issue.",
+    "Do not replace code review for high-risk work.",
+    "Do not claim summary sufficiency when proof, risk, or decision evidence is missing.",
+    "Do not add mandatory ceremony for small direct work."
+  ],
+  "review_mode": {
+    "mode": "context-cost",
+    "review question": "Can current AW surfaces be composed into a cheap human review path by work shape, or is a new surface needed?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1242",
+      "gh pr view 1233",
+      "gh pr view 1244",
+      "report --section closeout_report",
+      "report --section decision_pressure",
+      ".agentic-workspace/docs/reporting-contract.md",
+      "docs/reference/workspace-report.md"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "gh issue view 1242 --json number,title,url,state,body,comments,labels,createdAt,updatedAt",
+      "gh pr view 1233 --json number,title,state,mergedAt,url,body,files,commits",
+      "gh pr view 1244 --json number,title,state,mergedAt,url,body,files,commits",
+      "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      "uv run python scripts/run_agentic_workspace.py report --section decision_pressure --format json",
+      "rg -n \"closeout_report|final_response_rendering|authority_boundary|decision_pressure|completion_contract|task_contract\" .agentic-workspace/docs/reporting-contract.md docs/reference/workspace-report.md tests/test_workspace_report_cli.py src/agentic_workspace/workspace_runtime_primitives.py"
+    ],
+    "evidence sources": [
+      "#1242 issue body",
+      "PR #1233 and PR #1244 bodies and validation evidence",
+      "current closeout_report output",
+      "current decision_pressure output",
+      "reporting contract and workspace report reference",
+      "closeout_report tests"
+    ],
+    "limitation": "This review defines a grounded model from current surfaces. It does not run a human study or implement the model."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1242",
+      "label": "Draft review-compression model for human supervision",
+      "role": "review owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1242"
+    },
+    {
+      "kind": "github-pr",
+      "target": "#1233",
+      "label": "Add operator-facing closeout reporting",
+      "role": "broad closeout example",
+      "locator": "https://github.com/rickardvh/agentic-workspace/pull/1233"
+    },
+    {
+      "kind": "github-pr",
+      "target": "#1244",
+      "label": "Clarify AW authority boundaries",
+      "role": "system-shaping authority example",
+      "locator": "https://github.com/rickardvh/agentic-workspace/pull/1244"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      "label": "current closeout_report output",
+      "role": "primary compression surface evidence"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py report --section decision_pressure --format json",
+      "label": "current decision_pressure output",
+      "role": "decision-review dependency evidence"
+    },
+    {
+      "kind": "local-doc",
+      "target": ".agentic-workspace/docs/reporting-contract.md",
+      "label": "Reporting contract",
+      "role": "profile and rendering contract"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1242",
+      "kind": "review-only investigation",
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": ".agentic-workspace/planning/reviews/",
+      "implementation_allowed_now": false,
+      "reason": "The issue asks to define the model first and only then propose narrow follow-up issues."
+    }
+  ],
+  "summary": {
+    "draft_review_modes": [
+      {
+        "mode": "small direct edit",
+        "inspect": "final response rendered summary and proof statement only when no residue or lower-trust signal exists",
+        "current_surface": "closeout_report.final_response_rendering with minimal or compact profile"
+      },
+      {
+        "mode": "planned slice",
+        "inspect": "intended outcome, changed surfaces, proof, closure boundary, completeness, and follow-up owner",
+        "current_surface": "closeout_report plus Planning closeout evidence"
+      },
+      {
+        "mode": "broad PR",
+        "inspect": "planned-slice facts plus validation breadth, changed public/contract surfaces, and unresolved issue residue",
+        "current_surface": "closeout_report, closeout_trust, completion_contract, PR body"
+      },
+      {
+        "mode": "system-shaping change",
+        "inspect": "broad-PR facts plus material decision facts and durable owner",
+        "current_surface": "closeout_report plus #1241 decision-traceability model"
+      },
+      {
+        "mode": "partial or lower-trust closeout",
+        "inspect": "blocking caveat, missing proof or intent evidence, residual risk, owner, and allowed closure claim",
+        "current_surface": "closeout_report profile policy, final_response_rendering constraints, closeout_trust"
+      },
+      {
+        "mode": "follow-up or residue-heavy work",
+        "inspect": "residue owner, activation trigger, durable routing, and whether final closure is honest",
+        "current_surface": "Planning reviews, closeout_trust, completion_contract, issue follow-up"
+      }
+    ],
+    "primary_surface_recommendation": "Prefer closeout_report/final_response_rendering as the first compression surface; add decision facts through #1241 before creating any new review surface.",
+    "manual_human_judgment": "The human still owns acceptance of residual intent, risk tolerance, and whether the evidence is good enough for merge or closure."
+  },
+  "findings": [
+    {
+      "title": "AW already has enough review inputs to create overload",
+      "summary": "The current system exposes startup, implement, proof, summary, report sections, closeout_report, completion_contract, closeout_trust, decision_pressure, Planning reviews, and PR validation evidence. #1242 is right that more surfaces without a mode map can increase review cost.",
+      "evidence": "#1242 names the surface-sprawl risk directly. PR #1233 and #1244 bodies each contain substantial validation and dogfooding detail. Current closeout_report output includes profile policy, validation, residue, traceability, completeness, rendered summary, authority boundary, and detail commands.",
+      "risk if unchanged": "The human may receive more evidence but still lack a clear path for what to inspect first for the work shape in front of them.",
+      "suggested action": "Use #1242 to define review modes and first-inspection surfaces before adding any new report or dashboard.",
+      "confidence": "high",
+      "source class": "issue scope plus current report and PR evidence",
+      "promotion target": "#1242 review model",
+      "promotion trigger": "When deciding how to summarize a broad or system-shaping lane without asking the human to inspect every AW output."
+    },
+    {
+      "title": "closeout_report can be the primary compressor for most closeout review modes",
+      "summary": "The closeout_report profile policy already distinguishes minimal, compact, balanced, explanatory, and audit output, and final_response_rendering already supplies rendered text plus must_include and must_not_claim constraints.",
+      "evidence": "The reporting contract states balanced/explanatory/audit closeouts should render material human-facing facts: profile reason, closure boundary, changed work, proof, residual risk, routed residue, and follow-up owner. Current report --section closeout_report emits those fields and a rendered_summary. Tests assert terse minimal output and evidence-backed audit output.",
+      "risk if unchanged": "A new review-compression surface could duplicate closeout_report instead of making the first inspection path clearer.",
+      "suggested action": "Start with a closeout-first compression model: use rendered_summary for the user-facing answer, and let detail commands point to closeout_report, closeout_trust, completion_contract, or decision_pressure only when the mode requires it.",
+      "confidence": "high",
+      "source class": "contract plus current output plus regression tests",
+      "promotion target": "#1242 issue comment",
+      "promotion trigger": "When drafting implementation follow-ups for review compression."
+    },
+    {
+      "title": "System-shaping review compression depends on #1241 decision facts",
+      "summary": "The mode that cannot be satisfied by closeout_report alone is system-shaping review. It needs the concrete decisions, rationale, alternatives, affected contracts, proof, and durable owner from #1241.",
+      "evidence": "Current closeout_report traceability rows cover intent/work/proof/closure, not rejected alternatives or decision rationale. Current decision_pressure is not-configured and reports no decision candidates. #1241 explicitly asks for the missing decision-trace shape.",
+      "risk if unchanged": "Review compression could hide the exact thing humans need most for large agent-led work: why the system changed in a particular direction.",
+      "suggested action": "Make #1242 depend on the #1241 minimal decision-review shape for system-shaping mode. Do not declare broad PR review compressed until decision facts are visible or explicitly absent and routed.",
+      "confidence": "high",
+      "source class": "cross-issue comparison plus current command output",
+      "promotion target": "#1242 model with dependency on #1241",
+      "promotion trigger": "When defining system-shaping or broad PR review mode acceptance."
+    },
+    {
+      "title": "Compression must expose what the human still judges manually",
+      "summary": "The goal is not to replace review with summaries. The compressed view should explicitly name what remains a human acceptance, risk, or handoff decision.",
+      "evidence": "closeout_report authority_boundary lists human_owned_decisions such as acceptance of residual intent or follow-up ownership when residue exists. final_response_rendering constraints prevent plain-done claims for lower-trust or incomplete evidence. #1242 says summaries must not claim sufficiency when proof or risk evidence is missing.",
+      "risk if unchanged": "A polished summary could make the work feel reviewed when the actual acceptance, risk, or residual-intent decision has not been made.",
+      "suggested action": "Add a review-mode acceptance rule: every compressed review must include either 'no material human decision remains' or name the human-owned decision and owner surface.",
+      "confidence": "medium-high",
+      "source class": "authority-boundary contract plus issue success criteria",
+      "promotion target": "#1242 acceptance criteria",
+      "promotion trigger": "When converting the model into implementation or issue comments."
+    }
+  ],
+  "recommendation": {
+    "promote": "Do not promote implementation yet.",
+    "defer": "Keep #1242 as the model owner until the review modes are accepted and #1241 clarifies decision facts.",
+    "dismiss": "Do not dismiss; the current surfaces are useful but not yet organized into a low-cost human review path.",
+    "first_model": "Use closeout_report/final_response_rendering as the primary review compressor, with work-shape mode rules and explicit detail commands. Add decision facts through #1241 before introducing a new top-level surface.",
+    "possible_follow_up_after_refinement": "A narrow issue could add a derived review_mode packet or profile-bound closeout section only if the model cannot be expressed with current closeout_report fields."
+  },
+  "retention": {
+    "closeout shape": "keep until #1242 findings are promoted, dismissed, or superseded",
+    "trigger": "After #1242 has an issue comment or child issues that capture review modes and owner surfaces.",
+    "proof surface": "This review artifact plus promoted issue refinement."
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-03-open-issue-1242-review-compression-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-03: Review record created by create-review.",
+    "2026-06-03: Populated grounding review after inspecting #1242, PR #1233, PR #1244, closeout_report output, decision_pressure output, reporting contract, and workspace report reference."
+  ]
+}


### PR DESCRIPTION
## Summary

Adds three planning review artifacts that ground the open investigation issues before any implementation work:

- #1240 closeout adoption review
- #1241 decision traceability review
- #1242 review compression review

The reviews classify the issues as investigation lanes, map the current AW surfaces against recent PR evidence (#1233 and #1244), and record promote/defer guidance without creating new implementation work prematurely.

Refs #1240
Refs #1241
Refs #1242

## Validation

- `uv run python -m json.tool` for each new review artifact
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `git diff --check`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- commit hooks: sync-all, workspace lint, memory lint, memory markdownlint, planning lint, verification lint, absolute-path check