### PR TITLE
Surface generated CLI freshness guidance

### DIFF
--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -48,6 +48,13 @@ Cheap implementer context for a bounded changed-path scope.
 | `proof.selected_lanes` | array of object | yes |  | Proof lanes selected by changed paths. |  |  |
 | `proof.required_commands` | array of string | yes |  | Flattened required validation commands. |  |  |
 | `proof.optional_commands` | array of string | yes |  | Optional validation or orientation commands. |  |  |
+| `proof.generated_cli_freshness` | object | no |  | Generated CLI freshness signal for changed paths that affect generated command packages. |  |  |
+| `proof.generated_cli_freshness.kind` | const `"agentic-workspace/generated-cli-freshness/v1"` | no |  | Discriminator for generated CLI freshness guidance. |  |  |
+| `proof.generated_cli_freshness.status` | string | no |  | Whether the freshness check is required or advisory for the current changed paths. |  |  |
+| `proof.generated_cli_freshness.freshness_check_command` | string | no |  | Check command that detects stale generated CLI outputs without regenerating them. |  |  |
+| `proof.generated_cli_freshness.refresh_command` | string | no |  | Command to refresh generated CLI outputs when the freshness check reports staleness. |  |  |
+| `proof.generated_cli_freshness.validation_command` | string | no |  | Selected validation command that proves generated command package freshness. |  |  |
+| `proof.generated_cli_freshness.obligation` | string | no |  | Whether the named check is required or advisory. |  |  |
 | `proof.validation_plan` | ref `#/$defs/validation_plan` | yes |  | Executable validation plan derived from selected lanes. |  |  |
 | `proof.validation_plan.kind` | const `"validation-plan/v1"` | yes |  | Discriminator for validation plan details. |  |  |
 | `proof.validation_plan.status` | string | yes |  | Whether validation is ready to inspect or run. |  |  |

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -643,6 +643,37 @@
           },
           "description": "Optional validation or orientation commands."
         },
+        "generated_cli_freshness": {
+          "type": "object",
+          "description": "Generated CLI freshness signal for changed paths that affect generated command packages.",
+          "properties": {
+            "kind": {
+              "const": "agentic-workspace/generated-cli-freshness/v1",
+              "description": "Discriminator for generated CLI freshness guidance."
+            },
+            "status": {
+              "type": "string",
+              "description": "Whether the freshness check is required or advisory for the current changed paths."
+            },
+            "freshness_check_command": {
+              "type": "string",
+              "description": "Check command that detects stale generated CLI outputs without regenerating them."
+            },
+            "refresh_command": {
+              "type": "string",
+              "description": "Command to refresh generated CLI outputs when the freshness check reports staleness."
+            },
+            "validation_command": {
+              "type": "string",
+              "description": "Selected validation command that proves generated command package freshness."
+            },
+            "obligation": {
+              "type": "string",
+              "description": "Whether the named check is required or advisory."
+            }
+          },
+          "additionalProperties": true
+        },
         "validation_plan": {
           "$ref": "#/$defs/validation_plan",
           "description": "Executable validation plan derived from selected lanes."

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -20336,6 +20336,11 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     else []
                 ),
                 *(
+                    ["generated_cli_freshness=" + str(payload.get("proof", {}).get("generated_cli_freshness", {}).get("status"))]
+                    if isinstance(payload.get("proof"), dict) and isinstance(payload.get("proof", {}).get("generated_cli_freshness"), dict)
+                    else []
+                ),
+                *(
                     [f"reuse_pressure={reuse_pressure.get('state')}"]
                     if isinstance(reuse_pressure, dict) and reuse_pressure.get("state") not in {None, "", "none_found"}
                     else []
@@ -20367,6 +20372,9 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             if isinstance(payload.get("proof"), dict)
             else {},
             "acceptance_guidance": payload.get("proof", {}).get("acceptance_guidance", {})
+            if isinstance(payload.get("proof"), dict)
+            else {},
+            "generated_cli_freshness": payload.get("proof", {}).get("generated_cli_freshness", {})
             if isinstance(payload.get("proof"), dict)
             else {},
             "detail_command": _command_with_cli_invoke(
@@ -20466,6 +20474,9 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     compatibility_review = projected["proof"].get("tiny_surface_compatibility_review", {})
     if not (isinstance(compatibility_review, dict) and compatibility_review.get("status") == "required"):
         projected["proof"].pop("tiny_surface_compatibility_review", None)
+    generated_cli_freshness = projected["proof"].get("generated_cli_freshness", {})
+    if not (isinstance(generated_cli_freshness, dict) and generated_cli_freshness.get("kind")):
+        projected["proof"].pop("generated_cli_freshness", None)
     task_argument_mode = payload.get("task_intent", {}).get("task_argument_mode") if isinstance(payload.get("task_intent"), dict) else ""
     intent_proof = payload.get("proof", {}).get("intent_proof") if isinstance(payload.get("proof"), dict) else None
     acceptance_reconciliation = payload.get("acceptance_reconciliation", {})
@@ -29445,6 +29456,49 @@ def _transient_validation_retry_guidance(*, required_commands: list[str]) -> dic
     }
 
 
+def _generated_cli_freshness_payload(
+    *,
+    changed_paths: list[str],
+    selected_lanes: list[dict[str, Any]],
+    required_commands: list[str],
+) -> dict[str, Any] | None:
+    lane_ids = [str(lane.get("id", "")) for lane in selected_lanes if isinstance(lane, dict)]
+    relevant_lane_ids = [
+        lane_id
+        for lane_id in lane_ids
+        if lane_id in {"generated_command_packages", "cli_authority", "verification:generated_adapter_conformance"}
+    ]
+    related_commands = [
+        command
+        for command in required_commands
+        if "check_generated_command_packages.py" in command or "generate_command_packages.py" in command
+    ]
+    if not relevant_lane_ids and not related_commands:
+        return None
+    freshness_check = "uv run python scripts/generate/generate_command_packages.py --check"
+    refresh_command = "uv run python scripts/generate/generate_command_packages.py"
+    validation_command = next(
+        (command for command in related_commands if "check_generated_command_packages.py" in command),
+        "uv run python scripts/check/check_generated_command_packages.py",
+    )
+    obligation = "required" if related_commands else "advisory"
+    return {
+        "kind": "agentic-workspace/generated-cli-freshness/v1",
+        "status": obligation,
+        "triggered_by": changed_paths,
+        "selected_lanes": relevant_lane_ids,
+        "freshness_check_command": freshness_check,
+        "refresh_command": refresh_command,
+        "validation_command": validation_command,
+        "required_commands": related_commands,
+        "obligation": obligation,
+        "rule": (
+            "Generated CLI freshness is relevant only for generated command package surfaces. "
+            "Run the check path before trusting generated CLI output; refresh only when the check reports stale output."
+        ),
+    }
+
+
 def _tiny_surface_compatibility_review(changed_paths: list[str]) -> dict[str, Any]:
     risky_paths = [
         path
@@ -29946,6 +30000,11 @@ def _proof_selection_for_changed_paths(
         manual_verification=manual_verification,
         proof_execution_evidence=proof_execution_evidence,
     )
+    generated_cli_freshness = _generated_cli_freshness_payload(
+        changed_paths=changed_paths,
+        selected_lanes=selected_lanes,
+        required_commands=required_commands,
+    )
     optional_commands = ["agentic-workspace proof --target ./repo --current --format json", "agentic-workspace summary --format json"]
     for concern_lane in [*concern_lanes, *requirement_lanes, *verification_lanes]:
         for command in concern_lane.get("optional_commands", []):
@@ -30076,6 +30135,8 @@ def _proof_selection_for_changed_paths(
     }
     if routing_reductions:
         proof_selection["routing_reductions"] = routing_reductions
+    if generated_cli_freshness is not None:
+        proof_selection["generated_cli_freshness"] = generated_cli_freshness
     if proof_command_adjustments:
         proof_selection["proof_command_adjustments"] = proof_command_adjustments
     if unavailable_proof_commands:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -62,6 +62,13 @@ def test_implement_command_returns_bounded_context_and_boundary_warnings(tmp_pat
         "uv run python scripts/check/check_generated_command_packages.py --python-docker-conformance --require-docker",
         "uv run pytest tests/test_workspace_proof_generated_packages_cli.py -q",
     ]
+    freshness = payload["proof"]["generated_cli_freshness"]
+    assert freshness["status"] == "required"
+    assert freshness["obligation"] == "required"
+    assert freshness["freshness_check_command"] == "uv run python scripts/generate/generate_command_packages.py --check"
+    assert freshness["refresh_command"] == "uv run python scripts/generate/generate_command_packages.py"
+    assert freshness["validation_command"] == "uv run python scripts/check/check_generated_command_packages.py"
+    assert "uv run python scripts/check/check_generated_command_packages.py" in freshness["required_commands"]
     proof_tiers = {tier["id"]: tier["commands"] for tier in payload["proof"]["proof_command_tiers"]["tiers"]}
     assert proof_tiers["generated_contract"][0]["command"] == "uv run python scripts/check/check_generated_command_packages.py"
     assert any(item["command"].endswith("--require-docker") for item in proof_tiers["environmental"])
@@ -470,6 +477,34 @@ def test_implement_selector_surfaces_generated_surface_trust(tmp_path: Path, cap
     assert "Do not hand-edit generated command package outputs" in item["direct_edit_policy"]
 
 
+def test_implement_readme_change_omits_generated_cli_freshness(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "README.md", "hello\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "README.md",
+                "--task",
+                "Update README wording",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert "generated_cli_freshness" not in payload["proof"]
+    assert all("generated_cli_freshness" not in signal for signal in payload["action_signals"]["changed_signals"])
+    assert payload["context"]["generated_surface_trust"]["status"] == "not-applicable"
+
+
 def test_implement_selector_surfaces_task_contract_view(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
@@ -852,6 +887,7 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert signals["proof_required"] is True
     assert signals["proof_commands"] == payload["proof"]["required_commands"]
     assert "generated_surface_trust=present" in signals["changed_signals"]
+    assert "generated_cli_freshness=required" in signals["changed_signals"]
     assert "context.reuse_pressure" in signals["advisory_detail"]["selectors"]
     adaptive = context["adaptive_routing"]
     assert adaptive["current_need"] == "changed-path-next-action"
@@ -865,6 +901,8 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert context["scope"]["inspect_files"] == ["generated/workspace/python/cli.py"]
     assert "make test-workspace" in payload["proof"]["required_commands"]
     assert "uv run python scripts/check/check_generated_command_packages.py" in payload["proof"]["required_commands"]
+    assert payload["proof"]["generated_cli_freshness"]["status"] == "required"
+    assert payload["proof"]["generated_cli_freshness"]["refresh_command"] == "uv run python scripts/generate/generate_command_packages.py"
     trust = payload["generated_surface_trust"]
     assert trust["status"] == "present"
     assert trust["items"][0]["path"] == "generated/workspace/python/cli.py"

--- a/tests/test_workspace_proof_generated_packages_cli.py
+++ b/tests/test_workspace_proof_generated_packages_cli.py
@@ -62,6 +62,13 @@ def test_proof_changed_selector_routes_generated_command_packages(capsys) -> Non
         "verification:generated_adapter_conformance",
     ]
     assert "route back through command-package checks" in answer["selected_lanes"][0]["recovery_signal"]
+    freshness = answer["generated_cli_freshness"]
+    assert freshness["status"] == "required"
+    assert freshness["freshness_check_command"] == "uv run python scripts/generate/generate_command_packages.py --check"
+    assert freshness["refresh_command"] == "uv run python scripts/generate/generate_command_packages.py"
+    assert freshness["validation_command"] == "uv run python scripts/check/check_generated_command_packages.py"
+    assert "uv run python scripts/check/check_generated_command_packages.py" in freshness["required_commands"]
+    assert "refresh only when the check reports stale output" in freshness["rule"]
     focused_proof = "uv run pytest tests/test_workspace_proof_generated_packages_cli.py -q"
     assert answer["required_commands"] == [
         "uv run python scripts/check/check_generated_command_packages.py",
@@ -180,4 +187,5 @@ def test_proof_changed_selector_routes_contract_only_changes_to_focused_lane(cap
         "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
         "uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py",
     ]
+    assert "generated_cli_freshness" not in answer
     assert "uv run pytest tests -q" not in answer["required_commands"]


### PR DESCRIPTION
## Summary
- Add generated_cli_freshness guidance when changed paths select generated command package proof.
- Surface the freshness signal in proof selection, tiny implement proof, and implement action signals only for relevant generated-command surfaces.
- Document the new implementer proof field and cover relevant/irrelevant changed-path cases.

Closes #1286.

## Validation
- uv run pytest tests/test_workspace_implement_cli.py::test_implement_command_returns_bounded_context_and_boundary_warnings tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_workspace_implement_cli.py::test_implement_readme_change_omits_generated_cli_freshness -q
- uv run pytest tests/test_workspace_proof_generated_packages_cli.py::test_proof_changed_selector_routes_generated_command_packages tests/test_workspace_proof_generated_packages_cli.py::test_proof_changed_selector_routes_contract_only_changes_to_focused_lane -q
- make test-workspace
- make lint-workspace
- uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success
- uv run python scripts/check/check_structured_file_inventory.py --quiet-success
- uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py
- make maintainer-surfaces
- make schema-reference-docs
- uv run python scripts/check/check_generated_command_packages.py
- git diff --check