### PR TITLE
Add compact action-first output signals

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1273-compact-action-signals.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1273-compact-action-signals.plan.json
@@ -1,0 +1,329 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Compact action-first output signals",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Make compact start and implement output easier to scan by surfacing blockers, allowed action, proof, changed signals, and selector-backed advisory detail in a fixed action-first packet.",
+    "hard_constraints": "Do not weaken planning gates, proof requirements, selector-backed drill-down, or agent-owned judgment boundaries.",
+    "agent_may_decide": "Exact compact packet fields, ordering tests, schema wording, and whether non-immediate advisory detail remains top-level or selector-backed.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Validate the action_signals projection and selector-backed reuse-pressure behavior.",
+    "proof_expectations": [
+      "focused compact start/implement tests pass",
+      "make test-workspace",
+      "make lint-workspace",
+      "schema-reference docs are current",
+      "contract/tooling checks pass"
+    ],
+    "touched_scope": [
+      "workspace runtime compact start/implement projections",
+      "startup and implementer schemas/reference docs",
+      "compact-output tests"
+    ],
+    "completion_criteria": [
+      "Compact start and implement payloads expose action_signals with ordered blocker/action/proof/changed/advisory/judgment fields.",
+      "Ordinary tiny implement output keeps reuse-pressure detail selector-backed instead of emitting the full advisory packet by default.",
+      "Explicit reuse_pressure selectors continue to return the detailed packet."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Make compact start and implement output easier to scan by surfacing blockers, allowed action, proof, changed signals, and selector-backed advisory detail in a fixed action-first packet."
+  ],
+  "non_goals": [
+    "Do not redesign all report/profile surfaces.",
+    "Do not remove selector-backed advisory detail.",
+    "Do not weaken planning, proof, or completion-claim gates."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Make compact start and implement output easier to scan by surfacing blockers, allowed action, proof, changed signals, and selector-backed advisory detail in a fixed action-first packet.",
+      "constraints": "Do not weaken planning gates, proof requirements, selector-backed drill-down, or agent-owned judgment boundaries.",
+      "latitude": "Exact compact packet fields, ordering tests, schema wording, and whether non-immediate advisory detail remains top-level or selector-backed.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "focused compact output tests passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed; check_contract_tooling_surfaces passed; check_structured_file_inventory passed; ruff contract/check inventory subset passed; maintainer-surfaces passed"
+    },
+    "execution": {
+      "milestone": "issue-1273-compact-action-signals",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "focused compact output tests passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed; check_contract_tooling_surfaces passed; check_structured_file_inventory passed; ruff contract/check inventory subset passed; maintainer-surfaces passed"
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+        "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+        "docs/reference/startup-context.md",
+        "docs/reference/implementer-context.md",
+        "tests/test_workspace_start_preflight_cli.py",
+        "tests/test_workspace_implement_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Compact/default AW output should be action-first while preserving selector-backed detail.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1273 compact AW action-first output signals.",
+    "inferred intended outcome": "Make compact start and implement payloads cheaper to act on by exposing a stable action-first summary.",
+    "chosen concrete what": "Add action_signals to tiny start/implement and move ordinary reuse-pressure detail behind explicit selectors.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "workspace_runtime_primitives.py, startup/implementer schemas, generated schema reference docs, compact start/implement tests, and this execplan.",
+    "max changed files": "8 expected files plus generated reference docs.",
+    "required validation commands": "focused compact tests; make test-workspace; make lint-workspace; schema-reference-docs; contract/tooling checks.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue from the action_signals projection and selector-backed reuse-pressure validation.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Make compact start and implement output easier to scan by surfacing blockers, allowed action, proof, changed signals, and selector-backed advisory detail in a fixed action-first packet.",
+    "hard constraints": "Do not weaken planning gates, proof requirements, selector-backed drill-down, or agent-owned judgment boundaries.",
+    "agent may decide locally": "Exact compact packet fields, ordering tests, schema wording, and whether non-immediate advisory detail remains top-level or selector-backed.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1273-compact-action-signals",
+    "status": "completed",
+    "scope": "Bounded compact start/implement output UX slice for #1273.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Validate the action_signals projection and selector-backed reuse-pressure behavior."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+    "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+    "docs/reference/startup-context.md",
+    "docs/reference/implementer-context.md",
+    "tests/test_workspace_start_preflight_cli.py",
+    "tests/test_workspace_implement_cli.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_default_returns_selector_first_router tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_workspace_implement_cli.py::test_implement_compact_reuse_pressure_collapses_large_generated_file_sets tests/test_workspace_implement_cli.py::test_implement_selector_surfaces_reuse_pressure_without_blocking_direct_work -q",
+    "make test-workspace",
+    "make lint-workspace",
+    "make schema-reference-docs",
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Compact start and implement payloads expose action_signals with ordered blocker/action/proof/changed/advisory/judgment fields.",
+    "Ordinary tiny implement output keeps reuse-pressure detail selector-backed instead of emitting the full advisory packet by default.",
+    "Explicit reuse_pressure selectors continue to return the detailed packet."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added compact action_signals to tiny start and implement outputs, kept advisory reuse-pressure detail selector-backed by default, preserved explicit reuse_pressure selectors, and refreshed schema reference docs.",
+    "scope touched": "workspace runtime compact projections, startup and implementer schemas/reference docs, compact start/implement tests, and the #1273 execplan",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; docs/reference/startup-context.md; docs/reference/implementer-context.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_implement_cli.py",
+    "validations run": "focused compact output tests passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed; check_contract_tooling_surfaces passed; check_structured_file_inventory passed; ruff contract/check inventory subset passed; maintainer-surfaces passed",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1273 compact-output UX. action_signals orders hard blockers, allowed action, proof, changed signals, advisory selectors, and agent-owned judgment without weakening gates.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "focused compact output tests passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed; check_contract_tooling_surfaces passed; check_structured_file_inventory passed; ruff contract/check inventory subset passed; maintainer-surfaces passed",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "focused compact output tests passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed; check_contract_tooling_surfaces passed; check_structured_file_inventory passed; ruff contract/check inventory subset passed; maintainer-surfaces passed"
+  },
+  "intent_satisfaction": {
+    "original intent": "Make compact/default AW output action-first while preserving selector-backed detail.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "focused compact output tests passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed; check_contract_tooling_surfaces passed; check_structured_file_inventory passed; ruff contract/check inventory subset passed; maintainer-surfaces passed",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Compact/default start and implement outputs now expose action-first signals, while reuse-pressure detail remains available through explicit selectors instead of ordinary top-level noise.",
+    "validation confirmed": "focused compact output tests passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed; check_contract_tooling_surfaces passed; check_structured_file_inventory passed; ruff contract/check inventory subset passed; maintainer-surfaces passed",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "focused compact output tests passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed; check_contract_tooling_surfaces passed; check_structured_file_inventory passed; ruff contract/check inventory subset passed; maintainer-surfaces passed",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Make compact/default AW output action-first while preserving selector-backed detail.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: focused compact output tests passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed; check_contract_tooling_surfaces passed; check_structured_file_inventory passed; ruff contract/check inventory subset passed; maintainer-surfaces passed\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; docs/reference/startup-context.md; docs/reference/implementer-context.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_implement_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -13,6 +13,7 @@ Cheap implementer context for a bounded changed-path scope.
 | (root) | object | yes |  | Cheap implementer context for a bounded changed-path scope. |  | x-agentic-workspace-doc-role: "contract-reference" |
 | `kind` | const `"implementer-context/v1"` | yes |  | Discriminator for the implementer context payload shape. |  |  |
 | `target` | string | yes |  | Resolved target repository for the implementation context. |  |  |
+| `action_signals` | object | no |  | Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment. |  |  |
 | `planning_revision` | object | no |  | Optimistic Planning state revision observed by this implementer read surface. |  |  |
 | `active_plan_reliance` | object | no |  | Permission signal separating command-written integrity, planning freshness, and active-plan reliance. |  |  |
 | `adaptive_routing` | object | yes |  | Machine-readable need classification, read budget, and escalation detail commands for this implementer packet. |  |  |

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -13,6 +13,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | (root) | object | yes |  | Startup routing payload returned when an agent needs the minimum safe context for entering or resuming work in a repository. |  | x-agentic-workspace-doc-role: "contract-reference" |
 | `kind` | const `"startup-context/v1"` | yes |  | Discriminator for the startup context payload shape. |  |  |
 | `target` | string | yes |  | Resolved target repository for the startup decision. |  |  |
+| `action_signals` | object | no |  | Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment. |  |  |
 | `invoked_cli_identity` | ref `#/$defs/invoked_cli_identity` | no |  | Observed identity of the Agentic Workspace CLI that produced this payload. |  |  |
 | `invoked_cli_identity.kind` | const `"agentic-workspace/invoked-cli-identity/v1"` | yes |  | Discriminator identifying the payload or record shape. |  |  |
 | `invoked_cli_identity.package` | const `"agentic-workspace"` | yes |  | Fixed package value required by this contract. |  |  |

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -47,6 +47,11 @@
       "type": "string",
       "description": "Resolved target repository for the implementation context."
     },
+    "action_signals": {
+      "type": "object",
+      "description": "Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment.",
+      "additionalProperties": true
+    },
     "planning_revision": {
       "type": "object",
       "description": "Optimistic Planning state revision observed by this implementer read surface.",

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -17,6 +17,11 @@
       "type": "string",
       "description": "Resolved target repository for the startup decision."
     },
+    "action_signals": {
+      "type": "object",
+      "description": "Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment.",
+      "additionalProperties": true
+    },
     "invoked_cli_identity": {
       "$ref": "#/$defs/invoked_cli_identity",
       "description": "Observed identity of the Agentic Workspace CLI that produced this payload."

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -15279,6 +15279,49 @@ def _next_safe_action_packet(
     }
 
 
+def _compact_action_signals_payload(
+    *,
+    surface: str,
+    allowed_next_action: str,
+    hard_blockers: Sequence[str] | None = None,
+    implementation_allowed: bool | None = None,
+    read_only_allowed: bool | None = None,
+    proof_required: bool = False,
+    proof_commands: Sequence[str] | None = None,
+    changed_signals: Sequence[str] | None = None,
+    advisory_selectors: Sequence[str] | None = None,
+    agent_judgment: str = "Agent owns semantic fit and final completion judgment.",
+) -> dict[str, Any]:
+    blockers = [str(item) for item in (hard_blockers or []) if str(item).strip()]
+    commands = [str(item) for item in (proof_commands or []) if str(item).strip()]
+    signals = [str(item) for item in (changed_signals or []) if str(item).strip()]
+    selectors = [str(item) for item in (advisory_selectors or []) if str(item).strip()]
+    return {
+        "kind": "agentic-workspace/action-signals/v1",
+        "surface": surface,
+        "hard_blockers": blockers,
+        "allowed_next_action": allowed_next_action,
+        "implementation_allowed": implementation_allowed,
+        "read_only_allowed": read_only_allowed,
+        "proof_required": proof_required,
+        "proof_commands": commands,
+        "changed_signals": signals,
+        "advisory_detail": {
+            "selectors": selectors,
+            "rule": "Use selectors for advisory detail.",
+        },
+        "agent_judgment": agent_judgment,
+        "order": [
+            "hard_blockers",
+            "allowed_next_action",
+            "proof_required",
+            "changed_signals",
+            "advisory_detail",
+            "agent_judgment",
+        ],
+    }
+
+
 def _startup_closeout_report_route(closeout_inspection: dict[str, Any]) -> dict[str, Any]:
     trust = str(closeout_inspection.get("trust", "")).strip().lower()
     detail_command = str(closeout_inspection.get("required_next_inspection") or closeout_inspection.get("detail_command") or "")
@@ -16836,9 +16879,37 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                 context["task"][optional_key] = task_intent[optional_key]
     if "repair_plan_profile" in payload:
         context["repair_plan_profile"] = payload["repair_plan_profile"]
+    startup_changed_signals: list[str] = []
+    planning_gate = payload.get("planning_safety_gate", {})
+    if isinstance(planning_gate, dict) and planning_gate.get("status") not in {None, "", "clear"}:
+        startup_changed_signals.append(
+            f"planning_safety={planning_gate.get('status')}:{planning_gate.get('gate_result') or planning_gate.get('decision')}"
+        )
+    if isinstance(payload.get("cli_compatibility"), dict) and payload["cli_compatibility"].get("status") in {
+        "blocking-drift",
+        "warning-drift",
+    }:
+        startup_changed_signals.append(f"cli_compatibility={payload['cli_compatibility'].get('status')}")
+    startup_proof = payload.get("proof", {})
+    startup_proof_commands = _tiny_required_proof_commands(startup_proof) if isinstance(startup_proof, dict) else []
     selected: dict[str, Any] = {
         "kind": payload["kind"],
         "target": ".",
+        "action_signals": _compact_action_signals_payload(
+            surface="start",
+            allowed_next_action=str(next_safe_action.get("next_safe_action", "")),
+            hard_blockers=next_safe_action.get("closure_blockers", []),
+            implementation_allowed=bool(next_safe_action.get("implementation_allowed")),
+            read_only_allowed=bool(next_safe_action.get("read_only_allowed")),
+            proof_required=bool(next_safe_action.get("proof_required")),
+            proof_commands=startup_proof_commands,
+            changed_signals=startup_changed_signals,
+            advisory_selectors=[
+                "skill_routing",
+                "workflow_sufficiency",
+            ],
+            agent_judgment="Agent owns work-shape choice unless hard_blockers names a gate.",
+        ),
         "next_safe_action": next_safe_action,
         "skills": _startup_skills_projection(
             payload=payload,
@@ -19991,6 +20062,57 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     projected = {
         "kind": "implementer-context-tiny/v1",
         "target": payload.get("target"),
+        "action_signals": _compact_action_signals_payload(
+            surface="implement",
+            allowed_next_action=str(next_action),
+            hard_blockers=[
+                *[f"path_authority:{item.get('path')}" for item in path_warnings if isinstance(item, dict) and item.get("path")],
+                *(
+                    [str(planning_safety_gate.get("gate_result") or planning_safety_gate.get("decision"))]
+                    if isinstance(planning_safety_gate, dict) and planning_safety_gate.get("workflow_sufficient") is False
+                    else []
+                ),
+            ],
+            implementation_allowed=(
+                bool(planning_safety_gate.get("implementation_allowed"))
+                if isinstance(planning_safety_gate, dict) and "implementation_allowed" in planning_safety_gate
+                else None
+            ),
+            read_only_allowed=(
+                bool(planning_safety_gate.get("read_only_allowed"))
+                if isinstance(planning_safety_gate, dict) and "read_only_allowed" in planning_safety_gate
+                else True
+            ),
+            proof_required=bool(proof_commands),
+            proof_commands=proof_commands,
+            changed_signals=[
+                *(
+                    [
+                        f"planning_safety={planning_safety_gate.get('status')}:{planning_safety_gate.get('gate_result') or planning_safety_gate.get('decision')}"
+                    ]
+                    if isinstance(planning_safety_gate, dict) and planning_safety_gate.get("status") not in {None, "", "clear"}
+                    else []
+                ),
+                *(
+                    [f"generated_surface_trust={payload.get('generated_surface_trust', {}).get('status')}"]
+                    if isinstance(payload.get("generated_surface_trust"), dict)
+                    and payload.get("generated_surface_trust", {}).get("status") == "present"
+                    else []
+                ),
+                *(
+                    [f"reuse_pressure={reuse_pressure.get('state')}"]
+                    if isinstance(reuse_pressure, dict) and reuse_pressure.get("state") not in {None, "", "none_found"}
+                    else []
+                ),
+            ],
+            advisory_selectors=[
+                "context.reuse_pressure",
+                "context.guidance",
+                "context.delegation_decision",
+                "routine_work_context",
+            ],
+            agent_judgment="Agent owns semantic work shape and completion judgment after proof and acceptance reconciliation.",
+        ),
         "next": {
             "action": next_action,
             "summary": next_action,
@@ -20015,7 +20137,6 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 command="agentic-workspace proof --verbose --changed <paths> --format json", cli_invoke=config.cli_invoke
             ),
         },
-        "reuse_pressure": reuse_pressure,
         "context": {
             "workflow_sufficiency": workflow_sufficiency,
             "adaptive_routing": _tiny_adaptive_routing_payload(
@@ -20088,6 +20209,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "context.acceptance_reconciliation",
                 "context.objective_drift",
                 "context.reuse_pressure",
+                "reuse_pressure",
                 "task_contract",
                 "change_impact",
                 "generated_surface_trust",
@@ -26082,6 +26204,10 @@ def _selector_requests_routine_work_context(select: str | None) -> bool:
     return any(token == "routine_work_context" or token.startswith("routine_work_context.") for token in _selector_tokens(select))
 
 
+def _selector_requests_reuse_pressure(select: str | None) -> bool:
+    return any(token == "reuse_pressure" or token.startswith("reuse_pressure.") for token in _selector_tokens(select))
+
+
 def _run_implement_context_adapter(args: argparse.Namespace) -> int:
     target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
     _validate_target_root(command_name="implement", target_root=target_root)
@@ -26098,6 +26224,7 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
     assurance_requirements_selected = _selector_requests_assurance_requirements(selected_fields)
     verification_selected = _selector_requests_verification(selected_fields)
     routine_work_context_selected = _selector_requests_routine_work_context(selected_fields)
+    reuse_pressure_selected = _selector_requests_reuse_pressure(selected_fields)
     full_payload = _implement_payload(
         target_root=target_root,
         changed_paths=list(getattr(args, "changed", []) or []),
@@ -26123,6 +26250,13 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
             payload["verification"] = full_payload["verification"]
         if routine_work_context_selected:
             payload["routine_work_context"] = full_payload["routine_work_context"]
+        if reuse_pressure_selected:
+            payload["reuse_pressure"] = _reuse_pressure_payload(
+                target_root=target_root,
+                changed_paths=list(getattr(args, "changed", []) or []),
+                compact=True,
+                cli_invoke=_load_workspace_config(target_root=target_root).cli_invoke,
+            )
     if getattr(args, "select", None):
         payload = _select_payload_fields(payload, select=getattr(args, "select"), source_command="implement")
     _emit_payload(payload=payload, format_name=args.format)

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -304,6 +304,8 @@ def test_implement_compact_reuse_pressure_collapses_large_generated_file_sets(tm
                 str(tmp_path),
                 "--changed",
                 *changed_paths,
+                "--select",
+                "reuse_pressure",
                 "--format",
                 "json",
             ]
@@ -312,7 +314,7 @@ def test_implement_compact_reuse_pressure_collapses_large_generated_file_sets(tm
     )
 
     payload = json.loads(capsys.readouterr().out)
-    reuse_pressure = payload["reuse_pressure"]
+    reuse_pressure = payload["values"]["reuse_pressure"]
     route_command = reuse_pressure["memory_signals"]["route_command"]
     assert "--target ." in route_command
     assert "<collapsed-changed-paths>" in route_command
@@ -825,7 +827,32 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     context = _implement_context(payload)
     encoded = json.dumps(payload)
     assert payload["kind"] == "implementer-context-tiny/v1"
-    assert set(payload) <= {"kind", "target", "next", "proof", "generated_surface_trust", "reuse_pressure", "context", "drill_down"}
+    assert set(payload) <= {
+        "kind",
+        "target",
+        "action_signals",
+        "next",
+        "proof",
+        "generated_surface_trust",
+        "reuse_pressure",
+        "context",
+        "drill_down",
+    }
+    signals = payload["action_signals"]
+    assert signals["kind"] == "agentic-workspace/action-signals/v1"
+    assert signals["order"] == [
+        "hard_blockers",
+        "allowed_next_action",
+        "proof_required",
+        "changed_signals",
+        "advisory_detail",
+        "agent_judgment",
+    ]
+    assert signals["allowed_next_action"] == payload["next"]["action"]
+    assert signals["proof_required"] is True
+    assert signals["proof_commands"] == payload["proof"]["required_commands"]
+    assert "generated_surface_trust=present" in signals["changed_signals"]
+    assert "context.reuse_pressure" in signals["advisory_detail"]["selectors"]
     adaptive = context["adaptive_routing"]
     assert adaptive["current_need"] == "changed-path-next-action"
     assert adaptive["read_budget"]["profile"] == "tiny"

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -753,7 +753,7 @@ def test_start_default_returns_selector_first_router(tmp_path: Path, capsys) -> 
     encoded = json.dumps(payload, sort_keys=True)
     assert len(encoded) < 9000
     assert payload["kind"] == "startup-context/v1"
-    assert set(payload) == {"kind", "target", "next_safe_action", "skills", "context", "drill_down"}
+    assert set(payload) == {"kind", "target", "action_signals", "next_safe_action", "skills", "context", "drill_down"}
     competing_top_level_decision_fields = {
         "immediate_next_allowed_action",
         "skill_routing",
@@ -773,6 +773,20 @@ def test_start_default_returns_selector_first_router(tmp_path: Path, capsys) -> 
     }
     packet = payload["next_safe_action"]
     _assert_next_safe_action_valid(packet)
+    signals = payload["action_signals"]
+    assert signals["kind"] == "agentic-workspace/action-signals/v1"
+    assert signals["order"] == [
+        "hard_blockers",
+        "allowed_next_action",
+        "proof_required",
+        "changed_signals",
+        "advisory_detail",
+        "agent_judgment",
+    ]
+    assert signals["allowed_next_action"] == packet["next_safe_action"]
+    assert signals["hard_blockers"] == packet["closure_blockers"]
+    assert signals["proof_required"] == packet["proof_required"]
+    assert "skill_routing" in signals["advisory_detail"]["selectors"]
     assert packet["kind"] == "agentic-workspace/next-safe-action/v1"
     assert packet["next_safe_action"] == _start_primary_action(payload)["action"]
     assert packet["module_slot"] in {"workspace", "planning"}


### PR DESCRIPTION
## Summary
- Add compact `action_signals` to tiny start and implement outputs so blockers, allowed action, proof, changed signals, advisory selectors, and agent-owned judgment are in a stable scan order.
- Keep ordinary tiny implement reuse-pressure detail selector-backed instead of emitting the full advisory packet by default.
- Preserve explicit `reuse_pressure` selectors and refresh startup/implementer schema reference docs.

## Validation
- `uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_default_returns_selector_first_router tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_workspace_implement_cli.py::test_implement_compact_reuse_pressure_collapses_large_generated_file_sets tests/test_workspace_implement_cli.py::test_implement_selector_surfaces_reuse_pressure_without_blocking_direct_work -q`
- `make test-workspace`
- `make lint-workspace`
- `make schema-reference-docs`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make maintainer-surfaces`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `make planning-surfaces`
- `git diff --check`

Closes #1273.