### PR TITLE
Implement decision traceability owner model

### DIFF
--- a/.agentic-workspace/docs/reporting-contract.md
+++ b/.agentic-workspace/docs/reporting-contract.md
@@ -132,6 +132,16 @@ The active owner for decision facts is Planning, primarily `architecture_decisio
 `closeout_report.decision_review` may render those facts and check completeness, while `report --section decision_pressure` remains the routing and promotion-pressure surface.
 When system-shaping signals are present but no decision facts exist, `decision_review.status` should be `absent-required` and `decision_absent_because` must say that no agent-authored facts were found rather than pretending AW inferred the decision.
 
+`decision_review.owner_model` and `decision_pressure.owner_model` describe the proportional ownership split:
+
+- the agent authors semantic decision facts;
+- AW derives presence/completeness checks, closeout display, absence visibility, and scaffold/promote routes;
+- `decision_pressure` remains routing-only and must not infer decisions from diffs, filenames, or changed paths;
+- durable accepted decisions live in host-owned surfaces such as configured decision records, docs or ADRs, Memory, config/checks/tests/contracts, or issue follow-up.
+
+Small, local, or non-system-shaping work should remain decision-light.
+Material system-shaping changes should make decision absence visible and routed; absence may block or lower trust only when the claimed work affects public or durable contracts, long-lived operating loops, proof policy, module boundaries, or future-agent guidance.
+
 Decision-review facts are:
 
 - decision made;

--- a/.agentic-workspace/planning/execplans/archive/issue-1250-decision-owner-model.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1250-decision-owner-model.plan.json
@@ -1,0 +1,324 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1250 decision traceability owner model",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1250 by defining and testing the decision traceability owner split across closeout_report.decision_review and decision_pressure.",
+    "hard_constraints": "Keep decision_pressure routing-only; do not make AW infer semantic decisions from diffs, file names, or changed surfaces; do not build a new ADR subsystem.",
+    "agent_may_decide": "Exact owner-model packet wording, proportional absence policy, durable target descriptions, and representative tests.",
+    "escalate_when": "The slice requires new durable storage, broad historical migration, or changes outside closeout_report/decision_pressure contracts.",
+    "next_action": "Implement owner-model packets and focused tests, then run AW-selected proof.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_report_cli.py -q",
+      "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+      "make schema-reference-docs"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_workspace_report_cli.py",
+      ".agentic-workspace/docs/reporting-contract.md",
+      "src/agentic_workspace/contracts/schemas/workspace_report.schema.json"
+    ],
+    "completion_criteria": [
+      "closeout_report.decision_review exposes the agent/AW/host owner split for present, missing, and not-applicable decisions.",
+      "decision_pressure exposes the same owner split while remaining routing-only.",
+      "Configured and unconfigured durable targets are represented without requiring a formal ADR system for small work.",
+      "Tests prove small work remains decision-light and system-shaping absence remains visible and routed."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Implement #1250 decision traceability owner model without turning AW into an ADR system."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1250 by defining and testing the decision traceability owner split across closeout_report.decision_review and decision_pressure.",
+      "constraints": "Keep decision_pressure routing-only; do not make AW infer semantic decisions from diffs, file names, or changed surfaces; do not build a new ADR subsystem.",
+      "latitude": "Exact owner-model packet wording, proportional absence policy, durable target descriptions, and representative tests.",
+      "escalation": "Escalate when the slice requires new durable storage, broad historical migration, or changes outside closeout_report/decision_pressure contracts.",
+      "proof": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed"
+    },
+    "execution": {
+      "milestone": "issue-1250-decision-owner-model",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed"
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_workspace_report_cli.py",
+        ".agentic-workspace/docs/reporting-contract.md",
+        "src/agentic_workspace/contracts/schemas/workspace_report.schema.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Implement #1250 decision traceability owner model without turning AW into an ADR system.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1250 decision traceability owner model",
+    "inferred intended outcome": "Make decision traceability reviewable by naming who owns semantic facts, derived display, promotion routing, and durable host targets.",
+    "chosen concrete what": "Add an owner-model packet to decision_review and decision_pressure, with tests for proportional absence and durable target routing.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_report_cli.py; .agentic-workspace/docs/reporting-contract.md; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/workspace-report.md; this execplan and planning state",
+    "max changed files": "7",
+    "required validation commands": "uv run pytest tests/test_workspace_report_cli.py -q; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; make schema-reference-docs",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue #1250 owner-model implementation in decision_review and decision_pressure.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1250 by defining and testing the decision traceability owner split across closeout_report.decision_review and decision_pressure.",
+    "hard constraints": "Keep decision_pressure routing-only; do not make AW infer semantic decisions from diffs, file names, or changed surfaces; do not build a new ADR subsystem.",
+    "agent may decide locally": "Exact owner-model packet wording, proportional absence policy, durable target descriptions, and representative tests.",
+    "escalate when": "The slice requires new durable storage, broad historical migration, or changes outside closeout_report/decision_pressure contracts."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "Bounded runtime/docs/test contract slice; local context already loaded and delegation would not reduce proof burden.",
+    "decision command": "agentic-planning delegation-decision",
+    "planning revision observed": "f179da4bdad39998",
+    "recorded at": "2026-06-04T09:22:35+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1250-decision-owner-model",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Implement owner-model packets and focused tests, then run AW-selected proof."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "tests/test_workspace_report_cli.py",
+    ".agentic-workspace/docs/reporting-contract.md",
+    "src/agentic_workspace/contracts/schemas/workspace_report.schema.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_report_cli.py -q",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "make schema-reference-docs"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "closeout_report.decision_review exposes the agent/AW/host owner split for present, missing, and not-applicable decisions.",
+    "decision_pressure exposes the same owner split while remaining routing-only.",
+    "Configured and unconfigured durable targets are represented without requiring a formal ADR system for small work.",
+    "Tests prove small work remains decision-light and system-shaping absence remains visible and routed."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented a decision traceability owner-model packet shared by closeout_report.decision_review and decision_pressure, keeping decision_pressure routing-only.",
+    "scope touched": "decision review runtime, decision pressure runtime, report tests, reporting contract docs, workspace report schema/reference",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_report_cli.py; .agentic-workspace/docs/reporting-contract.md; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/workspace-report.md",
+    "validations run": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1250; no ADR subsystem was added; tests cover unconfigured/configured decision pressure and present/missing/not-applicable closeout decision review.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "Bounded runtime/docs/test contract slice; local context already loaded and delegation would not reduce proof burden.",
+    "expected savings": "unknown",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed"
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1250 decision traceability owner model without turning AW into an ADR system.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "decision_review and decision_pressure now expose the agent/AW/host owner split, durable target options, absence policy, promotion triggers, and routing-only rule.",
+    "validation confirmed": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Scaffolded by agentic-planning new-plan.",
+    "2026-06-04: Recorded delegation decision route=keep-local."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1250 decision traceability owner model without turning AW into an ADR system.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_report_cli.py -q passed; make test-workspace passed; make lint-workspace passed; contract tooling, structured inventory, ruff, summary, planning doctor, and schema-reference-docs passed\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_report_cli.py; .agentic-workspace/docs/reporting-contract.md; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/workspace-report.md\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -100,14 +100,14 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `closeout_report.authority_boundary.agent_owned_decisions` | array of string | yes |  | Semantic, route, proof-proportionality, or completion judgments the agent owns. |  |  |
 | `closeout_report.authority_boundary.human_owned_decisions` | array of string | yes |  | Intent, acceptance, or handoff decisions requiring human ownership when present. |  |  |
 | `closeout_report.authority_boundary.reporting_rule` | string | yes |  | How agents should report the boundary without overstating AW authority. |  |  |
-| `closeout_report.decision_review` | object | no |  | Derived review packet for agent-authored system decision facts, completeness, absence routing, and durable-owner guidance. |  |  |
+| `closeout_report.decision_review` | object | no |  | Derived review packet for agent-authored system decision facts, owner-model split, completeness, absence routing, and durable-owner guidance. |  |  |
 | `closeout_report.review_compression` | object | no |  | Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts and contract, rendered fact requirements, detail routes, and human-owned decisions. |  |  |
 | `closeout_report.closeout_adoption` | object | no |  | Derived closeout quality rubric, representative examples, and current rendering adoption status for human-useful final reports. |  |  |
 | `continuation_next_actions` | object | yes |  | Evidence-ranked next actions for safe continuation. |  |  |
 | `migration_pilot_template` | object | yes |  | Optional migration-pilot decomposition template with parity and rollout boundaries. |  |  |
 | `compact_output_criteria` | object | yes |  | Criteria for compact CLI outputs to remain sufficient for cheap continuation. |  |  |
 | `automation_readiness` | object | yes |  | Provider-agnostic automation-readiness checklist that keeps execution outside AW. |  |  |
-| `decision_pressure` | object | yes |  | Host architecture-decision configuration or discovered ADR target, existing decision index, promotion pressure, and command-owned scaffold routes. |  |  |
+| `decision_pressure` | object | yes |  | Routing-only architecture-decision pressure surface with owner-model split, host decision target discovery, existing decision index, promotion pressure, and command-owned scaffold routes. |  |  |
 | `maintenance_pressure` | object | yes |  | Maintainer-facing pressure signals and optional follow-up routes. |  |  |
 | `closeout_trust` | object | yes |  | Trust signals for whether recent or current work can be safely closed. |  |  |
 | `external_work_reconciliation` | object | yes |  | Provider-agnostic reconciliation between checked-in planning and external work evidence. |  |  |

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -297,7 +297,7 @@
         },
         "decision_review": {
           "type": "object",
-          "description": "Derived review packet for agent-authored system decision facts, completeness, absence routing, and durable-owner guidance."
+          "description": "Derived review packet for agent-authored system decision facts, owner-model split, completeness, absence routing, and durable-owner guidance."
         },
         "review_compression": {
           "type": "object",
@@ -328,7 +328,7 @@
     },
     "decision_pressure": {
       "type": "object",
-      "description": "Host architecture-decision configuration or discovered ADR target, existing decision index, promotion pressure, and command-owned scaffold routes."
+      "description": "Routing-only architecture-decision pressure surface with owner-model split, host decision target discovery, existing decision index, promotion pressure, and command-owned scaffold routes."
     },
     "maintenance_pressure": {
       "type": "object",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -7916,6 +7916,100 @@ def _closeout_report_completeness_payload(
     }
 
 
+def _decision_traceability_owner_model_payload(config_info: dict[str, Any] | None = None) -> dict[str, Any]:
+    config_info = _as_dict(config_info)
+    configured_target = str(config_info.get("target") or "").strip()
+    configured = bool(config_info.get("configured"))
+    durable_targets = [
+        {
+            "id": "configured-decision-target",
+            "owner": "host repo",
+            "status": "available" if configured else "not-configured",
+            "target": configured_target,
+            "role": "Durable accepted decision record when the host repo has configured or discoverable decision storage.",
+        },
+        {
+            "id": "docs-or-adr",
+            "owner": "host repo",
+            "status": "optional",
+            "target": "docs, ADR directory, or other repo-owned decision documentation",
+            "role": "Durable rationale for decisions likely to guide future maintainers or agents.",
+        },
+        {
+            "id": "memory",
+            "owner": "host repo memory policy",
+            "status": "optional",
+            "target": "Memory note or promotion pressure",
+            "role": "Reusable agent guidance when the decision is operational knowledge rather than a formal record.",
+        },
+        {
+            "id": "config-checks-tests-contracts",
+            "owner": "host repo",
+            "status": "optional",
+            "target": "config, checks, tests, or contracts",
+            "role": "Enforceable residue when the decision should become a rule instead of prose.",
+        },
+        {
+            "id": "issue-follow-up",
+            "owner": "human or repo maintainer",
+            "status": "fallback",
+            "target": "GitHub issue or equivalent tracker",
+            "role": "Human-owned durable route when no configured decision target exists or promotion needs review.",
+        },
+    ]
+    return {
+        "kind": "agentic-workspace/decision-traceability-owner-model/v1",
+        "status": "present",
+        "semantic_decision_owner": "agent",
+        "owner_split": {
+            "agent_authored_facts": [
+                "decision",
+                "rationale",
+                "meaningful alternatives or tradeoffs",
+                "affected surfaces",
+                "proof",
+                "durable owner",
+                "promotion status",
+            ],
+            "aw_derived_review": [
+                "presence and completeness checks",
+                "derived closeout display",
+                "absence visibility",
+                "promotion and scaffold route commands",
+            ],
+            "decision_pressure": [
+                "configuration discovery",
+                "existing decision index",
+                "active planning or memory promotion pressure",
+                "scaffold/promote command routes",
+            ],
+            "host_durable_targets": durable_targets,
+        },
+        "absence_policy": {
+            "not_applicable": "Small, local, or non-system-shaping work should not require decision records.",
+            "visible_and_routed": (
+                "Material system-shaping signals without agent-authored decision facts should be reported as absent-required "
+                "and routed through decision_pressure."
+            ),
+            "may_block_or_lower_trust": (
+                "Missing facts may block or lower trust only when the agent or workflow claims a material system, product, "
+                "public-contract, proof-policy, module-boundary, or long-lived operating-loop decision."
+            ),
+        },
+        "promotion_triggers": [
+            "public or durable contract change",
+            "long-lived operating-loop change",
+            "proof or closeout policy change",
+            "module-boundary or ownership change",
+            "decision likely to affect future agents or maintainers",
+        ],
+        "routing_only_rule": (
+            "AW must not infer the semantic decision from diffs, filenames, or changed paths; it may only preserve "
+            "agent-authored facts, check completeness, and route promotion."
+        ),
+    }
+
+
 def _closeout_report_decision_review_payload(
     *,
     active_planning_record: dict[str, Any],
@@ -8014,6 +8108,7 @@ def _closeout_report_decision_review_payload(
         "kind": "agentic-workspace/closeout-decision-review/v1",
         "status": status,
         "authority": "agent-authored-facts-derived-for-review",
+        "owner_model": _decision_traceability_owner_model_payload(),
         "system_shaping_signals": system_shaping_signals,
         "decision_facts": facts,
         "completeness": {
@@ -9206,6 +9301,7 @@ def _decision_pressure_payload(
         else "not-configured",
         "configuration": config_info,
         "existing_decisions": index,
+        "owner_model": _decision_traceability_owner_model_payload(config_info),
         "planning_pressure": planning_pressure,
         "memory_pressure": memory_pressure,
         "closeout_decision_state": closeout_state,

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -102,6 +102,10 @@ def test_report_decision_pressure_shows_unconfigured_repo(tmp_path: Path, capsys
     assert answer["status"] == "not-configured"
     assert answer["configuration"]["configured"] is False
     assert answer["actions"]["scaffold"]["available"] is False
+    owner_model = answer["owner_model"]
+    assert owner_model["semantic_decision_owner"] == "agent"
+    assert "diffs" in owner_model["routing_only_rule"]
+    assert owner_model["owner_split"]["host_durable_targets"][0]["status"] == "not-configured"
 
 
 def test_report_assurance_requirements_section_projects_configured_requirements(tmp_path: Path, capsys) -> None:
@@ -735,6 +739,9 @@ def test_decision_pressure_scaffolds_configured_decision_record(tmp_path: Path, 
     assert answer["status"] == "configured"
     assert answer["configuration"]["target"] == "docs/decisions/"
     assert answer["existing_decisions"]["decision_count"] == 0
+    assert answer["owner_model"]["owner_split"]["host_durable_targets"][0]["status"] == "available"
+    assert answer["owner_model"]["owner_split"]["host_durable_targets"][0]["target"] == "docs/decisions/"
+    assert "configuration discovery" in answer["owner_model"]["owner_split"]["decision_pressure"]
     assert "planning decision-scaffold" in answer["actions"]["scaffold"]["command"]
     assert "--target ./repo" not in answer["actions"]["scaffold"]["command"]
     assert answer["actions"]["scaffold"]["command_target"]["target"] == "<repo>"
@@ -3273,6 +3280,8 @@ def test_report_closeout_report_uses_audit_profile_for_strict_closeout(tmp_path:
     row_ids = {row["id"] for row in report["traceability"]["rows"]}
     assert {"intent-boundary", "work-completed", "changed-surfaces", "validation", "closure-boundary"} <= row_ids
     assert report["decision_review"]["status"] == "not-applicable"
+    assert report["decision_review"]["owner_model"]["absence_policy"]["not_applicable"].startswith("Small")
+    assert report["decision_review"]["owner_model"]["routing_only_rule"].startswith("AW must not infer")
     assert report["review_compression"]["selected_mode"] == "broad-pr"
     assert report["review_compression"]["first_inspection_contract"]["id"] == "broad-pr"
     assert report["closeout_adoption"]["status"] == "ready"
@@ -3361,6 +3370,9 @@ def test_report_closeout_report_renders_system_decision_facts(tmp_path: Path, ca
     report = json.loads(capsys.readouterr().out)["answer"]
     decision_review = report["decision_review"]
     assert decision_review["status"] == "present"
+    assert decision_review["owner_model"]["semantic_decision_owner"] == "agent"
+    assert "presence and completeness checks" in decision_review["owner_model"]["owner_split"]["aw_derived_review"]
+    assert "decision" in decision_review["owner_model"]["owner_split"]["agent_authored_facts"]
     assert decision_review["decision_facts"]["decision"] == "Use a derived decision-review packet instead of a durable decision store."
     assert decision_review["decision_facts"]["rationale"].startswith("The agent owns")
     assert decision_review["decision_facts"]["tradeoffs"] == ["Avoids a new ADR engine", "Keeps closeout_report derived"]
@@ -3432,6 +3444,8 @@ def test_report_closeout_report_routes_missing_system_decision_facts(tmp_path: P
     report = json.loads(capsys.readouterr().out)["answer"]
     decision_review = report["decision_review"]
     assert decision_review["status"] == "absent-required"
+    assert decision_review["owner_model"]["absence_policy"]["visible_and_routed"].startswith("Material system-shaping signals")
+    assert "changed paths" in decision_review["owner_model"]["routing_only_rule"]
     assert "no agent-authored decision facts" in decision_review["decision_absent_because"]
     assert decision_review["routing"]["promotion_pressure_surface"] == "report --section decision_pressure"
     assert report["review_compression"]["selected_mode"] == "system-shaping-change"


### PR DESCRIPTION
## Summary
- Add a shared decision traceability owner-model packet for closeout_report.decision_review and decision_pressure.
- Make the owner split explicit: agent-authored semantic facts, AW-derived review/completeness/routing, routing-only decision_pressure, and host-owned durable targets.
- Document and test proportional absence behavior so small work remains decision-light while material system-shaping gaps are visible and routed.

## Validation
- uv run pytest tests/test_workspace_report_cli.py -q
- make test-workspace
- make lint-workspace
- uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success
- uv run python scripts/check/check_structured_file_inventory.py --quiet-success
- uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py
- uv run python scripts/run_agentic_workspace.py summary --target . --format json
- uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json
- make schema-reference-docs

Stacked on PR #1261. Closes #1250.