### PR TITLE
[codex] Add human review closeout surfaces

### DIFF
--- a/.agentic-workspace/docs/reporting-contract.md
+++ b/.agentic-workspace/docs/reporting-contract.md
@@ -99,6 +99,9 @@ It keeps:
 - `closure_boundary`
 - `traceability`
 - `completeness`
+- `decision_review`
+- `review_compression`
+- `closeout_adoption`
 - `final_response_rendering`
 - `next_action`
 
@@ -122,6 +125,48 @@ agentic-workspace report --target ./repo --section closeout_report --format json
 
 Use `closeout_report.completeness` to see missing intent boundary, completed-work, changed-surface, validation, residual-risk, follow-up-owner, or traceability evidence before making final closeout claims.
 Use `closeout_report.traceability.rows` to connect each intent or requirement to its evidence surface and residual risk or follow-up.
+
+Use `closeout_report.decision_review` for material system or product decisions.
+It is a derived review packet over agent-authored Planning facts, not an AW classifier.
+The active owner for decision facts is Planning, primarily `architecture_decision_promotion` and `traceability_refs.decision_refs`.
+`closeout_report.decision_review` may render those facts and check completeness, while `report --section decision_pressure` remains the routing and promotion-pressure surface.
+When system-shaping signals are present but no decision facts exist, `decision_review.status` should be `absent-required` and `decision_absent_because` must say that no agent-authored facts were found rather than pretending AW inferred the decision.
+
+Decision-review facts are:
+
+- decision made;
+- why it was made;
+- meaningful rejected alternatives or trade-offs;
+- affected subsystem, contract, public behavior, or operating loop;
+- proof or validation supporting the decision;
+- durable owner;
+- promotion status.
+
+Use `closeout_report.review_compression` to see what a human should inspect first for the selected work shape.
+It is closeout-first, derived, and non-authoritative.
+Its modes are:
+
+- `small-direct-edit`;
+- `planned-slice`;
+- `broad-pr`;
+- `system-shaping-change`;
+- `partial-or-lower-trust-closeout`;
+- `follow-up-or-residue-heavy-work`.
+
+Every compressed review must either say no material human decision remains beyond ordinary acceptance, or name the human-owned acceptance, risk, handoff, or decision-fact question and its owner.
+
+Use `closeout_report.closeout_adoption` as the operator-facing closeout quality rubric.
+The rubric asks whether the final response answers:
+
+- what did the agent think the user wanted?
+- what changed?
+- why is the closure claim honest?
+- what proof supports it?
+- what remains unproven?
+- what follow-up or residue remains?
+
+Terse closeout is acceptable only when `plain_done_allowed` is true and no lower-trust, partial, residue, or decision-gap signal is present.
+Broad, lower-trust, partial, or system-shaping work must show proof, closure boundary, residual risk, follow-up owner when present, authority boundary, and system-decision facts or routed absence.
 
 When no active plan exists, `closeout_report.planning_evidence.authority` may be `retained-closeout-evidence` or `archived-planning-evidence`.
 Retained closeout evidence is the compact record written when full archive retention was skipped by size guardrails.
@@ -157,6 +202,7 @@ It keeps:
 Minimal and guidance-only closeouts without trust, residue, or follow-up signals should stay terse.
 Guidance-only closeouts with audit, lower-trust, residue, or follow-up signals should stay compact but still render the caveat and disallow a plain-done claim.
 Balanced, explanatory, audit, partial, or lower-trust closeouts should render the material human-facing facts: profile reason, closure boundary, changed work, proof, residual risk, routed residue, and follow-up owner.
+System-shaping closeouts should also render decision facts or a decision-gap line from `decision_review`.
 The final response should prefer `rendered_summary.rendered_text` as concise prose or bullets and must not dump raw JSON.
 `required_fact_coverage` must make omitted required facts visible before the agent claims completion.
 Custom wording or template selection is a future-safe extension only when it cannot hide `must_include`, `must_not_claim`, `plain_done_allowed`, or `raw_json_allowed`.

--- a/.agentic-workspace/planning/execplans/archive/github-1240-1242-human-review-control-surfaces.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1240-1242-human-review-control-surfaces.plan.json
@@ -1,0 +1,361 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement human review control surfaces for closeout, decisions, and review compression",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1240, #1241, and #1242 in full: closeout adoption rubric/examples, system-decision traceability, and closeout-first review-compression modes.",
+    "hard_constraints": "Keep closeout_report derived; do not make AW infer semantic decisions; do not add a dashboard, ADR engine, durable decision database, or mandatory ceremony for small work.",
+    "agent_may_decide": "Exact field names, derived packet shape, documentation placement, tests, and whether the issues fit one cohesive PR or a stack.",
+    "escalate_when": "A correct implementation requires a new durable store, broad unrelated refactor, or behavior that would make AW decide architecture/product semantics for the agent.",
+    "next_action": "Implement the derived decision-review and human-review surfaces, document the adoption and compression contracts, then validate schemas, docs, generated outputs, and runtime tests.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_report_cli.py -q",
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+      "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+      "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+      "docs/reference/workspace-report.md",
+      ".agentic-workspace/docs/reporting-contract.md",
+      "tests/test_workspace_report_cli.py",
+      ".agentic-workspace/planning/execplans/github-1240-1242-human-review-control-surfaces.plan.json"
+    ],
+    "completion_criteria": [
+      "#1240 closeout adoption rubric and representative examples are documented and test-backed.",
+      "#1241 decision-review shape is implemented without making AW infer semantic decisions.",
+      "#1242 review-compression modes are available as closeout-first derived guidance and human-owned decisions remain explicit."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Implement #1240 closeout adoption examples and quality rubric.",
+    "Implement #1241 system-decision traceability review shape.",
+    "Implement #1242 closeout-first review-compression modes."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1240, #1241, and #1242 in full: closeout adoption rubric/examples, system-decision traceability, and closeout-first review-compression modes.",
+      "constraints": "Keep closeout_report derived; do not make AW infer semantic decisions; do not add a dashboard, ADR engine, durable decision database, or mandatory ceremony for small work.",
+      "latitude": "Exact field names, derived packet shape, documentation placement, tests, and whether the issues fit one cohesive PR or a stack.",
+      "escalation": "Escalate when a correct implementation requires a new durable store, broad unrelated refactor, or behavior that would make AW decide architecture/product semantics for the agent.",
+      "proof": "Passed: focused closeout_report tests; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; check_generated_command_packages; ruff check selected surfaces; make maintainer-surfaces; make schema-reference-docs; AW summary; AW planning doctor."
+    },
+    "execution": {
+      "milestone": "github-1240-1242-human-review-control-surfaces",
+      "status": "active",
+      "next_step": "Implement the derived decision-review and human-review surfaces, document the adoption and compression contracts, then validate schemas, docs, generated outputs, and runtime tests.",
+      "proof": "Runtime report tests, generated schema/reference checks, structured inventory, AW summary, and planning doctor."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+        "docs/reference/workspace-report.md",
+        ".agentic-workspace/docs/reporting-contract.md",
+        "tests/test_workspace_report_cli.py",
+        ".agentic-workspace/planning/execplans/github-1240-1242-human-review-control-surfaces.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Humans can supervise agent-delivered work through closeout quality, decision facts, review modes, proof, risk, and ownership instead of reconstructing everything from diffs.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "current milestone validation remains pending",
+    "next likely slice": "continue the current milestone until the completion criteria are met"
+  },
+  "intent_interpretation": {
+    "literal request": "Implement human review control surfaces for closeout, decisions, and review compression",
+    "inferred intended outcome": "Make AW's closeout and report surfaces expose a usable human-control layer for ordinary, broad, lower-trust, and system-shaping work.",
+    "chosen concrete what": "Add derived decision-review and human-review guidance to closeout/report output, document the adoption and compression contracts, and cover representative examples in tests.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/workspace-report.md; .agentic-workspace/docs/reporting-contract.md; tests/test_workspace_report_cli.py; this execplan; generated report references only if schema/docs generation requires it.",
+    "max changed files": "About 8, unless generated reference/schema outputs require paired updates.",
+    "required validation commands": "uv run pytest tests/test_workspace_report_cli.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; AW summary and planning doctor.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue from the active plan, implement decision-review and human-review packets over closeout_report, then validate report tests and generated/schema consistency.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1240, #1241, and #1242 in full: closeout adoption rubric/examples, system-decision traceability, and closeout-first review-compression modes.",
+    "hard constraints": "Keep closeout_report derived; do not make AW infer semantic decisions; do not add a dashboard, ADR engine, durable decision database, or mandatory ceremony for small work.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "pending",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "traceability_refs": {
+    "domain_model_refs": [
+      "closeout_report",
+      "workspace_report.schema.json",
+      "planning-execplan.schema.json"
+    ],
+    "decision_refs": [
+      "Add derived human-review packets to closeout_report while keeping semantic decisions agent-authored in Planning."
+    ]
+  },
+  "architecture_decision_promotion": {
+    "status": "candidate",
+    "target": "Planning architecture_decision_promotion or later ADR/docs if this design becomes durable beyond closeout reporting.",
+    "decision_refs": [
+      "Add closeout_report.decision_review, closeout_report.review_compression, and closeout_report.closeout_adoption as derived report packets instead of a dashboard, decision database, or AW-owned semantic classifier."
+    ],
+    "decision": "Add derived human-review packets to closeout_report while keeping semantic decisions agent-authored in Planning.",
+    "rationale": "The three issues need human-control facts at closeout, but AW must not infer architecture/product decisions or create another durable state store.",
+    "tradeoffs": [
+      "Keeps closeout_report as the first review surface instead of adding a dashboard.",
+      "Requires agents to author decision facts in Planning before system-shaping closeout can be complete.",
+      "Leaves durable ADR/docs promotion to decision_pressure instead of embedding it in closeout_report."
+    ],
+    "affected_surfaces": [
+      "closeout_report",
+      "decision_pressure",
+      "Planning architecture_decision_promotion",
+      "workspace report schema/reference docs"
+    ],
+    "proof": "Focused closeout_report tests, make test-workspace, make lint-workspace, contract/schema checks, structured inventory, generated command package check, maintainer surfaces, schema-reference docs, AW summary, and AW planning doctor passed.",
+    "durable_owner": "Planning architecture_decision_promotion; decision_pressure for later promotion pressure",
+    "promotion_needed": false,
+    "notes": "No ADR is required for this PR unless later review decides the derived packet design should become a durable architecture decision."
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1240-1242-human-review-control-surfaces",
+    "status": "completed",
+    "scope": "Implement the three promoted issue outcomes without broad unrelated refactors.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Implement derived decision-review facts, closeout adoption guidance, review-compression modes, documentation, and tests."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+    "docs/reference/workspace-report.md",
+    ".agentic-workspace/docs/reporting-contract.md",
+    "tests/test_workspace_report_cli.py",
+    ".agentic-workspace/planning/execplans/github-1240-1242-human-review-control-surfaces.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_report_cli.py -q",
+    "rg -n \"AW classified|AW routed|AW decided|decision_review|review_compression|closeout_adoption|closeout report profile, traceability, completeness, validation\" .agentic-workspace/docs src docs tests .agentic-workspace/planning/execplans/github-1240-1242-human-review-control-surfaces.plan.json",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement human review control surfaces for closeout, decisions, and review compression is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented derived closeout decision_review, review_compression, and closeout_adoption packets; documented the adoption rubric, decision-review owner split, and review-compression modes; added report tests for decision facts present, decision facts absent, schema/reference coverage, and closeout rendering.",
+    "scope touched": "reporting runtime, workspace report schema/reference, reporting contract docs, closeout report tests, and planning closeout evidence",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/workspace-report.md; .agentic-workspace/docs/reporting-contract.md; tests/test_workspace_report_cli.py; .agentic-workspace/planning/state.toml; .agentic-workspace/planning/execplans/github-1240-1242-human-review-control-surfaces.plan.json",
+    "validations run": "Passed: focused closeout_report tests; stale-reference sweep reviewed intentional authority-boundary examples and new fields; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; check_generated_command_packages; ruff check selected surfaces; make maintainer-surfaces; make schema-reference-docs; AW summary; AW planning doctor.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope respected: implementation stayed in derived report/closeout surfaces and Planning evidence. Intent served: #1240 has adoption rubric/examples, #1241 has agent-authored decision-review facts with absence routing, and #1242 has closeout-first review-compression modes. No durable residue remains.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Passed: focused closeout_report tests; stale-reference sweep reviewed intentional authority-boundary examples and new fields; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; check_generated_command_packages; ruff check selected surfaces; make maintainer-surfaces; make schema-reference-docs; AW summary; AW planning doctor.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "Passed: focused closeout_report tests; stale-reference sweep reviewed intentional authority-boundary examples and new fields; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; check_generated_command_packages; ruff check selected surfaces; make maintainer-surfaces; make schema-reference-docs; AW summary; AW planning doctor."
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1240, #1241, and #1242 in full and create PRs when done.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "Passed: focused closeout_report tests; stale-reference sweep reviewed intentional authority-boundary examples and new fields; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; check_generated_command_packages; ruff check selected surfaces; make maintainer-surfaces; make schema-reference-docs; AW summary; AW planning doctor.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Human review control surfaces are implemented and validated without adding a dashboard, durable decision store, ADR engine, or AW-owned semantic decision classifier.",
+    "validation confirmed": "Passed: focused closeout_report tests; stale-reference sweep reviewed intentional authority-boundary examples and new fields; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; check_generated_command_packages; ruff check selected surfaces; make maintainer-surfaces; make schema-reference-docs; AW summary; AW planning doctor.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a lane claim with intent-status satisfied.",
+    "evidence carried forward": "Passed: focused closeout_report tests; stale-reference sweep reviewed intentional authority-boundary examples and new fields; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; check_generated_command_packages; ruff check selected surfaces; make maintainer-surfaces; make schema-reference-docs; AW summary; AW planning doctor.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-03: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1240, #1241, and #1242 in full and create PRs when done.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Passed: focused closeout_report tests; stale-reference sweep reviewed intentional authority-boundary examples and new fields; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; check_generated_command_packages; ruff check selected surfaces; make maintainer-surfaces; make schema-reference-docs; AW summary; AW planning doctor.\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/workspace-report.md; .agentic-workspace/docs/reporting-contract.md; tests/test_workspace_report_cli.py; .agentic-workspace/planning/state.toml; .agentic-workspace/planning/execplans/github-1240-1242-human-review-control-surfaces.plan.json\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -92,6 +92,12 @@
         "status": { "enum": ["none", "candidate", "needed", "promoted", "deferred"] },
         "target": { "type": "string" },
         "decision_refs": { "$ref": "#/$defs/string_array" },
+        "decision": { "type": "string" },
+        "rationale": { "type": "string" },
+        "tradeoffs": { "$ref": "#/$defs/string_array" },
+        "affected_surfaces": { "$ref": "#/$defs/string_array" },
+        "proof": { "type": "string" },
+        "durable_owner": { "type": "string" },
         "promotion_needed": { "type": "boolean" },
         "notes": { "type": "string" }
       }

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -87,7 +87,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `structured_findings` | object | yes |  | Structured finding residue shape for review and promotion routing. |  |  |
 | `external_evidence_safety` | object | yes |  | External evidence freshness, divergence, stale-after, and closeout-safety projection. |  |  |
 | `workflow_compliance_summary` | object | yes |  | Derived review and recovery summary of workflow entrypoint, satisfied or missing gates, trust impact, and recovery action. |  |  |
-| `closeout_report` | object | yes |  | Derived operator-facing closeout report profile, traceability, completeness, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary. |  |  |
+| `closeout_report` | object | yes |  | Derived operator-facing closeout report profile, traceability, completeness, decision-review facts, closeout-first review-compression guidance, closeout adoption rubric, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary. |  |  |
 | `closeout_report.authority_boundary` | ref `#/$defs/authority_boundary` | no |  | Authority boundary showing which closeout/report signals are AW-enforced, observed, recommended, or agent-owned. |  |  |
 | `closeout_report.authority_boundary.kind` | const `"agentic-workspace/authority-boundary/v1"` | yes |  | Discriminator for the authority-boundary packet. |  |  |
 | `closeout_report.authority_boundary.surface` | string | yes |  | Payload surface whose authority categories are being described. |  |  |
@@ -100,6 +100,9 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `closeout_report.authority_boundary.agent_owned_decisions` | array of string | yes |  | Semantic, route, proof-proportionality, or completion judgments the agent owns. |  |  |
 | `closeout_report.authority_boundary.human_owned_decisions` | array of string | yes |  | Intent, acceptance, or handoff decisions requiring human ownership when present. |  |  |
 | `closeout_report.authority_boundary.reporting_rule` | string | yes |  | How agents should report the boundary without overstating AW authority. |  |  |
+| `closeout_report.decision_review` | object | no |  | Derived review packet for agent-authored system decision facts, completeness, absence routing, and durable-owner guidance. |  |  |
+| `closeout_report.review_compression` | object | no |  | Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts, detail routes, and human-owned decisions. |  |  |
+| `closeout_report.closeout_adoption` | object | no |  | Derived closeout quality rubric, representative examples, and current rendering adoption status for human-useful final reports. |  |  |
 | `continuation_next_actions` | object | yes |  | Evidence-ranked next actions for safe continuation. |  |  |
 | `migration_pilot_template` | object | yes |  | Optional migration-pilot decomposition template with parity and rollout boundaries. |  |  |
 | `compact_output_criteria` | object | yes |  | Criteria for compact CLI outputs to remain sufficient for cheap continuation. |  |  |

--- a/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -92,6 +92,12 @@
         "status": { "enum": ["none", "candidate", "needed", "promoted", "deferred"] },
         "target": { "type": "string" },
         "decision_refs": { "$ref": "#/$defs/string_array" },
+        "decision": { "type": "string" },
+        "rationale": { "type": "string" },
+        "tradeoffs": { "$ref": "#/$defs/string_array" },
+        "affected_surfaces": { "$ref": "#/$defs/string_array" },
+        "proof": { "type": "string" },
+        "durable_owner": { "type": "string" },
         "promotion_needed": { "type": "boolean" },
         "notes": { "type": "string" }
       }

--- a/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -92,6 +92,12 @@
         "status": { "enum": ["none", "candidate", "needed", "promoted", "deferred"] },
         "target": { "type": "string" },
         "decision_refs": { "$ref": "#/$defs/string_array" },
+        "decision": { "type": "string" },
+        "rationale": { "type": "string" },
+        "tradeoffs": { "$ref": "#/$defs/string_array" },
+        "affected_surfaces": { "$ref": "#/$defs/string_array" },
+        "proof": { "type": "string" },
+        "durable_owner": { "type": "string" },
         "promotion_needed": { "type": "boolean" },
         "notes": { "type": "string" }
       }

--- a/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -92,6 +92,12 @@
         "status": { "enum": ["none", "candidate", "needed", "promoted", "deferred"] },
         "target": { "type": "string" },
         "decision_refs": { "$ref": "#/$defs/string_array" },
+        "decision": { "type": "string" },
+        "rationale": { "type": "string" },
+        "tradeoffs": { "$ref": "#/$defs/string_array" },
+        "affected_surfaces": { "$ref": "#/$defs/string_array" },
+        "proof": { "type": "string" },
+        "durable_owner": { "type": "string" },
         "promotion_needed": { "type": "boolean" },
         "notes": { "type": "string" }
       }

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -9900,7 +9900,18 @@ def _prepared_task_intent_promotion(record: dict[str, Any]) -> dict[str, Any]:
 def _closeout_value_needs_normalization(value: Any) -> bool:
     if not isinstance(value, str):
         return value is None
-    return value.strip().lower() in {"", "pending", "not_checked", "not-run-yet", "not run yet", "todo", "tbd"}
+    text = value.strip().lower()
+    if text in {"", "pending", "not_checked", "not-run-yet", "not run yet", "todo", "tbd"}:
+        return True
+    return any(
+        stale_closeout_fragment in text
+        for stale_closeout_fragment in (
+            "current milestone validation remains pending",
+            "validation remains pending until the current milestone closes",
+            "continue the current milestone until the completion criteria are met",
+            "finish the current milestone and archive",
+        )
+    )
 
 
 def _closeout_sequence_needs_normalization(value: Any) -> bool:

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -547,6 +547,14 @@ candidates = []
     record = json.loads(record_path.read_text(encoding="utf-8"))
     record["execution_summary"]["validation confirmed"] = "pytest"
     record["execution_summary"]["outcome delivered"] = "Implemented the bounded slice."
+    record["iterative_follow_through"] = {
+        "what this slice enabled": "none yet",
+        "intentionally deferred": "none",
+        "discovered implications": "none yet",
+        "proof achieved now": "validation remains pending until the current milestone closes.",
+        "validation still needed": "current milestone validation remains pending",
+        "next likely slice": "continue the current milestone until the completion criteria are met",
+    }
     record.pop("intent_satisfaction")
     record.pop("closure_check")
     record.pop("closeout_distillation", None)
@@ -590,7 +598,10 @@ candidates = []
     assert archived["machine_readable_contract"]["scope"]["touched"] == ["closeout scope recorded in closure_check and generated_closeout."]
     assert archived["task_intent_promotion"]["needs review"] is True
     assert archived["iterative_follow_through"]["proof achieved now"] != "pending"
-    assert archived["iterative_follow_through"]["validation still needed"].lower() != "pending"
+    assert archived["iterative_follow_through"]["validation still needed"] == (
+        "None for this archived slice; reopen only if new evidence invalidates the proof."
+    )
+    assert archived["iterative_follow_through"]["next likely slice"] == "No required continuation remains for this archived slice."
     assert archived["delegation_outcome_feedback"]["actual friction"] == "none recorded"
     assert archived["delegation_outcome_feedback"]["proof result"] != "pending"
     assert archived["improvement_signal_review"]["status"] == "not_checked"

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -294,9 +294,21 @@
         "authority_boundary": {
           "$ref": "#/$defs/authority_boundary",
           "description": "Authority boundary showing which closeout/report signals are AW-enforced, observed, recommended, or agent-owned."
+        },
+        "decision_review": {
+          "type": "object",
+          "description": "Derived review packet for agent-authored system decision facts, completeness, absence routing, and durable-owner guidance."
+        },
+        "review_compression": {
+          "type": "object",
+          "description": "Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts, detail routes, and human-owned decisions."
+        },
+        "closeout_adoption": {
+          "type": "object",
+          "description": "Derived closeout quality rubric, representative examples, and current rendering adoption status for human-useful final reports."
         }
       },
-      "description": "Derived operator-facing closeout report profile, traceability, completeness, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary."
+      "description": "Derived operator-facing closeout report profile, traceability, completeness, decision-review facts, closeout-first review-compression guidance, closeout adoption rubric, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary."
     },
     "continuation_next_actions": {
       "type": "object",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -7916,6 +7916,306 @@ def _closeout_report_completeness_payload(
     }
 
 
+def _closeout_report_decision_review_payload(
+    *,
+    active_planning_record: dict[str, Any],
+    proof_report: dict[str, Any],
+) -> dict[str, Any]:
+    promotion = _as_dict(active_planning_record.get("architecture_decision_promotion"))
+    traceability_refs = _as_dict(active_planning_record.get("traceability_refs"))
+    adaptive_assurance = _as_dict(active_planning_record.get("adaptive_assurance"))
+    invariant_refs = [str(item).strip() for item in _list_payload(active_planning_record.get("invariant_refs")) if str(item).strip()]
+    decision_refs = [
+        str(item).strip()
+        for item in (_list_payload(traceability_refs.get("decision_refs")) + _list_payload(promotion.get("decision_refs")))
+        if str(item).strip()
+    ]
+
+    def text(*keys: str) -> str:
+        for key in keys:
+            value = str(promotion.get(key) or "").strip()
+            if value and value.lower() not in {"none", "null", "unknown"}:
+                return value
+        return ""
+
+    def text_list(*keys: str) -> list[str]:
+        values: list[str] = []
+        for key in keys:
+            values.extend(str(item).strip() for item in _list_payload(promotion.get(key)) if str(item).strip())
+        return _dedupe(values)
+
+    affected_surfaces = text_list("affected_surfaces", "affected_subsystems", "affected_contracts")
+    if not affected_surfaces:
+        affected_surfaces = _dedupe(
+            [
+                str(item).strip()
+                for key in ("domain_model_refs", "risk_refs", "security_refs", "audit_refs")
+                for item in _list_payload(traceability_refs.get(key))
+                if str(item).strip()
+            ]
+        )
+    decision = text("decision", "summary", "title") or (decision_refs[0] if decision_refs else "")
+    rationale = text("rationale", "why", "notes")
+    tradeoffs = text_list("tradeoffs", "rejected_alternatives", "alternatives")
+    proof = text("proof", "validation") or str(proof_report.get("validation proof") or "").strip()
+    durable_owner = text("durable_owner", "owner", "target")
+    promotion_status = str(promotion.get("status") or "").strip()
+    facts = {
+        "decision": decision,
+        "rationale": rationale,
+        "tradeoffs": tradeoffs,
+        "affected_surfaces": affected_surfaces,
+        "proof": proof,
+        "durable_owner": durable_owner,
+        "promotion_status": promotion_status or "none",
+    }
+
+    system_shaping_signals: list[str] = []
+    if promotion or decision_refs:
+        system_shaping_signals.append("agent-authored decision candidate")
+    assurance_level = str(adaptive_assurance.get("level") or "").strip().lower()
+    if assurance_level in {"high", "critical"}:
+        system_shaping_signals.append(f"adaptive_assurance.level={assurance_level}")
+    for key in ("domain_model_refs", "risk_refs", "security_refs", "audit_refs"):
+        if _list_payload(traceability_refs.get(key)):
+            system_shaping_signals.append(f"traceability_refs.{key}")
+    if invariant_refs:
+        system_shaping_signals.append("invariant_refs")
+    system_shaping_signals = _dedupe(system_shaping_signals)
+
+    checks = [
+        {"fact": "decision made", "status": "present" if decision else "missing"},
+        {"fact": "why it was made", "status": "present" if rationale else "missing"},
+        {"fact": "meaningful rejected alternatives or trade-offs", "status": "present" if tradeoffs else "missing"},
+        {
+            "fact": "affected subsystem, contract, public behavior, or operating loop",
+            "status": "present" if affected_surfaces else "missing",
+        },
+        {"fact": "proof or validation supporting the decision", "status": "present" if proof else "missing"},
+        {"fact": "durable owner", "status": "present" if durable_owner else "missing"},
+        {"fact": "promotion status", "status": "present" if promotion_status else "missing"},
+    ]
+    missing_facts = [item["fact"] for item in checks if item["status"] == "missing"]
+    if decision or promotion:
+        status = "present" if not missing_facts else "partial"
+    elif system_shaping_signals:
+        status = "absent-required"
+    else:
+        status = "not-applicable"
+
+    decision_absent_because = ""
+    if status == "absent-required":
+        decision_absent_because = (
+            "System-shaping signals are present, but no agent-authored decision facts were found in "
+            "Planning architecture_decision_promotion or traceability_refs.decision_refs."
+        )
+
+    return {
+        "kind": "agentic-workspace/closeout-decision-review/v1",
+        "status": status,
+        "authority": "agent-authored-facts-derived-for-review",
+        "system_shaping_signals": system_shaping_signals,
+        "decision_facts": facts,
+        "completeness": {
+            "status": "complete" if status == "present" else "incomplete" if status == "absent-required" else status,
+            "checks": checks,
+            "missing_facts": missing_facts if status in {"partial", "absent-required"} else [],
+        },
+        "decision_absent_because": decision_absent_because,
+        "routing": {
+            "active_owner_surface": "planning.active.planning_record.architecture_decision_promotion + traceability_refs.decision_refs",
+            "derived_display_surface": "closeout_report.decision_review",
+            "promotion_pressure_surface": "report --section decision_pressure",
+            "durable_owner_options": ["Planning", "ADR/docs", "Memory", "config/checks", "issue follow-up"],
+        },
+        "rule": (
+            "The agent authors semantic system decisions; AW preserves, renders, checks completeness, and routes promotion "
+            "without inferring decisions from diffs."
+        ),
+    }
+
+
+def _closeout_report_review_compression_payload(
+    *,
+    profile_policy: dict[str, Any],
+    trust: str,
+    completeness: dict[str, Any],
+    decision_review: dict[str, Any],
+    residual_risk: str,
+    follow_up_owner: str,
+    detail_commands: dict[str, str],
+) -> dict[str, Any]:
+    profile = str(profile_policy.get("selected_profile") or "minimal")
+    completeness_status = str(completeness.get("status") or "").strip().lower()
+    decision_status = str(decision_review.get("status") or "").strip().lower()
+    lower_or_partial = str(trust).strip().lower() == "lower-trust" or completeness_status in {"partial", "incomplete"}
+    if decision_status in {"present", "partial", "absent-required"}:
+        selected_mode = "system-shaping-change"
+    elif lower_or_partial or profile == "explanatory":
+        selected_mode = "partial-or-lower-trust-closeout"
+    elif profile == "audit":
+        selected_mode = "broad-pr"
+    elif profile == "balanced":
+        selected_mode = "planned-slice"
+    elif profile == "compact":
+        selected_mode = "planned-slice"
+    else:
+        selected_mode = "small-direct-edit"
+
+    modes = [
+        {
+            "id": "small-direct-edit",
+            "first_inspection_facts": ["rendered summary", "proof statement if present", "plain_done_allowed"],
+            "detail_routes": ["closeout_report.final_response_rendering"],
+        },
+        {
+            "id": "planned-slice",
+            "first_inspection_facts": [
+                "intended outcome",
+                "changed surfaces",
+                "proof",
+                "closure boundary",
+                "completeness",
+                "follow-up owner",
+            ],
+            "detail_routes": ["closeout_report", "completion_contract"],
+        },
+        {
+            "id": "broad-pr",
+            "first_inspection_facts": [
+                "planned-slice facts",
+                "validation breadth",
+                "changed public or contract surfaces",
+                "unresolved issue residue",
+            ],
+            "detail_routes": ["closeout_report", "closeout_trust", "PR body"],
+        },
+        {
+            "id": "system-shaping-change",
+            "first_inspection_facts": [
+                "broad-pr facts",
+                "decision facts",
+                "decision proof",
+                "durable decision owner",
+                "decision absence routing when facts are missing",
+            ],
+            "detail_routes": ["closeout_report.decision_review", "decision_pressure"],
+        },
+        {
+            "id": "partial-or-lower-trust-closeout",
+            "first_inspection_facts": [
+                "blocking caveat",
+                "missing proof or intent evidence",
+                "residual risk",
+                "owner",
+                "allowed closure claim",
+            ],
+            "detail_routes": ["closeout_report", "closeout_trust", "completion_contract"],
+        },
+        {
+            "id": "follow-up-or-residue-heavy-work",
+            "first_inspection_facts": [
+                "residue owner",
+                "activation trigger",
+                "durable route",
+                "honest closure boundary",
+            ],
+            "detail_routes": ["closeout_trust", "Planning reviews", "issue follow-up"],
+        },
+    ]
+    human_owned: list[str] = []
+    if decision_status == "absent-required":
+        human_owned.append("accept whether system-shaping decision facts may remain absent or must be routed before merge")
+    if lower_or_partial:
+        human_owned.append("accept residual risk and missing proof or require more validation")
+    if follow_up_owner:
+        human_owned.append(f"accept follow-up ownership by {follow_up_owner}")
+    if not human_owned:
+        human_owned.append("no material human decision remains beyond ordinary acceptance of the delivered work")
+
+    return {
+        "kind": "agentic-workspace/closeout-review-compression/v1",
+        "status": "present",
+        "authority": "derived-review-guide",
+        "selected_mode": selected_mode,
+        "modes": modes,
+        "first_inspection": next((mode for mode in modes if mode["id"] == selected_mode), modes[0]),
+        "human_owned_decisions": human_owned,
+        "detail_commands": detail_commands,
+        "risk_note": residual_risk,
+        "rule": (
+            "Review compression tells humans what to inspect first; it does not replace acceptance, risk judgment, "
+            "or high-risk code review."
+        ),
+    }
+
+
+def _closeout_report_adoption_payload(
+    *,
+    profile_policy: dict[str, Any],
+    final_response_rendering: dict[str, Any],
+    decision_review: dict[str, Any],
+    review_compression: dict[str, Any],
+) -> dict[str, Any]:
+    rendered_summary = _as_dict(final_response_rendering.get("rendered_summary"))
+    coverage = _as_dict(rendered_summary.get("required_fact_coverage"))
+    missing_facts = _list_payload(coverage.get("missing_required_facts"))
+    warnings = _list_payload(rendered_summary.get("warnings"))
+    decision_gap = str(decision_review.get("status") or "") == "absent-required"
+    status = "needs-attention" if missing_facts or warnings or decision_gap else "ready"
+    return {
+        "kind": "agentic-workspace/closeout-adoption-rubric/v1",
+        "status": status,
+        "quality_bar": "Final closeout should make intent, change, proof, closure boundary, residual risk, follow-up, and decision facts reviewable without raw JSON.",
+        "human_control_questions": [
+            "what did the agent think the user wanted?",
+            "what changed?",
+            "why is the closure claim honest?",
+            "what proof supports it?",
+            "what remains unproven?",
+            "what follow-up or residue remains?",
+        ],
+        "terse_closeout_allowed_when": [
+            "profile is minimal or compact",
+            "plain_done_allowed is true",
+            "no lower-trust, partial, residue, or decision-gap signal is present",
+        ],
+        "must_be_visible_when_present": [
+            "proof, closure boundary, residual risk, follow-up owner, authority boundary, and system-decision facts or routed absence",
+        ],
+        "examples": [
+            {
+                "work_shape": "small direct edit",
+                "good": "Done. Validation passed.",
+                "anti_pattern": "Dumping closeout_report JSON for trivial work.",
+            },
+            {
+                "work_shape": "planned or broad work",
+                "good": "I judged this complete because the requested outcome, changed surfaces, proof, and closure boundary are all named.",
+                "anti_pattern": "Done; tests pass.",
+            },
+            {
+                "work_shape": "lower-trust or partial work",
+                "good": "The bounded slice landed, but proof or residue remains and the follow-up owner is named.",
+                "anti_pattern": "Plain done summary while plain_done_allowed is false.",
+            },
+            {
+                "work_shape": "system-shaping work",
+                "good": "Decision facts are shown, or their absence is explicitly routed through decision_review and decision_pressure.",
+                "anti_pattern": "Changed architecture without stating the agent-owned decision and durable owner.",
+            },
+        ],
+        "current_rendering": {
+            "profile": profile_policy.get("selected_profile"),
+            "rendering_mode": final_response_rendering.get("rendering_mode"),
+            "missing_required_facts": missing_facts,
+            "warnings": warnings,
+            "selected_review_mode": review_compression.get("selected_mode"),
+        },
+        "rule": "The rubric evaluates user-facing usefulness; canonical truth remains in closeout_report source fields.",
+    }
+
+
 def _closeout_report_final_response_rendering_payload(
     *,
     status: str,
@@ -7932,6 +8232,7 @@ def _closeout_report_final_response_rendering_payload(
     residual_risk: str,
     blockers: list[Any],
     next_action: str,
+    decision_review: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     profile = str(profile_policy.get("selected_profile") or "minimal")
     profile_reason = str(profile_policy.get("reason") or "").strip()
@@ -7943,6 +8244,7 @@ def _closeout_report_final_response_rendering_payload(
     must_include: list[str] = []
     summary_lines: list[str] = []
     must_not_claim: list[str] = ["Do not dump raw closeout_report JSON into the final user-facing response."]
+    decision_review = _as_dict(decision_review)
 
     def present(text: str) -> str:
         return text.strip() if text and text.strip().lower() not in {"none", "null", "unknown"} else ""
@@ -7957,7 +8259,7 @@ def _closeout_report_final_response_rendering_payload(
         plain_done_allowed: bool,
     ) -> dict[str, Any]:
         template_id = f"builtin/{rendering_mode}"
-        rendered_lines = summary_lines[:6]
+        rendered_lines = summary_lines[:8]
         if rendering_mode == "terse" and not rendered_lines:
             rendered_lines = ["Done."]
         required_checks: list[dict[str, str]] = []
@@ -7973,6 +8275,7 @@ def _closeout_report_final_response_rendering_payload(
             "authority boundary": ("authority:", "agent owns"),
             "outcome": ("outcome:", "done."),
             "validation": ("proof:", "validation:"),
+            "decision facts": ("decision:", "decision gap:"),
         }
         for fact in must_include:
             markers = fact_markers.get(fact, (fact,))
@@ -8074,6 +8377,18 @@ def _closeout_report_final_response_rendering_payload(
         summary_lines.append(f"Outcome: {outcome}")
     if present(changed_surfaces):
         summary_lines.append(f"Changed: {changed_surfaces}")
+    decision_status = str(decision_review.get("status") or "").strip()
+    decision_facts = _as_dict(decision_review.get("decision_facts"))
+    if decision_status in {"present", "partial"}:
+        must_include.append("decision facts")
+        decision_line = present(str(decision_facts.get("decision") or ""))
+        owner = present(str(decision_facts.get("durable_owner") or ""))
+        status_label = present(str(decision_facts.get("promotion_status") or ""))
+        suffix = "; ".join(item for item in [f"owner: {owner}" if owner else "", f"status: {status_label}" if status_label else ""] if item)
+        summary_lines.append(f"Decision: {decision_line}" + (f"; {suffix}" if suffix else ""))
+    elif decision_status == "absent-required":
+        must_include.append("decision facts")
+        summary_lines.append(f"Decision gap: {decision_review.get('decision_absent_because')}")
     if present(validation_proof):
         summary_lines.append(f"Proof: {validation_proof}")
 
@@ -8100,6 +8415,8 @@ def _closeout_report_final_response_rendering_payload(
         residue = present(next_action)
     if residue:
         summary_lines.append(f"Residue: {residue}")
+    elif profile_requires_detail:
+        summary_lines.append("Residue: none recorded.")
 
     if lower_trust or incomplete_or_partial or has_material_guidance_signal:
         must_not_claim.append("Do not render this closeout as a plain done summary without the lower-trust or incomplete-evidence caveat.")
@@ -8112,7 +8429,7 @@ def _closeout_report_final_response_rendering_payload(
         "required" if profile_requires_detail or lower_trust or incomplete_or_partial or has_material_guidance_signal else "available"
     )
     plain_done_allowed = not (lower_trust or incomplete_or_partial or has_material_guidance_signal)
-    summary_lines = summary_lines[:6]
+    summary_lines = summary_lines[:8]
     return {
         "kind": "agentic-workspace/final-closeout-rendering/v1",
         "status": status_value,
@@ -8208,6 +8525,10 @@ def _closeout_report_payload(
     completion_decision = str(completion_contract.get("completion_decision", "unknown"))
     residual_risk = str(_as_dict(closeout_trust.get("proof_confidence")).get("residual_risk", ""))
     blockers = first_blocking_option.get("blocking_fields", [])
+    decision_review = _closeout_report_decision_review_payload(
+        active_planning_record=active_planning_record,
+        proof_report=proof_report,
+    )
     final_response_rendering = _closeout_report_final_response_rendering_payload(
         status="present" if active_planning_record else "guidance-only",
         profile_policy=profile_policy,
@@ -8223,6 +8544,40 @@ def _closeout_report_payload(
         residual_risk=residual_risk,
         blockers=blockers if isinstance(blockers, list) else [],
         next_action=str(next_action),
+        decision_review=decision_review,
+    )
+    detail_commands = {
+        "closeout_report": profile_policy["next_command"],
+        "closeout_trust": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section closeout_trust --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+        "completion_contract": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section completion_contract --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+        "decision_pressure": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section decision_pressure --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+    }
+    follow_up_owner = str(
+        _as_dict(options.get("keep-parent-open")).get("owner") or completion_boundary.get("required_follow_up_owner") or ""
+    ).strip()
+    review_compression = _closeout_report_review_compression_payload(
+        profile_policy=profile_policy,
+        trust=trust,
+        completeness=completeness,
+        decision_review=decision_review,
+        residual_risk=residual_risk,
+        follow_up_owner=follow_up_owner,
+        detail_commands=detail_commands,
+    )
+    closeout_adoption = _closeout_report_adoption_payload(
+        profile_policy=profile_policy,
+        final_response_rendering=final_response_rendering,
+        decision_review=decision_review,
+        review_compression=review_compression,
     )
     closeout_authority_boundary = _authority_boundary_payload(
         surface="closeout_report",
@@ -8305,23 +8660,16 @@ def _closeout_report_payload(
             "rows": traceability_rows,
         },
         "completeness": completeness,
+        "decision_review": decision_review,
+        "review_compression": review_compression,
+        "closeout_adoption": closeout_adoption,
         "final_response_rendering": final_response_rendering,
         "next_action": {
             "summary": next_action,
             "command": profile_policy["next_command"],
             "run": profile_policy["next_command"],
         },
-        "detail_commands": {
-            "closeout_report": profile_policy["next_command"],
-            "closeout_trust": _command_with_cli_invoke(
-                command="agentic-workspace report --target ./repo --section closeout_trust --format json",
-                cli_invoke=config.cli_invoke,
-            ),
-            "completion_contract": _command_with_cli_invoke(
-                command="agentic-workspace report --target ./repo --section completion_contract --format json",
-                cli_invoke=config.cli_invoke,
-            ),
-        },
+        "detail_commands": detail_commands,
         "source_fields": [
             "planning.closeout_evidence.execution_run"
             if evidence_is_retained

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -1216,9 +1216,15 @@ def test_report_workspace_schema_documents_closeout_authority_boundary() -> None
 
     assert authority_boundary["$ref"] == "#/$defs/authority_boundary"
     assert "AW-enforced" in authority_boundary["description"]
+    assert "agent-authored system decision facts" in closeout_report["properties"]["decision_review"]["description"]
+    assert "first-inspection facts" in closeout_report["properties"]["review_compression"]["description"]
+    assert "quality rubric" in closeout_report["properties"]["closeout_adoption"]["description"]
     rendered = Path("docs/reference/workspace-report.md").read_text(encoding="utf-8")
     assert "closeout_report.authority_boundary" in rendered
     assert "Authority boundary showing which closeout/report signals" in rendered
+    assert "closeout_report.decision_review" in rendered
+    assert "closeout_report.review_compression" in rendered
+    assert "closeout_report.closeout_adoption" in rendered
 
 
 def test_report_router_surfaces_maintainer_mode_dogfooding_routes_from_local_config(tmp_path: Path, capsys) -> None:
@@ -3172,8 +3178,171 @@ def test_report_closeout_report_uses_audit_profile_for_strict_closeout(tmp_path:
     assert rendering["raw_json_allowed"] is False
     row_ids = {row["id"] for row in report["traceability"]["rows"]}
     assert {"intent-boundary", "work-completed", "changed-surfaces", "validation", "closure-boundary"} <= row_ids
+    assert report["decision_review"]["status"] == "not-applicable"
+    assert report["review_compression"]["selected_mode"] == "broad-pr"
+    assert report["closeout_adoption"]["status"] == "ready"
+    assert "what proof supports it?" in report["closeout_adoption"]["human_control_questions"]
     assert "derived operator-facing presentation" in report["boundary"]
     assert report["next_action"]["command"].endswith("--section closeout_report --format json")
+
+
+def test_report_closeout_report_renders_system_decision_facts(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write(
+        target / ".agentic-workspace" / "config.toml",
+        "schema_version = 1\n\n[assurance]\nstrict_closeout = true\n",
+    )
+    plan = target / ".agentic-workspace" / "planning" / "execplans" / "decision-closeout.plan.json"
+    _write_json(
+        plan,
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Decision Closeout",
+            "active_milestone": {"id": "decision-closeout", "status": "complete"},
+            "adaptive_assurance": {"level": "high", "reason": "system-shaping report behavior"},
+            "traceability_refs": {
+                "domain_model_refs": ["closeout_report"],
+                "decision_refs": ["Render agent-authored system decision facts in closeout."],
+            },
+            "architecture_decision_promotion": {
+                "status": "candidate",
+                "decision": "Use a derived decision-review packet instead of a durable decision store.",
+                "rationale": "The agent owns the semantic decision while AW preserves and renders the facts.",
+                "tradeoffs": ["Avoids a new ADR engine", "Keeps closeout_report derived"],
+                "affected_surfaces": ["closeout_report", "decision_pressure"],
+                "proof": "uv run pytest tests/test_workspace_report_cli.py -q passed",
+                "durable_owner": "Planning architecture_decision_promotion",
+            },
+            "delegated_judgment": {
+                "requested outcome": "Expose system-decision facts for human review.",
+                "hard constraints": "Do not let AW infer architecture decisions.",
+                "agent may decide locally": "Packet wording.",
+            },
+            "completion_criteria": ["Decision facts render in closeout_report."],
+            "validation_commands": ["uv run pytest tests/test_workspace_report_cli.py -q"],
+            "execution_run": {
+                "run status": "complete",
+                "what happened": "Implemented derived decision review for closeout.",
+                "scope touched": "reporting runtime and tests",
+                "changed surfaces": "workspace_runtime_primitives.py; tests/test_workspace_report_cli.py",
+                "validations run": "uv run pytest tests/test_workspace_report_cli.py -q",
+                "result for continuation": "close",
+            },
+            "proof_report": {
+                "validation proof": "uv run pytest tests/test_workspace_report_cli.py -q passed",
+                "proof achieved now": "yes",
+                "intent_proof": {
+                    "status": "sufficient_for_claim",
+                    "claim_boundary": "work",
+                    "intended_behavior": ["decision facts render"],
+                    "proof_dimensions": ["closeout report fixture"],
+                    "unproven_after_tests": [],
+                },
+            },
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": "closed",
+                "closure decision": "archive-and-close",
+                "why this decision is honest": "Decision facts, proof, and owner are visible.",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'decision-closeout', title = 'Decision closeout', surface = '.agentic-workspace/planning/execplans/decision-closeout.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_report", "--format", "json"]) == 0
+
+    report = json.loads(capsys.readouterr().out)["answer"]
+    decision_review = report["decision_review"]
+    assert decision_review["status"] == "present"
+    assert decision_review["decision_facts"]["decision"] == "Use a derived decision-review packet instead of a durable decision store."
+    assert decision_review["decision_facts"]["rationale"].startswith("The agent owns")
+    assert decision_review["decision_facts"]["tradeoffs"] == ["Avoids a new ADR engine", "Keeps closeout_report derived"]
+    assert decision_review["decision_facts"]["durable_owner"] == "Planning architecture_decision_promotion"
+    assert decision_review["completeness"]["missing_facts"] == []
+    assert report["review_compression"]["selected_mode"] == "system-shaping-change"
+    assert "decision facts" in report["review_compression"]["first_inspection"]["first_inspection_facts"]
+    rendered = report["final_response_rendering"]["rendered_summary"]["rendered_text"]
+    assert "Decision: Use a derived decision-review packet instead of a durable decision store." in rendered
+    assert "decision facts" in report["final_response_rendering"]["must_include"]
+    assert report["closeout_adoption"]["status"] == "ready"
+    assert report["detail_commands"]["decision_pressure"].endswith("--section decision_pressure --format json")
+
+
+def test_report_closeout_report_routes_missing_system_decision_facts(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write(
+        target / ".agentic-workspace" / "config.toml",
+        "schema_version = 1\n\n[assurance]\nstrict_closeout = true\n",
+    )
+    plan = target / ".agentic-workspace" / "planning" / "execplans" / "missing-decision.plan.json"
+    _write_json(
+        plan,
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Missing Decision Facts",
+            "active_milestone": {"id": "missing-decision", "status": "complete"},
+            "adaptive_assurance": {"level": "high", "reason": "system-shaping reporting contract"},
+            "traceability_refs": {"domain_model_refs": ["workspace report schema"]},
+            "delegated_judgment": {
+                "requested outcome": "Change a system-shaping report contract.",
+                "hard constraints": "Do not hide missing decision rationale.",
+            },
+            "completion_criteria": ["Decision absence is visible."],
+            "validation_commands": ["uv run pytest tests/test_workspace_report_cli.py -q"],
+            "execution_run": {
+                "run status": "complete",
+                "what happened": "Changed report contract behavior.",
+                "scope touched": "reporting contract",
+                "changed surfaces": "workspace_runtime_primitives.py",
+                "validations run": "uv run pytest tests/test_workspace_report_cli.py -q",
+            },
+            "proof_report": {"validation proof": "uv run pytest tests/test_workspace_report_cli.py -q passed"},
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": "closed",
+                "closure decision": "archive-and-close",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'missing-decision', title = 'Missing decision', surface = '.agentic-workspace/planning/execplans/missing-decision.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_report", "--format", "json"]) == 0
+
+    report = json.loads(capsys.readouterr().out)["answer"]
+    decision_review = report["decision_review"]
+    assert decision_review["status"] == "absent-required"
+    assert "no agent-authored decision facts" in decision_review["decision_absent_because"]
+    assert decision_review["routing"]["promotion_pressure_surface"] == "report --section decision_pressure"
+    assert report["review_compression"]["selected_mode"] == "system-shaping-change"
+    assert report["closeout_adoption"]["status"] == "needs-attention"
+    assert any("system-shaping decision facts" in item for item in report["review_compression"]["human_owned_decisions"])
+    rendered = report["final_response_rendering"]["rendered_summary"]["rendered_text"]
+    assert "Decision gap:" in rendered
+    assert "decision facts" in report["final_response_rendering"]["must_include"]
 
 
 def test_report_closeout_report_flags_incomplete_evidence_and_degrades_trust(tmp_path: Path, capsys) -> None:

--- a/tools/model-cli-harness/fixtures/aw-invalid-planning-host-repo/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/tools/model-cli-harness/fixtures/aw-invalid-planning-host-repo/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -91,6 +91,12 @@
         "status": { "enum": ["none", "candidate", "needed", "promoted", "deferred"] },
         "target": { "type": "string" },
         "decision_refs": { "$ref": "#/$defs/string_array" },
+        "decision": { "type": "string" },
+        "rationale": { "type": "string" },
+        "tradeoffs": { "$ref": "#/$defs/string_array" },
+        "affected_surfaces": { "$ref": "#/$defs/string_array" },
+        "proof": { "type": "string" },
+        "durable_owner": { "type": "string" },
         "promotion_needed": { "type": "boolean" },
         "notes": { "type": "string" }
       }

--- a/tools/model-cli-harness/fixtures/aw-minimal-host-repo/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/tools/model-cli-harness/fixtures/aw-minimal-host-repo/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -91,6 +91,12 @@
         "status": { "enum": ["none", "candidate", "needed", "promoted", "deferred"] },
         "target": { "type": "string" },
         "decision_refs": { "$ref": "#/$defs/string_array" },
+        "decision": { "type": "string" },
+        "rationale": { "type": "string" },
+        "tradeoffs": { "$ref": "#/$defs/string_array" },
+        "affected_surfaces": { "$ref": "#/$defs/string_array" },
+        "proof": { "type": "string" },
+        "durable_owner": { "type": "string" },
         "promotion_needed": { "type": "boolean" },
         "notes": { "type": "string" }
       }


### PR DESCRIPTION
## Summary

Implements the human-review closeout lane across the three refined issues:

- Adds derived `closeout_report.decision_review` so agent-authored system decision facts are visible at closeout, including absence routing when system-shaping signals exist without decision facts.
- Adds `closeout_report.review_compression` to tell reviewers what to inspect first for small edits, planned slices, broad PRs, system-shaping changes, lower-trust closeouts, and residue-heavy work.
- Adds `closeout_report.closeout_adoption` with the user-facing quality bar, human-control questions, terse-closeout criteria, examples, and anti-patterns.
- Updates workspace report schema/reference docs, reporting contract docs, Planning execplan schema payload copies, and tests.
- Dogfoods the new report on this lane and checks in archived closeout evidence showing the rendered `Decision:` line.

Closes #1240.
Closes #1241.
Closes #1242.

## Validation

- `uv run pytest tests/test_workspace_report_cli.py::test_report_workspace_schema_documents_closeout_authority_boundary tests/test_workspace_report_cli.py::test_report_closeout_report_uses_audit_profile_for_strict_closeout tests/test_workspace_report_cli.py::test_report_closeout_report_renders_system_decision_facts tests/test_workspace_report_cli.py::test_report_closeout_report_routes_missing_system_decision_facts tests/test_workspace_report_cli.py::test_report_closeout_report_flags_incomplete_evidence_and_degrades_trust -q`
- `uv run python -m py_compile src/agentic_workspace/workspace_runtime_primitives.py`
- `git diff --check`
- `uv run python -m json.tool .agentic-workspace/planning/execplans/archive/github-1240-1242-human-review-control-surfaces.plan.json`
- PowerShell `ConvertFrom-Json` parse check for the archived plan
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/check/check_generated_command_packages.py`
- `make maintainer-surfaces`
- `make schema-reference-docs`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`

## Dogfooding notes

The new closeout report now selects `system-shaping-change` for this lane and renders a concrete `Decision:` line in `final_response_rendering`. Two separate follow-up issues will be filed for unrelated dogfooding friction observed during validation: concurrent generated-CLI fingerprint cache writes on Windows, and closeout archive evidence with case-variant execution-summary keys.