### PR TITLE
Guard closeout authority language

### DIFF
--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -8394,6 +8394,32 @@ def _closeout_report_adoption_payload(
     }
 
 
+def _authority_language_guidance_payload() -> dict[str, Any]:
+    return {
+        "kind": "agentic-workspace/authority-language-guidance/v1",
+        "status": "present",
+        "preferred_phrasing": {
+            "observed_facts": "AW reports/observes <fact>; I used that as evidence.",
+            "recommendations": "AW recommends/suggests <route>; I chose <action> because <reason>.",
+            "enforced_gates": "AW enforces/blocks <gate>; completion waits until it is satisfied.",
+            "agent_judgment": "I judged/classified/decided <semantic outcome>, using AW evidence/guidance.",
+        },
+        "avoid_when_aw_is_advisory": [
+            "AW classified the task",
+            "AW routed the work",
+            "AW decided this is complete",
+        ],
+        "allowed_for_hard_gates": [
+            "AW enforced the gate",
+            "AW blocked completion until proof/acceptance is satisfied",
+        ],
+        "rule": (
+            "Use AW as the subject only for observed facts, recommendations, proof hints, and enforced gates. "
+            "Use the agent as the subject for semantic classification, routing choices, completion judgment, and final wording."
+        ),
+    }
+
+
 def _closeout_report_final_response_rendering_payload(
     *,
     status: str,
@@ -8577,6 +8603,7 @@ def _closeout_report_final_response_rendering_payload(
             "section_order": [section["id"] for section in sections],
             "sections": sections,
             "missing_required_sections": missing_required_sections,
+            "authority_language_guidance": _authority_language_guidance_payload(),
             "rendered_markdown": "\n".join(rendered_markdown_lines),
             "customization_points": [
                 "section titles",

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -1541,6 +1541,14 @@ def test_report_closeout_report_renders_planned_slice_first_inspection_contract(
     assert "Proof: uv run pytest tests/test_workspace_report_cli.py -q passed" in sections["proof"]["lines"]
     assert any(line.startswith("Closure boundary:") for line in sections["caveats"]["lines"])
     assert any("agent owns final wording" in line for line in sections["authority"]["lines"])
+    language_guidance = chat_template["authority_language_guidance"]
+    assert language_guidance["preferred_phrasing"]["observed_facts"].startswith("AW reports/observes")
+    assert language_guidance["preferred_phrasing"]["agent_judgment"].startswith("I judged/classified/decided")
+    assert "AW enforced the gate" in language_guidance["allowed_for_hard_gates"]
+    forbidden_fragments = ("AW classified", "AW routed", "AW decided")
+    rendered_markdown = chat_template["rendered_markdown"]
+    assert not any(fragment in rendered_markdown for fragment in forbidden_fragments)
+    assert "AW reports closeout evidence" in rendered_markdown
     assert "**Changed**" in chat_template["rendered_markdown"]
     assert "**Proof**" in chat_template["rendered_markdown"]
     assert "**Caveats**" in chat_template["rendered_markdown"]


### PR DESCRIPTION
## Summary
- Add authority-language guidance to the closeout chat report template with preferred phrasing for observed facts, recommendations, enforced gates, and agent-owned judgment.
- Explicitly list over-authoritative advisory phrases to avoid while preserving accurate hard-gate language.
- Guard the rendered closeout markdown against AW classified/routed/decided regressions.

Closes #1287.

## Validation
- uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_renders_planned_slice_first_inspection_contract -q
- make test-workspace
- make lint-workspace
- uv run python scripts/check/check_generated_command_packages.py
- git diff --check