### PR TITLE
[codex] Support behavior-preserving refactor closeouts

### DIFF
--- a/.agentic-workspace/docs/knowledge-promotion-workflow.md
+++ b/.agentic-workspace/docs/knowledge-promotion-workflow.md
@@ -61,3 +61,29 @@ evidence/source refs, `use_when`, `stale_when`, confidence, and retention or
 promotion expectation. When the lesson becomes stable policy, promote it onward
 to docs, config, checks, or tests instead of letting Memory become hidden
 business-logic authority.
+
+Example Memory-worthy refactoring fact:
+
+```markdown
+---
+use_when: "Touching parser normalization or replacing parser fixtures"
+stale_when: "The parser fixture suite is replaced or malformed-input behavior is documented in canonical parser docs"
+evidence: ["tests/fixtures/parser/valid_cases.json", "verification:parser_refactor_2026_06"]
+authority: "Memory is advisory context; parser docs/tests own enforceable behavior"
+owner: "parser-review"
+retention: "retain until promoted to parser docs/tests or superseded by a documented behavior change"
+---
+
+The parser accepts a legacy trailing delimiter because importer v1 emitted it.
+Keep the fixture and do not simplify it away during helper extraction without
+parser-review acceptance.
+```
+
+Good candidates include a non-obvious behavior invariant, a legacy quirk with a
+domain rationale, a dependency/runtime constraint, a fixture or protocol that
+protects important behavior, a dead-code candidate that is not yet safe to
+remove, or an anti-rediscovery warning for future agents. Do not promote
+transient observations, execution logs, raw transcripts, broad task chatter,
+"I looked at this file" notes, or unverified guesses. If the only fact is that
+this run had no durable lesson, record that in Planning closeout instead of
+creating a Memory note.

--- a/.agentic-workspace/docs/knowledge-promotion-workflow.md
+++ b/.agentic-workspace/docs/knowledge-promotion-workflow.md
@@ -41,3 +41,23 @@ In the `Execution Summary` of the archived plan, record where the knowledge was 
 - **Do not over-specify**: Keep Memory focused on interpretive value, not a copy of the source code.
 - **Do not hide friction**: Knowledge promotion should explain *how* to handle friction, not hide the fact that the friction exists.
 - **Prefer Repo-Native**: Always prefer checked-in docs/config over Memory when the knowledge is stable enough to be a hard rule.
+
+## Refactoring Facts
+
+Promote a refactoring discovery to Memory only when it will prevent expensive
+rediscovery in future work. Good Memory candidates include:
+
+- non-obvious behavior that must be preserved;
+- legacy quirks with a business or domain rationale;
+- dependency, runtime, or migration constraints discovered during the refactor;
+- tests, fixtures, snapshots, or verification protocols that protect important behavior;
+- dead-code or unused-path findings that are not yet safe to remove;
+- anti-rediscovery warnings for future agents.
+
+Reject transient observations such as "I read this file", raw test output,
+one-off implementation notes, or guesses about business behavior without
+evidence. A useful refactoring Memory note should include a compact summary,
+evidence/source refs, `use_when`, `stale_when`, confidence, and retention or
+promotion expectation. When the lesson becomes stable policy, promote it onward
+to docs, config, checks, or tests instead of letting Memory become hidden
+business-logic authority.

--- a/.agentic-workspace/docs/reporting-contract.md
+++ b/.agentic-workspace/docs/reporting-contract.md
@@ -126,6 +126,25 @@ agentic-workspace report --target ./repo --section closeout_report --format json
 Use `closeout_report.completeness` to see missing intent boundary, completed-work, changed-surface, validation, residual-risk, follow-up-owner, or traceability evidence before making final closeout claims.
 Use `closeout_report.traceability.rows` to connect each intent or requirement to its evidence surface and residual risk or follow-up.
 
+For behavior-preserving refactors, closeout must keep the preservation boundary
+separate from ordinary validation. Planning or proof evidence may record:
+
+- `preservation_claims`;
+- `allowed_behavior_changes`;
+- `unknown_behavior`;
+- `proof_classes`;
+- `preservation_evidence`;
+- `human_confirmation_needed`.
+
+`closeout_report.validation.behavior_preservation` reports those recorded facts,
+the evidence classes, unsupported claims, known gaps, and review focus. It must
+not infer business behavior from changed paths, filenames, or tests passing. A
+`no behavior changed`, `safe refactor`, `business logic preserved`,
+compatibility, migration-complete, or dependency-upgrade-compatible claim needs
+characterization, golden-master, current-behavior, compatibility, migration
+dry-run, manual-scenario, or domain-acceptance evidence, or it must render a
+behavior caveat and block broad completion claims.
+
 Use `closeout_report.decision_review` for material system or product decisions.
 It is a derived review packet over agent-authored Planning facts, not an AW classifier.
 The active owner for decision facts is Planning, primarily `architecture_decision_promotion` and `traceability_refs.decision_refs`.
@@ -161,6 +180,7 @@ Its modes are:
 - `planned-slice`;
 - `broad-pr`;
 - `system-shaping-change`;
+- `behavior-preserving-refactor`;
 - `partial-or-lower-trust-closeout`;
 - `follow-up-or-residue-heavy-work`.
 
@@ -171,6 +191,13 @@ Every mode must name:
 - rendered facts that must appear in the final response for that work shape;
 - secondary detail routes;
 - the policy for when raw report/detail inspection is still needed.
+
+For `behavior-preserving-refactor`, the first inspection path should emphasize
+semantic-risk surfaces before line-count breadth: changed business-rule paths,
+persistence/migration/data-shape code, serialization or public contracts,
+dependency/runtime semantics, deleted compatibility paths, updated fixtures or
+snapshots, and unproven behavior gaps. These are advisory review targets; the
+agent and human own the preservation judgment.
 
 Use `closeout_report.closeout_adoption` as the operator-facing closeout quality rubric.
 The rubric asks whether the final response answers:
@@ -220,6 +247,9 @@ Minimal and guidance-only closeouts without trust, residue, or follow-up signals
 Guidance-only closeouts with audit, lower-trust, residue, or follow-up signals should stay compact but still render the caveat and disallow a plain-done claim.
 Balanced, explanatory, audit, partial, or lower-trust closeouts should render the material human-facing facts: profile reason, closure boundary, changed work, proof, residual risk, routed residue, and follow-up owner.
 System-shaping closeouts should also render decision facts or a decision-gap line from `decision_review`.
+Behavior-preserving refactor closeouts should render behavior proof class and
+behavior caveat lines when preservation claims exist, especially when ordinary
+tests passed but characterization or compatibility proof is missing.
 `final_response_rendering.selected_review_mode` and `final_response_rendering.first_inspection_contract` must match `review_compression.selected_mode` and its selected contract so the rendered chat summary cannot drift from the review-compression guidance.
 The final response should prefer `rendered_summary.rendered_text` as concise prose or bullets and must not dump raw JSON.
 `required_fact_coverage` must make omitted required facts visible before the agent claims completion.

--- a/.agentic-workspace/planning/closeout-evidence/behavior-preservation-refactor-support.closeout.json
+++ b/.agentic-workspace/planning/closeout-evidence/behavior-preservation-refactor-support.closeout.json
@@ -1,0 +1,99 @@
+{
+  "kind": "planning-closeout-evidence/v1",
+  "title": "Behavior preservation refactor support",
+  "plan_id": "behavior-preservation-refactor-support",
+  "created_at": "2026-06-04T17:30:43.856049+00:00",
+  "source_plan": ".agentic-workspace/planning/execplans/behavior-preservation-refactor-support.plan.json",
+  "intended_archive": ".agentic-workspace/planning/execplans/archive/behavior-preservation-refactor-support.plan.json",
+  "retention": {
+    "state": "archive-retention-skipped",
+    "reason": "retained archive would exceed the structured-file inventory max_bytes guardrail; closing after distillation instead",
+    "rule": "Retained closeout evidence preserves reportable closeout facts when the full execplan archive exceeds inventory size guardrails."
+  },
+  "active_milestone": {
+    "id": "behavior-preservation-refactor-support",
+    "status": "completed",
+    "scope": "Runtime closeout/proof/report support plus existing Planning, Verification, Memory, and reporting guidance surfaces.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1289 and child issues #1291-#1298.",
+    "hard constraints": "Use existing surfaces; no new refactoring module, state store, or authoritative business-logic inference.",
+    "agent may decide locally": "Exact names, caveat wording, examples, tests, and reference updates.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented behavior-preservation support across existing AW Planning guidance, Verification examples, proof/closeout report packets, final-response rendering, Memory promotion guidance, and review-compression mode.",
+    "scope touched": "workspace closeout/proof/report runtime, workspace_report schema/reference docs, planning execplan guidance/template, reporting contract, verification docs, Memory guidance, and focused tests",
+    "changed surfaces": ".agentic-workspace/docs/knowledge-promotion-workflow.md; .agentic-workspace/docs/reporting-contract.md; .agentic-workspace/planning/execplans/README.md; .agentic-workspace/planning/execplans/TEMPLATE.plan.json; docs/verification.md; docs/reference/workspace-report.md; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_report_cli.py",
+    "validations run": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs",
+    "result for continuation": "bounded closeout complete",
+    "next step": "compact closeout evidence retained; no active planning work remains"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within existing AW surfaces; unsupported no-behavior-change claims are now caveated and blocked from broad closeout claims; AW reports recorded evidence/gaps while agents and humans own semantic preservation sufficiency.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs"
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1289 and its child issues.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs",
+    "unsolved intent passed to": "none"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a lane claim with intent-status satisfied.",
+    "evidence carried forward": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "execution_summary": {
+    "outcome delivered": "Behavior-preserving refactors now have explicit planning fields, characterization proof examples, closeout behavior proof/caveat facts, final-response rendering requirements, Memory promotion guidance, and semantic-risk review-compression focus.",
+    "validation confirmed": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  }
+}

--- a/.agentic-workspace/planning/closeout-evidence/behavior-preservation-refactor-support.closeout.json
+++ b/.agentic-workspace/planning/closeout-evidence/behavior-preservation-refactor-support.closeout.json
@@ -6,53 +6,43 @@
   "source_plan": ".agentic-workspace/planning/execplans/behavior-preservation-refactor-support.plan.json",
   "intended_archive": ".agentic-workspace/planning/execplans/archive/behavior-preservation-refactor-support.plan.json",
   "retention": {
-    "state": "archive-retention-skipped",
-    "reason": "retained archive would exceed the structured-file inventory max_bytes guardrail; closing after distillation instead",
-    "rule": "Retained closeout evidence preserves reportable closeout facts when the full execplan archive exceeds inventory size guardrails."
+    "state": "compact-closeout-evidence",
+    "reason": "Full archive exceeded structured-file inventory guardrails; compact evidence preserves reportable closure facts."
   },
   "active_milestone": {
     "id": "behavior-preservation-refactor-support",
     "status": "completed",
-    "scope": "Runtime closeout/proof/report support plus existing Planning, Verification, Memory, and reporting guidance surfaces.",
-    "ready": "ready",
-    "blocked": "none",
-    "optional_deps": "none"
+    "scope": "Planning, Verification, proof/report, closeout_report, final_response_rendering, Memory guidance, and review_compression support for behavior-preserving refactors."
   },
   "delegated_judgment": {
     "requested outcome": "Implement #1289 and child issues #1291-#1298.",
     "hard constraints": "Use existing surfaces; no new refactoring module, state store, or authoritative business-logic inference.",
     "agent may decide locally": "Exact names, caveat wording, examples, tests, and reference updates.",
-    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    "duplicate issue handling": "#1294/#1295 share the same closeout-caveat implementation; #1297/#1298 share the same review-compression semantic-risk implementation."
   },
   "execution_run": {
     "run status": "completed",
-    "executor": "agentic-planning closeout",
-    "handoff source": "agentic-planning new-plan",
     "what happened": "Implemented behavior-preservation support across existing AW Planning guidance, Verification examples, proof/closeout report packets, final-response rendering, Memory promotion guidance, and review-compression mode.",
-    "scope touched": "workspace closeout/proof/report runtime, workspace_report schema/reference docs, planning execplan guidance/template, reporting contract, verification docs, Memory guidance, and focused tests",
     "changed surfaces": ".agentic-workspace/docs/knowledge-promotion-workflow.md; .agentic-workspace/docs/reporting-contract.md; .agentic-workspace/planning/execplans/README.md; .agentic-workspace/planning/execplans/TEMPLATE.plan.json; docs/verification.md; docs/reference/workspace-report.md; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_report_cli.py",
-    "validations run": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs",
-    "result for continuation": "bounded closeout complete",
-    "next step": "compact closeout evidence retained; no active planning work remains"
+    "validations run": "focused closeout/report caveat test; focused proof tiny/verbose tests; stale-reference sweep; AW summary and planning doctor; maintainer surfaces; contract tooling; structured inventory; ruff; workspace tests; lint; schema-reference docs",
+    "result for continuation": "bounded closeout complete"
   },
   "finished_run_review": {
     "review status": "complete",
-    "scope respected": "Scope stayed within existing AW surfaces; unsupported no-behavior-change claims are now caveated and blocked from broad closeout claims; AW reports recorded evidence/gaps while agents and humans own semantic preservation sufficiency.",
+    "scope respected": "Existing AW surfaces only; AW reports recorded evidence and gaps while agents/humans own semantic preservation sufficiency.",
     "proof status": "passed",
     "intent served": "yes",
-    "config compliance": "used planning closeout command-owned writer",
-    "misinterpretation risk": "low",
     "follow-on decision": "none"
   },
   "proof_report": {
-    "validation proof": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs",
-    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
-    "evidence for \"proof achieved\" state": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs"
+    "validation proof": "Focused closeout/report and proof-output tests plus maintainer/static/workspace validation passed.",
+    "proof achieved now": "yes",
+    "evidence for proof achieved state": "Representative caveat test covers unsupported preservation claims, blocked broad claims, final response rendering, and review-compression mode."
   },
   "intent_satisfaction": {
-    "original intent": "Implement #1289 and its child issues.",
+    "original intent": "Implement #1289 and child issues #1291-#1298.",
     "was original intent fully satisfied?": "yes",
-    "evidence of intent satisfaction": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs",
+    "evidence of intent satisfaction": "#1289 parent pattern spans Planning, Verification, proof/report, closeout, Memory guidance, and review compression; duplicate child pairs are explicitly handled.",
     "unsolved intent passed to": "none"
   },
   "closure_check": {
@@ -60,39 +50,30 @@
     "slice status": "completed",
     "larger-intent status": "closed",
     "closure decision": "archive-and-close",
-    "why this decision is honest": "planning closeout accepted a lane claim with intent-status satisfied.",
-    "evidence carried forward": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs",
-    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+    "why this decision is honest": "#1291 planning fields, #1292 Verification examples, #1293 proof/report distinction, #1294/#1295 closeout caveats, #1296 Memory guidance, and #1297/#1298 review-compression guidance are all represented by concrete code, docs, or tests.",
+    "evidence carried forward": "PR #1303 closure matrix and tests/test_workspace_report_cli.py behavior-preservation fixtures.",
+    "reopen trigger": "New evidence shows a child issue lacks representative Planning, Verification, Memory, proof/report, closeout, or review-compression coverage."
   },
   "durable_residue": {
     "status": "none",
-    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
-    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "learned constraint": "No separate residue remains after compact closeout evidence and PR body closure matrix.",
     "canonical owner now": "archive",
     "promotion trigger": "none",
     "retention after promotion": "retain"
   },
   "execution_summary": {
-    "outcome delivered": "Behavior-preserving refactors now have explicit planning fields, characterization proof examples, closeout behavior proof/caveat facts, final-response rendering requirements, Memory promotion guidance, and semantic-risk review-compression focus.",
-    "validation confirmed": "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q; uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q; rg -n \"behavior_preservation|behavior-preserving-refactor|preservation_claims|allowed_behavior_changes|unknown_behavior|proof_classes|preservation_evidence|business logic preserved|no behavior changed|ordinary tests\" .agentic-workspace/docs .agentic-workspace/planning/execplans/README.md .agentic-workspace/planning/execplans/TEMPLATE.plan.json docs src/agentic_workspace/contracts/schemas src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py tests/test_workspace_proof_cli.py; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace; make schema-reference-docs",
+    "outcome delivered": "Behavior-preserving refactors have explicit planning fields, characterization proof examples, closeout behavior proof/caveat facts, final-response rendering requirements, Memory promotion guidance, and semantic-risk review-compression focus.",
+    "validation confirmed": "focused tests, maintainer/static checks, full workspace tests, lint, and schema-reference docs",
     "follow-on routed to": "none",
-    "post-work posterity capture": "archive closeout distillation",
-    "resume from": "archive",
-    "knowledge promoted (Memory/Docs/Config)": "none"
+    "knowledge promoted (Memory/Docs/Config)": "docs and runtime/tests in PR #1303"
   },
   "closeout_distillation": {
     "buckets": {
-      "discard": [
-        {
-          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
-          "owner": "discard",
-          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
-        }
-      ],
+      "discard": ["Repeated raw proof command strings from the oversized archive."],
       "continuation": [],
       "memory": [],
       "config_check": [],
-      "docs": [],
+      "docs": ["PR #1303 closure matrix carries issue-by-issue evidence."],
       "issue_follow_up": []
     }
   }

--- a/.agentic-workspace/planning/execplans/README.md
+++ b/.agentic-workspace/planning/execplans/README.md
@@ -18,6 +18,8 @@ Use `archive-plan --apply-cleanup` only when you want the helper to also remove 
 
 After `agentic-workspace planning new-plan`, treat the result as a valid scaffold, not an implementation-ready plan. Before editing product or package files, tighten the concrete goal, non-goals, intent continuity, execution bounds, touched paths, validation commands, completion criteria, and `adaptive_assurance` when risk or scope requires it.
 
+For behavior-preserving refactors, modernization, extraction, migration, dependency upgrades, or "safe/no behavior changed" work, use existing plan fields before broad code changes when the boundary is not obvious. Put preservation invariants in `invariants`, allowed changes and stop conditions in `execution_bounds`/`stop_conditions`, and expected preservation proof in `validation_commands`. Mirror closeout evidence into `proof_report.intent_proof` using its `preservation_claims`, `allowed_behavior_changes`, `unknown_behavior`, `proof_classes`, `preservation_evidence`, and `human_confirmation_needed` fields so reports can distinguish ordinary test pass from preservation evidence and can caveat unsupported no-behavior-change claims.
+
 This planning system is for execution. It is not intended to become a generic tracker, backlog database, or Jira replacement.
 
 ## Source And Projection Roles

--- a/.agentic-workspace/planning/execplans/TEMPLATE.plan.json
+++ b/.agentic-workspace/planning/execplans/TEMPLATE.plan.json
@@ -246,7 +246,20 @@
   "proof_report": {
     "validation proof": "",
     "proof achieved now": "",
-    "evidence for \"proof achieved\" state": ""
+    "evidence for \"proof achieved\" state": "",
+    "intent_proof": {
+      "status": "not_recorded",
+      "claim_boundary": "work",
+      "intended_behavior": [],
+      "proof_dimensions": [],
+      "unproven_after_tests": [],
+      "preservation_claims": [],
+      "allowed_behavior_changes": [],
+      "unknown_behavior": [],
+      "proof_classes": [],
+      "preservation_evidence": [],
+      "human_confirmation_needed": []
+    }
   },
   "intent_satisfaction": {
     "original intent": "",

--- a/.agentic-workspace/planning/execplans/archive/pr-1303-closure-evidence-hardening.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/pr-1303-closure-evidence-hardening.plan.json
@@ -1,0 +1,320 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "PR 1303 closure evidence hardening",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Strengthen PR #1303 so closure of #1289 and child issues #1291-#1298 is supported by representative behavior-preserving refactor evidence, not wording alone.",
+    "hard_constraints": "Keep scope inside existing AW Planning, Verification, Memory, proof/report, closeout_report, final_response_rendering, review_compression, and authority-boundary surfaces; do not add a refactoring module, broad dashboard, new state store, or automatic business-logic classifier.",
+    "agent_may_decide": "Exact compact fixture, assertions, documentation wording, closeout residue, and PR body matrix needed to make closure evidence honest.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Add representative closure evidence, run focused and workspace validation, update PR body, and close this plan.",
+    "proof_expectations": [
+      "focused report tests for unsupported and representative behavior-preservation closeout",
+      "proof tiny/verbose focused tests if proof output remains touched",
+      "contract tooling, structured inventory, maintainer surfaces, workspace tests, lint, and schema reference docs"
+    ],
+    "touched_scope": [
+      "tests/test_workspace_report_cli.py",
+      ".agentic-workspace/docs/knowledge-promotion-workflow.md",
+      "docs/verification.md",
+      ".agentic-workspace/planning closeout evidence/state for this plan"
+    ],
+    "completion_criteria": [
+      "A representative test demonstrates Planning preservation boundary, Verification characterization/known-gap concepts, proof classification, closeout caveat/support behavior, review-compression semantic-risk focus, and Memory non-promotion rationale.",
+      "Verification docs show characterization evidence using protocols, scenarios, evidence_bundles, known_gaps, and claim_boundaries.",
+      "Memory guidance covers promotion examples, anti-dump boundaries, use_when, stale_when, evidence, owner/authority, and retention.",
+      "PR body includes an explicit issue-to-evidence closure matrix and duplicate handling for #1294/#1295 and #1297/#1298."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for PR 1303 closure evidence hardening."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Strengthen PR #1303 closure evidence for #1289 and child issues.",
+      "constraints": "Use existing AW surfaces only; no new refactoring module, state store, dashboard, or automatic business-logic classifier.",
+      "latitude": "Choose compact evidence, assertions, and documentation wording that keep closeout/report quiet while preventing unsafe overclaiming.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "Focused report tests passed; focused proof-output tests passed; AW summary and planning doctor passed; git diff docs proof inspected; maintainer surfaces passed; contract tooling passed; structured inventory passed; scoped ruff passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed."
+    },
+    "execution": {
+      "milestone": "pr-1303-closure-evidence-hardening",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "Focused report tests passed; focused proof-output tests passed; AW summary and planning doctor passed; git diff docs proof inspected; maintainer surfaces passed; contract tooling passed; structured inventory passed; scoped ruff passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed."
+    },
+    "scope": {
+      "touched": [
+        "tests/test_workspace_report_cli.py",
+        ".agentic-workspace/docs/knowledge-promotion-workflow.md",
+        "docs/verification.md"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "PR #1303 can honestly close #1289 and child issues because representative evidence covers the full behavior-preserving refactor operating pattern.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "none for this archived slice; rerun proof only if the PR closure evidence changes",
+    "next likely slice": "none if the representative evidence and PR body matrix satisfy the requested closure standard"
+  },
+  "intent_interpretation": {
+    "literal request": "Make the closure of #1289 and all child issues honestly supportable in PR #1303.",
+    "inferred intended outcome": "Add compact representative evidence across existing AW surfaces and update the PR body closure matrix.",
+    "chosen concrete what": "Add a sibling representative report fixture, strengthen Verification/Memory examples, run required validation, and update PR #1303 body.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "tests/test_workspace_report_cli.py, docs/verification.md, .agentic-workspace/docs/knowledge-promotion-workflow.md, PR body, and planning closeout residue for this active plan.",
+    "max changed files": "About 6 files plus command-owned planning state/closeout evidence.",
+    "required validation commands": "Use implement --changed proof selection; at minimum run focused report tests, relevant proof tests, contract tooling, structured inventory, maintainer surfaces, workspace tests, lint, and schema-reference docs.",
+    "ask-before-refactor threshold": "Ask before changing runtime semantics beyond what the representative evidence needs.",
+    "stop before touching": "New refactoring modules, new stores, dashboards, automatic business classifiers, or unrelated backlog."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Strengthen PR #1303 closure evidence, validate, update PR body matrix, and close this plan.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Make PR #1303 closure of #1289 and child issues honestly supportable.",
+    "hard constraints": "Use existing AW surfaces only; no new refactoring module, state store, dashboard, or automatic business-logic classifier.",
+    "agent may decide locally": "Exact compact test/docs evidence and PR body wording.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "pr-1303-closure-evidence-hardening",
+    "status": "completed",
+    "scope": "Representative behavior-preservation closure evidence for PR #1303.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Add representative evidence and run selected proof."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "tests/test_workspace_report_cli.py",
+    ".agentic-workspace/docs/knowledge-promotion-workflow.md",
+    "docs/verification.md"
+  ],
+  "invariants": [
+    "Keep behavior-preservation support repo- and agent-agnostic: AW reports recorded evidence and guidance; agents/humans own semantic preservation judgment."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim -q",
+    "focused representative behavior-preservation report test",
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "make maintainer-surfaces",
+    "make test-workspace",
+    "make lint-workspace",
+    "make schema-reference-docs"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Representative closure evidence exists across Planning, Verification, proof/report, closeout, Memory guidance, and review compression.",
+    "PR body matrix maps #1289 and #1291-#1298 to concrete evidence and explicitly handles duplicate pairs.",
+    "Required validation passes."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added representative behavior-preserving refactor closure evidence for PR #1303, strengthened Verification and Memory guidance, compacted oversized closeout evidence, and prepared PR body closure matrix.",
+    "scope touched": "tests/test_workspace_report_cli.py, docs/verification.md, .agentic-workspace/docs/knowledge-promotion-workflow.md, compact closeout evidence, and planning closeout residue",
+    "changed surfaces": "tests/test_workspace_report_cli.py; docs/verification.md; .agentic-workspace/docs/knowledge-promotion-workflow.md; .agentic-workspace/planning/closeout-evidence/behavior-preservation-refactor-support.closeout.json",
+    "validations run": "Focused report tests passed; focused proof-output tests passed; AW summary and planning doctor passed; git diff docs proof inspected; maintainer surfaces passed; contract tooling passed; structured inventory passed; scoped ruff passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Representative fixture now demonstrates Planning preservation fields, Verification characterization evidence and known gap, proof/report ordinary-test caveat, closeout blocked broad claims, final response behavior caveat, review-compression semantic-risk focus, and Memory non-promotion rationale.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Focused report tests passed; focused proof-output tests passed; AW summary and planning doctor passed; git diff docs proof inspected; maintainer surfaces passed; contract tooling passed; structured inventory passed; scoped ruff passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "Focused report tests passed; focused proof-output tests passed; AW summary and planning doctor passed; git diff docs proof inspected; maintainer surfaces passed; contract tooling passed; structured inventory passed; scoped ruff passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for PR 1303 closure evidence hardening.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "Focused report tests passed; focused proof-output tests passed; AW summary and planning doctor passed; git diff docs proof inspected; maintainer surfaces passed; contract tooling passed; structured inventory passed; scoped ruff passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "PR #1303 now has concrete evidence supporting honest closure of #1289 and child issues #1291-#1298, with duplicate pairs handled explicitly.",
+    "validation confirmed": "Focused report tests passed; focused proof-output tests passed; AW summary and planning doctor passed; git diff docs proof inspected; maintainer surfaces passed; contract tooling passed; structured inventory passed; scoped ruff passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "Focused report tests passed; focused proof-output tests passed; AW summary and planning doctor passed; git diff docs proof inspected; maintainer surfaces passed; contract tooling passed; structured inventory passed; scoped ruff passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for PR 1303 closure evidence hardening.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Focused report tests passed; focused proof-output tests passed; AW summary and planning doctor passed; git diff docs proof inspected; maintainer surfaces passed; contract tooling passed; structured inventory passed; scoped ruff passed; make test-workspace passed; make lint-workspace passed; make schema-reference-docs passed.\nChanged surfaces: tests/test_workspace_report_cli.py; docs/verification.md; .agentic-workspace/docs/knowledge-promotion-workflow.md; .agentic-workspace/planning/closeout-evidence/behavior-preservation-refactor-support.closeout.json\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -87,7 +87,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `structured_findings` | object | yes |  | Structured finding residue shape for review and promotion routing. |  |  |
 | `external_evidence_safety` | object | yes |  | External evidence freshness, divergence, stale-after, and closeout-safety projection. |  |  |
 | `workflow_compliance_summary` | object | yes |  | Derived review and recovery summary of workflow entrypoint, satisfied or missing gates, trust impact, and recovery action. |  |  |
-| `closeout_report` | object | yes |  | Derived operator-facing closeout report profile, traceability, completeness, decision-review facts, closeout-first review-compression contract, closeout adoption rubric, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary. |  |  |
+| `closeout_report` | object | yes |  | Derived operator-facing closeout report profile, traceability, completeness, decision-review facts, behavior-preservation proof/caveat facts, closeout-first review-compression contract, closeout adoption rubric, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary. |  |  |
 | `closeout_report.authority_boundary` | ref `#/$defs/authority_boundary` | no |  | Authority boundary showing which closeout/report signals are AW-enforced, observed, recommended, or agent-owned. |  |  |
 | `closeout_report.authority_boundary.kind` | const `"agentic-workspace/authority-boundary/v1"` | yes |  | Discriminator for the authority-boundary packet. |  |  |
 | `closeout_report.authority_boundary.surface` | string | yes |  | Payload surface whose authority categories are being described. |  |  |
@@ -103,7 +103,8 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `closeout_report.intent_evidence` | object | no |  | Closeout intent provenance showing whether interpreted intent came from planning evidence, user text, issue/reference evidence, handoff evidence, or agent inference. |  |  |
 | `closeout_report.interpreted_intent` | object | no |  | Requested outcome, intent-source evidence, satisfaction status, and closure decision rendered for the closeout report. |  |  |
 | `closeout_report.decision_review` | object | no |  | Derived review packet for agent-authored system decision facts, owner-model split, completeness, absence routing, and durable-owner guidance. |  |  |
-| `closeout_report.review_compression` | object | no |  | Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts and contract, rendered fact requirements, detail routes, and human-owned decisions. |  |  |
+| `closeout_report.review_compression` | object | no |  | Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts and contract, rendered fact requirements, behavior-preserving refactor semantic-risk focus, detail routes, and human-owned decisions. |  |  |
+| `closeout_report.validation` | object | no |  | Closeout validation projection, including proof confidence and behavior_preservation facts when preservation claims, proof classes, unsupported claims, or caveats were recorded. |  |  |
 | `closeout_report.closeout_adoption` | object | no |  | Derived closeout quality rubric, representative examples, and current rendering adoption status for human-useful final reports. |  |  |
 | `continuation_next_actions` | object | yes |  | Evidence-ranked next actions for safe continuation. |  |  |
 | `migration_pilot_template` | object | yes |  | Optional migration-pilot decomposition template with parity and rollout boundaries. |  |  |

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -137,7 +137,11 @@ Closeout may cite this evidence as characterization/current-behavior proof. If
 only ordinary tests ran, closeout should say that explicitly and caveat any
 `no behavior changed`, `business logic preserved`, compatibility, migration, or
 dependency-upgrade claim unless domain acceptance or a stronger evidence class is
-recorded.
+recorded. The same pattern can represent golden-master comparisons,
+compatibility checks, migration dry-runs, or manual-scenario evidence by naming
+the protocol, scenario, evidence bundle, claim boundary, and known gap. Keep raw
+outputs out of Verification unless they are intentionally retained artifacts;
+prefer compact summaries and stable evidence labels.
 
 ## Non-Goals
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -90,6 +90,55 @@ of primary evaluator prompts and appear only as post-score review metadata.
 Memory receives durable lessons or repeated gaps after verification. It should
 not store raw transcript content or active evidence.
 
+## Behavior-Preserving Refactors
+
+For refactors and modernization work, use Verification to record current
+behavior evidence before making or closing preservation claims. Keep the record
+compact and claim-boundary focused:
+
+```toml
+[scenarios.parser_characterization]
+protocol_id = "parser_refactor_characterization"
+title = "Parser characterization"
+steps = ["Run representative parser fixtures before and after the refactor"]
+expected_observations = ["Existing valid-input outputs remain byte-for-byte stable"]
+pass_evidence_labels = ["parser_characterization_passed"]
+fail_evidence_labels = ["parser_characterization_changed"]
+
+[protocols.parser_refactor_characterization]
+title = "Parser refactor characterization"
+purpose = "Current-behavior proof for a behavior-preserving parser refactor."
+applies_to_paths = ["src/parser/**", "tests/fixtures/parser/**"]
+scenario_refs = ["parser_characterization"]
+expected_evidence = ["parser_characterization_passed"]
+review_owner = "parser-review"
+
+[evidence_bundles.parser_refactor_2026_06]
+protocol_id = "parser_refactor_characterization"
+scenario_id = "parser_characterization"
+outcome = "passed"
+evidence_items = ["parser_characterization_passed"]
+transcript_summaries = ["Representative parser fixtures matched before and after; raw outputs not retained."]
+claim_boundaries = ["work"]
+residual_risk = "Malformed legacy inputs are not characterized."
+retention_until = "2026-12-31"
+
+[known_gaps.parser_malformed_legacy_gap]
+protocol_id = "parser_refactor_characterization"
+scenario_id = "parser_characterization"
+reason = "Malformed legacy-input behavior lacks fixtures and domain acceptance."
+owner = "parser-review"
+evidence_labels = ["malformed_legacy_characterization"]
+blocked_claims = ["close-parent-lane"]
+residual_risk = "Do not claim full parser behavior preservation until this gap is closed or accepted."
+```
+
+Closeout may cite this evidence as characterization/current-behavior proof. If
+only ordinary tests ran, closeout should say that explicitly and caveat any
+`no behavior changed`, `business logic preserved`, compatibility, migration, or
+dependency-upgrade claim unless domain acceptance or a stronger evidence class is
+recorded.
+
 ## Non-Goals
 
 - No generic QA management system.

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -369,6 +369,35 @@ The installed `WORKFLOW.md` under `.agentic-workspace/memory/` is the full refer
 
 Starter note templates are part of that installed contract too. Use `.agentic-workspace/memory/repo/templates/memory-note.template.md`, `.agentic-workspace/memory/repo/templates/invariant.template.md`, and `.agentic-workspace/memory/repo/templates/runbook.template.md` when you add the first real repo-specific notes for those classes.
 
+### Durable Refactoring Facts
+
+Use Memory for a refactoring discovery only when future agents would otherwise
+pay meaningful rediscovery cost. Good candidates include a non-obvious behavior
+invariant, a legacy quirk with domain rationale, a dependency or runtime
+constraint, the purpose of a fixture or verification protocol that protects
+important behavior, an unsafe dead-code candidate that is not yet removable, or
+an anti-rediscovery warning for future agents.
+
+Do not store transient observations, execution logs, raw transcripts, broad task
+chatter, or "I inspected this file" notes. Keep raw characterization output in
+tests, fixtures, Verification evidence, or local artifacts as appropriate;
+Memory should carry the compact interpretive fact and routing value.
+
+Expected shape:
+
+```markdown
+summary: "Parser accepts the legacy trailing delimiter because importer v1 emitted it."
+evidence: ["tests/fixtures/parser/valid_cases.json", "verification:parser_refactor_2026_06"]
+use_when: "Refactoring parser normalization or replacing parser fixtures"
+stale_when: "Importer v1 compatibility is removed or parser behavior is documented in canonical parser docs"
+owner: "parser-review"
+authority: "advisory context; parser docs/tests own enforceable behavior"
+retention: "retain until promoted to parser docs/tests or demoted after the compatibility path is removed"
+```
+
+If the refactor produces no durable lesson, say that in Planning closeout instead
+of creating a Memory note.
+
 For manifest discoverability, the quickest installed guidance path is:
 
 - `.agentic-workspace/memory/repo/manifest.toml` for the machine-readable note map and optional improvement-pressure fields

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -309,14 +309,18 @@
         },
         "review_compression": {
           "type": "object",
-          "description": "Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts and contract, rendered fact requirements, detail routes, and human-owned decisions."
+          "description": "Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts and contract, rendered fact requirements, behavior-preserving refactor semantic-risk focus, detail routes, and human-owned decisions."
+        },
+        "validation": {
+          "type": "object",
+          "description": "Closeout validation projection, including proof confidence and behavior_preservation facts when preservation claims, proof classes, unsupported claims, or caveats were recorded."
         },
         "closeout_adoption": {
           "type": "object",
           "description": "Derived closeout quality rubric, representative examples, and current rendering adoption status for human-useful final reports."
         }
       },
-      "description": "Derived operator-facing closeout report profile, traceability, completeness, decision-review facts, closeout-first review-compression contract, closeout adoption rubric, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary."
+      "description": "Derived operator-facing closeout report profile, traceability, completeness, decision-review facts, behavior-preservation proof/caveat facts, closeout-first review-compression contract, closeout adoption rubric, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary."
     },
     "continuation_next_actions": {
       "type": "object",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -7599,6 +7599,8 @@ def _closeout_report_profile_policy_payload(
     completeness = completeness if isinstance(completeness, dict) else {}
     strict = bool(config.assurance.strict_closeout) if config is not None else False
     trust = str(closeout_trust.get("trust", "")).strip().lower()
+    proof_confidence = _as_dict(closeout_trust.get("proof_confidence"))
+    behavior_preservation = _as_dict(proof_confidence.get("behavior_preservation"))
     completion_decision = str(completion_contract.get("completion_decision", "")).strip().lower()
     completeness_status = str(completeness.get("status", "")).strip().lower()
     verification_status = str(verification.get("status", "")).strip().lower()
@@ -7615,6 +7617,8 @@ def _closeout_report_profile_policy_payload(
         high_risk_reasons.append("assurance.strict_closeout enabled")
     if trust == "lower-trust" or lower_trust_count:
         high_risk_reasons.append("closeout_trust lower-trust signals present")
+    if behavior_preservation.get("status") == "claim-needs-evidence":
+        high_risk_reasons.append("behavior-preservation claim lacks supporting evidence")
     if completeness_status == "incomplete":
         high_risk_reasons.append("closeout report completeness is incomplete")
     if verification_status in {"attention", "blocked", "missing-evidence"}:
@@ -7720,6 +7724,7 @@ def _closeout_report_traceability_rows(
     proof_report = _as_dict(active_planning_record.get("proof_report"))
     completion_boundary = _as_dict(completion_contract.get("completion_boundary"))
     proof_confidence = _as_dict(closeout_trust.get("proof_confidence"))
+    behavior_preservation = _as_dict(proof_confidence.get("behavior_preservation"))
     intent_check = _as_dict(closeout_trust.get("intent_satisfaction_check"))
     assurance = _as_dict(closeout_trust.get("assurance_requirements"))
     evidence_status = [item for item in _list_payload(assurance.get("evidence_status")) if isinstance(item, dict)]
@@ -7768,6 +7773,24 @@ def _closeout_report_traceability_rows(
             "residual_risk_or_follow_up": text_from(proof_confidence.get("residual_risk")),
         },
         {
+            "id": "behavior-preservation",
+            "intent_or_requirement": "behavior-preservation claim and proof boundary",
+            "evidence_surface": "planning.active.planning_record.proof_report.intent_proof",
+            "evidence": text_from(
+                "; ".join(_list_payload(behavior_preservation.get("proof_classes"))),
+                fallback=text_from("; ".join(_list_payload(behavior_preservation.get("evidence")))),
+            ),
+            "status": "present"
+            if behavior_preservation.get("status") in {"present", "supported", "not-claimed"}
+            else "missing"
+            if behavior_preservation.get("status") == "claim-needs-evidence"
+            else "present",
+            "residual_risk_or_follow_up": text_from(
+                "; ".join(_list_payload(behavior_preservation.get("caveats"))),
+                fallback=text_from("; ".join(_list_payload(behavior_preservation.get("unknown_behavior")))),
+            ),
+        },
+        {
             "id": "closure-boundary",
             "intent_or_requirement": "closure boundary",
             "evidence_surface": "completion_contract.completion_boundary",
@@ -7805,6 +7828,7 @@ def _closeout_report_completeness_payload(
     proof_report = _as_dict(active_planning_record.get("proof_report"))
     completion_boundary = _as_dict(completion_contract.get("completion_boundary"))
     proof_confidence = _as_dict(closeout_trust.get("proof_confidence"))
+    behavior_preservation = _as_dict(proof_confidence.get("behavior_preservation"))
     intent_check = _as_dict(closeout_trust.get("intent_satisfaction_check"))
     options = {str(item.get("id", "")): item for item in _list_payload(closeout_trust.get("completion_options")) if isinstance(item, dict)}
     keep_parent_open = _as_dict(options.get("keep-parent-open"))
@@ -7887,6 +7911,17 @@ def _closeout_report_completeness_payload(
         residual or "no residual risk explicitly recorded",
         "residual risk statement is not explicit",
     )
+    preservation_status = str(behavior_preservation.get("status") or "").strip()
+    preservation_claims = _list_payload(behavior_preservation.get("claims"))
+    preservation_caveats = _list_payload(behavior_preservation.get("caveats"))
+    if preservation_claims:
+        add_check(
+            "behavior-preservation-claim",
+            "complete" if preservation_status in {"present", "supported"} and not preservation_caveats else "incomplete",
+            "; ".join(str(item) for item in preservation_claims),
+            "; ".join(str(item) for item in preservation_caveats)
+            or "behavior-preservation claim lacks explicit characterization, compatibility, manual-scenario, or domain-acceptance evidence",
+        )
     add_check(
         "follow-up-owner",
         "complete" if (not follow_up_required or owner) else "incomplete",
@@ -8208,6 +8243,32 @@ def _closeout_report_review_mode_contracts() -> list[dict[str, Any]]:
             "secondary_detail_policy": "Route to decision_review and decision_pressure when decision facts are missing or need durable promotion.",
         },
         {
+            "id": "behavior-preserving-refactor",
+            "work_shape": "behavior-preserving refactor",
+            "first_inspection_facts": [
+                "preservation boundary",
+                "allowed behavior changes",
+                "current-behavior or compatibility proof class",
+                "known behavior gaps",
+                "semantic-risk changed surfaces",
+                "human or domain acceptance needs",
+            ],
+            "rendered_must_include": [
+                "outcome",
+                "changed surfaces",
+                "proof or validation",
+                "behavior preservation proof",
+                "behavior preservation caveat",
+                "residue or follow-up status",
+                "authority boundary",
+            ],
+            "rendered_should_include": ["allowed behavior changes", "known behavior gaps", "review focus"],
+            "detail_routes": ["closeout_report.validation.proof_confidence.behavior_preservation", "verification", "closeout_trust"],
+            "secondary_detail_policy": (
+                "Inspect semantic-risk surfaces first; AW reports evidence and gaps, while the agent and human own preservation sufficiency."
+            ),
+        },
+        {
             "id": "partial-or-lower-trust-closeout",
             "work_shape": "partial or lower-trust closeout",
             "first_inspection_facts": [
@@ -8255,13 +8316,18 @@ def _closeout_report_selected_review_mode(
     trust: str,
     completeness: dict[str, Any],
     decision_review: dict[str, Any],
+    behavior_preservation: dict[str, Any] | None = None,
 ) -> str:
     profile = str(profile_policy.get("selected_profile") or "minimal")
     completeness_status = str(completeness.get("status") or "").strip().lower()
     decision_status = str(decision_review.get("status") or "").strip().lower()
+    behavior_preservation = _as_dict(behavior_preservation)
+    preservation_status = str(behavior_preservation.get("status") or "").strip().lower()
     lower_or_partial = str(trust).strip().lower() == "lower-trust" or completeness_status in {"partial", "incomplete"}
     if decision_status in {"present", "partial", "absent-required"}:
         return "system-shaping-change"
+    if preservation_status in {"present", "supported", "claim-needs-evidence"}:
+        return "behavior-preserving-refactor"
     if lower_or_partial or profile == "explanatory":
         return "partial-or-lower-trust-closeout"
     if profile == "audit":
@@ -8285,18 +8351,22 @@ def _closeout_report_review_compression_payload(
     trust: str,
     completeness: dict[str, Any],
     decision_review: dict[str, Any],
+    behavior_preservation: dict[str, Any] | None = None,
     residual_risk: str,
     follow_up_owner: str,
     detail_commands: dict[str, str],
 ) -> dict[str, Any]:
     completeness_status = str(completeness.get("status") or "").strip().lower()
     decision_status = str(decision_review.get("status") or "").strip().lower()
+    behavior_preservation = _as_dict(behavior_preservation)
+    preservation_status = str(behavior_preservation.get("status") or "").strip().lower()
     lower_or_partial = str(trust).strip().lower() == "lower-trust" or completeness_status in {"partial", "incomplete"}
     selected_mode = _closeout_report_selected_review_mode(
         profile_policy=profile_policy,
         trust=trust,
         completeness=completeness,
         decision_review=decision_review,
+        behavior_preservation=behavior_preservation,
     )
     modes = _closeout_report_review_mode_contracts()
     first_inspection = _closeout_report_review_mode_contract(selected_mode)
@@ -8305,6 +8375,10 @@ def _closeout_report_review_compression_payload(
         human_owned.append("accept whether system-shaping decision facts may remain absent or must be routed before merge")
     if lower_or_partial:
         human_owned.append("accept residual risk and missing proof or require more validation")
+    if preservation_status == "claim-needs-evidence":
+        human_owned.append("accept the explicit preservation caveat or require characterization, compatibility, manual, or domain proof")
+    elif preservation_status in {"present", "supported"}:
+        human_owned.append("accept whether recorded preservation proof is sufficient for the claimed behavior boundary")
     if follow_up_owner:
         human_owned.append(f"accept follow-up ownership by {follow_up_owner}")
     if not human_owned:
@@ -8437,6 +8511,7 @@ def _closeout_report_final_response_rendering_payload(
     blockers: list[Any],
     next_action: str,
     decision_review: dict[str, Any] | None = None,
+    behavior_preservation: dict[str, Any] | None = None,
     review_mode: str = "",
 ) -> dict[str, Any]:
     profile = str(profile_policy.get("selected_profile") or "minimal")
@@ -8450,6 +8525,7 @@ def _closeout_report_final_response_rendering_payload(
     summary_lines: list[str] = []
     must_not_claim: list[str] = ["Do not dump raw closeout_report JSON into the final user-facing response."]
     decision_review = _as_dict(decision_review)
+    behavior_preservation = _as_dict(behavior_preservation)
     review_contract = _closeout_report_review_mode_contract(review_mode or "small-direct-edit")
 
     def present(text: str) -> str:
@@ -8483,6 +8559,9 @@ def _closeout_report_final_response_rendering_payload(
             "changed surfaces": ("changed:",),
             "validation": ("proof:", "validation:"),
             "decision facts": ("decision:", "decision gap:"),
+            "behavior preservation proof": ("behavior proof:",),
+            "behavior preservation caveat": ("behavior caveat:",),
+            "review focus": ("review focus:",),
         }
         for fact in must_include:
             markers = fact_markers.get(fact, (fact,))
@@ -8533,10 +8612,15 @@ def _closeout_report_final_response_rendering_payload(
         if present(changed_surfaces):
             behavior_lines.append(f"Changed: {changed_surfaces}")
         proof_lines = [f"Proof: {validation_proof}"] if present(validation_proof) else []
+        preservation_proof = "; ".join(str(item) for item in _list_payload(behavior_preservation.get("proof_classes")) if str(item))
+        if preservation_proof:
+            proof_lines.append(f"Behavior proof: {preservation_proof}")
 
         caveat_lines: list[str] = []
         for line in summary_lines:
-            if line.startswith(("Closeout caveat:", "Closure boundary:", "Residue:", "Evidence caveat:", "Decision gap:")):
+            if line.startswith(
+                ("Closeout caveat:", "Closure boundary:", "Residue:", "Evidence caveat:", "Decision gap:", "Behavior caveat:")
+            ):
                 caveat_lines.append(line)
         if not caveat_lines and not plain_done_allowed:
             caveat_lines.append("Caveat: closeout requires non-terse reporting before claiming completion.")
@@ -8562,7 +8646,7 @@ def _closeout_report_final_response_rendering_payload(
                 "title": "Proof",
                 "required": any(item in must_include for item in ("proof or validation", "validation")),
                 "lines": proof_lines,
-                "source_fields": ["proof.validation_proof", "proof.intent_proof"],
+                "source_fields": ["proof.validation_proof", "proof.intent_proof", "proof.behavior_preservation"],
             },
             {
                 "id": "caveats",
@@ -8707,6 +8791,21 @@ def _closeout_report_final_response_rendering_payload(
         summary_lines.append(f"Decision gap: {decision_review.get('decision_absent_because')}")
     if present(validation_proof):
         summary_lines.append(f"Proof: {validation_proof}")
+    preservation_claims = [str(item) for item in _list_payload(behavior_preservation.get("claims")) if str(item).strip()]
+    preservation_proof_classes = [str(item) for item in _list_payload(behavior_preservation.get("proof_classes")) if str(item).strip()]
+    preservation_caveats = [str(item) for item in _list_payload(behavior_preservation.get("caveats")) if str(item).strip()]
+    preservation_status = str(behavior_preservation.get("status") or "").strip()
+    if preservation_claims:
+        if preservation_proof_classes:
+            summary_lines.append(f"Behavior proof: {'; '.join(preservation_proof_classes[:4])}")
+        if preservation_caveats:
+            summary_lines.append(f"Behavior caveat: {'; '.join(preservation_caveats[:2])}")
+        elif preservation_status in {"present", "supported"}:
+            summary_lines.append("Behavior caveat: preservation sufficiency remains agent/human judgment against the recorded boundary.")
+        must_include.extend(["behavior preservation proof", "behavior preservation caveat"])
+        must_not_claim.append(
+            "Do not claim no behavior changed, business logic preserved, migration complete, or compatibility proved unless behavior_preservation evidence supports that claim or the caveat is rendered."
+        )
 
     boundary_text = present(completion_decision)
     completion_boundary_text = present(
@@ -8858,7 +8957,9 @@ def _closeout_report_payload(
     changed_surfaces = str(execution.get("changed surfaces") or "").strip()
     validation_proof = str(proof_report.get("validation proof") or execution.get("validations run") or "").strip()
     completion_decision = str(completion_contract.get("completion_decision", "unknown"))
-    residual_risk = str(_as_dict(closeout_trust.get("proof_confidence")).get("residual_risk", ""))
+    proof_confidence = _as_dict(closeout_trust.get("proof_confidence"))
+    behavior_preservation = _as_dict(proof_confidence.get("behavior_preservation"))
+    residual_risk = str(proof_confidence.get("residual_risk", ""))
     blockers = first_blocking_option.get("blocking_fields", [])
     decision_review = _closeout_report_decision_review_payload(
         active_planning_record=active_planning_record,
@@ -8869,6 +8970,7 @@ def _closeout_report_payload(
         trust=trust,
         completeness=completeness,
         decision_review=decision_review,
+        behavior_preservation=behavior_preservation,
     )
     final_response_rendering = _closeout_report_final_response_rendering_payload(
         status="present" if active_planning_record else "guidance-only",
@@ -8886,6 +8988,7 @@ def _closeout_report_payload(
         blockers=blockers if isinstance(blockers, list) else [],
         next_action=str(next_action),
         decision_review=decision_review,
+        behavior_preservation=behavior_preservation,
         review_mode=selected_review_mode,
     )
     detail_commands = {
@@ -8911,6 +9014,7 @@ def _closeout_report_payload(
         trust=trust,
         completeness=completeness,
         decision_review=decision_review,
+        behavior_preservation=behavior_preservation,
         residual_risk=residual_risk,
         follow_up_owner=follow_up_owner,
         detail_commands=detail_commands,
@@ -8982,6 +9086,7 @@ def _closeout_report_payload(
             "proof": validation_proof,
             "proof_achieved_now": str(proof_report.get("proof achieved now") or "").strip(),
             "proof_confidence": closeout_trust.get("proof_confidence", {}),
+            "behavior_preservation": behavior_preservation,
         },
         "gaps_and_residual_risk": {
             "completion_blockers": blockers,
@@ -11990,6 +12095,8 @@ def _closeout_completion_options(
     intent_proof_status = str(intent_proof_check.get("status", "not_recorded")).strip().lower() or "not_recorded"
     intent_proof_supports_work = intent_proof_status in {"representative", "sufficient_for_claim"}
     intent_proof_needs_review = intent_proof_status == "needs_review"
+    behavior_preservation = _behavior_preservation_confidence_payload(intent_proof_check)
+    unsupported_preservation = behavior_preservation.get("status") == "claim-needs-evidence"
     larger_closure = closure_scope.get("larger_intent_closure", {})
     larger_closure = larger_closure if isinstance(larger_closure, dict) else {}
     larger_status = str(larger_closure.get("status", "")).strip().lower()
@@ -12036,6 +12143,8 @@ def _closeout_completion_options(
         completion_blockers.append("continuation_owner")
     if not intent_proof_supports_work:
         completion_blockers.append("intent_proof")
+    if unsupported_preservation:
+        completion_blockers.append("behavior_preservation")
     assurance_claim_blockers = _assurance_claim_blockers(assurance_requirements)
 
     slice_blockers = [
@@ -12052,6 +12161,7 @@ def _closeout_completion_options(
         and acceptance_ok
         and not residue_required
         and not intent_proof_needs_review
+        and not unsupported_preservation
         and not assurance_claim_blockers.get("claim-slice-complete")
     )
     claim_work_allowed = (
@@ -12070,6 +12180,7 @@ def _closeout_completion_options(
         status in {"unavailable", "invalid"}
         or intent_trust == "needs-review"
         or intent_proof_needs_review
+        or unsupported_preservation
         or str(strict_gate.get("status", "")) == "requires-review"
         or assurance_review_required
     )
@@ -12127,11 +12238,13 @@ def _closeout_completion_options(
         _completion_option(
             "request-review",
             allowed=request_review_allowed,
-            why="intent satisfaction or strict closeout evidence requires human/domain review"
+            why="intent satisfaction, preservation proof, assurance, or strict closeout evidence requires human/domain review"
             if request_review_allowed
             else "a concrete closeout action is available without requiring review",
             blocking_fields=["intent_satisfaction"]
             if intent_trust == "needs-review"
+            else ["behavior_preservation"]
+            if unsupported_preservation
             else ["assurance_requirements"]
             if assurance_review_required
             else None,
@@ -13501,6 +13614,18 @@ def _intent_proof_check_payload(*, planning_report: dict[str, Any], target_root:
         "intended_behavior": [str(item) for item in _list_payload(raw_intent_proof.get("intended_behavior")) if str(item).strip()][:5],
         "proof_dimensions": [str(item) for item in _list_payload(raw_intent_proof.get("proof_dimensions")) if str(item).strip()][:5],
         "unproven_after_tests": [str(item) for item in _list_payload(raw_intent_proof.get("unproven_after_tests")) if str(item).strip()][
+            :5
+        ],
+        "preservation_claims": [str(item) for item in _list_payload(raw_intent_proof.get("preservation_claims")) if str(item).strip()][:5],
+        "allowed_behavior_changes": [
+            str(item) for item in _list_payload(raw_intent_proof.get("allowed_behavior_changes")) if str(item).strip()
+        ][:5],
+        "unknown_behavior": [str(item) for item in _list_payload(raw_intent_proof.get("unknown_behavior")) if str(item).strip()][:5],
+        "human_confirmation_needed": [
+            str(item) for item in _list_payload(raw_intent_proof.get("human_confirmation_needed")) if str(item).strip()
+        ][:5],
+        "proof_classes": [str(item) for item in _list_payload(raw_intent_proof.get("proof_classes")) if str(item).strip()][:8],
+        "preservation_evidence": [str(item) for item in _list_payload(raw_intent_proof.get("preservation_evidence")) if str(item).strip()][
             :5
         ],
         "evidence": str(raw_intent_proof.get("evidence", raw_intent_proof.get("reason", ""))),
@@ -26279,6 +26404,18 @@ def _tiny_required_proof_commands(answer: dict[str, Any]) -> list[str]:
     return _compact_tiny_required_proof_commands(non_verification_commands or required_commands)
 
 
+def _compact_tiny_intent_proof(intent_proof: Any) -> dict[str, Any]:
+    if not isinstance(intent_proof, dict):
+        return {}
+    compact = dict(intent_proof)
+    compact.pop("behavior_preservation_prompt", None)
+    compact.pop("rule", None)
+    for key in ("intended_behavior", "unproven_after_tests"):
+        if compact.get(key) == []:
+            compact.pop(key, None)
+    return compact
+
+
 def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
     if payload.get("profile") == "compact-contract-answer/v1":
         answer = payload.get("answer", {})
@@ -26312,7 +26449,7 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
                     "selection_order": answer.get("proof_strategy", {}).get("selection_order", []),
                 }
             if include_intent_proof:
-                next_decision["intent_proof"] = answer["intent_proof"]
+                next_decision["intent_proof"] = _compact_tiny_intent_proof(answer["intent_proof"])
             next_decision.setdefault(
                 "detail_command",
                 _command_with_cli_invoke(
@@ -26348,7 +26485,7 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
                 "required": primary.get("required", bool(required_commands)),
             },
             "required_commands": required_commands,
-            **({"intent_proof": answer["intent_proof"]} if include_intent_proof else {}),
+            **({"intent_proof": _compact_tiny_intent_proof(answer["intent_proof"])} if include_intent_proof else {}),
             **(
                 {"proof_command_adjustments": answer["proof_command_adjustments"]}
                 if isinstance(answer, dict) and answer.get("proof_command_adjustments")
@@ -29429,9 +29566,100 @@ def _intent_proof_prompt_payload(
             "representative user path",
             "negative or boundary case",
             "integration or consumer behavior",
+            "behavior-preservation claim and allowed behavior changes",
+            "characterization, golden-master, compatibility, migration dry-run, or manual scenario evidence",
         ],
+        "behavior_preservation_prompt": {
+            "status": "agent-owned",
+            "record_when": "refactor, modernization, extraction, dependency upgrade, migration, or safe/no-behavior-change claim is part of the work",
+            "fields": [
+                "preservation_claims",
+                "allowed_behavior_changes",
+                "unknown_behavior",
+                "proof_classes",
+                "human_confirmation_needed",
+            ],
+            "rule": "Ordinary tests passing can be one evidence class, but it does not by itself prove a no-behavior-change or business-logic-preserved claim.",
+        },
         "unproven_after_tests": [],
         "rule": "Intent-proof is an agent judgment prompt; AW selects proof commands but does not score test quality automatically.",
+    }
+
+
+_BEHAVIOR_PRESERVATION_SUPPORTING_PROOF_CLASSES = {
+    "characterization",
+    "golden-master",
+    "current-behavior",
+    "compatibility",
+    "api-compatibility",
+    "cli-output-compatibility",
+    "migration-dry-run",
+    "manual-scenario",
+    "domain-acceptance",
+    "human-domain-acceptance",
+}
+
+
+def _behavior_preservation_confidence_payload(intent_proof: dict[str, Any]) -> dict[str, Any]:
+    claims = [str(item).strip() for item in _list_payload(intent_proof.get("preservation_claims")) if str(item).strip()][:5]
+    allowed_changes = [str(item).strip() for item in _list_payload(intent_proof.get("allowed_behavior_changes")) if str(item).strip()][:5]
+    unknown_behavior = [str(item).strip() for item in _list_payload(intent_proof.get("unknown_behavior")) if str(item).strip()][:5]
+    human_confirmation = [str(item).strip() for item in _list_payload(intent_proof.get("human_confirmation_needed")) if str(item).strip()][
+        :5
+    ]
+    proof_classes = [
+        str(item).strip().lower().replace("_", "-") for item in _list_payload(intent_proof.get("proof_classes")) if str(item).strip()
+    ][:8]
+    evidence = [str(item).strip() for item in _list_payload(intent_proof.get("preservation_evidence")) if str(item).strip()][:5]
+    supported_classes = [item for item in proof_classes if item in _BEHAVIOR_PRESERVATION_SUPPORTING_PROOF_CLASSES]
+    ordinary_only = bool(proof_classes) and not supported_classes
+    unsupported_claims = claims if claims and (ordinary_only or (not proof_classes and not evidence)) else []
+    caveats: list[str] = []
+    if unsupported_claims:
+        caveats.append(
+            "Preservation claim is recorded, but no characterization, golden-master, compatibility, migration dry-run, manual scenario, or domain-acceptance evidence is recorded."
+        )
+    if unknown_behavior:
+        caveats.append("Unknown or undocumented behavior remains: " + "; ".join(unknown_behavior[:3]))
+    if human_confirmation:
+        caveats.append("Human/domain confirmation remains: " + "; ".join(human_confirmation[:3]))
+    if not claims:
+        status = "not-claimed"
+    elif unsupported_claims:
+        status = "claim-needs-evidence"
+    else:
+        status = "supported" if supported_classes or evidence else "present"
+    return {
+        "kind": "agentic-workspace/behavior-preservation-proof/v1",
+        "status": status,
+        "claims": claims,
+        "allowed_behavior_changes": allowed_changes,
+        "unknown_behavior": unknown_behavior,
+        "human_confirmation_needed": human_confirmation,
+        "proof_classes": proof_classes,
+        "supporting_proof_classes": supported_classes,
+        "ordinary_test_only": ordinary_only,
+        "evidence": evidence,
+        "unsupported_claims": unsupported_claims,
+        "caveats": caveats,
+        "review_focus": [
+            "changed business-rule or domain paths",
+            "persistence, migration, or data-shape code",
+            "serialization, public contracts, API, or CLI output",
+            "dependency/runtime semantics",
+            "deleted compatibility paths",
+            "updated fixtures, snapshots, or golden outputs",
+            "known gaps and unproven behavior",
+        ],
+        "authority_boundary": {
+            "observed_by_aw": ["agent-recorded preservation claims", "agent-recorded proof classes"],
+            "agent_owned_decisions": ["semantic preservation sufficiency", "material caveat selection"],
+            "human_owned_decisions": ["business/domain acceptance when requested or unproven"],
+        },
+        "rule": (
+            "AW reports recorded preservation claims, evidence classes, and gaps; it does not infer business behavior "
+            "or decide that behavior was preserved."
+        ),
     }
 
 
@@ -29486,6 +29714,7 @@ def _proof_confidence_payload(
         "residual_risk": residual_risk_by_status.get(
             status, "Proof confidence cannot be classified from the available intent-proof evidence."
         ),
+        "behavior_preservation": _behavior_preservation_confidence_payload(intent_proof),
         "evidence_state": str(proof_execution_evidence.get("status", "")) or "unknown",
         "rule": "Proof confidence interprets proof strength; it does not execute proof or score test quality automatically.",
     }

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -3558,6 +3558,95 @@ def test_report_closeout_report_flags_incomplete_evidence_and_degrades_trust(tmp
     assert rendered["rendered_text"] != "Done."
 
 
+def test_report_closeout_report_caveats_unsupported_behavior_preservation_claim(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    plan = target / ".agentic-workspace" / "planning" / "execplans" / "refactor-preservation.plan.json"
+    _write_json(
+        plan,
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Refactor Preservation",
+            "active_milestone": {"id": "refactor-preservation", "status": "complete"},
+            "delegated_judgment": {
+                "requested outcome": "Refactor parser helpers while preserving behavior.",
+                "hard constraints": "Do not claim no behavior changed without preservation evidence.",
+            },
+            "execution_run": {
+                "run status": "complete",
+                "what happened": "Refactored parser helpers.",
+                "scope touched": "parser helpers",
+                "changed surfaces": "src/parser.py; tests/test_parser.py",
+                "validations run": "uv run pytest tests/test_parser.py",
+                "result for continuation": "close with caveat",
+            },
+            "proof_report": {
+                "validation proof": "uv run pytest tests/test_parser.py passed",
+                "proof achieved now": "yes",
+                "intent_proof": {
+                    "status": "sufficient_for_claim",
+                    "claim_boundary": "work",
+                    "intended_behavior": ["parser output behavior preserved"],
+                    "proof_dimensions": ["focused regression tests"],
+                    "unproven_after_tests": ["legacy malformed-input behavior"],
+                    "preservation_claims": ["no behavior changed for parser output"],
+                    "allowed_behavior_changes": ["internal helper names may change"],
+                    "unknown_behavior": ["legacy malformed-input behavior has no fixture"],
+                    "proof_classes": ["ordinary-tests"],
+                    "human_confirmation_needed": ["domain owner confirms malformed-input behavior if needed"],
+                },
+            },
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": "closed",
+                "closure decision": "archive-and-close",
+                "why this decision is honest": "Implementation is complete, but preservation proof remains caveated.",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'refactor-preservation', title = 'Refactor preservation', surface = '.agentic-workspace/planning/execplans/refactor-preservation.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_report", "--format", "json"]) == 0
+
+    report = json.loads(capsys.readouterr().out)["answer"]
+    preservation = report["validation"]["behavior_preservation"]
+    assert preservation["status"] == "claim-needs-evidence"
+    assert preservation["unsupported_claims"] == ["no behavior changed for parser output"]
+    assert preservation["ordinary_test_only"] is True
+    assert "semantic-risk changed surfaces" in report["review_compression"]["first_inspection_contract"]["first_inspection_facts"]
+    assert report["review_compression"]["selected_mode"] == "behavior-preserving-refactor"
+    assert any("preservation caveat" in item for item in report["review_compression"]["human_owned_decisions"])
+    assert report["profile"] == "audit"
+    assert report["trust"] == "lower-trust"
+    checks = {check["id"]: check for check in report["completeness"]["checks"]}
+    assert checks["behavior-preservation-claim"]["status"] == "incomplete"
+    rows = {row["id"]: row for row in report["traceability"]["rows"]}
+    assert rows["behavior-preservation"]["status"] == "missing"
+    options = {option["id"]: option for option in report["closure_boundary"]["completion_options"]}
+    assert options["claim-work-complete"]["allowed"] is False
+    assert "behavior_preservation" in options["claim-work-complete"]["blocking_fields"]
+    rendering = report["final_response_rendering"]
+    assert rendering["plain_done_allowed"] is False
+    assert "behavior preservation caveat" in rendering["must_include"]
+    assert "behavior preservation proof" in rendering["must_include"]
+    rendered = rendering["rendered_summary"]
+    assert "Behavior proof: ordinary-tests" in rendered["rendered_text"]
+    assert "Behavior caveat:" in rendered["rendered_text"]
+    assert "no behavior changed" in " ".join(rendering["must_not_claim"])
+    assert rendered["required_fact_coverage"]["status"] == "complete"
+
+
 def test_report_closeout_trust_blocks_broad_claim_for_missing_assurance_evidence(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -3647,6 +3647,202 @@ def test_report_closeout_report_caveats_unsupported_behavior_preservation_claim(
     assert rendered["required_fact_coverage"]["status"] == "complete"
 
 
+def test_report_closeout_report_represents_behavior_preserving_refactor_operating_pattern(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write(
+        target / ".agentic-workspace/verification/manifest.toml",
+        """
+schema_version = "agentic-workspace/verification-manifest/v1"
+
+[scenarios.parser_characterization]
+protocol_id = "parser_refactor_characterization"
+title = "Parser characterization"
+steps = ["Run representative parser fixtures before and after the helper extraction"]
+expected_observations = ["Stable valid-input parse trees match current behavior"]
+pass_evidence_labels = ["parser_regression_pytest_passed"]
+fail_evidence_labels = ["parser_characterization_changed"]
+manual_boundary = "Domain owner must review malformed-input behavior before parent closure."
+
+[protocols.parser_refactor_characterization]
+title = "Parser refactor characterization"
+purpose = "Current-behavior evidence for a parser helper refactor."
+applies_to_paths = ["src/parser/**", "tests/fixtures/parser/**"]
+scenario_refs = ["parser_characterization"]
+expected_evidence = ["parser_regression_pytest_passed"]
+review_owner = "parser-review"
+retention = "retain-summary"
+
+[evidence_bundles.parser_refactor_2026_06]
+protocol_id = "parser_refactor_characterization"
+scenario_id = "parser_characterization"
+changed_paths = ["src/parser/helpers.py", "tests/fixtures/parser/valid_cases.json"]
+executor = "test-agent"
+executed_at = "2026-06-04T12:00:00Z"
+outcome = "passed"
+evidence_items = ["parser_regression_pytest_passed"]
+transcript_summaries = ["Representative valid-input fixtures matched current behavior; raw fixture output not retained."]
+residual_risk = "Malformed legacy inputs remain uncharacterized."
+claim_boundaries = ["work"]
+reviewer = "parser-review"
+retention_until = "2099-01-01"
+
+[known_gaps.parser_malformed_legacy_gap]
+protocol_id = "parser_refactor_characterization"
+scenario_id = "parser_characterization"
+reason = "Malformed legacy-input behavior lacks fixtures and domain acceptance."
+owner = "parser-review"
+status = "open"
+evidence_labels = ["malformed_legacy_characterization"]
+blocked_claims = ["close-parent-lane"]
+residual_risk = "Do not claim parent-lane behavior preservation until this gap is characterized or accepted."
+reopen_trigger = "parent lane asks for full parser behavior-preservation closure"
+""",
+    )
+    plan = target / ".agentic-workspace" / "planning" / "execplans" / "parser-refactor.plan.json"
+    _write_json(
+        plan,
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Parser Refactor",
+            "active_milestone": {"id": "parser-refactor", "status": "complete"},
+            "delegated_judgment": {
+                "requested outcome": "Extract parser helpers while preserving current valid-input behavior.",
+                "hard constraints": "Do not claim parent-lane behavior preservation until malformed legacy inputs are characterized.",
+                "agent may decide locally": "Internal helper names and file layout.",
+                "escalate when": "Characterization evidence changes or domain acceptance is unavailable.",
+            },
+            "immediate_next_action": ["Close work with explicit behavior caveat; keep parent closure blocked by known gap."],
+            "invariants": [
+                "Valid-input parse tree behavior must remain stable.",
+                "AW reports evidence and gaps; agent and parser-review own semantic preservation sufficiency.",
+            ],
+            "validation_commands": [
+                "uv run pytest tests/test_parser.py",
+                "uv run python scripts/run_agentic_workspace.py report --section verification --format json",
+            ],
+            "completion_criteria": [
+                "Planning records preservation claims, allowed behavior changes, unknown behavior, proof classes, and human confirmation needs.",
+                "Verification records characterization evidence and the malformed-input known gap.",
+                "Closeout reports ordinary-test-only caveat and semantic-risk review focus.",
+                "Memory promotion is explicitly not needed for this fixture because no durable host-specific lesson was discovered.",
+            ],
+            "execution_run": {
+                "run status": "complete",
+                "executor": "test-agent",
+                "what happened": "Extracted parser helpers and kept representative valid-input fixtures stable.",
+                "scope touched": "parser helper extraction",
+                "changed surfaces": "src/parser/helpers.py; src/parser/rules.py; tests/fixtures/parser/valid_cases.json",
+                "validations run": "uv run pytest tests/test_parser.py; verification evidence bundle parser_refactor_2026_06 present",
+                "result for continuation": "close work with caveat",
+                "next step": "do not close parent until malformed legacy behavior is characterized or accepted",
+            },
+            "proof_report": {
+                "validation proof": "uv run pytest tests/test_parser.py passed; verification evidence bundle parser_refactor_2026_06 present",
+                "acceptance reconciliation": "valid-input behavior preservation -> ordinary regression tests and Verification bundle present; malformed-input behavior -> known gap",
+                "proof achieved now": "yes, with behavior-preservation caveat",
+                "intent_proof": {
+                    "status": "sufficient_for_claim",
+                    "claim_boundary": "work",
+                    "intended_behavior": ["valid-input parse tree behavior remains stable"],
+                    "proof_dimensions": ["ordinary regression tests", "verification characterization evidence"],
+                    "unproven_after_tests": ["malformed legacy-input behavior"],
+                    "preservation_claims": ["no behavior changed for valid parser output"],
+                    "allowed_behavior_changes": ["internal helper names may change", "private helper file layout may change"],
+                    "unknown_behavior": ["malformed legacy-input behavior has no fixture"],
+                    "proof_classes": ["ordinary-tests"],
+                    "preservation_evidence": ["parser_regression_pytest_passed", "parser_refactor_2026_06"],
+                    "human_confirmation_needed": ["parser-review accepts malformed-input gap before parent closure"],
+                },
+            },
+            "execution_summary": {
+                "outcome delivered": "Parser helper extraction completed with a behavior-preservation caveat.",
+                "validation confirmed": "ordinary tests and Verification evidence bundle were recorded",
+                "follow-on routed to": "parser-review for parent-lane malformed-input acceptance only",
+                "knowledge promoted (Memory/Docs/Config)": (
+                    "none; this fixture recorded evidence in Planning and Verification, and no durable "
+                    "non-obvious host behavior was discovered that future agents would need in Memory"
+                ),
+            },
+            "durable_residue": {
+                "status": "none",
+                "learned constraint": "none",
+                "canonical owner now": "verification",
+                "promotion trigger": "Promote to Memory only if malformed-input behavior becomes a repeated rediscovery hazard.",
+                "retention after promotion": "retain-summary-until-fixture-or-domain-rule-supersedes-it",
+            },
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": "open",
+                "closure decision": "archive-but-keep-lane-open",
+                "why this decision is honest": "Work-scope preservation has ordinary test and Verification evidence, while the parent malformed-input boundary remains a known gap.",
+                "evidence carried forward": "parser_refactor_2026_06 evidence bundle and parser_malformed_legacy_gap known gap",
+                "reopen trigger": "Malformed-input behavior must be claimed as preserved.",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'parser-refactor', title = 'Parser refactor', surface = '.agentic-workspace/planning/execplans/parser-refactor.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "verification", "--format", "json"]) == 0
+
+    verification = json.loads(capsys.readouterr().out)["answer"]
+    assert verification["configured_protocols"][0]["id"] == "parser_refactor_characterization"
+    assert verification["configured_scenarios"][0]["id"] == "parser_characterization"
+    assert verification["evidence_bundle_status"][0]["protocol_id"] == "parser_refactor_characterization"
+    assert verification["evidence_bundle_status"][0]["state"] == "present"
+    assert verification["known_gaps"][0]["id"] == "parser_malformed_legacy_gap"
+    assert verification["evidence_bundle_status"][0]["claim_boundaries"] == ["work"]
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_report", "--format", "json"]) == 0
+
+    report = json.loads(capsys.readouterr().out)["answer"]
+    preservation = report["validation"]["behavior_preservation"]
+    assert preservation["claims"] == ["no behavior changed for valid parser output"]
+    assert preservation["allowed_behavior_changes"] == ["internal helper names may change", "private helper file layout may change"]
+    assert preservation["unknown_behavior"] == ["malformed legacy-input behavior has no fixture"]
+    assert preservation["proof_classes"] == ["ordinary-tests"]
+    assert preservation["evidence"] == ["parser_regression_pytest_passed", "parser_refactor_2026_06"]
+    assert preservation["supporting_proof_classes"] == []
+    assert preservation["status"] == "claim-needs-evidence"
+    assert "malformed legacy-input behavior has no fixture" in " ".join(preservation["caveats"])
+    assert "parser-review accepts malformed-input gap before parent closure" in " ".join(preservation["caveats"])
+    assert report["review_compression"]["selected_mode"] == "behavior-preserving-refactor"
+    review_focus = preservation["review_focus"]
+    assert "changed business-rule or domain paths" in review_focus
+    assert "persistence, migration, or data-shape code" in review_focus
+    assert "serialization, public contracts, API, or CLI output" in review_focus
+    assert "dependency/runtime semantics" in review_focus
+    assert "deleted compatibility paths" in review_focus
+    assert "updated fixtures, snapshots, or golden outputs" in review_focus
+    assert "known gaps and unproven behavior" in review_focus
+    authority = preservation["authority_boundary"]
+    assert "agent-recorded preservation claims" in authority["observed_by_aw"]
+    assert "semantic preservation sufficiency" in authority["agent_owned_decisions"]
+    assert "business/domain acceptance when requested or unproven" in authority["human_owned_decisions"]
+    assert any("preservation caveat" in item for item in report["review_compression"]["human_owned_decisions"])
+    options = {option["id"]: option for option in report["closure_boundary"]["completion_options"]}
+    assert options["claim-work-complete"]["allowed"] is False
+    assert "behavior_preservation" in options["claim-work-complete"]["blocking_fields"]
+    assert report["final_response_rendering"]["plain_done_allowed"] is False
+    rendered_text = report["final_response_rendering"]["rendered_summary"]["rendered_text"]
+    assert "Behavior proof: ordinary-tests" in rendered_text
+    assert "Behavior caveat:" in rendered_text
+    assert "no behavior changed" in " ".join(report["final_response_rendering"]["must_not_claim"])
+    traceability = {row["id"]: row for row in report["traceability"]["rows"]}
+    assert "1 verification evidence row(s)" in traceability["assurance-verification"]["evidence"]
+
+
 def test_report_closeout_trust_blocks_broad_claim_for_missing_assurance_evidence(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()


### PR DESCRIPTION
## What landed

This PR implements behavior-preservation support for refactoring tasks across existing AW surfaces, without adding a new refactoring module, state store, dashboard, or automatic business-logic classifier.

- Planning guidance/template fields now record preservation claims, allowed behavior changes, unknown behavior, proof classes, preservation evidence, and human confirmation needs.
- Verification docs show compact characterization/current-behavior evidence using protocols, scenarios, evidence bundles, claim boundaries, and known gaps.
- Proof/report and closeout report now distinguish ordinary tests from preservation-supporting evidence, expose behavior proof/caveat facts, and keep semantic preservation judgment with the agent/human.
- Final-response rendering includes behavior proof/caveat lines and blocks plain-done/broad completion claims when preservation proof is insufficient.
- Memory guidance explains when durable refactoring facts should be promoted, with evidence, `use_when`, `stale_when`, authority/owner, retention, and anti-dump boundaries.
- Review compression includes a `behavior-preserving-refactor` mode that points first to semantic-risk surfaces while remaining advisory.
- Added a representative report fixture that exercises the full pattern across Planning, Verification, proof/report, closeout, Memory non-promotion rationale, and review compression.
- Compacted retained closeout evidence so closure residue stays under structured-file inventory limits.

## Closure matrix

| Issue | Closure evidence |
| --- | --- |
| #1289 | Representative refactoring workflow evidence covering Planning preservation boundary, Verification characterization evidence and known gap, proof classification, closeout caveat/support, Memory promotion guidance/non-promotion rationale, and review-compression focus. See `test_report_closeout_report_represents_behavior_preserving_refactor_operating_pattern`. |
| #1291 | Planning README/template fields for preservation claims, allowed changes, unknown behavior, proof classes, preservation evidence, and human confirmation needs. |
| #1292 | Verification characterization example with protocol, scenario, evidence bundle, known gap, claim boundary, and characterization/current-behavior/golden-master/manual-scenario wording. |
| #1293 | Proof/report output distinguishes ordinary tests from preservation evidence, records unproven behavior, and renders behavior proof/caveat facts. |
| #1294/#1295 | Closeout caveat behavior for unsupported preservation claims, including blocked broad completion/plain-done claims. The issues are duplicates; this PR satisfies both with the same implementation and tests. |
| #1296 | Memory guidance/example for durable refactoring facts, including non-obvious invariants, legacy quirks, dependency/runtime constraints, fixtures/protocols, dead-code candidates, anti-rediscovery warnings, evidence, `use_when`, `stale_when`, authority/owner, retention, and anti-dump boundaries. |
| #1297/#1298 | Review-compression semantic-risk guidance/test with advisory first-inspection targets for business-rule paths, persistence/migration/data-shape code, serialization/public contracts, dependency/runtime semantics, deleted compatibility paths, updated fixtures/snapshots, and unproven behavior gaps. The issues are duplicates; this PR satisfies both with the same behavior-preserving-refactor mode and fixture assertions. |

## Why #1289 parent closure is honest

The parent lane asked for the operating pattern, not just wording. The PR now demonstrates a representative behavior-preserving refactor path: Planning records the boundary and preservation proof fields; Verification contributes characterization evidence and a known gap; proof/report distinguishes ordinary-test evidence from preservation-supporting proof; closeout renders the caveat and blocks unsafe broad claims; Memory guidance explains when to promote durable refactoring facts or record no promotion; and review compression points reviewers to semantic-risk surfaces without claiming AW knows business risk.

## Validation

- `uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim tests/test_workspace_report_cli.py::test_report_closeout_report_represents_behavior_preserving_refactor_operating_pattern -q`
- `uv run pytest tests/test_workspace_proof_cli.py::test_proof_tiny_profile_returns_next_validation_action tests/test_workspace_proof_cli.py::test_proof_changed_surfaces_compact_intent_proof_prompt tests/test_workspace_proof_cli.py::test_proof_changed_verbose_surfaces_proof_confidence -q`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make test-workspace`
- `make lint-workspace`
- `make schema-reference-docs`

## Remaining limitation

AW still does not infer business behavior preservation from changed paths, filenames, or passing tests. That is intentional and non-blocking: AW reports recorded evidence, proof classes, caveats, and review focus; agents and humans own semantic preservation sufficiency and domain acceptance.

Closes #1289
Closes #1291
Closes #1292
Closes #1293
Closes #1294
Closes #1295
Closes #1296
Closes #1297
Closes #1298