### PR TITLE
Surface Memory freshness trust signals

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1257-memory-freshness-contradictions.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1257-memory-freshness-contradictions.plan.json
@@ -1,0 +1,323 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement memory freshness and contradiction signals",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1257 by giving Memory notes explicit freshness, supersession, and contradiction metadata and projecting that status in report and route consult output.",
+    "hard_constraints": "Keep the slice bounded to explicit manifest metadata, advisory trust projection, and focused Memory package tests. Do not implement semantic contradiction clustering or make stale notes block unrelated work.",
+    "agent_may_decide": "Exact field names, projection wording, focused tests, and whether route consult or report output needs compact human-readable rendering.",
+    "escalate_when": "A correct fix requires cross-agent semantic inference, automatic contradiction discovery, changing Memory note ownership, or hard-gating ordinary work on stale advisory memory.",
+    "next_action": "Run focused tests, fix any failures, then run required Memory package validation.",
+    "proof_expectations": [
+      "uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q",
+      "make test-memory",
+      "make lint-memory"
+    ],
+    "touched_scope": [
+      "packages/memory/src/repo_memory_bootstrap/_installer_shared.py",
+      "packages/memory/src/repo_memory_bootstrap/_installer_memory.py",
+      "packages/memory/src/repo_memory_bootstrap/installer.py",
+      "packages/memory/src/repo_memory_bootstrap/runtime_primitives.py",
+      "packages/memory/tests/test_report.py",
+      "packages/memory/tests/test_routing.py"
+    ],
+    "completion_criteria": [
+      "Manifest note records can carry last_confirmed, valid_until, superseded_by, and contradicted_by metadata.",
+      "Memory report exposes fresh, stale, superseded, and contradicted note trust as advisory findings.",
+      "Memory route consult exposes selected-note freshness/trust before an agent relies on routed notes.",
+      "Focused and package-level Memory validation pass."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Implement #1257 by giving Memory notes explicit freshness, supersession, and contradiction metadata and projecting that status in report and route consult output."
+  ],
+  "non_goals": [
+    "Do not implement automatic semantic contradiction clustering.",
+    "Do not make stale or superseded memory a hard blocker for unrelated work.",
+    "Do not broaden into adjacent command-generation or planning issues."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1257 Memory freshness and contradiction signals.",
+      "constraints": "Keep scope bounded to explicit metadata and advisory projection; no semantic contradiction clustering or hard-gating unrelated work.",
+      "latitude": "Choose exact projection shape, compact rendering, and focused tests.",
+      "escalation": "Escalate if the work needs automatic semantic inference, cross-agent trust decisions, or broader Memory ownership changes.",
+      "proof": "uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q; make test-memory; make lint-memory"
+    },
+    "execution": {
+      "milestone": "issue-1257-memory-freshness-contradictions",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q; make test-memory; make lint-memory"
+    },
+    "scope": {
+      "touched": [
+        "packages/memory/src/repo_memory_bootstrap/_installer_shared.py",
+        "packages/memory/src/repo_memory_bootstrap/_installer_memory.py",
+        "packages/memory/src/repo_memory_bootstrap/installer.py",
+        "packages/memory/src/repo_memory_bootstrap/runtime_primitives.py",
+        "packages/memory/tests/test_report.py",
+        "packages/memory/tests/test_routing.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Memory should help agents judge whether durable lessons are current before relying on them.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement memory freshness and contradiction signals",
+    "inferred intended outcome": "Expose note freshness, supersession, and contradiction status where agents consult Memory.",
+    "chosen concrete what": "Add explicit manifest metadata and advisory report/route trust projection with focused tests.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "Memory package manifest model/parser/validator, Memory report/route/runtime projection, focused Memory tests, and this execplan.",
+    "max changed files": "8 source/test/planning files unless validation reveals a directly related generated or contract surface.",
+    "required validation commands": "uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q; make test-memory; make lint-memory.",
+    "ask-before-refactor threshold": "Ask before extracting new packages, changing command-generation contracts, or introducing automatic semantic contradiction discovery.",
+    "stop before touching": "Unrelated backlog, adjacent planning lanes, command-generation extraction, or broad Memory note migration."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue #1257 from Memory note metadata and advisory trust projection; next step is focused tests and Memory validation.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1257 Memory freshness and contradiction signals.",
+    "hard constraints": "Keep stale/superseded/contradicted signals advisory and explicit; do not add semantic clustering in this slice.",
+    "agent may decide locally": "Projection shape, wording, and focused test fixtures.",
+    "escalate when": "The fix requires automatic contradiction inference, a hard gate, or a broader ownership rewrite."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1257-memory-freshness-contradictions",
+    "status": "completed",
+    "scope": "Explicit Memory note freshness metadata and advisory report/route trust projection for #1257.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run focused Memory report/routing tests, fix failures, then run make test-memory and make lint-memory."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "packages/memory/src/repo_memory_bootstrap/_installer_shared.py",
+    "packages/memory/src/repo_memory_bootstrap/_installer_memory.py",
+    "packages/memory/src/repo_memory_bootstrap/installer.py",
+    "packages/memory/src/repo_memory_bootstrap/runtime_primitives.py",
+    "packages/memory/tests/test_report.py",
+    "packages/memory/tests/test_routing.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q",
+    "make test-memory",
+    "make lint-memory"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement memory freshness and contradiction signals is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented explicit Memory note freshness, supersession, and contradiction metadata with advisory report and route-consult trust projection.",
+    "scope touched": "Memory manifest model/parser/validator, Memory report trust output, Memory route consult summary, runtime text rendering, and focused tests.",
+    "changed surfaces": "packages/memory/src/repo_memory_bootstrap/_installer_shared.py; packages/memory/src/repo_memory_bootstrap/_installer_memory.py; packages/memory/src/repo_memory_bootstrap/installer.py; packages/memory/src/repo_memory_bootstrap/runtime_primitives.py; packages/memory/tests/test_report.py; packages/memory/tests/test_routing.py",
+    "validations run": "uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q; make test-memory; make lint-memory",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed bounded to #1257. Stale, superseded, and contradicted Memory notes are advisory visibility signals, not hard blockers; semantic contradiction clustering remains out of scope.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q; make test-memory; make lint-memory",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q; make test-memory; make lint-memory"
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1257 Memory freshness and contradiction signals.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q; make test-memory; make lint-memory",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Memory consult/report now surfaces whether selected durable notes are fresh, expired/stale, superseded, or contradicted before an agent relies on them.",
+    "validation confirmed": "uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q; make test-memory; make lint-memory",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q; make test-memory; make lint-memory",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1257 Memory freshness and contradiction signals.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q; make test-memory; make lint-memory\nChanged surfaces: packages/memory/src/repo_memory_bootstrap/_installer_shared.py; packages/memory/src/repo_memory_bootstrap/_installer_memory.py; packages/memory/src/repo_memory_bootstrap/installer.py; packages/memory/src/repo_memory_bootstrap/runtime_primitives.py; packages/memory/tests/test_report.py; packages/memory/tests/test_routing.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/packages/memory/src/repo_memory_bootstrap/_installer_memory.py
+++ b/packages/memory/src/repo_memory_bootstrap/_installer_memory.py
@@ -126,6 +126,10 @@ def _load_memory_manifest(path: Path) -> MemoryManifest | None:
                 use_when=tuple(_string_list(raw.get("use_when"))),
                 routes_from=tuple(_string_list(raw.get("routes_from"))),
                 stale_when=tuple(_string_list(raw.get("stale_when"))),
+                last_confirmed=str(raw.get("last_confirmed", "") or "").strip(),
+                valid_until=str(raw.get("valid_until", "") or "").strip(),
+                superseded_by=tuple(_string_list(raw.get("superseded_by"))),
+                contradicted_by=tuple(_string_list(raw.get("contradicted_by"))),
                 evidence=tuple(_string_list(raw.get("evidence"))),
                 related_validations=tuple(_string_list(raw.get("related_validations"))),
                 routing_only=bool(raw.get("routing_only", False)),
@@ -230,12 +234,14 @@ def _memory_manifest_typed_validator_findings(path: Path) -> list[str]:
                 "use_when",
                 "routes_from",
                 "stale_when",
+                "superseded_by",
+                "contradicted_by",
                 "evidence",
                 "related_validations",
             ):
                 if field in raw and not _is_string_array(raw[field]):
                     findings.append(f"manifest notes.{note_path}.{field} must be an array of strings")
-            for field in ("summary", "promotion_target", "promotion_trigger", "retention_after_promotion"):
+            for field in ("summary", "last_confirmed", "valid_until", "promotion_target", "promotion_trigger", "retention_after_promotion"):
                 if field in raw and (not isinstance(raw[field], str) or not raw[field].strip()):
                     findings.append(f"manifest notes.{note_path}.{field} must be a non-empty string when present")
             for field in ("routing_only", "high_level", "improvement_candidate"):

--- a/packages/memory/src/repo_memory_bootstrap/_installer_shared.py
+++ b/packages/memory/src/repo_memory_bootstrap/_installer_shared.py
@@ -459,6 +459,10 @@ class MemoryNoteRecord:
     use_when: tuple[str, ...] = ()
     routes_from: tuple[str, ...] = ()
     stale_when: tuple[str, ...] = ()
+    last_confirmed: str = ""
+    valid_until: str = ""
+    superseded_by: tuple[str, ...] = ()
+    contradicted_by: tuple[str, ...] = ()
     evidence: tuple[str, ...] = ()
     related_validations: tuple[str, ...] = ()
     routing_only: bool = False

--- a/packages/memory/src/repo_memory_bootstrap/installer.py
+++ b/packages/memory/src/repo_memory_bootstrap/installer.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+from datetime import date
 from pathlib import Path
 from typing import Any, Iterable, cast
 
@@ -1663,6 +1664,11 @@ def route_memory(
 
     kept_suggestions = [*required, *kept_optionals]
     result.route_summary = _build_route_summary(kept_suggestions)
+    result.route_summary["selected_note_trust"] = _selected_route_note_trust(
+        manifest=manifest,
+        kept_suggestions=kept_suggestions,
+        target_root=target_root,
+    )
     result.missing_note_hint = "If routing missed something, record which note was missing."
 
     if result.route_summary.get("warning"):
@@ -1746,6 +1752,52 @@ def route_memory(
         match_source="missing-note-prompt",
     )
     return result
+
+
+def _selected_route_note_trust(
+    *,
+    manifest: MemoryManifest | None,
+    kept_suggestions: list[tuple[str, str, str, str, int]],
+    target_root: Path,
+) -> dict[str, object]:
+    if manifest is None:
+        return {
+            "status": "unavailable",
+            "selected_note_count": 0,
+            "attention_count": 0,
+            "items": [],
+            "rule": "No manifest was available, so selected Memory notes have no structured freshness signal.",
+        }
+
+    selected_paths = list(dict.fromkeys(note for _recommendation, note, _reason, _match_source, _priority in kept_suggestions))
+    items: list[dict[str, object]] = []
+    for selected_path in selected_paths:
+        note = _lookup_manifest_note(manifest, Path(selected_path))
+        if note is None:
+            continue
+        trust_item = _memory_trust_item(note=note, target_root=target_root)
+        items.append(
+            {
+                "path": trust_item["path"],
+                "state": trust_item["state"],
+                "freshness": trust_item["freshness"],
+                "reason": trust_item["reason"],
+                "last_confirmed": trust_item["last_confirmed"],
+                "valid_until": trust_item["valid_until"],
+                "superseded_by": trust_item["superseded_by"],
+                "contradicted_by": trust_item["contradicted_by"],
+            }
+        )
+
+    attention_states = {"stale", "questionable", "superseded", "contradicted"}
+    attention_count = sum(1 for item in items if item.get("state") in attention_states)
+    return {
+        "status": "attention" if attention_count else "clear",
+        "selected_note_count": len(items),
+        "attention_count": attention_count,
+        "items": items,
+        "rule": "Memory route selection is advisory; agents must confirm stale, superseded, or contradicted notes before relying on them.",
+    }
 
 
 def review_routes(*, target: str | Path | None = None) -> InstallResult:
@@ -2475,20 +2527,49 @@ def _memory_matching_anchor_patterns(*, target_root: Path, anchors: list[str]) -
     return matched_patterns, matched_paths
 
 
+def _parse_memory_date(value: str) -> date | None:
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
 def _memory_trust_item(*, note: MemoryNoteRecord, target_root: Path) -> dict[str, object]:
     anchors = _memory_evidence_anchors(note)
     matched_patterns, matched_paths = _memory_matching_anchor_patterns(target_root=target_root, anchors=anchors)
     note_path = target_root / note.path
     exists = note_path.exists()
-    scope = "durable" if note.memory_role in {"durable_truth", "improvement_signal"} or note.authority == "canonical" else "advisory"
+    scope = (
+        "advisory"
+        if note.routing_only or note.high_level
+        else "durable"
+        if note.memory_role in {"durable_truth", "improvement_signal"} or note.authority == "canonical"
+        else "advisory"
+    )
+    valid_until = _parse_memory_date(note.valid_until) if note.valid_until else None
 
     state = "supported"
+    freshness = "fresh" if note.last_confirmed or note.valid_until else "needs-confirmation"
     reason = "note is grounded in current repo anchors"
     if not exists:
         state = "stale"
+        freshness = "missing"
         reason = "manifest note path is missing from the repo"
+    elif note.contradicted_by:
+        state = "contradicted"
+        freshness = "contradicted"
+        reason = "manifest note declares contradicted_by; confirm before relying on it"
+    elif note.superseded_by:
+        state = "superseded"
+        freshness = "superseded"
+        reason = "manifest note declares superseded_by; prefer the replacement note"
+    elif valid_until is not None and valid_until < date.today():
+        state = "stale"
+        freshness = "expired"
+        reason = "manifest note valid_until date has passed"
     elif scope != "durable":
         state = "advisory"
+        freshness = "advisory"
         reason = "advisory/current note trust is reported through current-check and freshness surfaces"
     elif not anchors:
         state = "questionable"
@@ -2506,7 +2587,12 @@ def _memory_trust_item(*, note: MemoryNoteRecord, target_root: Path) -> dict[str
         "authority": note.authority,
         "memory_role": note.memory_role or "unclassified",
         "state": state,
+        "freshness": freshness,
         "reason": reason,
+        "last_confirmed": note.last_confirmed,
+        "valid_until": note.valid_until,
+        "superseded_by": list(note.superseded_by),
+        "contradicted_by": list(note.contradicted_by),
         "evidence_anchor_count": len(anchors),
         "matched_anchor_count": len(matched_patterns),
         "evidence_anchors": anchors,
@@ -3141,7 +3227,10 @@ def memory_report(*, target: str | Path | None = None) -> dict[str, object]:
     remediation_counts = remediation.counts()
     stale_notes = [item for item in trust_items if item["state"] == "stale"]
     questionable_notes = [item for item in trust_items if item["state"] == "questionable"]
+    superseded_notes = [item for item in trust_items if item["state"] == "superseded"]
+    contradicted_notes = [item for item in trust_items if item["state"] == "contradicted"]
     elimination_candidates = [item for item in trust_items if item["state"] == "elimination_candidate"]
+    trust_attention_notes = [*contradicted_notes, *stale_notes, *superseded_notes, *questionable_notes]
     recurring_friction = _recurring_friction_report(target_root=target_root)
     durable_facts = _durable_fact_routing_view(manifest=manifest, route_snapshot=route_snapshot, target_root=target_root)
     usefulness_audit = _memory_usefulness_audit(
@@ -3213,20 +3302,31 @@ def memory_report(*, target: str | Path | None = None) -> dict[str, object]:
     merge_safety_warning_count = sum(
         1 for finding in merge_safety_findings if isinstance(finding, dict) and cast(dict[str, Any], finding).get("severity") == "warning"
     )
-    if manual_review_total or warning_total or stale_notes or questionable_notes or merge_safety_warning_count:
+    if manual_review_total or warning_total or trust_attention_notes or merge_safety_warning_count:
         health = "attention-needed"
     else:
         health = "healthy"
 
     next_action_summary = "Memory looks healthy right now."
     next_action_commands: list[str] = []
-    if stale_notes:
+    if contradicted_notes:
+        note = contradicted_notes[0]
+        next_action_summary = f"Resolve contradicted memory note {note['path']} before relying on it."
+        next_action_commands = [
+            "agentic-memory report --target ./repo --format json",
+            "agentic-memory promotion-report --target ./repo --mode remediation",
+        ]
+    elif stale_notes:
         note = stale_notes[0]
         next_action_summary = f"Review stale memory note {note['path']} before trusting it again."
         next_action_commands = [
             "agentic-memory report --target ./repo --format json",
             "agentic-memory promotion-report --target ./repo --mode remediation",
         ]
+    elif superseded_notes:
+        note = superseded_notes[0]
+        next_action_summary = f"Prefer the superseding memory note for {note['path']} before relying on it."
+        next_action_commands = ["agentic-memory report --target ./repo --format json"]
     elif manual_review_total or warning_total:
         first_finding = findings[0] if findings else None
         if isinstance(first_finding, dict):
@@ -3337,6 +3437,10 @@ def memory_report(*, target: str | Path | None = None) -> dict[str, object]:
         "merge_safety": merge_safety,
         "promotion_pressure": promotion_pressure,
         "trust": {
+            "status": "attention" if trust_attention_notes or manual_review_total or warning_total else "clear",
+            "attention_count": len(trust_attention_notes) + manual_review_total + warning_total,
+            "finding_count": len(trust_items),
+            "detail_command": "agentic-memory report --target ./repo --verbose --format json",
             "warning_count": warning_total,
             "manual_review_count": manual_review_total,
             "advisory_count": advisory_total,
@@ -3344,6 +3448,8 @@ def memory_report(*, target: str | Path | None = None) -> dict[str, object]:
             "state_counts": trust_state_counts,
             "questionable_notes": questionable_notes[:5],
             "stale_notes": stale_notes[:5],
+            "superseded_notes": superseded_notes[:5],
+            "contradicted_notes": contradicted_notes[:5],
             "elimination_candidates": elimination_candidates[:5],
         },
         "recurring_friction": recurring_friction,

--- a/packages/memory/src/repo_memory_bootstrap/runtime_primitives.py
+++ b/packages/memory/src/repo_memory_bootstrap/runtime_primitives.py
@@ -449,6 +449,11 @@ def _emit_result(result, *, output_format: str, include_install_summary: bool = 
             print(f"Route justification: {result.route_summary['justification']}")
         if result.route_summary.get("warning"):
             print(f"Route warning: {result.route_summary['warning']}")
+        selected_trust = cast(dict[str, Any], result.route_summary.get("selected_note_trust", {}))
+        if isinstance(selected_trust, dict) and selected_trust.get("attention_count"):
+            print(
+                f"Route note trust: status={selected_trust.get('status', 'unknown')}, attention={selected_trust.get('attention_count', 0)}"
+            )
     if result.missing_note_hint:
         print(f"Routing feedback: {result.missing_note_hint}")
     if result.review_summary:
@@ -570,7 +575,7 @@ def _print_report(report: dict[str, object]) -> None:
         )
         if isinstance(state_counts, dict) and state_counts:
             print(
-                f"Trust states: {state_counts.get('supported', 0)} supported / {state_counts.get('questionable', 0)} questionable / {state_counts.get('stale', 0)} stale / {state_counts.get('elimination_candidate', 0)} elimination-biased"
+                f"Trust states: {state_counts.get('supported', 0)} supported / {state_counts.get('questionable', 0)} questionable / {state_counts.get('stale', 0)} stale / {state_counts.get('superseded', 0)} superseded / {state_counts.get('contradicted', 0)} contradicted / {state_counts.get('elimination_candidate', 0)} elimination-biased"
             )
     recurring_friction = cast(dict[str, Any], report.get("recurring_friction", {}))
     if isinstance(recurring_friction, dict) and recurring_friction.get("status") == "present":

--- a/packages/memory/tests/test_report.py
+++ b/packages/memory/tests/test_report.py
@@ -697,8 +697,18 @@ def test_memory_report_classifies_trust_states_from_manifest_metadata(tmp_path: 
 
     questionable_note = target / ".agentic-workspace" / "memory" / "repo" / "decisions" / "questionable-note.md"
     questionable_note.write_text("# Questionable\n", encoding="utf-8")
+    fresh_note = target / ".agentic-workspace" / "memory" / "repo" / "decisions" / "fresh-note.md"
+    fresh_note.write_text("# Fresh\n", encoding="utf-8")
     stale_note = target / ".agentic-workspace" / "memory" / "repo" / "decisions" / "stale-note.md"
     stale_note.write_text("# Stale\n", encoding="utf-8")
+    superseded_note = target / ".agentic-workspace" / "memory" / "repo" / "decisions" / "superseded-note.md"
+    superseded_note.write_text("# Superseded\n", encoding="utf-8")
+    replacement_note = target / ".agentic-workspace" / "memory" / "repo" / "decisions" / "replacement-note.md"
+    replacement_note.write_text("# Replacement\n", encoding="utf-8")
+    contradicted_note = target / ".agentic-workspace" / "memory" / "repo" / "decisions" / "contradicted-note.md"
+    contradicted_note.write_text("# Contradicted\n", encoding="utf-8")
+    contradicting_note = target / ".agentic-workspace" / "memory" / "repo" / "decisions" / "contradicting-note.md"
+    contradicting_note.write_text("# Contradicting\n", encoding="utf-8")
     improvement_note = target / ".agentic-workspace" / "memory" / "repo" / "mistakes" / "improvement-note.md"
     improvement_note.write_text("# Improvement\n", encoding="utf-8")
 
@@ -718,6 +728,21 @@ subsystems = ["test"]
 surfaces = ["decision"]
 memory_role = "durable_truth"
 
+[notes.".agentic-workspace/memory/repo/decisions/fresh-note.md"]
+note_type = "decision"
+canonical_home = ".agentic-workspace/memory/repo/decisions/fresh-note.md"
+authority = "canonical"
+audience = "human+agent"
+canonicality = "agent_only"
+task_relevance = "optional"
+subsystems = ["test"]
+surfaces = ["decision"]
+routes_from = ["AGENTS.md"]
+stale_when = ["AGENTS.md"]
+last_confirmed = "2999-01-01"
+valid_until = "2999-12-31"
+memory_role = "durable_truth"
+
 [notes.".agentic-workspace/memory/repo/decisions/stale-note.md"]
 note_type = "decision"
 canonical_home = ".agentic-workspace/memory/repo/decisions/stale-note.md"
@@ -727,8 +752,40 @@ canonicality = "agent_only"
 task_relevance = "optional"
 subsystems = ["test"]
 surfaces = ["decision"]
-routes_from = ["missing/**/*.md"]
-stale_when = ["missing/**/*.md"]
+routes_from = ["AGENTS.md"]
+stale_when = ["AGENTS.md"]
+last_confirmed = "1999-01-01"
+valid_until = "2000-01-01"
+memory_role = "durable_truth"
+
+[notes.".agentic-workspace/memory/repo/decisions/superseded-note.md"]
+note_type = "decision"
+canonical_home = ".agentic-workspace/memory/repo/decisions/superseded-note.md"
+authority = "canonical"
+audience = "human+agent"
+canonicality = "agent_only"
+task_relevance = "optional"
+subsystems = ["test"]
+surfaces = ["decision"]
+routes_from = ["AGENTS.md"]
+stale_when = ["AGENTS.md"]
+last_confirmed = "2026-01-01"
+superseded_by = [".agentic-workspace/memory/repo/decisions/replacement-note.md"]
+memory_role = "durable_truth"
+
+[notes.".agentic-workspace/memory/repo/decisions/contradicted-note.md"]
+note_type = "decision"
+canonical_home = ".agentic-workspace/memory/repo/decisions/contradicted-note.md"
+authority = "canonical"
+audience = "human+agent"
+canonicality = "agent_only"
+task_relevance = "optional"
+subsystems = ["test"]
+surfaces = ["decision"]
+routes_from = ["AGENTS.md"]
+stale_when = ["AGENTS.md"]
+last_confirmed = "2026-01-01"
+contradicted_by = [".agentic-workspace/memory/repo/decisions/contradicting-note.md"]
 memory_role = "durable_truth"
 
 [notes.".agentic-workspace/memory/repo/mistakes/improvement-note.md"]
@@ -754,8 +811,24 @@ elimination_target = "promote"
     report = installer.memory_report(target=target)
 
     assert report["trust"]["state_counts"]["questionable"] >= 1
+    assert report["trust"]["state_counts"]["supported"] >= 1
     assert report["trust"]["state_counts"]["stale"] >= 1
+    assert report["trust"]["state_counts"]["superseded"] >= 1
+    assert report["trust"]["state_counts"]["contradicted"] >= 1
     assert report["trust"]["state_counts"]["elimination_candidate"] >= 1
+    assert report["trust"]["status"] == "attention"
+    assert report["trust"]["attention_count"] >= 3
+    assert any(item["freshness"] == "expired" for item in report["trust"]["stale_notes"])
+    assert any(
+        item["path"] == ".agentic-workspace/memory/repo/decisions/superseded-note.md"
+        and item["superseded_by"] == [".agentic-workspace/memory/repo/decisions/replacement-note.md"]
+        for item in report["trust"]["superseded_notes"]
+    )
+    assert any(
+        item["path"] == ".agentic-workspace/memory/repo/decisions/contradicted-note.md"
+        and item["contradicted_by"] == [".agentic-workspace/memory/repo/decisions/contradicting-note.md"]
+        for item in report["trust"]["contradicted_notes"]
+    )
     assert any(
         item["path"] == ".agentic-workspace/memory/repo/decisions/questionable-note.md" for item in report["trust"]["questionable_notes"]
     )

--- a/packages/memory/tests/test_routing.py
+++ b/packages/memory/tests/test_routing.py
@@ -101,6 +101,85 @@ surfaces = ["api"]
     assert result.route_summary["weak_signal_note_count"] == 0
 
 
+def test_route_memory_exposes_selected_note_freshness_trust(tmp_path: Path) -> None:
+    target = tmp_path / "repo"
+    (target / ".git").mkdir(parents=True, exist_ok=True)
+    notes_dir = target / ".agentic-workspace" / "memory" / "repo" / "domains"
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    (target / ".agentic-workspace" / "memory" / "repo" / "index.md").write_text(_memory_index_text(), encoding="utf-8")
+    (notes_dir / "fresh.md").write_text("# Fresh\n", encoding="utf-8")
+    (notes_dir / "expired.md").write_text("# Expired\n", encoding="utf-8")
+    (notes_dir / "superseded.md").write_text("# Superseded\n", encoding="utf-8")
+    (notes_dir / "replacement.md").write_text("# Replacement\n", encoding="utf-8")
+    (target / ".agentic-workspace" / "memory" / "repo" / "manifest.toml").write_text(
+        """
+version = 1
+
+[notes.".agentic-workspace/memory/repo/index.md"]
+note_type = "routing"
+canonical_home = ".agentic-workspace/memory/repo/index.md"
+authority = "canonical"
+audience = "human+agent"
+canonicality = "agent_only"
+task_relevance = "required"
+routing_only = true
+
+[notes.".agentic-workspace/memory/repo/domains/fresh.md"]
+note_type = "domain"
+canonical_home = ".agentic-workspace/memory/repo/domains/fresh.md"
+authority = "canonical"
+audience = "human+agent"
+canonicality = "agent_only"
+task_relevance = "optional"
+routes_from = ["src/api.py"]
+stale_when = ["src/api.py"]
+last_confirmed = "2999-01-01"
+valid_until = "2999-12-31"
+memory_role = "durable_truth"
+
+[notes.".agentic-workspace/memory/repo/domains/expired.md"]
+note_type = "domain"
+canonical_home = ".agentic-workspace/memory/repo/domains/expired.md"
+authority = "canonical"
+audience = "human+agent"
+canonicality = "agent_only"
+task_relevance = "optional"
+routes_from = ["src/api.py"]
+stale_when = ["src/api.py"]
+last_confirmed = "1999-01-01"
+valid_until = "2000-01-01"
+memory_role = "durable_truth"
+
+[notes.".agentic-workspace/memory/repo/domains/superseded.md"]
+note_type = "domain"
+canonical_home = ".agentic-workspace/memory/repo/domains/superseded.md"
+authority = "canonical"
+audience = "human+agent"
+canonicality = "agent_only"
+task_relevance = "optional"
+routes_from = ["src/api.py"]
+stale_when = ["src/api.py"]
+last_confirmed = "2026-01-01"
+superseded_by = [".agentic-workspace/memory/repo/domains/replacement.md"]
+memory_role = "durable_truth"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (target / "src").mkdir(parents=True, exist_ok=True)
+    (target / "src" / "api.py").write_text("pass\n", encoding="utf-8")
+
+    result = installer.route_memory(target=target, files=["src/api.py"])
+
+    selected_trust = result.route_summary["selected_note_trust"]
+    assert selected_trust["status"] == "attention"
+    assert selected_trust["attention_count"] == 2
+    trust_by_path = {item["path"]: item for item in selected_trust["items"]}
+    assert trust_by_path[".agentic-workspace/memory/repo/domains/fresh.md"]["freshness"] == "fresh"
+    assert trust_by_path[".agentic-workspace/memory/repo/domains/expired.md"]["freshness"] == "expired"
+    assert trust_by_path[".agentic-workspace/memory/repo/domains/superseded.md"]["state"] == "superseded"
+
+
 def test_route_memory_falls_back_to_index_when_manifest_is_incomplete(tmp_path: Path) -> None:
     target = tmp_path / "repo"
     (target / ".git").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- add Memory manifest metadata for last_confirmed, valid_until, superseded_by, and contradicted_by
- project stale, superseded, and contradicted note status into memory report trust output
- add selected-note trust to memory route consult output so agents see advisory freshness before relying on routed notes

Closes #1257.

## Validation
- uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py -q
- make test-memory
- make lint-memory
- uv run python scripts/run_agentic_workspace.py summary --target . --format json
- uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json