### PR TITLE
Route issue refs to external intent refresh

### DIFF
--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -15532,6 +15532,8 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         projected["durable_intent"] = _tiny_durable_intent(durable_intent)
     if "intent_evidence" in payload:
         projected["intent_evidence"] = _compact_intent_evidence(payload.get("intent_evidence", {}))
+    if "issue_reference_intent" in payload:
+        projected["issue_reference_intent"] = payload["issue_reference_intent"]
     if isinstance(task_intent, dict) and task_intent.get("status") == "present":
         acceptance = task_intent.get("acceptance", {})
         projected["task_intent"] = {
@@ -16057,6 +16059,7 @@ _START_TINY_ONLY_SELECTORS = {
     "delegation_decision",
     "durable_intent",
     "immediate_next_allowed_action",
+    "issue_reference_intent",
     "planning_safety_gate",
     "planning_revision",
     "routine_work_context",
@@ -16286,6 +16289,33 @@ def _start_payload(
             "read_first": [planning_safety_gate["promotion_command"]],
             "open_execplan_only_when": startup_template["open_execplan_only_when"],
         }
+    issue_reference_intent = _issue_reference_intent_payload(
+        issue_scope_evidence=planning_safety_gate.get("issue_scope_evidence", {}), cli_invoke=config.cli_invoke
+    )
+    if (
+        issue_reference_intent.get("status") == "details-needed"
+        and not active_planning_present
+        and not changed_paths
+        and not _is_config_posture_task(task_text)
+        and not _is_prep_only_handoff_task(task_text)
+    ):
+        payload["issue_reference_intent"] = issue_reference_intent
+        command = str(issue_reference_intent.get("next_command") or "")
+        if payload["immediate_next_allowed_action"].get("action") == "choose-smallest-workflow-shape":
+            payload["immediate_next_allowed_action"] = {
+                "action": "refresh-external-issue-intent",
+                "summary": (
+                    "The task names external issue ref(s). Fetch issue details before treating the issue body as confirmed "
+                    "scope; this is missing issue evidence, not user-intent ambiguity."
+                ),
+                "command": command,
+                "run": command,
+                "risk": "read-only issue intent grounding",
+                "required_inputs": ["target repo", "issue ref(s)"],
+                "next_proof": "rerun start or implement after refresh and use the fetched issue evidence for scope.",
+                "read_first": [command],
+                "open_execplan_only_when": startup_template["open_execplan_only_when"],
+            }
     intent_acknowledgement = _intent_acknowledgement_payload(
         task_text=task_text, execution_posture=execution_posture, vague_orientation=vague_orientation
     )
@@ -16583,6 +16613,7 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "intent_discovery_dialogue",
         "intent_acknowledgement",
         "intent_evidence",
+        "issue_reference_intent",
         "workflow_sufficiency",
         "next_safe_action",
         "health",
@@ -16613,6 +16644,7 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "context.intent_discovery_dialogue",
         "context.intent_acknowledgement",
         "context.intent_evidence",
+        "context.issue_reference_intent",
         "context.workflow_sufficiency",
         "context.guidance",
         "context.acceptance_reconciliation",
@@ -16962,6 +16994,8 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         context["durable_intent"] = _tiny_durable_intent(durable_intent)
     if "intent_evidence" in payload:
         context["intent_evidence"] = _compact_intent_evidence(payload.get("intent_evidence", {}))
+    if "issue_reference_intent" in payload:
+        context["issue_reference_intent"] = payload["issue_reference_intent"]
     for optional_key in (
         "proof",
         "path_boundaries",
@@ -17293,6 +17327,33 @@ def _start_tiny_payload_fast(
             "read_first": [planning_safety_gate["promotion_command"]],
             "open_execplan_only_when": startup_template["open_execplan_only_when"],
         }
+    issue_reference_intent = _issue_reference_intent_payload(
+        issue_scope_evidence=planning_safety_gate.get("issue_scope_evidence", {}), cli_invoke=config.cli_invoke
+    )
+    if (
+        issue_reference_intent.get("status") == "details-needed"
+        and not active_planning_present
+        and not changed_paths
+        and not _is_config_posture_task(task_text)
+        and not _is_prep_only_handoff_task(task_text)
+    ):
+        payload["issue_reference_intent"] = issue_reference_intent
+        command = str(issue_reference_intent.get("next_command") or "")
+        if payload["immediate_next_allowed_action"].get("action") == "choose-smallest-workflow-shape":
+            payload["immediate_next_allowed_action"] = {
+                "action": "refresh-external-issue-intent",
+                "summary": (
+                    "The task names external issue ref(s). Fetch issue details before treating the issue body as confirmed "
+                    "scope; this is missing issue evidence, not user-intent ambiguity."
+                ),
+                "command": command,
+                "run": command,
+                "risk": "read-only issue intent grounding",
+                "required_inputs": ["target repo", "issue ref(s)"],
+                "next_proof": "rerun start or implement after refresh and use the fetched issue evidence for scope.",
+                "read_first": [command],
+                "open_execplan_only_when": startup_template["open_execplan_only_when"],
+            }
     normalized_paths = _normalize_changed_paths(changed_paths)
     if normalized_paths and not active_planning_present:
         proof_command = str(
@@ -17677,6 +17738,58 @@ def _issue_scope_evidence_payload(*, target_root: Path, config: WorkspaceConfig,
             cli_invoke=config.cli_invoke,
         ),
         "rule": "Issue refs are external-intent handles until cached provider-agnostic evidence or active Planning owns the scope.",
+    }
+
+
+def _issue_reference_intent_payload(*, issue_scope_evidence: dict[str, Any], cli_invoke: str) -> dict[str, Any]:
+    if not isinstance(issue_scope_evidence, dict):
+        return {"kind": "agentic-workspace/issue-reference-intent/v1", "status": "not-applicable", "issue_refs": []}
+    issue_refs = [str(item) for item in _list_payload(issue_scope_evidence.get("issue_refs")) if str(item).strip()]
+    if not issue_refs:
+        return {"kind": "agentic-workspace/issue-reference-intent/v1", "status": "not-applicable", "issue_refs": []}
+    evidence_status = str(issue_scope_evidence.get("status") or "unknown").strip()
+    refresh_command = str(issue_scope_evidence.get("refresh_command") or "").strip()
+    if not refresh_command:
+        refresh_command = _command_with_cli_invoke(
+            command="agentic-workspace external-intent refresh-github --target . --state all --format json",
+            cli_invoke=cli_invoke,
+        )
+    details_needed = evidence_status in {"unknown", "partial"}
+    provider_hint = "github" if "refresh-github" in refresh_command else "external-intent"
+    return {
+        "kind": "agentic-workspace/issue-reference-intent/v1",
+        "status": "details-needed" if details_needed else "evidence-available",
+        "issue_refs": issue_refs,
+        "evidence_status": evidence_status,
+        "missing_issue_refs": issue_scope_evidence.get("missing_issue_refs", []),
+        "source_path": issue_scope_evidence.get("source_path", ""),
+        "storage": issue_scope_evidence.get("storage", "none"),
+        "provider_hint": provider_hint,
+        "next_command": refresh_command if details_needed else "",
+        "required_next_action": "refresh-external-issue-intent" if details_needed else "use-cached-issue-intent",
+        "intent_state": "issue-details-need-fetching" if details_needed else "issue-details-available",
+        "not_intent_ambiguity": details_needed,
+        "reason": (
+            "The task names external issue ref(s); fetch issue details before treating the issue body as confirmed scope."
+            if details_needed
+            else "Cached external issue evidence is available for the named issue ref(s)."
+        ),
+        "repo_agnostic_rule": (
+            "This packet appears only when task text contains issue refs. The provider route comes from existing "
+            "external-intent evidence guidance; without issue refs, startup should not assume GitHub or any other provider."
+        ),
+        "authority_boundary": _authority_boundary_payload(
+            surface="issue_reference_intent",
+            observed_by_aw=[f"issue_ref={issue_ref}" for issue_ref in issue_refs[:3]] + [f"evidence_status={evidence_status}"],
+            recommended_by_aw=["refresh-external-issue-intent"] if details_needed else ["use-cached-issue-intent"],
+            proof_hints=["rerun start or implement after refresh so issue evidence can guide scope"] if details_needed else [],
+            agent_owned_decisions=[
+                "whether fetched issue details make the work bounded",
+                "whether to proceed with a stated bounded slice before refresh",
+            ],
+            human_owned_decisions=["issue intent if external issue evidence remains unavailable"] if details_needed else [],
+            rule="AW identifies issue-reference grounding state; the agent owns semantic scope and implementation judgment.",
+        ),
     }
 
 

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -836,6 +836,7 @@ def test_start_default_returns_selector_first_router(tmp_path: Path, capsys) -> 
     assert "summary --" not in startup_text or _start_primary_action(payload)["action"] == "continue-active-planning-record"
     assert _start_context(payload)["acceptance"]["items"]
     assert _start_context(payload)["acceptance"]["items"][0]["status"] == "unchecked"
+    assert "issue_reference_intent" not in _start_context(payload)
     assert "acceptance" in payload["drill_down"]["available_selectors"]
     assert "durable_intent_promotion" in payload["drill_down"]["available_selectors"]
     assert "available_selectors" in payload["drill_down"]
@@ -1788,7 +1789,7 @@ candidates = [
     assert next_action["claim_boundary"]["required_before_implementation"] == ["select-or-promote-candidate-lane"]
 
 
-def test_start_marks_bare_issue_ref_scope_unknown_without_external_evidence(tmp_path: Path, capsys) -> None:
+def test_start_routes_issue_ref_task_to_external_intent_refresh_without_ambiguity(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(
         tmp_path / ".agentic-workspace" / "planning" / "state.toml",
@@ -1806,16 +1807,31 @@ candidates = []
 """,
     )
 
-    assert cli.main(["start", "--target", str(tmp_path), "--task", "Implement #1189", "--format", "json"]) == 0
+    assert cli.main(["start", "--target", str(tmp_path), "--task", "Implement #1234", "--format", "json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
+    assert payload["next_safe_action"]["next_safe_action"] == "refresh-external-issue-intent"
+    assert payload["next_safe_action"]["preferred_cli_effect"] == "read-only"
+    assert "external-intent refresh-github" in payload["next_safe_action"]["preferred_cli"]
+    assert "not user-intent ambiguity" in _start_primary_action(payload)["summary"]
+    issue_intent = _start_context(payload)["issue_reference_intent"]
+    assert issue_intent["kind"] == "agentic-workspace/issue-reference-intent/v1"
+    assert issue_intent["status"] == "details-needed"
+    assert issue_intent["intent_state"] == "issue-details-need-fetching"
+    assert issue_intent["not_intent_ambiguity"] is True
+    assert issue_intent["issue_refs"] == ["#1234"]
+    assert issue_intent["missing_issue_refs"] == ["#1234"]
+    assert issue_intent["required_next_action"] == "refresh-external-issue-intent"
+    assert "external-intent refresh-github" in issue_intent["next_command"]
+    assert "without issue refs, startup should not assume GitHub" in issue_intent["repo_agnostic_rule"]
+    assert "issue_reference_intent" in payload["drill_down"]["available_selectors"]
     gate = _start_planning_safety_gate(payload)
     assert gate["status"] == "attention"
     assert gate["gate_result"] == "external-issue-scope-unknown"
     assert gate["implementation_allowed"] is True
     assert gate["issue_scope_evidence"]["status"] == "unknown"
     assert gate["issue_scope_evidence"]["risk"] == "high"
-    assert gate["issue_scope_evidence"]["missing_issue_refs"] == ["#1189"]
+    assert gate["issue_scope_evidence"]["missing_issue_refs"] == ["#1234"]
     assert "external-intent refresh-github" in gate["issue_scope_evidence"]["refresh_command"]
 
 


### PR DESCRIPTION
## Summary
- Adds an `issue_reference_intent` startup packet for tasks that name external issue refs.
- Routes missing issue evidence directly to `external-intent refresh-github` instead of leaving the default action as generic work-shape choice.
- Separates "issue details need fetching" from user-intent ambiguity, while keeping the route absent when no issue refs are present.

Closes #1284.

## Validation
- `uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_routes_issue_ref_task_to_external_intent_refresh_without_ambiguity -q`
- `uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_default_returns_selector_first_router -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `git diff --check`
