### PR TITLE
Implement closeout first-inspection contracts

### DIFF
--- a/.agentic-workspace/docs/reporting-contract.md
+++ b/.agentic-workspace/docs/reporting-contract.md
@@ -144,6 +144,7 @@ Decision-review facts are:
 
 Use `closeout_report.review_compression` to see what a human should inspect first for the selected work shape.
 It is closeout-first, derived, and non-authoritative.
+It is also the first-inspection contract that `closeout_report.final_response_rendering` must honor for user-facing closeout text.
 Its modes are:
 
 - `small-direct-edit`;
@@ -154,6 +155,12 @@ Its modes are:
 - `follow-up-or-residue-heavy-work`.
 
 Every compressed review must either say no material human decision remains beyond ordinary acceptance, or name the human-owned acceptance, risk, handoff, or decision-fact question and its owner.
+Every mode must name:
+
+- first-inspection facts;
+- rendered facts that must appear in the final response for that work shape;
+- secondary detail routes;
+- the policy for when raw report/detail inspection is still needed.
 
 Use `closeout_report.closeout_adoption` as the operator-facing closeout quality rubric.
 The rubric asks whether the final response answers:
@@ -203,6 +210,7 @@ Minimal and guidance-only closeouts without trust, residue, or follow-up signals
 Guidance-only closeouts with audit, lower-trust, residue, or follow-up signals should stay compact but still render the caveat and disallow a plain-done claim.
 Balanced, explanatory, audit, partial, or lower-trust closeouts should render the material human-facing facts: profile reason, closure boundary, changed work, proof, residual risk, routed residue, and follow-up owner.
 System-shaping closeouts should also render decision facts or a decision-gap line from `decision_review`.
+`final_response_rendering.selected_review_mode` and `final_response_rendering.first_inspection_contract` must match `review_compression.selected_mode` and its selected contract so the rendered chat summary cannot drift from the review-compression guidance.
 The final response should prefer `rendered_summary.rendered_text` as concise prose or bullets and must not dump raw JSON.
 `required_fact_coverage` must make omitted required facts visible before the agent claims completion.
 Custom wording or template selection is a future-safe extension only when it cannot hide `must_include`, `must_not_claim`, `plain_done_allowed`, or `raw_json_allowed`.

--- a/.agentic-workspace/planning/execplans/archive/issue-1249-closeout-first-inspection.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1249-closeout-first-inspection.plan.json
@@ -1,0 +1,318 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1249 closeout first-inspection compression",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1249 by making closeout_report review_compression a tested first-inspection contract and making final_response_rendering honor the selected work-shape mode.",
+    "hard_constraints": "Do not add another top-level report surface; keep the slice focused on closeout_report, final_response_rendering, docs, schema wording, and focused tests.",
+    "agent_may_decide": "Exact packet field names, rendered fact requirements, and test fixtures for representative work shapes.",
+    "escalate_when": "The fix requires changing Planning source truth, replacing closeout_report, or implementing adjacent decision-traceability/proof-route issues.",
+    "next_action": "Run focused closeout_report tests, repair failures, then run AW-selected workspace proof.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_report_cli.py -q",
+      "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+      "make schema-reference-docs"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_workspace_report_cli.py",
+      ".agentic-workspace/docs/reporting-contract.md",
+      "src/agentic_workspace/contracts/schemas/workspace_report.schema.json"
+    ],
+    "completion_criteria": [
+      "review_compression exposes a reusable first-inspection contract for each supported work shape.",
+      "final_response_rendering carries the selected review mode and contract.",
+      "Rendered summaries require and cover mode-specific first-inspection facts for small direct work, planned slices, broad PRs, system-shaping changes, and lower-trust/partial closeouts.",
+      "Reporting contract and schema wording describe the contract without adding another surface."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Implement #1249 closeout first-inspection compression without adding another report surface."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1249 by making closeout_report review_compression a tested first-inspection contract and making final_response_rendering honor the selected work-shape mode.",
+      "constraints": "Do not add another top-level report surface; keep the slice focused on closeout_report, final_response_rendering, docs, schema wording, and focused tests.",
+      "latitude": "Exact packet field names, rendered fact requirements, and test fixtures for representative work shapes.",
+      "escalation": "Escalate when the fix requires changing Planning source truth, replacing closeout_report, or implementing adjacent decision-traceability/proof-route issues.",
+      "proof": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed"
+    },
+    "execution": {
+      "milestone": "issue-1249-closeout-first-inspection",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed"
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_workspace_report_cli.py",
+        ".agentic-workspace/docs/reporting-contract.md",
+        "src/agentic_workspace/contracts/schemas/workspace_report.schema.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Implement #1249 closeout first-inspection compression without adding another report surface.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "closeout_report can show first-inspection contracts by work shape and render user-facing summaries against those contracts",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1249 closeout first-inspection compression",
+    "inferred intended outcome": "Make closeout_report reduce first-inspection cost by work shape.",
+    "chosen concrete what": "Add reusable review-mode contracts, expose the selected contract in final_response_rendering, and prove rendered summaries change by work shape.",
+    "interpretation distance": "low",
+    "review guidance": "Inspect closeout_report.review_compression and final_response_rendering first; detail routes remain available when required facts are missing."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_report_cli.py; .agentic-workspace/docs/reporting-contract.md; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; this execplan and planning state",
+    "max changed files": "6",
+    "required validation commands": "uv run pytest tests/test_workspace_report_cli.py -q; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; make schema-reference-docs",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue validating #1249 review-mode contracts in closeout_report and final_response_rendering.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1249 by making closeout_report review_compression a tested first-inspection contract and making final_response_rendering honor the selected work-shape mode.",
+    "hard constraints": "Do not add another top-level report surface; keep the slice focused on closeout_report, final_response_rendering, docs, schema wording, and focused tests.",
+    "agent may decide locally": "Exact packet field names, rendered fact requirements, and test fixtures for representative work shapes.",
+    "escalate when": "The fix requires changing Planning source truth, replacing closeout_report, or implementing adjacent decision-traceability/proof-route issues."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1249-closeout-first-inspection",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run focused closeout_report tests, repair failures, then run AW-selected workspace proof."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "tests/test_workspace_report_cli.py",
+    ".agentic-workspace/docs/reporting-contract.md",
+    "src/agentic_workspace/contracts/schemas/workspace_report.schema.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_report_cli.py -q",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "make schema-reference-docs"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "review_compression exposes a reusable first-inspection contract for each supported work shape.",
+    "final_response_rendering carries the selected review mode and contract.",
+    "Rendered summaries require and cover mode-specific first-inspection facts for small direct work, planned slices, broad PRs, system-shaping changes, and lower-trust/partial closeouts.",
+    "Reporting contract and schema wording describe the contract without adding another surface."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented closeout_report first-inspection contracts by work shape and made final_response_rendering expose and honor the selected review mode.",
+    "scope touched": "closeout report runtime, closeout report tests, reporting contract docs, workspace report schema/reference",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_report_cli.py; .agentic-workspace/docs/reporting-contract.md; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/workspace-report.md",
+    "validations run": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1249; no new top-level report surface was added; representative work-shape rendering is covered by tests.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed"
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement #1249 closeout first-inspection compression.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "review_compression now exposes mode contracts and final_response_rendering carries selected_review_mode plus first_inspection_contract with mode-specific must_include coverage.",
+    "validation confirmed": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement #1249 closeout first-inspection compression.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_report_cli.py; .agentic-workspace/docs/reporting-contract.md; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/workspace-report.md\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -87,7 +87,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `structured_findings` | object | yes |  | Structured finding residue shape for review and promotion routing. |  |  |
 | `external_evidence_safety` | object | yes |  | External evidence freshness, divergence, stale-after, and closeout-safety projection. |  |  |
 | `workflow_compliance_summary` | object | yes |  | Derived review and recovery summary of workflow entrypoint, satisfied or missing gates, trust impact, and recovery action. |  |  |
-| `closeout_report` | object | yes |  | Derived operator-facing closeout report profile, traceability, completeness, decision-review facts, closeout-first review-compression guidance, closeout adoption rubric, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary. |  |  |
+| `closeout_report` | object | yes |  | Derived operator-facing closeout report profile, traceability, completeness, decision-review facts, closeout-first review-compression contract, closeout adoption rubric, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary. |  |  |
 | `closeout_report.authority_boundary` | ref `#/$defs/authority_boundary` | no |  | Authority boundary showing which closeout/report signals are AW-enforced, observed, recommended, or agent-owned. |  |  |
 | `closeout_report.authority_boundary.kind` | const `"agentic-workspace/authority-boundary/v1"` | yes |  | Discriminator for the authority-boundary packet. |  |  |
 | `closeout_report.authority_boundary.surface` | string | yes |  | Payload surface whose authority categories are being described. |  |  |
@@ -101,7 +101,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `closeout_report.authority_boundary.human_owned_decisions` | array of string | yes |  | Intent, acceptance, or handoff decisions requiring human ownership when present. |  |  |
 | `closeout_report.authority_boundary.reporting_rule` | string | yes |  | How agents should report the boundary without overstating AW authority. |  |  |
 | `closeout_report.decision_review` | object | no |  | Derived review packet for agent-authored system decision facts, completeness, absence routing, and durable-owner guidance. |  |  |
-| `closeout_report.review_compression` | object | no |  | Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts, detail routes, and human-owned decisions. |  |  |
+| `closeout_report.review_compression` | object | no |  | Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts and contract, rendered fact requirements, detail routes, and human-owned decisions. |  |  |
 | `closeout_report.closeout_adoption` | object | no |  | Derived closeout quality rubric, representative examples, and current rendering adoption status for human-useful final reports. |  |  |
 | `continuation_next_actions` | object | yes |  | Evidence-ranked next actions for safe continuation. |  |  |
 | `migration_pilot_template` | object | yes |  | Optional migration-pilot decomposition template with parity and rollout boundaries. |  |  |

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -301,14 +301,14 @@
         },
         "review_compression": {
           "type": "object",
-          "description": "Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts, detail routes, and human-owned decisions."
+          "description": "Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts and contract, rendered fact requirements, detail routes, and human-owned decisions."
         },
         "closeout_adoption": {
           "type": "object",
           "description": "Derived closeout quality rubric, representative examples, and current rendering adoption status for human-useful final reports."
         }
       },
-      "description": "Derived operator-facing closeout report profile, traceability, completeness, decision-review facts, closeout-first review-compression guidance, closeout adoption rubric, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary."
+      "description": "Derived operator-facing closeout report profile, traceability, completeness, decision-review facts, closeout-first review-compression contract, closeout adoption rubric, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary."
     },
     "continuation_next_actions": {
       "type": "object",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -8035,6 +8035,155 @@ def _closeout_report_decision_review_payload(
     }
 
 
+def _closeout_report_review_mode_contracts() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "small-direct-edit",
+            "work_shape": "small direct edit",
+            "first_inspection_facts": ["rendered summary", "proof statement if present", "plain_done_allowed"],
+            "rendered_must_include": [],
+            "rendered_should_include": ["outcome", "validation when present"],
+            "detail_routes": ["closeout_report.final_response_rendering"],
+            "secondary_detail_policy": "Do not require raw closeout_report inspection when the rendered summary is terse and complete.",
+        },
+        {
+            "id": "planned-slice",
+            "work_shape": "planned slice",
+            "first_inspection_facts": [
+                "intended outcome",
+                "changed surfaces",
+                "proof",
+                "closure boundary",
+                "completeness",
+                "follow-up owner",
+            ],
+            "rendered_must_include": [
+                "outcome",
+                "changed surfaces",
+                "proof or validation",
+                "closure boundary",
+                "residue or follow-up status",
+            ],
+            "rendered_should_include": ["completeness when non-complete"],
+            "detail_routes": ["closeout_report", "completion_contract"],
+            "secondary_detail_policy": "Inspect full closeout_report only when the rendered slice summary omits a required fact.",
+        },
+        {
+            "id": "broad-pr",
+            "work_shape": "broad PR or strict closeout",
+            "first_inspection_facts": [
+                "planned-slice facts",
+                "validation breadth",
+                "changed public or contract surfaces",
+                "unresolved issue residue",
+            ],
+            "rendered_must_include": [
+                "profile reason",
+                "changed surfaces",
+                "proof or validation",
+                "closure boundary",
+                "residue or follow-up status",
+                "authority boundary",
+            ],
+            "rendered_should_include": ["validation breadth", "public or contract surface when present"],
+            "detail_routes": ["closeout_report", "closeout_trust", "PR body"],
+            "secondary_detail_policy": "Use detail routes to audit breadth, public surface impact, or unresolved issue residue.",
+        },
+        {
+            "id": "system-shaping-change",
+            "work_shape": "system-shaping change",
+            "first_inspection_facts": [
+                "broad-pr facts",
+                "decision facts",
+                "decision proof",
+                "durable decision owner",
+                "decision absence routing when facts are missing",
+            ],
+            "rendered_must_include": [
+                "profile reason",
+                "changed surfaces",
+                "proof or validation",
+                "closure boundary",
+                "residue or follow-up status",
+                "authority boundary",
+                "decision facts",
+            ],
+            "rendered_should_include": ["decision proof", "durable decision owner"],
+            "detail_routes": ["closeout_report.decision_review", "decision_pressure"],
+            "secondary_detail_policy": "Route to decision_review and decision_pressure when decision facts are missing or need durable promotion.",
+        },
+        {
+            "id": "partial-or-lower-trust-closeout",
+            "work_shape": "partial or lower-trust closeout",
+            "first_inspection_facts": [
+                "blocking caveat",
+                "missing proof or intent evidence",
+                "residual risk",
+                "owner",
+                "allowed closure claim",
+            ],
+            "rendered_must_include": [
+                "profile reason or caveat",
+                "missing or partial evidence caveat",
+                "closure boundary",
+                "residue or follow-up status",
+                "authority boundary",
+            ],
+            "rendered_should_include": ["proof gap", "allowed closure claim"],
+            "detail_routes": ["closeout_report", "closeout_trust", "completion_contract"],
+            "secondary_detail_policy": "Keep caveats in the user-facing closeout and inspect detail routes before accepting the risk.",
+        },
+        {
+            "id": "follow-up-or-residue-heavy-work",
+            "work_shape": "follow-up or residue-heavy work",
+            "first_inspection_facts": [
+                "residue owner",
+                "activation trigger",
+                "durable route",
+                "honest closure boundary",
+            ],
+            "rendered_must_include": [
+                "closure boundary",
+                "residue or follow-up status",
+                "authority boundary",
+            ],
+            "rendered_should_include": ["activation trigger", "durable route"],
+            "detail_routes": ["closeout_trust", "Planning reviews", "issue follow-up"],
+            "secondary_detail_policy": "Inspect residue routes before treating the parent intent as fully closed.",
+        },
+    ]
+
+
+def _closeout_report_selected_review_mode(
+    *,
+    profile_policy: dict[str, Any],
+    trust: str,
+    completeness: dict[str, Any],
+    decision_review: dict[str, Any],
+) -> str:
+    profile = str(profile_policy.get("selected_profile") or "minimal")
+    completeness_status = str(completeness.get("status") or "").strip().lower()
+    decision_status = str(decision_review.get("status") or "").strip().lower()
+    lower_or_partial = str(trust).strip().lower() == "lower-trust" or completeness_status in {"partial", "incomplete"}
+    if decision_status in {"present", "partial", "absent-required"}:
+        return "system-shaping-change"
+    if lower_or_partial or profile == "explanatory":
+        return "partial-or-lower-trust-closeout"
+    if profile == "audit":
+        return "broad-pr"
+    if profile in {"balanced", "compact"}:
+        return "planned-slice"
+    return "small-direct-edit"
+
+
+def _closeout_report_review_mode_contract(mode_id: str) -> dict[str, Any]:
+    for mode in _closeout_report_review_mode_contracts():
+        if mode["id"] == mode_id:
+            return {key: list(value) if isinstance(value, list) else value for key, value in mode.items()}
+    fallback = _closeout_report_review_mode_contracts()[0]
+    return {key: list(value) if isinstance(value, list) else value for key, value in fallback.items()}
+
+
 def _closeout_report_review_compression_payload(
     *,
     profile_policy: dict[str, Any],
@@ -8045,84 +8194,17 @@ def _closeout_report_review_compression_payload(
     follow_up_owner: str,
     detail_commands: dict[str, str],
 ) -> dict[str, Any]:
-    profile = str(profile_policy.get("selected_profile") or "minimal")
     completeness_status = str(completeness.get("status") or "").strip().lower()
     decision_status = str(decision_review.get("status") or "").strip().lower()
     lower_or_partial = str(trust).strip().lower() == "lower-trust" or completeness_status in {"partial", "incomplete"}
-    if decision_status in {"present", "partial", "absent-required"}:
-        selected_mode = "system-shaping-change"
-    elif lower_or_partial or profile == "explanatory":
-        selected_mode = "partial-or-lower-trust-closeout"
-    elif profile == "audit":
-        selected_mode = "broad-pr"
-    elif profile == "balanced":
-        selected_mode = "planned-slice"
-    elif profile == "compact":
-        selected_mode = "planned-slice"
-    else:
-        selected_mode = "small-direct-edit"
-
-    modes = [
-        {
-            "id": "small-direct-edit",
-            "first_inspection_facts": ["rendered summary", "proof statement if present", "plain_done_allowed"],
-            "detail_routes": ["closeout_report.final_response_rendering"],
-        },
-        {
-            "id": "planned-slice",
-            "first_inspection_facts": [
-                "intended outcome",
-                "changed surfaces",
-                "proof",
-                "closure boundary",
-                "completeness",
-                "follow-up owner",
-            ],
-            "detail_routes": ["closeout_report", "completion_contract"],
-        },
-        {
-            "id": "broad-pr",
-            "first_inspection_facts": [
-                "planned-slice facts",
-                "validation breadth",
-                "changed public or contract surfaces",
-                "unresolved issue residue",
-            ],
-            "detail_routes": ["closeout_report", "closeout_trust", "PR body"],
-        },
-        {
-            "id": "system-shaping-change",
-            "first_inspection_facts": [
-                "broad-pr facts",
-                "decision facts",
-                "decision proof",
-                "durable decision owner",
-                "decision absence routing when facts are missing",
-            ],
-            "detail_routes": ["closeout_report.decision_review", "decision_pressure"],
-        },
-        {
-            "id": "partial-or-lower-trust-closeout",
-            "first_inspection_facts": [
-                "blocking caveat",
-                "missing proof or intent evidence",
-                "residual risk",
-                "owner",
-                "allowed closure claim",
-            ],
-            "detail_routes": ["closeout_report", "closeout_trust", "completion_contract"],
-        },
-        {
-            "id": "follow-up-or-residue-heavy-work",
-            "first_inspection_facts": [
-                "residue owner",
-                "activation trigger",
-                "durable route",
-                "honest closure boundary",
-            ],
-            "detail_routes": ["closeout_trust", "Planning reviews", "issue follow-up"],
-        },
-    ]
+    selected_mode = _closeout_report_selected_review_mode(
+        profile_policy=profile_policy,
+        trust=trust,
+        completeness=completeness,
+        decision_review=decision_review,
+    )
+    modes = _closeout_report_review_mode_contracts()
+    first_inspection = _closeout_report_review_mode_contract(selected_mode)
     human_owned: list[str] = []
     if decision_status == "absent-required":
         human_owned.append("accept whether system-shaping decision facts may remain absent or must be routed before merge")
@@ -8139,7 +8221,8 @@ def _closeout_report_review_compression_payload(
         "authority": "derived-review-guide",
         "selected_mode": selected_mode,
         "modes": modes,
-        "first_inspection": next((mode for mode in modes if mode["id"] == selected_mode), modes[0]),
+        "first_inspection": first_inspection,
+        "first_inspection_contract": first_inspection,
         "human_owned_decisions": human_owned,
         "detail_commands": detail_commands,
         "risk_note": residual_risk,
@@ -8233,6 +8316,7 @@ def _closeout_report_final_response_rendering_payload(
     blockers: list[Any],
     next_action: str,
     decision_review: dict[str, Any] | None = None,
+    review_mode: str = "",
 ) -> dict[str, Any]:
     profile = str(profile_policy.get("selected_profile") or "minimal")
     profile_reason = str(profile_policy.get("reason") or "").strip()
@@ -8245,6 +8329,7 @@ def _closeout_report_final_response_rendering_payload(
     summary_lines: list[str] = []
     must_not_claim: list[str] = ["Do not dump raw closeout_report JSON into the final user-facing response."]
     decision_review = _as_dict(decision_review)
+    review_contract = _closeout_report_review_mode_contract(review_mode or "small-direct-edit")
 
     def present(text: str) -> str:
         return text.strip() if text and text.strip().lower() not in {"none", "null", "unknown"} else ""
@@ -8274,6 +8359,7 @@ def _closeout_report_final_response_rendering_payload(
             "missing or partial evidence caveat": ("missing", "partial", "incomplete", "plain done"),
             "authority boundary": ("authority:", "agent owns"),
             "outcome": ("outcome:", "done."),
+            "changed surfaces": ("changed:",),
             "validation": ("proof:", "validation:"),
             "decision facts": ("decision:", "decision gap:"),
         }
@@ -8333,6 +8419,8 @@ def _closeout_report_final_response_rendering_payload(
             "status": "guidance-only",
             "profile": profile,
             "rendering_mode": rendering_mode,
+            "selected_review_mode": review_contract["id"],
+            "first_inspection_contract": review_contract,
             "rendering_guidance": "Keep the final response terse; no active closeout claim needs expanded reporting.",
             "summary_lines": summary_lines,
             "rendered_summary": rendered_summary_payload(
@@ -8424,6 +8512,8 @@ def _closeout_report_final_response_rendering_payload(
         must_include.append("missing or partial evidence caveat")
         summary_lines.append("Evidence caveat: missing or partial closeout evidence; do not claim plain done.")
 
+    must_include.extend(str(item) for item in _list_payload(review_contract.get("rendered_must_include")))
+
     rendering_mode = "compact" if guidance_only else "evidence-backed" if profile_requires_detail else "compact"
     status_value = (
         "required" if profile_requires_detail or lower_trust or incomplete_or_partial or has_material_guidance_signal else "available"
@@ -8435,6 +8525,8 @@ def _closeout_report_final_response_rendering_payload(
         "status": status_value,
         "profile": profile,
         "rendering_mode": rendering_mode,
+        "selected_review_mode": review_contract["id"],
+        "first_inspection_contract": review_contract,
         "rendering_guidance": (
             "Render these closeout facts in the final user-facing response; keep them concise and omit empty fields."
             if rendering_mode == "evidence-backed"
@@ -8529,6 +8621,12 @@ def _closeout_report_payload(
         active_planning_record=active_planning_record,
         proof_report=proof_report,
     )
+    selected_review_mode = _closeout_report_selected_review_mode(
+        profile_policy=profile_policy,
+        trust=trust,
+        completeness=completeness,
+        decision_review=decision_review,
+    )
     final_response_rendering = _closeout_report_final_response_rendering_payload(
         status="present" if active_planning_record else "guidance-only",
         profile_policy=profile_policy,
@@ -8545,6 +8643,7 @@ def _closeout_report_payload(
         blockers=blockers if isinstance(blockers, list) else [],
         next_action=str(next_action),
         decision_review=decision_review,
+        review_mode=selected_review_mode,
     )
     detail_commands = {
         "closeout_report": profile_policy["next_command"],

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -1419,12 +1419,102 @@ def test_report_closeout_report_guidance_only_without_active_closeout_claim(tmp_
     assert rendering["kind"] == "agentic-workspace/final-closeout-rendering/v1"
     assert rendering["status"] == "guidance-only"
     assert rendering["rendering_mode"] == "terse"
+    assert report["review_compression"]["selected_mode"] == "small-direct-edit"
+    assert rendering["selected_review_mode"] == "small-direct-edit"
+    assert rendering["first_inspection_contract"]["id"] == "small-direct-edit"
     assert rendering["summary_lines"] == []
     assert rendering["rendered_summary"]["kind"] == "agentic-workspace/final-closeout-summary/v1"
     assert rendering["rendered_summary"]["template_id"] == "builtin/terse"
     assert rendering["rendered_summary"]["rendered_text"] == "Done."
     assert rendering["rendered_summary"]["required_fact_coverage"]["status"] == "complete"
     assert rendering["plain_done_allowed"] is True
+
+
+def test_report_closeout_report_renders_planned_slice_first_inspection_contract(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    plan = target / ".agentic-workspace" / "planning" / "execplans" / "planned-slice.plan.json"
+    _write_json(
+        plan,
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Planned Slice",
+            "active_milestone": {"id": "planned-slice", "status": "complete"},
+            "delegated_judgment": {
+                "requested outcome": "Make closeout rendering show planned slice facts first.",
+                "hard constraints": "Do not add another report surface.",
+            },
+            "completion_criteria": ["Planned slice facts render before detail inspection."],
+            "validation_commands": ["uv run pytest tests/test_workspace_report_cli.py -q"],
+            "intent_continuity": {
+                "larger intended outcome": "Make closeout reports easier to inspect.",
+                "this slice completes the larger intended outcome": "yes",
+            },
+            "required_continuation": {
+                "required follow-on for the larger intended outcome": "no",
+                "owner surface": "none",
+                "activation trigger": "none",
+            },
+            "execution_run": {
+                "run status": "complete",
+                "what happened": "Implemented planned-slice first-inspection rendering.",
+                "scope touched": "closeout report runtime and tests",
+                "changed surfaces": "workspace_runtime_primitives.py; tests/test_workspace_report_cli.py",
+                "validations run": "uv run pytest tests/test_workspace_report_cli.py -q",
+                "result for continuation": "close",
+            },
+            "proof_report": {
+                "validation proof": "uv run pytest tests/test_workspace_report_cli.py -q passed",
+                "proof achieved now": "yes",
+                "intent_proof": {
+                    "status": "sufficient_for_claim",
+                    "claim_boundary": "work",
+                    "intended_behavior": ["planned slice rendered facts"],
+                    "proof_dimensions": ["closeout report fixture"],
+                    "unproven_after_tests": [],
+                },
+            },
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": "closed",
+                "closure decision": "archive-and-close",
+                "why this decision is honest": "The planned-slice first-inspection facts are visible.",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'planned-slice', title = 'Planned slice', surface = '.agentic-workspace/planning/execplans/planned-slice.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_report", "--format", "json"]) == 0
+
+    report = json.loads(capsys.readouterr().out)["answer"]
+    assert report["profile"] == "balanced"
+    assert report["review_compression"]["selected_mode"] == "planned-slice"
+    contract = report["review_compression"]["first_inspection_contract"]
+    assert contract["id"] == "planned-slice"
+    assert "changed surfaces" in contract["rendered_must_include"]
+    rendering = report["final_response_rendering"]
+    assert rendering["selected_review_mode"] == "planned-slice"
+    assert rendering["first_inspection_contract"]["id"] == "planned-slice"
+    assert "changed surfaces" in rendering["must_include"]
+    assert "closure boundary" in rendering["must_include"]
+    assert "residue or follow-up status" in rendering["must_include"]
+    rendered = rendering["rendered_summary"]
+    assert "Changed: workspace_runtime_primitives.py; tests/test_workspace_report_cli.py" in rendered["rendered_text"]
+    assert "Proof: uv run pytest tests/test_workspace_report_cli.py -q passed" in rendered["rendered_text"]
+    assert "Closure boundary:" in rendered["rendered_text"]
+    assert "Residue:" in rendered["rendered_text"]
+    assert rendered["required_fact_coverage"]["status"] == "complete"
 
 
 def test_report_closeout_report_uses_recent_archived_closeout_evidence_without_active_plan(tmp_path: Path, capsys) -> None:
@@ -3158,7 +3248,10 @@ def test_report_closeout_report_uses_audit_profile_for_strict_closeout(tmp_path:
     rendering = report["final_response_rendering"]
     assert rendering["status"] == "required"
     assert rendering["rendering_mode"] == "evidence-backed"
+    assert rendering["selected_review_mode"] == "broad-pr"
+    assert rendering["first_inspection_contract"]["id"] == "broad-pr"
     assert "profile reason" in rendering["must_include"]
+    assert "changed surfaces" in rendering["must_include"]
     assert "proof or validation" in rendering["must_include"]
     assert "closure boundary" in rendering["must_include"]
     assert "authority boundary" in rendering["must_include"]
@@ -3170,6 +3263,7 @@ def test_report_closeout_report_uses_audit_profile_for_strict_closeout(tmp_path:
     assert rendered["template_id"] == "builtin/evidence-backed"
     assert "Closeout profile: audit because assurance.strict_closeout enabled" in rendered["rendered_text"]
     assert "agent owns completion judgment" in rendered["rendered_text"]
+    assert "Changed: workspace_runtime_primitives.py; reporting_support.py; reporting-contract.md" in rendered["rendered_text"]
     assert "Proof: uv run pytest tests/test_workspace_report_cli.py -q passed" in rendered["rendered_text"]
     assert "Closure boundary:" in rendered["rendered_text"]
     assert "Residue:" in rendered["rendered_text"]
@@ -3180,6 +3274,7 @@ def test_report_closeout_report_uses_audit_profile_for_strict_closeout(tmp_path:
     assert {"intent-boundary", "work-completed", "changed-surfaces", "validation", "closure-boundary"} <= row_ids
     assert report["decision_review"]["status"] == "not-applicable"
     assert report["review_compression"]["selected_mode"] == "broad-pr"
+    assert report["review_compression"]["first_inspection_contract"]["id"] == "broad-pr"
     assert report["closeout_adoption"]["status"] == "ready"
     assert "what proof supports it?" in report["closeout_adoption"]["human_control_questions"]
     assert "derived operator-facing presentation" in report["boundary"]
@@ -3272,6 +3367,8 @@ def test_report_closeout_report_renders_system_decision_facts(tmp_path: Path, ca
     assert decision_review["decision_facts"]["durable_owner"] == "Planning architecture_decision_promotion"
     assert decision_review["completeness"]["missing_facts"] == []
     assert report["review_compression"]["selected_mode"] == "system-shaping-change"
+    assert report["final_response_rendering"]["selected_review_mode"] == "system-shaping-change"
+    assert report["final_response_rendering"]["first_inspection_contract"]["id"] == "system-shaping-change"
     assert "decision facts" in report["review_compression"]["first_inspection"]["first_inspection_facts"]
     rendered = report["final_response_rendering"]["rendered_summary"]["rendered_text"]
     assert "Decision: Use a derived decision-review packet instead of a durable decision store." in rendered
@@ -3402,6 +3499,8 @@ def test_report_closeout_report_flags_incomplete_evidence_and_degrades_trust(tmp
     assert "strict" in report["completeness"]["strict_or_high_risk_rule"].lower()
     rendering = report["final_response_rendering"]
     assert rendering["status"] == "required"
+    assert rendering["selected_review_mode"] == "partial-or-lower-trust-closeout"
+    assert rendering["first_inspection_contract"]["id"] == "partial-or-lower-trust-closeout"
     assert rendering["plain_done_allowed"] is False
     assert "missing or partial evidence caveat" in rendering["must_include"]
     assert any("plain done summary" in item for item in rendering["must_not_claim"])


### PR DESCRIPTION
## Summary
- Add reusable closeout review-mode contracts for small direct edits, planned slices, broad PRs, system-shaping changes, lower-trust closeouts, and residue-heavy work.
- Make final_response_rendering expose selected_review_mode and first_inspection_contract, and require rendered facts from the selected work-shape contract.
- Update reporting docs/schema reference and add representative closeout_report tests for rendered UX by work shape.

## Validation
- uv run pytest tests/test_workspace_report_cli.py -q
- make test-workspace
- make lint-workspace
- uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success
- uv run python scripts/check/check_structured_file_inventory.py --quiet-success
- uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py
- uv run python scripts/run_agentic_workspace.py summary --target . --format json
- uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json
- make schema-reference-docs

Stacked on PR #1259. Closes #1249.

Dogfooding follow-up: #1260 tracks the planning closeout writer leaving stale compatibility projection fields in archived plans.