### PR TITLE
Surface generated-source trust in implement output

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1258-generated-source-freshness.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1258-generated-source-freshness.plan.json
@@ -1,0 +1,299 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1258 generated-source trust packet",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for Implement #1258 generated-source trust packet.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check"
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Implement #1258 generated-source trust packet is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Implement #1258 generated-source trust packet."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Implement #1258 generated-source trust packet.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check"
+    },
+    "execution": {
+      "milestone": "issue-1258-generated-source-freshness",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check"
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Implement #1258 generated-source trust packet.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1258 generated-source trust packet",
+    "inferred intended outcome": "Create a bounded plan for Implement #1258 generated-source trust packet.",
+    "chosen concrete what": "Generated paths now surface an actionable generated_surface_trust packet, and generated/workspace/python/cli.py is no longer presented as a direct-edit source file.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Implement #1258 generated-source trust packet.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1258-generated-source-freshness",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement #1258 generated-source trust packet is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented generated_surface_trust for generated changed paths in implement output, corrected generated CLI direct-edit authority, and added tests for ordinary tiny output and selector drill-down.",
+    "scope touched": "implement context runtime, proof selection rules contract, implementer context schema/reference docs, implement/proof/start tests",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/proof_selection_rules.json; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; docs/reference/implementer-context.md; tests/test_workspace_implement_cli.py; tests/test_workspace_proof_cli.py; tests/test_workspace_start_preflight_cli.py",
+    "validations run": "focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1258 promoted generated-source trust packet. Ordinary implement output now names canonical source, freshness status, refresh command, direct-edit policy, and validation command for generated paths.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check"
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement #1258 generated-source trust packet.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Generated paths now surface an actionable generated_surface_trust packet, and generated/workspace/python/cli.py is no longer presented as a direct-edit source file.",
+    "validation confirmed": "focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement #1258 generated-source trust packet.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: focused implement/proof/start tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make schema-reference-docs; git diff --check\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/proof_selection_rules.json; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; docs/reference/implementer-context.md; tests/test_workspace_implement_cli.py; tests/test_workspace_proof_cli.py; tests/test_workspace_start_preflight_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -27,6 +27,7 @@ Cheap implementer context for a bounded changed-path scope.
 | `path_boundaries` | array of ref `#/$defs/path_boundary` | yes |  | Path-specific ownership and locality constraints for the changed paths. |  |  |
 | `authority_markers` | array of ref `#/$defs/authority_marker` | yes |  | Authority markers relevant to the implementation scope. |  |  |
 | `change_impact` | object | yes |  | Changed-path ownership, generatedness, authority, related contract, and proof-impact projection. |  |  |
+| `generated_surface_trust` | object | yes |  | Compact generated-source trust packet naming canonical source, freshness status, refresh command, direct-edit policy, and validation command for generated changed paths. |  |  |
 | `task_contract` | object | yes |  | Compact assembled task contract view covering intent, acceptance, autonomy/escalation, proof expectations, and stop conditions. |  |  |
 | `task_intent` | object | yes |  | Task-intent carry-forward packet used to derive acceptance, proof guidance, objective-drift checks, and closeout prompts. |  |  |
 | `acceptance` | ref `#/$defs/task_acceptance` | yes |  | Definition-of-done expectations inferred from task intent. |  |  |

--- a/src/agentic_workspace/contracts/proof_selection_rules.json
+++ b/src/agentic_workspace/contracts/proof_selection_rules.json
@@ -242,15 +242,15 @@
     "classifications": [
       {
         "id": "root-workspace-cli-runtime",
-        "role": "hand-owned-executable",
+        "role": "projection",
         "exact": [
           "generated/workspace/python/cli.py"
         ],
-        "direct_edit_allowed": true,
-        "source_contract": "src/agentic_workspace/contracts/operation_contracts.json + src/agentic_workspace/contracts/cli_commands.json + src/agentic_workspace/contracts/python_runtime_boundary.json",
-        "generator_contract": null,
-        "regeneration_path": null,
-        "edit_policy": "Direct edits are allowed only for runtime primitives, live inspection, dispatch glue, or explicit migration exceptions; visible interface authority should route to contracts or generated metadata, and any cli.py edit must select generated command package proof so interface drift cannot bypass the generated package gate."
+        "direct_edit_allowed": false,
+        "source_contract": "src/agentic_workspace/contracts/command_package_ir.json",
+        "generator_contract": "scripts/generate/generate_command_packages.py",
+        "regeneration_path": "uv run python scripts/generate/generate_command_packages.py",
+        "edit_policy": "Do not hand-edit generated/workspace/python/cli.py; command/interface changes belong in command_package_ir and runtime behavior belongs in hand-written primitive implementation before regenerating the CLI."
       },
       {
         "id": "package-cli-runtime",

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -23,6 +23,7 @@
     "acceptance_reconciliation",
     "intent_acknowledgement",
     "objective_drift",
+    "generated_surface_trust",
     "reuse_pressure",
     "assurance_requirements",
     "verification",
@@ -108,6 +109,11 @@
     "change_impact": {
       "type": "object",
       "description": "Changed-path ownership, generatedness, authority, related contract, and proof-impact projection.",
+      "additionalProperties": true
+    },
+    "generated_surface_trust": {
+      "type": "object",
+      "description": "Compact generated-source trust packet naming canonical source, freshness status, refresh command, direct-edit policy, and validation command for generated changed paths.",
       "additionalProperties": true
     },
     "task_contract": {

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -19150,6 +19150,106 @@ def _change_impact_payload(*, target_root: Path, changed_paths: list[str], proof
     }
 
 
+def _generated_surface_validation_command(*, path: str, proof: dict[str, Any]) -> str:
+    commands = [str(command) for command in _list_payload(proof.get("required_commands")) if str(command).strip()]
+    if path.startswith("docs/reference/"):
+        return next((command for command in commands if "schema-reference-docs" in command), "make schema-reference-docs")
+    if path.startswith("generated/") or path.startswith("command_generation/"):
+        return next(
+            (command for command in commands if "check_generated_command_packages.py" in command),
+            "uv run python scripts/check/check_generated_command_packages.py",
+        )
+    return next(iter(commands), "")
+
+
+def _generated_surface_source_status(*, target_root: Path, canonical_source: str) -> str:
+    if not canonical_source:
+        return "unknown"
+    source_paths = [part.strip() for part in canonical_source.split("+") if part.strip()]
+    existing: list[str] = []
+    missing: list[str] = []
+    for source_path in source_paths:
+        if " " in source_path or not any(separator in source_path for separator in ("/", "\\")):
+            continue
+        if (target_root / source_path).exists():
+            existing.append(source_path)
+        else:
+            missing.append(source_path)
+    if missing:
+        return "missing"
+    if existing:
+        return "present"
+    return "not-checked"
+
+
+def _generated_surface_trust_path_payload(*, target_root: Path, path: str, proof: dict[str, Any], cli_invoke: str) -> dict[str, Any] | None:
+    def clean_text(value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    normalized = path.replace("\\", "/").strip("/")
+    classification = _cli_authority_classification_for_path(normalized)
+    authority_marker = _authority_marker_for_path(normalized, agent_instructions_file=DEFAULT_AGENT_INSTRUCTIONS_FILE)
+    is_schema_reference = normalized.startswith("docs/reference/")
+    is_generated = normalized.startswith("generated/") or is_schema_reference
+    if not is_generated and classification is None:
+        return None
+    role = str(classification.get("role", "generated-doc") if classification else "generated-doc" if is_schema_reference else "generated")
+    canonical_source = clean_text(classification.get("source_contract") if classification else authority_marker.get("canonical_source"))
+    refresh_command = clean_text(classification.get("regeneration_path") if classification else authority_marker.get("refresh_command"))
+    direct_edit_allowed = bool(classification.get("direct_edit_allowed", False)) if classification else False
+    direct_edit_policy = clean_text(classification.get("edit_policy") if classification else "")
+    if is_schema_reference:
+        canonical_source = "src/agentic_workspace/contracts/schemas"
+        refresh_command = "make render-schema-reference"
+        direct_edit_policy = "Do not hand-edit generated schema reference docs; edit the source schema and rerender."
+    if not direct_edit_policy:
+        direct_edit_policy = "Do not hand-edit generated surfaces when a canonical source or refresh command exists."
+    validation_command = _generated_surface_validation_command(path=normalized, proof=proof)
+    source_status = _generated_surface_source_status(target_root=target_root, canonical_source=canonical_source)
+    freshness_status = "validation-required"
+    if not refresh_command or source_status == "missing":
+        freshness_status = "missing-source-or-refresh-command"
+    return {
+        "kind": "generated-surface-trust-item/v1",
+        "path": normalized,
+        "classification_id": str(classification.get("id", "")) if classification else "generated-reference-doc",
+        "role": role,
+        "canonical_source": canonical_source,
+        "canonical_source_status": source_status,
+        "freshness_status": freshness_status,
+        "freshness_checked_by_implement": False,
+        "refresh_command": _command_with_cli_invoke(command=refresh_command, cli_invoke=cli_invoke) if refresh_command else "",
+        "validation_command": _command_with_cli_invoke(command=validation_command, cli_invoke=cli_invoke) if validation_command else "",
+        "direct_edit_allowed": direct_edit_allowed,
+        "direct_edit_policy": direct_edit_policy,
+    }
+
+
+def _generated_surface_trust_payload(
+    *, target_root: Path, changed_paths: list[str], proof: dict[str, Any], cli_invoke: str
+) -> dict[str, Any]:
+    items = [
+        item
+        for path in changed_paths
+        for item in [_generated_surface_trust_path_payload(target_root=target_root, path=path, proof=proof, cli_invoke=cli_invoke)]
+        if item is not None
+    ]
+    return {
+        "kind": "agentic-workspace/generated-surface-trust/v1",
+        "status": "present" if items else "not-applicable",
+        "changed_path_count": len(items),
+        "items": items,
+        "direct_edit_blocked_paths": [item["path"] for item in items if not item["direct_edit_allowed"]],
+        "rule": (
+            "Generated surfaces are derived artifacts. Edit the canonical source first, refresh the generated output, "
+            "and run the validation command before trusting freshness."
+        ),
+        "detail_selector": "generated_surface_trust",
+    }
+
+
 def _task_contract_payload(
     *,
     changed_paths: list[str],
@@ -19435,6 +19535,12 @@ def _implement_payload(
             task_text=task_text, execution_posture=execution_posture, vague_orientation=vague_orientation
         ),
         "objective_drift": _objective_drift_payload(target_root=target_root, changed_paths=normalized_paths, task_text=task_text),
+        "generated_surface_trust": _generated_surface_trust_payload(
+            target_root=target_root,
+            changed_paths=normalized_paths,
+            proof=proof,
+            cli_invoke=config.cli_invoke,
+        ),
         "reuse_pressure": _reuse_pressure_payload(
             target_root=target_root, changed_paths=normalized_paths, cli_invoke=config.cli_invoke, compact=False
         ),
@@ -19657,6 +19763,15 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "acceptance_reconciliation": _tiny_acceptance_reconciliation(payload.get("acceptance_reconciliation", {})),
             "objective_drift": _tiny_objective_drift(payload.get("objective_drift", {})),
             "reuse_pressure": context_reuse_pressure,
+            "generated_surface_trust": {
+                "status": payload.get("generated_surface_trust", {}).get("status", "not-applicable")
+                if isinstance(payload.get("generated_surface_trust"), dict)
+                else "not-applicable",
+                "changed_path_count": payload.get("generated_surface_trust", {}).get("changed_path_count", 0)
+                if isinstance(payload.get("generated_surface_trust"), dict)
+                else 0,
+                "detail_selector": "generated_surface_trust",
+            },
             "durable_intent_promotion": _tiny_task_intent_promotion_guidance(payload.get("durable_intent_promotion", {})),
             "guidance": {
                 "work_shape_guidance": _tiny_work_shape_guidance(planning_safety_gate.get("work_shape_guidance"))
@@ -19684,6 +19799,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "context.reuse_pressure",
                 "task_contract",
                 "change_impact",
+                "generated_surface_trust",
                 "assurance_requirements",
                 "verification",
                 "routine_work_context",
@@ -19692,6 +19808,9 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             ],
         },
     }
+    generated_surface_trust = payload.get("generated_surface_trust", {})
+    if isinstance(generated_surface_trust, dict) and generated_surface_trust.get("status") == "present":
+        projected["generated_surface_trust"] = _tiny_generated_surface_trust(generated_surface_trust)
     assurance_requirements = payload.get("assurance_requirements", {})
     if isinstance(assurance_requirements, dict) and int(assurance_requirements.get("active_count", 0) or 0) > 0:
         projected["assurance_requirements"] = _compact_assurance_requirements(assurance_requirements)
@@ -19720,6 +19839,30 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "clarify_only_if_blocked": True,
         }
     return projected
+
+
+def _tiny_generated_surface_trust(value: dict[str, Any]) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    for item in _list_payload(value.get("items"))[:3]:
+        if not isinstance(item, dict):
+            continue
+        items.append(
+            {
+                "path": item.get("path"),
+                "canonical_source": item.get("canonical_source"),
+                "freshness_status": item.get("freshness_status"),
+                "refresh_command": item.get("refresh_command"),
+                "validation_command": item.get("validation_command"),
+                "direct_edit_allowed": item.get("direct_edit_allowed"),
+                "direct_edit_policy": "Do not hand-edit generated output; edit the canonical source, refresh, then validate.",
+            }
+        )
+    return {
+        "status": value.get("status", "present"),
+        "changed_path_count": value.get("changed_path_count", len(items)),
+        "items": items,
+        "detail_selector": "generated_surface_trust",
+    }
 
 
 def _compact_selector_next_safe_action(packet: dict[str, Any]) -> dict[str, Any]:
@@ -25529,6 +25672,10 @@ def _selector_requests_change_impact(select: str | None) -> bool:
     return any(token == "change_impact" or token.startswith("change_impact.") for token in _selector_tokens(select))
 
 
+def _selector_requests_generated_surface_trust(select: str | None) -> bool:
+    return any(token == "generated_surface_trust" or token.startswith("generated_surface_trust.") for token in _selector_tokens(select))
+
+
 def _selector_requests_task_contract(select: str | None) -> bool:
     return any(token == "task_contract" or token.startswith("task_contract.") for token in _selector_tokens(select))
 
@@ -25556,6 +25703,7 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
     profile = _diagnostic_profile(args, default="tiny")
     selected_fields = getattr(args, "select", None)
     change_impact_selected = _selector_requests_change_impact(selected_fields)
+    generated_surface_trust_selected = _selector_requests_generated_surface_trust(selected_fields)
     task_contract_selected = _selector_requests_task_contract(selected_fields)
     assurance_requirements_selected = _selector_requests_assurance_requirements(selected_fields)
     verification_selected = _selector_requests_verification(selected_fields)
@@ -25577,6 +25725,8 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
             payload["task_contract"] = full_payload["task_contract"]
         if change_impact_selected:
             payload["change_impact"] = full_payload["change_impact"]
+        if generated_surface_trust_selected:
+            payload["generated_surface_trust"] = full_payload["generated_surface_trust"]
         if assurance_requirements_selected:
             payload["assurance_requirements"] = full_payload["assurance_requirements"]
         if verification_selected:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -30,6 +30,7 @@ def _implement_context(payload: dict[str, object]) -> dict[str, object]:
 def test_implement_command_returns_bounded_context_and_boundary_warnings(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "agentic_workspace" / "contracts" / "command_package_ir.json", "{}")
 
     assert (
         cli.main(
@@ -69,7 +70,16 @@ def test_implement_command_returns_bounded_context_and_boundary_warnings(tmp_pat
     assert retry["retry_limit"] == 1
     assert "uv run python scripts/check/check_generated_command_packages.py --python-conformance" in retry["applies_to"]
     assert payload["proof"]["unavailable_commands"] == []
-    assert payload["proof"]["cli_authority_review"]["classifications"][0]["role"] == "hand-owned-executable"
+    assert payload["proof"]["cli_authority_review"]["classifications"][0]["role"] == "projection"
+    trust = payload["generated_surface_trust"]
+    assert trust["status"] == "present"
+    assert trust["direct_edit_blocked_paths"] == ["generated/workspace/python/cli.py"]
+    assert trust["items"][0]["canonical_source"] == "src/agentic_workspace/contracts/command_package_ir.json"
+    assert trust["items"][0]["freshness_status"] == "validation-required"
+    assert trust["items"][0]["refresh_command"] == "uv run python scripts/generate/generate_command_packages.py"
+    assert trust["items"][0]["validation_command"] == "uv run python scripts/check/check_generated_command_packages.py"
+    assert trust["items"][0]["direct_edit_allowed"] is False
+    assert "Do not hand-edit generated/workspace/python/cli.py" in trust["items"][0]["direct_edit_policy"]
     assert payload["orientation"]["status"] == "changed-path-context"
     assert "preflight" in payload["orientation"]["preflight_command"]
     assert "lowers continuation and review trust" in payload["orientation"]["trust_note"]
@@ -418,6 +428,46 @@ def test_implement_selector_surfaces_changed_path_impact_map(tmp_path: Path, cap
     assert impact["proof_impact"]["required_commands"]
 
 
+def test_implement_selector_surfaces_generated_surface_trust(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "agentic_workspace" / "contracts" / "command_package_ir.json", "{}")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "generated/workspace/python/command_package.json",
+                "--select",
+                "generated_surface_trust",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    trust = json.loads(capsys.readouterr().out)["values"]["generated_surface_trust"]
+    assert trust["kind"] == "agentic-workspace/generated-surface-trust/v1"
+    assert trust["status"] == "present"
+    assert trust["changed_path_count"] == 1
+    assert trust["rule"].startswith("Generated surfaces are derived artifacts")
+    item = trust["items"][0]
+    assert item["path"] == "generated/workspace/python/command_package.json"
+    assert item["classification_id"] == "generated-command-package-output"
+    assert item["role"] == "projection"
+    assert item["canonical_source"] == "src/agentic_workspace/contracts/command_package_ir.json"
+    assert item["canonical_source_status"] == "present"
+    assert item["freshness_status"] == "validation-required"
+    assert item["refresh_command"] == "uv run python scripts/check/check_generated_command_packages.py"
+    assert item["validation_command"] == "uv run python scripts/check/check_generated_command_packages.py"
+    assert item["direct_edit_allowed"] is False
+    assert "Do not hand-edit generated command package outputs" in item["direct_edit_policy"]
+
+
 def test_implement_selector_surfaces_task_contract_view(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
@@ -752,6 +802,7 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
     _write(tmp_path / "Makefile", "test-workspace:\n\tpytest tests\n\nlint-workspace:\n\truff check src tests\n")
+    _write(tmp_path / "src" / "agentic_workspace" / "contracts" / "command_package_ir.json", "{}")
 
     assert (
         cli.main(
@@ -774,7 +825,7 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     context = _implement_context(payload)
     encoded = json.dumps(payload)
     assert payload["kind"] == "implementer-context-tiny/v1"
-    assert set(payload) <= {"kind", "target", "next", "proof", "reuse_pressure", "context", "drill_down"}
+    assert set(payload) <= {"kind", "target", "next", "proof", "generated_surface_trust", "reuse_pressure", "context", "drill_down"}
     adaptive = context["adaptive_routing"]
     assert adaptive["current_need"] == "changed-path-next-action"
     assert adaptive["read_budget"]["profile"] == "tiny"
@@ -787,6 +838,16 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert context["scope"]["inspect_files"] == ["generated/workspace/python/cli.py"]
     assert "make test-workspace" in payload["proof"]["required_commands"]
     assert "uv run python scripts/check/check_generated_command_packages.py" in payload["proof"]["required_commands"]
+    trust = payload["generated_surface_trust"]
+    assert trust["status"] == "present"
+    assert trust["items"][0]["path"] == "generated/workspace/python/cli.py"
+    assert trust["items"][0]["canonical_source"] == "src/agentic_workspace/contracts/command_package_ir.json"
+    assert trust["items"][0]["direct_edit_allowed"] is False
+    assert context["generated_surface_trust"] == {
+        "status": "present",
+        "changed_path_count": 1,
+        "detail_selector": "generated_surface_trust",
+    }
     assert payload["proof"]["acceptance_guidance"]["status"] == "present"
     guidance = context["guidance"]
     assert guidance["rule"].startswith("AW exposes facts")
@@ -818,7 +879,9 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert "authority_markers" not in payload
     assert "durable_intent" not in payload
     assert "inference_limits" not in payload
-    assert len(encoded) < 14500
+    assert "generated_surface_trust" in payload["drill_down"]["available_selectors"]
+    assert len(json.dumps(payload["generated_surface_trust"])) < 700
+    assert len(encoded) < 15500
 
 
 def test_implement_detail_commands_use_resolved_cli_invoke(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -1817,12 +1817,13 @@ def test_proof_changed_selector_flags_direct_cli_edits(capsys) -> None:
         "verification:generated_adapter_conformance",
     ]
     authority_review = answer["cli_authority_review"]
-    assert authority_review["status"] == "review-ready"
+    assert authority_review["status"] == "blocked-direct-edit-route-to-source"
     assert answer["escalate_when"][0] == "changed paths span multiple validation lanes; run all selected commands or split the work"
     root_cli = authority_review["classifications"][0]
-    assert root_cli["role"] == "hand-owned-executable"
-    assert root_cli["direct_edit_allowed"] is True
-    assert root_cli["source_contract"].endswith("src/agentic_workspace/contracts/python_runtime_boundary.json")
+    assert root_cli["role"] == "projection"
+    assert root_cli["direct_edit_allowed"] is False
+    assert root_cli["source_contract"] == "src/agentic_workspace/contracts/command_package_ir.json"
+    assert root_cli["regeneration_path"] == "uv run python scripts/generate/generate_command_packages.py"
     assert authority_review["authority_query"] == "agentic-workspace defaults --section root_cli_authority --format json"
     review = payload["answer"]["direct_cli_edit_review"]
     assert review["status"] == "review-needed"

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -648,7 +648,8 @@ def test_start_command_returns_minimum_safe_startup_context(tmp_path: Path, caps
         "uv run python scripts/check/check_generated_command_packages.py --python-docker-conformance --require-docker",
         "uv run pytest tests/test_workspace_proof_generated_packages_cli.py -q",
     ]
-    assert payload["proof"]["cli_authority_review"]["classifications"][0]["role"] == "hand-owned-executable"
+    assert payload["proof"]["cli_authority_review"]["classifications"][0]["role"] == "projection"
+    assert payload["proof"]["cli_authority_review"]["classifications"][0]["direct_edit_allowed"] is False
     assert payload["path_boundaries"] == [
         {
             "path": "generated/workspace/python/cli.py",


### PR DESCRIPTION
## What changed

- Adds `generated_surface_trust` to `implement --changed` output for generated changed paths.
- Includes canonical source, freshness status, refresh command, direct-edit policy, and validation command in ordinary tiny output and full selector output.
- Corrects `generated/workspace/python/cli.py` authority from direct-edit executable to generated projection routed through `command_package_ir` and regeneration.
- Adds focused tests for tiny output, selector drill-down, proof authority status, and start/preflight routing.

Closes #1258

## Validation

- Focused implement/proof/start tests for generated-surface trust and CLI authority
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `make schema-reference-docs`
- `git diff --check`