### PR TITLE
Add intent discovery evidence path

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1251-intent-discovery-evidence.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1251-intent-discovery-evidence.plan.json
@@ -1,0 +1,347 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement intent-discovery evidence path",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1251 by making intent source, assumptions, and correction points visible through startup, implement, and closeout/report.",
+    "hard_constraints": "Preserve agent judgment; do not add keyword-based hard gates or require clarification for every vague prompt.",
+    "agent_may_decide": "Exact packet fields, compact projections, schema wording, and scenario fixture shape.",
+    "escalate_when": "A correct fix requires a new hard clarification gate, broad Planning semantics, or changes outside startup/implement/report evidence projection.",
+    "next_action": "Finish validation and close out the intent-evidence implementation.",
+    "proof_expectations": [
+      "Focused startup/implement/report tests prove scenario evidence.",
+      "Workspace lint and schema/reference checks prove contract consistency."
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "src/agentic_workspace/contracts/schemas/*.schema.json",
+      "docs/reference/workspace-report.md",
+      "tests/test_workspace_start_preflight_cli.py",
+      "tests/test_workspace_implement_cli.py",
+      "tests/test_workspace_report_cli.py"
+    ],
+    "completion_criteria": [
+      "Startup exposes intent_evidence for ask-human and issue-backed proceed-with-assumption scenarios.",
+      "Implement tiny context exposes compact intent_evidence for changed-path work.",
+      "Closeout report exposes intent provenance alongside interpreted intent.",
+      "Direct small fixes remain light and do not show intent-discovery interruption."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Implement intent-discovery evidence path."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1251 by making intent source, assumptions, and correction points visible through startup, implement, and closeout/report.",
+      "constraints": "Preserve agent judgment; do not add keyword-based hard gates or require clarification for every vague prompt.",
+      "latitude": "Exact packet fields, compact projections, schema wording, and scenario fixture shape.",
+      "escalation": "Escalate when a correct fix requires a new hard clarification gate, broad Planning semantics, or changes outside startup/implement/report evidence projection.",
+      "proof": "focused intent-evidence tests passed; make test-workspace passed; make lint-workspace passed; contract tooling passed; structured file inventory passed; generated command package check passed; maintainer surfaces passed; schema-reference docs passed; planning surfaces passed"
+    },
+    "execution": {
+      "milestone": "issue-1251-intent-discovery-evidence",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "focused intent-evidence tests passed; make test-workspace passed; make lint-workspace passed; contract tooling passed; structured file inventory passed; generated command package check passed; maintainer surfaces passed; schema-reference docs passed; planning surfaces passed"
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/contracts/schemas/*.schema.json",
+        "docs/reference/workspace-report.md",
+        "tests/test_workspace_start_preflight_cli.py",
+        "tests/test_workspace_implement_cli.py",
+        "tests/test_workspace_report_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Agents and reviewers can cheaply see whether broad or vague work preserved human intent or proceeded under visible assumptions.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Startup, implement, and closeout/report can share a compact intent-source evidence path.",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "none unless validation reveals a narrower follow-up"
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1251 intent-discovery compliance evidence path.",
+    "inferred intended outcome": "Make skipped or assumption-based intent discovery visible without replacing agent judgment with prompt keywords.",
+    "chosen concrete what": "Add a reusable intent_evidence packet, compact projections, schemas/docs, and scenario tests.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the packet exposes provenance and assumptions without changing ordinary permission behavior."
+  },
+  "execution_bounds": {
+    "allowed paths": "workspace runtime primitives, workspace schemas, workspace report reference doc, focused workspace tests, and this closeout plan.",
+    "max changed files": "about 10 tracked files plus generated/reference updates if required by validation.",
+    "required validation commands": "focused pytest for startup/implement/report, make test-workspace, make lint-workspace, contract tooling checks, maintainer surfaces, schema reference docs, generated command package checks if required.",
+    "ask-before-refactor threshold": "Ask before adding a new hard clarification gate, new subsystem, or changing Planning archive/closeout semantics beyond report projection.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Validate the intent_evidence packet across start, implement, and closeout/report, then close this plan.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1251 by making intent source, assumptions, and correction points visible through startup, implement, and closeout/report.",
+    "hard constraints": "Preserve agent judgment; do not add keyword-based hard gates or require clarification for every vague prompt.",
+    "agent may decide locally": "Exact packet fields, compact projections, schema wording, and scenario fixture shape.",
+    "escalate when": "A correct fix requires a new hard clarification gate, broad Planning semantics, or changes outside startup/implement/report evidence projection."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1251",
+      "role": "source_intent"
+    },
+    {
+      "kind": "planning-review",
+      "target": ".agentic-workspace/planning/reviews/2026-06-04-open-issue-1251-intent-discovery-compliance-grounding.review.json",
+      "role": "grounding"
+    }
+  ],
+  "active_milestone": {
+    "id": "issue-1251-intent-discovery-evidence",
+    "status": "completed",
+    "scope": "Add intent-source evidence path through startup, implement, closeout/report, contracts, docs, and tests.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No next action remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+    "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+    "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+    "docs/reference/workspace-report.md",
+    "tests/test_workspace_start_preflight_cli.py",
+    "tests/test_workspace_implement_cli.py",
+    "tests/test_workspace_report_cli.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_start_preflight_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py -q -k \"intent_evidence or intent_discovery or closeout_report\"",
+    "make test-workspace",
+    "make lint-workspace",
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py",
+    "make maintainer-surfaces",
+    "make schema-reference-docs"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Startup exposes intent_evidence for ask-human and issue-backed proceed-with-assumption scenarios.",
+    "Implement tiny context exposes compact intent_evidence for changed-path work.",
+    "Closeout report exposes intent provenance alongside interpreted intent.",
+    "Direct small fixes remain light and do not show intent-discovery interruption."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented intent_evidence through startup, implement, and closeout/report projections with scenario tests and schema/reference docs.",
+    "scope touched": "workspace runtime intent evidence, startup/implement/report projections, schemas, reference docs, and focused tests",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/startup-context.md; docs/reference/implementer-context.md; docs/reference/workspace-report.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_implement_cli.py; tests/test_workspace_report_cli.py",
+    "validations run": "focused intent-evidence tests passed; make test-workspace passed; make lint-workspace passed; contract tooling passed; structured file inventory passed; generated command package check passed; maintainer surfaces passed; schema-reference docs passed; planning surfaces passed",
+    "result for continuation": "bounded closeout complete",
+    "next step": "none; this execplan is archived"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1251 evidence-path implementation; compact outputs preserve agent judgment and avoid keyword hard gates.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "focused intent-evidence tests passed; make test-workspace passed; make lint-workspace passed; contract tooling passed; structured file inventory passed; generated command package check passed; maintainer surfaces passed; schema-reference docs passed; planning surfaces passed",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "focused intent-evidence tests passed; make test-workspace passed; make lint-workspace passed; contract tooling passed; structured file inventory passed; generated command package check passed; maintainer surfaces passed; schema-reference docs passed; planning surfaces passed"
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1251 by making intent source, assumptions, and correction points visible through startup, implement, and closeout/report.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "focused intent-evidence tests passed; make test-workspace passed; make lint-workspace passed; contract tooling passed; structured file inventory passed; generated command package check passed; maintainer surfaces passed; schema-reference docs passed; planning surfaces passed",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Startup, implement, and closeout/report now expose intent source, assumption state, and correction posture for vague or issue-backed work.",
+    "validation confirmed": "focused intent-evidence tests passed; make test-workspace passed; make lint-workspace passed; contract tooling passed; structured file inventory passed; generated command package check passed; maintainer surfaces passed; schema-reference docs passed; planning surfaces passed",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "focused intent-evidence tests passed; make test-workspace passed; make lint-workspace passed; contract tooling passed; structured file inventory passed; generated command package check passed; maintainer surfaces passed; schema-reference docs passed; planning surfaces passed",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "no_signal_found",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": [
+        {
+          "summary": "#1251",
+          "owner": "github-issue",
+          "source": "#1251"
+        }
+      ]
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1251 by making intent source, assumptions, and correction points visible through startup, implement, and closeout/report.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: focused intent-evidence tests passed; make test-workspace passed; make lint-workspace passed; contract tooling passed; structured file inventory passed; generated command package check passed; maintainer surfaces passed; schema-reference docs passed; planning surfaces passed\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/startup-context.md; docs/reference/implementer-context.md; docs/reference/workspace-report.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_implement_cli.py; tests/test_workspace_report_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -71,6 +71,7 @@ Cheap implementer context for a bounded changed-path scope.
 | `acceptance_reconciliation.task_text_available` | boolean | yes |  | Whether the CLI invocation included task text to reconcile. |  |  |
 | `acceptance_reconciliation.task_carry_forward_hint` | string | yes |  | Short reminder to preserve task text across start and implement calls. |  |  |
 | `intent_acknowledgement` | object | yes |  | Guidance for stating inferred intent, first slice, non-goals, and correction point before non-direct implementation. |  |  |
+| `intent_evidence` | object | yes |  | Compact provenance and assumption evidence for the task intent being implemented, including source chain, correction point, and clarification/proceed posture. |  |  |
 | `reuse_pressure` | object | yes |  | Changed-path reuse and abstraction-pressure facts that help the agent decide whether to reuse, accept duplication, or route extraction follow-up. |  |  |
 | `assurance_requirements` | object | yes |  | Repo-declared assurance requirements matched to the task or changed paths, with evidence status and claim-boundary facts. |  |  |
 | `verification` | object | yes |  | Matched repo-native verification protocols and bounded evidence status for the task or changed paths. |  |  |

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -137,6 +137,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `acceptance` | object | no |  | Definition-of-done expectations inferred from task intent for selector-first startup drill-down. |  |  |
 | `durable_intent_promotion` | object | no |  | Guidance for promoting non-finishable task intent into durable memory, docs, subsystem intent, or system intent. |  |  |
 | `intent_acknowledgement` | object | no |  | Guidance for the middle path between silent inference and clarification halt: state inferred intent, first slice, non-goals, and correction point before non-direct work. |  |  |
+| `intent_evidence` | object | no |  | Compact provenance and assumption evidence for the current task intent, including source chain, correction point, and clarification/proceed posture. |  |  |
 | `durable_intent` | object | no |  | Compact durable task, subsystem, and system intent pressure to consider before implementation. |  |  |
 | `skill_routing` | ref `#/$defs/skill_routing` | no |  | Skill-discovery route and fallback guidance for task-specific instructions. |  |  |
 | `skill_routing.status` | string | yes |  | Current lifecycle, readiness, or health state. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -100,6 +100,8 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `closeout_report.authority_boundary.agent_owned_decisions` | array of string | yes |  | Semantic, route, proof-proportionality, or completion judgments the agent owns. |  |  |
 | `closeout_report.authority_boundary.human_owned_decisions` | array of string | yes |  | Intent, acceptance, or handoff decisions requiring human ownership when present. |  |  |
 | `closeout_report.authority_boundary.reporting_rule` | string | yes |  | How agents should report the boundary without overstating AW authority. |  |  |
+| `closeout_report.intent_evidence` | object | no |  | Closeout intent provenance showing whether interpreted intent came from planning evidence, user text, issue/reference evidence, handoff evidence, or agent inference. |  |  |
+| `closeout_report.interpreted_intent` | object | no |  | Requested outcome, intent-source evidence, satisfaction status, and closure decision rendered for the closeout report. |  |  |
 | `closeout_report.decision_review` | object | no |  | Derived review packet for agent-authored system decision facts, owner-model split, completeness, absence routing, and durable-owner guidance. |  |  |
 | `closeout_report.review_compression` | object | no |  | Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts and contract, rendered fact requirements, detail routes, and human-owned decisions. |  |  |
 | `closeout_report.closeout_adoption` | object | no |  | Derived closeout quality rubric, representative examples, and current rendering adoption status for human-useful final reports. |  |  |

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -22,6 +22,7 @@
     "required_validation_commands",
     "acceptance_reconciliation",
     "intent_acknowledgement",
+    "intent_evidence",
     "objective_drift",
     "generated_surface_trust",
     "reuse_pressure",
@@ -149,6 +150,11 @@
     "intent_acknowledgement": {
       "type": "object",
       "description": "Guidance for stating inferred intent, first slice, non-goals, and correction point before non-direct implementation.",
+      "additionalProperties": true
+    },
+    "intent_evidence": {
+      "type": "object",
+      "description": "Compact provenance and assumption evidence for the task intent being implemented, including source chain, correction point, and clarification/proceed posture.",
       "additionalProperties": true
     },
     "reuse_pressure": {

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -346,6 +346,11 @@
       "description": "Guidance for the middle path between silent inference and clarification halt: state inferred intent, first slice, non-goals, and correction point before non-direct work.",
       "additionalProperties": true
     },
+    "intent_evidence": {
+      "type": "object",
+      "description": "Compact provenance and assumption evidence for the current task intent, including source chain, correction point, and clarification/proceed posture.",
+      "additionalProperties": true
+    },
     "durable_intent": {
       "type": "object",
       "description": "Compact durable task, subsystem, and system intent pressure to consider before implementation."

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -295,6 +295,14 @@
           "$ref": "#/$defs/authority_boundary",
           "description": "Authority boundary showing which closeout/report signals are AW-enforced, observed, recommended, or agent-owned."
         },
+        "intent_evidence": {
+          "type": "object",
+          "description": "Closeout intent provenance showing whether interpreted intent came from planning evidence, user text, issue/reference evidence, handoff evidence, or agent inference."
+        },
+        "interpreted_intent": {
+          "type": "object",
+          "description": "Requested outcome, intent-source evidence, satisfaction status, and closure decision rendered for the closeout report."
+        },
         "decision_review": {
           "type": "object",
           "description": "Derived review packet for agent-authored system decision facts, owner-model split, completeness, absence routing, and durable-owner guidance."

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -8707,6 +8707,12 @@ def _closeout_report_payload(
     requested_outcome = str(
         delegated.get("requested outcome") or delegated.get("requested_outcome") or completion_contract.get("must_be_true") or ""
     ).strip()
+    intent_evidence = _closeout_intent_evidence_payload(
+        active_planning_record=active_planning_record,
+        evidence_state=evidence_state,
+        requested_outcome=requested_outcome,
+        intent_check=intent_check,
+    )
     changed_surfaces = str(execution.get("changed surfaces") or "").strip()
     validation_proof = str(proof_report.get("validation proof") or execution.get("validations run") or "").strip()
     completion_decision = str(completion_contract.get("completion_decision", "unknown"))
@@ -8812,6 +8818,7 @@ def _closeout_report_payload(
         "work_completed": work_completed,
         "interpreted_intent": {
             "requested_outcome": requested_outcome,
+            "intent_evidence": intent_evidence,
             "intent_satisfaction": {
                 key: intent_check.get(key)
                 for key in ("status", "trust", "required_follow_on", "continuation_surface")
@@ -8819,6 +8826,7 @@ def _closeout_report_payload(
             },
             "closure_decision": str(closure_check.get("closure decision") or closure_check.get("closure_decision") or "").strip(),
         },
+        "intent_evidence": intent_evidence,
         "changes": {
             "changed_surfaces": changed_surfaces,
             "scope_touched": str(execution.get("scope touched") or "").strip(),
@@ -15479,6 +15487,8 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
     matched_count = int(subsystem_intent.get("matched_count", 0) or 0) if isinstance(subsystem_intent, dict) else 0
     if isinstance(durable_intent, dict) and durable_intent.get("status") == "present" and matched_count:
         projected["durable_intent"] = _tiny_durable_intent(durable_intent)
+    if "intent_evidence" in payload:
+        projected["intent_evidence"] = _compact_intent_evidence(payload.get("intent_evidence", {}))
     if isinstance(task_intent, dict) and task_intent.get("status") == "present":
         acceptance = task_intent.get("acceptance", {})
         projected["task_intent"] = {
@@ -16243,6 +16253,23 @@ def _start_payload(
         and (not _is_prep_only_handoff_task(task_text))
     ):
         payload["intent_acknowledgement"] = intent_acknowledgement
+    intent_evidence = _task_intent_evidence_payload(
+        task_text=task_text,
+        task_intent=task_intent,
+        intent_discovery=intent_discovery,
+        intent_acknowledgement=intent_acknowledgement,
+    )
+    if (
+        intent_evidence["status"] == "present"
+        and (
+            intent_evidence["assumption_state"] != "low-risk-direct"
+            or intent_evidence.get("issue_refs")
+            or intent_discovery.get("applies_to_current_task")
+        )
+        and task_intent.get("task_argument_mode") != "task-file"
+        and not _is_prep_only_handoff_task(task_text)
+    ):
+        payload["intent_evidence"] = intent_evidence
     if (
         intent_discovery.get("status") == "ask-human"
         and not active_planning_present
@@ -16512,6 +16539,7 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "delegation_decision",
         "intent_discovery_dialogue",
         "intent_acknowledgement",
+        "intent_evidence",
         "workflow_sufficiency",
         "next_safe_action",
         "health",
@@ -16541,6 +16569,7 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "context.delegation_decision",
         "context.intent_discovery_dialogue",
         "context.intent_acknowledgement",
+        "context.intent_evidence",
         "context.workflow_sufficiency",
         "context.guidance",
         "context.acceptance_reconciliation",
@@ -16860,6 +16889,8 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     matched_count = int(subsystem_intent.get("matched_count", 0) or 0) if isinstance(subsystem_intent, dict) else 0
     if isinstance(durable_intent, dict) and durable_intent.get("status") == "present" and matched_count:
         context["durable_intent"] = _tiny_durable_intent(durable_intent)
+    if "intent_evidence" in payload:
+        context["intent_evidence"] = _compact_intent_evidence(payload.get("intent_evidence", {}))
     for optional_key in (
         "proof",
         "path_boundaries",
@@ -17063,6 +17094,23 @@ def _start_tiny_payload_fast(
         and (not _is_prep_only_handoff_task(task_text))
     ):
         payload["intent_acknowledgement"] = intent_acknowledgement
+    intent_evidence = _task_intent_evidence_payload(
+        task_text=task_text,
+        task_intent=task_intent,
+        intent_discovery=intent_discovery,
+        intent_acknowledgement=intent_acknowledgement,
+    )
+    if (
+        intent_evidence["status"] == "present"
+        and (
+            intent_evidence["assumption_state"] != "low-risk-direct"
+            or intent_evidence.get("issue_refs")
+            or intent_discovery.get("applies_to_current_task")
+        )
+        and task_intent.get("task_argument_mode") != "task-file"
+        and not _is_prep_only_handoff_task(task_text)
+    ):
+        payload["intent_evidence"] = intent_evidence
     if (
         intent_discovery.get("status") == "ask-human"
         and not active_planning_present
@@ -18101,6 +18149,230 @@ def _intent_acknowledgement_payload(
         "silent_inference_ok_when": "The change is direct, local, low-risk, and validation is obvious.",
         "ask_human_when": "Stop for clarification only when the intent, authority boundary, safety risk, or required input blocks choosing a bounded first slice.",
         "template": "Inferred intent: <outcome>. First slice: <bounded work>. Non-goals/deferred: <scope>. I will proceed on that interpretation unless corrected.",
+    }
+
+
+def _task_intent_evidence_payload(
+    *,
+    task_text: str | None,
+    task_intent: dict[str, Any] | None = None,
+    intent_discovery: dict[str, Any] | None = None,
+    intent_acknowledgement: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    task = str(task_text or "").strip()
+    task_intent = task_intent if isinstance(task_intent, dict) else {}
+    intent_discovery = intent_discovery if isinstance(intent_discovery, dict) else {}
+    intent_acknowledgement = intent_acknowledgement if isinstance(intent_acknowledgement, dict) else {}
+    if not task:
+        return {
+            "kind": "agentic-workspace/intent-evidence/v1",
+            "status": "absent",
+            "reason": "No task text was provided.",
+            "rule": "Intent evidence is required only when a task intent exists or a closeout claim is being evaluated.",
+        }
+
+    issue_refs = re.findall(r"#\d+\b", task)
+    discovery_status = str(intent_discovery.get("status", "available"))
+    acknowledgement_decision = str(intent_acknowledgement.get("decision", "silent-ok"))
+    chain: list[dict[str, Any]] = [
+        {
+            "source": "current-user-task",
+            "trust": "explicit-text",
+            "summary": "The current task text is the first intent source.",
+        }
+    ]
+    if task_intent.get("task_argument_mode") == "task-file":
+        chain.append(
+            {
+                "source": "task-file",
+                "trust": "explicit-text",
+                "path": task_intent.get("task_file", ""),
+                "summary": "Task text was carried through a local task file.",
+            }
+        )
+    if issue_refs:
+        chain.append(
+            {
+                "source": "external-issue-reference",
+                "trust": "needs-refresh-or-human-context",
+                "refs": issue_refs,
+                "summary": "Issue references may carry product intent; refresh or cite issue evidence before treating them as confirmed.",
+            }
+        )
+    if discovery_status != "available":
+        chain.append(
+            {
+                "source": "workspace-intent-discovery",
+                "trust": "advisory-support",
+                "status": discovery_status,
+                "summary": "Intent-discovery guidance explains whether to ask or proceed with visible assumptions.",
+            }
+        )
+    if acknowledgement_decision == "proceed-with-stated-assumption":
+        chain.append(
+            {
+                "source": "agent-stated-assumption-required",
+                "trust": "agent-inference",
+                "summary": "The agent may proceed only after stating inferred intent, first slice, non-goals, and correction point.",
+            }
+        )
+
+    if discovery_status == "ask-human":
+        assumption_state = "clarification-required"
+        source_class = "human-clarification-needed"
+        confidence = str(intent_discovery.get("inferred_intent_confidence", "low"))
+        required_next_action = "ask-intent-discovery-question"
+        proceed_without_question = False
+    elif acknowledgement_decision == "proceed-with-stated-assumption":
+        assumption_state = "visible-assumption-required"
+        source_class = "agent-inference-with-evidence"
+        confidence = str(intent_discovery.get("inferred_intent_confidence") or ("medium" if issue_refs else "medium-high"))
+        required_next_action = "state-assumptions-before-editing"
+        proceed_without_question = True
+    else:
+        assumption_state = "low-risk-direct"
+        source_class = "direct-user-text"
+        confidence = "high"
+        required_next_action = "continue-direct"
+        proceed_without_question = True
+
+    return {
+        "kind": "agentic-workspace/intent-evidence/v1",
+        "status": "present",
+        "source_class": source_class,
+        "assumption_state": assumption_state,
+        "confidence": confidence,
+        "issue_refs": issue_refs,
+        "source_chain": chain,
+        "required_next_action": required_next_action,
+        "proceed_without_question": proceed_without_question,
+        "correction_point": intent_acknowledgement.get("correction_point")
+        or "Proceed only when the bounded interpretation is visible and can be corrected.",
+        "ask_human_when": intent_acknowledgement.get("ask_human_when")
+        or "Ask when intent, authority, safety, or required input blocks choosing a bounded first slice.",
+        "closeout_carry_forward": [
+            "source_class",
+            "assumption_state",
+            "source_chain",
+            "correction_point",
+            "issue_refs",
+        ],
+        "scenario_expectations": [
+            {
+                "scenario": "vague-broad-prompt",
+                "expected_evidence": "ask or visible assumptions before implementation",
+            },
+            {
+                "scenario": "issue-backed-prompt",
+                "expected_evidence": "issue reference plus stated interpretation and correction point",
+            },
+            {
+                "scenario": "high-stakes-system-shaping",
+                "expected_evidence": "clarification or Planning/issue owner before broad work proceeds",
+            },
+            {
+                "scenario": "direct-small-fix",
+                "expected_evidence": "direct-user-text is enough; no clarification interruption",
+            },
+        ],
+        "rule": "AW exposes intent-source and assumption evidence; the agent owns semantic interpretation and whether clarification is genuinely blocking.",
+    }
+
+
+def _compact_intent_evidence(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact = {
+        key: value[key]
+        for key in (
+            "kind",
+            "status",
+            "source_class",
+            "assumption_state",
+            "confidence",
+            "issue_refs",
+            "required_next_action",
+            "proceed_without_question",
+        )
+        if key in value
+    }
+    compact["source_count"] = len(_list_payload(value.get("source_chain")))
+    return compact
+
+
+def _closeout_intent_evidence_payload(
+    *,
+    active_planning_record: dict[str, Any],
+    evidence_state: str,
+    requested_outcome: str,
+    intent_check: dict[str, Any],
+) -> dict[str, Any]:
+    if not active_planning_record:
+        return {
+            "kind": "agentic-workspace/intent-evidence/v1",
+            "status": "guidance-only",
+            "source_class": "no-closeout-evidence",
+            "assumption_state": "not-evaluated",
+            "rule": "Closeout intent provenance is available once active, retained, or archived planning evidence exists.",
+        }
+    execution = _as_dict(active_planning_record.get("execution_run"))
+    intent_satisfaction = _as_dict(active_planning_record.get("intent_satisfaction"))
+    references = _list_payload(active_planning_record.get("references"))
+    source_chain: list[dict[str, Any]] = []
+    if requested_outcome:
+        source_chain.append(
+            {
+                "source": "planning.delegated_judgment.requested_outcome",
+                "trust": "planning-record",
+                "summary": requested_outcome,
+            }
+        )
+    original_intent = str(intent_satisfaction.get("original intent", "")).strip()
+    if original_intent:
+        source_chain.append(
+            {
+                "source": "planning.intent_satisfaction.original_intent",
+                "trust": "closeout-evidence",
+                "summary": original_intent,
+            }
+        )
+    handoff_source = str(execution.get("handoff source") or execution.get("handoff_source") or "").strip()
+    if handoff_source:
+        source_chain.append(
+            {
+                "source": "planning.execution_run.handoff_source",
+                "trust": "handoff-evidence",
+                "summary": handoff_source,
+            }
+        )
+    reference_refs = [
+        {
+            "source": "planning.references",
+            "trust": "external-or-planning-reference",
+            "target": item.get("target") or item.get("url") or item.get("path") or "",
+            "role": item.get("role", ""),
+        }
+        for item in references[:5]
+        if isinstance(item, dict)
+    ]
+    source_chain.extend(reference_refs)
+    source_class = "planning-evidence"
+    if reference_refs:
+        source_class = "planning-plus-external-reference"
+    elif not source_chain:
+        source_class = "planning-record-with-implicit-intent"
+    trust = str(intent_check.get("trust") or "unknown")
+    return {
+        "kind": "agentic-workspace/intent-evidence/v1",
+        "status": "present",
+        "source_class": source_class,
+        "assumption_state": "closeout-derived-from-planning",
+        "confidence": "high" if requested_outcome and trust not in {"needs-review", "follow-up-required"} else "medium",
+        "planning_evidence_state": evidence_state,
+        "source_chain": source_chain,
+        "closeout_trust": trust,
+        "correction_point": "If this source chain does not match the user's intended outcome, do not claim completion; route the mismatch to Planning, an issue, or Memory.",
+        "rule": "Closeout must distinguish user-confirmed, issue-derived, planning-derived, and agent-inferred intent before claiming satisfaction.",
     }
 
 
@@ -19447,6 +19719,24 @@ def _implement_payload(
             "closeout_required": acceptance.get("closeout_required", False),
         }
     vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
+    intent_acknowledgement = _intent_acknowledgement_payload(
+        task_text=task_text, execution_posture=execution_posture, vague_orientation=vague_orientation
+    )
+    intent_discovery = (
+        {}
+        if normalized_paths
+        else _intent_discovery_dialogue_payload(
+            task_text=task_text,
+            vague_orientation=vague_orientation,
+            cli_invoke=config.cli_invoke,
+        )
+    )
+    intent_evidence = _task_intent_evidence_payload(
+        task_text=task_text,
+        task_intent=task_intent,
+        intent_discovery=intent_discovery,
+        intent_acknowledgement=intent_acknowledgement,
+    )
     implement_current_need = "changed-path-implementation" if normalized_paths else "unknown-scope-routing"
     payload = {
         "kind": "implementer-context/v1",
@@ -19531,9 +19821,8 @@ def _implement_payload(
         "proof": proof,
         "required_validation_commands": proof["required_commands"],
         "acceptance_reconciliation": _acceptance_reconciliation_prompt_payload(task_text=task_text, acceptance=acceptance),
-        "intent_acknowledgement": _intent_acknowledgement_payload(
-            task_text=task_text, execution_posture=execution_posture, vague_orientation=vague_orientation
-        ),
+        "intent_acknowledgement": intent_acknowledgement,
+        "intent_evidence": intent_evidence,
         "objective_drift": _objective_drift_payload(target_root=target_root, changed_paths=normalized_paths, task_text=task_text),
         "generated_surface_trust": _generated_surface_trust_payload(
             target_root=target_root,
@@ -19759,6 +20048,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 if isinstance(payload.get("task_intent"), dict)
                 else [],
             },
+            "intent_evidence": _compact_intent_evidence(payload.get("intent_evidence", {})),
             "acceptance": _tiny_acceptance_payload(payload.get("acceptance", {})),
             "acceptance_reconciliation": _tiny_acceptance_reconciliation(payload.get("acceptance_reconciliation", {})),
             "objective_drift": _tiny_objective_drift(payload.get("objective_drift", {})),
@@ -19794,6 +20084,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "context.scope",
                 "context.workflow_sufficiency",
                 "context.acceptance",
+                "context.intent_evidence",
                 "context.acceptance_reconciliation",
                 "context.objective_drift",
                 "context.reuse_pressure",

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -866,6 +866,11 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
         "correction_point",
     ]
     assert acknowledgement["proceed_unless_corrected"] is True
+    intent_evidence = context["intent_evidence"]
+    assert intent_evidence["source_class"] == "agent-inference-with-evidence"
+    assert intent_evidence["assumption_state"] == "visible-assumption-required"
+    assert intent_evidence["required_next_action"] == "state-assumptions-before-editing"
+    assert intent_evidence["proceed_without_question"] is True
     assert context["delegation_decision"]["status"] == "evaluated"
     assert context["delegation_decision"]["mode"] in {"suggest", "auto"}
     delegation_boundary = context["delegation_decision"]["authority_boundary"]

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -1223,12 +1223,14 @@ def test_report_workspace_schema_documents_closeout_authority_boundary() -> None
 
     assert authority_boundary["$ref"] == "#/$defs/authority_boundary"
     assert "AW-enforced" in authority_boundary["description"]
+    assert "intent provenance" in closeout_report["properties"]["intent_evidence"]["description"]
     assert "agent-authored system decision facts" in closeout_report["properties"]["decision_review"]["description"]
     assert "first-inspection facts" in closeout_report["properties"]["review_compression"]["description"]
     assert "quality rubric" in closeout_report["properties"]["closeout_adoption"]["description"]
     rendered = Path("docs/reference/workspace-report.md").read_text(encoding="utf-8")
     assert "closeout_report.authority_boundary" in rendered
     assert "Authority boundary showing which closeout/report signals" in rendered
+    assert "closeout_report.intent_evidence" in rendered
     assert "closeout_report.decision_review" in rendered
     assert "closeout_report.review_compression" in rendered
     assert "closeout_report.closeout_adoption" in rendered
@@ -1454,6 +1456,7 @@ def test_report_closeout_report_renders_planned_slice_first_inspection_contract(
                 "requested outcome": "Make closeout rendering show planned slice facts first.",
                 "hard constraints": "Do not add another report surface.",
             },
+            "references": [{"kind": "issue", "target": "#1251", "role": "source_intent"}],
             "completion_criteria": ["Planned slice facts render before detail inspection."],
             "validation_commands": ["uv run pytest tests/test_workspace_report_cli.py -q"],
             "intent_continuity": {
@@ -1506,6 +1509,12 @@ def test_report_closeout_report_renders_planned_slice_first_inspection_contract(
 
     report = json.loads(capsys.readouterr().out)["answer"]
     assert report["profile"] == "balanced"
+    intent_evidence = report["intent_evidence"]
+    assert intent_evidence["source_class"] == "planning-plus-external-reference"
+    assert intent_evidence["assumption_state"] == "closeout-derived-from-planning"
+    assert intent_evidence["planning_evidence_state"] == "active"
+    assert any(item.get("source") == "planning.references" and item.get("target") == "#1251" for item in intent_evidence["source_chain"])
+    assert report["interpreted_intent"]["intent_evidence"] == intent_evidence
     assert report["review_compression"]["selected_mode"] == "planned-slice"
     contract = report["review_compression"]["first_inspection_contract"]
     assert contract["id"] == "planned-slice"

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -2522,6 +2522,7 @@ def test_start_vague_high_stakes_task_routes_to_intent_discovery_dialogue(tmp_pa
 
     payload = json.loads(capsys.readouterr().out)
     discovery = _start_context_value(payload, "intent_discovery_dialogue")
+    intent_evidence = _start_context_value(payload, "intent_evidence")
     assert discovery["status"] == "ask-human"
     assert discovery["inferred_intent_confidence"] == "low"
     assert discovery["stakes_if_wrong"] == "high"
@@ -2531,6 +2532,10 @@ def test_start_vague_high_stakes_task_routes_to_intent_discovery_dialogue(tmp_pa
     assert discovery["loop_control"]["max_questions_before_progress"] == 1
     assert "captured_intent_after_reply" in discovery["output_shape"]["fields"]
     assert "Planning" in discovery["output_shape"]["promotion_targets"]
+    assert intent_evidence["source_class"] == "human-clarification-needed"
+    assert intent_evidence["assumption_state"] == "clarification-required"
+    assert intent_evidence["required_next_action"] == "ask-intent-discovery-question"
+    assert intent_evidence["proceed_without_question"] is False
 
     next_action = payload["next_safe_action"]
     assert next_action["next_safe_action"] == "ask-intent-discovery-question"
@@ -2553,7 +2558,7 @@ def test_start_detailed_issue_uses_intent_discovery_without_interrupting(tmp_pat
                 "--task",
                 "Implement #1197",
                 "--select",
-                "intent_discovery_dialogue,intent_acknowledgement,immediate_next_allowed_action",
+                "intent_discovery_dialogue,intent_acknowledgement,intent_evidence,immediate_next_allowed_action",
                 "--format",
                 "json",
             ]
@@ -2567,6 +2572,11 @@ def test_start_detailed_issue_uses_intent_discovery_without_interrupting(tmp_pat
     assert discovery["required_next_action"] == "state-assumptions-before-editing"
     assert payload["immediate_next_allowed_action"]["action"] != "ask-intent-discovery-question"
     assert payload["intent_acknowledgement"]["decision"] == "proceed-with-stated-assumption"
+    intent_evidence = payload["intent_evidence"]
+    assert intent_evidence["source_class"] == "agent-inference-with-evidence"
+    assert intent_evidence["assumption_state"] == "visible-assumption-required"
+    assert intent_evidence["issue_refs"] == ["#1197"]
+    assert any(item["source"] == "external-issue-reference" for item in intent_evidence["source_chain"])
 
 
 def test_start_task_surfaces_stated_assumption_middle_path(tmp_path: Path, capsys) -> None:
@@ -2625,6 +2635,7 @@ def test_start_direct_task_keeps_stated_assumption_out_of_default(tmp_path: Path
     payload = json.loads(capsys.readouterr().out)
     assert "intent_acknowledgement" not in payload
     assert "intent_discovery_dialogue" not in payload
+    assert "intent_evidence" not in payload.get("context", {})
 
 
 def test_startup_skillspec_pilot_keeps_direct_work_light_and_blocks_epic_work(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -71,6 +71,7 @@ candidates = [
         "execution_readiness",
         "current_execution_pressure",
         "decomposition",
+        "residue_governance",
         "roadmap",
         "detail_commands",
         "available_selectors",


### PR DESCRIPTION
## Summary
- Adds an `intent_evidence` packet through startup, implement, and closeout/report projections.
- Carries compact intent source, assumption state, correction posture, and issue-reference evidence without making AW own semantic classification.
- Updates schemas, generated reference docs, and scenario tests for vague broad prompts, issue-backed prompts, direct small fixes, and closeout provenance.

## Validation
- `uv run pytest tests/test_workspace_start_preflight_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py -q -k "intent_evidence or intent_discovery or closeout_report"`
- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_workspace_start_preflight_cli.py::test_start_tiny_compacts_long_task_carry_forward_command tests/test_workspace_start_preflight_cli.py::test_start_tiny_routes_prep_only_handoff_to_planning_bridge tests/test_workspace_summary_cli.py::test_workspace_summary_json_defaults_to_tiny_profile -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make schema-reference-docs`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/check/check_generated_command_packages.py`
- `make maintainer-surfaces`
- `make planning-surfaces`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `git diff --check`

Closes #1251.