### PR TITLE
Fix closeout proof and EOL handling

### DIFF
--- a/generated/planning/python/adapter_commands.json
+++ b/generated/planning/python/adapter_commands.json
@@ -277,6 +277,13 @@
         },
         {
           "flags": [
+            "--proof-file"
+          ],
+          "help": "Read closeout proof text from a repo-contained file instead of a shell-sensitive argument.",
+          "name": "proof_file"
+        },
+        {
+          "flags": [
             "--residue-owner"
           ],
           "help": "Canonical owner for non-empty residue or deferred intent.",

--- a/generated/planning/python/command_package.json
+++ b/generated/planning/python/command_package.json
@@ -388,6 +388,13 @@
           },
           {
             "flags": [
+              "--proof-file"
+            ],
+            "help": "Read closeout proof text from a repo-contained file instead of a shell-sensitive argument.",
+            "name": "proof_file"
+          },
+          {
+            "flags": [
               "--residue-owner"
             ],
             "help": "Canonical owner for non-empty residue or deferred intent.",
@@ -3032,6 +3039,11 @@
           "arg": "proof_from",
           "default": "last",
           "name": "proof_from"
+        },
+        {
+          "arg": "proof_file",
+          "default": null,
+          "name": "proof_file"
         },
         {
           "arg": "residue_owner",

--- a/generated/planning/python/operations/planning.closeout.lifecycle.json
+++ b/generated/planning/python/operations/planning.closeout.lifecycle.json
@@ -50,6 +50,11 @@
       "source": "cli-option"
     },
     {
+      "name": "proof_file",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
       "name": "residue_owner",
       "required": false,
       "source": "cli-option"

--- a/generated/planning/python/primitives/operation_executor.py
+++ b/generated/planning/python/primitives/operation_executor.py
@@ -108,6 +108,7 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'intent_status': getattr(args, 'intent_status', 'satisfied'),
                 'residue': getattr(args, 'residue', 'none'),
                 'proof_from': getattr(args, 'proof_from', 'last'),
+                'proof_file': getattr(args, 'proof_file', None),
                 'residue_owner': getattr(args, 'residue_owner', None),
                 'what_happened': getattr(args, 'what_happened', None),
                 'scope_touched': getattr(args, 'scope_touched', None),

--- a/generated/planning/typescript/resources/command_package.json
+++ b/generated/planning/typescript/resources/command_package.json
@@ -388,6 +388,13 @@
           },
           {
             "flags": [
+              "--proof-file"
+            ],
+            "help": "Read closeout proof text from a repo-contained file instead of a shell-sensitive argument.",
+            "name": "proof_file"
+          },
+          {
+            "flags": [
               "--residue-owner"
             ],
             "help": "Canonical owner for non-empty residue or deferred intent.",
@@ -3032,6 +3039,11 @@
           "arg": "proof_from",
           "default": "last",
           "name": "proof_from"
+        },
+        {
+          "arg": "proof_file",
+          "default": null,
+          "name": "proof_file"
         },
         {
           "arg": "residue_owner",

--- a/generated/planning/typescript/resources/operations/planning.closeout.lifecycle.json
+++ b/generated/planning/typescript/resources/operations/planning.closeout.lifecycle.json
@@ -50,6 +50,11 @@
       "source": "cli-option"
     },
     {
+      "name": "proof_file",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
       "name": "residue_owner",
       "required": false,
       "source": "cli-option"

--- a/generated/planning/typescript/src/cli.mjs
+++ b/generated/planning/typescript/src/cli.mjs
@@ -292,6 +292,13 @@ const commandDefinitions = [
         },
         {
           "flags": [
+            "--proof-file"
+          ],
+          "help": "Read closeout proof text from a repo-contained file instead of a shell-sensitive argument.",
+          "name": "proof_file"
+        },
+        {
+          "flags": [
             "--residue-owner"
           ],
           "help": "Canonical owner for non-empty residue or deferred intent.",

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -615,6 +615,13 @@
             },
             {
               "flags": [
+                "--proof-file"
+              ],
+              "help": "Read closeout proof text from a repo-contained file instead of a shell-sensitive argument.",
+              "name": "proof_file"
+            },
+            {
+              "flags": [
                 "--residue-owner"
               ],
               "help": "Canonical owner for non-empty residue or deferred intent.",

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -733,6 +733,13 @@
               },
               {
                 "flags": [
+                  "--proof-file"
+                ],
+                "help": "Read closeout proof text from a repo-contained file instead of a shell-sensitive argument.",
+                "name": "proof_file"
+              },
+              {
+                "flags": [
                   "--residue-owner"
                 ],
                 "help": "Canonical owner for non-empty residue or deferred intent.",

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -733,6 +733,13 @@
               },
               {
                 "flags": [
+                  "--proof-file"
+                ],
+                "help": "Read closeout proof text from a repo-contained file instead of a shell-sensitive argument.",
+                "name": "proof_file"
+              },
+              {
+                "flags": [
                   "--residue-owner"
                 ],
                 "help": "Canonical owner for non-empty residue or deferred intent.",

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -630,6 +630,13 @@ const commandDefinitions = [
             },
             {
               "flags": [
+                "--proof-file"
+              ],
+              "help": "Read closeout proof text from a repo-contained file instead of a shell-sensitive argument.",
+              "name": "proof_file"
+            },
+            {
+              "flags": [
                 "--residue-owner"
               ],
               "help": "Canonical owner for non-empty residue or deferred intent.",

--- a/packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.closeout.lifecycle.json
+++ b/packages/planning/src/repo_planning_bootstrap/contracts/operations/planning.closeout.lifecycle.json
@@ -40,6 +40,11 @@
       "required": false
     },
     {
+      "name": "proof_file",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "residue_owner",
       "source": "cli-option",
       "required": false

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -467,7 +467,7 @@ def _write_schema_backed_planning_record(*, record_path: Path, record: dict[str,
     if findings:
         raise ValueError(f"planning record does not validate against {schema_path.name}: {'; '.join(findings)}")
     record_path.parent.mkdir(parents=True, exist_ok=True)
-    record_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    record_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
 
 
 def planning_record_schema_findings(record_path: Path) -> list[str]:
@@ -11029,6 +11029,30 @@ def _load_last_proof_receipt(*, target_root: Path, record: dict[str, Any], plan:
     return None, "receipt has neither matching plan_id nor changed-path scope"
 
 
+def _read_closeout_proof_file(*, target_root: Path, proof_file: str) -> tuple[str, str, str]:
+    raw_path = proof_file.strip()
+    if not raw_path:
+        return "", "", "--proof-file was empty"
+    proof_path = Path(raw_path)
+    if not proof_path.is_absolute():
+        proof_path = target_root / proof_path
+    try:
+        resolved_target = target_root.resolve()
+        resolved_path = proof_path.resolve()
+        relative_path = resolved_path.relative_to(resolved_target).as_posix()
+    except (OSError, ValueError):
+        return "", "", "--proof-file must point to a file inside the target repository"
+    if not resolved_path.exists() or not resolved_path.is_file():
+        return "", relative_path, "--proof-file path does not exist or is not a file"
+    try:
+        proof = resolved_path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        return "", relative_path, f"--proof-file could not be read: {exc}"
+    if not proof:
+        return "", relative_path, "--proof-file did not contain proof text"
+    return proof, relative_path, ""
+
+
 def closeout_execplan(
     plan: str,
     *,
@@ -11038,6 +11062,7 @@ def closeout_execplan(
     intent_status: str = "satisfied",
     residue: str = "none",
     proof_from: str = "last",
+    proof_file: str | None = None,
     residue_owner: str | None = None,
     retain_archive: bool = True,
     what_happened: str | None = None,
@@ -11116,10 +11141,25 @@ def closeout_execplan(
         return clean(value)
 
     proof_request = clean(proof_from)
+    proof_file_ref = ""
     proof_report = _record_section_dict(record, "proof_report") or {}
     existing_proof = clean(proof_report.get("validation proof"))
     receipt: dict[str, Any] | None = None
-    if proof_request and proof_request.lower() != "last":
+    if provided(proof_file):
+        proof, proof_file_ref, proof_file_error = _read_closeout_proof_file(target_root=target_root, proof_file=provided(proof_file))
+        if proof_file_error:
+            result.warnings.append(
+                {
+                    "warning_class": "closeout_proof_file_unusable",
+                    "path": proof_file_ref or PLANNING_STATE_PATH.as_posix(),
+                    "message": proof_file_error,
+                    "suggested_fix": "Write proof evidence to a repo-contained text file and rerun closeout with --proof-file <path>.",
+                }
+            )
+            result.add("manual review", target_root / (proof_file_ref or PLANNING_STATE_PATH.as_posix()), proof_file_error)
+            return result
+        proof_source = "file"
+    elif proof_request and proof_request.lower() != "last":
         proof = proof_request
         proof_source = "explicit"
     elif existing_proof and not is_placeholder(existing_proof):
@@ -11200,6 +11240,87 @@ def closeout_execplan(
 
     status, default_owner = PLANNING_CLOSEOUT_RESIDUE_MAP[normalized_residue]
     owner = residue_owner or default_owner
+
+    if dry_run:
+        follow_on = continuation_owner if closure_decision == "archive-but-keep-lane-open" else "none"
+        normalized_preview = {
+            "active_milestone": {"status": "completed", "ready": "ready", "blocked": "none"},
+            "execution_run": {
+                "run status": "completed",
+                "what happened": run_evidence_inputs["what happened"] or clean(execution_run.get("what happened")),
+                "scope touched": run_evidence_inputs["scope touched"] or clean(execution_run.get("scope touched")),
+                "changed surfaces": run_evidence_inputs["changed surfaces"] or clean(execution_run.get("changed surfaces")),
+                "validations run": proof,
+                "result for continuation": (
+                    f"continue from {continuation_owner}"
+                    if closure_decision == "archive-but-keep-lane-open"
+                    else "bounded closeout complete"
+                ),
+                "next step": (
+                    f"promote the next bounded slice from {continuation_owner}"
+                    if closure_decision == "archive-but-keep-lane-open"
+                    else "archive this execplan"
+                ),
+            },
+            "finished_run_review": {
+                "review status": "complete",
+                "scope respected": provided(review_summary) or "yes; closeout accepted the bounded claim.",
+                "proof status": "passed",
+                "intent served": (
+                    "yes" if normalized_intent == "satisfied" else f"no; intent-status={normalized_intent} keeps continuation explicit."
+                ),
+                "follow-on decision": follow_on,
+            },
+            "execution_summary": {
+                "outcome delivered": provided(outcome_summary)
+                or clean(execution_summary.get("outcome delivered"))
+                or "closeout accepted the finished run evidence",
+                "validation confirmed": proof,
+                "follow-on routed to": follow_on,
+                "post-work posterity capture": "archive closeout distillation",
+                "resume from": continuation_owner if closure_decision == "archive-but-keep-lane-open" else "archive",
+            },
+            "proof_report": {
+                "validation proof": proof,
+                "proof achieved now": "yes; planning closeout dry-run resolved explicit proof evidence.",
+                'evidence for "proof achieved" state': proof,
+            },
+            "closure_check": {
+                "closeout scope": normalized_claim,
+                "slice status": "completed",
+                "larger-intent status": "open" if closure_decision == "archive-but-keep-lane-open" else "closed",
+                "closure decision": closure_decision,
+                "why this decision is honest": (
+                    f"planning closeout accepted a {normalized_claim} claim with intent-status {normalized_intent}."
+                ),
+                "evidence carried forward": proof,
+                "reopen trigger": (
+                    f"Reopen when {continuation_owner} activates a fresh bounded slice."
+                    if closure_decision == "archive-but-keep-lane-open"
+                    else "None unless new evidence shows the closeout was incomplete."
+                ),
+            },
+            "durable_residue": {"status": status, "canonical owner now": owner},
+        }
+        if proof_source == "file":
+            normalized_preview["proof_report"]["proof source"] = proof_file_ref
+        result.add("would update", record_path, f"normalized closeout state: {json.dumps(normalized_preview, sort_keys=True)}")
+        result.add("would archive", record_path, "archive validation would run against the normalized closeout state")
+        result.completion_options.extend(
+            [
+                {
+                    "id": "claim-slice-complete",
+                    "allowed": False,
+                    "why": "dry-run preview only; rerun without --dry-run before claiming completion",
+                },
+                {
+                    "id": "closeout-dry-run-status",
+                    "allowed": True,
+                    "why": "dry-run preview uses normalized completed closeout state rather than pending archive fields",
+                },
+            ]
+        )
+        return result
 
     if not dry_run:
         active_milestone = _record_section_dict(record, "active_milestone") or {}
@@ -11290,12 +11411,16 @@ def closeout_execplan(
             else "when the routed closeout residue is acted on",
             "retention after promotion": "retain",
         }
-        if proof and proof_source == "explicit":
+        if proof and proof_source in {"explicit", "file"}:
             record["proof_report"] = {
                 "validation proof": proof,
-                "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+                "proof achieved now": "yes; planning closeout recorded explicit proof input."
+                if proof_source == "explicit"
+                else "yes; planning closeout recorded proof input from a repo-contained proof file.",
                 'evidence for "proof achieved" state': proof,
             }
+            if proof_source == "file":
+                record["proof_report"]["proof source"] = proof_file_ref
         elif proof and proof_source == "existing":
             record["proof_report"] = proof_report
         elif proof and proof_source == "receipt":
@@ -12030,6 +12155,7 @@ def archive_execplan(
     retention_skip_reason = (
         "retained archive would exceed the structured-file inventory max_bytes guardrail; closing after distillation instead"
     )
+    archive_record = _compact_closeout_archive_record(closeout_record)
 
     if retain_archive:
         if destination.exists() and destination.suffix == ".md":
@@ -12140,6 +12266,7 @@ def archive_execplan(
             record_path=record_path,
             plan_path=plan_path,
             has_record=has_record,
+            record_override=archive_record,
         )
         if archive_size_warning is not None:
             if apply_cleanup:
@@ -12213,8 +12340,10 @@ def archive_execplan(
         archive_dir.mkdir(parents=True, exist_ok=True)
         if has_record:
             shutil.move(str(record_path), str(destination_record))
+            if archive_record != closeout_record:
+                _write_execplan_record(record_path=destination_record, record=archive_record)
         else:
-            _write_execplan_record(record_path=destination_record, record=closeout_record)
+            _write_execplan_record(record_path=destination_record, record=archive_record)
         if plan_path.exists() and plan_path != record_path:
             plan_path.unlink()
     else:
@@ -12235,7 +12364,11 @@ def archive_execplan(
         if record_path.exists():
             record_path.unlink()
     if cleanup_todo_lines is not None and not (cleanup_roadmap_state["changed"] and apply_cleanup):
-        (target_root / ".agentic-workspace/planning/state.toml").write_text("\n".join(cleanup_todo_lines).rstrip() + "\n", encoding="utf-8")
+        (target_root / ".agentic-workspace/planning/state.toml").write_text(
+            "\n".join(cleanup_todo_lines).rstrip() + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
     if cleanup_roadmap_state["changed"] and apply_cleanup:
         state_to_write = cleanup_roadmap_state["state"]
         if cleanup_todo_lines is not None and isinstance(state_to_write, dict):
@@ -12338,6 +12471,28 @@ def _write_closeout_evidence_record(*, record_path: Path, record: dict[str, Any]
     _write_schema_backed_planning_record(record_path=record_path, record=record, schema_path=CLOSEOUT_EVIDENCE_SCHEMA_PATH)
 
 
+def _compact_closeout_archive_record(record: dict[str, Any]) -> dict[str, Any]:
+    proof_report = _record_section_dict(record, "proof_report") or {}
+    validation_proof = str(proof_report.get("validation proof", "")).strip()
+    if len(validation_proof) < 200:
+        return record
+    replacement = "See proof_report.validation proof."
+
+    def compact(value: Any, path: tuple[str, ...]) -> Any:
+        if isinstance(value, str):
+            if value == validation_proof and path != ("proof_report", "validation proof"):
+                return replacement
+            return value
+        if isinstance(value, list):
+            return [compact(item, path + (str(index),)) for index, item in enumerate(value)]
+        if isinstance(value, dict):
+            return {str(key): compact(item, path + (str(key),)) for key, item in value.items()}
+        return value
+
+    compacted = compact(record, ())
+    return compacted if isinstance(compacted, dict) else record
+
+
 def _archive_size_guardrail_warning(
     *,
     target_root: Path,
@@ -12345,11 +12500,14 @@ def _archive_size_guardrail_warning(
     record_path: Path,
     plan_path: Path,
     has_record: bool,
+    record_override: dict[str, Any] | None = None,
 ) -> dict[str, str] | None:
     max_bytes = _structured_file_inventory_max_bytes(target_root, ".agentic-workspace/planning/execplans/archive/*.plan.json")
     if max_bytes is None:
         return None
-    if has_record:
+    if record_override is not None:
+        projected_bytes = len((json.dumps(record_override, ensure_ascii=False, indent=2) + "\n").encode("utf-8"))
+    elif has_record:
         projected_bytes = record_path.stat().st_size if record_path.exists() else 0
     else:
         record = _build_execplan_record_from_markdown(plan_path)
@@ -14960,7 +15118,7 @@ def _remove_close_item_state_candidate(state: dict[str, Any], candidate: dict[st
 def _write_state_to_toml(target_root: Path, state: dict[str, Any]) -> None:
     state_path = target_root / PLANNING_STATE_PATH
     state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text("\n".join(_state_to_toml_lines(state)), encoding="utf-8")
+    state_path.write_text("\n".join(_state_to_toml_lines(state)), encoding="utf-8", newline="\n")
 
 
 def _merge_todo_state_from_toml_lines(state: dict[str, Any], lines: list[str]) -> dict[str, Any]:

--- a/packages/planning/src/repo_planning_bootstrap/runtime_projection.py
+++ b/packages/planning/src/repo_planning_bootstrap/runtime_projection.py
@@ -141,6 +141,7 @@ def apply_planning_closeout_operation(values: dict, _arguments: dict, _context):
         intent_status=str(values.get("intent_status") or "satisfied"),
         residue=str(values.get("residue") or "none"),
         proof_from=str(values.get("proof_from") or "last"),
+        proof_file=values.get("proof_file"),
         residue_owner=values.get("residue_owner"),
         retain_archive=not bool(values.get("discard_archive")),
         what_happened=values.get("what_happened"),

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -861,6 +861,150 @@ candidates = []
     assert any(
         action["kind"] == "dogfooding reflection" and "issues, Memory, planning" in action["detail"] for action in payload["actions"]
     )
+    assert b"\r\n" not in (tmp_path / ".agentic-workspace/planning/state.toml").read_bytes()
+
+
+def test_planning_closeout_reads_shell_sensitive_proof_from_file(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    proof_text = 'uv run pytest tests/test_a.py -q; rg "alpha|beta" src\\pkg --glob "*.py"'
+    _write(tmp_path / ".agentic-workspace" / "local" / "closeout-proof.txt", proof_text + "\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="active")
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--proof-file",
+                ".agentic-workspace/local/closeout-proof.txt",
+                "--what-happened",
+                "recorded closeout proof through a file input.",
+                "--scope-touched",
+                "packages/planning/src/repo_planning_bootstrap/installer.py",
+                "--changed-surfaces",
+                "planning closeout command",
+                "--review-summary",
+                "yes; file proof was read as data.",
+                "--outcome-summary",
+                "proof capture no longer requires shell-sensitive inline text.",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    archived = json.loads(
+        (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json").read_text(encoding="utf-8")
+    )
+
+    assert payload["warnings"] == []
+    assert archived["proof_report"]["validation proof"] == proof_text
+    assert archived["proof_report"]["proof source"] == ".agentic-workspace/local/closeout-proof.txt"
+    assert archived["execution_run"]["validations run"] == proof_text
+
+
+def test_planning_closeout_dry_run_previews_normalized_completed_state(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="active")
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--proof-from",
+                "uv run pytest packages/planning/tests/test_archive.py::test_closeout_dry_run -q",
+                "--what-happened",
+                "completed dry-run closeout preview normalization.",
+                "--scope-touched",
+                "packages/planning closeout dry-run",
+                "--changed-surfaces",
+                "packages/planning/src/repo_planning_bootstrap/installer.py",
+                "--review-summary",
+                "yes; dry-run reports the final completed state.",
+                "--outcome-summary",
+                "dry-run no longer previews pending archive state.",
+                "--dry-run",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    rendered = json.dumps(payload, sort_keys=True).lower()
+
+    assert any(action["kind"] == "would update" and "normalized closeout state" in action["detail"] for action in payload["actions"])
+    assert "current milestone validation remains pending" not in rendered
+    assert "continue the current milestone until the completion criteria are met" not in rendered
+    assert '"pending"' not in rendered
+    assert record_path.exists()
+    assert not (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json").exists()
+
+
+def test_planning_closeout_compacts_repeated_long_proof_before_archive_size_guardrail(tmp_path: Path, capsys) -> None:
+    long_proof = ('uv run pytest packages/planning/tests/test_archive.py -q; rg "alpha|beta" packages/planning; ' * 80).strip()
+    _write(
+        tmp_path / "src/agentic_workspace/contracts/structured_file_inventory.json",
+        json.dumps(
+            {
+                "entries": [
+                    {
+                        "pattern": ".agentic-workspace/planning/execplans/archive/*.plan.json",
+                        "schema_or_validator": ".agentic-workspace/planning/schemas/planning-execplan.schema.json",
+                        "owner": "planning",
+                        "guardrails": {"max_bytes": 35000},
+                    }
+                ]
+            }
+        )
+        + "\n",
+    )
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="active")
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--proof-from",
+                long_proof,
+                "--what-happened",
+                "closed a plan with long multi-command proof.",
+                "--scope-touched",
+                "packages/planning closeout proof compaction",
+                "--changed-surfaces",
+                "packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_archive.py",
+                "--review-summary",
+                "yes; repeated proof text is compacted before archive retention.",
+                "--outcome-summary",
+                "long proof closeout archives without size-guardrail false positives.",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    archived_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json"
+    archived = json.loads(archived_path.read_text(encoding="utf-8"))
+
+    assert payload["warnings"] == []
+    assert archived_path.exists()
+    assert archived["proof_report"]["validation proof"] == long_proof
+    assert archived["execution_run"]["validations run"] == "See proof_report.validation proof."
+    assert archived["closure_check"]["evidence carried forward"] == "See proof_report.validation proof."
 
 
 def test_planning_closeout_treats_retention_size_skip_as_non_blocking(tmp_path: Path, capsys) -> None:

--- a/scripts/generate/generate_schema_reference.py
+++ b/scripts/generate/generate_schema_reference.py
@@ -307,15 +307,20 @@ def _normalized_generated_content(content: str) -> str:
     return content.replace("\r\n", "\n").replace("\r", "\n")
 
 
-def _needs_generated_write(current: str, next_content: str) -> bool:
-    return _normalized_generated_content(current) != _normalized_generated_content(next_content)
+def _needs_generated_write(current_bytes: bytes, next_content: str) -> bool:
+    try:
+        current = current_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return True
+    next_bytes = next_content.encode("utf-8")
+    return current_bytes != next_bytes or _normalized_generated_content(current) != _normalized_generated_content(next_content)
 
 
 def generate(*, targets: tuple[ReferenceTarget, ...] = DEFAULT_TARGETS, repo_root: Path = REPO_ROOT, check: bool = False) -> list[Path]:
     stale: list[Path] = []
     for output_path, content in render_targets(targets, repo_root=repo_root):
         absolute_output_path = repo_root / output_path
-        current = absolute_output_path.read_text(encoding="utf-8") if absolute_output_path.exists() else ""
+        current = absolute_output_path.read_bytes() if absolute_output_path.exists() else b""
         if check:
             if _needs_generated_write(current, content):
                 stale.append(output_path)
@@ -323,7 +328,7 @@ def generate(*, targets: tuple[ReferenceTarget, ...] = DEFAULT_TARGETS, repo_roo
         if absolute_output_path.exists() and not _needs_generated_write(current, content):
             continue
         absolute_output_path.parent.mkdir(parents=True, exist_ok=True)
-        absolute_output_path.write_text(content, encoding="utf-8")
+        absolute_output_path.write_text(content, encoding="utf-8", newline="\n")
     return stale
 
 

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -537,6 +537,13 @@
               "help": "Use existing proof with 'last' or record the supplied proof command/text."
             },
             {
+              "name": "proof_file",
+              "flags": [
+                "--proof-file"
+              ],
+              "help": "Read closeout proof text from a repo-contained file instead of a shell-sensitive argument."
+            },
+            {
               "name": "residue_owner",
               "flags": [
                 "--residue-owner"

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -1408,6 +1408,13 @@
                     "help": "Use existing proof with 'last' or record the supplied proof command/text."
                   },
                   {
+                    "name": "proof_file",
+                    "flags": [
+                      "--proof-file"
+                    ],
+                    "help": "Read closeout proof text from a repo-contained file instead of a shell-sensitive argument."
+                  },
+                  {
                     "name": "residue_owner",
                     "flags": [
                       "--residue-owner"
@@ -5384,6 +5391,11 @@
               "default": "last"
             },
             {
+              "name": "proof_file",
+              "arg": "proof_file",
+              "default": null
+            },
+            {
               "name": "residue_owner",
               "arg": "residue_owner",
               "default": null
@@ -6180,6 +6192,13 @@
                 ],
                 "default": "last",
                 "help": "Use existing proof with 'last' or record the supplied proof command/text."
+              },
+              {
+                "name": "proof_file",
+                "flags": [
+                  "--proof-file"
+                ],
+                "help": "Read closeout proof text from a repo-contained file instead of a shell-sensitive argument."
               },
               {
                 "name": "residue_owner",

--- a/tests/test_schema_reference_docs.py
+++ b/tests/test_schema_reference_docs.py
@@ -44,7 +44,7 @@ def test_schema_reference_default_targets_cover_all_contract_schemas() -> None:
     assert sorted(target.schema_path for target in module.DEFAULT_TARGETS) == schemas
 
 
-def test_schema_reference_generator_skips_crlf_only_rewrites(tmp_path: Path) -> None:
+def test_schema_reference_generator_rewrites_crlf_only_output_to_lf(tmp_path: Path) -> None:
     module = _load_generator()
     schema = tmp_path / "schema.schema.json"
     output = tmp_path / "reference.md"
@@ -69,11 +69,12 @@ def test_schema_reference_generator_skips_crlf_only_rewrites(tmp_path: Path) -> 
     target = module.ReferenceTarget(schema.relative_to(tmp_path), output.relative_to(tmp_path))
     rendered = module.render_schema_reference(target.schema_path, repo_root=tmp_path)
     output.write_bytes(rendered.replace("\n", "\r\n").encode("utf-8"))
-    before = output.read_bytes()
 
-    assert module.generate(targets=(target,), repo_root=tmp_path, check=True) == []
+    assert module.generate(targets=(target,), repo_root=tmp_path, check=True) == [target.output_path]
     assert module.generate(targets=(target,), repo_root=tmp_path, check=False) == []
-    assert output.read_bytes() == before
+    rewritten = output.read_bytes()
+    assert b"\r\n" not in rewritten
+    assert rewritten == rendered.encode("utf-8")
 
 
 def test_schema_reference_generator_still_detects_semantic_staleness(tmp_path: Path) -> None:


### PR DESCRIPTION
## What landed

- Adds `planning closeout --proof-file` so shell-sensitive proof text can be captured from a repo-contained UTF-8 file instead of an inline argument.
- Compacts repeated long closeout proof before archive size validation while preserving the full proof under `proof_report.validation proof`.
- Makes closeout dry-run render the normalized completed closeout state instead of stale pending archive wording.
- Writes planning records/state and schema-reference docs with LF line endings, and makes the schema-reference generator treat CRLF-only output as stale.
- Refreshes generated workspace/planning command packages for the new `proof_file` option.

## Issue closure

Closes #1304: `--proof-file` reads repo-contained proof safely and records the proof source.
Closes #1305: archive retention size validation now uses a compacted closeout record for repeated proof fields.
Closes #1306: closeout dry-run previews normalized completed closeout state and avoids pending/continue wording.
Closes #1307: managed planning writes use LF output.
Closes #1315: schema-reference generation detects and rewrites CRLF-only generated docs.

## Proof

- `uv run pytest tests/test_schema_reference_docs.py::test_schema_reference_generator_rewrites_crlf_only_output_to_lf packages/planning/tests/test_archive.py::test_planning_closeout_reads_shell_sensitive_proof_from_file packages/planning/tests/test_archive.py::test_planning_closeout_dry_run_previews_normalized_completed_state packages/planning/tests/test_archive.py::test_planning_closeout_compacts_repeated_long_proof_before_archive_size_guardrail packages/planning/tests/test_archive.py::test_planning_closeout_completes_active_run_before_archive_validation -q`
- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `make schema-reference-docs`