### PR TITLE
Add dogfooding feedback taxonomy pack

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1255-model-zoo-feedback-taxonomy.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1255-model-zoo-feedback-taxonomy.plan.json
@@ -1,0 +1,319 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1255 model-zoo dogfooding feedback taxonomy",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1255 Stage 1 by adding a schema-backed dogfooding feedback taxonomy, capture template, first frozen fixture set, and one Codex/Copilot sample record.",
+    "hard_constraints": "Do not build the full model registry, automated judge, or broad runner expansion in this slice.",
+    "agent_may_decide": "Exact schema fields, sample pack layout, taxonomy wording, and focused validation tests.",
+    "escalate_when": "The first record shape cannot represent the 2026-06-04 evaluation evidence without adding runner infrastructure.",
+    "next_action": "Validate the Stage 1 feedback pack and run AW-selected proof.",
+    "proof_expectations": [
+      "uv run pytest tests/test_model_cli_harness.py -q",
+      "uv run python scripts/check/check_structured_file_inventory.py --quiet-success"
+    ],
+    "touched_scope": [
+      "tools/model-cli-harness/schemas/dogfooding-feedback.schema.json",
+      "tools/model-cli-harness/feedback/2026-06-04-codex-copilot-stage1.json",
+      "tests/test_model_cli_harness.py",
+      "docs/maintainer/dogfooding-feedback.md",
+      "src/agentic_workspace/contracts/structured_file_inventory.json"
+    ],
+    "completion_criteria": [
+      "A schema-backed Stage 1 dogfooding feedback pack exists.",
+      "The pack contains a normalized taxonomy, capture template, at least three frozen task fixtures, and one Codex/Copilot comparison record.",
+      "Maintainer docs describe where future comparable records belong.",
+      "Tests validate the schema and sample pack."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Implement #1255 Stage 1 model-zoo dogfooding feedback taxonomy and first record pack."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1255 Stage 1 by adding a schema-backed dogfooding feedback taxonomy, capture template, first frozen fixture set, and one Codex/Copilot sample record.",
+      "constraints": "Do not build the full model registry, automated judge, or broad runner expansion in this slice.",
+      "latitude": "Exact schema fields, sample pack layout, taxonomy wording, and focused validation tests.",
+      "escalation": "Escalate when the first record shape cannot represent the 2026-06-04 evaluation evidence without adding runner infrastructure.",
+      "proof": "uv run pytest tests/test_model_cli_harness.py -q passed; make test-workspace passed; make lint-workspace passed; make maintainer-surfaces passed; contract tooling, structured inventory, ruff, summary, and planning doctor passed"
+    },
+    "execution": {
+      "milestone": "issue-1255-model-zoo-feedback-taxonomy",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "uv run pytest tests/test_model_cli_harness.py -q passed; make test-workspace passed; make lint-workspace passed; make maintainer-surfaces passed; contract tooling, structured inventory, ruff, summary, and planning doctor passed"
+    },
+    "scope": {
+      "touched": [
+        "tools/model-cli-harness/schemas/dogfooding-feedback.schema.json",
+        "tools/model-cli-harness/feedback/2026-06-04-codex-copilot-stage1.json",
+        "tests/test_model_cli_harness.py",
+        "docs/maintainer/dogfooding-feedback.md",
+        "src/agentic_workspace/contracts/structured_file_inventory.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Implement #1255 Stage 1 model-zoo dogfooding feedback taxonomy and first record pack.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "future model-zoo dogfooding can produce comparable schema-backed records before runner expansion",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1255 model-zoo dogfooding feedback taxonomy",
+    "inferred intended outcome": "Make cross-agent dogfooding evidence comparable before expanding model-zoo automation.",
+    "chosen concrete what": "Add a dogfooding feedback schema, sample pack, frozen fixture seeds, maintainer docs, inventory coverage, and focused validation.",
+    "interpretation distance": "low",
+    "review guidance": "Inspect tools/model-cli-harness/feedback packs for comparable failure classes, severity, evidence, suggested lanes, and aggregation signal."
+  },
+  "execution_bounds": {
+    "allowed paths": "tools/model-cli-harness/schemas/dogfooding-feedback.schema.json; tools/model-cli-harness/feedback/2026-06-04-codex-copilot-stage1.json; tests/test_model_cli_harness.py; docs/maintainer/dogfooding-feedback.md; src/agentic_workspace/contracts/structured_file_inventory.json; this execplan and planning state",
+    "max changed files": "7",
+    "required validation commands": "uv run pytest tests/test_model_cli_harness.py -q; uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue #1255 Stage 1 feedback-pack validation.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1255 Stage 1 by adding a schema-backed dogfooding feedback taxonomy, capture template, first frozen fixture set, and one Codex/Copilot sample record.",
+    "hard constraints": "Do not build the full model registry, automated judge, or broad runner expansion in this slice.",
+    "agent may decide locally": "Exact schema fields, sample pack layout, taxonomy wording, and focused validation tests.",
+    "escalate when": "The first record shape cannot represent the 2026-06-04 evaluation evidence without adding runner infrastructure."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1255-model-zoo-feedback-taxonomy",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Validate the Stage 1 feedback pack and run AW-selected proof."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "tools/model-cli-harness/schemas/dogfooding-feedback.schema.json",
+    "tools/model-cli-harness/feedback/2026-06-04-codex-copilot-stage1.json",
+    "tests/test_model_cli_harness.py",
+    "docs/maintainer/dogfooding-feedback.md",
+    "src/agentic_workspace/contracts/structured_file_inventory.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_model_cli_harness.py -q",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "A schema-backed Stage 1 dogfooding feedback pack exists.",
+    "The pack contains a normalized taxonomy, capture template, at least three frozen task fixtures, and one Codex/Copilot comparison record.",
+    "Maintainer docs describe where future comparable records belong.",
+    "Tests validate the schema and sample pack."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented Stage 1 dogfooding feedback taxonomy with a schema-backed feedback pack, frozen task fixture seeds, and one Codex/Copilot comparison record.",
+    "scope touched": "model CLI harness feedback schema and sample pack, maintainer dogfooding docs, structured inventory, model harness tests",
+    "changed surfaces": "tools/model-cli-harness/schemas/dogfooding-feedback.schema.json; tools/model-cli-harness/feedback/2026-06-04-codex-copilot-stage1.json; tests/test_model_cli_harness.py; docs/maintainer/dogfooding-feedback.md; src/agentic_workspace/contracts/structured_file_inventory.json",
+    "validations run": "uv run pytest tests/test_model_cli_harness.py -q passed; make test-workspace passed; make lint-workspace passed; make maintainer-surfaces passed; contract tooling, structured inventory, ruff, summary, and planning doctor passed",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1255 Stage 1; full model registry, judge automation, and broad runner expansion remain deferred.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_model_cli_harness.py -q passed; make test-workspace passed; make lint-workspace passed; make maintainer-surfaces passed; contract tooling, structured inventory, ruff, summary, and planning doctor passed",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run pytest tests/test_model_cli_harness.py -q passed; make test-workspace passed; make lint-workspace passed; make maintainer-surfaces passed; contract tooling, structured inventory, ruff, summary, and planning doctor passed"
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement #1255 model-zoo dogfooding feedback taxonomy.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "uv run pytest tests/test_model_cli_harness.py -q passed; make test-workspace passed; make lint-workspace passed; make maintainer-surfaces passed; contract tooling, structured inventory, ruff, summary, and planning doctor passed",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Future model-zoo dogfooding can now record comparable failure classes, severity, evidence, suggested lanes, and aggregation signal in a checked-in schema-backed pack.",
+    "validation confirmed": "uv run pytest tests/test_model_cli_harness.py -q passed; make test-workspace passed; make lint-workspace passed; make maintainer-surfaces passed; contract tooling, structured inventory, ruff, summary, and planning doctor passed",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "uv run pytest tests/test_model_cli_harness.py -q passed; make test-workspace passed; make lint-workspace passed; make maintainer-surfaces passed; contract tooling, structured inventory, ruff, summary, and planning doctor passed",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement #1255 model-zoo dogfooding feedback taxonomy.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_model_cli_harness.py -q passed; make test-workspace passed; make lint-workspace passed; make maintainer-surfaces passed; contract tooling, structured inventory, ruff, summary, and planning doctor passed\nChanged surfaces: tools/model-cli-harness/schemas/dogfooding-feedback.schema.json; tools/model-cli-harness/feedback/2026-06-04-codex-copilot-stage1.json; tests/test_model_cli_harness.py; docs/maintainer/dogfooding-feedback.md; src/agentic_workspace/contracts/structured_file_inventory.json\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/docs/maintainer/dogfooding-feedback.md
+++ b/docs/maintainer/dogfooding-feedback.md
@@ -51,6 +51,21 @@ Classify friction into one of these buckets before routing it:
 - proof or review surface issue
 - monorepo-only friction
 
+For model-zoo and external-agent evaluations, use the Stage 1 feedback pack instead of prose-only notes.
+The schema is `tools/model-cli-harness/schemas/dogfooding-feedback.schema.json`.
+Checked-in packs live under `tools/model-cli-harness/feedback/`.
+
+Each pack must include:
+
+- the normalized failure taxonomy used by the run;
+- the capture template fields required from each record and finding;
+- at least three frozen task fixtures that can later become runner scenarios;
+- one or more captured records naming model, agent surface, task, failure class, severity, evidence, suggested lane, status, and issue refs;
+- an aggregation summary that turns repeated classes into prioritization signal.
+
+Use the checked-in `tools/model-cli-harness/feedback/2026-06-04-codex-copilot-stage1.json` pack as the first template.
+The local source transcripts can stay under `.agentic-workspace/local/evaluations`; the checked-in pack should carry only the durable, comparable evidence needed for prioritization.
+
 ## Admission Rule
 
 New planning or contract work should enter the queue only when at least one of these is true:

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -634,6 +634,18 @@
       "checked_in_justification": "Test fixture or checkout diagnostic data used to prove behavior, not package runtime authority."
     },
     {
+      "pattern": "tools/model-cli-harness/feedback/*.json",
+      "format": "json",
+      "owner": "model-cli-harness",
+      "status": "schema-backed",
+      "schema_or_validator": "tools/model-cli-harness/schemas/dogfooding-feedback.schema.json",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Stage 1 dogfooding feedback packs normalize cross-agent evaluation records, taxonomy, and frozen benchmark fixture seeds before full runner automation.",
+      "storage_class": "diagnostic-fixture",
+      "checked_in_justification": "Maintainer-reviewed dogfooding evidence used to prioritize product work; not package runtime authority."
+    },
+    {
       "pattern": "tools/model-cli-harness/episodes/*.json",
       "format": "json",
       "owner": "model-cli-harness",

--- a/tests/test_model_cli_harness.py
+++ b/tests/test_model_cli_harness.py
@@ -6,6 +6,8 @@ import os
 import sys
 from pathlib import Path
 
+from jsonschema import Draft202012Validator
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 HARNESS_PATH = REPO_ROOT / "scripts" / "model_cli_harness" / "run_model_cli_harness.py"
 
@@ -57,6 +59,30 @@ def test_model_cli_harness_default_output_root_uses_workspace_local_scratch() ->
     harness = _load_harness()
 
     assert harness.DEFAULT_OUTPUT_ROOT == REPO_ROOT / ".agentic-workspace" / "local" / "scratch" / "model-cli-harness"
+
+
+def test_model_cli_harness_validates_stage1_dogfooding_feedback_pack() -> None:
+    schema = json.loads(
+        (REPO_ROOT / "tools" / "model-cli-harness" / "schemas" / "dogfooding-feedback.schema.json").read_text(encoding="utf-8")
+    )
+    pack = json.loads(
+        (REPO_ROOT / "tools" / "model-cli-harness" / "feedback" / "2026-06-04-codex-copilot-stage1.json").read_text(encoding="utf-8")
+    )
+
+    Draft202012Validator.check_schema(schema)
+    errors = list(Draft202012Validator(schema).iter_errors(pack))
+
+    assert errors == []
+    assert len(pack["benchmark_fixtures"]) >= 3
+    assert {finding["failure_class"] for record in pack["records"] for finding in record["findings"]} >= {
+        "closeout_reporting_gap",
+        "decision_traceability_gap",
+        "evaluation_capture_gap",
+    }
+    assert {agent["model"] for record in pack["records"] for agent in record["agents"]} == {
+        "gpt-5.4-mini",
+        "claude-sonnet-4.6",
+    }
 
 
 def test_model_cli_harness_reads_configured_startup_instruction_file(tmp_path: Path) -> None:

--- a/tools/model-cli-harness/feedback/2026-06-04-codex-copilot-stage1.json
+++ b/tools/model-cli-harness/feedback/2026-06-04-codex-copilot-stage1.json
@@ -1,0 +1,184 @@
+{
+  "kind": "agentic-workspace/dogfooding-feedback-pack/v1",
+  "schema_version": "agentic-workspace/dogfooding-feedback/v1",
+  "pack_id": "2026-06-04-codex-copilot-stage1",
+  "created_at": "2026-06-04",
+  "source_refs": [
+    ".agentic-workspace/local/evaluations/codex-gpt-5.4-mini-focus-review.md",
+    ".agentic-workspace/local/evaluations/copilot-claude-4.6-sonnet-focus-review.md",
+    "agent-evaluation-roadmap.md",
+    "agent-feedback-prompt.txt"
+  ],
+  "taxonomy": [
+    {
+      "id": "startup_routing_confusion",
+      "description": "Agent fails to enter through the configured repo workflow or cannot recover when the first startup command is awkward.",
+      "surfaces": ["AGENTS.md", "start", "preflight"],
+      "default_route": "issue"
+    },
+    {
+      "id": "proof_ambiguity",
+      "description": "Agent cannot identify which proof lane is required or treats weak proof as sufficient for the claim.",
+      "surfaces": ["implement", "proof", "closeout_report"],
+      "default_route": "issue"
+    },
+    {
+      "id": "ownership_ambiguity",
+      "description": "Agent cannot tell whether AW, the agent, a host repo surface, or a human owns the decision or residue.",
+      "surfaces": ["authority_boundary", "decision_pressure", "Memory", "Planning"],
+      "default_route": "issue"
+    },
+    {
+      "id": "restart_reread_cost",
+      "description": "Continuation requires broad rereading because the compact state does not name the right current evidence or route.",
+      "surfaces": ["summary", "planning reviews", "closeout evidence"],
+      "default_route": "planning"
+    },
+    {
+      "id": "closeout_reporting_gap",
+      "description": "Final user-facing report does not make outcome, proof, caveats, residue, or review-first facts inspectable cheaply.",
+      "surfaces": ["closeout_report", "final_response_rendering"],
+      "default_route": "issue"
+    },
+    {
+      "id": "decision_traceability_gap",
+      "description": "System-shaping rationale, tradeoffs, proof, durable owner, or missing-decision route is not reviewable.",
+      "surfaces": ["decision_review", "decision_pressure", "Planning"],
+      "default_route": "issue"
+    },
+    {
+      "id": "generated_surface_trust_gap",
+      "description": "Agent cannot tell whether a generated surface is fresh, directly editable, or needs a refresh command.",
+      "surfaces": ["doctor", "implement", "generated outputs"],
+      "default_route": "issue"
+    },
+    {
+      "id": "evaluation_capture_gap",
+      "description": "Dogfooding output is prose-only or local scratch, making cross-agent failures hard to compare or aggregate.",
+      "surfaces": ["model-cli-harness", "agent feedback records"],
+      "default_route": "harness"
+    }
+  ],
+  "capture_template": {
+    "required_record_fields": ["id", "evaluated_at", "task", "agents", "findings", "prioritization_signal"],
+    "required_finding_fields": [
+      "failure_class",
+      "severity",
+      "summary",
+      "evidence",
+      "agent_scope",
+      "suggested_lane",
+      "status"
+    ],
+    "severity_scale": ["low", "medium", "high", "critical"],
+    "status_values": ["new", "routed", "implemented", "deferred", "dismissed"]
+  },
+  "benchmark_fixtures": [
+    {
+      "id": "startup-routing-first-contact",
+      "task_shape": "fresh repo orientation",
+      "prompt": "Inspect this repo enough to identify the safe next action for the user's requested work.",
+      "primary_surface": "AGENTS.md plus start output",
+      "success_signal": "Agent runs the configured AW start command before broad raw file inspection and reports the agent-owned work-shape judgment.",
+      "why_frozen": "Startup routing confusion appeared in external runs and is a cheap cross-agent first-contact probe."
+    },
+    {
+      "id": "proof-route-learned-host",
+      "task_shape": "host proof selection",
+      "prompt": "Make a small code change in an unfamiliar host repo and choose validation without assuming AW's own pytest workflow.",
+      "primary_surface": "implement/proof output plus host repo evidence",
+      "success_signal": "Agent distinguishes discovered proof hints from confirmed proof routes and avoids hard-coded pytest selection.",
+      "why_frozen": "Both evaluations highlighted proof ambiguity and repo-assumption risk."
+    },
+    {
+      "id": "closeout-decision-reporting",
+      "task_shape": "system-shaping closeout",
+      "prompt": "Close out a broad system-shaping slice and report what changed, proof, caveats, and decision ownership.",
+      "primary_surface": "closeout_report, decision_review, decision_pressure",
+      "success_signal": "Final report names first-inspection facts, proof, residual risk, and agent-authored decision facts or routed absence.",
+      "why_frozen": "Closeout UX and decision traceability were the strongest shared priority signals."
+    }
+  ],
+  "records": [
+    {
+      "id": "2026-06-04-focus-review-comparison",
+      "evaluated_at": "2026-06-04",
+      "task": {
+        "id": "external-focus-review",
+        "prompt_ref": "local evaluation prompt for next engineering lanes",
+        "summary": "Ask two external agent surfaces to identify the next AW engineering focus areas from current repo evidence."
+      },
+      "agents": [
+        {
+          "agent": "Codex CLI",
+          "model": "gpt-5.4-mini",
+          "surface": "codex",
+          "run_ref": ".agentic-workspace/local/evaluations/codex-gpt-5.4-mini-focus-review.md"
+        },
+        {
+          "agent": "Copilot CLI",
+          "model": "claude-sonnet-4.6",
+          "surface": "copilot",
+          "run_ref": ".agentic-workspace/local/evaluations/copilot-claude-4.6-sonnet-focus-review.md"
+        }
+      ],
+      "findings": [
+        {
+          "id": "closeout-reporting-shared-priority",
+          "failure_class": "closeout_reporting_gap",
+          "severity": "high",
+          "summary": "Both evaluations treated closeout/report UX as a top trust loop for long-horizon work.",
+          "evidence": [
+            "Codex ranked closeout reporting profiles and review compression in its top three focus areas.",
+            "Copilot emphasized closeout reporting acceptance criteria and user-facing report quality."
+          ],
+          "agent_scope": "multi-agent",
+          "suggested_lane": "#1249 closeout/report first-inspection compression",
+          "issue_refs": ["#1249"],
+          "status": "routed"
+        },
+        {
+          "id": "decision-traceability-shared-priority",
+          "failure_class": "decision_traceability_gap",
+          "severity": "high",
+          "summary": "Both evaluations identified decision traceability as necessary for system-shaping work.",
+          "evidence": [
+            "Codex called for decision facts, alternatives, proof, and durable owner.",
+            "Copilot identified decision traceability as a trust gap for architecture/product changes."
+          ],
+          "agent_scope": "multi-agent",
+          "suggested_lane": "#1250 decision traceability owner model",
+          "issue_refs": ["#1250"],
+          "status": "routed"
+        },
+        {
+          "id": "feedback-shape-missing",
+          "failure_class": "evaluation_capture_gap",
+          "severity": "medium",
+          "summary": "The useful cross-agent signal was still local prose until this Stage 1 record shape.",
+          "evidence": [
+            "The source evaluation files lived under .agentic-workspace/local/evaluations.",
+            "#1255 was created because prose-only evaluation output was hard to aggregate."
+          ],
+          "agent_scope": "multi-agent",
+          "suggested_lane": "#1255 model-zoo dogfooding feedback taxonomy",
+          "issue_refs": ["#1255"],
+          "status": "implemented"
+        }
+      ],
+      "prioritization_signal": {
+        "summary": "Shared high-severity findings should outrank single-agent ergonomic friction unless proof or safety is at risk.",
+        "recommended_next_action": "Use repeated failure_class counts plus severity to order implementation lanes before expanding the runner."
+      }
+    }
+  ],
+  "aggregation": {
+    "repeated_failure_classes": ["closeout_reporting_gap", "decision_traceability_gap", "evaluation_capture_gap"],
+    "top_issue_refs": ["#1249", "#1250", "#1255"],
+    "deferred_work": [
+      "Full model registry",
+      "Automated scoring and judge-agent integration",
+      "Large benchmark runner expansion beyond the first frozen fixture set"
+    ]
+  }
+}

--- a/tools/model-cli-harness/schemas/dogfooding-feedback.schema.json
+++ b/tools/model-cli-harness/schemas/dogfooding-feedback.schema.json
@@ -1,0 +1,374 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "agentic-workspace/dogfooding-feedback-pack.schema.json",
+  "title": "Dogfooding Feedback Pack",
+  "description": "Stage 1 structured feedback pack for comparing long-horizon agent dogfooding runs before building a full model-zoo runner.",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "pack_id",
+    "created_at",
+    "taxonomy",
+    "capture_template",
+    "benchmark_fixtures",
+    "records",
+    "aggregation"
+  ],
+  "properties": {
+    "kind": {
+      "const": "agentic-workspace/dogfooding-feedback-pack/v1"
+    },
+    "schema_version": {
+      "const": "agentic-workspace/dogfooding-feedback/v1"
+    },
+    "pack_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "taxonomy": {
+      "type": "array",
+      "minItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "description",
+          "surfaces",
+          "default_route"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/$defs/failure_class"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "surfaces": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          },
+          "default_route": {
+            "enum": [
+              "issue",
+              "planning",
+              "memory",
+              "docs",
+              "checks",
+              "harness",
+              "dismissed"
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "capture_template": {
+      "type": "object",
+      "required": [
+        "required_record_fields",
+        "required_finding_fields",
+        "severity_scale",
+        "status_values"
+      ],
+      "properties": {
+        "required_record_fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "required_finding_fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "severity_scale": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/severity"
+          }
+        },
+        "status_values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/finding_status"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "benchmark_fixtures": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "task_shape",
+          "prompt",
+          "primary_surface",
+          "success_signal",
+          "why_frozen"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "task_shape": {
+            "type": "string",
+            "minLength": 1
+          },
+          "prompt": {
+            "type": "string",
+            "minLength": 1
+          },
+          "primary_surface": {
+            "type": "string",
+            "minLength": 1
+          },
+          "success_signal": {
+            "type": "string",
+            "minLength": 1
+          },
+          "why_frozen": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "records": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "evaluated_at",
+          "task",
+          "agents",
+          "findings",
+          "prioritization_signal"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evaluated_at": {
+            "type": "string",
+            "minLength": 1
+          },
+          "task": {
+            "type": "object",
+            "required": [
+              "id",
+              "prompt_ref",
+              "summary"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "prompt_ref": {
+                "type": "string"
+              },
+              "summary": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "agents": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "agent",
+                "model",
+                "surface",
+                "run_ref"
+              ],
+              "properties": {
+                "agent": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "surface": {
+                  "type": "string"
+                },
+                "run_ref": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "findings": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "failure_class",
+                "severity",
+                "summary",
+                "evidence",
+                "agent_scope",
+                "suggested_lane",
+                "status"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "failure_class": {
+                  "$ref": "#/$defs/failure_class"
+                },
+                "severity": {
+                  "$ref": "#/$defs/severity"
+                },
+                "summary": {
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "agent_scope": {
+                  "enum": [
+                    "single-agent",
+                    "multi-agent",
+                    "model-tier-specific",
+                    "harness-only"
+                  ]
+                },
+                "suggested_lane": {
+                  "type": "string"
+                },
+                "issue_refs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": []
+                },
+                "status": {
+                  "$ref": "#/$defs/finding_status"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "prioritization_signal": {
+            "type": "object",
+            "required": [
+              "summary",
+              "recommended_next_action"
+            ],
+            "properties": {
+              "summary": {
+                "type": "string"
+              },
+              "recommended_next_action": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "aggregation": {
+      "type": "object",
+      "required": [
+        "repeated_failure_classes",
+        "top_issue_refs",
+        "deferred_work"
+      ],
+      "properties": {
+        "repeated_failure_classes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/failure_class"
+          }
+        },
+        "top_issue_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deferred_work": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "failure_class": {
+      "enum": [
+        "startup_routing_confusion",
+        "proof_ambiguity",
+        "ownership_ambiguity",
+        "plan_curation_drift",
+        "restart_reread_cost",
+        "handoff_insufficiency",
+        "mixed_agent_posture_confusion",
+        "closeout_reporting_gap",
+        "decision_traceability_gap",
+        "generated_surface_trust_gap",
+        "evaluation_capture_gap"
+      ]
+    },
+    "severity": {
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "finding_status": {
+      "enum": [
+        "new",
+        "routed",
+        "implemented",
+        "deferred",
+        "dismissed"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- adds a schema-backed Stage 1 dogfooding feedback pack for Codex/Copilot comparison records
- freezes first benchmark fixture seeds and the initial failure-class taxonomy
- documents the capture workflow and registers the feedback pack pattern in the structured file inventory

## Stack
- Stacked on #1262 / `codex/1250-decision-owner-model`

Closes #1255.

## Validation
- `uv run pytest tests/test_model_cli_harness.py -q`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `git diff --check`