### PR TITLE
Remove prompt keyword semantic routing

### DIFF
--- a/.agentic-workspace/planning/execplans/github-1309-workspace-replace-prompt-keyword-semantic-routin.plan.json
+++ b/.agentic-workspace/planning/execplans/github-1309-workspace-replace-prompt-keyword-semantic-routin.plan.json
@@ -1,0 +1,329 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Replace prompt keyword semantic routing with agent judgment",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "lane",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "required_continuation",
+      "iterative_follow_through",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Remove host-repo prompt keyword semantic routing from startup, durable-intent promotion, architecture-decision prompting, completion-status routing, vague-outcome/intent-discovery routing, and related tests; keep AW support as advisory contracts, structural facts, and selectable guidance owned by agent judgment.",
+    "hard_constraints": "Do not replace keyword tables with another automatic business/task classifier; keep Memory, Planning, Verification, proof/report, and closeout behavior repo-agnostic and quiet by default.",
+    "agent_may_decide": "How to preserve useful guidance through explicit selectors, structural path evidence, authority-boundary wording, schema docs, and tests.",
+    "escalate_when": "A required fix would add a new semantic classifier, broaden beyond the open issue lane, or leave a closure keyword unsupported.",
+    "next_action": "Create the PR after proof passes and the closure matrix maps #1309-#1313 to concrete evidence.",
+    "proof_expectations": [
+      "Focused startup, implement, report, summary, and guardrail tests pass.",
+      "make test-workspace, make lint-workspace, make maintainer-surfaces, and make schema-reference-docs pass.",
+      "Contract/tooling checks and structured file inventory pass."
+    ],
+    "touched_scope": [
+      ".agentic-workspace/planning/state.toml",
+      ".agentic-workspace/planning/execplans/github-1309-workspace-replace-prompt-keyword-semantic-routin.plan.json",
+      "Makefile",
+      "docs/reference/implementer-context.md",
+      "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "scripts/check/check_prompt_semantic_markers.py",
+      "tests/test_workspace_implement_cli.py",
+      "tests/test_workspace_report_cli.py",
+      "tests/test_workspace_start_preflight_cli.py",
+      "tests/test_workspace_summary_cli.py",
+      "tests/test_prompt_semantic_markers.py"
+    ],
+    "completion_criteria": [
+      "#1310: startup no longer routes config posture, prep-only handoff, completion/status, vague-outcome, intent-discovery, or stated-assumption behavior from prompt keyword tables.",
+      "#1311: durable-intent promotion no longer derives candidates from task-text markers; structural architecture path evidence remains advisory and agent-owned.",
+      "#1312: configured/learned route matching remains structural/configured and documents authority boundaries instead of AW-owned semantic classification.",
+      "#1313: lint guardrail fails on new hardcoded prompt semantic marker tables in guarded startup/routing functions."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "ready-for-pr"
+  },
+  "goal": [
+    "Replace prompt keyword semantic routing with agent-owned judgment supported by repo-agnostic AW facts, selectors, guidance, and guardrails."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Remove prompt keyword semantic routing and preserve useful AW support as advisory/selectable/structural evidence.",
+      "constraints": "No replacement semantic classifier; keep AW repo- and agent-agnostic.",
+      "latitude": "Use authority boundaries, explicit selectors, tests, docs, and lint guardrails.",
+      "escalation": "Escalate if closure requires automatic prompt semantics or broad new runtime concepts."
+    },
+    "execution": {
+      "milestone": "github-1309-workspace-replace-prompt-keyword-semantic-routin",
+      "status": "in-progress",
+      "next_step": "Create PR with closure matrix and passing proof.",
+      "proof": "Required proof set passed on 2026-06-04."
+    },
+    "scope": {
+      "touched": [
+        "workspace runtime startup/report/implement primitives",
+        "schema/reference docs",
+        "startup/implement/report/summary tests",
+        "prompt semantic marker lint guardrail"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "AW should support agent judgment and learned repo knowledge instead of making host-repo assumptions from prompt text.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Startup, closeout, durable-intent, and architecture-decision guidance can remain useful without AW owning prompt semantic classification.",
+    "intentionally deferred": "none",
+    "discovered implications": "Useful advisory packets must be explicitly selectable after automatic applicability is removed; objective-drift removal/retirement also needs to stay agent-owned.",
+    "proof achieved now": "passed",
+    "validation still needed": "none for this lane before PR",
+    "next likely slice": "review PR feedback"
+  },
+  "intent_interpretation": {
+    "literal request": "Implement the lane and create a PR.",
+    "inferred intended outcome": "Close #1309 and child issues #1310-#1313 by removing prompt keyword semantic routing and adding guardrails/proof.",
+    "chosen concrete what": "Remove keyword tables from guarded startup/routing surfaces, hydrate explicit advisory selectors, update tests/docs/schema, and add a lint guardrail.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "workspace runtime primitives, schema/reference docs, relevant tests, Makefile lint target, prompt-marker guardrail script, and this execplan.",
+    "max changed files": "about 12 files",
+    "required validation commands": "AW summary/doctor, focused tests, make test-workspace, make lint-workspace, make maintainer-surfaces, make schema-reference-docs, contract/tooling checks, structured inventory, and scoped ruff.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Inspect the issue body, choose the smallest workflow shape, and record exact proof before closeout.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Open upstream issue from refreshed external intent evidence; priority P1 inferred from inferred-lane.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "Scope is tightly coupled across startup routing, selected advisory packets, tests, generated-schema wording, and the lint guardrail; local implementation preserves context and proof ownership.",
+    "decision command": "agentic-planning delegation-decision",
+    "planning revision observed": "7242779c3a6bca76",
+    "recorded at": "2026-06-04T20:15:58+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1309-workspace-replace-prompt-keyword-semantic-routin",
+    "status": "in-progress",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Create the pull request with closure matrix and proof summary."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    ".agentic-workspace/planning/state.toml",
+    ".agentic-workspace/planning/execplans/github-1309-workspace-replace-prompt-keyword-semantic-routin.plan.json",
+    "Makefile",
+    "docs/reference/implementer-context.md",
+    "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "scripts/check/check_prompt_semantic_markers.py",
+    "tests/test_workspace_implement_cli.py",
+    "tests/test_workspace_report_cli.py",
+    "tests/test_workspace_start_preflight_cli.py",
+    "tests/test_workspace_summary_cli.py",
+    "tests/test_prompt_semantic_markers.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_start_preflight_cli.py -q",
+    "uv run pytest tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_workspace_report_cli.py::test_report_closeout_trust_does_not_infer_architecture_decision_candidate_from_planning_text tests/test_workspace_summary_cli.py::test_workspace_summary_completion_task_surfaces_closeout_trust tests/test_workspace_start_preflight_cli.py tests/test_prompt_semantic_markers.py -q",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json",
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py",
+    "make test-workspace",
+    "make lint-workspace",
+    "make maintainer-surfaces",
+    "make schema-reference-docs"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Default startup/preflight/summary/report behavior no longer infers semantic routes from prompt keywords.",
+    "Explicit selectors still expose advisory intent/vague-outcome/closeout guidance with authority boundaries.",
+    "Durable-intent promotion and architecture-decision candidates no longer use task-text marker tables.",
+    "Generated schema docs describe matched_markers as reserved for structural/configured evidence.",
+    "Lint catches new hardcoded prompt semantic marker tables in guarded functions."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning promote-to-plan",
+    "what happened": "Removed prompt keyword semantic routing from startup/closeout/durable-intent/architecture-decision guidance, added explicit selector hydration and authority boundaries, updated schema docs/tests, and added a lint guardrail.",
+    "scope touched": "workspace runtime, schema/reference docs, startup/implement/report/summary tests, guardrail script, Makefile, and planning state.",
+    "changed surfaces": "start/preflight/summary/report/implement payload behavior and lint validation.",
+    "validations run": "focused tests; make test-workspace; make lint-workspace; make maintainer-surfaces; make schema-reference-docs; AW summary/doctor; contract tooling; structured inventory; scoped ruff.",
+    "result for continuation": "ready for PR review.",
+    "next step": "Open PR and link closure matrix."
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "yes",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "yes",
+    "misinterpretation risk": "low; explicit selectors preserve guidance without AW-owned prompt semantics",
+    "follow-on decision": "no follow-on required for the prompt-keyword-routing lane."
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "Scope is tightly coupled across startup routing, selected advisory packets, tests, generated-schema wording, and the lint guardrail; local implementation preserves context and proof ownership.",
+    "expected savings": "unknown",
+    "actual friction": "Useful guidance surfaces had to be made explicitly selectable after prompt applicability was removed.",
+    "proof result": "passed",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "passed",
+    "proof achieved now": "passed",
+    "evidence for \"proof achieved\" state": "Focused tests, make test-workspace, make lint-workspace, make maintainer-surfaces, make schema-reference-docs, AW summary/doctor, contract tooling, structured inventory, and scoped ruff all passed on 2026-06-04."
+  },
+  "intent_satisfaction": {
+    "original intent": "Replace assumptions and clever hard-coded host-repo prompt rules with agent judgment supported by AW facts, guidance, and learning surfaces.",
+    "was original intent fully satisfied?": "yes for #1309 and children #1310-#1313",
+    "evidence of intent satisfaction": "Runtime prompt marker tables were removed from guarded startup/routing and objective-drift surfaces; advisory guidance is explicitly selectable; durable-intent and architecture-decision routing use structural/configured evidence; tests cover quiet defaults and selected guidance; lint blocks reintroduction of prompt semantic marker tables, including removal-intent classifiers.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "prompt keyword semantic routing removed from the scoped lane and replaced with agent-owned advisory/selectable guidance",
+    "validation confirmed": "passed",
+    "follow-on routed to": "none yet",
+    "post-work posterity capture": "closure evidence recorded in this execplan and PR body",
+    "knowledge promoted (Memory/Docs/Config)": "none",
+    "resume from": "PR review"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "pending",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "",
+    "target scope": "",
+    "proposed durable intent": "",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": ""
+  },
+  "closure_check": {
+    "slice status": "complete",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
+    "why this decision is honest": "The PR demonstrates the scoped replacement across runtime behavior, selectable advisory packets, schema/reference wording, tests, and lint guardrails for #1309-#1313.",
+    "evidence carried forward": "PR closure matrix plus passing proof commands listed in validation_commands and proof_report.",
+    "reopen trigger": "Review finds a remaining prompt keyword semantic router in the scoped guarded surfaces, or the guardrail misses an equivalent marker table."
+  },
+  "improvement_signal_review": {
+    "status": "no_signal_found",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": ""
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-04: Promoted from TODO direct-task shape into an execplan.",
+    "2026-06-04: Recorded delegation decision route=keep-local."
+  ]
+}

--- a/.agentic-workspace/planning/state.toml
+++ b/.agentic-workspace/planning/state.toml
@@ -9,7 +9,9 @@ schema_version = "planning-state/v1"
 work_items = []
 
 [active]
-execplans = []
+execplans = [
+  { id = "github-1309-workspace-replace-prompt-keyword-semantic-routin", maturity = "active", status = "active", priority = "P1", refs = "GitHub #1309", title = "[Workspace]: Replace prompt keyword semantic routing with agent judgment and learned guidance", outcome = "Route the upstream issue into a bounded Agentic Workspace slice before implementation.", reason = "Open upstream issue from refreshed external intent evidence; priority P1 inferred from inferred-lane.", suggested_first_slice = "Inspect the issue body, choose the smallest workflow shape, and record exact proof before closeout.", path = ".agentic-workspace/planning/execplans/github-1309-workspace-replace-prompt-keyword-semantic-routin.plan.json" },
+]
 
 [todo]
 active_items = []

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ test: sync-all test-workspace test-memory test-planning test-verification
 
 lint-workspace:
 	@$(COMPACT_RUN) --label "workspace lint" -- uv run ruff check src tests
+	@$(COMPACT_RUN) --label "prompt semantic markers" -- uv run python scripts/check/check_prompt_semantic_markers.py
 
 lint-memory:
 	@$(COMPACT_RUN) --label "memory lint" --cwd packages/memory -- uv run ruff check .

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -88,9 +88,9 @@ Cheap implementer context for a bounded changed-path scope.
 | `intent_acknowledgement` | object | yes |  | Guidance for stating inferred intent, first slice, non-goals, and correction point before non-direct implementation. |  |  |
 | `intent_evidence` | object | yes |  | Compact provenance and assumption evidence for the task intent being implemented, including source chain, correction point, and clarification/proceed posture. |  |  |
 | `reuse_pressure` | object | yes |  | Changed-path reuse and abstraction-pressure facts that help the agent decide whether to reuse, accept duplication, or route extraction follow-up. |  |  |
-| `assurance_requirements` | object | yes |  | Repo-declared assurance requirements matched to the task or changed paths, with evidence status and claim-boundary facts. |  |  |
-| `verification` | object | yes |  | Matched repo-native verification protocols and bounded evidence status for the task or changed paths. |  |  |
-| `routine_work_context` | object | yes |  | Assembled routine router projection grouping existing owner surfaces into authority, active work, evidence/proof, durable knowledge, and promotion/residue. |  |  |
+| `assurance_requirements` | object | yes |  | Repo-declared assurance requirements matched to the task or changed paths, with evidence status and claim-boundary facts; task-marker matches cite explicit config while semantic acceptance remains agent/human owned. |  |  |
+| `verification` | object | yes |  | Matched repo-native verification protocols and bounded evidence status for the task or changed paths; task-marker matches are configured protocol evidence, not AW-owned intent classification. |  |  |
+| `routine_work_context` | object | yes |  | Assembled routine router projection grouping existing owner surfaces into authority, active work, evidence/proof, durable knowledge, and promotion/residue; configured or learned Memory matches remain owner-surface evidence, not AW-owned semantic classification. |  |  |
 | `objective_drift` | object | yes |  | Heuristic warning when changed files do not mention explicit requested outcomes. |  |  |
 | `objective_drift.kind` | const `"agentic-workspace/objective-drift/v1"` | yes |  | Discriminator for the lightweight objective-drift heuristic. |  |  |
 | `objective_drift.status` | string | yes |  | Whether requested task terms appear missing from changed surfaces. |  |  |
@@ -99,9 +99,11 @@ Cheap implementer context for a bounded changed-path scope.
 | `objective_drift.acceptance_item_count` | integer | no |  | Number of inferred acceptance items that should be reconciled before closeout. |  |  |
 | `objective_drift.acceptance_closeout_rule` | string | no |  | Acceptance-specific closeout rule carried into objective-drift guidance. |  |  |
 | `objective_drift.missing_from_changed_surface` | array of string | yes |  | Requested terms that were not observed in changed files. |  |  |
+| `objective_drift.removed_or_retired_outcomes` | array of string | no |  | Reserved for explicit reconciliation evidence; AW does not infer removal or retirement from prompt keyword markers. |  |  |
 | `objective_drift.rule` | string | no |  | Closeout rule agents should apply when drift is suspected. |  |  |
 | `objective_drift.recommended_next_action` | string | no |  | Small next step for resolving or dismissing the drift signal. |  |  |
 | `objective_drift.heuristic` | string | no |  | Brief explanation of the comparison method. |  |  |
+| `objective_drift.agent_owned_decisions` | array of string | no |  | Semantic acceptance decisions AW must not infer from prompt keyword markers. |  |  |
 | `orientation` | object | yes |  | Minimum workspace orientation guidance for the implementer. |  |  |
 | `orientation.status` | string | yes |  | Whether the implementer context is based on changed paths or an unknown scope. |  |  |
 | `orientation.minimum_before_editing` | string | yes |  | Minimum orientation step an agent should complete before implementation. |  |  |
@@ -166,7 +168,7 @@ Cheap implementer context for a bounded changed-path scope.
 | `durable_intent_promotion.kind` | const `"agentic-workspace/task-intent-promotion-guidance/v1"` | yes |  | Discriminator for durable task-intent promotion guidance. |  |  |
 | `durable_intent_promotion.status` | string | yes |  | Whether the task intent contains durable promotion signals. |  |  |
 | `durable_intent_promotion.reason` | string | no |  | Reason promotion guidance is not applicable, when absent. |  |  |
-| `durable_intent_promotion.matched_markers` | array of string | no |  | Heuristic durable-intent markers found in task text. |  |  |
+| `durable_intent_promotion.matched_markers` | array of string | no |  | Reserved for structural or configured evidence; AW does not infer durable intent from prompt keyword markers. |  |  |
 | `durable_intent_promotion.rule` | string | no |  | Promotion rule to apply before closeout. |  |  |
 | `durable_intent_promotion.route_options` | array of object | yes |  | Candidate durable surfaces for non-finishable task intent. |  |  |
 | `durable_intent_promotion.acceptance_item_count` | integer | no |  | Number of acceptance items considered for durable promotion. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -62,7 +62,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `branch_workflow_posture` | object | yes |  | Branch and worktree posture relevant to safe continuation. |  |  |
 | `local_memory` | object | yes |  | Machine-local memory configuration and advisory state. |  |  |
 | `memory_consult` | object | yes |  | Recommended checked-in Memory lookup route for the current report. |  |  |
-| `routine_work_context` | object | yes |  | Assembled routine router projection grouping existing owner surfaces into authority, active work, evidence/proof, durable knowledge, and promotion/residue. |  |  |
+| `routine_work_context` | object | yes |  | Assembled routine router projection grouping existing owner surfaces into authority, active work, evidence/proof, durable knowledge, and promotion/residue; configured or learned Memory matches remain owner-surface evidence, not AW-owned semantic classification. |  |  |
 | `reuse_pressure` | object | yes |  | Entry point for changed-path reuse and abstraction-pressure facts. |  |  |
 | `agent_aids` | object | yes |  | Reusable agent aid availability, manifest coverage, and startup role information. |  |  |
 | `agent_configuration_system` | object | yes |  | How repo-owned agent configuration classes are represented in this workspace. |  |  |
@@ -70,8 +70,8 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `system_intent_mirror` | object | no |  | Compiled system-intent mirror status and source metadata. |  |  |
 | `durable_intent` | object | yes |  | Compact decision projection for durable task, subsystem, and system intent pressure. |  |  |
 | `workflow_obligations` | object | yes |  | Repo-configured workflow obligations surfaced for report consumers. |  |  |
-| `assurance_requirements` | object | yes |  | Repo-declared assurance requirements, active matches, and evidence status projection. |  |  |
-| `verification` | object | yes |  | Repo-native verification protocols, scenarios, bounded evidence bundles, and soft verification routing projection. |  |  |
+| `assurance_requirements` | object | yes |  | Repo-declared assurance requirements, active matches, and evidence status projection; task-marker matches cite explicit config while semantic acceptance remains agent/human owned. |  |  |
+| `verification` | object | yes |  | Repo-native verification protocols, scenarios, bounded evidence bundles, and soft verification routing projection; task-marker matches are configured protocol evidence, not AW-owned intent classification. |  |  |
 | `authority_hierarchy` | object | no |  | Authority and promotion-path guidance for deciding which repo surfaces are current instruction, durable memory, future work, or historical audit. |  |  |
 | `continuation_state` | object | no |  | Compact continuation-state contract for preserving only unfinished or handoff-relevant work, not historical residue. |  |  |
 | `compliance_economics` | object | no |  | Boundary statement for what Agentic Workspace can enforce directly and where it instead makes noncompliance visible or costly. |  |  |

--- a/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
+++ b/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
@@ -605,7 +605,32 @@ def verification_report_payload(
         missing_evidence = [item for item in expected_evidence if item not in evidence_present]
         stale_expected_evidence = [item for item in missing_evidence if item in stale_evidence]
         if matched:
-            active_protocols.append({**protocol, "applies_because": applies_because, "evidence_bundle_ids": [b["id"] for b in bundles]})
+            active_protocols.append(
+                {
+                    **protocol,
+                    "applies_because": applies_because,
+                    "evidence_bundle_ids": [b["id"] for b in bundles],
+                    "authority_boundary": {
+                        "kind": "agentic-workspace/authority-boundary/v1",
+                        "surface": "verification.protocol",
+                        "authority_class": "advisory-support",
+                        "observed_by_aw": [
+                            f"configured verification protocol {protocol['id']}",
+                            *applies_because,
+                        ],
+                        "recommended_by_aw": ["run or record the configured verification evidence when agent judgment finds it relevant"],
+                        "agent_owned_decisions": [
+                            "whether the configured protocol is semantically relevant to the current work",
+                            "whether evidence is sufficient for the intended claim boundary",
+                        ],
+                        "human_owned_decisions": ["acceptance or waiver of manual verification gaps"],
+                        "reporting_rule": (
+                            "Verification task-marker matches are configured protocol evidence; AW reports them and does not "
+                            "classify user intent."
+                        ),
+                    },
+                }
+            )
             state = (
                 "satisfied"
                 if expected_evidence and not missing_evidence
@@ -664,6 +689,19 @@ def verification_report_payload(
         "configured": bool(manifest["configured"]),
         "path": manifest["path"],
         "rule": "Verification owns reusable protocols and bounded evidence records; Assurance requires evidence and Closeout decides claim honesty.",
+        "authority_boundary": {
+            "kind": "agentic-workspace/authority-boundary/v1",
+            "surface": "verification",
+            "authority_class": "advisory-support" if active_protocols else "observed-facts",
+            "observed_by_aw": ["verification manifest protocols/scenarios/evidence", "configured activation match facts"],
+            "recommended_by_aw": ["use active protocols as proof guidance when agent judgment finds they fit the task"],
+            "agent_owned_decisions": [
+                "semantic fit of configured verification protocols",
+                "proof sufficiency and claim-boundary judgment",
+            ],
+            "human_owned_decisions": ["acceptance or waiver of manual verification gaps"],
+            "reporting_rule": ("Verification is configured evidence and proof guidance; AW does not decide the user's semantic intent."),
+        },
         "protocol_count": len(configured_protocols),
         "scenario_count": len(configured_scenarios),
         "evidence_bundle_count": len(evidence_bundles),

--- a/packages/verification/tests/test_runtime_primitives.py
+++ b/packages/verification/tests/test_runtime_primitives.py
@@ -47,6 +47,40 @@ changed_paths = ["web/app.py"]
     assert payload["evidence_status"][0]["state"] == "satisfied"
 
 
+def test_verification_report_task_marker_match_reports_configured_protocol_authority(tmp_path: Path) -> None:
+    manifest = tmp_path / ".agentic-workspace" / "verification" / "manifest.toml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        """
+schema_version = "agentic-workspace/verification-manifest/v1"
+
+[protocols.privacy_review]
+title = "Privacy review"
+purpose = "Check privacy-sensitive behavior."
+applies_to_task_markers = ["privacy"]
+expected_evidence = ["privacy_reviewed"]
+review_owner = "privacy-owner"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(
+        target_root=tmp_path,
+        changed_paths=["README.md"],
+        task_text="Update privacy wording",
+    )
+
+    assert payload["status"] == "attention"
+    assert payload["active_protocols"][0]["id"] == "privacy_review"
+    assert payload["active_protocols"][0]["applies_because"] == ["task marker matched privacy"]
+    protocol_boundary = payload["active_protocols"][0]["authority_boundary"]
+    assert "configured verification protocol privacy_review" in protocol_boundary["observed_by_aw"]
+    assert "task marker matched privacy" in protocol_boundary["observed_by_aw"]
+    assert "whether the configured protocol is semantically relevant to the current work" in protocol_boundary["agent_owned_decisions"]
+    assert "does not classify user intent" in protocol_boundary["reporting_rule"]
+    assert "does not decide the user's semantic intent" in payload["authority_boundary"]["reporting_rule"]
+
+
 def test_verification_report_rejects_protocol_without_activation(tmp_path: Path) -> None:
     manifest = tmp_path / ".agentic-workspace" / "verification" / "manifest.toml"
     manifest.parent.mkdir(parents=True)

--- a/scripts/check/check_prompt_semantic_markers.py
+++ b/scripts/check/check_prompt_semantic_markers.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKSPACE_RUNTIME = REPO_ROOT / "src" / "agentic_workspace" / "workspace_runtime_primitives.py"
+
+GUARDED_FUNCTIONS = {
+    "_architecture_decision_signal",
+    "_completion_closeout_inspection_payload",
+    "_intent_acknowledgement_payload",
+    "_intent_discovery_dialogue_payload",
+    "_objective_drift_payload",
+    "_is_completion_status_task",
+    "_is_config_posture_task",
+    "_is_prep_only_handoff_task",
+    "_task_intent_promotion_guidance_payload",
+    "_vague_outcome_orientation_payload",
+}
+
+DENIED_FUNCTION_NAMES = {
+    "_task_has_removal_intent",
+}
+
+DENIED_LOCAL_NAMES = {
+    "broad_markers",
+    "completion_markers",
+    "direct_markers",
+    "durable_markers",
+    "future_or_handoff",
+    "high_stakes_markers",
+    "implementation_blocked",
+    "non_direct_markers",
+    "posture_markers",
+    "prep_or_plan",
+    "question_starters",
+    "question_terms",
+    "removal_intent",
+    "removal_markers",
+    "retirement_markers",
+    "scope_terms",
+}
+
+DENIED_MODULE_CONSTANTS = {
+    "_ARCHITECTURE_DECISION_MARKERS",
+}
+
+
+def _string_sequence(node: ast.AST) -> bool:
+    if not isinstance(node, ast.List | ast.Tuple | ast.Set):
+        return False
+    return len(node.elts) >= 2 and all(isinstance(item, ast.Constant) and isinstance(item.value, str) for item in node.elts)
+
+
+def _assigned_names(target: ast.AST) -> list[str]:
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Tuple | ast.List):
+        names: list[str] = []
+        for item in target.elts:
+            names.extend(_assigned_names(item))
+        return names
+    return []
+
+
+def prompt_semantic_marker_findings(source_path: Path = WORKSPACE_RUNTIME) -> list[str]:
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    findings: list[str] = []
+    try:
+        source_label = source_path.relative_to(REPO_ROOT)
+    except ValueError:
+        source_label = source_path
+
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names = [name for target in node.targets for name in _assigned_names(target)]
+            for name in names:
+                if name in DENIED_MODULE_CONSTANTS and _string_sequence(node.value):
+                    findings.append(f"{source_label}:{node.lineno}: denied prompt marker constant {name}")
+        if isinstance(node, ast.FunctionDef) and node.name in DENIED_FUNCTION_NAMES:
+            findings.append(f"{source_label}:{node.lineno}: denied prompt semantic classifier {node.name}")
+        if not isinstance(node, ast.FunctionDef) or node.name not in GUARDED_FUNCTIONS:
+            continue
+        for child in ast.walk(node):
+            if isinstance(child, ast.Assign):
+                names = [name for target in child.targets for name in _assigned_names(target)]
+                for name in names:
+                    if name in DENIED_LOCAL_NAMES:
+                        findings.append(
+                            f"{source_label}:{child.lineno}: {node.name} assigns denied prompt semantic marker {name}"
+                        )
+                    elif name.endswith("_markers") and _string_sequence(child.value):
+                        findings.append(
+                            f"{source_label}:{child.lineno}: {node.name} assigns prompt marker table {name}"
+                        )
+    return findings
+
+
+def main() -> int:
+    findings = prompt_semantic_marker_findings()
+    if findings:
+        print("Hardcoded prompt semantic marker findings:")
+        for finding in findings:
+            print(f"- {finding}")
+        print("Use structural parsing or configured/learned surfaces with explicit authority boundaries instead.")
+        return 1
+    print("[ok] no hardcoded prompt semantic marker tables in guarded startup/routing functions")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -169,17 +169,17 @@
     },
     "assurance_requirements": {
       "type": "object",
-      "description": "Repo-declared assurance requirements matched to the task or changed paths, with evidence status and claim-boundary facts.",
+      "description": "Repo-declared assurance requirements matched to the task or changed paths, with evidence status and claim-boundary facts; task-marker matches cite explicit config while semantic acceptance remains agent/human owned.",
       "additionalProperties": true
     },
     "verification": {
       "type": "object",
-      "description": "Matched repo-native verification protocols and bounded evidence status for the task or changed paths.",
+      "description": "Matched repo-native verification protocols and bounded evidence status for the task or changed paths; task-marker matches are configured protocol evidence, not AW-owned intent classification.",
       "additionalProperties": true
     },
     "routine_work_context": {
       "type": "object",
-      "description": "Assembled routine router projection grouping existing owner surfaces into authority, active work, evidence/proof, durable knowledge, and promotion/residue.",
+      "description": "Assembled routine router projection grouping existing owner surfaces into authority, active work, evidence/proof, durable knowledge, and promotion/residue; configured or learned Memory matches remain owner-surface evidence, not AW-owned semantic classification.",
       "additionalProperties": true
     },
     "objective_drift": {
@@ -511,6 +511,14 @@
           },
           "description": "Requested terms that were not observed in changed files."
         },
+        "removed_or_retired_outcomes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Requested outcome the agent explicitly reconciled as removed or retired."
+          },
+          "description": "Reserved for explicit reconciliation evidence; AW does not infer removal or retirement from prompt keyword markers."
+        },
         "rule": {
           "type": "string",
           "description": "Closeout rule agents should apply when drift is suspected."
@@ -522,6 +530,14 @@
         "heuristic": {
           "type": "string",
           "description": "Brief explanation of the comparison method."
+        },
+        "agent_owned_decisions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Objective-drift judgment the agent owns."
+          },
+          "description": "Semantic acceptance decisions AW must not infer from prompt keyword markers."
         }
       },
       "additionalProperties": false,
@@ -862,7 +878,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Heuristic durable-intent markers found in task text."
+          "description": "Reserved for structural or configured evidence; AW does not infer durable intent from prompt keyword markers."
         },
         "rule": {
           "type": "string",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -190,7 +190,7 @@
     },
     "routine_work_context": {
       "type": "object",
-      "description": "Assembled routine router projection grouping existing owner surfaces into authority, active work, evidence/proof, durable knowledge, and promotion/residue."
+      "description": "Assembled routine router projection grouping existing owner surfaces into authority, active work, evidence/proof, durable knowledge, and promotion/residue; configured or learned Memory matches remain owner-surface evidence, not AW-owned semantic classification."
     },
     "reuse_pressure": {
       "type": "object",
@@ -222,11 +222,11 @@
     },
     "assurance_requirements": {
       "type": "object",
-      "description": "Repo-declared assurance requirements, active matches, and evidence status projection."
+      "description": "Repo-declared assurance requirements, active matches, and evidence status projection; task-marker matches cite explicit config while semantic acceptance remains agent/human owned."
     },
     "verification": {
       "type": "object",
-      "description": "Repo-native verification protocols, scenarios, bounded evidence bundles, and soft verification routing projection."
+      "description": "Repo-native verification protocols, scenarios, bounded evidence bundles, and soft verification routing projection; task-marker matches are configured protocol evidence, not AW-owned intent classification."
     },
     "authority_hierarchy": {
       "type": "object",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -820,7 +820,26 @@ def _assurance_requirements_report_payload(
             }
         )
         if matched:
-            active.append({**requirement, "applies_because": applies_because})
+            active.append(
+                {
+                    **requirement,
+                    "applies_because": applies_because,
+                    "authority_boundary": _authority_boundary_payload(
+                        surface="assurance_requirements.requirement",
+                        observed_by_aw=[
+                            f"configured assurance requirement {requirement['id']}",
+                            *applies_because,
+                        ],
+                        recommended_by_aw=["honor configured evidence/review/claim-boundary obligations before closeout"],
+                        agent_owned_decisions=[
+                            "whether the current task intent is satisfied",
+                            "whether evidence is sufficient to claim completion",
+                        ],
+                        human_owned_decisions=["waiver, dismissal, or acceptance when required evidence is unavailable"],
+                        rule="Assurance task-marker matches are explicit config evidence; AW reports configured pressure and does not decide user intent.",
+                    ),
+                }
+            )
             evidence_status.append(status)
     required_missing = [
         item
@@ -832,6 +851,17 @@ def _assurance_requirements_report_payload(
         "kind": "agentic-workspace/assurance-requirements/v1",
         "status": "attention" if required_missing else "matched" if active else "configured" if configured else "absent",
         "rule": "Repo-declared assurance requirements are domain-generic routing and claim-boundary facts; AW does not certify compliance.",
+        "authority_boundary": _authority_boundary_payload(
+            surface="assurance_requirements",
+            observed_by_aw=["repo-declared assurance configuration", "changed-path/task-marker/planning match facts"],
+            recommended_by_aw=["carry configured evidence, review-owner, and blocking-claim obligations into proof and closeout"],
+            agent_owned_decisions=[
+                "semantic user-intent acceptance",
+                "whether proof and evidence justify a completion claim",
+            ],
+            human_owned_decisions=["waiver, dismissal, or final acceptance for configured assurance exceptions"],
+            rule="Assurance requirements are configured claim-boundary evidence; AW does not classify the task's semantic intent.",
+        ),
         "configured_count": len(configured),
         "active_count": len(active),
         "missing_required_evidence_count": len(required_missing),
@@ -11546,6 +11576,20 @@ def _knowledge_authority_review_payload(
                     if item
                 ],
             },
+            "authority_boundary": _authority_boundary_payload(
+                surface="knowledge_authority_review.memory_source",
+                observed_by_aw=[
+                    "Memory manifest metadata",
+                    "Memory route/use_when/task-relevance match evidence",
+                ],
+                recommended_by_aw=["read or review the matched Memory owner surface when agent judgment finds it relevant"],
+                agent_owned_decisions=[
+                    "whether the matched Memory fact is semantically relevant to the task",
+                    "whether to rely on, refresh, promote, or ignore the matched note",
+                ],
+                human_owned_decisions=["semantic acceptance of repo knowledge when Memory evidence conflicts with current intent"],
+                rule="Memory matches are Memory-owned configured or learned evidence; AW reports the match and does not classify user intent.",
+            ),
         }
         matched_sources.append(source)
         if len(matched_sources) >= 5:
@@ -11569,6 +11613,13 @@ def _knowledge_authority_review_payload(
                 },
                 "supersession": {"status": "none", "why": ""},
                 "claim_effect": {"blocks": [], "advises": ["route promotion or dismissal during closeout"]},
+                "authority_boundary": _authority_boundary_payload(
+                    surface="knowledge_authority_review.memory_source",
+                    observed_by_aw=["Memory promotion pressure sample"],
+                    recommended_by_aw=["route or dismiss the Memory promotion pressure"],
+                    agent_owned_decisions=["whether the promotion pressure is semantically relevant to the current task"],
+                    rule="Memory promotion pressure is Memory-owned evidence; AW does not classify user intent from it.",
+                ),
             }
         )
         if len(matched_sources) >= 5:
@@ -11587,6 +11638,17 @@ def _knowledge_authority_review_payload(
         "promotion_candidate_count": promotion_count,
         "supersession_attention_count": supersession_count,
         "rule": "Compose existing Memory metadata, workflow obligations, proof, and closeout effects; do not create a new knowledge owner.",
+        "authority_boundary": _authority_boundary_payload(
+            surface="knowledge_authority_review",
+            observed_by_aw=["Memory manifest metadata", "workflow obligation match facts", "promotion pressure samples"],
+            recommended_by_aw=["inspect matched owner surfaces before relying on durable repo knowledge"],
+            agent_owned_decisions=[
+                "semantic relevance of matched Memory/config evidence",
+                "whether matched evidence changes the implementation or closeout decision",
+            ],
+            human_owned_decisions=["final semantic acceptance when matched durable knowledge conflicts with user intent"],
+            rule="AW assembles Memory/config evidence and owner surfaces; it does not make semantic task classifications.",
+        ),
         "next_actions": [],
     }
     if promotion_count:
@@ -16074,137 +16136,34 @@ def _compact_start_prep_only_handoff(value: Any) -> dict[str, Any]:
 
 
 def _is_prep_only_handoff_task(task_text: str | None) -> bool:
-    normalized = " ".join((task_text or "").lower().split())
-    if not normalized:
-        return False
-    future_or_handoff = any(
-        (
-            marker in normalized
-            for marker in (
-                "future agent",
-                "later agent",
-                "later coding pass",
-                "future coding pass",
-                "durable state",
-                "durable implementation",
-                "plan/state",
-                "repository state",
-                "repo-visible state",
-                "handoff",
-                "continue later",
-                "continuation",
-                "prepare enough",
-                "groundwork",
-                "later pass",
-                "next pass",
-                "first slice",
-                "safe start",
-                "prepare the repo",
-                "prepare repository",
-                "future",
-                "ready for",
-            )
-        )
-    )
-    prep_or_plan = any((marker in normalized for marker in ("prepare", "plan", "decompose", "shape", "scaffold planning")))
-    implementation_blocked = any(
-        (
-            marker in normalized
-            for marker in (
-                "do not implement",
-                "don't implement",
-                "without implementing",
-                "not implement",
-                "no implementation",
-                "no code changes",
-                "no feature implementation",
-                "do not build",
-                "don't build",
-                "do not scaffold",
-                "don't scaffold",
-                "not build",
-            )
-        )
-    )
-    return future_or_handoff and (prep_or_plan or implementation_blocked)
+    _ = task_text
+    return False
 
 
 def _is_config_posture_task(task_text: str | None) -> bool:
-    normalized = " ".join((task_text or "").lower().split())
-    if not normalized:
-        return False
-    posture_markers = (
-        "configured operating",
-        "operating posture",
-        "reporting posture",
-        "closeout setting",
-        "closeout settings",
-        "reporting setting",
-        "reporting settings",
-        "repository-specific closeout",
-        "repo-specific closeout",
-        "configured operating settings",
-        "configured settings",
-        "config settings",
-        "local runtime settings",
-        "delegation posture",
-        "safe_to_auto_run_commands",
-        "improvement_latitude",
-        "optimization_bias",
-        "workflow_obligations",
-    )
-    return any((marker in normalized for marker in posture_markers))
+    _ = task_text
+    return False
 
 
 def _is_completion_status_task(task_text: str | None) -> bool:
-    normalized = " ".join((task_text or "").lower().split())
-    if not normalized:
-        return False
-    completion_markers = (
-        "is the work complete",
-        "is this work complete",
-        "is it complete",
-        "how much remains",
-        "what remains",
-        "what is left",
-        "can this lane be considered done",
-        "can the lane be considered done",
-        "is the lane done",
-        "is this lane done",
-        "is the epic satisfied",
-        "is this epic satisfied",
-        "is the epic done",
-        "completion status",
-        "status of completion",
-        "ready to close",
-        "can we close",
-        "can i close",
-        "can this be closed",
-        "can this issue be closed",
-        "can this lane close",
-        "can this lane be closed",
-        "considered done",
-    )
-    if any((marker in normalized for marker in completion_markers)):
-        return True
-    question_terms = ("complete", "completed", "done", "closed", "satisfied", "finished", "remaining", "remains")
-    scope_terms = ("work", "lane", "epic", "issue", "task", "milestone", "closeout", "closure")
-    question_starters = ("is ", "are ", "can ", "should ", "how ", "what ")
-    return (
-        normalized.endswith("?")
-        and normalized.startswith(question_starters)
-        and any((term in normalized for term in question_terms))
-        and any((term in normalized for term in scope_terms))
-    )
+    _ = task_text
+    return False
 
 
-def _completion_closeout_inspection_payload(*, target_root: Path, config: WorkspaceConfig, task_text: str | None) -> dict[str, Any]:
+def _completion_closeout_inspection_payload(
+    *, target_root: Path, config: WorkspaceConfig, task_text: str | None, explicit_request: bool = False
+) -> dict[str, Any]:
     target_arg = _command_target_arg(target_root)
     command = _command_with_cli_invoke(
         command=f"agentic-workspace report --target {target_arg} --section closeout_trust --format json", cli_invoke=config.cli_invoke
     )
-    if not _is_completion_status_task(task_text):
-        return {"status": "not-applicable", "reason": "current task is not completion/status oriented", "detail_command": command}
+    if not explicit_request and not _is_completion_status_task(task_text):
+        return {
+            "status": "not-applicable",
+            "reason": "task-text semantics are agent-owned; AW does not infer completion/status posture from prompt keywords",
+            "detail_command": command,
+            "agent_owned_decision": "whether the user is asking for completion, status, or closeout judgment",
+        }
     try:
         from repo_planning_bootstrap.installer import planning_report
     except ImportError:
@@ -16227,9 +16186,9 @@ def _completion_closeout_inspection_payload(*, target_root: Path, config: Worksp
     needs_surface = trust != "normal" or lower_trust_count > 0 or gate_blocking
     return {
         "status": "required" if needs_surface else "clear",
-        "reason": "completion/status question must inspect closeout_trust before claiming broad work is done"
+        "reason": "explicit closeout_trust inspection found residue to reconcile before claiming broad work is done"
         if needs_surface
-        else "completion/status question inspected closeout_trust and found no lower-trust blocker",
+        else "explicit closeout_trust inspection found no lower-trust blocker",
         "trust": trust,
         "lower_trust_closeout_count": lower_trust_count,
         "strict_closeout_gate": {key: strict_gate.get(key) for key in ("status", "blocking", "summary", "reason") if key in strict_gate},
@@ -16241,7 +16200,14 @@ def _completion_closeout_inspection_payload(*, target_root: Path, config: Worksp
         "sample_signals": closeout.get("sample_signals", [])[:2] if isinstance(closeout.get("sample_signals"), list) else [],
         "required_next_inspection": command,
         "detail_command": command,
-        "rule": "Do not answer done/complete/closeable for lane, epic, or broad work without reconciling this surface.",
+        "rule": "Do not answer done/complete/closeable for lane, epic, or broad work without reconciling this surface when agent judgment says the user is asking for closeout status.",
+        "authority_boundary": _authority_boundary_payload(
+            surface="closeout_trust_inspection",
+            observed_by_aw=["closeout_trust report facts", "strict closeout gate state"],
+            recommended_by_aw=["inspect closeout_trust before broad completion/status claims"],
+            agent_owned_decisions=["whether the user is asking for a completion/status judgment"],
+            rule="AW reports closeout residue when asked; it does not infer completion/status intent from prompt keywords.",
+        ),
     }
 
 
@@ -16846,6 +16812,57 @@ def _select_payload_fields(payload: dict[str, Any], *, select: str | None, sourc
         selected["selector_rule"] = "Comma-separated dot paths select exact JSON fields; unknown fields are reported in missing."
         selected["available_selectors"] = _available_selectors_for_payload(payload)
     return selected
+
+
+def _selector_requests(select: str | None, key: str) -> bool:
+    return any(token == key or token.startswith(f"{key}.") for token in _selector_tokens(select))
+
+
+def _hydrate_selected_start_advisory_payloads(
+    *,
+    payload: dict[str, Any],
+    select: str | None,
+    target_root: Path,
+    task_text: str | None,
+    config: WorkspaceConfig,
+) -> None:
+    vague_orientation: dict[str, Any] | None = None
+    if _selector_requests(select, "vague_outcome_orientation"):
+        vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
+        payload.setdefault("vague_outcome_orientation", vague_orientation)
+    if _selector_requests(select, "intent_discovery_dialogue"):
+        if vague_orientation is None:
+            vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
+        payload.setdefault(
+            "intent_discovery_dialogue",
+            _intent_discovery_dialogue_payload(
+                task_text=task_text,
+                vague_orientation=vague_orientation,
+                cli_invoke=config.cli_invoke,
+            ),
+        )
+    if _selector_requests(select, "intent_acknowledgement"):
+        if vague_orientation is None:
+            vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
+        execution_posture = _execution_posture_payload(config=config, changed_paths=[], task_text=task_text, target_root=target_root)
+        payload.setdefault(
+            "intent_acknowledgement",
+            _intent_acknowledgement_payload(
+                task_text=task_text,
+                execution_posture=execution_posture,
+                vague_orientation=vague_orientation,
+            ),
+        )
+    if _selector_requests(select, "closeout_trust_inspection"):
+        payload.setdefault(
+            "closeout_trust_inspection",
+            _completion_closeout_inspection_payload(
+                target_root=target_root,
+                config=config,
+                task_text=task_text,
+                explicit_request=True,
+            ),
+        )
 
 
 def _select_summary_payload(
@@ -18323,41 +18340,16 @@ def _task_acceptance_payload(*, task_text: str | None, requested_outcomes: list[
     }
 
 
-_ARCHITECTURE_DECISION_MARKERS = (
-    "adr",
-    "architecture decision",
-    "architectural decision",
-    "decision record",
-    "database system",
-    "database migration",
-    "storage migration",
-    "storage engine",
-    "schema strategy",
-    "security posture",
-    "compliance boundary",
-    "api contract",
-    "api boundary",
-    "domain boundary",
-)
-
-
 def _architecture_decision_signal(*, task_text: str | None, changed_paths: Sequence[str] = ()) -> dict[str, Any]:
-    normalized = " ".join(str(task_text or "").lower().split())
-    matched = [marker for marker in _ARCHITECTURE_DECISION_MARKERS if marker in normalized]
-    if any(marker in normalized for marker in ("migration", "migrate", "migrated", "migrating")) and any(
-        token in normalized for token in ("database", "storage", "schema")
-    ):
-        matched.append("migration + database/storage/schema")
-    if "change" in normalized and any(token in normalized for token in ("database", "storage engine", "schema", "api contract")):
-        matched.append("change + architecture surface")
+    _ = task_text
     decision_path_matches = [
         path
         for path in _normalize_changed_paths(list(changed_paths))
         if any(part in path.lower().split("/") for part in ("adr", "adrs", "decisions"))
     ]
     return {
-        "status": "candidate" if matched or decision_path_matches else "not-detected",
-        "matched_markers": sorted(dict.fromkeys(matched))[:8],
+        "status": "candidate" if decision_path_matches else "not-detected",
+        "matched_markers": [],
         "decision_path_matches": decision_path_matches[:6],
     }
 
@@ -18405,11 +18397,11 @@ def _architecture_decision_candidate_payload(
             "target": str(config_info.get("target", "")) if has_decision_target else ".agentic-workspace/memory/repo/decisions/",
             "command": scaffold_command if has_decision_target else memory_command,
             "command_target": _decision_command_placeholder_payload(),
-            "why": "Route architecture decisions directly to the host decision-record target when one is configured or discoverable."
+            "why": "Changed decision/ADR paths indicate a structural decision-record surface; route through the host decision target when one is configured or discoverable."
             if has_decision_target
-            else "No decision-record target is configured or discoverable; preserve a typed promotion-ready memory candidate instead of a generic note.",
+            else "Changed decision/ADR paths indicate durable decision residue, but no decision-record target is configured or discoverable; preserve a typed promotion-ready memory candidate instead of a generic note.",
         },
-        "rule": "This is an attention signal, not an instruction to force an ADR for every task.",
+        "rule": "This structural path signal is advisory; the agent owns whether the changed surface represents a durable architecture decision.",
     }
 
 
@@ -18430,25 +18422,6 @@ def _task_intent_promotion_guidance_payload(
             "reason": "no task text was provided",
             "route_options": [],
         }
-    normalized = task.lower()
-    durable_markers = (
-        "should",
-        "must",
-        "always",
-        "never",
-        "prefer",
-        "optimi",
-        "easy to",
-        "auditable",
-        "invariant",
-        "system intent",
-        "subsystem",
-        "durable",
-        "over time",
-        "going forward",
-        "from now on",
-    )
-    matched = [marker for marker in durable_markers if marker in normalized]
     architecture_candidate = _architecture_decision_candidate_payload(
         task_text=task,
         target_root=target_root,
@@ -18456,7 +18429,7 @@ def _task_intent_promotion_guidance_payload(
         changed_paths=changed_paths,
         cli_invoke=cli_invoke,
     )
-    status = "candidate" if matched or architecture_candidate.get("status") == "candidate" else "no-durable-signal"
+    status = "candidate" if architecture_candidate.get("status") == "candidate" else "available"
     items = acceptance.get("items", []) if isinstance(acceptance, dict) else []
     route_options = [
         {
@@ -18483,11 +18456,22 @@ def _task_intent_promotion_guidance_payload(
     payload: dict[str, Any] = {
         "kind": "agentic-workspace/task-intent-promotion-guidance/v1",
         "status": status,
-        "matched_markers": matched[:6],
-        "rule": "If task intent expresses a lasting direction rather than a finishable task, route the reusable part to Memory, docs, subsystem intent, or system intent before closeout.",
+        "matched_markers": [],
+        "rule": "AW does not infer durable intent from prompt keywords. The agent owns whether the task revealed reusable knowledge or lasting direction.",
         "route_options": route_options,
         "acceptance_item_count": len(items) if isinstance(items, list) else 0,
         "closeout_question": "Does any acceptance item encode durable intent that should survive beyond this task?",
+        "authority_boundary": _authority_boundary_payload(
+            surface="durable_intent_promotion",
+            observed_by_aw=[f"changed_path_count={len(_normalize_changed_paths(list(changed_paths)))}"],
+            recommended_by_aw=["consider Memory, Planning, docs, or decision-record promotion when the agent has explicit evidence"],
+            proof_hints=["cite changed durable surfaces, Memory/Planning/configured evidence, or agent-stated rationale before promotion"],
+            agent_owned_decisions=[
+                "whether the task revealed durable knowledge",
+                "which owner surface should retain reusable guidance",
+            ],
+            rule="AW provides route options and structural hints; the agent owns durable intent judgment.",
+        ),
     }
     if architecture_candidate.get("status") == "candidate":
         payload["architecture_decision_candidate"] = architecture_candidate
@@ -18623,7 +18607,7 @@ def _intent_acknowledgement_payload(
     *, task_text: str | None, execution_posture: dict[str, Any], vague_orientation: dict[str, Any] | None = None
 ) -> dict[str, Any]:
     task = str(task_text or "").strip()
-    task_lower = " ".join(task.lower().split())
+    _ = (execution_posture, vague_orientation)
     if not task:
         return {
             "kind": "agentic-workspace/intent-acknowledgement/v1",
@@ -18631,54 +18615,41 @@ def _intent_acknowledgement_payload(
             "decision": "silent-ok",
             "reason": "No task text was provided, so there is no inferred user intent to restate.",
         }
-    direct_markers = ("typo", "spelling", "one-line", "one line", "formatting", "format only", "rename", "fix lint", "fix the lint")
-    non_direct_markers = (
-        "implement",
-        "improve",
-        "optimise",
-        "optimize",
-        "evaluate",
-        "review",
-        "design",
-        "refactor",
-        "decompose",
-        "plan",
-        "lane",
-        "epic",
-        "workflow",
-        "delegation",
-        "intent",
-        "satisfaction",
-        "handoff",
-        "schema",
-        "contract",
-        "configuration",
-        "config",
-    )
-    vague_applies = bool(isinstance(vague_orientation, dict) and vague_orientation.get("applies_to_current_task"))
     has_issue_ref = bool(re.search("#\\d+", task))
-    direct_only = any((marker in task_lower for marker in direct_markers)) and (
-        not any((marker in task_lower for marker in non_direct_markers))
-    )
-    should_state = vague_applies or has_issue_ref or any((marker in task_lower for marker in non_direct_markers))
-    if direct_only or not should_state:
+    if not has_issue_ref:
         return {
             "kind": "agentic-workspace/intent-acknowledgement/v1",
             "status": "available",
             "decision": "silent-ok",
-            "reason": "Task appears direct enough that a separate stated-assumption preface is optional.",
-            "use_stated_assumption_when": "Use the middle path if the edit stops being obvious, proof becomes non-obvious, or scope starts to widen.",
+            "reason": "Task-text semantics are agent-owned; AW does not infer whether a stated-assumption preface is required from prompt keywords.",
+            "agent_owned_decision": "whether to state inferred intent, first slice, non-goals, and correction point before editing",
+            "authority_boundary": _authority_boundary_payload(
+                surface="intent_acknowledgement",
+                observed_by_aw=["task_text_available=True"],
+                recommended_by_aw=["state assumptions when agent judgment finds intent risk"],
+                agent_owned_decisions=["whether a stated-assumption preface is needed before editing"],
+                human_owned_decisions=["corrected intent or non-goals when the stated assumption is wrong"],
+                rule="AW exposes an acknowledgement contract; it does not infer preface requirements from prompt keywords.",
+            ),
         }
     return {
         "kind": "agentic-workspace/intent-acknowledgement/v1",
         "status": "recommended",
         "decision": "proceed-with-stated-assumption",
-        "rule": "Before editing non-direct or vague-outcome work, briefly state the inferred intent and first slice, then proceed unless corrected.",
+        "rule": "Issue references are structural external-intent handles; briefly state the inferred issue-backed intent and first slice before editing.",
         "before_editing": ["inferred_intent", "concrete_first_slice", "non_goals_or_deferred_scope", "correction_point"],
         "correction_point": "Say that you will proceed on the stated interpretation unless the user corrects it.",
-        "silent_inference_ok_when": "The change is direct, local, low-risk, and validation is obvious.",
-        "ask_human_when": "Stop for clarification only when the intent, authority boundary, safety risk, or required input blocks choosing a bounded first slice.",
+        "silent_inference_ok_when": "The agent judges the task direct, local, low-risk, and validation is obvious.",
+        "ask_human_when": "Stop for clarification only when the agent judges intent, authority boundary, safety risk, or required input blocks choosing a bounded first slice.",
         "template": "Inferred intent: <outcome>. First slice: <bounded work>. Non-goals/deferred: <scope>. I will proceed on that interpretation unless corrected.",
+        "authority_boundary": _authority_boundary_payload(
+            surface="intent_acknowledgement",
+            observed_by_aw=["external issue reference present in task text"],
+            recommended_by_aw=["state the issue-backed interpretation before editing"],
+            agent_owned_decisions=["the concrete first slice and non-goals inferred from refreshed issue evidence"],
+            human_owned_decisions=["corrections to the issue-backed interpretation"],
+            rule="Issue references are structural handles; AW recommends acknowledgement but the agent owns the interpretation.",
+        ),
     }
 
 
@@ -18943,46 +18914,6 @@ def _read_changed_surface_text(*, target_root: Path, changed_paths: list[str], m
     return "\n".join(chunks)
 
 
-def _task_has_removal_intent(task_text: str | None) -> bool:
-    normalized = " ".join(str(task_text or "").lower().split())
-    return any(
-        (
-            marker in normalized
-            for marker in (
-                "delete",
-                "deleted",
-                "deleting",
-                "remove",
-                "removed",
-                "removing",
-                "retire",
-                "retired",
-                "retiring",
-                "drop",
-                "dropped",
-                "dropping",
-                "get rid of",
-            )
-        )
-    )
-
-
-def _outcome_matches_changed_path(outcome: str, changed_paths: list[str]) -> bool:
-    needle = outcome.lower().strip().strip("`'\".,:;()[]{}")
-    if not needle:
-        return False
-    for raw_path in changed_paths:
-        normalized = str(raw_path).replace("\\", "/").lower().strip("/")
-        if not normalized:
-            continue
-        parts = [part for part in normalized.split("/") if part]
-        if needle == normalized or needle in parts:
-            return True
-        if "/" not in needle and parts and (needle == parts[-1]):
-            return True
-    return False
-
-
 def _objective_drift_payload(*, target_root: Path, changed_paths: list[str], task_text: str | None) -> dict[str, Any]:
     requested_outcomes = _extract_requested_outcomes(task_text)
     acceptance = _task_acceptance_payload(task_text=task_text, requested_outcomes=requested_outcomes)
@@ -19007,9 +18938,8 @@ def _objective_drift_payload(*, target_root: Path, changed_paths: list[str], tas
         }
     surface_text = _read_changed_surface_text(target_root=target_root, changed_paths=changed_paths)
     searchable = surface_text.lower()
-    removal_intent = _task_has_removal_intent(task_text)
-    removed_or_retired = [item for item in requested_outcomes if removal_intent and _outcome_matches_changed_path(item, changed_paths)]
-    missing = [item for item in requested_outcomes if item.lower() not in searchable and item not in removed_or_retired]
+    removed_or_retired: list[str] = []
+    missing = [item for item in requested_outcomes if item.lower() not in searchable]
     status = "warning" if missing and changed_paths else "clear"
     return {
         "kind": "agentic-workspace/objective-drift/v1",
@@ -19023,7 +18953,11 @@ def _objective_drift_payload(*, target_root: Path, changed_paths: list[str], tas
         "recommended_next_action": "Inspect changed files, exports, docs, and tests for the missing requested outcomes before closeout."
         if status == "warning"
         else "Use acceptance reconciliation before closeout.",
-        "heuristic": "identifier and backtick-term overlap between task text and changed file contents; explicit removal or retirement intent may satisfy an outcome through a matching changed path",
+        "heuristic": "identifier and backtick-term overlap between task text and changed file contents; AW does not infer removal or retirement intent from prompt keywords",
+        "agent_owned_decisions": [
+            "whether a missing requested outcome was intentionally removed, retired, replaced, or out of scope",
+            "whether proof and acceptance reconciliation justify marking the missing outcome satisfied",
+        ],
     }
 
 
@@ -20868,6 +20802,8 @@ def _tiny_objective_drift(value: Any) -> dict[str, Any]:
         "removed_or_retired_outcomes": value.get("removed_or_retired_outcomes", []),
         "missing_from_changed_surface": value.get("missing_from_changed_surface", []),
         "recommended_next_action": value.get("recommended_next_action", ""),
+        "heuristic": value.get("heuristic", ""),
+        "agent_owned_decisions": value.get("agent_owned_decisions", [])[:2] if isinstance(value.get("agent_owned_decisions"), list) else [],
     }
 
 
@@ -25675,28 +25611,12 @@ def _task_skill_recommendations_payload(
 
 
 def _vague_outcome_orientation_payload(*, task_text: str | None, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
-    task_lower = (task_text or "").lower()
-    markers = (
-        "feel more trustworthy",
-        "trustworthy",
-        "trust",
-        "repeat what i meant",
-        "what i meant",
-        "less rework",
-        "rework",
-        "handoff",
-        "hand work back",
-        "intended outcome",
-        "intent",
-        "vague outcome",
-        "satisfaction",
-        "satisfied",
-    )
-    applies = bool(task_lower and any((marker in task_lower for marker in markers)))
+    applies = False
+    task_present = bool(str(task_text or "").strip())
     return {
-        "status": "applicable" if applies else "available",
+        "status": "available",
         "applies_to_current_task": applies,
-        "rule": "For vague outcome prompts, resolve intent and satisfaction evidence from compact CLI output before raw workspace reads.",
+        "rule": "AW does not infer vague-outcome status from prompt keywords; the agent owns whether this guidance applies.",
         "first_surface": "startup_guidance.primary_next_action from preflight or immediate_next_allowed_action from start",
         "compact_commands": [
             _command_with_cli_invoke(command='agentic-workspace preflight --target . --task "<task>" --format json', cli_invoke=cli_invoke),
@@ -25712,6 +25632,7 @@ def _vague_outcome_orientation_payload(*, task_text: str | None, cli_invoke: str
             "separate one possible solution from the intended outcome",
         ],
         "raw_read_rule": "Open raw .agentic-workspace files only after compact output points there or the CLI is unavailable.",
+        "task_text_available": task_present,
     }
 
 
@@ -25719,7 +25640,7 @@ def _intent_discovery_dialogue_payload(
     *, task_text: str | None, vague_orientation: dict[str, Any] | None = None, cli_invoke: str = DEFAULT_CLI_INVOKE
 ) -> dict[str, Any]:
     task = str(task_text or "").strip()
-    task_lower = " ".join(task.lower().split())
+    _ = vague_orientation
     skill_command = _command_with_cli_invoke(
         command=f"agentic-workspace skills --target . --task {_shell_quote(task or '<task>')} --format json",
         cli_invoke=cli_invoke,
@@ -25771,101 +25692,16 @@ def _intent_discovery_dialogue_payload(
             "examples": examples,
         }
 
-    direct_markers = ("typo", "spelling", "formatting", "rename", "fix lint", "readme.md")
-    broad_markers = (
-        "improve",
-        "better",
-        "build",
-        "design",
-        "implement",
-        "create",
-        "make",
-        "workflow",
-        "protocol",
-        "onboarding",
-        "experience",
-        "system",
-        "architecture",
-        "planning",
-        "intent",
-        "clarify",
-        "discover",
-        "trust",
-        "safe",
-    )
-    high_stakes_markers = (
-        "workflow",
-        "protocol",
-        "planning",
-        "architecture",
-        "migration",
-        "auth",
-        "security",
-        "delete",
-        "remove",
-        "production",
-        "system",
-        "all",
-    )
-    question_words = ("why", "outcome", "non-goal", "scope", "first slice", "acceptable")
-    has_issue_ref = bool(re.search(r"#\d+\b", task))
-    has_named_path = bool(re.search(r"\b[\w./-]+\.(md|py|json|toml|ts|tsx|js|mjs|yaml|yml)\b", task_lower))
-    token_count = len(task_lower.split())
-    broad_signal = any(marker in task_lower for marker in broad_markers)
-    direct_signal = any(marker in task_lower for marker in direct_markers) or has_named_path
-    explicit_workflow_instruction = any(
-        marker in task_lower for marker in ("decompose", "epic", "lane", "execplan", "active planning", "implement #")
-    )
-    task_already_answers_intent = sum(1 for marker in question_words if marker in task_lower) >= 2
-    vague_applies = bool(isinstance(vague_orientation, dict) and vague_orientation.get("applies_to_current_task"))
-    confidence = "high" if direct_signal or task_already_answers_intent or has_issue_ref else "medium"
-    if (broad_signal and token_count <= 8) or (vague_applies and token_count <= 18):
-        confidence = "low"
-    if has_issue_ref and token_count <= 4:
-        confidence = "medium"
-    stakes = "high" if any(marker in task_lower for marker in high_stakes_markers) or (broad_signal and not direct_signal) else "medium"
-    if direct_signal and not broad_signal:
-        stakes = "low"
-    should_ask = confidence == "low" and stakes == "high" and not explicit_workflow_instruction
-    should_acknowledge = (
-        (confidence in {"low", "medium"} or broad_signal or has_issue_ref) and not should_ask and not (direct_signal and not broad_signal)
-    )
-    status = "ask-human" if should_ask else "acknowledge-and-proceed" if should_acknowledge else "available"
-    candidates = [
-        {
-            "id": "workflow-behavior",
-            "interpretation": "Change agent workflow behavior so vague requests get bounded intent discovery before implementation.",
-            "proposed_first_slice": "Add startup/skill routing and focused examples before broader Planning changes.",
-            "promotion_target": "task_intent",
-        },
-        {
-            "id": "planning-surface",
-            "interpretation": "Capture the clarified outcome as Planning state before decomposing work.",
-            "proposed_first_slice": "Create or tighten a planning item after the human confirms the intended outcome.",
-            "promotion_target": "Planning",
-        },
-        {
-            "id": "documentation-only",
-            "interpretation": "Document the intended behavior without changing runtime routing.",
-            "proposed_first_slice": "Update reference docs and leave runtime behavior unchanged.",
-            "promotion_target": "issue",
-        },
-    ]
-    question = (
-        "Which outcome should I optimize for, what is explicitly out of scope, and what first slice would be acceptable?"
-        if should_ask
-        else ""
-    )
     return {
         "kind": "agentic-workspace/intent-discovery-dialogue/v1",
-        "status": status,
-        "applies_to_current_task": status != "available",
+        "status": "available",
+        "applies_to_current_task": False,
         "skill": "workspace-intent-discovery",
         "skill_command": skill_command,
-        "inferred_intent_confidence": confidence,
-        "stakes_if_wrong": stakes,
-        "required_next_action": "ask-intent-discovery-question" if should_ask else "state-assumptions-before-editing",
-        "candidate_interpretations": candidates if status != "available" else [],
+        "inferred_intent_confidence": "agent-owned",
+        "stakes_if_wrong": "agent-owned",
+        "required_next_action": "agent-decides-whether-intent-discovery-is-needed",
+        "candidate_interpretations": [],
         "likely_non_goals": [
             "Do not silently choose a convenient implementation slice.",
             "Do not create Planning state until the intended outcome is clear enough.",
@@ -25876,8 +25712,8 @@ def _intent_discovery_dialogue_payload(
             "desired_outcome": "<capture after reply>",
             "non_goals": "<capture after reply>",
             "acceptable_first_slice": "<capture after reply>",
-            "uncertainty": confidence,
-            "question_to_user": question,
+            "uncertainty": "agent-owned",
+            "question_to_user": "",
             "proceed_without_answer_when": "After one bounded question, proceed only if the first slice is low-risk, reversible, and the stated assumptions are visible.",
         },
         "output_shape": output_shape,
@@ -25895,6 +25731,17 @@ def _intent_discovery_dialogue_payload(
             "promotion_target",
         ],
         "examples": examples,
+        "authority_boundary": _authority_boundary_payload(
+            surface="intent_discovery_dialogue",
+            observed_by_aw=["task_text_available=True"],
+            recommended_by_aw=["use workspace-intent-discovery skill when agent judgment finds intent ambiguity"],
+            agent_owned_decisions=[
+                "whether intent is ambiguous enough to ask",
+                "whether visible assumptions are sufficient to proceed",
+            ],
+            human_owned_decisions=["clarified intent when the agent cannot choose a bounded first slice"],
+            rule="AW exposes an intent-discovery contract; it does not classify prompt ambiguity from keywords.",
+        ),
     }
 
 
@@ -26641,14 +26488,24 @@ def _run_start_context_adapter(args: argparse.Namespace) -> int:
     target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
     _validate_target_root(command_name="start", target_root=target_root)
     start_profile = "full" if getattr(args, "verbose", False) else getattr(args, "profile", None)
+    task_text = getattr(args, "task", None)
+    selected_fields = getattr(args, "select", None)
     payload = _start_payload(
         target_root=target_root,
         changed_paths=list(getattr(args, "changed", []) or []),
-        task_text=getattr(args, "task", None),
-        profile=_start_profile_for_select(requested_profile=start_profile, select=getattr(args, "select", None)),
+        task_text=task_text,
+        profile=_start_profile_for_select(requested_profile=start_profile, select=selected_fields),
     )
-    if getattr(args, "select", None):
-        payload = _select_payload_fields(payload, select=getattr(args, "select"), source_command="start")
+    if selected_fields:
+        config = _load_workspace_config(target_root=target_root)
+        _hydrate_selected_start_advisory_payloads(
+            payload=payload,
+            select=selected_fields,
+            target_root=target_root,
+            task_text=task_text,
+            config=config,
+        )
+        payload = _select_payload_fields(payload, select=selected_fields, source_command="start")
     _emit_payload(payload=payload, format_name=args.format)
     return 0
 
@@ -26663,7 +26520,10 @@ def _run_summary_report_adapter(args: argparse.Namespace) -> int:
     changed_paths = list(getattr(args, "changed", []) or [])
     if getattr(args, "select", None):
         closeout_inspection = _completion_closeout_inspection_payload(
-            target_root=target_root, config=config, task_text=getattr(args, "task", None)
+            target_root=target_root,
+            config=config,
+            task_text=getattr(args, "task", None),
+            explicit_request=_selector_requests(getattr(args, "select", None), "closeout_trust_inspection"),
         )
         payload = _select_summary_payload(
             target_root=target_root,

--- a/tests/test_prompt_semantic_markers.py
+++ b/tests/test_prompt_semantic_markers.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check" / "check_prompt_semantic_markers.py"
+SPEC = importlib.util.spec_from_file_location("check_prompt_semantic_markers", MODULE_PATH)
+check_prompt_semantic_markers = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = check_prompt_semantic_markers
+SPEC.loader.exec_module(check_prompt_semantic_markers)
+
+
+def test_prompt_semantic_marker_guardrail_accepts_current_runtime() -> None:
+    assert check_prompt_semantic_markers.prompt_semantic_marker_findings() == []
+
+
+def test_prompt_semantic_marker_guardrail_rejects_guarded_marker_table(tmp_path: Path) -> None:
+    source = tmp_path / "runtime.py"
+    source.write_text(
+        """
+def _intent_discovery_dialogue_payload():
+    broad_markers = ("improve", "better")
+    return broad_markers
+""",
+        encoding="utf-8",
+    )
+
+    findings = check_prompt_semantic_markers.prompt_semantic_marker_findings(source)
+
+    assert len(findings) == 1
+    assert "broad_markers" in findings[0]
+
+
+def test_prompt_semantic_marker_guardrail_rejects_removal_intent_classifier(tmp_path: Path) -> None:
+    source = tmp_path / "runtime.py"
+    source.write_text(
+        """
+def _task_has_removal_intent(task_text):
+    return "remove" in task_text
+""",
+        encoding="utf-8",
+    )
+
+    findings = check_prompt_semantic_markers.prompt_semantic_marker_findings(source)
+
+    assert len(findings) == 1
+    assert "_task_has_removal_intent" in findings[0]
+
+
+def test_prompt_semantic_marker_guardrail_rejects_objective_drift_marker_table(tmp_path: Path) -> None:
+    source = tmp_path / "runtime.py"
+    source.write_text(
+        """
+def _objective_drift_payload():
+    removal_markers = ("remove", "delete")
+    return removal_markers
+""",
+        encoding="utf-8",
+    )
+
+    findings = check_prompt_semantic_markers.prompt_semantic_marker_findings(source)
+
+    assert len(findings) == 1
+    assert "removal_markers" in findings[0]

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -185,6 +185,124 @@ force = "required-before-closeout"
     assert "assurance_requirements" not in payload
 
 
+def test_implement_routine_work_context_reports_memory_use_when_as_learned_evidence(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / ".agentic-workspace" / "memory" / "repo" / "index.md", "# Memory index\n")
+    _write(tmp_path / ".agentic-workspace" / "memory" / "repo" / "domains" / "parser.md", "# Parser\n")
+    _write(
+        tmp_path / ".agentic-workspace" / "memory" / "repo" / "manifest.toml",
+        """
+version = 1
+
+[notes.".agentic-workspace/memory/repo/index.md"]
+note_type = "routing"
+canonical_home = ".agentic-workspace/memory/repo/index.md"
+authority = "canonical"
+audience = "human+agent"
+canonicality = "agent_only"
+task_relevance = "required"
+routing_only = true
+
+[notes.".agentic-workspace/memory/repo/domains/parser.md"]
+note_type = "domain"
+canonical_home = ".agentic-workspace/memory/repo/domains/parser.md"
+authority = "learned"
+audience = "human+agent"
+canonicality = "agent_only"
+task_relevance = "optional"
+use_when = ["parser refactor"]
+evidence = ["Memory fixture"]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/parser.py",
+                "--task",
+                "Plan parser refactor safely",
+                "--select",
+                "routine_work_context",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    routine = json.loads(capsys.readouterr().out)["values"]["routine_work_context"]
+    review = routine["knowledge_authority_review"]
+    source = review["matched_sources"][0]
+    assert source["owner_surface"] == ".agentic-workspace/memory/repo/domains/parser.md"
+    assert source["authority"] == "learned"
+    assert source["applies_because"] == ["task text matched parser refactor"]
+    assert "Memory manifest metadata" in source["authority_boundary"]["observed_by_aw"]
+    assert "semantically relevant" in source["authority_boundary"]["agent_owned_decisions"][0]
+    assert "does not classify user intent" in source["authority_boundary"]["reporting_rule"]
+    assert "does not make semantic task classifications" in review["authority_boundary"]["reporting_rule"]
+
+
+def test_implement_verification_task_marker_reports_configured_protocol_authority(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "verification" / "manifest.toml",
+        """
+schema_version = "agentic-workspace/verification-manifest/v1"
+
+[scenarios.privacy_walkthrough]
+protocol_id = "privacy_review"
+title = "Privacy walkthrough"
+steps = ["Inspect privacy handling"]
+expected_observations = ["Authority and evidence labels are visible"]
+pass_evidence_labels = ["privacy_reviewed"]
+fail_evidence_labels = ["privacy_gap"]
+
+[protocols.privacy_review]
+title = "Privacy review"
+purpose = "Configured privacy verification protocol."
+applies_to_task_markers = ["privacy"]
+scenario_refs = ["privacy_walkthrough"]
+expected_evidence = ["privacy_reviewed"]
+review_owner = "privacy-review"
+authority_refs = ["docs/compliance/privacy.md"]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "README.md",
+                "--task",
+                "Update privacy handling",
+                "--select",
+                "verification",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    verification = json.loads(capsys.readouterr().out)["values"]["verification"]
+    protocol = verification["active_protocols"][0]
+    assert protocol["id"] == "privacy_review"
+    assert protocol["applies_because"] == ["task marker matched privacy"]
+    assert "configured verification protocol privacy_review" in protocol["authority_boundary"]["observed_by_aw"]
+    assert "semantically relevant" in protocol["authority_boundary"]["agent_owned_decisions"][0]
+    assert "does not classify user intent" in protocol["authority_boundary"]["reporting_rule"]
+    assert "does not decide the user's semantic intent" in verification["authority_boundary"]["reporting_rule"]
+
+
 def test_implement_matches_non_code_assurance_requirement(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
@@ -971,19 +1089,11 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert guidance_boundary["surface"] == "work_shape_guidance"
     assert "semantic work shape" in guidance_boundary["agent_owned_decisions"]
     assert any(item.startswith("dirty_shape=") for item in guidance_boundary["observed_by_aw"])
-    acknowledgement = context["intent_acknowledgement"]
-    assert acknowledgement["decision"] == "proceed-with-stated-assumption"
-    assert acknowledgement["fields"] == [
-        "inferred_intent",
-        "concrete_first_slice",
-        "non_goals_or_deferred_scope",
-        "correction_point",
-    ]
-    assert acknowledgement["proceed_unless_corrected"] is True
+    assert "intent_acknowledgement" not in context
     intent_evidence = context["intent_evidence"]
-    assert intent_evidence["source_class"] == "agent-inference-with-evidence"
-    assert intent_evidence["assumption_state"] == "visible-assumption-required"
-    assert intent_evidence["required_next_action"] == "state-assumptions-before-editing"
+    assert intent_evidence["source_class"] == "direct-user-text"
+    assert intent_evidence["assumption_state"] == "low-risk-direct"
+    assert intent_evidence["required_next_action"] == "continue-direct"
     assert intent_evidence["proceed_without_question"] is True
     assert context["delegation_decision"]["status"] == "evaluated"
     assert context["delegation_decision"]["mode"] in {"suggest", "auto"}
@@ -1725,7 +1835,7 @@ def test_implement_task_specific_acceptance_warns_on_objective_drift(tmp_path: P
     assert "self-authored tests alone" in acceptance["compact_closeout_prompt"]
 
 
-def test_implement_objective_drift_accepts_explicit_deleted_outcome(tmp_path: Path, capsys) -> None:
+def test_implement_objective_drift_does_not_accept_deleted_outcome_from_prompt_keywords(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
 
     assert (
@@ -1747,10 +1857,12 @@ def test_implement_objective_drift_accepts_explicit_deleted_outcome(tmp_path: Pa
 
     payload = json.loads(capsys.readouterr().out)
     drift = _implement_context(payload)["objective_drift"]
-    assert drift["status"] == "clear"
+    assert drift["status"] == "warning"
     assert drift["requested_outcomes"] == ["llms.txt"]
-    assert drift["removed_or_retired_outcomes"] == ["llms.txt"]
-    assert drift["missing_from_changed_surface"] == []
+    assert drift["removed_or_retired_outcomes"] == []
+    assert drift["missing_from_changed_surface"] == ["llms.txt"]
+    assert "does not infer removal or retirement intent from prompt keywords" in drift["heuristic"]
+    assert "whether a missing requested outcome was intentionally removed" in drift["agent_owned_decisions"][0]
 
 
 def test_implement_objective_drift_keeps_missing_path_without_removal_intent(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -913,7 +913,7 @@ def test_report_decision_pressure_surfaces_memory_decision_candidate_when_adr_ta
     assert answer["memory_pressure"]["sample"][0]["promotion_target"] == "decision-record"
 
 
-def test_report_closeout_trust_routes_architecture_decision_candidate_to_discovered_adr_target(tmp_path: Path, capsys) -> None:
+def test_report_closeout_trust_does_not_infer_architecture_decision_candidate_from_planning_text(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
@@ -966,13 +966,8 @@ def test_report_closeout_trust_routes_architecture_decision_candidate_to_discove
     assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
 
     closeout = json.loads(capsys.readouterr().out)["answer"]
-    candidate = closeout["architecture_decision_candidate"]
-    assert candidate["status"] == "candidate"
-    assert candidate["primary_route"] == "decision-record"
-    assert candidate["decision_target"]["target"] == "docs/adr/"
-    assert "planning decision-scaffold" in candidate["route"]["command"]
-    assert "--target ./repo" not in candidate["route"]["command"]
-    assert candidate["route"]["command_target"]["target"] == "<repo>"
+    assert "architecture_decision" not in closeout
+    assert "architecture_decision_candidate" not in closeout
 
 
 def test_report_closeout_trust_surfaces_memory_promotion_pressure_in_knowledge_review(

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -210,7 +210,7 @@ def test_preflight_command_with_target_argument(tmp_path: Path, capsys) -> None:
     assert target.as_posix() in payload["target"]
 
 
-def test_preflight_task_surfaces_vague_outcome_orientation(capsys) -> None:
+def test_preflight_task_keeps_vague_outcome_orientation_out_of_default(capsys) -> None:
     assert (
         cli.main(
             [
@@ -226,12 +226,7 @@ def test_preflight_task_surfaces_vague_outcome_orientation(capsys) -> None:
     )
 
     payload = json.loads(capsys.readouterr().out)
-    orientation = payload["startup_guidance"]["vague_outcome_orientation"]
-    assert orientation["status"] == "applicable"
-    assert orientation["applies_to_current_task"] is True
-    assert orientation["first_surface"].startswith("startup_guidance.primary_next_action")
-    assert f"{REPO_LOCAL_CLI_INVOKE} start" in orientation["compact_commands"][1]
-    assert "intended outcome" in orientation["answer_contract"][0]
+    assert "vague_outcome_orientation" not in payload["startup_guidance"]
 
 
 def test_preflight_command_emits_gate_token(capsys) -> None:
@@ -413,6 +408,12 @@ blocking_claims = ["claim-work-complete", "close-parent-lane"]
     assert requirements["status"] == "attention"
     assert requirements["active"][0]["id"] == "privacy_data"
     assert requirements["active"][0]["applies_because"] == ["task marker matched privacy"]
+    assert "does not classify the task's semantic intent" in requirements["authority_boundary"]["reporting_rule"]
+    active_boundary = requirements["active"][0]["authority_boundary"]
+    assert "configured assurance requirement privacy_data" in active_boundary["observed_by_aw"]
+    assert "task marker matched privacy" in active_boundary["observed_by_aw"]
+    assert "whether the current task intent is satisfied" in active_boundary["agent_owned_decisions"]
+    assert "does not decide user intent" in active_boundary["reporting_rule"]
 
 
 def test_start_surfaces_compact_routine_work_context(tmp_path: Path, capsys) -> None:
@@ -1007,26 +1008,36 @@ candidates = [
 
     payload = json.loads(capsys.readouterr().out)
     action = _start_primary_action(payload)
-    assert action["action"] == "inspect-closeout-trust-before-completion-answer"
+    assert action["action"] != "inspect-closeout-trust-before-completion-answer"
     relative_target = os.path.relpath(target.resolve(), Path.cwd().resolve()).replace("\\", "/")
-    assert action["command"] == f"agentic-workspace report --target {relative_target} --section closeout_trust --format json"
     packet = payload["next_safe_action"]
     _assert_next_safe_action_valid(packet)
-    assert packet["preferred_cli_effect"] == "reporting"
-    assert packet["continuation_owner_required"] is True
-    assert "claim completion before closeout trust is reconciled" in packet["closure_blockers"]
-    closeout = _start_context_value(payload, "closeout_trust_inspection")
+    assert "closeout_trust_inspection" not in payload
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(target),
+                "--task",
+                "Can I mark this work complete?",
+                "--select",
+                "closeout_trust_inspection",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    selected = json.loads(capsys.readouterr().out)["values"]
+    closeout = selected["closeout_trust_inspection"]
     assert closeout["status"] == "required"
     assert closeout["trust"] == "lower-trust"
     assert closeout["strict_closeout_gate"]["status"] == "blocked"
     assert closeout["intent_satisfaction"]["trust"] == "follow-up-required"
-    closeout_route = _start_context_value(payload, "closeout_report_route")
-    assert closeout_route["profile"] == "audit"
-    assert closeout_route["next_command"] == f"agentic-workspace report --target {relative_target} --section closeout_report --format json"
-    assert closeout_route["selector"] == "closeout_report"
-    assert "completion_options" not in payload
-    assert "completion_options" not in closeout
-    assert "closeout_trust_inspection" in payload["drill_down"]["available_selectors"]
+    assert closeout["detail_command"] == f"agentic-workspace report --target {relative_target} --section closeout_trust --format json"
+    assert "prompt keywords" in closeout["authority_boundary"]["reporting_rule"]
 
 
 def test_start_select_returns_requested_startup_fields(capsys) -> None:
@@ -1051,9 +1062,9 @@ def test_start_select_returns_acceptance_and_durable_promotion(capsys) -> None:
     assert acceptance["closeout_required"] is True
     assert acceptance["items"][0]["id"] == "A1"
     promotion = payload["values"]["durable_intent_promotion"]
-    assert promotion["status"] == "candidate"
-    assert "should" in promotion["matched_markers"]
-    assert "going forward" in promotion["matched_markers"]
+    assert promotion["status"] == "available"
+    assert promotion["matched_markers"] == []
+    assert "whether the task revealed durable knowledge" in promotion["authority_boundary"]["agent_owned_decisions"]
 
 
 def test_start_surfaces_architecture_decision_candidate_for_database_migration_with_adr_target(tmp_path: Path, capsys) -> None:
@@ -1072,6 +1083,8 @@ def test_start_surfaces_architecture_decision_candidate_for_database_migration_w
                 str(target),
                 "--task",
                 "Migrate database system from SQLite to MariaDB",
+                "--changed",
+                "docs/adr/new-decision.md",
                 "--select",
                 "durable_intent_promotion",
                 "--format",
@@ -1086,6 +1099,8 @@ def test_start_surfaces_architecture_decision_candidate_for_database_migration_w
     assert promotion["status"] == "candidate"
     assert candidate["primary_route"] == "decision-record"
     assert candidate["decision_target"]["target"] == "docs/adr/"
+    assert candidate["matched_markers"] == []
+    assert candidate["decision_path_matches"] == ["docs/adr/new-decision.md"]
     assert "planning decision-scaffold" in candidate["route"]["command"]
     assert "--target ./repo" not in candidate["route"]["command"]
     assert candidate["route"]["command_target"]["target"] == "<repo>"
@@ -1106,6 +1121,8 @@ def test_start_surfaces_typed_memory_fallback_for_database_migration_without_adr
                 str(target),
                 "--task",
                 "Migrate database storage from SQLite to MariaDB",
+                "--changed",
+                "docs/decisions/storage.md",
                 "--select",
                 "durable_intent_promotion",
                 "--format",
@@ -1118,6 +1135,8 @@ def test_start_surfaces_typed_memory_fallback_for_database_migration_without_adr
     promotion = json.loads(capsys.readouterr().out)["values"]["durable_intent_promotion"]
     candidate = promotion["architecture_decision_candidate"]
     assert candidate["primary_route"] == "typed-memory-fallback"
+    assert candidate["matched_markers"] == []
+    assert candidate["decision_path_matches"] == ["docs/decisions/storage.md"]
     assert candidate["decision_target"]["configured"] is False
     assert candidate["route"]["target"] == ".agentic-workspace/memory/repo/decisions/"
     assert "memory capture-note" in candidate["route"]["command"]
@@ -1152,7 +1171,8 @@ def test_start_keeps_adr_directory_quiet_for_tiny_typo_task(tmp_path: Path, caps
     )
 
     promotion = json.loads(capsys.readouterr().out)["values"]["durable_intent_promotion"]
-    assert promotion["status"] == "no-durable-signal"
+    assert promotion["status"] == "available"
+    assert promotion["matched_markers"] == []
     assert "architecture_decision_candidate" not in promotion
 
 
@@ -1214,7 +1234,7 @@ def test_start_tiny_routes_existing_task_paths_to_implement_surface(tmp_path: Pa
     assert action["read_first"] == [action["command"]]
 
 
-def test_start_tiny_routes_config_posture_questions_to_tiny_config(capsys) -> None:
+def test_start_tiny_does_not_route_config_posture_questions_from_prompt_keywords(capsys) -> None:
     task = (
         "Inspect this repo enough to answer how a small follow-up should be reported. "
         "Keep the answer aligned with the repo's configured operating and reporting posture."
@@ -1224,10 +1244,7 @@ def test_start_tiny_routes_config_posture_questions_to_tiny_config(capsys) -> No
 
     payload = json.loads(capsys.readouterr().out)
     action = _start_primary_action(payload)
-    assert action["action"] == "inspect-effective-config"
-    assert action["command"] == f"{REPO_LOCAL_CLI_INVOKE} config --format json"
-    assert action["read_first"] == [action["command"]]
-    assert "tiny config surface" in action["summary"]
+    assert action["action"] != "inspect-effective-config"
     assert len(json.dumps(payload, sort_keys=True)) < 14500
 
 
@@ -1264,7 +1281,7 @@ def test_start_tiny_compacts_long_task_carry_forward_command(tmp_path: Path, cap
     assert len(json.dumps(payload, sort_keys=True)) < 8800
 
 
-def test_start_tiny_routes_prep_only_handoff_to_planning_bridge(tmp_path: Path, capsys) -> None:
+def test_start_tiny_does_not_route_prep_only_handoff_from_prompt_keywords(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
@@ -1279,35 +1296,14 @@ def test_start_tiny_routes_prep_only_handoff_to_planning_bridge(tmp_path: Path, 
 
     payload = json.loads(capsys.readouterr().out)
     action = _start_primary_action(payload)
-    assert action["action"] == "create-prep-only-planning-state"
-    assert action["command"].startswith("agentic-workspace planning new-plan")
-    assert "--prep-only" in action["command"]
-    assert action["next_proof"] == "agentic-workspace summary --verbose --format json"
-    assert action["read_first"] == []
+    assert action["action"] == "choose-smallest-workflow-shape"
+    assert "prep_only_handoff" not in _start_context(payload)
     packet = payload["next_safe_action"]
-    assert packet["next_safe_action"] == "create-prep-only-planning-state"
-    assert packet["module_slot"] == "planning"
-    assert packet["preferred_cli"] == action["command"]
-    assert packet["completion_claim_allowed"] is False
-    assert {"edit product source", "claim implementation complete"} <= set(packet["forbidden_actions"])
-    assert packet["proof_required"] is True
-    assert "do not create product source" in action["summary"]
-    prep_only = _start_context_value(payload, "prep_only_handoff")
-    assert prep_only["first_command"].startswith("agentic-workspace planning new-plan")
-    assert prep_only["reference_command"] == "agentic-workspace planning --format json"
-    assert "--prep-only" in prep_only["preferred_mutation_command_template"]
-    assert prep_only["after_write"] == "agentic-workspace summary --verbose --format json"
-    assert prep_only["stop_after_summary"] is True
-    assert "no" in prep_only["open_execplan_after_creation"]
-    assert "defer unless summary reports" in prep_only["manual_execplan_tightening"]
-    assert any("smallest schema-preserving" in item for item in prep_only["allowed_after_new_plan"])
-    assert ".agentic-workspace/planning/execplans/" in prep_only["allowed_write_scope"]
-    assert "tests or fixtures" in prep_only["forbidden_until_implementation_requested"]
-    assert "manual JSON polishing or ad hoc validation loops" in prep_only["forbidden_until_implementation_requested"]
+    assert packet["next_safe_action"] == "choose-smallest-workflow-shape"
     assert len(json.dumps(payload, sort_keys=True)) < 9500
 
 
-def test_start_tiny_routes_paraphrased_prep_only_handoff_to_planning_bridge(tmp_path: Path, capsys) -> None:
+def test_start_tiny_keeps_paraphrased_prep_only_prompt_agent_owned(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
@@ -1318,11 +1314,11 @@ def test_start_tiny_routes_paraphrased_prep_only_handoff_to_planning_bridge(tmp_
     assert cli.main(["start", "--target", str(target), "--task", task, "--format", "json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
-    assert _start_primary_action(payload)["action"] == "create-prep-only-planning-state"
-    assert _start_context_value(payload, "prep_only_handoff")["status"] == "required"
+    assert _start_primary_action(payload)["action"] == "choose-smallest-workflow-shape"
+    assert "prep_only_handoff" not in _start_context(payload)
 
 
-def test_start_tiny_routes_groundwork_without_implementation_to_prep_only(tmp_path: Path, capsys) -> None:
+def test_start_tiny_keeps_groundwork_without_implementation_prompt_agent_owned(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
@@ -1334,12 +1330,11 @@ def test_start_tiny_routes_groundwork_without_implementation_to_prep_only(tmp_pa
 
     payload = json.loads(capsys.readouterr().out)
     action = _start_primary_action(payload)
-    assert action["action"] == "create-prep-only-planning-state"
-    assert action["command"].startswith("agentic-workspace planning new-plan")
-    assert action["read_first"] == []
+    assert action["action"] == "choose-smallest-workflow-shape"
+    assert "prep_only_handoff" not in _start_context(payload)
 
 
-def test_start_tiny_routes_durable_plan_state_without_code_to_prep_only(tmp_path: Path, capsys) -> None:
+def test_start_tiny_keeps_durable_plan_state_without_code_prompt_agent_owned(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
@@ -1351,8 +1346,8 @@ def test_start_tiny_routes_durable_plan_state_without_code_to_prep_only(tmp_path
 
     payload = json.loads(capsys.readouterr().out)
     action = _start_primary_action(payload)
-    assert action["action"] == "create-prep-only-planning-state"
-    assert "--prep-only" in action["command"]
+    assert action["action"] == "choose-smallest-workflow-shape"
+    assert "prep_only_handoff" not in _start_context(payload)
 
 
 def test_start_tiny_respects_ask_first_clarification_mode(tmp_path: Path, capsys) -> None:
@@ -2580,7 +2575,7 @@ def test_planning_close_item_front_door_forwards_item_positionally() -> None:
     assert argv[argv.index("--issue") + 1] == "#953"
 
 
-def test_start_task_surfaces_vague_outcome_orientation(tmp_path: Path, capsys) -> None:
+def test_start_select_surfaces_vague_outcome_orientation_as_agent_owned_guidance(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
@@ -2593,6 +2588,8 @@ def test_start_task_surfaces_vague_outcome_orientation(tmp_path: Path, capsys) -
                 str(target),
                 "--task",
                 "Agents keep making me repeat what I meant after they finish",
+                "--select",
+                "vague_outcome_orientation",
                 "--format",
                 "json",
             ]
@@ -2600,15 +2597,16 @@ def test_start_task_surfaces_vague_outcome_orientation(tmp_path: Path, capsys) -
         == 0
     )
 
-    payload = json.loads(capsys.readouterr().out)
-    orientation = _start_context_value(payload, "vague_outcome_orientation")
-    assert orientation["status"] == "applicable"
+    payload = json.loads(capsys.readouterr().out)["values"]
+    orientation = payload["vague_outcome_orientation"]
+    assert orientation["status"] == "available"
+    assert orientation["applies_to_current_task"] is False
+    assert "does not infer vague-outcome status from prompt keywords" in orientation["rule"]
     assert "say you will proceed on that interpretation unless corrected" in orientation["answer_contract"]
     assert orientation["raw_read_rule"].startswith("Open raw .agentic-workspace files only after compact output")
-    assert "skills" in payload
 
 
-def test_start_vague_high_stakes_task_routes_to_intent_discovery_dialogue(tmp_path: Path, capsys) -> None:
+def test_start_select_surfaces_intent_discovery_dialogue_without_prompt_classification(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
@@ -2621,6 +2619,8 @@ def test_start_vague_high_stakes_task_routes_to_intent_discovery_dialogue(tmp_pa
                 str(target),
                 "--task",
                 "Improve onboarding",
+                "--select",
+                "intent_discovery_dialogue,immediate_next_allowed_action",
                 "--format",
                 "json",
             ]
@@ -2628,28 +2628,22 @@ def test_start_vague_high_stakes_task_routes_to_intent_discovery_dialogue(tmp_pa
         == 0
     )
 
-    payload = json.loads(capsys.readouterr().out)
-    discovery = _start_context_value(payload, "intent_discovery_dialogue")
-    intent_evidence = _start_context_value(payload, "intent_evidence")
-    assert discovery["status"] == "ask-human"
-    assert discovery["inferred_intent_confidence"] == "low"
-    assert discovery["stakes_if_wrong"] == "high"
-    assert discovery["required_next_action"] == "ask-intent-discovery-question"
-    assert len(discovery["candidate_interpretations"]) >= 2
-    assert "question_to_user" in discovery["dialogue_packet"]
+    payload = json.loads(capsys.readouterr().out)["values"]
+    discovery = payload["intent_discovery_dialogue"]
+    assert discovery["status"] == "available"
+    assert discovery["applies_to_current_task"] is False
+    assert discovery["inferred_intent_confidence"] == "agent-owned"
+    assert discovery["stakes_if_wrong"] == "agent-owned"
+    assert discovery["required_next_action"] == "agent-decides-whether-intent-discovery-is-needed"
+    assert discovery["candidate_interpretations"] == []
+    assert discovery["dialogue_packet"]["question_to_user"] == ""
     assert discovery["loop_control"]["max_questions_before_progress"] == 1
     assert "captured_intent_after_reply" in discovery["output_shape"]["fields"]
     assert "Planning" in discovery["output_shape"]["promotion_targets"]
-    assert intent_evidence["source_class"] == "human-clarification-needed"
-    assert intent_evidence["assumption_state"] == "clarification-required"
-    assert intent_evidence["required_next_action"] == "ask-intent-discovery-question"
-    assert intent_evidence["proceed_without_question"] is False
+    assert "does not classify prompt ambiguity from keywords" in discovery["authority_boundary"]["reporting_rule"]
 
-    next_action = payload["next_safe_action"]
-    assert next_action["next_safe_action"] == "ask-intent-discovery-question"
-    assert next_action["required_skill"] == "workspace-intent-discovery"
-    assert next_action["implementation_allowed"] is False
-    assert "begin implementation" in next_action["forbidden_actions"]
+    next_action = payload["immediate_next_allowed_action"]
+    assert next_action["action"] != "ask-intent-discovery-question"
 
 
 def test_start_detailed_issue_uses_intent_discovery_without_interrupting(tmp_path: Path, capsys) -> None:
@@ -2676,10 +2670,11 @@ def test_start_detailed_issue_uses_intent_discovery_without_interrupting(tmp_pat
 
     payload = json.loads(capsys.readouterr().out)["values"]
     discovery = payload["intent_discovery_dialogue"]
-    assert discovery["status"] == "acknowledge-and-proceed"
-    assert discovery["required_next_action"] == "state-assumptions-before-editing"
+    assert discovery["status"] == "available"
+    assert discovery["required_next_action"] == "agent-decides-whether-intent-discovery-is-needed"
     assert payload["immediate_next_allowed_action"]["action"] != "ask-intent-discovery-question"
     assert payload["intent_acknowledgement"]["decision"] == "proceed-with-stated-assumption"
+    assert "agent owns the interpretation" in payload["intent_acknowledgement"]["authority_boundary"]["reporting_rule"]
     intent_evidence = payload["intent_evidence"]
     assert intent_evidence["source_class"] == "agent-inference-with-evidence"
     assert intent_evidence["assumption_state"] == "visible-assumption-required"
@@ -2687,7 +2682,7 @@ def test_start_detailed_issue_uses_intent_discovery_without_interrupting(tmp_pat
     assert any(item["source"] == "external-issue-reference" for item in intent_evidence["source_chain"])
 
 
-def test_start_task_surfaces_stated_assumption_middle_path(tmp_path: Path, capsys) -> None:
+def test_start_select_surfaces_stated_assumption_guidance_as_agent_owned(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
@@ -2700,6 +2695,8 @@ def test_start_task_surfaces_stated_assumption_middle_path(tmp_path: Path, capsy
                 str(target),
                 "--task",
                 "Improve onboarding so agents stop drifting from user intent",
+                "--select",
+                "intent_acknowledgement",
                 "--format",
                 "json",
             ]
@@ -2707,17 +2704,12 @@ def test_start_task_surfaces_stated_assumption_middle_path(tmp_path: Path, capsy
         == 0
     )
 
-    payload = json.loads(capsys.readouterr().out)
-    acknowledgement = _start_context_value(payload, "intent_acknowledgement")
-    assert acknowledgement["decision"] == "proceed-with-stated-assumption"
-    assert acknowledgement["fields"] == [
-        "inferred_intent",
-        "concrete_first_slice",
-        "non_goals_or_deferred_scope",
-        "correction_point",
-    ]
-    assert acknowledgement["proceed_unless_corrected"] is True
-    assert acknowledgement["clarify_only_if_blocked"] is True
+    payload = json.loads(capsys.readouterr().out)["values"]
+    acknowledgement = payload["intent_acknowledgement"]
+    assert acknowledgement["status"] == "available"
+    assert acknowledgement["decision"] == "silent-ok"
+    assert "does not infer whether a stated-assumption preface is required from prompt keywords" in acknowledgement["reason"]
+    assert "does not infer preface requirements from prompt keywords" in acknowledgement["authority_boundary"]["reporting_rule"]
 
 
 def test_start_direct_task_keeps_stated_assumption_out_of_default(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -166,9 +166,24 @@ candidates = [
         ),
     )
 
-    assert cli.main(["summary", "--target", str(tmp_path), "--task", "Can this lane be considered done?", "--format", "json"]) == 0
+    assert (
+        cli.main(
+            [
+                "summary",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Can this lane be considered done?",
+                "--select",
+                "closeout_trust_inspection",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
 
-    payload = json.loads(capsys.readouterr().out)
+    payload = json.loads(capsys.readouterr().out)["values"]
     closeout = payload["closeout_trust_inspection"]
     assert closeout["status"] == "required"
     assert closeout["trust"] == "lower-trust"


### PR DESCRIPTION
## What landed

- Removed prompt keyword semantic routers for prep-only handoff, config-posture questions, completion/status questions, vague-outcome orientation, intent-discovery, stated-assumption acknowledgement, durable-intent promotion, architecture-decision candidates, and objective-drift removal/retirement acceptance.
- Kept useful guidance available through explicit selectors and authority-boundary/agent-owned packets: AW reports facts/contracts/recommendations, while the agent owns semantic judgment.
- Preserved useful configured/learned matching as evidence only: Memory route/use_when matches, Verification task-marker protocols, and Assurance task-marker requirements now carry explicit authority boundaries saying semantic relevance and acceptance remain agent/human-owned.
- Changed architecture-decision/durable-intent candidates to rely on structural/configured evidence instead of task-text marker tables.
- Changed objective drift so deletion/removal/retirement wording no longer clears a missing requested outcome; agents must reconcile removal/retirement explicitly before closeout.
- Added a lint guardrail (`scripts/check/check_prompt_semantic_markers.py`) and wired it into `make lint-workspace`.
- Updated schema/reference wording for `durable_intent_promotion.matched_markers`, `objective_drift`, `routine_work_context`, `verification`, and `assurance_requirements` so none describe prompt heuristics or configured evidence as AW-owned semantic decisions.

## Closure matrix

| Issue | Closure evidence |
| --- | --- |
| Closes #1309 | Parent lane is covered end-to-end: default startup/preflight/summary/report/implement behavior no longer infers semantic routes from prompt text; selected advisory packets still support agent judgment; structural/configured evidence remains available; objective-drift removal/retirement is agent-owned; tests and lint guardrail prevent regression. |
| Closes #1310 | Startup prompt keyword routers were retired for prep-only, config posture, completion/status, vague-outcome, intent-discovery, and stated-assumption paths. Tests assert quiet defaults and explicit selector guidance. |
| Closes #1311 | Durable-intent promotion no longer uses task-text marker lists. `matched_markers` is empty/reserved unless future structural/configured evidence exists, and the packet names durable knowledge promotion as agent-owned. |
| Closes #1312 | Configured/learned route matching is preserved only as structural/configured advisory evidence. Focused fixtures cover one learned Memory route (`tests/test_workspace_implement_cli.py::test_implement_routine_work_context_reports_memory_use_when_as_learned_evidence`), one configured Verification protocol task-marker match (`tests/test_workspace_implement_cli.py::test_implement_verification_task_marker_reports_configured_protocol_authority` and `packages/verification/tests/test_runtime_primitives.py::test_verification_report_task_marker_match_reports_configured_protocol_authority`), and one configured Assurance requirement task-marker match (`tests/test_workspace_start_preflight_cli.py::test_start_surfaces_active_assurance_requirement_from_task_marker`). Each asserts authority wording that AW reports configured/learned evidence and the agent/human owns semantic relevance, proof sufficiency, and acceptance. |
| Closes #1313 | New lint guardrail fails on hardcoded prompt semantic marker tables in guarded startup/routing/objective-drift functions, including a denied removal-intent classifier. |

## Why parent closure is honest

This is not just wording. The runtime no longer evaluates the scoped prompt semantic marker tables, including the previous objective-drift deletion/removal/retirement shortcut. Guidance that agents still need is available by explicit selector (`intent_discovery_dialogue`, `intent_acknowledgement`, `vague_outcome_orientation`, `closeout_trust_inspection`) or by structural/configured evidence such as decision-path changes, Memory manifests, Verification protocols, and Assurance requirements. Objective drift now reports missing requested outcomes and leaves removal/retirement acceptance to agent-owned reconciliation.

## Proof run

- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_routine_work_context_reports_memory_use_when_as_learned_evidence tests/test_workspace_implement_cli.py::test_implement_verification_task_marker_reports_configured_protocol_authority tests/test_workspace_start_preflight_cli.py::test_start_surfaces_active_assurance_requirement_from_task_marker packages/verification/tests/test_runtime_primitives.py::test_verification_report_task_marker_match_reports_configured_protocol_authority -q`
- `uv run pytest packages/verification/tests/test_runtime_primitives.py -q`
- `uv run pytest tests/test_workspace_start_preflight_cli.py -q`
- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_workspace_report_cli.py::test_report_closeout_trust_does_not_infer_architecture_decision_candidate_from_planning_text tests/test_workspace_summary_cli.py::test_workspace_summary_completion_task_surfaces_closeout_trust tests/test_workspace_start_preflight_cli.py tests/test_prompt_semantic_markers.py -q`
- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_objective_drift_does_not_accept_deleted_outcome_from_prompt_keywords tests/test_workspace_implement_cli.py::test_implement_objective_drift_keeps_missing_path_without_removal_intent tests/test_prompt_semantic_markers.py -q`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `uv run python scripts/run_agentic_workspace.py proof --verbose --changed src/agentic_workspace/workspace_runtime_primitives.py packages/verification/src/repo_verification_bootstrap/runtime_primitives.py packages/verification/tests/test_runtime_primitives.py src/agentic_workspace/contracts/schemas/workspace_report.schema.json src/agentic_workspace/contracts/schemas/implementer_context.schema.json docs/reference/workspace-report.md docs/reference/implementer-context.md tests/test_workspace_implement_cli.py tests/test_workspace_start_preflight_cli.py --format json`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `make schema-reference-docs`

## Remaining limitation

No known prompt-keyword semantic router remains in the scoped lane. The guardrail covers the guarded startup/routing/objective-drift surfaces touched here; future new surfaces should either be added to the guardrail or avoid prompt marker tables by construction. Configured/learned matching remains intentionally available when it is backed by owner surfaces such as Memory manifests, Verification protocols, or Assurance requirements, and the new fixtures pin that distinction.