### PR TITLE
Normalize closeout projection fields

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1260-closeout-projection-normalization.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1260-closeout-projection-normalization.plan.json
@@ -1,0 +1,309 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1260 closeout projection normalization",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1260 by normalizing closeout-facing compatibility projections during plan closeout.",
+    "hard_constraints": "Do not weaken archive validation or closeout evidence requirements.",
+    "agent_may_decide": "Exact helper shape and focused test placement inside the existing closeout/archive coverage.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Patch the closeout writer normalization helpers and prove archived records no longer carry active/pending compatibility residue.",
+    "proof_expectations": [
+      "uv run pytest packages/planning/tests/test_archive.py -q"
+    ],
+    "touched_scope": [
+      "packages/planning/src/repo_planning_bootstrap/installer.py",
+      "packages/planning/tests/test_archive.py",
+      ".agentic-workspace/planning/execplans/issue-1260-closeout-projection-normalization.plan.json"
+    ],
+    "completion_criteria": [
+      "Completed no-residue closeouts now archive internally consistent terminal execution and delegation projection fields."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Implement #1260 closeout projection normalization."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1260 by normalizing closeout-facing compatibility projections during plan closeout.",
+      "constraints": "Do not weaken archive validation or closeout evidence requirements.",
+      "latitude": "Exact helper shape and focused test placement inside the existing closeout/archive coverage.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "uv run pytest packages/planning/tests/test_archive.py -q passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; summary, planning doctor, and git diff --check passed"
+    },
+    "execution": {
+      "milestone": "issue-1260-closeout-projection-normalization",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "uv run pytest packages/planning/tests/test_archive.py -q passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; summary, planning doctor, and git diff --check passed"
+    },
+    "scope": {
+      "touched": [
+        "packages/planning/src/repo_planning_bootstrap/installer.py",
+        "packages/planning/tests/test_archive.py",
+        ".agentic-workspace/planning/execplans/issue-1260-closeout-projection-normalization.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Implement #1260 closeout projection normalization.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Completed no-residue closeouts now archive internally consistent terminal execution and delegation projection fields.",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1260 closeout projection normalization",
+    "inferred intended outcome": "Create a bounded plan for Implement #1260 closeout projection normalization.",
+    "chosen concrete what": "Normalized closeout-facing compatibility projections during prepare-closeout/planning closeout.",
+    "interpretation distance": "low",
+    "review guidance": "Inspect generated_closeout, closure_check, proof_report, and closeout_distillation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "uv run pytest packages/planning/tests/test_archive.py -q passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; summary, planning doctor, and git diff --check passed",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Implement #1260 closeout projection normalization.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "#1260 is a narrow closeout writer/test fix; local execution keeps the command-owned closeout behavior and proof loop in one place.",
+    "decision command": "agentic-planning delegation-decision",
+    "planning revision observed": "d2d0672d76d9ed78",
+    "recorded at": "2026-06-04T09:53:21+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1260-closeout-projection-normalization",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Fill in execution bounds, touched paths, and validation before implementation starts."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest packages/planning/tests/test_archive.py -q passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; summary, planning doctor, and git diff --check passed"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement #1260 closeout projection normalization is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Normalized closeout-facing compatibility projections during prepare-closeout/planning closeout, including machine_readable_contract.execution and post_decomposition_delegation.",
+    "scope touched": "planning closeout writer and archive tests",
+    "changed surfaces": "packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_archive.py",
+    "validations run": "uv run pytest packages/planning/tests/test_archive.py -q passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; summary, planning doctor, and git diff --check passed",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1260; archive validation remains unchanged while completed archives no longer carry active/pending compatibility residue.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "#1260 is a narrow closeout writer/test fix; local execution keeps the command-owned closeout behavior and proof loop in one place.",
+    "expected savings": "unknown",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest packages/planning/tests/test_archive.py -q passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; summary, planning doctor, and git diff --check passed",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run pytest packages/planning/tests/test_archive.py -q passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; summary, planning doctor, and git diff --check passed"
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement #1260 closeout projection normalization.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "uv run pytest packages/planning/tests/test_archive.py -q passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; summary, planning doctor, and git diff --check passed",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Completed no-residue closeouts now archive internally consistent terminal execution and delegation projection fields.",
+    "validation confirmed": "uv run pytest packages/planning/tests/test_archive.py -q passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; summary, planning doctor, and git diff --check passed",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "uv run pytest packages/planning/tests/test_archive.py -q passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; summary, planning doctor, and git diff --check passed",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Scaffolded by agentic-planning new-plan.",
+    "2026-06-04: Recorded delegation decision route=keep-local."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement #1260 closeout projection normalization.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest packages/planning/tests/test_archive.py -q passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; summary, planning doctor, and git diff --check passed\nChanged surfaces: packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_archive.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -9961,7 +9961,13 @@ def _prepared_canonical_core_closeout(
     return canonical_core
 
 
-def _prepared_machine_readable_contract_closeout(*, record: dict[str, Any], validation_evidence: str) -> dict[str, Any]:
+def _prepared_machine_readable_contract_closeout(
+    *,
+    record: dict[str, Any],
+    validation_evidence: str,
+    normalized_closure: str,
+    routed_unsolved_intent: str,
+) -> dict[str, Any]:
     raw_contract = _record_section_value(record, "machine_readable_contract")
     contract = copy.deepcopy(raw_contract) if isinstance(raw_contract, dict) else {}
     intent = dict(contract.get("intent", {})) if isinstance(contract.get("intent"), dict) else {}
@@ -9970,8 +9976,13 @@ def _prepared_machine_readable_contract_closeout(*, record: dict[str, Any], vali
     proof = validation_evidence.strip() or "closeout proof recorded in proof_report."
     if _closeout_sequence_needs_normalization(intent.get("proof")):
         intent["proof"] = proof
-    if _closeout_sequence_needs_normalization(execution.get("proof")):
-        execution["proof"] = proof
+    execution["status"] = "completed"
+    execution["next_step"] = (
+        f"Continue via {routed_unsolved_intent}."
+        if normalized_closure == "archive-but-keep-lane-open"
+        else "No required continuation remains for this archived slice."
+    )
+    execution["proof"] = proof
     if _closeout_sequence_needs_normalization(scope.get("touched")):
         scope["touched"] = ["closeout scope recorded in closure_check and generated_closeout."]
     if intent:
@@ -9981,6 +9992,16 @@ def _prepared_machine_readable_contract_closeout(*, record: dict[str, Any], vali
     if scope:
         contract["scope"] = scope
     return contract
+
+
+def _prepared_post_decomposition_delegation_closeout(*, record: dict[str, Any], normalized_closure: str) -> dict[str, str]:
+    existing = _record_section_dict(record, "post_decomposition_delegation") or {}
+    prepared = dict(existing)
+    if _closeout_value_needs_normalization(prepared.get("status")):
+        prepared["status"] = (
+            "closed-with-continuation-routed" if normalized_closure == "archive-but-keep-lane-open" else "skipped-local-bounded-slice"
+        )
+    return prepared
 
 
 def _prepared_execution_bounds_closeout(*, record: dict[str, Any], validation_evidence: str) -> dict[str, Any]:
@@ -9995,6 +10016,25 @@ def _prepared_execution_bounds_closeout(*, record: dict[str, Any], validation_ev
         if _closeout_sequence_needs_normalization(bounds.get(key)):
             bounds[key] = replacement
     return bounds
+
+
+def _prepared_intent_interpretation_closeout(*, record: dict[str, Any], outcome_delivered: str) -> dict[str, str]:
+    existing = _record_section_dict(record, "intent_interpretation") or {}
+    prepared = dict(existing)
+    outcome = outcome_delivered.strip() or "The bounded slice completed with recorded closeout evidence."
+    if _closeout_sequence_needs_normalization(prepared.get("chosen concrete what")):
+        prepared["chosen concrete what"] = outcome
+    if _closeout_sequence_needs_normalization(prepared.get("review guidance")):
+        prepared["review guidance"] = "Inspect generated_closeout, closure_check, proof_report, and closeout_distillation."
+    return prepared
+
+
+def _prepared_context_budget_closeout(*, record: dict[str, Any]) -> dict[str, str]:
+    existing = _record_section_dict(record, "context_budget") or {}
+    prepared = dict(existing)
+    if _closeout_sequence_needs_normalization(prepared.get("tiny resumability note")):
+        prepared["tiny resumability note"] = "Archived slice is complete; reopen only if closeout evidence is invalidated."
+    return prepared
 
 
 def _prepared_iterative_follow_through(
@@ -10424,11 +10464,20 @@ def _prepare_execplan_closeout(
     patch["machine_readable_contract"] = _prepared_machine_readable_contract_closeout(
         record=record,
         validation_evidence=validation_evidence,
+        normalized_closure=normalized_closure,
+        routed_unsolved_intent=routed_unsolved_intent,
     )
     patch["execution_bounds"] = _prepared_execution_bounds_closeout(
         record=record,
         validation_evidence=validation_evidence,
     )
+    patch["intent_interpretation"] = _prepared_intent_interpretation_closeout(
+        record=record,
+        outcome_delivered=str(execution_summary.get("outcome delivered", "")).strip(),
+    )
+    patch["context_budget"] = _prepared_context_budget_closeout(record=record)
+    if _closeout_sequence_needs_normalization(record.get("immediate_next_action")):
+        patch["immediate_next_action"] = ["No required continuation remains for this archived slice."]
     if _closeout_sequence_needs_normalization(record.get("touched_paths")):
         patch["touched_paths"] = ["closeout scope recorded in closure_check and generated_closeout."]
     if _closeout_sequence_needs_normalization(record.get("validation_commands")):
@@ -10444,6 +10493,10 @@ def _prepare_execplan_closeout(
     patch["delegation_outcome_feedback"] = _prepared_delegation_outcome_feedback(
         record=record,
         proof_now=proof_now,
+        normalized_closure=normalized_closure,
+    )
+    patch["post_decomposition_delegation"] = _prepared_post_decomposition_delegation_closeout(
+        record=record,
         normalized_closure=normalized_closure,
     )
     patch["improvement_signal_review"] = _prepared_improvement_signal_review(record)

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -598,6 +598,9 @@ candidates = []
         "proof": "uv run pytest tests/test_check_planning_surfaces.py",
     }
     assert archived["machine_readable_contract"]["scope"]["touched"] == ["closeout scope recorded in closure_check and generated_closeout."]
+    assert archived["machine_readable_contract"]["execution"]["status"] == "completed"
+    assert archived["machine_readable_contract"]["execution"]["next_step"] == ("No required continuation remains for this archived slice.")
+    assert archived["machine_readable_contract"]["execution"]["proof"] == "uv run pytest tests/test_check_planning_surfaces.py"
     assert archived["task_intent_promotion"]["needs review"] is True
     assert archived["iterative_follow_through"]["proof achieved now"] != "pending"
     assert archived["iterative_follow_through"]["validation still needed"] == (
@@ -608,6 +611,7 @@ candidates = []
     assert archived["execution_summary"]["knowledge promoted (Memory/Docs/Config)"] == "none"
     assert archived["delegation_outcome_feedback"]["actual friction"] == "none recorded"
     assert archived["delegation_outcome_feedback"]["proof result"] != "pending"
+    assert archived["post_decomposition_delegation"]["status"] == "skipped-local-bounded-slice"
     assert archived["improvement_signal_review"]["status"] == "not_checked"
     assert archived["improvement_signal_review"]["next owner"] == "agent closeout reflection"
     assert "Intent satisfied: yes" in archived["generated_closeout"]["text"]
@@ -840,6 +844,15 @@ candidates = []
         "Keep scope bounded to the promoted TODO item and its stated touched paths."
     )
     assert archived["machine_readable_contract"]["intent"]["proof"] == "uv run pytest packages/planning/tests/test_archive.py -q"
+    assert archived["machine_readable_contract"]["execution"]["status"] == "completed"
+    assert archived["machine_readable_contract"]["execution"]["next_step"] == ("No required continuation remains for this archived slice.")
+    assert archived["machine_readable_contract"]["execution"]["proof"] == "uv run pytest packages/planning/tests/test_archive.py -q"
+    assert archived["post_decomposition_delegation"]["status"] == "skipped-local-bounded-slice"
+    archived_text = json.dumps(archived, sort_keys=True).lower()
+    assert '"status": "active"' not in archived_text
+    assert "current milestone validation remains pending" not in archived_text
+    assert "continue the current milestone until the completion criteria are met" not in archived_text
+    assert "fill in execution bounds" not in archived_text
     assert archived["task_intent_promotion"]["needs review"] is True
     options = {option["id"]: option for option in payload["completion_options"]}
     assert options["claim-slice-complete"]["allowed"] is True


### PR DESCRIPTION
## Summary
- normalizes `machine_readable_contract.execution` during prepare-closeout/planning closeout so archived plans no longer say active or point at pre-closeout next steps
- normalizes stale post-decomposition and scaffold-style closeout projections when a slice is archived
- expands archive/closeout regression tests to assert completed archives do not retain active/pending/continue-current-milestone residue

## Stack
- Stacked on #1264 / `codex/1256-read-only-planning-gate`

Closes #1260.

## Validation
- `uv run pytest packages/planning/tests/test_archive.py -q`
- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `git diff --check`