### PR TITLE
Implement proof-route lifecycle states

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1252-proof-route-lifecycle.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1252-proof-route-lifecycle.plan.json
@@ -1,0 +1,299 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1252 proof-route lifecycle",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for Implement #1252 proof-route lifecycle.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check"
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Implement #1252 proof-route lifecycle is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Implement #1252 proof-route lifecycle."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Implement #1252 proof-route lifecycle.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check"
+    },
+    "execution": {
+      "milestone": "issue-1252-proof-route-lifecycle",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check"
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Implement #1252 proof-route lifecycle.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1252 proof-route lifecycle",
+    "inferred intended outcome": "Create a bounded plan for Implement #1252 proof-route lifecycle.",
+    "chosen concrete what": "Proof route hints now expose candidate, confirmed, stale, negative, superseded, and invalid-authority lifecycle states, and required proof reports material reliance on confirmed learned routes.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Implement #1252 proof-route lifecycle.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1252-proof-route-lifecycle",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement #1252 proof-route lifecycle is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented explicit proof-route lifecycle states, stale/negative/superseded/invalid-authority handling, and material learned-route reliance disclosure.",
+    "scope touched": "proof route hints runtime, proof-route schema, proof CLI tests",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/proof_route_hints.schema.json; tests/test_workspace_proof_cli.py",
+    "validations run": "uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1252 promoted lifecycle slice; tests cover all lifecycle states and learned-route closeout disclosure.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check"
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement #1252 proof-route lifecycle.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Proof route hints now expose candidate, confirmed, stale, negative, superseded, and invalid-authority lifecycle states, and required proof reports material reliance on confirmed learned routes.",
+    "validation confirmed": "uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement #1252 proof-route lifecycle.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_proof_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; git diff --check\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/proof_route_hints.schema.json; tests/test_workspace_proof_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/src/agentic_workspace/contracts/schemas/proof_route_hints.schema.json
+++ b/src/agentic_workspace/contracts/schemas/proof_route_hints.schema.json
@@ -122,7 +122,8 @@
               "confirmed",
               "stale",
               "negative",
-              "superseded"
+              "superseded",
+              "invalid-authority"
             ]
           },
           "intent_type": {
@@ -199,6 +200,11 @@
             "type": "string",
             "minLength": 1,
             "description": "ISO date or timestamp when this lesson was learned or last confirmed."
+          },
+          "superseded_by": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Replacement command, route id, or owner surface that supersedes this historical route."
           }
         },
         "additionalProperties": false

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -26812,7 +26812,7 @@ def _proof_route_hints_payload(*, target_root: Path) -> dict[str, Any]:
 
 
 _PROOF_ROUTE_MEMORY_PREFIX = "agentic-workspace-proof-route:"
-_PROOF_ROUTE_STATES = {"candidate", "confirmed", "stale", "negative", "superseded"}
+_PROOF_ROUTE_STATES = {"candidate", "confirmed", "stale", "negative", "superseded", "invalid-authority"}
 _PROOF_ROUTE_INTENT_TYPES = {"behavior-test", "static-check", "type-check", "general-check"}
 _AUTHORITATIVE_PROOF_ROUTE_REQUIRED_FIELDS = (
     "candidate_command",
@@ -26872,7 +26872,7 @@ def _normalize_proof_route_hint(
             field_name for field_name in _AUTHORITATIVE_PROOF_ROUTE_REQUIRED_FIELDS if not explicit_values[field_name]
         ]
         if missing_authoritative_fields:
-            state = "stale"
+            state = "invalid-authority"
             requires_live_confirmation = True
     record: dict[str, Any] = {
         "id": str(hint.get("id") or f"{source}:{_decision_slug(command)}"),
@@ -26888,6 +26888,9 @@ def _normalize_proof_route_hint(
         "provenance": str(hint.get("provenance") or hint.get("observed") or source_path or source).strip(),
         "learned_at": str(hint.get("learned_at") or hint.get("last_confirmed") or "").strip(),
     }
+    superseded_by = str(hint.get("superseded_by") or hint.get("replacement_command") or "").strip()
+    if superseded_by:
+        record["superseded_by"] = superseded_by
     if missing_authoritative_fields:
         record.update(
             {
@@ -27024,7 +27027,12 @@ def _apply_learned_route_hints_to_capabilities(
     capabilities["learned_routes"] = {
         "confirmed_count": len(learned_route_hints.get("confirmed", [])),
         "negative_count": len(learned_route_hints.get("negative", [])),
-        "rule": "Confirmed learned routes may add proof candidates; negative learned routes suppress matching candidates before selection.",
+        "superseded_count": len(learned_route_hints.get("superseded", [])),
+        "invalid_authority_count": len(learned_route_hints.get("invalid", [])),
+        "rule": (
+            "Confirmed learned routes may add proof candidates; negative learned routes suppress matching candidates before "
+            "selection; superseded and invalid-authority routes remain explanatory only."
+        ),
     }
     return {
         **capabilities,
@@ -27054,6 +27062,7 @@ def _confirm_learned_route_hints(*, learned_hints: dict[str, Any], target_capabi
     confirmed: list[dict[str, Any]] = []
     stale: list[dict[str, Any]] = []
     negative: list[dict[str, Any]] = []
+    superseded: list[dict[str, Any]] = []
     invalid: list[dict[str, Any]] = []
     for hint in learned_hints.get("hints", []):
         command = str(hint.get("candidate_command", "")).strip()
@@ -27070,19 +27079,22 @@ def _confirm_learned_route_hints(*, learned_hints: dict[str, Any], target_capabi
             "owner": str(hint.get("owner", "")),
             "provenance": str(hint.get("provenance", "")),
             "learned_at": str(hint.get("learned_at", "")),
+            "superseded_by": str(hint.get("superseded_by", "")),
             "invalid_authority": bool(hint.get("invalid_authority", False)),
             "original_state": str(hint.get("original_state", "")),
             "missing_fields": list(hint.get("missing_fields", [])) if isinstance(hint.get("missing_fields"), list) else [],
             "recovery": str(hint.get("recovery", "")),
         }
         record = {key: value for key, value in record.items() if value != "" and value != []}
-        if record.get("invalid_authority"):
+        state = str(record.get("state", "candidate"))
+        if record.get("invalid_authority") or state == "invalid-authority":
             invalid_record = {**record, "confirmation": "invalid-authoritative-learning-evidence"}
             invalid.append(invalid_record)
-            stale.append(invalid_record)
-        elif record.get("state") == "negative":
+        elif state == "superseded":
+            superseded.append({**record, "confirmation": "superseded-learned-route"})
+        elif state == "negative":
             negative.append({**record, "confirmation": "negative-learned-route"})
-        elif command and not record.get("requires_live_confirmation", True) and record.get("state") == "confirmed":
+        elif command and not record.get("requires_live_confirmation", True) and state == "confirmed":
             confirmed.append({**record, "confirmation": "learned-confirmed"})
         elif command and command in live_commands:
             confirmed.append({**record, "confirmation": "live-confirmed"})
@@ -27093,8 +27105,91 @@ def _confirm_learned_route_hints(*, learned_hints: dict[str, Any], target_capabi
         "confirmed": confirmed,
         "stale": stale,
         "negative": negative,
+        "superseded": superseded,
         "invalid": invalid,
-        "rule": "Learned route hints can explain or suggest proof routes, but only live-confirmed hints may support command selection.",
+        "lifecycle": _proof_route_lifecycle_payload(
+            learned_hints=learned_hints,
+            confirmed=confirmed,
+            stale=stale,
+            negative=negative,
+            superseded=superseded,
+            invalid=invalid,
+        ),
+        "rule": (
+            "Learned route hints can explain or suggest proof routes, but only live-confirmed or explicitly "
+            "learned-confirmed hints may support command selection."
+        ),
+    }
+
+
+def _proof_route_lifecycle_payload(
+    *,
+    learned_hints: dict[str, Any],
+    confirmed: list[dict[str, Any]],
+    stale: list[dict[str, Any]],
+    negative: list[dict[str, Any]],
+    superseded: list[dict[str, Any]],
+    invalid: list[dict[str, Any]],
+) -> dict[str, Any]:
+    raw_hints = [hint for hint in learned_hints.get("hints", []) if isinstance(hint, dict)]
+    state_counts = {state: 0 for state in sorted(_PROOF_ROUTE_STATES)}
+    for hint in raw_hints:
+        state = str(hint.get("state") or "candidate")
+        if state not in _PROOF_ROUTE_STATES:
+            state = "candidate"
+        state_counts[state] = state_counts.get(state, 0) + 1
+    return {
+        "kind": "proof-route-lifecycle/v1",
+        "state_model": [
+            {
+                "state": "candidate",
+                "selection_effect": "advisory only until live repo capabilities confirm the command",
+                "proof_effect": "cannot satisfy required proof by itself",
+                "correction_path": "confirm live, promote to Memory/config, or leave advisory",
+            },
+            {
+                "state": "confirmed",
+                "selection_effect": "may support command selection when live-confirmed or explicitly learned-confirmed",
+                "proof_effect": "can affect required proof; closeout must disclose learned-route reliance when material",
+                "correction_path": "refresh provenance if command, scope, or owner changes",
+            },
+            {
+                "state": "stale",
+                "selection_effect": "not selectable until revalidated",
+                "proof_effect": "signals residual risk and possible negative evidence capture",
+                "correction_path": "reconfirm live or recapture as negative/superseded/confirmed evidence",
+            },
+            {
+                "state": "negative",
+                "selection_effect": "suppresses matching discovered candidates",
+                "proof_effect": "prevents repeated use of known-bad proof routes",
+                "correction_path": "supersede or recapture if the repo later makes the command valid",
+            },
+            {
+                "state": "superseded",
+                "selection_effect": "not selectable; points readers toward the replacement route when known",
+                "proof_effect": "documents lifecycle history without suppressing unrelated commands",
+                "correction_path": "remove after replacement is durable or promote replacement to confirmed evidence",
+            },
+            {
+                "state": "invalid-authority",
+                "selection_effect": "not selectable and not suppressive",
+                "proof_effect": "prevents incomplete confirmed/negative claims from becoming authority",
+                "correction_path": "recapture with candidate_command, state, intent_type, owner, scope, provenance, and learned_at",
+            },
+        ],
+        "state_counts": state_counts,
+        "bucket_counts": {
+            "confirmed": len(confirmed),
+            "stale": len(stale),
+            "negative": len(negative),
+            "superseded": len(superseded),
+            "invalid": len(invalid),
+        },
+        "reporting_rule": (
+            "Report the lifecycle state and authority boundary for any learned route that changes required proof; "
+            "do not describe candidate, stale, superseded, negative, or invalid-authority records as AW-selected proof."
+        ),
     }
 
 
@@ -27103,6 +27198,9 @@ def _setup_adopt_route_learning_projection(learned_route_hints: dict[str, Any]) 
     hints = learned_route_hints.get("hints", []) if isinstance(learned_route_hints.get("hints", []), list) else []
     confirmed = learned_route_hints.get("confirmed", []) if isinstance(learned_route_hints.get("confirmed", []), list) else []
     stale = learned_route_hints.get("stale", []) if isinstance(learned_route_hints.get("stale", []), list) else []
+    negative = learned_route_hints.get("negative", []) if isinstance(learned_route_hints.get("negative", []), list) else []
+    superseded = learned_route_hints.get("superseded", []) if isinstance(learned_route_hints.get("superseded", []), list) else []
+    invalid = learned_route_hints.get("invalid", []) if isinstance(learned_route_hints.get("invalid", []), list) else []
     persisted = status == "loaded"
     return {
         "kind": "setup-adopt-proof-route-learning/v1",
@@ -27111,6 +27209,10 @@ def _setup_adopt_route_learning_projection(learned_route_hints: dict[str, Any]) 
         "hint_count": len(hints),
         "confirmed_count": len(confirmed),
         "stale_count": len(stale),
+        "negative_count": len(negative),
+        "superseded_count": len(superseded),
+        "invalid_authority_count": len(invalid),
+        "lifecycle_field": "learned_route_hints.lifecycle",
         "route_map_decision": "use-advisory-hints-only" if persisted else "no-persisted-route-map-needed",
         "reason": "Setup/adopt-discovered route hints are persisted as advisory memory and must be live-confirmed before command selection."
         if persisted
@@ -27224,6 +27326,7 @@ def _proof_route_decision_payload(
     required_commands: list[str],
     manual_verification: dict[str, Any] | None,
     unavailable_commands: list[dict[str, Any]],
+    learned_route_reliance: dict[str, Any],
 ) -> dict[str, Any]:
     next_action = dict(proof_next_decision.get("next", {}))
     selected_command = selected_commands[0] if selected_commands else None
@@ -27235,7 +27338,7 @@ def _proof_route_decision_payload(
             "summary": manual_verification.get("summary") or manual_verification.get("reason"),
             "unavailable_command_count": len(unavailable_commands),
         }
-    return {
+    payload = {
         "kind": "proof-route-decision/v1",
         "next_action": next_action,
         "selected_command": {
@@ -27254,6 +27357,60 @@ def _proof_route_decision_payload(
         "critical_warnings": list(proof_next_decision.get("warnings", [])),
         "explanation_field": "proof_route_explanation",
         "legacy_aliases": {"proof_route_decision": "proof_route_selection"},
+    }
+    if learned_route_reliance.get("material_to_required_proof"):
+        payload["learned_route_reliance"] = learned_route_reliance
+        payload["closeout_disclosure"] = {
+            "status": "required",
+            "rule": (
+                "When learned_route_reliance.material_to_required_proof is true, final closeout should say which "
+                "required proof command relied on confirmed learned repo evidence and name the provenance."
+            ),
+        }
+    return payload
+
+
+def _learned_route_reliance_payload(*, selected_commands: list[dict[str, Any]], learned_route_hints: dict[str, Any]) -> dict[str, Any]:
+    confirmed_hints = [
+        hint
+        for hint in learned_route_hints.get("confirmed", [])
+        if isinstance(hint, dict) and str(hint.get("confirmation", "")) == "learned-confirmed"
+    ]
+    confirmed_by_command = {
+        str(hint.get("candidate_command", "")).strip(): hint for hint in confirmed_hints if str(hint.get("candidate_command", "")).strip()
+    }
+    items: list[dict[str, Any]] = []
+    for selected in selected_commands:
+        command = str(selected.get("command", "")).strip()
+        hint = confirmed_by_command.get(command)
+        if hint is None:
+            continue
+        items.append(
+            {
+                "kind": "learned-route-reliance-item/v1",
+                "command": command,
+                "state": "confirmed",
+                "confirmation": str(hint.get("confirmation", "")),
+                "source": str(hint.get("source", "")),
+                "source_path": str(hint.get("source_path", "")),
+                "owner": str(hint.get("owner", "")),
+                "scope": str(hint.get("scope", "")),
+                "provenance": str(hint.get("provenance", "")),
+                "learned_at": str(hint.get("learned_at", "")),
+                "selected_lane": str(selected.get("lane", "")),
+                "selected_route_source": str(selected.get("selected_from", "")),
+                "why_material": "This required proof command was added by confirmed learned route evidence.",
+            }
+        )
+    return {
+        "kind": "learned-route-reliance/v1",
+        "status": "present" if items else "none",
+        "material_to_required_proof": bool(items),
+        "items": items,
+        "reporting_rule": (
+            "If present, report this as the agent relying on confirmed repo Memory evidence; do not say AW decided or classified the route."
+        ),
+        "closeout_visibility": "required when material_to_required_proof is true",
     }
 
 
@@ -27408,7 +27565,7 @@ def _host_repo_learning_posture_payload(
         "kind": "host-repo-learning-posture/v1",
         "status": "active",
         "authority_rule": "Host-repo heuristics may propose discovery candidates; authoritative workflow and proof decisions require confirmed repo evidence or host configuration.",
-        "evidence_states": ["candidate", "confirmed", "stale", "negative", "superseded"],
+        "evidence_states": ["candidate", "confirmed", "stale", "negative", "superseded", "invalid-authority"],
         "owner_routes": [
             {
                 "owner": "Memory",
@@ -27441,7 +27598,7 @@ def _host_repo_learning_posture_payload(
             "status": "present" if invalid_hints else "none",
             "items": [
                 {
-                    "state": "invalid",
+                    "state": "invalid-authority",
                     "original_state": str(hint.get("original_state", "")),
                     "command": str(hint.get("candidate_command", "")),
                     "missing_fields": list(hint.get("missing_fields", [])),
@@ -27475,6 +27632,7 @@ def _proof_route_explanation_payload(
     proof_intents: list[dict[str, Any]],
     configured_policy: list[dict[str, Any]],
     learned_route_hints: dict[str, Any],
+    learned_route_reliance: dict[str, Any],
     target_capabilities: dict[str, Any],
     host_repo_learning: dict[str, Any],
     selected_commands: list[dict[str, Any]],
@@ -27497,6 +27655,7 @@ def _proof_route_explanation_payload(
         "proof_intents": proof_intents,
         "configured_policy": configured_policy,
         "learned_route_hints": learned_route_hints,
+        "learned_route_reliance": learned_route_reliance,
         "setup_adopt_route_learning": _setup_adopt_route_learning_projection(learned_route_hints),
         "target_capabilities": target_capabilities,
         "host_repo_learning": host_repo_learning,
@@ -28796,6 +28955,10 @@ def _proof_selection_for_changed_paths(
         for lane in [*concern_lanes, *requirement_lanes]
         if lane.get("proof_profile")
     ]
+    learned_route_reliance = _learned_route_reliance_payload(
+        selected_commands=selected_commands,
+        learned_route_hints=learned_route_hints,
+    )
     proof_next_decision = _proof_next_decision_payload(
         required_commands=required_commands,
         selected_commands=selected_commands,
@@ -28810,6 +28973,7 @@ def _proof_selection_for_changed_paths(
         required_commands=required_commands,
         manual_verification=manual_verification,
         unavailable_commands=unavailable_commands,
+        learned_route_reliance=learned_route_reliance,
     )
     host_repo_learning = _host_repo_learning_posture_payload(
         target_capabilities=target_capabilities,
@@ -28822,6 +28986,7 @@ def _proof_selection_for_changed_paths(
         proof_intents=proof_intents,
         configured_policy=configured_policy,
         learned_route_hints=learned_route_hints,
+        learned_route_reliance=learned_route_reliance,
         target_capabilities=target_capabilities,
         host_repo_learning=host_repo_learning,
         selected_commands=selected_commands,
@@ -28885,6 +29050,7 @@ def _proof_selection_for_changed_paths(
         "target_proof_capabilities": target_capabilities,
         "host_repo_learning": host_repo_learning,
         "learned_route_hints": learned_route_hints,
+        "learned_route_reliance": learned_route_reliance,
         "proof_intents": proof_intents,
         "configured_policy": configured_policy,
         "verification": verification,

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -778,6 +778,16 @@ def test_proof_changed_reports_live_confirmed_learned_route_hints(tmp_path: Path
     assert hints["confirmed"][0]["confirmation"] == "live-confirmed"
     assert hints["stale"][0]["candidate_command"] == "npm run stale"
     assert hints["stale"][0]["confirmation"] == "stale-or-unavailable"
+    assert hints["lifecycle"]["state_counts"] == {
+        "candidate": 2,
+        "confirmed": 0,
+        "invalid-authority": 0,
+        "negative": 0,
+        "stale": 0,
+        "superseded": 0,
+    }
+    assert hints["lifecycle"]["bucket_counts"]["confirmed"] == 1
+    assert "invalid-authority" in {state["state"] for state in hints["lifecycle"]["state_model"]}
     decision = answer["proof_route_selection"]
     assert decision["critical_warnings"] == ["1 learned route hint(s) are stale or unavailable."]
     assert decision["selected_command"]["command"] == "npm test"
@@ -791,6 +801,10 @@ def test_proof_changed_reports_live_confirmed_learned_route_hints(tmp_path: Path
         "hint_count": 2,
         "confirmed_count": 1,
         "stale_count": 1,
+        "negative_count": 0,
+        "superseded_count": 0,
+        "invalid_authority_count": 0,
+        "lifecycle_field": "learned_route_hints.lifecycle",
         "route_map_decision": "use-advisory-hints-only",
         "reason": (
             "Setup/adopt-discovered route hints are persisted as advisory memory and must be live-confirmed before command selection."
@@ -827,6 +841,13 @@ agentic-workspace-proof-route: {"state":"confirmed","intent_type":"behavior-test
     assert hints["confirmed"][0]["confirmation"] == "learned-confirmed"
     assert answer["proof_route_selection"]["selected_command"]["command"] == "python -m compileall src"
     assert answer["proof_route_selection"]["selected_command"]["route_source"] == "live-adapted-target-capability"
+    reliance = answer["proof_route_selection"]["learned_route_reliance"]
+    assert reliance["status"] == "present"
+    assert reliance["material_to_required_proof"] is True
+    assert reliance["items"][0]["command"] == "python -m compileall src"
+    assert reliance["items"][0]["provenance"] == "manual verification passed on 2026-06-02"
+    assert answer["proof_route_selection"]["closeout_disclosure"]["status"] == "required"
+    assert answer["proof_route_explanation"]["learned_route_reliance"] == reliance
     learning = answer["host_repo_learning"]
     assert learning["confirmed_evidence"]["status"] == "present"
     assert "memory capture-note" in learning["confirmed_evidence"]["items"][0]["capture"]["command_to_run"]
@@ -859,6 +880,54 @@ agentic-workspace-proof-route: {"state":"negative","intent_type":"behavior-test"
     assert learning["actionable_next_steps"]["status"] == "present"
 
 
+def test_proof_changed_reports_proof_route_lifecycle_states(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "package.json", json.dumps({"scripts": {"test": "vitest run", "lint": "eslint ."}}))
+    _write(
+        tmp_path / ".agentic-workspace" / "memory" / "repo" / "runbooks" / "proof-routes.md",
+        """
+# Proof route lifecycle
+
+agentic-workspace-proof-route: {"state":"confirmed","intent_type":"static-check","candidate_command":"npm run lint","source":"memory","confidence":"high","requires_live_confirmation":false,"scope":"repo","owner":"Memory","provenance":"lint route confirmed in prior closeout","learned_at":"2026-06-02"}
+agentic-workspace-proof-route: {"state":"stale","intent_type":"behavior-test","candidate_command":"npm run old-test","source":"memory","confidence":"medium","requires_live_confirmation":true,"scope":"repo","owner":"Memory","provenance":"old route was not found during setup","learned_at":"2026-06-02"}
+agentic-workspace-proof-route: {"state":"negative","intent_type":"behavior-test","candidate_command":"npm test","source":"memory","confidence":"high","requires_live_confirmation":true,"scope":"repo","owner":"Memory","provenance":"npm test invokes the wrong runner","learned_at":"2026-06-02"}
+agentic-workspace-proof-route: {"state":"superseded","intent_type":"behavior-test","candidate_command":"npm run legacy-test","source":"memory","confidence":"medium","requires_live_confirmation":true,"scope":"repo","owner":"Memory","provenance":"legacy route replaced by package lint route","learned_at":"2026-06-02","superseded_by":"npm run lint"}
+agentic-workspace-proof-route: {"state":"confirmed","intent_type":"behavior-test","candidate_command":"npm run missing-owner","source":"memory","confidence":"high","requires_live_confirmation":false}
+""",
+    )
+
+    assert cli.main(["proof", "--verbose", "--target", str(tmp_path), "--changed", "src/app.ts", "--format", "json"]) == 0
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    hints = answer["learned_route_hints"]
+    lifecycle = hints["lifecycle"]
+    assert lifecycle["state_counts"] == {
+        "candidate": 0,
+        "confirmed": 1,
+        "invalid-authority": 1,
+        "negative": 1,
+        "stale": 1,
+        "superseded": 1,
+    }
+    assert lifecycle["bucket_counts"] == {
+        "confirmed": 1,
+        "stale": 1,
+        "negative": 1,
+        "superseded": 1,
+        "invalid": 1,
+    }
+    assert hints["confirmed"][0]["candidate_command"] == "npm run lint"
+    assert hints["negative"][0]["candidate_command"] == "npm test"
+    assert hints["superseded"][0]["superseded_by"] == "npm run lint"
+    assert hints["invalid"][0]["state"] == "invalid-authority"
+    assert hints["invalid"][0]["original_state"] == "confirmed"
+    assert "npm test" not in answer["target_proof_capabilities"]["candidate_commands"]
+    warnings = answer["proof_next_decision"]["warnings"]
+    assert "1 learned route lesson(s) are missing authoritative provenance metadata." in warnings
+    assert "1 learned route hint(s) are stale or unavailable." in warnings
+    assert "1 learned negative route(s) suppressed candidate proof commands." in warnings
+
+
 def test_proof_changed_incomplete_confirmed_memory_route_is_not_authoritative(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(tmp_path / "src" / "app.py", "print('ok')\n")
@@ -877,6 +946,8 @@ agentic-workspace-proof-route: {"state":"confirmed","intent_type":"behavior-test
     hints = answer["learned_route_hints"]
     assert hints["confirmed"] == []
     assert hints["invalid"][0]["original_state"] == "confirmed"
+    assert hints["invalid"][0]["state"] == "invalid-authority"
+    assert hints["lifecycle"]["state_counts"]["invalid-authority"] == 1
     assert set(hints["invalid"][0]["missing_fields"]) == {"owner", "scope", "provenance", "learned_at"}
     assert answer["required_commands"] == []
     assert answer["proof_route_selection"]["selected_command"] is None
@@ -906,6 +977,7 @@ agentic-workspace-proof-route: {"state":"negative","intent_type":"behavior-test"
     hints = answer["learned_route_hints"]
     assert hints["negative"] == []
     assert hints["invalid"][0]["original_state"] == "negative"
+    assert hints["invalid"][0]["state"] == "invalid-authority"
     assert "npm test" in answer["target_proof_capabilities"]["candidate_commands"]
     assert answer["proof_route_selection"]["selected_command"]["command"] == "npm test"
     learning = answer["host_repo_learning"]


### PR DESCRIPTION
## What changed

- Adds an explicit proof-route lifecycle packet covering candidate, confirmed, stale, negative, superseded, and invalid-authority learned routes.
- Separates invalid authoritative learned-route evidence from stale hints so incomplete confirmed/negative Memory lessons cannot become proof authority.
- Adds material learned-route reliance disclosure when a required proof command is selected because of confirmed Memory evidence.
- Extends proof-route hint schema and proof CLI tests for lifecycle buckets, stale/negative handling, superseded routes, invalid-authority routes, and closeout disclosure guidance.

Closes #1252

## Validation

- `uv run pytest tests/test_workspace_proof_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make schema-reference-docs`
- `git diff --check`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --format json` (reported pre-existing lifecycle attention items unrelated to this slice)