### PR TITLE
Clarify read-only planning gate allowance

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1256-read-only-planning-gate.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1256-read-only-planning-gate.plan.json
@@ -1,0 +1,305 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1256 read-only planning gate clarity",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1256 by making read-only exploration/review permission explicit when implementation is gated.",
+    "hard_constraints": "Do not weaken implementation gates, proof requirements, or completion-claim boundaries.",
+    "agent_may_decide": "Exact packet field names and test placement, provided the fields are top-level enough for ordinary agents to see.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Add read-only allowance fields to next_safe_action and planning_safety_gate, then validate the gated review/task fixture.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_start_preflight_cli.py -q"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_workspace_start_preflight_cli.py",
+      ".agentic-workspace/planning/execplans/issue-1256-read-only-planning-gate.plan.json"
+    ],
+    "completion_criteria": [
+      "Gated start output explicitly reports read_only_allowed/exploration_allowed and allowed read-only action classes.",
+      "Implementation remains blocked and completion claims remain blocked under the gate.",
+      "Tests recreate candidate-lane gate confusion and prove the new boundary."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Implement #1256 read-only planning gate clarity."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1256 by making read-only exploration/review permission explicit when implementation is gated.",
+      "constraints": "Do not weaken implementation gates, proof requirements, or completion-claim boundaries.",
+      "latitude": "Exact packet field names and test placement, provided the fields are top-level enough for ordinary agents to see.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "uv run pytest tests/test_workspace_start_preflight_cli.py -q passed; make test-workspace passed; make lint-workspace passed; schema-reference-docs passed; contract tooling, structured inventory, ruff, summary, planning doctor, and git diff --check passed"
+    },
+    "execution": {
+      "milestone": "issue-1256-read-only-planning-gate",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "uv run pytest tests/test_workspace_start_preflight_cli.py -q passed; make test-workspace passed; make lint-workspace passed; schema-reference-docs passed; contract tooling, structured inventory, ruff, summary, planning doctor, and git diff --check passed"
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_workspace_start_preflight_cli.py",
+        ".agentic-workspace/planning/execplans/issue-1256-read-only-planning-gate.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Implement #1256 read-only planning gate clarity.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "planning-gated outputs now explicitly permit read-only review and exploration while blocking implementation and completion claims",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1256 read-only planning gate clarity",
+    "inferred intended outcome": "Create a bounded plan for Implement #1256 read-only planning gate clarity.",
+    "chosen concrete what": "Added read-only allowance and claim-boundary fields to next_safe_action and planning_safety_gate, with gated review/task tests.",
+    "interpretation distance": "low",
+    "review guidance": "Inspect the generated packet fields in gated start output; no further plan continuation is required."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "uv run pytest tests/test_workspace_start_preflight_cli.py -q passed; make test-workspace passed; make lint-workspace passed; schema-reference-docs passed; contract tooling, structured inventory, ruff, summary, planning doctor, and git diff --check passed",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if the read-only allowance fields regress.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Implement #1256 read-only planning gate clarity.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1256-read-only-planning-gate",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Fill in execution bounds, touched paths, and validation before implementation starts."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_start_preflight_cli.py -q passed; make test-workspace passed; make lint-workspace passed; schema-reference-docs passed; contract tooling, structured inventory, ruff, summary, planning doctor, and git diff --check passed"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement #1256 read-only planning gate clarity is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented explicit read-only/exploration allowance for planning-gated work in next_safe_action and planning_safety_gate, including claim-boundary fields and review-shaped candidate-gate tests.",
+    "scope touched": "startup/runtime planning safety packets, startup schema and reference docs, startup preflight tests",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; docs/reference/startup-context.md; tests/test_workspace_start_preflight_cli.py",
+    "validations run": "uv run pytest tests/test_workspace_start_preflight_cli.py -q passed; make test-workspace passed; make lint-workspace passed; schema-reference-docs passed; contract tooling, structured inventory, ruff, summary, planning doctor, and git diff --check passed",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1256; implementation gates and completion-claim boundaries remain intact while read-only/review work is explicit.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_start_preflight_cli.py -q passed; make test-workspace passed; make lint-workspace passed; schema-reference-docs passed; contract tooling, structured inventory, ruff, summary, planning doctor, and git diff --check passed",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run pytest tests/test_workspace_start_preflight_cli.py -q passed; make test-workspace passed; make lint-workspace passed; schema-reference-docs passed; contract tooling, structured inventory, ruff, summary, planning doctor, and git diff --check passed"
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement #1256 read-only planning gate clarity.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "uv run pytest tests/test_workspace_start_preflight_cli.py -q passed; make test-workspace passed; make lint-workspace passed; schema-reference-docs passed; contract tooling, structured inventory, ruff, summary, planning doctor, and git diff --check passed",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Agents can now see that review, issue triage, and read-only exploration may continue when candidate-lane planning blocks implementation.",
+    "validation confirmed": "uv run pytest tests/test_workspace_start_preflight_cli.py -q passed; make test-workspace passed; make lint-workspace passed; schema-reference-docs passed; contract tooling, structured inventory, ruff, summary, planning doctor, and git diff --check passed",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "uv run pytest tests/test_workspace_start_preflight_cli.py -q passed; make test-workspace passed; make lint-workspace passed; schema-reference-docs passed; contract tooling, structured inventory, ruff, summary, planning doctor, and git diff --check passed",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement #1256 read-only planning gate clarity.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_start_preflight_cli.py -q passed; make test-workspace passed; make lint-workspace passed; schema-reference-docs passed; contract tooling, structured inventory, ruff, summary, planning doctor, and git diff --check passed\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; docs/reference/startup-context.md; tests/test_workspace_start_preflight_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -92,8 +92,17 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `next_safe_action.allowed_next_actions` | array of string | yes |  | Actions allowed before the next wider context read or implementation step. |  |  |
 | `next_safe_action.forbidden_actions` | array of string | yes |  | Actions forbidden by this packet until a newer compact packet supersedes it. |  |  |
 | `next_safe_action.implementation_allowed` | boolean | yes |  | Whether implementation may begin from this packet without additional planning, proof setup, or skill-guided escalation. |  |  |
+| `next_safe_action.read_only_allowed` | boolean | yes |  | Whether non-mutating inspection, review, issue triage, or report generation may continue from this packet. |  |  |
+| `next_safe_action.exploration_allowed` | boolean | yes |  | Whether exploratory read-only work may continue even when implementation is gated. |  |  |
+| `next_safe_action.allowed_read_only_actions` | array of string | yes |  | Examples of read-only action classes allowed before implementation ownership changes. |  |  |
 | `next_safe_action.proof_required` | boolean | yes |  | Whether proof is required before claiming the next action is complete. |  |  |
 | `next_safe_action.completion_claim_allowed` | boolean | yes |  | Whether the packet permits claiming completion at the current claim level. |  |  |
+| `next_safe_action.claim_boundary` | object | yes |  | Boundary packet that prevents read-only allowance from being mistaken for implementation or completion permission. |  |  |
+| `next_safe_action.claim_boundary.implementation` | enum `"allowed"`, `"blocked-until-planning-ownership"` | yes |  | Implementation permission state represented independently from read-only allowance. |  |  |
+| `next_safe_action.claim_boundary.completion_claim` | enum `"allowed-after-proof"`, `"blocked-until-proof-and-acceptance"` | yes |  | Completion-claim permission state represented independently from read-only allowance. |  |  |
+| `next_safe_action.claim_boundary.gate_result` | string | yes |  | Gate or action result that explains the implementation boundary. |  |  |
+| `next_safe_action.claim_boundary.required_before_implementation` | array of string | yes |  | Required action ids or commands before implementation may proceed. |  |  |
+| `next_safe_action.claim_boundary.rule` | string | yes |  | Human-readable rule distinguishing exploration permission from implementation and completion claims. |  |  |
 | `next_safe_action.closure_blockers` | array of string | yes |  | Reasons closure or completion claims are blocked. |  |  |
 | `next_safe_action.continuation_owner_required` | boolean | yes |  | Whether unfinished intent needs an explicit continuation owner before closeout. |  |  |
 | `next_safe_action.memory_consultation_status` | string | yes |  | Memory consultation or durable-residue status relevant to the next action. |  |  |

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -810,8 +810,12 @@
         "allowed_next_actions",
         "forbidden_actions",
         "implementation_allowed",
+        "read_only_allowed",
+        "exploration_allowed",
+        "allowed_read_only_actions",
         "proof_required",
         "completion_claim_allowed",
+        "claim_boundary",
         "closure_blockers",
         "continuation_owner_required",
         "memory_consultation_status",
@@ -886,6 +890,23 @@
           "type": "boolean",
           "description": "Whether implementation may begin from this packet without additional planning, proof setup, or skill-guided escalation."
         },
+        "read_only_allowed": {
+          "type": "boolean",
+          "description": "Whether non-mutating inspection, review, issue triage, or report generation may continue from this packet."
+        },
+        "exploration_allowed": {
+          "type": "boolean",
+          "description": "Whether exploratory read-only work may continue even when implementation is gated."
+        },
+        "allowed_read_only_actions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Examples of read-only action classes allowed before implementation ownership changes."
+        },
         "proof_required": {
           "type": "boolean",
           "description": "Whether proof is required before claiming the next action is complete."
@@ -893,6 +914,52 @@
         "completion_claim_allowed": {
           "type": "boolean",
           "description": "Whether the packet permits claiming completion at the current claim level."
+        },
+        "claim_boundary": {
+          "type": "object",
+          "required": [
+            "implementation",
+            "completion_claim",
+            "gate_result",
+            "required_before_implementation",
+            "rule"
+          ],
+          "properties": {
+            "implementation": {
+              "enum": [
+                "allowed",
+                "blocked-until-planning-ownership"
+              ],
+              "description": "Implementation permission state represented independently from read-only allowance."
+            },
+            "completion_claim": {
+              "enum": [
+                "allowed-after-proof",
+                "blocked-until-proof-and-acceptance"
+              ],
+              "description": "Completion-claim permission state represented independently from read-only allowance."
+            },
+            "gate_result": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Gate or action result that explains the implementation boundary."
+            },
+            "required_before_implementation": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": "Required action ids or commands before implementation may proceed."
+            },
+            "rule": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Human-readable rule distinguishing exploration permission from implementation and completion claims."
+            }
+          },
+          "additionalProperties": false,
+          "description": "Boundary packet that prevents read-only allowance from being mistaken for implementation or completion permission."
         },
         "closure_blockers": {
           "type": "array",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -15106,6 +15106,36 @@ def _preferred_cli_effect(preferred_cli: str) -> str:
     return "read-only"
 
 
+def _read_only_allowance_packet(
+    *,
+    implementation_allowed: bool,
+    completion_claim_allowed: bool,
+    gate_result: str,
+    required_next_action: str,
+) -> dict[str, Any]:
+    implementation_state = "allowed" if implementation_allowed else "blocked-until-planning-ownership"
+    completion_state = "allowed-after-proof" if completion_claim_allowed else "blocked-until-proof-and-acceptance"
+    return {
+        "read_only_allowed": True,
+        "exploration_allowed": True,
+        "allowed_read_only_actions": [
+            "inspect files and planning state",
+            "review issues, PRs, logs, docs, and command output",
+            "run read-only AW start, preflight, skills, summary, status, report, or doctor commands",
+            "draft review, triage, evaluation, or implementation recommendations without editing source",
+        ],
+        "claim_boundary": {
+            "implementation": implementation_state,
+            "completion_claim": completion_state,
+            "gate_result": gate_result,
+            "required_before_implementation": [] if implementation_allowed else [required_next_action],
+            "rule": (
+                "Read-only exploration/review may continue; implementation and completion claims still need gate, proof, and acceptance."
+            ),
+        },
+    }
+
+
 def _next_safe_action_packet(
     *,
     immediate: dict[str, Any],
@@ -15178,6 +15208,14 @@ def _next_safe_action_packet(
     if skill in {"planning-reporting", "planning-autopilot", "planning-decompose", "planning-new-plan-tighten"}:
         proof_required = True
     implementation_allowed = not forbidden_actions and not skill.startswith("planning")
+    completion_claim_allowed = not forbidden_actions and action not in {"choose-smallest-workflow-shape"}
+    gate_result = decision or action
+    read_only_allowance = _read_only_allowance_packet(
+        implementation_allowed=implementation_allowed,
+        completion_claim_allowed=completion_claim_allowed,
+        gate_result=gate_result,
+        required_next_action=action,
+    )
     authority_boundary = _authority_boundary_payload(
         surface="next_safe_action",
         enforced_by_aw=[
@@ -15189,6 +15227,7 @@ def _next_safe_action_packet(
             f"preferred_cli_effect={command_effect}",
             f"module_slot={module_slot}",
             f"memory_consultation_status={memory_status}",
+            f"read_only_allowed={read_only_allowance['read_only_allowed']}",
         ],
         recommended_by_aw=[action, skill, preferred_cli],
         proof_hints=[proof_hint],
@@ -15217,8 +15256,12 @@ def _next_safe_action_packet(
         "allowed_next_actions": allowed_next_actions,
         "forbidden_actions": sorted(set(forbidden_actions)),
         "implementation_allowed": implementation_allowed,
+        "read_only_allowed": read_only_allowance["read_only_allowed"],
+        "exploration_allowed": read_only_allowance["exploration_allowed"],
+        "allowed_read_only_actions": read_only_allowance["allowed_read_only_actions"],
         "proof_required": proof_required,
-        "completion_claim_allowed": not forbidden_actions and action not in {"choose-smallest-workflow-shape"},
+        "completion_claim_allowed": completion_claim_allowed,
+        "claim_boundary": read_only_allowance["claim_boundary"],
         "closure_blockers": closure_blockers,
         "continuation_owner_required": continuation_owner_required,
         "memory_consultation_status": memory_status,
@@ -16632,6 +16675,11 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         "delegation_decision_required": gate.get("delegation_decision_required"),
         "authority_boundary": _compact_authority_boundary(gate.get("authority_boundary")),
     }
+    if gate.get("implementation_allowed") is False or gate.get("workflow_sufficient") is False:
+        compact["read_only_allowed"] = gate.get("read_only_allowed")
+        compact["exploration_allowed"] = gate.get("exploration_allowed")
+        compact["allowed_read_only_actions"] = gate.get("allowed_read_only_actions")
+        compact["claim_boundary"] = gate.get("claim_boundary")
     if "changed_path_facts" in gate or "changed_path_classification" in gate:
         compact["changed_path_facts"] = gate.get("changed_path_facts") or gate.get("changed_path_classification")
     if "work_shape_guidance" in gate:
@@ -20683,6 +20731,12 @@ def _planning_safety_gate_payload(
             "are support signals for agent judgment."
         ),
     )
+    read_only_allowance = _read_only_allowance_packet(
+        implementation_allowed=workflow_sufficient,
+        completion_claim_allowed=workflow_sufficient,
+        gate_result=decision,
+        required_next_action=required_next_action,
+    )
     return {
         "kind": "agentic-workspace/planning-safety-gate/v1",
         "status": status,
@@ -20727,6 +20781,10 @@ def _planning_safety_gate_payload(
         "active_delegation_requirement": active_delegation_requirement,
         "active_parent_decomposition_requirement": active_parent_decomposition_requirement,
         "implementation_allowed": workflow_sufficient,
+        "read_only_allowed": read_only_allowance["read_only_allowed"],
+        "exploration_allowed": read_only_allowance["exploration_allowed"],
+        "allowed_read_only_actions": read_only_allowance["allowed_read_only_actions"],
+        "claim_boundary": read_only_allowance["claim_boundary"],
         "new_plan_command": _command_with_cli_invoke(
             command=_command_with_expected_planning_revision(
                 "agentic-workspace planning new-plan --id <id> --title <title> --target . --activate --format json",

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -780,6 +780,13 @@ def test_start_default_returns_selector_first_router(tmp_path: Path, capsys) -> 
     assert packet["allowed_next_actions"]
     assert isinstance(packet["closure_blockers"], list)
     assert isinstance(packet["continuation_owner_required"], bool)
+    assert packet["read_only_allowed"] is True
+    assert packet["exploration_allowed"] is True
+    assert packet["allowed_read_only_actions"]
+    assert packet["claim_boundary"]["completion_claim"] in {
+        "allowed-after-proof",
+        "blocked-until-proof-and-acceptance",
+    }
     assert packet["memory_consultation_status"] in {"recommended", "unknown"}
     boundary = packet["authority_boundary"]
     assert boundary["kind"] == "agentic-workspace/authority-boundary/v1"
@@ -1644,6 +1651,16 @@ def test_start_blocks_broad_work_when_decomposition_lane_needs_promotion(tmp_pat
     assert _start_workflow_sufficiency(payload)["sufficiency_result"] == "candidate-lane-promotion-required"
     assert _start_primary_action(payload)["action"] == "select-or-promote-candidate-lane"
     assert payload["next_safe_action"]["implementation_allowed"] is False
+    assert payload["next_safe_action"]["read_only_allowed"] is True
+    assert payload["next_safe_action"]["exploration_allowed"] is True
+    assert "review issues, PRs, logs, docs, and command output" in payload["next_safe_action"]["allowed_read_only_actions"]
+    assert payload["next_safe_action"]["completion_claim_allowed"] is False
+    assert payload["next_safe_action"]["claim_boundary"]["implementation"] == "blocked-until-planning-ownership"
+    assert payload["next_safe_action"]["claim_boundary"]["completion_claim"] == "blocked-until-proof-and-acceptance"
+    assert payload["next_safe_action"]["claim_boundary"]["required_before_implementation"] == ["select-or-promote-candidate-lane"]
+    assert gate["read_only_allowed"] is True
+    assert gate["exploration_allowed"] is True
+    assert gate["claim_boundary"]["gate_result"] == "candidate-lane-promotion-required"
     decision = _start_context_value(payload, "delegation_decision")
     assert decision["decomposition_delegation"]["status"] == "available-without-active-planning"
 
@@ -1695,6 +1712,65 @@ candidates = [
     ]
     assert "planning promote-to-plan --item-id github-1201-command-package" in gate["candidate_pressure"]["route_options"][0]["command"]
     assert payload["next_safe_action"]["implementation_allowed"] is False
+    assert payload["next_safe_action"]["read_only_allowed"] is True
+    assert payload["next_safe_action"]["exploration_allowed"] is True
+    assert payload["next_safe_action"]["completion_claim_allowed"] is False
+    assert payload["next_safe_action"]["claim_boundary"]["implementation"] == "blocked-until-planning-ownership"
+
+
+def test_start_allows_read_only_review_under_candidate_lane_gate(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "github-1201-command-package", maturity = "candidate", status = "next", priority = "P1", refs = "GitHub #1201", title = "Command package extraction", outcome = "Extract the command package.", reason = "Open issue.", promotion_signal = "Promote before implementation.", suggested_first_slice = "Shape a bounded lane." },
+  { id = "github-1202-runtime-parity", maturity = "candidate", status = "next", priority = "P1", refs = "GitHub #1202", title = "Runtime parity", outcome = "Prove generated runtime parity.", reason = "Open issue.", promotion_signal = "Promote before implementation.", suggested_first_slice = "Shape a bounded lane." },
+]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Review #1201 and #1202 and report implementation risks before editing",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    gate = _start_planning_safety_gate(payload)
+    assert gate["gate_result"] == "candidate-lane-promotion-required"
+    assert gate["implementation_allowed"] is False
+    assert gate["read_only_allowed"] is True
+    assert gate["exploration_allowed"] is True
+    assert "draft review, triage, evaluation, or implementation recommendations without editing source" in gate["allowed_read_only_actions"]
+
+    next_action = payload["next_safe_action"]
+    _assert_next_safe_action_valid(next_action)
+    assert next_action["implementation_allowed"] is False
+    assert next_action["read_only_allowed"] is True
+    assert next_action["exploration_allowed"] is True
+    assert next_action["completion_claim_allowed"] is False
+    assert next_action["claim_boundary"]["implementation"] == "blocked-until-planning-ownership"
+    assert next_action["claim_boundary"]["completion_claim"] == "blocked-until-proof-and-acceptance"
+    assert next_action["claim_boundary"]["required_before_implementation"] == ["select-or-promote-candidate-lane"]
 
 
 def test_start_marks_bare_issue_ref_scope_unknown_without_external_evidence(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- adds explicit `read_only_allowed` / `exploration_allowed` signals to `next_safe_action` and gated `planning_safety_gate` projections
- adds `allowed_read_only_actions` and `claim_boundary` so review/exploration permission cannot be confused with implementation or completion permission
- covers the candidate-lane gate with a review-shaped regression and updates the startup schema/reference docs

## Stack
- Stacked on #1263 / `codex/1255-model-zoo-feedback-taxonomy`

Closes #1256.

## Validation
- `uv run pytest tests/test_workspace_start_preflight_cli.py -q`
- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q`
- `make test-workspace`
- `make lint-workspace`
- `make schema-reference-docs`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `git diff --check`