### PR TITLE
Separate required and optional proof guidance

### DIFF
--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -48,6 +48,13 @@ Cheap implementer context for a bounded changed-path scope.
 | `proof.selected_lanes` | array of object | yes |  | Proof lanes selected by changed paths. |  |  |
 | `proof.required_commands` | array of string | yes |  | Flattened required validation commands. |  |  |
 | `proof.optional_commands` | array of string | yes |  | Optional validation or orientation commands. |  |  |
+| `proof.proof_obligations` | object | no |  | Structured proof contract separating required proof gates, recommended confidence checks, and agent-selected extra validation. |  |  |
+| `proof.proof_obligations.kind` | const `"agentic-workspace/proof-obligations/v1"` | no |  | Discriminator for the proof-obligations packet. |  |  |
+| `proof.proof_obligations.required_proof` | object | no |  | Required proof gate for completion claims. |  |  |
+| `proof.proof_obligations.recommended_confidence_checks` | object | no |  | Optional checks that may raise confidence but do not replace required proof. |  |  |
+| `proof.proof_obligations.agent_selected_extra_validation` | object | no |  | Validation the agent chooses when task risk or failures warrant more evidence. |  |  |
+| `proof.proof_obligations.completion_claim_rule` | string | no |  | Rule that blocks completion claims until required proof is satisfied. |  |  |
+| `proof.proof_obligations.compatibility` | object | no |  | Compatibility notes for existing proof command list consumers. |  |  |
 | `proof.validation_plan` | ref `#/$defs/validation_plan` | yes |  | Executable validation plan derived from selected lanes. |  |  |
 | `proof.validation_plan.kind` | const `"validation-plan/v1"` | yes |  | Discriminator for validation plan details. |  |  |
 | `proof.validation_plan.status` | string | yes |  | Whether validation is ready to inspect or run. |  |  |

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -643,6 +643,41 @@
           },
           "description": "Optional validation or orientation commands."
         },
+        "proof_obligations": {
+          "type": "object",
+          "description": "Structured proof contract separating required proof gates, recommended confidence checks, and agent-selected extra validation.",
+          "properties": {
+            "kind": {
+              "const": "agentic-workspace/proof-obligations/v1",
+              "description": "Discriminator for the proof-obligations packet."
+            },
+            "required_proof": {
+              "type": "object",
+              "description": "Required proof gate for completion claims.",
+              "additionalProperties": true
+            },
+            "recommended_confidence_checks": {
+              "type": "object",
+              "description": "Optional checks that may raise confidence but do not replace required proof.",
+              "additionalProperties": true
+            },
+            "agent_selected_extra_validation": {
+              "type": "object",
+              "description": "Validation the agent chooses when task risk or failures warrant more evidence.",
+              "additionalProperties": true
+            },
+            "completion_claim_rule": {
+              "type": "string",
+              "description": "Rule that blocks completion claims until required proof is satisfied."
+            },
+            "compatibility": {
+              "type": "object",
+              "description": "Compatibility notes for existing proof command list consumers.",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        },
         "validation_plan": {
           "$ref": "#/$defs/validation_plan",
           "description": "Executable validation plan derived from selected lanes."

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -20369,6 +20369,11 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "acceptance_guidance": payload.get("proof", {}).get("acceptance_guidance", {})
             if isinstance(payload.get("proof"), dict)
             else {},
+            "proof_obligations": _tiny_proof_obligations_payload(
+                payload.get("proof", {}).get("proof_obligations", {}), required_commands=proof_commands
+            )
+            if isinstance(payload.get("proof"), dict) and isinstance(payload.get("proof", {}).get("proof_obligations"), dict)
+            else {},
             "detail_command": _command_with_cli_invoke(
                 command="agentic-workspace proof --verbose --changed <paths> --format json", cli_invoke=config.cli_invoke
             ),
@@ -29424,6 +29429,76 @@ def _proof_command_tiers(*, selected_commands: list[dict[str, Any]], required_co
     }
 
 
+def _proof_obligations_payload(
+    *,
+    required_commands: list[str],
+    optional_commands: list[str],
+    manual_verification: dict[str, Any] | None,
+) -> dict[str, Any]:
+    manual_required = manual_verification is not None
+    return {
+        "kind": "agentic-workspace/proof-obligations/v1",
+        "status": "required-proof-selected" if required_commands else "manual-proof-required" if manual_required else "no-required-proof",
+        "required_proof": {
+            "kind": "agentic-workspace/required-proof/v1",
+            "status": "required" if required_commands or manual_required else "not-selected",
+            "commands": required_commands,
+            "manual_verification_required": manual_required,
+            "manual_verification_status": manual_verification.get("status") if manual_required else "not-needed",
+            "source_field": "required_commands",
+            "rule": (
+                "These commands, or required manual verification when commands are unavailable, are the proof gate for completion claims."
+            ),
+        },
+        "recommended_confidence_checks": {
+            "kind": "agentic-workspace/recommended-confidence-checks/v1",
+            "status": "available" if optional_commands else "not-selected",
+            "commands": optional_commands,
+            "source_field": "optional_commands",
+            "rule": "Recommended checks may refresh state or raise confidence, but they do not replace or relax required proof.",
+        },
+        "agent_selected_extra_validation": {
+            "kind": "agentic-workspace/agent-selected-extra-validation/v1",
+            "status": "agent-owned",
+            "commands": [],
+            "examples": [
+                "rerun a focused failing test after the fix",
+                "inspect the final diff against requested acceptance",
+                "add task-specific validation when failures or risk expose an unproven behavior",
+            ],
+            "rule": "The agent may add validation when task intent, failures, or risk warrant it; AW does not pre-claim that extra work is mandatory.",
+        },
+        "completion_claim_rule": (
+            "Completion claims remain blocked until required proof passes or required manual verification is recorded, "
+            "then acceptance and residue are reconciled."
+        ),
+        "compatibility": {
+            "required_commands": "unchanged hard-gate field for existing callers",
+            "optional_commands": "unchanged advisory confidence-check field for existing callers",
+        },
+    }
+
+
+def _tiny_proof_obligations_payload(value: dict[str, Any], *, required_commands: list[str] | None = None) -> dict[str, Any]:
+    required = value.get("required_proof", {}) if isinstance(value.get("required_proof"), dict) else {}
+    recommended = value.get("recommended_confidence_checks", {}) if isinstance(value.get("recommended_confidence_checks"), dict) else {}
+    visible_required_commands = list(required_commands) if required_commands is not None else required.get("commands", [])
+    return {
+        "kind": value.get("kind", "agentic-workspace/proof-obligations/v1"),
+        "required_proof": {
+            "status": required.get("status", "unknown"),
+            "commands": visible_required_commands,
+            "manual_verification_required": bool(required.get("manual_verification_required", False)),
+        },
+        "recommended_confidence_checks": {
+            "status": recommended.get("status", "unknown"),
+            "commands": recommended.get("commands", []),
+            "rule": recommended.get("rule", ""),
+        },
+        "completion_claim_rule": value.get("completion_claim_rule", ""),
+    }
+
+
 def _transient_validation_retry_guidance(*, required_commands: list[str]) -> dict[str, Any]:
     sensitive = [
         command
@@ -29959,6 +30034,11 @@ def _proof_selection_for_changed_paths(
         )
         for command in optional_commands
     ]
+    proof_obligations = _proof_obligations_payload(
+        required_commands=required_commands,
+        optional_commands=optional_commands,
+        manual_verification=manual_verification,
+    )
     intent_proof = _intent_proof_prompt_payload(task_text=task_text, acceptance=acceptance, claim_boundary="slice")
     proof_selection = {
         "kind": "proof-selection/v1",
@@ -30020,6 +30100,7 @@ def _proof_selection_for_changed_paths(
         "legacy_aliases": {"proof_route_decision": "proof_route_selection"},
         "proof_next_decision": proof_next_decision,
         "proof_command_tiers": _proof_command_tiers(selected_commands=selected_commands, required_commands=required_commands),
+        "proof_obligations": proof_obligations,
         "transient_validation_retry": _transient_validation_retry_guidance(required_commands=required_commands),
         "tiny_surface_compatibility_review": _tiny_surface_compatibility_review(changed_paths),
         "selected_lanes": [

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -593,6 +593,50 @@ force = "required-before-closeout"
     assert routine["activation"]["small_work_rule"].startswith("If no category is attention")
 
 
+def test_implement_separates_required_proof_from_recommended_confidence_checks(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / "Makefile",
+        (
+            "test-planning:\n\tpytest packages/planning/tests\n\n"
+            "lint-planning:\n\truff check packages/planning\n\n"
+            "typecheck-planning:\n\tpyright packages/planning\n\n"
+        ),
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "packages/planning/src/repo_planning_bootstrap/installer.py",
+                "--task",
+                "Update planning package installer",
+                "--verbose",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    proof = payload["proof"]
+    obligations = proof["proof_obligations"]
+    assert "make test-planning" in proof["required_commands"]
+    assert "make lint-planning" in proof["required_commands"]
+    assert "make typecheck-planning" in proof["required_commands"]
+    assert obligations["required_proof"]["commands"] == proof["required_commands"]
+    assert obligations["recommended_confidence_checks"]["commands"] == proof["optional_commands"]
+    assert obligations["recommended_confidence_checks"]["commands"] != proof["required_commands"]
+    assert obligations["agent_selected_extra_validation"]["status"] == "agent-owned"
+    assert "Completion claims remain blocked" in obligations["completion_claim_rule"]
+    assert payload["required_validation_commands"] == proof["required_commands"]
+
+
 def test_implement_routine_context_surfaces_memory_freshness_and_promotion_pressure(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
@@ -865,6 +909,11 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert context["scope"]["inspect_files"] == ["generated/workspace/python/cli.py"]
     assert "make test-workspace" in payload["proof"]["required_commands"]
     assert "uv run python scripts/check/check_generated_command_packages.py" in payload["proof"]["required_commands"]
+    obligations = payload["proof"]["proof_obligations"]
+    assert obligations["required_proof"]["commands"] == payload["proof"]["required_commands"]
+    assert obligations["recommended_confidence_checks"]["status"] == "available"
+    assert "do not replace or relax required proof" in obligations["recommended_confidence_checks"]["rule"]
+    assert "Completion claims remain blocked" in obligations["completion_claim_rule"]
     trust = payload["generated_surface_trust"]
     assert trust["status"] == "present"
     assert trust["items"][0]["path"] == "generated/workspace/python/cli.py"

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -1748,6 +1748,14 @@ def test_proof_changed_selector_includes_planning_source_typecheck_ci_parity(cap
     assert "planning_package" in lane_ids
     assert "planning_source_typecheck_ci_parity" in lane_ids
     assert "make typecheck-planning" in answer["required_commands"]
+    obligations = answer["proof_obligations"]
+    assert obligations["required_proof"]["commands"] == answer["required_commands"]
+    assert obligations["required_proof"]["status"] == "required"
+    assert obligations["recommended_confidence_checks"]["commands"] == answer["optional_commands"]
+    assert obligations["recommended_confidence_checks"]["commands"] != answer["required_commands"]
+    assert "do not replace or relax required proof" in obligations["recommended_confidence_checks"]["rule"]
+    assert "Completion claims remain blocked" in obligations["completion_claim_rule"]
+    assert obligations["compatibility"]["required_commands"] == "unchanged hard-gate field for existing callers"
     typecheck_lane = next(lane for lane in answer["selected_lanes"] if lane["id"] == "planning_source_typecheck_ci_parity")
     assert typecheck_lane["matched_paths"] == ["packages/planning/src/repo_planning_bootstrap/installer.py"]
     typecheck_step = next(step for step in answer["validation_plan"]["required"] if step["command"] == "make typecheck-planning")


### PR DESCRIPTION
## Summary
- Add a proof_obligations packet that separates required proof gates, recommended confidence checks, and agent-selected extra validation.
- Mirror the distinction into tiny implement output while preserving required_commands and optional_commands compatibility.
- Update the implementer-context schema/reference docs and add planning-package proof tests.

Closes #1285.

## Validation
- uv run pytest tests/test_workspace_proof_cli.py::test_proof_changed_selector_includes_planning_source_typecheck_ci_parity -q
- uv run pytest tests/test_workspace_implement_cli.py::test_implement_separates_required_proof_from_recommended_confidence_checks tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q
- make test-workspace (initial parallel run hit a Windows pytest/xdist access violation during collection; standalone rerun passed)
- make lint-workspace
- uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success
- uv run python scripts/check/check_structured_file_inventory.py --quiet-success
- uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py
- make schema-reference-docs
- uv run python scripts/check/check_generated_command_packages.py
- git diff --check