### PR TITLE
Add grounding reviews for open issues

### DIFF
--- a/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1249-closeout-review-compression-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1249-closeout-review-compression-grounding.review.json
@@ -1,0 +1,158 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1249 closeout/report first-inspection compression",
+  "date": "2026-06-04",
+  "classification": "review-compression",
+  "goal": [
+    "Ground #1249 in current closeout_report, final_response_rendering, decision_review, and review_compression behavior before implementation.",
+    "Identify the first bounded slice that reduces human review cost without adding another broad surface."
+  ],
+  "scope": [
+    "Issue #1249 and the existing closeout/report contract.",
+    "Current report --section closeout_report output on this repo.",
+    "Regression tests and reference docs that already define closeout rendering, decision review, and review compression behavior."
+  ],
+  "non_goals": [
+    "Do not implement a new review dashboard in this review.",
+    "Do not remove high-risk code review or human acceptance judgment.",
+    "Do not claim #1249 is complete until the work-shape inspection contract is implemented or explicitly rejected."
+  ],
+  "review_mode": {
+    "mode": "grounding-review",
+    "review question": "Which closeout/report facts should be first-inspection material by work shape, and what should stay secondary detail?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1249",
+      "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      ".agentic-workspace/docs/reporting-contract.md",
+      "docs/reference/workspace-report.md",
+      "tests/test_workspace_report_cli.py"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "uv run python scripts/run_agentic_workspace.py start --task \"create and link in-depth grounding reviews for each open GitHub issue\" --format json",
+      "gh issue list --state open --limit 100 --json number,title,labels,url,body",
+      "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      "rg -n \"closeout_report|final_response_rendering|review_compression|decision_review|authority_boundary\" .agentic-workspace docs src tests"
+    ],
+    "evidence sources": [
+      "#1249 issue body",
+      "current closeout_report JSON",
+      ".agentic-workspace/docs/reporting-contract.md",
+      "docs/reference/workspace-report.md",
+      "tests/test_workspace_report_cli.py closeout_report tests"
+    ],
+    "limitation": "This review grounds implementation shape from product and test surfaces; it did not run a human usability study."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1249",
+      "label": "Closeout/report first-inspection compression by work shape",
+      "role": "implementation owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1249"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      "label": "Current closeout_report",
+      "role": "primary behavior evidence"
+    },
+    {
+      "kind": "local-doc",
+      "target": ".agentic-workspace/docs/reporting-contract.md",
+      "label": "Reporting contract",
+      "role": "contract owner"
+    },
+    {
+      "kind": "local-test",
+      "target": "tests/test_workspace_report_cli.py",
+      "label": "Closeout/report tests",
+      "role": "regression surface"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1249",
+      "kind": "review/trust gap",
+      "implementation_allowed_after_review": true,
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": "closeout_report/final_response_rendering plus issue follow-up"
+    }
+  ],
+  "summary": {
+    "current_state": "The current closeout_report already emits profile_policy, traceability, completeness, decision_review, review_compression, closeout_adoption, authority_boundary, and final_response_rendering.",
+    "implementation_posture": "Do not add a new top-level report surface first. Make the existing review_compression and final_response_rendering packets more directly actionable for first inspection by work shape.",
+    "first_slice": "Codify a small work-shape mode contract and tests for small direct, planned slice, broad PR, system-shaping, partial/lower-trust, and residue-heavy closeouts."
+  },
+  "findings": [
+    {
+      "title": "The compression data already exists but needs a first-inspection contract",
+      "summary": "Current closeout_report includes a review_compression packet with modes and first_inspection_facts, but #1249 is still valid because the issue asks for a review contract that tells humans and agents what to inspect first and what can be secondary.",
+      "evidence": "Current closeout_report selected mode partial-or-lower-trust-closeout and listed first inspection facts such as blocking caveat, missing proof or intent evidence, residual risk, owner, and allowed closure claim. The same output also includes many adjacent packets, confirming the overload risk named in #1249.",
+      "risk if unchanged": "Agents may keep dumping or paraphrasing many report fields instead of giving a predictable review path by work shape.",
+      "suggested action": "Promote the existing review_compression packet from descriptive guidance into a tested contract for first-inspection facts, detail routes, and human-owned decisions by work shape.",
+      "confidence": "high",
+      "source": "current closeout_report output and #1249 issue body",
+      "promotion target": "#1249 implementation slice",
+      "promotion trigger": "When implementing the first-inspection mode map."
+    },
+    {
+      "title": "final_response_rendering is the right user-facing front door",
+      "summary": "The final response packet already carries rendered text, must_include, must_not_claim, plain_done_allowed, and raw_json_allowed. This is where the user-facing compression should land before adding another output surface.",
+      "evidence": "Current final_response_rendering rendered an audit summary and explicitly prohibited raw JSON and plain done output while lower-trust caveats were present.",
+      "risk if unchanged": "Implementation could add another review artifact while the actual in-chat report remains unchanged, repeating the closeout UX gap the user flagged earlier.",
+      "suggested action": "Make work-shape selection visibly affect rendered_summary and constraints. Tests should assert final response guidance, not only raw report fields.",
+      "confidence": "high",
+      "source": "current closeout_report.final_response_rendering and tests/test_workspace_report_cli.py",
+      "promotion target": "#1249 tests and rendering contract",
+      "promotion trigger": "When choosing the first implementation surface."
+    },
+    {
+      "title": "System-shaping mode must depend on decision facts rather than raw diff scale",
+      "summary": "The current decision_review packet correctly separates decision facts from closeout traceability. Review compression should select system-shaping mode from explicit signals or authored decision facts, not merely file count or broad change shape.",
+      "evidence": "Current closeout_report.decision_review is not-applicable for the recent bug-fix closeout while review_compression selects partial/lower-trust because of trust and residue signals. Tests already cover present and missing decision facts.",
+      "risk if unchanged": "AW could reintroduce heuristic-style classification by treating broad changes as system decisions without agent-authored rationale.",
+      "suggested action": "Require system-shaping review mode to show decision facts when present, or an explicit routed absence when a system-shaping signal exists and facts are missing.",
+      "confidence": "medium-high",
+      "source": "closeout_report.decision_review, review_compression output, #1250 dependency",
+      "promotion target": "#1249 plus #1250",
+      "promotion trigger": "When adding system-shaping mode fixtures."
+    },
+    {
+      "title": "The implementation should subtract or prioritize before adding fields",
+      "summary": "#1249 is a compression issue. The first slice should specify precedence and detail routing over adding new visible facts.",
+      "evidence": "The current report already includes profile_policy, authority_boundary, traceability, completeness, decision_review, review_compression, closeout_adoption, final_response_rendering, and detail_commands.",
+      "risk if unchanged": "The fix could worsen review cost by increasing the amount of first-screen material.",
+      "suggested action": "For each mode, define the smallest must-include set and the secondary detail commands. Make tests fail when a mode requires raw JSON or too many unrelated packets for first inspection.",
+      "confidence": "high",
+      "source": "current report field inventory",
+      "promotion target": "#1249 acceptance criteria",
+      "promotion trigger": "Before implementation expands any report schema."
+    }
+  ],
+  "recommendation": {
+    "promote": "Promote a bounded implementation slice for review_compression/final_response_rendering mode contracts.",
+    "defer": "Defer any new dashboard or top-level report surface.",
+    "dismiss": "Do not dismiss; the current report is powerful but still costly to inspect without a prioritized mode contract.",
+    "first_slice": "Add or tighten tests for selected_mode, first_inspection_facts, detail_routes, human_owned_decisions, and rendered_summary constraints across representative work shapes.",
+    "validation": "Focused tests in tests/test_workspace_report_cli.py plus AW summary and planning doctor."
+  },
+  "retention": {
+    "closeout shape": "keep until #1249 implementation or superseding issue comment captures the mode contract",
+    "trigger": "Findings promoted into tests, reporting contract, or issue refinement",
+    "proof surface": "This review, #1249, and resulting closeout_report tests",
+    "source retention rule": "Keep the judgment and exact source references; avoid copying full report JSON into future artifacts."
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-04-open-issue-1249-closeout-review-compression-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-04: Review record created by create-review.",
+    "2026-06-04: Populated grounding review after inspecting #1249, current closeout_report output, reporting contract, reference docs, and closeout tests."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1250-decision-traceability-owner-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1250-decision-traceability-owner-grounding.review.json
@@ -1,0 +1,163 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1250 decision traceability owner model",
+  "date": "2026-06-04",
+  "classification": "decision-traceability",
+  "goal": [
+    "Ground #1250 in current decision_pressure and closeout_report decision_review behavior.",
+    "Define the owner split needed before implementing durable decision traceability."
+  ],
+  "scope": [
+    "Issue #1250 and the current decision-related report surfaces.",
+    "closeout_report.decision_review, decision_pressure, Planning closeout evidence, reporting contract text, and representative tests.",
+    "Durable owner options: Planning, ADR/docs, Memory, config/checks, and issue follow-up."
+  ],
+  "non_goals": [
+    "Do not build a new ADR engine in this review.",
+    "Do not require formal decision records for small direct work.",
+    "Do not make AW infer semantic decisions from diffs or file names."
+  ],
+  "review_mode": {
+    "mode": "contract-integrity",
+    "review question": "What should the agent author, what may AW derive, and where should durable system decisions live?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1250",
+      "uv run python scripts/run_agentic_workspace.py report --section decision_pressure --format json",
+      "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      ".agentic-workspace/docs/reporting-contract.md",
+      "tests/test_workspace_report_cli.py"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "gh issue list --state open --limit 100 --json number,title,labels,url,body",
+      "uv run python scripts/run_agentic_workspace.py report --section decision_pressure --format json",
+      "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      "rg -n \"decision_pressure|decision_review|architecture_decision|decision facts|durable owner\" .agentic-workspace docs src tests packages"
+    ],
+    "evidence sources": [
+      "#1250 issue body",
+      "current decision_pressure output",
+      "current closeout_report decision_review output",
+      "reporting contract",
+      "tests covering present and missing decision facts"
+    ],
+    "limitation": "This review defines implementation boundaries. It does not evaluate every historical system-shaping PR."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1250",
+      "label": "Decision traceability owner model",
+      "role": "implementation owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1250"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py report --section decision_pressure --format json",
+      "label": "Current decision_pressure",
+      "role": "routing evidence"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      "label": "Current closeout_report decision_review",
+      "role": "derived display evidence"
+    },
+    {
+      "kind": "local-doc",
+      "target": ".agentic-workspace/docs/reporting-contract.md",
+      "label": "Reporting contract",
+      "role": "authority and decision boundary contract"
+    },
+    {
+      "kind": "local-test",
+      "target": "tests/test_workspace_report_cli.py",
+      "label": "Decision-review tests",
+      "role": "expected behavior evidence"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1250",
+      "kind": "review/trust gap",
+      "implementation_allowed_after_review": true,
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": "Planning-authored facts rendered by closeout_report and routed by decision_pressure"
+    }
+  ],
+  "summary": {
+    "current_state": "decision_pressure is not configured in this repo, but it already exposes the intended role: preserve and route decision records without forcing every task to create one. closeout_report.decision_review renders agent-authored decision facts when present and treats the current bug-fix closeout as not-applicable.",
+    "owner_model": "The agent authors semantic decision facts; AW checks presence, derives display packets, and routes promotion; durable accepted decisions live in host-owned docs/ADR/Memory/config/checks/issues depending on scope.",
+    "first_slice": "Add an explicit owner-model contract and fixtures for no decision, decision facts present, missing facts under system-shaping signals, and configured durable target."
+  },
+  "findings": [
+    {
+      "title": "AW already has the authority boundary; it still needs a durable-owner decision model",
+      "summary": "The current surfaces correctly avoid saying AW makes semantic decisions, but #1250 remains necessary because they do not yet define when active Planning facts must be promoted into durable host-owned records.",
+      "evidence": "decision_pressure output states: 'Agent owns architecture judgment; AW preserves and routes decision records without forcing every task to create one.' closeout_report.decision_review says the agent authors semantic system decisions while AW preserves, renders, checks completeness, and routes promotion.",
+      "risk if unchanged": "System-shaping work may have correct authority wording but still leave decision rationale trapped in transient planning residue or PR prose.",
+      "suggested action": "Implement a proportional owner model that distinguishes active decision facts, derived review display, promotion pressure, and durable host-owned records.",
+      "confidence": "high",
+      "source": "current decision_pressure and closeout_report output",
+      "promotion target": "#1250 implementation",
+      "promotion trigger": "When a system-shaping change has material decision facts or missing decision facts."
+    },
+    {
+      "title": "decision_pressure should remain routing, not semantic classification",
+      "summary": "The safest implementation keeps decision_pressure focused on configuration, existing durable records, active planning decision candidates, memory pressure, and commands. It should not infer the architecture decision from changed files.",
+      "evidence": "Current decision_pressure reports configuration not-configured, candidate_count 0, and no available scaffold/promote actions because no durable target is configured.",
+      "risk if unchanged": "A deeper implementation could reintroduce the earlier 'AW classified/routed/decided' UX bug by presenting inferred decisions as AW-owned facts.",
+      "suggested action": "Require agent-authored decision fields for semantic decision content. AW may only report absence, completeness, and routes.",
+      "confidence": "high",
+      "source": "decision_pressure output and authority-boundary direction",
+      "promotion target": "#1250 acceptance criteria",
+      "promotion trigger": "When defining decision_pressure behavior under system-shaping work."
+    },
+    {
+      "title": "Small work must remain decision-light",
+      "summary": "The current bug-fix closeout is correctly marked decision_review not-applicable even though it touched multiple files and planning archives. This is a useful guardrail for proportionality.",
+      "evidence": "closeout_report.decision_review status is not-applicable for the generated CLI cache and closeout evidence bug-fix closeout. Missing decision facts are not treated as blockers when there are no system_shaping_signals.",
+      "risk if unchanged": "A formal decision model could create too much ceremony and weaken ordinary agent ergonomics.",
+      "suggested action": "Tests should assert that small direct or bug-fix work does not require decision records unless explicit system-shaping signals or agent-authored architecture_decision_promotion facts exist.",
+      "confidence": "high",
+      "source": "current closeout_report output",
+      "promotion target": "#1250 tests",
+      "promotion trigger": "When adding durable-owner or missing-decision checks."
+    },
+    {
+      "title": "Durable target configuration is the first practical implementation seam",
+      "summary": "The report already names configuration fields for a decision record target, format, template, and statuses. Implementation can start by making this route clearer before designing new storage.",
+      "evidence": "decision_pressure.configuration lists assurance.decision_record_target, assurance.decision_record_format, assurance.decision_record_template, and assurance.decision_record_statuses; actions are unavailable because no target is configured.",
+      "risk if unchanged": "Agents will know decision facts are missing but not where to promote them, leaving system-shaping decisions in issue comments or chat.",
+      "suggested action": "First slice should define behavior for configured and unconfigured durable targets: scaffold, promote, or explicitly route to issue follow-up when no configured target exists.",
+      "confidence": "medium-high",
+      "source": "decision_pressure configuration output",
+      "promotion target": "#1250 first bounded slice",
+      "promotion trigger": "When turning the owner model into command/report behavior."
+    }
+  ],
+  "recommendation": {
+    "promote": "Promote implementation after accepting the owner split: agent-authored facts, AW-derived display/completeness, decision_pressure promotion, host-owned durable targets.",
+    "defer": "Defer a full ADR subsystem and broad historical migration.",
+    "dismiss": "Do not dismiss; decision routing exists but durable ownership remains unresolved.",
+    "first_slice": "Add a contract/test slice around configured versus unconfigured durable target behavior and proportional missing-decision routing.",
+    "validation": "Focused tests in tests/test_workspace_report_cli.py plus any decision-scaffold/promote tests if command behavior changes."
+  },
+  "retention": {
+    "closeout shape": "keep until #1250 implementation or issue refinement captures the owner model",
+    "trigger": "Findings promoted into reporting contract, tests, or a narrower implementation issue",
+    "proof surface": "This review, #1250, decision_pressure output, and closeout_report decision_review tests"
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-04-open-issue-1250-decision-traceability-owner-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-04: Review record created by create-review.",
+    "2026-06-04: Populated grounding review after inspecting #1250, decision_pressure, closeout_report.decision_review, reporting contract, and tests."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1251-intent-discovery-compliance-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1251-intent-discovery-compliance-grounding.review.json
@@ -1,0 +1,157 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1251 intent-discovery compliance",
+  "date": "2026-06-04",
+  "classification": "intent-discovery",
+  "goal": [
+    "Ground #1251 in current startup, intent acknowledgement, Planning, closeout, and skill surfaces.",
+    "Identify the smallest implementation that makes inferred or assumption-based intent visible without blocking ordinary work."
+  ],
+  "scope": [
+    "Issue #1251 and the workspace-intent-discovery skill.",
+    "start and implement outputs that include intent_acknowledgement and acceptance reconciliation.",
+    "Planning and closeout fields that preserve interpreted intent and closure boundaries."
+  ],
+  "non_goals": [
+    "Do not require clarification for every vague prompt.",
+    "Do not replace agent judgment with keyword-based prompt classes.",
+    "Do not implement new gates before the evidence path is clear."
+  ],
+  "review_mode": {
+    "mode": "workflow-compliance",
+    "review question": "Where should evidence of user clarification, issue-derived intent, or agent assumptions be visible before broad work proceeds?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1251",
+      ".agentic-workspace/skills/workspace-intent-discovery/SKILL.md",
+      "start --task output",
+      "implement --changed output",
+      "closeout_report interpreted_intent fields"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "uv run python scripts/run_agentic_workspace.py start --task \"create and link in-depth grounding reviews for each open GitHub issue\" --format json",
+      "uv run python scripts/run_agentic_workspace.py implement --changed <review paths> --task \"create and link in-depth grounding reviews for each open GitHub issue\" --format json",
+      "uv run python scripts/run_agentic_workspace.py report --section closeout_report --format json",
+      "rg -n \"intent_acknowledgement|durable_intent|intent-discovery|interpreted_intent|acceptance_reconciliation\" .agentic-workspace src tests packages"
+    ],
+    "evidence sources": [
+      "#1251 issue body",
+      ".agentic-workspace/skills/workspace-intent-discovery/SKILL.md",
+      "current start and implement JSON",
+      "closeout_report interpreted_intent and closure_boundary",
+      "reporting and planning tests around intent fields"
+    ],
+    "limitation": "This review did not create a full vague-prompt fixture matrix; it identifies the implementation seam for that matrix."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1251",
+      "label": "Intent-discovery compliance and evidence path",
+      "role": "implementation owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1251"
+    },
+    {
+      "kind": "local-skill",
+      "target": ".agentic-workspace/skills/workspace-intent-discovery/SKILL.md",
+      "label": "Intent discovery skill",
+      "role": "behavioral guidance"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py start --task ... --format json",
+      "label": "startup intent acknowledgement",
+      "role": "current output evidence"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py implement --changed <review paths> --task ... --format json",
+      "label": "implement acceptance reconciliation",
+      "role": "current output evidence"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1251",
+      "kind": "review/trust gap",
+      "implementation_allowed_after_review": true,
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": "startup/implement intent acknowledgement plus Planning closeout interpreted-intent evidence"
+    }
+  ],
+  "summary": {
+    "current_state": "start and implement already include intent_acknowledgement and acceptance_reconciliation packets, but they do not yet expose a rich source-of-intent chain such as user clarification, issue evidence, or agent assumption.",
+    "implementation_posture": "Add evidence-path clarity before adding hard clarification gates.",
+    "first_slice": "Create fixtures for vague/high-stakes prompts showing ask, proceed-with-assumption, and issue-evidence-derived intent."
+  },
+  "findings": [
+    {
+      "title": "The evidence path exists in pieces but is not yet reviewable as a chain",
+      "summary": "Intent appears in start/implement acceptance packets and closeout interpreted_intent, but the user or takeover agent cannot cheaply see whether it came from clarification, issue evidence, or agent inference.",
+      "evidence": "Current start output includes intent_acknowledgement with decision proceed-with-stated-assumption and fields such as inferred_intent, concrete_first_slice, non_goals_or_deferred_scope, and correction_point. implement output includes acceptance_reconciliation and objective_drift status.",
+      "risk if unchanged": "Agents can narrow broad work to plausible bounded slices without making the source and risk of that interpretation visible.",
+      "suggested action": "Add or formalize an intent_source/evidence packet that can be carried from startup into Planning and closeout.",
+      "confidence": "high",
+      "source": "current start and implement output",
+      "promotion target": "#1251 implementation",
+      "promotion trigger": "When a task proceeds with assumptions or issue-derived intent rather than user clarification."
+    },
+    {
+      "title": "Proceed-with-assumptions should remain allowed but auditable",
+      "summary": "The current behavior rightly avoids blocking every ambiguous task. The gap is not permission; it is auditability and correction.",
+      "evidence": "Current start output says proceed_unless_corrected true and clarify_only_if_blocked true. AW also tells the agent to ask only if scope, authority, risk, or intent is genuinely blocked.",
+      "risk if unchanged": "A stricter fix could make AW annoying for ordinary work, while the current state can hide risky assumptions.",
+      "suggested action": "Keep proceed-with-assumptions, but require visible assumption text and correction point for broad, high-stakes, or externally sourced work.",
+      "confidence": "high",
+      "source": "start output and #1251 issue intent",
+      "promotion target": "#1251 acceptance criteria",
+      "promotion trigger": "When defining clarification versus proceed behavior."
+    },
+    {
+      "title": "Closeout should expose intent source, not only intent satisfaction",
+      "summary": "closeout_report currently reports interpreted_intent and intent_satisfaction status, but the implementation should preserve whether the interpretation came from user text, issue fields, or agent assumptions.",
+      "evidence": "Current closeout_report.interpreted_intent shows requested_outcome and intent_satisfaction, while closure_boundary reports completion decision and sources from planning active fields.",
+      "risk if unchanged": "A final report may say the intent was satisfied while hiding that the intent was inferred under uncertainty.",
+      "suggested action": "Add source and confidence facts to the closeout/report chain when intent was not directly clarified by the user.",
+      "confidence": "medium-high",
+      "source": "closeout_report interpreted_intent and closure_boundary output",
+      "promotion target": "#1251 plus closeout_report tests",
+      "promotion trigger": "When implementing vague-prompt fixtures."
+    },
+    {
+      "title": "The first tests should be scenario-based, not keyword-based",
+      "summary": "The issue exists because skill text alone is not enough to make agents preserve intent. Tests should exercise scenarios and expected evidence, not prompt keyword classifiers.",
+      "evidence": "#1251 explicitly warns that agents prefer to start working when they can invent a plausible bounded slice. Recent AW direction also rejects prompt phrase exceptions and asks agents to own semantic judgment with AW support.",
+      "risk if unchanged": "The implementation could rebuild the hard-coded heuristic behavior the repo has been moving away from.",
+      "suggested action": "Create fixtures for vague broad request, high-stakes ambiguous request, issue-evidence request, and ordinary direct request; assert evidence posture and allowed action rather than keyword categories.",
+      "confidence": "high",
+      "source": "#1251 issue body and current authority-boundary direction",
+      "promotion target": "#1251 tests",
+      "promotion trigger": "Before adding any new gate."
+    }
+  ],
+  "recommendation": {
+    "promote": "Promote a bounded evidence-path implementation after fixtures define ask/proceed/issue-evidence scenarios.",
+    "defer": "Defer broad hard gates for vague language.",
+    "dismiss": "Do not dismiss; current packets are not enough to reconstruct intent source cheaply.",
+    "first_slice": "Add scenario fixtures and a compact intent-source/assumption/correction-point packet through start/implement and closeout/report where applicable.",
+    "validation": "Focused startup/report tests plus AW summary and planning doctor."
+  },
+  "retention": {
+    "closeout shape": "keep until #1251 implementation or issue refinement captures the evidence path",
+    "trigger": "Findings promoted into tests, contract, or narrower follow-up",
+    "proof surface": "This review, #1251, startup/implement fixtures, and closeout/report tests"
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-04-open-issue-1251-intent-discovery-compliance-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-04: Review record created by create-review.",
+    "2026-06-04: Populated grounding review after inspecting #1251, intent-discovery skill, start/implement output, and closeout_report intent fields."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1252-proof-route-lifecycle-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1252-proof-route-lifecycle-grounding.review.json
@@ -1,0 +1,164 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1252 proof-route learning lifecycle",
+  "date": "2026-06-04",
+  "classification": "proof-route-lifecycle",
+  "goal": [
+    "Ground #1252 in current proof selection, proof-route hint, Memory, and closeout proof surfaces.",
+    "Define lifecycle boundaries that let agents reuse learned proof routes without turning stale hints into hidden heuristics."
+  ],
+  "scope": [
+    "Issue #1252 and proof-route behavior across workspace, Memory, Verification, and closeout/report surfaces.",
+    "Current proof command behavior on an unscoped repo and changed-path implement output.",
+    "Host-repo learning guidance that warns against assuming pytest or other proof commands from weak markers."
+  ],
+  "non_goals": [
+    "Do not select a universal proof command for all host repos.",
+    "Do not implement full proof-route promotion in this review.",
+    "Do not treat Memory or route hints as authoritative without provenance and freshness."
+  ],
+  "review_mode": {
+    "mode": "proof-governance",
+    "review question": "How should proof routes move between candidate, confirmed, stale, negative, and superseded without becoming hidden assumptions?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1252",
+      "uv run python scripts/run_agentic_workspace.py proof --format json",
+      "uv run python scripts/run_agentic_workspace.py implement --changed <review paths> --format json",
+      "docs/host-repo-learning.md",
+      "src/agentic_workspace/workspace_runtime_primitives.py proof-route functions",
+      "packages/verification runtime proof-route and stale evidence handling"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "uv run python scripts/run_agentic_workspace.py proof --format json",
+      "uv run python scripts/run_agentic_workspace.py implement --changed <review paths> --task \"create and link in-depth grounding reviews for each open GitHub issue\" --format json",
+      "rg -n \"proof_route|proof-route|canonical_proof_route|PROOF_ROUTE_HINTS_PATH|stale-evidence|negative|superseded\" src packages tests docs .agentic-workspace"
+    ],
+    "evidence sources": [
+      "#1252 issue body",
+      "proof command output",
+      "implement proof-selection output",
+      "docs/host-repo-learning.md",
+      "workspace proof-route hint loading and Verification stale-evidence code",
+      "closeout_report proof confidence fields"
+    ],
+    "limitation": "This review did not trace every proof-route state transition in code; it identifies the states and proof obligations implementation must preserve."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1252",
+      "label": "Proof-route learning lifecycle and stale-evidence handling",
+      "role": "implementation owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1252"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py proof --format json",
+      "label": "Unscoped proof output",
+      "role": "current selection behavior"
+    },
+    {
+      "kind": "local-doc",
+      "target": "docs/host-repo-learning.md",
+      "label": "Host-repo learning guidance",
+      "role": "anti-heuristic proof selection contract"
+    },
+    {
+      "kind": "local-code",
+      "target": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "label": "Proof-route hint loading",
+      "role": "runtime behavior surface"
+    },
+    {
+      "kind": "local-code",
+      "target": "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py",
+      "label": "Verification stale evidence",
+      "role": "staleness model precedent"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1252",
+      "kind": "review/trust gap",
+      "implementation_allowed_after_review": true,
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": "proof selection, Memory proof-route notes, Verification stale evidence, and closeout proof reporting"
+    }
+  ],
+  "summary": {
+    "current_state": "Unscoped proof output correctly has no required commands. Changed-path implement output can select focused proof. Runtime code has proof-route hint concepts, and Verification already models stale evidence.",
+    "implementation_posture": "Define lifecycle state transitions and reporting before expanding proof-route automation.",
+    "first_slice": "Add fixtures for candidate, confirmed, stale, negative, superseded, and invalid-authority routes, with explicit closeout/report visibility."
+  },
+  "findings": [
+    {
+      "title": "Unscoped proof selection is appropriately conservative",
+      "summary": "The current proof command does not require proof without changed paths or task-specific evidence. This is the correct baseline for a repo-agnostic product.",
+      "evidence": "uv run python scripts/run_agentic_workspace.py proof --format json returned action select-proof-scope, required false, and required_commands empty.",
+      "risk if unchanged": "If learned routes bypass this conservatism, AW could force stale or host-specific proof commands on unrelated work.",
+      "suggested action": "Lifecycle rules should require scope evidence before a learned route becomes required proof, even when a route is confirmed.",
+      "confidence": "high",
+      "source": "current proof command output",
+      "promotion target": "#1252 proof lifecycle contract",
+      "promotion trigger": "When confirmed proof routes are reused across changed-path scopes."
+    },
+    {
+      "title": "Proof-route hints need explicit authority and freshness",
+      "summary": "A route can reduce repeated discovery cost only when its source, state, and revalidation trigger are visible. Otherwise it becomes the kind of hidden heuristic #1211/#1222 were meant to retire.",
+      "evidence": "#1252 names candidate, confirmed, stale, negative, and superseded route states. Runtime surfaces include proof-route hints, canonical_proof_route concepts, and closeout proof evidence; Verification already tracks stale evidence when changed paths invalidate expected evidence.",
+      "risk if unchanged": "Agents may rely on old Memory notes or route hints without knowing whether the command is still valid for the current host repo.",
+      "suggested action": "Require state, authoritative evidence, last-confirmed or stale trigger, and correction path for every promoted proof route.",
+      "confidence": "high",
+      "source": "#1252 body, runtime proof-route hints, Verification stale-evidence precedent",
+      "promotion target": "#1252 first implementation slice",
+      "promotion trigger": "When loading proof-route hints into proof selection output."
+    },
+    {
+      "title": "Negative evidence is as important as confirmed routes",
+      "summary": "Repo-agnostic proof selection should remember when a plausible route is wrong, such as a pyproject.toml-only or tests-directory-only host where pytest is not confirmed.",
+      "evidence": "Codex evaluation and docs/host-repo-learning.md both identify proof selection as a risk area where weak Python markers can over-promote pytest-like commands.",
+      "risk if unchanged": "AW can keep rediscovering and retrying bad proof assumptions, wasting time and weakening user trust.",
+      "suggested action": "Treat negative routes as first-class lifecycle entries with authority requirements and expiry/revalidation conditions.",
+      "confidence": "medium-high",
+      "source": "long-horizon evaluation plus host-repo learning guidance",
+      "promotion target": "#1252 fixtures",
+      "promotion trigger": "When adding candidate/confirmed route tests."
+    },
+    {
+      "title": "Closeout must disclose learned-route reliance",
+      "summary": "If a validation claim depended on a learned route, the closeout/report surface should expose that route's state and confidence so reviewers can assess proof quality.",
+      "evidence": "Current closeout_report includes proof_confidence and residual risk, but the recent bug-fix closeout reports low confidence because intent_proof_status was not recorded. #1252 asks for visibility when proof relied on learned routes.",
+      "risk if unchanged": "A final report can say proof passed while hiding that the selected route was stale, candidate-only, or recently superseded.",
+      "suggested action": "Add a learned_route_reliance or proof_route_state detail to proof selection and closeout proof confidence when applicable.",
+      "confidence": "medium",
+      "source": "current closeout_report proof_confidence and #1252 desired signal",
+      "promotion target": "#1252 reporting follow-up",
+      "promotion trigger": "When learned proof routes affect required_commands."
+    }
+  ],
+  "recommendation": {
+    "promote": "Promote a bounded lifecycle/test slice before expanding route automation.",
+    "defer": "Defer full host-repo proof learning until candidate/confirmed/stale/negative/superseded behavior is testable.",
+    "dismiss": "Do not dismiss; proof selection is central to repo-agnostic trust.",
+    "first_slice": "Define route state schema and add fixtures for positive, negative, stale, superseded, and invalid-authority cases.",
+    "validation": "Focused proof-selection tests, Memory route fixtures if touched, plus AW summary and planning doctor."
+  },
+  "retention": {
+    "closeout shape": "keep until #1252 lifecycle states and reporting expectations are promoted",
+    "trigger": "Findings promoted into proof-route tests, Memory note format, or verification/reporting follow-up",
+    "proof surface": "This review, #1252, proof output, and route-state fixtures"
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-04-open-issue-1252-proof-route-lifecycle-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-04: Review record created by create-review.",
+    "2026-06-04: Populated grounding review after inspecting #1252, proof output, implement proof selection, proof-route hints, host-repo learning guidance, and Verification stale-evidence precedent."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1253-command-generation-seam-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1253-command-generation-seam-grounding.review.json
@@ -1,0 +1,163 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1253 command-generation extraction seams",
+  "date": "2026-06-04",
+  "classification": "package-boundary-review",
+  "goal": [
+    "Ground #1253 in the current external command-generation dependency, generated targets, and AW host integration contracts.",
+    "Identify the first bounded seam review before implementing further extraction work."
+  ],
+  "scope": [
+    "Issue #1253 and the command-generation extraction lane.",
+    "pyproject dependency boundary, command_package_ir, generated Python/TypeScript outputs, and projection inventory.",
+    "AW-specific host integration and compatibility rendering that may still remain in generic-looking contracts."
+  ],
+  "non_goals": [
+    "Do not move more runtime code in this review.",
+    "Do not change the external command-generation dependency.",
+    "Do not claim the seam is clean without non-AW fixture evidence."
+  ],
+  "review_mode": {
+    "mode": "extraction-seam-review",
+    "review question": "Which responsibilities are generic command-generation, AW host integration, generated target-local resources, or accepted temporary coupling?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1253",
+      "pyproject.toml",
+      "src/agentic_workspace/contracts/command_package_ir.json",
+      "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
+      "generated/workspace/python/cli.py",
+      "generated/workspace/typescript"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "gh issue list --state open --limit 100 --json number,title,labels,url,body",
+      "rg -n \"command-generation|command_package_ir|generated TypeScript|generated Python|compatibility|accepted coupling|primitive registry\" pyproject.toml src generated packages docs tests",
+      "uv run python scripts/check/check_generated_command_packages.py"
+    ],
+    "evidence sources": [
+      "#1253 issue body",
+      "pyproject.toml command-generation dependency",
+      "command_package_ir and operation/projection inventories",
+      "generated workspace Python and TypeScript packages",
+      "check_generated_command_packages proof surface"
+    ],
+    "limitation": "The review identifies seam risks in AW. It does not inspect the external command-generation repository beyond the dependency declaration."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1253",
+      "label": "Command-generation extraction seams after dependency split",
+      "role": "review owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1253"
+    },
+    {
+      "kind": "local-file",
+      "target": "pyproject.toml",
+      "label": "External command-generation dependency",
+      "role": "package boundary evidence"
+    },
+    {
+      "kind": "local-contract",
+      "target": "src/agentic_workspace/contracts/command_package_ir.json",
+      "label": "Command package IR",
+      "role": "coupling inventory"
+    },
+    {
+      "kind": "local-generated",
+      "target": "generated/workspace/python/cli.py",
+      "label": "Generated Python CLI",
+      "role": "generated target evidence"
+    },
+    {
+      "kind": "local-generated",
+      "target": "generated/workspace/typescript",
+      "label": "Generated TypeScript target",
+      "role": "native target evidence"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1253",
+      "kind": "product-vs-repo ambiguity",
+      "implementation_allowed_after_review": false,
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": "review artifact, then narrower AW or command-generation follow-up issues"
+    }
+  ],
+  "summary": {
+    "current_state": "AW now consumes command-generation externally, but AW still owns host integration, command package IR, generated target resources, compatibility renderers, and runtime projection inventories.",
+    "implementation_posture": "Review and classify couplings before moving code or editing generated contracts.",
+    "first_slice": "Inspect command_package_ir plus one generated target and classify top couplings as acceptable, temporary, or misplaced."
+  },
+  "findings": [
+    {
+      "title": "The dependency split is real but not sufficient proof of a clean seam",
+      "summary": "The package boundary moved, but AW still carries substantial generated-command contracts and host-specific projections. The seam is only clean if those remaining couplings are intentional and classified.",
+      "evidence": "#1253 says command-generation is now external while AW still carries host integration, command package IR, accepted couplings, generated package resources, and compatibility-rendering assumptions.",
+      "risk if unchanged": "Future work can accidentally put AW-specific assumptions into generic command-generation behavior or duplicate responsibilities across the repos.",
+      "suggested action": "Create a coupling inventory from command_package_ir and generated targets, then classify each as generic, AW-host, target-local, accepted temporary, or misplaced.",
+      "confidence": "high",
+      "source": "#1253 issue body and current contract layout",
+      "promotion target": "#1253 review completion",
+      "promotion trigger": "Before any further extraction or abstraction work."
+    },
+    {
+      "title": "Generated target behavior needs non-AW fixture pressure",
+      "summary": "A seam can look clean inside AW while still encoding AW-shaped assumptions. The review should include at least one non-AW or minimal host fixture before declaring portability.",
+      "evidence": "The issue explicitly asks whether AW-specific assumptions remain embedded in generic command-generation contracts. Current generated Python and TypeScript targets are AW-owned package outputs.",
+      "risk if unchanged": "The external dependency may become generic in name but still require AW-specific operation shapes or resource conventions.",
+      "suggested action": "Use a fixture or audit that exercises the generator with non-AW package metadata or a minimal operation set.",
+      "confidence": "medium-high",
+      "source": "#1253 acceptance and generated target ownership",
+      "promotion target": "#1253 first review slice or child issue",
+      "promotion trigger": "When classifying generic command-generation responsibilities."
+    },
+    {
+      "title": "Runtime compatibility renderers are likely AW-host integration, not generator core",
+      "summary": "Compatibility renderers and host front-door projections are necessary, but they should be named as AW integration surfaces unless proven generic.",
+      "evidence": "The issue names output compatibility renderers, primitive registry concerns, generated target resources, and AW operation projections as remaining concerns.",
+      "risk if unchanged": "Generic generator code may accumulate product-specific rendering and front-door assumptions.",
+      "suggested action": "Classify compatibility rendering as AW-host-owned by default, then move only deterministic target-local rendering into generic command-generation.",
+      "confidence": "medium",
+      "source": "#1253 evidence list and projection inventory terms",
+      "promotion target": "#1253 recommendations",
+      "promotion trigger": "When deciding whether a coupling belongs in AW or command-generation."
+    },
+    {
+      "title": "The proof surface should include generated package checks, not only diff inspection",
+      "summary": "The seam review should be tied to generated command package validation so ownership recommendations remain mechanically grounded.",
+      "evidence": "Recent bug work and generated CLI freshness work already rely on scripts/check/check_generated_command_packages.py as a proof command.",
+      "risk if unchanged": "A review can recommend boundary changes that break generated package consistency or leave stale generated artifacts.",
+      "suggested action": "Treat check_generated_command_packages as required proof for any follow-up that changes command IR, adapters, generated outputs, or external dependency assumptions.",
+      "confidence": "high",
+      "source": "repo proof practice and generated command package check",
+      "promotion target": "#1253 validation expectations",
+      "promotion trigger": "When opening implementation follow-ups."
+    }
+  ],
+  "recommendation": {
+    "promote": "Promote review-only work first, not implementation.",
+    "defer": "Defer deeper extraction until coupling classification and non-AW fixture pressure exist.",
+    "dismiss": "Do not dismiss; the external dependency boundary still needs ownership review.",
+    "first_slice": "Review command_package_ir and one generated target, classify the top couplings, and file narrower implementation follow-ups only for misplaced or temporary couplings.",
+    "validation": "check_generated_command_packages plus structured inventory after any artifact changes."
+  },
+  "retention": {
+    "closeout shape": "keep until #1253 coupling classifications are promoted or superseded",
+    "trigger": "Review findings promoted into #1253 comment, child issues, or command-generation repo issues",
+    "proof surface": "This review, #1253, command_package_ir, generated outputs, and generated package check"
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-04-open-issue-1253-command-generation-seam-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-04: Review record created by create-review.",
+    "2026-06-04: Populated grounding review after inspecting #1253, generated command package surfaces, dependency boundary, and generated package proof expectations."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1254-planning-residue-governance-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1254-planning-residue-governance-grounding.review.json
@@ -1,0 +1,164 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1254 planning residue retention governance",
+  "date": "2026-06-04",
+  "classification": "residue-governance",
+  "goal": [
+    "Ground #1254 in current Planning summaries, archived execplans, retained closeout evidence, reviews, and Memory/report surfaces.",
+    "Recommend retention and promotion rules that reduce future context cost without losing useful continuation evidence."
+  ],
+  "scope": [
+    "Issue #1254 and current planning residue surfaces.",
+    "Planning summary, state, reviews, archived execplans, closeout evidence, Memory routing, and structured inventory guardrails.",
+    "Recent cleanup behavior and current open review backlog."
+  ],
+  "non_goals": [
+    "Do not delete or prune residue in this review.",
+    "Do not move historical artifacts by hand.",
+    "Do not treat Memory as active execution state."
+  ],
+  "review_mode": {
+    "mode": "continuation-cost",
+    "review question": "Which residue should be retained, promoted, pruned, or de-emphasized so agents can resume cheaply?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1254",
+      "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+      ".agentic-workspace/planning/reviews",
+      ".agentic-workspace/planning/execplans/archive",
+      ".agentic-workspace/memory/repo/index.md",
+      "scripts/check/check_structured_file_inventory.py"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+      "Get-ChildItem .agentic-workspace/planning/reviews -File",
+      "rg -n \"retention|residue|archive|closeout_evidence|review_residue|Memory\" .agentic-workspace src packages tests scripts"
+    ],
+    "evidence sources": [
+      "#1254 issue body",
+      "current planning summary",
+      "review artifact inventory",
+      "archived execplan inventory",
+      "Memory index loading rule",
+      "structured file inventory retention guardrails"
+    ],
+    "limitation": "This review inventories governance needs; it does not adjudicate every historical artifact."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1254",
+      "label": "Planning residue retention and promotion governance",
+      "role": "review owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1254"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+      "label": "Current planning summary",
+      "role": "active-state evidence"
+    },
+    {
+      "kind": "local-directory",
+      "target": ".agentic-workspace/planning/reviews",
+      "label": "Planning reviews",
+      "role": "review residue surface"
+    },
+    {
+      "kind": "local-directory",
+      "target": ".agentic-workspace/planning/execplans/archive",
+      "label": "Archived execplans",
+      "role": "closeout evidence surface"
+    },
+    {
+      "kind": "local-script",
+      "target": "scripts/check/check_structured_file_inventory.py",
+      "label": "Structured inventory guardrails",
+      "role": "retention validation"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1254",
+      "kind": "continuation/handoff friction",
+      "implementation_allowed_after_review": false,
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": "review artifact, then narrower retention/report/promotion follow-ups"
+    }
+  ],
+  "summary": {
+    "current_state": "Planning summary is clean with no active execplans, but there are many review and archive artifacts and six roadmap candidates. Memory index warns against bulk reading and says active state belongs in planning/status.",
+    "implementation_posture": "Review residue classes and promotion rules before pruning or adding new report output.",
+    "first_slice": "Inventory residue classes and define retention actions: keep, shrink, promote to Memory/docs/issues, de-emphasize in summary, or prune through owned commands."
+  },
+  "findings": [
+    {
+      "title": "Current active state is clean, but historical residue remains expensive to navigate",
+      "summary": "The repo has no active execplans or todos, yet a large review/archive corpus remains available. That is useful evidence but can become the default reading path for agents.",
+      "evidence": "summary reports todo.active_count 0, execplans.active_count 0, planning_surface_health clean, and roadmap candidate_count 6. The reviews directory contains many planning-review records, and archived execplans preserve closeout evidence.",
+      "risk if unchanged": "Agents may over-read historical reviews and archived plans before acting, raising context cost and stale-context risk.",
+      "suggested action": "Define report/summary guidance that distinguishes active execution state from historical review/archive evidence and points to recent or relevant artifacts only.",
+      "confidence": "high",
+      "source": "summary output and planning review/archive inventory",
+      "promotion target": "#1254 review recommendations",
+      "promotion trigger": "When implementing residue guidance or cleanup."
+    },
+    {
+      "title": "Residue needs class-specific promotion rules",
+      "summary": "Planning reviews, archived execplans, retained closeout evidence, Memory notes, and issue comments serve different jobs. Treating them uniformly as residue will either discard useful evidence or keep too much.",
+      "evidence": "#1254 names archived execplans, retained closeout evidence, planning reviews, Memory, reporting contracts, and external-intent evidence. The Memory index says durable repo knowledge belongs in Memory, while active intent belongs in planning/status.",
+      "risk if unchanged": "Reusable learning stays in archives where agents will not route to it, while evidence-only artifacts become over-promoted to Memory or docs.",
+      "suggested action": "Create class rules: active intent to Planning/issues, reusable non-canonical knowledge to Memory, stable rules to docs/contracts/checks, evidence-only to review/archive, obsolete artifacts to command-owned pruning.",
+      "confidence": "high",
+      "source": "#1254 and Memory index",
+      "promotion target": "#1254 governance model",
+      "promotion trigger": "Before pruning, promotion, or report changes."
+    },
+    {
+      "title": "Structured inventory already has retention guardrails for large reviews",
+      "summary": "The repo has a partial retention mechanism: large review/audit records require retention metadata. #1254 can build on this instead of inventing a new governance system.",
+      "evidence": "scripts/check/check_structured_file_inventory.py checks planning-review/v1 records with many issue_classifications for retention fields and source refs.",
+      "risk if unchanged": "The governance lane could create parallel validation instead of extending existing inventory checks.",
+      "suggested action": "Extend structured inventory/reporting only where the existing guardrails cannot express residue class, freshness, or promotion state.",
+      "confidence": "medium-high",
+      "source": "structured inventory checker",
+      "promotion target": "#1254 implementation follow-up",
+      "promotion trigger": "When adding retention validation."
+    },
+    {
+      "title": "Open review issues should be linked to reviews but not treated as closed by review creation",
+      "summary": "The current task creates grounding reviews for open issues, but those artifacts are evidence and implementation guidance, not final satisfaction.",
+      "evidence": "Open issues #1249-#1258 generally state partial PR may close no and require final completion evidence beyond a review artifact.",
+      "risk if unchanged": "A review PR could be mistaken for issue completion, losing the implementation intent.",
+      "suggested action": "Issue comments should link the review and explicitly say the issue remains open for implementation or refinement.",
+      "confidence": "high",
+      "source": "open issue bodies and current task",
+      "promotion target": "issue comments",
+      "promotion trigger": "When linking this review branch to issues."
+    }
+  ],
+  "recommendation": {
+    "promote": "Promote review-only residue governance first.",
+    "defer": "Defer deletion or migration until residue classes and owner commands are agreed.",
+    "dismiss": "Do not dismiss; continuation cost is a real long-horizon friction.",
+    "first_slice": "Create a residue class matrix and map each class to keep/shrink/promote/prune/de-emphasize rules.",
+    "validation": "structured inventory check, AW summary, and planning doctor."
+  },
+  "retention": {
+    "closeout shape": "keep until #1254 residue class rules are promoted or superseded",
+    "trigger": "Findings promoted into issue refinement, report guidance, or cleanup implementation",
+    "proof surface": "This review, #1254, structured inventory guardrails, and planning summary"
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-04-open-issue-1254-planning-residue-governance-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-04: Review record created by create-review.",
+    "2026-06-04: Populated grounding review after inspecting #1254, planning summary, review/archive residue surfaces, Memory index, and structured inventory guardrails."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1255-model-zoo-evaluation-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1255-model-zoo-evaluation-grounding.review.json
@@ -1,0 +1,166 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1255 model-zoo dogfooding feedback taxonomy",
+  "date": "2026-06-04",
+  "classification": "evaluation-framework",
+  "goal": [
+    "Ground #1255 in the existing agent evaluation roadmap, feedback prompt, long-horizon episode harness, and 2026-06-04 Codex/Copilot evaluation results.",
+    "Identify the first structured dogfooding slice that produces comparable feedback without building the full model-zoo harness."
+  ],
+  "scope": [
+    "Issue #1255 and current evaluation artifacts.",
+    "agent-evaluation-roadmap.md, agent-feedback-prompt.txt, scripts/model_cli_harness, and tests/test_long_horizon_episode.py.",
+    "The Codex GPT 5.4 mini and Copilot Claude 4.6 Sonnet evaluation reports stored under .agentic-workspace/local/evaluations."
+  ],
+  "non_goals": [
+    "Do not build the full benchmark runner in this review.",
+    "Do not let automated evaluation replace human product judgment.",
+    "Do not require every dogfooding note to be a benchmark run."
+  ],
+  "review_mode": {
+    "mode": "evaluation-grounding",
+    "review question": "What first-stage taxonomy and fixture work is needed before model-zoo results can drive planning?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1255",
+      "agent-evaluation-roadmap.md",
+      "agent-feedback-prompt.txt",
+      "tests/test_long_horizon_episode.py",
+      ".agentic-workspace/local/evaluations/codex-gpt-5.4-mini-focus-review.md",
+      ".agentic-workspace/local/evaluations/copilot-claude-4.6-sonnet-focus-review.md"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "gh issue list --state open --limit 100 --json number,title,labels,url,body",
+      "Get-Content agent-evaluation-roadmap.md -TotalCount 140",
+      "Get-Content agent-feedback-prompt.txt -TotalCount 120",
+      "Get-Content tests/test_long_horizon_episode.py -TotalCount 120",
+      "Get-Content .agentic-workspace/local/evaluations/codex-gpt-5.4-mini-focus-review.md",
+      "Get-Content .agentic-workspace/local/evaluations/copilot-claude-4.6-sonnet-focus-review.md -TotalCount 220"
+    ],
+    "evidence sources": [
+      "#1255 issue body",
+      "agent-evaluation-roadmap.md Stage 1 and Stage 2",
+      "agent-feedback-prompt.txt",
+      "test_long_horizon_episode.py fixture/schema tests",
+      "2026-06-04 external evaluation artifacts"
+    ],
+    "limitation": "This review treats the local evaluation artifacts as evidence but does not check them into the repo or run additional models."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1255",
+      "label": "Model-zoo dogfooding feedback taxonomy",
+      "role": "implementation owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1255"
+    },
+    {
+      "kind": "local-doc",
+      "target": "agent-evaluation-roadmap.md",
+      "label": "Evaluation roadmap",
+      "role": "stage plan"
+    },
+    {
+      "kind": "local-doc",
+      "target": "agent-feedback-prompt.txt",
+      "label": "Agent feedback prompt",
+      "role": "current qualitative feedback shape"
+    },
+    {
+      "kind": "local-test",
+      "target": "tests/test_long_horizon_episode.py",
+      "label": "Long-horizon episode tests",
+      "role": "harness schema precedent"
+    },
+    {
+      "kind": "local-evidence",
+      "target": ".agentic-workspace/local/evaluations",
+      "label": "Codex/Copilot evaluation outputs",
+      "role": "dogfooding source evidence"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1255",
+      "kind": "cross-cutting proposal",
+      "implementation_allowed_after_review": true,
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": "checked-in taxonomy/capture format and later benchmark fixtures"
+    }
+  ],
+  "summary": {
+    "current_state": "The roadmap already defines Stage 1 taxonomy and Stage 2 benchmark runner goals. The prompt produces useful qualitative reviews, and test_long_horizon_episode.py proves a long-horizon episode format exists, but no checked-in taxonomy or comparable feedback record exists yet.",
+    "implementation_posture": "Start with Stage 1. Do not build a large harness before the failure taxonomy and capture shape are validated against real runs.",
+    "first_slice": "Add a compact taxonomy and capture template/schema, then backfill one sample record from the 2026-06-04 Codex/Copilot evaluation."
+  },
+  "findings": [
+    {
+      "title": "The roadmap already names the right stages; the missing artifact is a checked-in feedback record shape",
+      "summary": "Stage 1 asks for a compact failure taxonomy and rules for when dogfooding friction becomes cleanup, review finding, or roadmap candidate. #1255 should implement that first, not skip to the benchmark runner.",
+      "evidence": "agent-evaluation-roadmap.md Stage 1 lists startup/routing confusion, proof ambiguity, ownership ambiguity, plan curation drift, restart reread cost, handoff insufficiency, and mixed-agent posture confusion as taxonomy examples.",
+      "risk if unchanged": "Future model runs will keep producing prose that is hard to compare or aggregate.",
+      "suggested action": "Create a schema-backed dogfooding feedback record with model, surface, task, failure_class, severity, evidence, suggested lane, and status.",
+      "confidence": "high",
+      "source": "agent-evaluation-roadmap.md and #1255",
+      "promotion target": "#1255 first implementation slice",
+      "promotion trigger": "Before running more model-zoo evaluations."
+    },
+    {
+      "title": "The existing feedback prompt is useful but not comparable",
+      "summary": "agent-feedback-prompt.txt asks the right operational questions, but its output structure is prose sections. It does not force normalized failure classes, severity, or surface IDs.",
+      "evidence": "The prompt asks for verdict, benefits, friction points, overhead, discovery cost, handoff/restart, proof/trust, agent-agnostic fit, and concrete improvements.",
+      "risk if unchanged": "Strong agents will keep producing high-quality narrative reports while smaller-agent failures remain hard to cluster.",
+      "suggested action": "Keep the prose prompt as qualitative input, but add a structured capture layer that extracts comparable records.",
+      "confidence": "high",
+      "source": "agent-feedback-prompt.txt",
+      "promotion target": "#1255 taxonomy and capture template",
+      "promotion trigger": "When converting the 2026-06-04 evaluations into durable evidence."
+    },
+    {
+      "title": "The long-horizon episode harness can be reused after taxonomy stabilization",
+      "summary": "The test harness already has episode, fixture, adapter, evaluator, and result-shape precedent. That makes Stage 2 plausible, but taxonomy should come first.",
+      "evidence": "tests/test_long_horizon_episode.py writes fake adapters and validates long-horizon evaluation result fields such as intent_satisfied, scope_respected, proof_sufficient, restartable_from_repo_state, completion_claim_honest, mistake_classes, and aw_effect.",
+      "risk if unchanged": "A runner-first implementation could optimize for easy-to-run scenarios before defining what failures matter.",
+      "suggested action": "Use the existing episode result shape as inspiration for taxonomy fields, then add fixtures once the record shape is accepted.",
+      "confidence": "medium-high",
+      "source": "tests/test_long_horizon_episode.py",
+      "promotion target": "#1255 second slice",
+      "promotion trigger": "After taxonomy/capture template lands."
+    },
+    {
+      "title": "The 2026-06-04 evaluations are good seed records",
+      "summary": "Codex and Copilot independently surfaced closeout UX, decision traceability, proof/routing, generated-surface trust, and evaluation taxonomy gaps. These should seed the first structured records.",
+      "evidence": "The local evaluation reports led directly to issues #1255-#1258 and reinforced existing issues #1249-#1254.",
+      "risk if unchanged": "The run's useful evidence stays in local scratch and final chat text instead of becoming durable product signal.",
+      "suggested action": "Add one or two sample records summarizing these evaluations, while keeping full transcripts out of checked-in Memory unless intentionally promoted.",
+      "confidence": "high",
+      "source": ".agentic-workspace/local/evaluations and created issues",
+      "promotion target": "#1255 sample feedback records",
+      "promotion trigger": "When implementing the capture format."
+    }
+  ],
+  "recommendation": {
+    "promote": "Promote Stage 1 taxonomy/capture implementation.",
+    "defer": "Defer full model registry, automated judge, and large benchmark suite.",
+    "dismiss": "Do not dismiss; cross-agent evidence is now producing real planning signal.",
+    "first_slice": "Add failure taxonomy, capture template/schema, and one sample record from the 2026-06-04 evaluations.",
+    "validation": "Schema/inventory validation plus a focused test if records are machine-validated."
+  },
+  "retention": {
+    "closeout shape": "keep until #1255 taxonomy/capture format lands or is superseded",
+    "trigger": "Findings promoted into taxonomy files, tests, or issue refinement",
+    "proof surface": "This review, #1255, roadmap, prompt, and sample dogfooding records"
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-04-open-issue-1255-model-zoo-evaluation-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-04: Review record created by create-review.",
+    "2026-06-04: Populated grounding review after inspecting #1255, evaluation roadmap, feedback prompt, long-horizon episode tests, and 2026-06-04 external evaluation outputs."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1256-read-only-gate-clarity-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1256-read-only-gate-clarity-grounding.review.json
@@ -1,0 +1,156 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1256 read-only planning gate clarity",
+  "date": "2026-06-04",
+  "classification": "routing-ux",
+  "goal": [
+    "Ground #1256 in current next_safe_action, planning gates, operation read_only metadata, and dogfooding evidence.",
+    "Identify the smallest output contract that clarifies read-only exploration without weakening implementation gates."
+  ],
+  "scope": [
+    "Issue #1256 and current start/implement outputs.",
+    "Planning hard gates versus read-only review, issue triage, and report generation.",
+    "Operation contract read_only metadata and the 2026-06-04 Codex/Copilot evaluation friction."
+  ],
+  "non_goals": [
+    "Do not allow implementation without active planning when AW reports a hard gate.",
+    "Do not make prompt keyword matching decide review versus implementation.",
+    "Do not remove proof or completion-claim gates."
+  ],
+  "review_mode": {
+    "mode": "routing-ux",
+    "review question": "How should AW tell agents that implementation is blocked but read-only review/exploration is still allowed?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1256",
+      "start output for review task",
+      "implement output for planning-only review files",
+      "operation contracts with effects.read_only",
+      "2026-06-04 Codex/Copilot evaluation dogfooding notes"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "uv run python scripts/run_agentic_workspace.py start --task \"create and link in-depth grounding reviews for each open GitHub issue\" --format json",
+      "uv run python scripts/run_agentic_workspace.py implement --changed <review paths> --task \"create and link in-depth grounding reviews for each open GitHub issue\" --format json",
+      "rg -n \"read_only|implementation_allowed|allowed_next_actions|candidate-lane-promotion|required_next_action|effects\" src packages tests .agentic-workspace"
+    ],
+    "evidence sources": [
+      "#1256 issue body",
+      "start next_safe_action output",
+      "implement planning_safety_gate output",
+      "operation contract effects.read_only metadata",
+      "Copilot evaluation dogfooding note"
+    ],
+    "limitation": "This review compares current outputs and dogfooding evidence; it does not implement the new field."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1256",
+      "label": "Read-only and exploration allowance under planning gates",
+      "role": "implementation owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1256"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py start --task ... --format json",
+      "label": "Startup next_safe_action",
+      "role": "current UX evidence"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py implement --changed <review paths> --format json",
+      "label": "Implement planning safety gate",
+      "role": "current UX evidence"
+    },
+    {
+      "kind": "local-contract",
+      "target": "src/agentic_workspace/contracts/operation_primitives.json",
+      "label": "Operation read-only metadata",
+      "role": "existing contract precedent"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1256",
+      "kind": "dogfooding friction",
+      "implementation_allowed_after_review": true,
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": "next_safe_action and planning_safety_gate output contract"
+    }
+  ],
+  "summary": {
+    "current_state": "AW clearly reports implementation_allowed and forbidden implementation actions, and operation contracts already know read_only effects. The missing UX is a top-level, task-facing statement that read-only review/exploration/reporting may continue under an implementation gate.",
+    "implementation_posture": "Add explicit permission and claim boundaries; do not weaken hard gates.",
+    "first_slice": "Add read_only_allowed or exploration_allowed plus allowed_read_only_actions to next_safe_action/planning_safety_gate fixtures."
+  },
+  "findings": [
+    {
+      "title": "Implementation gates are clear, but read-only allowance is implicit",
+      "summary": "Current outputs tell agents whether implementation is allowed, but not always whether review, issue triage, or report generation can proceed without promoting a plan.",
+      "evidence": "start output foregrounds next_safe_action, allowed_next_actions, forbidden_actions, implementation_allowed, proof_required, and completion_claim_allowed. #1256 records that Copilot interpreted candidate-lane-promotion-required as blocking a read-only review task.",
+      "risk if unchanged": "Agents may create plans just to inspect issues or produce reviews, increasing ceremony and mutating state unnecessarily.",
+      "suggested action": "Add a compact read_only_allowed/exploration_allowed signal next to implementation_allowed, with examples of allowed non-mutating actions.",
+      "confidence": "high",
+      "source": "current start output and #1256 dogfooding evidence",
+      "promotion target": "#1256 implementation",
+      "promotion trigger": "When next_safe_action reports implementation_allowed false."
+    },
+    {
+      "title": "The new field should preserve completion-claim boundaries",
+      "summary": "Read-only allowance must not be confused with permission to claim completion, close issues, or proceed with implementation.",
+      "evidence": "Current outputs already carry completion_claim_allowed false and proof_required where relevant. implement output for these review files requires proof before closeout even though implementation is planning-only.",
+      "risk if unchanged": "A broad 'allowed' signal could make agents overclaim after a review or skip proof/ownership for implementation.",
+      "suggested action": "Pair read_only_allowed with explicit claim_boundary: review/exploration allowed, implementation gated when applicable, completion claims still require proof and acceptance reconciliation.",
+      "confidence": "high",
+      "source": "start and implement outputs",
+      "promotion target": "#1256 output contract",
+      "promotion trigger": "When adding read-only permission fields."
+    },
+    {
+      "title": "Existing operation metadata can supply the vocabulary",
+      "summary": "Many operation contracts already classify commands as read-only reports. The UX contract can reuse that concept rather than invent a prompt-text classifier.",
+      "evidence": "Operation contracts include effects.read_only for memory/report/help/list-files and other commands. The user intent is review/exploration; AW should expose command/action classes, not prompt keyword matches.",
+      "risk if unchanged": "The fix could become another heuristic prompt classifier instead of a general command-safety affordance.",
+      "suggested action": "Define read-only allowance in terms of action classes and command effects: report, summary, issue inspection, file reads, review artifacts; exclude mutations unless explicitly allowed.",
+      "confidence": "medium-high",
+      "source": "operation contracts and #1256 issue scope",
+      "promotion target": "#1256 implementation design",
+      "promotion trigger": "When choosing how to compute allowed_read_only_actions."
+    },
+    {
+      "title": "The test should recreate the dogfooding confusion",
+      "summary": "The regression should cover a review-shaped or issue-triage task under a candidate-lane gate and assert that read-only work is allowed while implementation remains blocked.",
+      "evidence": "Copilot's evaluation ran in a detached worktree and reported candidate-lane-promotion-required hard-gate confusion for a read-only task. The current main-repo start output for issue creation is less strict, so fixtures need to force the gated state.",
+      "risk if unchanged": "A field may work only in ordinary no-gate startup and fail in the state that caused the problem.",
+      "suggested action": "Add a fixture with roadmap candidates or broad-work pressure, then assert read_only_allowed true, implementation_allowed false, and completion_claim_allowed false.",
+      "confidence": "high",
+      "source": "dogfooding note and current output contrast",
+      "promotion target": "#1256 tests",
+      "promotion trigger": "Before claiming the UX gap is fixed."
+    }
+  ],
+  "recommendation": {
+    "promote": "Promote a small output-contract/test slice.",
+    "defer": "Defer broader planning-gate redesign.",
+    "dismiss": "Do not dismiss; this is direct dogfooding friction with a small likely fix.",
+    "first_slice": "Add read_only_allowed/exploration_allowed, allowed_read_only_actions, and claim_boundary fields to next_safe_action or planning_safety_gate, with gated review-task fixtures.",
+    "validation": "Focused startup/implement tests plus AW summary and planning doctor."
+  },
+  "retention": {
+    "closeout shape": "keep until #1256 field contract and tests land or are superseded",
+    "trigger": "Findings promoted into next_safe_action tests or issue refinement",
+    "proof surface": "This review, #1256, start/implement outputs, and dogfooding evaluations"
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-04-open-issue-1256-read-only-gate-clarity-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-04: Review record created by create-review.",
+    "2026-06-04: Populated grounding review after inspecting #1256, start/implement outputs, operation read-only metadata, and 2026-06-04 evaluation notes."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1257-memory-freshness-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1257-memory-freshness-grounding.review.json
@@ -1,0 +1,166 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1257 memory freshness and contradiction signals",
+  "date": "2026-06-04",
+  "classification": "memory-trust",
+  "goal": [
+    "Ground #1257 in current Memory manifest, memory report, memory index, and doctor output.",
+    "Identify the first freshness/supersession signal that improves trust without turning Memory into active planning state."
+  ],
+  "scope": [
+    "Issue #1257 and durable Memory trust surfaces.",
+    ".agentic-workspace/memory/repo/manifest.toml, memory report output, memory index loading rules, and doctor findings.",
+    "Relationship to proof-route freshness in #1252."
+  ],
+  "non_goals": [
+    "Do not rewrite all memory notes in this review.",
+    "Do not make stale memory a hard blocker by default.",
+    "Do not use Memory as an issue tracker or active task board."
+  ],
+  "review_mode": {
+    "mode": "memory-freshness",
+    "review question": "What metadata and consult output are needed so agents can trust, confirm, or ignore durable Memory notes?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1257",
+      "uv run python scripts/run_agentic_workspace.py memory report --target . --format json",
+      ".agentic-workspace/memory/repo/manifest.toml",
+      ".agentic-workspace/memory/repo/index.md",
+      "uv run python scripts/run_agentic_workspace.py doctor --target . --format json"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "uv run python scripts/run_agentic_workspace.py memory report --target . --format json",
+      "uv run python scripts/run_agentic_workspace.py doctor --target . --format json",
+      "Get-Content .agentic-workspace/memory/repo/manifest.toml",
+      "Get-Content .agentic-workspace/memory/repo/index.md",
+      "rg -n \"stale_when|last_confirmed|superseded|trust|memory_consult|Memory\" .agentic-workspace packages src tests docs"
+    ],
+    "evidence sources": [
+      "#1257 issue body",
+      "memory report output",
+      "Memory manifest",
+      "Memory index",
+      "doctor output",
+      "#1252 proof-route lifecycle review"
+    ],
+    "limitation": "This review grounds the product shape; it does not migrate memory metadata."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1257",
+      "label": "Memory freshness and contradiction signals",
+      "role": "implementation owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1257"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py memory report --target . --format json",
+      "label": "Memory report",
+      "role": "current trust output"
+    },
+    {
+      "kind": "local-file",
+      "target": ".agentic-workspace/memory/repo/manifest.toml",
+      "label": "Memory manifest",
+      "role": "metadata owner"
+    },
+    {
+      "kind": "local-file",
+      "target": ".agentic-workspace/memory/repo/index.md",
+      "label": "Memory index",
+      "role": "loading policy"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1252",
+      "label": "Proof-route lifecycle",
+      "role": "related freshness lane",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1252"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1257",
+      "kind": "cross-cutting proposal",
+      "implementation_allowed_after_review": true,
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": "Memory manifest metadata and memory consult/report output"
+    }
+  ],
+  "summary": {
+    "current_state": "The manifest already has stale_when and routing metadata, and memory report exposes note counts and habitual pull. Tiny report trust is not evaluated, and notes do not yet carry last_confirmed or superseded_by style signals.",
+    "implementation_posture": "Build on manifest metadata and consult/report output. Keep freshness advisory unless an existing hard invariant is violated.",
+    "first_slice": "Add last_confirmed/superseded_by metadata and a memory consult/report fixture showing fresh, stale, and superseded notes."
+  },
+  "findings": [
+    {
+      "title": "Memory has routing metadata but not enough trust metadata",
+      "summary": "The manifest tells agents where notes route from and when they may stale, but it does not yet tell agents when a note was last confirmed or what supersedes it.",
+      "evidence": "manifest.toml entries include note_type, authority, canonicality, routes_from, stale_when, routing_only, and task_relevance. The issue asks for freshness/supersession signals such as last_confirmed and superseded_by.",
+      "risk if unchanged": "Agents must infer freshness from dates, recent PR history, or manual broad reading.",
+      "suggested action": "Add minimal note-level freshness fields and expose them through memory consult/report.",
+      "confidence": "high",
+      "source": "Memory manifest and #1257 issue body",
+      "promotion target": "#1257 schema/manifest slice",
+      "promotion trigger": "When touching Memory manifest or consult output."
+    },
+    {
+      "title": "Tiny memory report does not evaluate trust",
+      "summary": "The current memory report is healthy and compact, but trust and promotion_pressure are not evaluated in tiny mode. For freshness work, the output needs at least a compact attention signal when selected notes are stale or superseded.",
+      "evidence": "memory report shows health healthy, manifest_status present, note_count 6, habitual_pull available, but trust.status not-evaluated and promotion_pressure.status not-evaluated.",
+      "risk if unchanged": "Agents can follow the memory consultation route without seeing whether relevant notes are old or contradicted.",
+      "suggested action": "Expose a compact memory trust summary only when freshness/supersession attention exists; keep verbose detail behind a command.",
+      "confidence": "medium-high",
+      "source": "memory report output",
+      "promotion target": "#1257 consult/report output",
+      "promotion trigger": "When freshness metadata exists."
+    },
+    {
+      "title": "Doctor already reveals memory-managed drift, but that is not note freshness",
+      "summary": "Doctor reports a safe memory lifecycle repair and current-note role problems, showing lifecycle diagnostics exist. That should not be confused with durable note freshness.",
+      "evidence": "doctor health is attention-needed and reports stale module-managed memory surfaces plus routing-feedback role warnings, while memory report itself is healthy.",
+      "risk if unchanged": "Implementation could conflate managed payload drift with stale durable knowledge.",
+      "suggested action": "Separate memory install/lifecycle health from memory note trust in output names and tests.",
+      "confidence": "high",
+      "source": "doctor and memory report output",
+      "promotion target": "#1257 reporting contract",
+      "promotion trigger": "When adding trust/freshness statuses."
+    },
+    {
+      "title": "Coordinate with proof-route freshness but keep a broader Memory model",
+      "summary": "Proof routes are a special case of durable learned knowledge. General Memory freshness should support proof routes without being limited to them.",
+      "evidence": "#1257 explicitly relates to #1252 but covers durable Memory freshness and contradiction trust signals beyond proof routes.",
+      "risk if unchanged": "Proof-route freshness and general memory freshness could diverge into incompatible metadata.",
+      "suggested action": "Define shared freshness fields that proof-route notes can reuse, with proof-specific lifecycle state layered on top.",
+      "confidence": "medium-high",
+      "source": "#1257 and #1252 relationship",
+      "promotion target": "#1257 plus #1252 coordination",
+      "promotion trigger": "Before implementing either lane's metadata."
+    }
+  ],
+  "recommendation": {
+    "promote": "Promote a metadata/output fixture slice.",
+    "defer": "Defer contradiction clustering and broad migration.",
+    "dismiss": "Do not dismiss; durable memory trust is necessary for repo-learning to avoid becoming stale heuristic reuse.",
+    "first_slice": "Add last_confirmed/superseded_by metadata and memory consult/report tests for fresh, stale, and superseded notes.",
+    "validation": "Memory tests/report fixtures plus structured inventory, AW summary, and planning doctor."
+  },
+  "retention": {
+    "closeout shape": "keep until #1257 metadata and consult/report expectations are promoted",
+    "trigger": "Findings promoted into memory schema, report tests, or issue refinement",
+    "proof surface": "This review, #1257, Memory manifest, memory report, and #1252 coordination"
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-04-open-issue-1257-memory-freshness-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-04: Review record created by create-review.",
+    "2026-06-04: Populated grounding review after inspecting #1257, Memory report, manifest, index, doctor output, and proof-route lifecycle relationship."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1258-generated-surface-trust-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-04-open-issue-1258-generated-surface-trust-grounding.review.json
@@ -1,0 +1,164 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1258 generated-source freshness and direct-edit policy",
+  "date": "2026-06-04",
+  "classification": "generated-surface-trust",
+  "goal": [
+    "Ground #1258 in current generated CLI freshness, doctor generated-surface diagnostics, generated package checks, and ordinary agent UX.",
+    "Identify the smallest output surface that should expose canonical source, freshness, refresh command, direct-edit policy, and validation."
+  ],
+  "scope": [
+    "Issue #1258 and generated-source trust surfaces.",
+    "scripts/run_agentic_workspace.py fingerprint cache behavior, generated package checks, doctor output, generated workspace packages, and collaboration-safety guidance.",
+    "Ordinary agent-facing outputs when generated files are touched or inspected."
+  ],
+  "non_goals": [
+    "Do not change the generator in this review.",
+    "Do not make generated files the canonical editing surface.",
+    "Do not add maintainer-only detail to every ordinary report."
+  ],
+  "review_mode": {
+    "mode": "generated-surface-ux",
+    "review question": "Where should ordinary agents see generated-source freshness and direct-edit policy before editing or trusting generated files?",
+    "default finding cap": "4 findings",
+    "inputs inspected first": [
+      "gh issue view 1258",
+      "scripts/run_agentic_workspace.py",
+      "tests/test_agentic_workspace_launcher.py",
+      "uv run python scripts/run_agentic_workspace.py doctor --target . --format json",
+      "scripts/check/check_generated_command_packages.py",
+      "docs/collaboration-safety.md"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "uv run python scripts/run_agentic_workspace.py doctor --target . --format json",
+      "rg -n \"generated|stale_generated_surfaces|direct-edit|canonical source|refresh command|generated-cli-fingerprint|ensure_generated_cli_current\" scripts src tests docs generated packages",
+      "uv run python scripts/check/check_generated_command_packages.py"
+    ],
+    "evidence sources": [
+      "#1258 issue body",
+      "scripts/run_agentic_workspace.py generated CLI fingerprint code",
+      "tests/test_agentic_workspace_launcher.py",
+      "doctor output generated_artifacts/stale_generated_surfaces fields",
+      "docs/collaboration-safety.md generated surface guidance",
+      "generated command package check"
+    ],
+    "limitation": "This review grounds the UX need; it does not decide which output surface must be changed first."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1258",
+      "label": "Generated-source freshness and direct-edit policy in ordinary outputs",
+      "role": "implementation owner",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1258"
+    },
+    {
+      "kind": "local-code",
+      "target": "scripts/run_agentic_workspace.py",
+      "label": "Generated CLI freshness launcher",
+      "role": "freshness/cache behavior"
+    },
+    {
+      "kind": "local-test",
+      "target": "tests/test_agentic_workspace_launcher.py",
+      "label": "Launcher freshness tests",
+      "role": "regression surface"
+    },
+    {
+      "kind": "command-output",
+      "target": "uv run python scripts/run_agentic_workspace.py doctor --target . --format json",
+      "label": "Doctor generated surface fields",
+      "role": "current ordinary output evidence"
+    },
+    {
+      "kind": "local-doc",
+      "target": "docs/collaboration-safety.md",
+      "label": "Collaboration safety generated guidance",
+      "role": "policy precedent"
+    }
+  ],
+  "issue_classifications": [
+    {
+      "issue": "#1258",
+      "kind": "review/trust gap",
+      "implementation_allowed_after_review": true,
+      "partial_pr_may_close": "no",
+      "primary_owner_surface": "doctor/report/implement generated-surface packet"
+    }
+  ],
+  "summary": {
+    "current_state": "The launcher keeps generated CLI current via fingerprint cache and tests, and doctor has stale_generated_surfaces/generated_artifacts fields. Ordinary outputs still do not expose a compact generated-source packet when generated paths are encountered.",
+    "implementation_posture": "Surface policy in one high-value ordinary output first, probably implement --changed for generated paths or doctor/report if diagnostics already know the stale generated surface.",
+    "first_slice": "Add a generated_surface_trust packet with canonical source, freshness status, refresh command, direct-edit policy, and validation command for changed generated paths."
+  },
+  "findings": [
+    {
+      "title": "Freshness is enforced for the generated CLI, but trust is not visible to ordinary agents",
+      "summary": "The launcher now computes a fingerprint and refreshes generated CLI output, but agents inspecting generated paths need a user-facing explanation of source, freshness, and safe action.",
+      "evidence": "scripts/run_agentic_workspace.py defines generated input patterns, CACHE_SCHEMA generated-cli-fingerprint/v1, compute_generated_cli_fingerprint, ensure_generated_cli_current, and retry-safe cache writes. tests/test_agentic_workspace_launcher.py covers cache match, regeneration, and transient PermissionError retry.",
+      "risk if unchanged": "Agents may mistrust generated output, edit it directly, or miss the fact that the launcher already refreshes a specific generated surface.",
+      "suggested action": "Expose generated CLI freshness and canonical source in ordinary output when generated workspace CLI paths are touched or when doctor detects drift.",
+      "confidence": "high",
+      "source": "launcher code and launcher tests",
+      "promotion target": "#1258 implementation",
+      "promotion trigger": "When implement --changed or doctor/report sees generated paths."
+    },
+    {
+      "title": "Doctor has generated fields but not an ordinary policy packet",
+      "summary": "Doctor currently reports generated_artifacts and stale_generated_surfaces, but when there is no drift it does not teach agents what to do with generated files.",
+      "evidence": "doctor output includes generated_artifacts: [] and stale_generated_surfaces: []. It also reports repair plans for managed memory surfaces, showing the lifecycle surface can name safe actions when configured.",
+      "risk if unchanged": "The signal only appears when something is stale, leaving ordinary generated-path edits under-guided.",
+      "suggested action": "Add the packet to implement --changed for generated paths first; optionally let doctor show it when stale_generated_surfaces is non-empty.",
+      "confidence": "medium-high",
+      "source": "doctor output",
+      "promotion target": "#1258 first bounded slice",
+      "promotion trigger": "When selecting the first output surface."
+    },
+    {
+      "title": "The policy should reuse collaboration-safety guidance",
+      "summary": "The repo already says generated or derived surfaces should be repaired from canonical source and rerendered, not hand-edited. #1258 should make that operational in AW output.",
+      "evidence": "docs/collaboration-safety.md says if a generated or derived surface is stale, identify the canonical source and rerender command before editing generated output by hand, and do not turn generated surfaces into a second handbook.",
+      "risk if unchanged": "The rule remains in docs but does not reach the agent at the moment a generated path is changed.",
+      "suggested action": "The generated_surface_trust packet should include direct_edit_policy and refresh_command fields, with docs/collaboration-safety.md as policy precedent.",
+      "confidence": "high",
+      "source": "docs/collaboration-safety.md",
+      "promotion target": "#1258 output contract",
+      "promotion trigger": "When generated path routing is implemented."
+    },
+    {
+      "title": "Validation must include generated package checks",
+      "summary": "Any generated-surface policy change must keep generated package consistency in proof, not only unit tests.",
+      "evidence": "scripts/check/check_generated_command_packages.py is the established proof command for generated command package consistency and was used in recent generated CLI freshness work.",
+      "risk if unchanged": "Output guidance could drift from actual generator/package behavior.",
+      "suggested action": "Require check_generated_command_packages plus focused generated-path output tests for #1258 implementation.",
+      "confidence": "high",
+      "source": "generated package check and recent validation practice",
+      "promotion target": "#1258 validation requirements",
+      "promotion trigger": "When modifying generated-surface reporting."
+    }
+  ],
+  "recommendation": {
+    "promote": "Promote a bounded output-packet implementation for generated paths.",
+    "defer": "Defer broad generator changes or all-surface reporting expansion.",
+    "dismiss": "Do not dismiss; the generated CLI is maintained but ordinary generated-path trust remains under-surfaced.",
+    "first_slice": "Add generated_surface_trust to implement --changed for generated paths, with canonical_source, freshness_status, refresh_command, direct_edit_policy, and validation_command.",
+    "validation": "Focused output tests, launcher tests if touched, check_generated_command_packages, AW summary, and planning doctor."
+  },
+  "retention": {
+    "closeout shape": "keep until #1258 generated-surface packet lands or is superseded",
+    "trigger": "Findings promoted into output contract, tests, or issue refinement",
+    "proof surface": "This review, #1258, launcher tests, doctor output, collaboration safety doc, and generated package checks"
+  },
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/reviews/2026-06-04-open-issue-1258-generated-surface-trust-grounding.review.json",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "drift_log": [
+    "2026-06-04: Review record created by create-review.",
+    "2026-06-04: Populated grounding review after inspecting #1258, launcher freshness code/tests, doctor generated-surface fields, collaboration safety guidance, and generated package proof expectations."
+  ]
+}


### PR DESCRIPTION
## Summary

Adds in-depth grounding review records for every currently open issue, #1249 through #1258.

The reviews are intentionally implementation-grounding artifacts: each one records scoped evidence, findings, first bounded slice guidance, and validation expectations. They do not close the issues by themselves.

## Reviews Added

- #1249 closeout/report first-inspection compression
- #1250 decision traceability owner model
- #1251 intent-discovery compliance
- #1252 proof-route learning lifecycle
- #1253 command-generation extraction seams
- #1254 planning residue retention governance
- #1255 model-zoo dogfooding feedback taxonomy
- #1256 read-only planning gate clarity
- #1257 memory freshness and contradiction signals
- #1258 generated-source freshness and direct-edit policy

## Validation

- `uv run python -m json.tool` for all new review records
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `git diff --check`
- commit hooks: sync-all, workspace lint, memory lint/markdownlint, planning lint, verification lint, absolute path check