### PR TITLE
Preserve parent intent across planning slices

### DIFF
--- a/.agentic-workspace/planning/decompositions/README.md
+++ b/.agentic-workspace/planning/decompositions/README.md
@@ -2,6 +2,8 @@
 
 Use decomposition records for epic-shaped requests before implementation lanes exist.
 
-An epic is a work-shape classification, not a freehand artifact type. A `planning-decomposition/v1` record captures the larger intended outcome, candidate lanes, dependency and parallelization assumptions, and high-level proof expectations. Ready implementation slices move into `.agentic-workspace/planning/execplans/*.plan.json`; this directory should not carry lane execution journals.
+An epic is a work-shape classification, not a freehand artifact type. A `planning-decomposition/v1` record captures the larger intended outcome, parent acceptance target, candidate lanes, dependency and parallelization assumptions, and high-level proof expectations. Ready implementation slices move into `.agentic-workspace/planning/execplans/*.plan.json`; this directory should not carry lane execution journals.
+
+Use `parent_acceptance` to keep the user's full original intent separate from slice mechanics. Each lane should state how it advances the parent, what parent intent remains, and whether its proof is slice-only, parent-closing, or requires human confirmation.
 
 Create records by copying `TEMPLATE.decomposition.json` when a request needs product shaping before a lane can be promoted. After editing, run `agentic-workspace summary --format json` or the planning surface checker.

--- a/.agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json
@@ -3,6 +3,13 @@
   "title": "Epic-shaped request decomposition",
   "status": "shaping",
   "larger_intended_outcome": "Describe the larger outcome before choosing implementation lanes.",
+  "parent_acceptance": {
+    "original_intent": "State the full user/request parent intent before decomposition.",
+    "acceptance_target": "State what must be true before the parent can be called complete.",
+    "parent_proof_required": "State the evidence needed for parent closure, not only slice proof.",
+    "residual_intent_rule": "Each promoted lane must name what parent intent remains unsatisfied.",
+    "clarification_needed_when": "Ask or keep the parent open when clear broad intent would otherwise be narrowed."
+  },
   "non_goals": [
     "Do not put milestone execution detail here; promote ready slices into execplans."
   ],
@@ -14,6 +21,10 @@
       "outcome": "The bounded result this lane would deliver.",
       "owner_surface": "",
       "proof": "High-level proof expectation; exact commands belong in the execplan.",
+      "slice_contribution_to_parent": "How this lane advances the parent acceptance target.",
+      "residual_parent_intent": "What parent intent remains after this lane if it lands.",
+      "parent_proof_boundary": "slice-only|parent-closure|manual-confirmation-needed",
+      "human_confirmation_needed": [],
       "depends_on": [],
       "parallel_with": []
     }

--- a/.agentic-workspace/planning/decompositions/github-1318-original-intent-preservation.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/github-1318-original-intent-preservation.decomposition.json
@@ -1,0 +1,177 @@
+{
+  "kind": "planning-decomposition/v1",
+  "title": "Original intent preservation parent lane",
+  "status": "partially-promoted",
+  "larger_intended_outcome": "Implement #1318 so broad original user intent and applicable user/system/subsystem/soft intent remain the parent acceptance target across startup, implement, Planning decomposition, child slices, proof, closeout, and final user reporting. Slices are execution mechanics, not user-level completion unless the user explicitly asks for a slice.",
+  "parent_acceptance": {
+    "original_intent": "Preserve full original user intent and applicable intent constraints across epics, decomposition, slices, closeout, and final response.",
+    "acceptance_target": "#1318 and child issues #1319-#1325 are proven end to end, including the generated-code runtime-boundary regression and applicable-intent conflict/manual-verification fixture.",
+    "parent_proof_required": "Focused tests and PR closure matrix demonstrate Planning parent acceptance, startup/implement context, closeout blocking, final response rendering, and applicable intent handling.",
+    "residual_intent_rule": "If any child issue lacks proof, #1318 remains open and final response must name the residual parent intent.",
+    "clarification_needed_when": "Ask or keep parent open when clear broad intent would otherwise be narrowed to a slice."
+  },
+  "non_goals": [
+    "Do not create a new project-management system or broad dashboard.",
+    "Do not add an automatic business-logic classifier or policy engine.",
+    "Do not force full Planning ceremony for small direct work."
+  ],
+  "candidate_lanes": [
+    {
+      "id": "github-1319-grounding-review",
+      "title": "Grounding review before implementation",
+      "readiness": "promoted",
+      "outcome": "Review existing startup, implement, Planning, Verification, closeout, and final-response surfaces before implementation.",
+      "owner_surface": ".agentic-workspace/planning/reviews/2026-06-05-issue-1318-original-intent-preservation-grounding.review.json",
+      "proof": "Review record names current gaps and concrete reuse points.",
+      "slice_contribution_to_parent": "Provides grounding evidence for all implementation lanes.",
+      "residual_parent_intent": "Implementation and proof still remain after review.",
+      "parent_proof_boundary": "slice-only",
+      "human_confirmation_needed": [],
+      "depends_on": [],
+      "parallel_with": []
+    },
+    {
+      "id": "github-1320-start-implement-parent-intent",
+      "title": "Capture parent original intent in startup and implement context",
+      "readiness": "promoted",
+      "outcome": "Startup and implement surfaces preserve the original parent intent when current work is a slice.",
+      "owner_surface": ".agentic-workspace/planning/execplans/github-1318-preserve-original-intent.plan.json",
+      "proof": "Focused startup/implement tests show parent intent survives broad request handling.",
+      "slice_contribution_to_parent": "Preserves parent intent before code changes and changed-path proof selection.",
+      "residual_parent_intent": "Planning contract, closeout blocking, final response, and applicable-intent proof remain unless implemented together.",
+      "parent_proof_boundary": "slice-only",
+      "human_confirmation_needed": [],
+      "depends_on": [
+        "github-1319-grounding-review"
+      ],
+      "parallel_with": [
+        "github-1321-parent-acceptance-contract"
+      ]
+    },
+    {
+      "id": "github-1321-parent-acceptance-contract",
+      "title": "Parent acceptance contract in decomposition and child slices",
+      "readiness": "promoted",
+      "outcome": "Decomposition and active slices record original parent acceptance, slice contribution, residual parent intent, and parent closure proof.",
+      "owner_surface": ".agentic-workspace/planning/execplans/github-1318-preserve-original-intent.plan.json",
+      "proof": "Planning schema/template/projection tests cover the parent acceptance contract.",
+      "slice_contribution_to_parent": "Makes parent acceptance explicit in decomposition and child slice records.",
+      "residual_parent_intent": "Parent closeout still needs blocking/final-response proof.",
+      "parent_proof_boundary": "slice-only",
+      "human_confirmation_needed": [],
+      "depends_on": [
+        "github-1319-grounding-review"
+      ],
+      "parallel_with": [
+        "github-1322-block-parent-closeout"
+      ]
+    },
+    {
+      "id": "github-1322-block-parent-closeout",
+      "title": "Block parent closeout on narrower proof",
+      "readiness": "promoted",
+      "outcome": "Closeout blocks broad parent completion when proof only covers a narrower slice.",
+      "owner_surface": ".agentic-workspace/planning/execplans/github-1318-preserve-original-intent.plan.json",
+      "proof": "Closeout completion_options and final_response_rendering tests block parent/plain-done claims.",
+      "slice_contribution_to_parent": "Prevents narrow proof from authorizing parent closure.",
+      "residual_parent_intent": "Generated-code regression and final UX still need proof unless included.",
+      "parent_proof_boundary": "parent-closure",
+      "human_confirmation_needed": [],
+      "depends_on": [
+        "github-1321-parent-acceptance-contract"
+      ],
+      "parallel_with": [
+        "github-1323-generated-code-runtime-boundary-fixture"
+      ]
+    },
+    {
+      "id": "github-1323-generated-code-runtime-boundary-fixture",
+      "title": "Generated-code runtime-boundary regression fixture",
+      "readiness": "promoted",
+      "outcome": "A request that all runtime code be generated from IR cannot be narrowed to one fresh generated target or one primitive migration.",
+      "owner_surface": ".agentic-workspace/planning/execplans/github-1318-preserve-original-intent.plan.json",
+      "proof": "Representative fixture asserts parent status remains open and final response must name residual runtime-boundary intent.",
+      "slice_contribution_to_parent": "Proves the motivating under-scoping failure mode is blocked.",
+      "residual_parent_intent": "None for #1323 if fixture passes; remaining child lanes still govern #1318.",
+      "parent_proof_boundary": "parent-closure",
+      "human_confirmation_needed": [],
+      "depends_on": [
+        "github-1322-block-parent-closeout"
+      ],
+      "parallel_with": []
+    },
+    {
+      "id": "github-1324-final-response-slice-parent-status",
+      "title": "Plain slice-vs-parent final response",
+      "readiness": "promoted",
+      "outcome": "Final user-facing closeout says what landed, what parent intent remains, what proof covers, and what must not be claimed.",
+      "owner_surface": ".agentic-workspace/planning/execplans/github-1318-preserve-original-intent.plan.json",
+      "proof": "Final-response rendering tests cover required facts and must_not_claim constraints.",
+      "slice_contribution_to_parent": "Makes parent-vs-slice status visible to the user.",
+      "residual_parent_intent": "None for #1324 if rendered output passes; remaining child lanes still govern #1318.",
+      "parent_proof_boundary": "parent-closure",
+      "human_confirmation_needed": [],
+      "depends_on": [
+        "github-1322-block-parent-closeout"
+      ],
+      "parallel_with": []
+    },
+    {
+      "id": "github-1325-applicable-intent-stack",
+      "title": "Applicable intent stack and conflict handling",
+      "readiness": "promoted",
+      "outcome": "User, system, subsystem, soft/manual, compliance, assurance, and Verification intents are surfaced with conflict and manual-verification state.",
+      "owner_surface": ".agentic-workspace/planning/execplans/github-1318-preserve-original-intent.plan.json",
+      "proof": "Fixture shows conflict or missing authority blocks or caveats closeout and final response cannot hide it.",
+      "slice_contribution_to_parent": "Reconciles user intent with applicable system/subsystem/soft/manual obligations.",
+      "residual_parent_intent": "#1326 durable source discovery remains separate unless explicitly implemented.",
+      "parent_proof_boundary": "manual-confirmation-needed",
+      "human_confirmation_needed": [
+        "Human/domain owner accepts or clarifies conflicts and manual verification obligations."
+      ],
+      "depends_on": [
+        "github-1319-grounding-review"
+      ],
+      "parallel_with": [
+        "github-1320-start-implement-parent-intent",
+        "github-1321-parent-acceptance-contract"
+      ]
+    }
+  ],
+  "dependency_assumptions": [
+    "#1321 and #1322 should land together or in close sequence because parent acceptance without closeout blocking is weak.",
+    "#1323 should land early enough to prevent a generic wording-only fix.",
+    "#1325 is part of #1318 closure standard, while broader durable intent-source discovery in #1326 remains a sibling lane unless this PR explicitly implements it."
+  ],
+  "parallelization_assumptions": [
+    "Review, Planning contract, closeout blocking, final rendering, and applicable-intent evidence can be implemented in one integrated PR only if tests prove the end-to-end path.",
+    "A child slice may close only when its proof maps back to the parent acceptance target."
+  ],
+  "proof_expectations": [
+    "Grounding review exists before implementation.",
+    "Startup/implement, Planning decomposition/slice, closeout_report, completion_options, final_response_rendering, Verification/applicable-intent, and generated-code runtime-boundary fixtures all pass.",
+    "Parent closure remains blocked unless the original parent intent and applicable intent stack are satisfied or explicitly routed."
+  ],
+  "promotion_rule": "Promote child lanes only with explicit parent acceptance, slice contribution, residual parent intent, proof boundary, and final-response consequence.",
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1318",
+      "label": "parent lane",
+      "role": "parent"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1319",
+      "label": "grounding review",
+      "role": "child"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1320-#1325",
+      "label": "implementation children",
+      "role": "child-set"
+    }
+  ],
+  "notes": "Parent acceptance target: broad original intent remains the completion target; decomposition does not authorize reducing scope. Generated-code regression target: all runtime code should be generated from IR representations as a single source of truth cannot be closed by proof that some generated target is fresh."
+}

--- a/.agentic-workspace/planning/execplans/archive/github-1309-workspace-replace-prompt-keyword-semantic-routin.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1309-workspace-replace-prompt-keyword-semantic-routin.plan.json
@@ -59,7 +59,7 @@
       "#1313: lint guardrail fails on new hardcoded prompt semantic marker tables in guarded startup/routing functions."
     ],
     "continuation_owner": "none",
-    "closeout_decision": "ready-for-pr"
+    "closeout_decision": "archive-and-close"
   },
   "goal": [
     "Replace prompt keyword semantic routing with agent-owned judgment supported by repo-agnostic AW facts, selectors, guidance, and guardrails."
@@ -72,13 +72,14 @@
       "outcome": "Remove prompt keyword semantic routing and preserve useful AW support as advisory/selectable/structural evidence.",
       "constraints": "No replacement semantic classifier; keep AW repo- and agent-agnostic.",
       "latitude": "Use authority boundaries, explicit selectors, tests, docs, and lint guardrails.",
-      "escalation": "Escalate if closure requires automatic prompt semantics or broad new runtime concepts."
+      "escalation": "Escalate if closure requires automatic prompt semantics or broad new runtime concepts.",
+      "proof": "passed"
     },
     "execution": {
       "milestone": "github-1309-workspace-replace-prompt-keyword-semantic-routin",
-      "status": "in-progress",
-      "next_step": "Create PR with closure matrix and passing proof.",
-      "proof": "Required proof set passed on 2026-06-04."
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "passed"
     },
     "scope": {
       "touched": [
@@ -165,7 +166,7 @@
   "references": [],
   "active_milestone": {
     "id": "github-1309-workspace-replace-prompt-keyword-semantic-routin",
-    "status": "in-progress",
+    "status": "completed",
     "scope": "Keep this execution thread bounded to the promoted TODO item.",
     "ready": "ready",
     "blocked": "none",
@@ -201,6 +202,7 @@
     "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json",
     "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
     "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "rg \"prompt keyword|semantic marker|hard-coded prompt\" src tests scripts docs .agentic-workspace -g \"*.py\" -g \"*.md\" -g \"*.json\"",
     "uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py",
     "make test-workspace",
     "make lint-workspace",
@@ -253,17 +255,17 @@
   },
   "intent_satisfaction": {
     "original intent": "Replace assumptions and clever hard-coded host-repo prompt rules with agent judgment supported by AW facts, guidance, and learning surfaces.",
-    "was original intent fully satisfied?": "yes for #1309 and children #1310-#1313",
+    "was original intent fully satisfied?": "yes",
     "evidence of intent satisfaction": "Runtime prompt marker tables were removed from guarded startup/routing and objective-drift surfaces; advisory guidance is explicitly selectable; durable-intent and architecture-decision routing use structural/configured evidence; tests cover quiet defaults and selected guidance; lint blocks reintroduction of prompt semantic marker tables, including removal-intent classifiers.",
     "unsolved intent passed to": "none"
   },
   "execution_summary": {
     "outcome delivered": "prompt keyword semantic routing removed from the scoped lane and replaced with agent-owned advisory/selectable guidance",
     "validation confirmed": "passed",
-    "follow-on routed to": "none yet",
+    "follow-on routed to": "none",
     "post-work posterity capture": "closure evidence recorded in this execplan and PR body",
-    "knowledge promoted (Memory/Docs/Config)": "none",
-    "resume from": "PR review"
+    "resume from": "PR review",
+    "knowledge promoted (Memory/Docs/Config)": "none"
   },
   "durable_residue": {
     "status": "none",
@@ -274,20 +276,20 @@
     "retention after promotion": "retain"
   },
   "task_intent_promotion": {
-    "decision": "pending",
+    "decision": "do-not-promote",
     "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
-    "evidence source": "",
-    "target scope": "",
-    "proposed durable intent": "",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "none",
+    "proposed durable intent": "none yet",
     "confidence": "low",
     "needs review": true,
-    "owner surface": ""
+    "owner surface": "none"
   },
   "closure_check": {
+    "closeout scope": "slice",
     "slice status": "complete",
     "larger-intent status": "closed",
     "closure decision": "archive-and-close",
-    "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
     "why this decision is honest": "The PR demonstrates the scoped replacement across runtime behavior, selectable advisory packets, schema/reference wording, tests, and lint guardrails for #1309-#1313.",
     "evidence carried forward": "PR closure matrix plus passing proof commands listed in validation_commands and proof_report.",
     "reopen trigger": "Review finds a remaining prompt keyword semantic router in the scoped guarded surfaces, or the guardrail misses an equivalent marker table."
@@ -310,11 +312,17 @@
     "signals fixed": [],
     "signals routed": [],
     "signals dismissed": [],
-    "next owner": ""
+    "next owner": "none"
   },
   "closeout_distillation": {
     "buckets": {
-      "discard": [],
+      "discard": [
+        {
+          "summary": "Improvement signal review was checked and no signal was found.",
+          "owner": "none",
+          "source": "improvement_signal_review.status"
+        }
+      ],
       "continuation": [],
       "memory": [],
       "config_check": [],
@@ -325,5 +333,20 @@
   "drift_log": [
     "2026-06-04: Promoted from TODO direct-task shape into an execplan.",
     "2026-06-04: Recorded delegation decision route=keep-local."
-  ]
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Replace assumptions and clever hard-coded host-repo prompt rules with agent judgment supported by AW facts, guidance, and learning surfaces.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: passed\nChanged surfaces: start/preflight/summary/report/implement payload behavior and lint validation.\nDurable residue: none (none)\nMemory learning: none\nFollow-up: none yet"
+  }
 }

--- a/.agentic-workspace/planning/execplans/github-1318-preserve-original-intent.plan.json
+++ b/.agentic-workspace/planning/execplans/github-1318-preserve-original-intent.plan.json
@@ -1,0 +1,394 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Preserve full original intent across planning slices",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "lane",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "required_continuation",
+      "iterative_follow_through",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1318 and child issues #1319-#1325 so broad original user intent and applicable user/system/subsystem/soft intents remain visible and validated across Planning, startup/implement context, proof, closeout, and final user reporting.",
+    "hard_constraints": "Do not silently narrow clear broad intent into a smaller slice; do not add an automatic business classifier, new policy engine, broad dashboard, or project-management system; keep AW repo- and agent-agnostic and use existing Planning, Verification, closeout_report, completion_options, final_response_rendering, authority-boundary, schema/template, tests, and docs surfaces.",
+    "agent_may_decide": "Exact field names, compact projection shape, test layout, and whether #1326 remains a sibling residual lane, provided #1318/#1319-#1325 closure remains honest.",
+    "escalate_when": "A correct fix requires hiding residual parent intent, closing #1318 with only wording evidence, treating AW as the semantic intent owner, or implementing the broader #1326 lane without explicit scope.",
+    "next_action": "Create the PR with closure matrix and proof summary.",
+    "proof_expectations": [
+      "Focused tests show startup/implement context, Planning decomposition/slice projection, closeout_report, completion_options, final_response_rendering, and Verification/applicable-intent evidence preserve parent intent.",
+      "A generated-code/runtime-boundary fixture proves `all runtime code should be generated from IR representations as a single source of truth` cannot be closed by `some generated target is fresh` or `one primitive migration landed`.",
+      "Planning schema/template/projection checks pass and the review/decomposition/execplan artifacts remain schema-valid.",
+      "Workspace proof commands selected by changed paths pass before PR creation."
+    ],
+    "touched_scope": [
+      ".agentic-workspace/planning/execplans/github-1318-preserve-original-intent.plan.json",
+      ".agentic-workspace/planning/decompositions/github-1318-original-intent-preservation.decomposition.json",
+      ".agentic-workspace/planning/reviews/2026-06-05-issue-1318-original-intent-preservation-grounding.review.json",
+      ".agentic-workspace/planning/state.toml",
+      ".agentic-workspace/planning/schemas/planning-decomposition.schema.json",
+      ".agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json",
+      ".agentic-workspace/planning/decompositions/README.md",
+      "packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-decomposition.schema.json",
+      "packages/planning/bootstrap/.agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json",
+      "packages/planning/bootstrap/.agentic-workspace/planning/decompositions/README.md",
+      "packages/planning/src/repo_planning_bootstrap/installer.py",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_workspace_start_preflight_cli.py",
+      "tests/test_workspace_implement_cli.py",
+      "tests/test_workspace_report_cli.py",
+      "packages/planning/tests/test_summary.py",
+      "packages/planning/tests/test_promote.py",
+      "packages/planning/tests/test_check_planning_surfaces.py"
+    ],
+    "completion_criteria": [
+      "#1319: grounding review exists and maps implementation to existing AW surfaces.",
+      "#1320: startup/implement context carries parent original intent when work is broad or slice-backed.",
+      "#1321: decomposition and child slices carry parent acceptance, slice contribution, residual parent intent, proof boundary, and human clarification needs.",
+      "#1322: closeout blocks parent/full-work claims when proof only covers a narrower slice.",
+      "#1323: generated-code/runtime-boundary fixture blocks narrowing `all runtime code should be generated from IR` to freshness or one primitive migration.",
+      "#1324: final user-facing report plainly says current slice status, parent/original intent status, proof boundary, residual intent, and claims that must not be made.",
+      "#1325: applicable user/system/subsystem/soft intent evidence, conflict/missing-authority state, and manual-verification obligations are visible and block or caveat closeout/final response.",
+      "#1318 parent: PR body includes closure matrix for #1318-#1325 and does not close sibling #1326 unless explicitly implemented."
+    ],
+    "continuation_owner": "none if all criteria are proven; otherwise #1318 remains parent owner",
+    "closeout_decision": "archive-and-close after PR creation"
+  },
+  "goal": [
+    "Preserve the user's full original intent as the parent acceptance target across broad Planning, decomposition, child slices, proof, closeout, and final response.",
+    "Represent applicable user/system/subsystem/soft intents, conflicts, and manual-verification obligations clearly enough that closeout cannot hide them.",
+    "Prove the generated-code runtime-boundary under-scoping failure is blocked by executable fixtures."
+  ],
+  "non_goals": [
+    "Do not implement a new policy engine, automatic semantic classifier, broad dashboard, or project-management system.",
+    "Do not force this ceremony onto small direct work.",
+    "Do not close #1326 or its children unless their separate durable source-discovery scope is explicitly implemented."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Full #1318 parent closure with child issues #1319-#1325 satisfied end to end.",
+      "constraints": "Preserve parent intent; use existing AW surfaces; keep authority boundaries clear; avoid automatic semantic classification.",
+      "latitude": "Choose compact field names and projection shape that reduce review/continuation cost.",
+      "escalation": "Escalate if proof cannot honestly satisfy all child issues or if implementation would only improve wording."
+    },
+    "execution": {
+      "milestone": "github-1318-preserve-original-intent",
+      "status": "completed",
+      "next_step": "Create the PR and keep #1326 open as a sibling residual lane.",
+      "proof": "Focused fixtures plus workspace/planning validation listed in validation_commands passed."
+    },
+    "scope": {
+      "touched": [
+        "workspace runtime closeout/start/implement projections",
+        "Planning decomposition schema/template/projection/promotion",
+        "Planning review/decomposition/execplan artifacts",
+        "focused workspace and planning tests"
+      ],
+      "invariants": [
+        "Slices are execution units, not completion of the user's parent intent unless parent acceptance is proven.",
+        "AW surfaces evidence and gates; agent and human own semantic reconciliation and acceptance."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "The original user request remains the completion target across epics, decomposition, slices, closeout, and final response unless the user explicitly narrows it.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none if #1318-#1325 all pass; otherwise #1318 remains open"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no if all #1318-#1325 acceptance passes; yes if any child issue or parent fixture remains unsupported",
+    "owner surface": "#1318",
+    "activation trigger": "Any missing child closure evidence, generated-code fixture gap, applicable-intent conflict gap, or final-response caveat gap."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Parent/original-intent and applicable-intent status now flow through Planning decomposition, startup, implement, closeout_report, completion options, and final-response rendering.",
+    "intentionally deferred": "Broader #1326 durable applicable-intent source discovery unless implemented explicitly.",
+    "discovered implications": "The stale #1309 active plan had to be archived before #1318 implementation; this is dogfooding evidence for #1318.",
+    "proof achieved now": "yes",
+    "validation still needed": "none before PR creation",
+    "next likely slice": "none if this PR honestly closes #1318-#1325; otherwise keep #1318 open with named residual intent"
+  },
+  "intent_interpretation": {
+    "literal request": "Implement the #1318 lane in a new PR.",
+    "inferred intended outcome": "Do not ship a partial wording-only PR; implement the original-intent preservation lane end to end or keep parent closure open.",
+    "chosen concrete what": "Add compact parent-intent/applicable-intent contracts to existing AW surfaces and prove the generated-code under-scoping regression.",
+    "interpretation distance": "medium; issue comments require decomposition and child closure evidence before parent closure.",
+    "review guidance": "Reject closure if any child issue is supported only by prose, if final response can say plain done while parent intent is open, or if applicable-intent conflicts can be hidden."
+  },
+  "execution_bounds": {
+    "allowed paths": "Planning artifacts, Planning decomposition schema/template/projection/promotion/tests, workspace runtime projections, focused workspace tests, and generated/reference outputs required by changed contracts.",
+    "max changed files": "about 20 files including generated/reference updates if schema/docs generation requires them",
+    "required validation commands": "Focused workspace/planning tests, check_planning_surfaces, contract/tooling checks, structured inventory, maintainer surfaces, workspace tests/lint, planning tests/lint if Planning code changes, schema-reference-docs.",
+    "ask-before-refactor threshold": "Ask before adding a new module, classifier, policy engine, dashboard, or implementing #1326 as a separate parent lane.",
+    "stop before touching": "Unrelated command-generation primitive migration, direct runtime boundary enforcement, model harness changes, or broad Memory source-discovery lanes."
+  },
+  "stop_conditions": {
+    "stop when": "The implementation can only support a partial PR while claiming #1318 closure.",
+    "escalate when boundary reached": "A required fix changes parent scope, closes #1326 implicitly, or needs a new authoritative semantic classifier.",
+    "escalate on scope drift": "Implementation needs unrelated modules or a new state store.",
+    "escalate on proof failure": "Generated-code fixture, closeout blocking, applicable-intent conflict, or final-response rendering cannot be proven."
+  },
+  "context_budget": {
+    "live working set": "#1318-#1325 issues, this execplan, decomposition record, #1319 review, workspace_runtime_primitives closeout/start/implement functions, Planning decomposition schema/promotion/projection, focused tests.",
+    "recoverable later": "Historical archives and #1326 child issues unless compact routing points there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and PR closure matrix before pausing.",
+    "pre-work config pull": "Use AW start/summary/implement outputs before editing.",
+    "pre-work memory pull": "Consult Memory only if changed paths or task require durable repo knowledge.",
+    "tiny resumability note": "Implement #1318 through parent_intent/applicable_intent projections and generated-code fixture; do not close parent with wording only.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1318 and child issues #1319-#1325 end to end in a new PR.",
+    "hard constraints": "Parent intent remains completion target; no silent narrowing; no new classifier/policy engine; closure matrix required.",
+    "agent may decide locally": "Compact projection shape, test organization, PR wording, and exact child evidence mapping.",
+    "escalate when": "A child cannot be honestly closed or a broader sibling lane would be needed."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "Decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality without reducing proof.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "The lane spans tightly coupled Planning contracts, runtime projections, final-response rendering, and fixtures; local implementation preserves parent-intent continuity and proof ownership.",
+    "decision command": "agentic-planning delegation-decision",
+    "recorded at": "2026-06-05"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from bounded slices and keep AW authority boundaries clear.",
+    "slice shaping bias": "Use slices for execution while reporting parent status separately.",
+    "broader-lane validation question": "Did this implementation satisfy the user's original parent intent, or only make a slice easier to close?",
+    "intent evidence source": "#1318 issue body/comments and .agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1318",
+      "label": "parent original-intent lane",
+      "role": "parent",
+      "locator": "issue body and comments"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1319-#1325",
+      "label": "child closure issues",
+      "role": "children",
+      "locator": "issue bodies"
+    },
+    {
+      "kind": "planning-decomposition",
+      "target": ".agentic-workspace/planning/decompositions/github-1318-original-intent-preservation.decomposition.json",
+      "label": "parent decomposition",
+      "role": "decomposition",
+      "locator": "candidate_lanes"
+    },
+    {
+      "kind": "planning-review",
+      "target": ".agentic-workspace/planning/reviews/2026-06-05-issue-1318-original-intent-preservation-grounding.review.json",
+      "label": "#1319 grounding review",
+      "role": "review",
+      "locator": "findings"
+    }
+  ],
+  "active_milestone": {
+    "id": "github-1318-preserve-original-intent",
+    "status": "complete",
+    "scope": "Implement #1318 parent and children #1319-#1325 end to end using existing AW surfaces.",
+    "ready": "complete",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Create the PR with the closure matrix and proof summary."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    ".agentic-workspace/planning/execplans/github-1318-preserve-original-intent.plan.json",
+    ".agentic-workspace/planning/decompositions/github-1318-original-intent-preservation.decomposition.json",
+    ".agentic-workspace/planning/reviews/2026-06-05-issue-1318-original-intent-preservation-grounding.review.json",
+    ".agentic-workspace/planning/state.toml",
+    ".agentic-workspace/planning/schemas/planning-decomposition.schema.json",
+    ".agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json",
+    ".agentic-workspace/planning/decompositions/README.md",
+    "packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-decomposition.schema.json",
+    "packages/planning/bootstrap/.agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json",
+    "packages/planning/bootstrap/.agentic-workspace/planning/decompositions/README.md",
+    "packages/planning/src/repo_planning_bootstrap/installer.py",
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "tests/test_workspace_start_preflight_cli.py",
+    "tests/test_workspace_implement_cli.py",
+    "tests/test_workspace_report_cli.py",
+    "packages/planning/tests/test_summary.py",
+    "packages/planning/tests/test_promote.py",
+    "packages/planning/tests/test_check_planning_surfaces.py"
+  ],
+  "invariants": [
+    "Original parent intent remains the completion target unless the user explicitly narrows it.",
+    "A slice proof cannot close parent intent unless it proves parent acceptance.",
+    "AW surfaces evidence, gates, and conflicts; agent/human own semantic reconciliation and acceptance."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_represents_generated_code_parent_intent_boundary -q",
+    "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_surfaces_parent_intent_status_for_active_generated_code_slice tests/test_workspace_implement_cli.py::test_implement_context_surfaces_parent_intent_for_active_slice tests/test_workspace_report_cli.py::test_report_closeout_report_represents_generated_code_parent_intent_boundary tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim packages/planning/tests/test_summary.py::test_planning_summary_projects_decomposition_records packages/planning/tests/test_promote.py::test_promote_to_plan_supports_decomposition_lane -q",
+    "uv run pytest tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_workspace_implement_cli.py::test_implement_context_surfaces_parent_intent_for_active_slice tests/test_workspace_report_cli.py::test_report_closeout_report_renders_planned_slice_first_inspection_contract tests/test_workspace_report_cli.py::test_report_closeout_report_uses_audit_profile_for_strict_closeout tests/test_workspace_report_cli.py::test_report_closeout_report_represents_generated_code_parent_intent_boundary -q",
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "make maintainer-surfaces",
+    "make test-workspace",
+    "make lint-workspace",
+    "make test-planning",
+    "make lint-planning",
+    "make typecheck-planning",
+    "make schema-reference-docs",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "required_tools": [
+    "gh",
+    "uv",
+    "make"
+  ],
+  "completion_criteria": [
+    "#1319 grounding review record exists and is referenced by the PR closure matrix.",
+    "#1320 startup/implement context carries parent original intent for broad or slice-backed work.",
+    "#1321 decomposition/schema/template/projection and active slice records carry parent acceptance, residual parent intent, proof boundary, and human clarification needs.",
+    "#1322 closeout_report/completion_options block parent/full-work claims when proof only covers a narrower slice.",
+    "#1323 generated-code runtime-boundary fixture blocks under-scoped completion.",
+    "#1324 final_response_rendering renders slice-vs-parent status plainly and blocks plain done claims.",
+    "#1325 applicable-intent conflict/manual-verification fixture blocks or caveats closeout and final response.",
+    "PR body includes closure matrix and clearly states #1326 is not closed unless implemented."
+  ],
+  "execution_run": {
+    "run status": "complete",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan plus #1318 decomposition",
+    "what happened": "Implemented parent/original-intent and applicable-intent status packets across startup, implement, closeout_report, completion options, final-response rendering, Planning decomposition/promotion, schemas, templates, generated payloads, and focused fixtures.",
+    "scope touched": "workspace runtime projections; workspace contracts and reference docs; Planning decomposition schema/template/projection/promotion and generated payloads; focused workspace and Planning tests; #1318 Planning artifacts.",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas; docs/reference; packages/planning/src/repo_planning_bootstrap/installer.py; Planning schemas/templates/generated payloads; focused tests; #1318 Planning artifacts.",
+    "validations run": "Focused workspace/planning tests passed; contract tooling passed; structured inventory passed; maintainer surfaces passed; make test-workspace passed; make lint-workspace passed; make test-planning passed; make lint-planning passed; make typecheck-planning passed; schema-reference-docs passed; generated command package check passed; AW summary and Planning doctor passed.",
+    "result for continuation": "create PR; keep #1326 open as a sibling residual lane",
+    "next step": "Create PR with closure matrix."
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "yes; implementation stayed within existing Planning, Verification-derived closeout, report, final-response, authority-boundary, schema/template, docs, generated payload, and test surfaces.",
+    "proof status": "passed",
+    "intent served": "yes for #1318 and child issues #1319-#1325; #1326 remains a sibling residual lane and is not closed.",
+    "config compliance": "yes; used repo-local AW invocation, refreshed schema/reference/generated payload surfaces, and validated generated command package freshness.",
+    "misinterpretation risk": "lowered; final response and closeout now distinguish slice proof from parent/original-intent satisfaction and applicable-intent blockers.",
+    "follow-on decision": "PR should close #1318-#1325; leave #1326 open unless implemented separately."
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "Tightly coupled parent-intent runtime/planning/reporting contract; local implementation preserves proof ownership.",
+    "expected savings": "low",
+    "actual friction": "No delegation used; local context was large but tightly coupled. AW caught schema drift and stale active-plan residue through validation.",
+    "proof result": "passed",
+    "quality concern": "The first implementation attempted to add parent packets too broadly; existing closeout tests caught the over-reporting and the fix now keeps guidance-only packets quiet.",
+    "decomposition adjustment": "created explicit #1318 decomposition after user caught missing epic Planning artifacts"
+  },
+  "proof_report": {
+    "validation proof": "focused pytest suites; make test-workspace; make lint-workspace; make test-planning; make lint-planning; make typecheck-planning; maintainer-surfaces; schema-reference-docs; contract tooling; structured inventory; generated command package check; AW summary; Planning doctor all passed.",
+    "proof achieved now": "yes",
+    "evidence for \"proof achieved\" state": "Validation commands listed in validation_commands passed after targeted regressions were fixed."
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1318 so original user intent and applicable intent stack are preserved and validated across epics, decomposition, child slices, closeout, and final response.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "The PR-ready diff includes #1319 grounding review, #1320 startup/implement parent status, #1321 Planning decomposition/promotion parent acceptance, #1322 closeout completion-option blocking, #1323 generated-code runtime-boundary fixture, #1324 final-response parent/applicable rendering, and #1325 applicable-intent conflict/manual-verification blocking.",
+    "unsolved intent passed to": "#1326 remains open as a sibling residual durable source-discovery lane; not required to close #1318."
+  },
+  "execution_summary": {
+    "outcome delivered": "Parent/original-intent and applicable-intent preservation implemented across Planning, startup, implement, closeout, completion options, and final-response reporting.",
+    "validation confirmed": "yes",
+    "follow-on routed to": "#1326 sibling lane remains open; no #1318 child residue remains.",
+    "post-work posterity capture": "PR body closure matrix and this execplan closeout evidence.",
+    "knowledge promoted (Memory/Docs/Config)": "none",
+    "resume from": "PR review if feedback arrives"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "This lane implements explicit GitHub issues, not a newly discovered durable repo behavior.",
+    "target scope": "none",
+    "proposed durable intent": "",
+    "confidence": "high",
+    "needs review": false,
+    "owner surface": ""
+  },
+  "closure_check": {
+    "slice status": "complete",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
+    "why this decision is honest": "Each #1318 child issue has concrete evidence in code, schemas/templates/generated payloads, tests, docs/reference, and PR body closure matrix; #1326 is explicitly left open.",
+    "evidence carried forward": "PR body closure matrix, focused fixtures, validation log in proof_report, #1319 grounding review, and #1318 decomposition/execplan.",
+    "reopen trigger": "Any review finding that parent/original intent can still be silently narrowed, applicable-intent blockers can be hidden, or a #1318 child issue lacks executable/schema/doc evidence."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      "Dogfooding found that I classified #1318 as epic-shaped but initially skipped creating the required Planning decomposition/execplan artifacts."
+    ],
+    "signals fixed": [
+      "Archived stale #1309 plan, created #1318 execplan, #1318 decomposition, and #1319 grounding review before implementation."
+    ],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": ""
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-05: Scaffolded by agentic-planning new-plan.",
+    "2026-06-05: User caught that the work had been treated as epic-shaped without creating the corresponding Planning decomposition/execplan artifacts; archived stale #1309 and created #1318 Planning structure before implementation."
+  ]
+}

--- a/.agentic-workspace/planning/reviews/2026-06-05-issue-1318-original-intent-preservation-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-05-issue-1318-original-intent-preservation-grounding.review.json
@@ -1,0 +1,164 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1318 original intent preservation",
+  "date": "2026-06-05",
+  "scope": [
+    "Inspect existing startup/implement, Planning decomposition, closeout, final-response, Verification, and applicable-intent surfaces before implementation."
+  ],
+  "classification": "original-intent-preservation",
+  "goal": [
+    "Ground #1318 implementation in existing AW surfaces before changing runtime behavior.",
+    "Identify the smallest contracts needed so broad parent intent cannot be silently narrowed to a completed child slice."
+  ],
+  "non_goals": [
+    "Do not add a new project-management module, policy engine, or automatic business classifier.",
+    "Do not solve the broader #1326 durable applicable-intent source lane unless #1325 needs a compact first slice."
+  ],
+  "review_mode": {
+    "mode": "original-intent-preservation",
+    "review question": "Can existing startup/implement, Planning, Verification, closeout, completion_options, and final_response_rendering surfaces preserve parent intent end to end?",
+    "default finding cap": "bounded",
+    "inputs inspected first": "compact planning and task-specific surfaces"
+  },
+  "review_method": {
+    "commands used": "uv run python scripts/run_agentic_workspace.py start --task <#1318 implementation> --format json; uv run python scripts/run_agentic_workspace.py summary --format json; gh issue view 1318, 1319-1325; rg over workspace_runtime_primitives.py, Planning installer/schema/tests, Verification tests, closeout/final-response tests.",
+    "evidence sources": "Issue #1318 comments and child issues #1319-#1325; src/agentic_workspace/workspace_runtime_primitives.py; packages/planning/src/repo_planning_bootstrap/installer.py; planning-decomposition schema/template; tests/test_workspace_report_cli.py; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_implement_cli.py; packages/planning/tests."
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1318",
+      "label": "parent original-intent lane",
+      "role": "parent",
+      "locator": "issue body and owner comments"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1319-#1325",
+      "label": "child issues",
+      "role": "closure standard",
+      "locator": "issue bodies"
+    },
+    {
+      "kind": "code",
+      "target": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "label": "startup/implement/report closeout projection",
+      "role": "implementation surface",
+      "locator": "completion_boundary, completion_options, closeout_report, final_response_rendering"
+    },
+    {
+      "kind": "code",
+      "target": "packages/planning/src/repo_planning_bootstrap/installer.py",
+      "label": "Planning archive and decomposition promotion",
+      "role": "implementation surface",
+      "locator": "archive-plan, closeout, promote decomposition lane"
+    }
+  ],
+  "findings": [
+    {
+      "title": "Existing closeout options already separate slice and parent claims, but parent intent is not plain enough.",
+      "summary": "completion_options has claim-slice-complete, claim-work-complete, keep-parent-open, and close-parent-lane, and closeout_report renders final_response_rendering. The missing contract is a compact parent-original-intent status that final chat output must include when parent status is open or proof is narrower.",
+      "evidence": "workspace_runtime_primitives.py exposes _closeout_completion_options, _completion_boundary_payload, _closeout_report_payload, and _closeout_report_final_response_rendering_payload.",
+      "risk if unchanged": "An agent can pass proof for a slice and still write a user-facing report that sounds like the broad original request is complete.",
+      "suggested action": "Add a parent_intent_status or equivalent projection from intent_satisfaction, closure_check, required_continuation, completion_boundary, and proof_report; make it drive must_include and must_not_claim in final_response_rendering.",
+      "confidence": "high",
+      "source": "code inspection",
+      "promotion target": "#1322 and #1324",
+      "promotion trigger": "implement before parent closeout",
+      "post-remediation note shape": "Keep a fixture proving parent open plus slice complete produces an explicit final-response caveat."
+    },
+    {
+      "title": "Planning decomposition names the larger outcome but lacks a first-class parent acceptance contract.",
+      "summary": "planning-decomposition/v1 currently carries larger_intended_outcome, proof_expectations, and candidate_lanes. That is enough for high-level decomposition, but not enough to force each lane to state parent acceptance, residual parent intent, and parent closure proof.",
+      "evidence": ".agentic-workspace/planning/schemas/planning-decomposition.schema.json and TEMPLATE.decomposition.json have no parent_acceptance or residual_parent_intent field.",
+      "risk if unchanged": "A promoted child lane can inherit a broad title while the actionable acceptance narrows to the lane only.",
+      "suggested action": "Extend decomposition schema/template/projection and promotion behavior with compact parent acceptance fields, then keep child execplans tied to those fields.",
+      "confidence": "high",
+      "source": "schema/template inspection",
+      "promotion target": "#1321",
+      "promotion trigger": "before implementing child-slice closeout semantics",
+      "post-remediation note shape": "Retain schema/template tests rather than prose-only guidance."
+    },
+    {
+      "title": "The generated-code runtime-boundary example should be a representative regression, not wording only.",
+      "summary": "The parent issue's motivating phrase is precise: all runtime code should be generated from IR representations as a single source of truth. The fixture needs to prove that a freshness or primitive-migration slice cannot close that parent.",
+      "evidence": "#1318 issue body and comments; existing closeout tests already create active Planning records with behavior-preservation and Verification evidence.",
+      "risk if unchanged": "The PR could improve language while still allowing the exact under-scoping failure to recur.",
+      "suggested action": "Add a report/closeout fixture where current slice proof is generated target freshness, parent intent remains open, close-parent-lane and claim-work-complete are blocked, and final_response_rendering names the residual runtime-boundary intent.",
+      "confidence": "high",
+      "source": "issue body plus existing test patterns",
+      "promotion target": "#1323",
+      "promotion trigger": "land before claiming #1318 closure",
+      "post-remediation note shape": "Keep the exact broad phrase in the test fixture."
+    },
+    {
+      "title": "Applicable intent stack can be represented compactly with existing evidence surfaces for #1325.",
+      "summary": "Verification, assurance requirements, system intent, Memory guidance, and closeout_report already carry evidence and authority boundaries. #1325 needs a compact conflict/manual-verification packet, not a new policy engine.",
+      "evidence": "workspace_runtime_primitives.py already imports Verification reports and assurance requirements; closeout_report already has authority_boundary and final_response_rendering constraints.",
+      "risk if unchanged": "A broad user request can appear complete while an applicable subsystem or soft/manual requirement remains unresolved.",
+      "suggested action": "Add a compact applicable_intent_status projection that surfaces user/system/subsystem/soft intent evidence, conflicts or missing authority, manual verification needs, and the closeout/final-response consequence.",
+      "confidence": "medium-high",
+      "source": "report and Verification surface inspection",
+      "promotion target": "#1325",
+      "promotion trigger": "same PR if #1318 parent closure is claimed",
+      "post-remediation note shape": "Do not close sibling #1326 unless durable source discovery/precedence children are also implemented."
+    }
+  ],
+  "recommendation": {
+    "promote": "Implement through existing Planning, Verification, closeout_report, completion_options, final_response_rendering, authority-boundary, schema/template, and test surfaces.",
+    "defer": "Broader #1326 durable source discovery and precedence can remain open unless implemented explicitly.",
+    "dismiss": "Do not pursue a new automatic semantic classifier, dashboard, or policy engine for this lane."
+  },
+  "retention": {
+    "closeout shape": "shrink",
+    "trigger": "findings promoted, dismissed, or superseded",
+    "proof surface": "routed issues, planning state, docs, checks, Memory, or a compact retained review stub"
+  },
+  "prose_templates": {
+    "review_finding": {
+      "sections": [
+        "Finding",
+        "Evidence",
+        "Impact",
+        "Recommendation",
+        "Owner",
+        "Status"
+      ],
+      "field_map": {
+        "Finding": "findings[].title + findings[].summary",
+        "Evidence": "findings[].evidence + findings[].source",
+        "Impact": "findings[].risk if unchanged",
+        "Recommendation": "findings[].suggested action + findings[].promotion target",
+        "Owner": "findings[].promotion target",
+        "Status": "recommendation/promote|defer|dismiss"
+      },
+      "rule": "Use only these headings when a prose finding is needed; keep the canonical fields structured."
+    },
+    "handoff_or_closeout": {
+      "sections": [
+        "Intent",
+        "What changed",
+        "Proof",
+        "Remaining risk",
+        "Durable residue",
+        "Next owner"
+      ],
+      "field_map": {
+        "Intent": "intent/outcome or requested_outcome",
+        "What changed": "execution_summary/outcome delivered",
+        "Proof": "proof_report/validation proof",
+        "Remaining risk": "finished_run_review/misinterpretation risk or follow-on decision",
+        "Durable residue": "durable_residue + closeout_distillation",
+        "Next owner": "execution_summary/follow-on routed to or required_continuation/owner surface"
+      },
+      "rule": "Prefer structured fields; use this shape only for short human-readable summaries."
+    }
+  },
+  "validation_commands": [
+    "uv run python scripts/check/check_planning_surfaces.py",
+    "uv run pytest tests/test_workspace_report_cli.py packages/planning/tests/test_summary.py packages/planning/tests/test_promote.py -q"
+  ],
+  "drift_log": [
+    "2026-06-05: Review record created by create-review."
+  ]
+}

--- a/.agentic-workspace/planning/schemas/planning-decomposition.schema.json
+++ b/.agentic-workspace/planning/schemas/planning-decomposition.schema.json
@@ -32,6 +32,9 @@
     "larger_intended_outcome": {
       "type": "string"
     },
+    "parent_acceptance": {
+      "$ref": "#/$defs/parent_acceptance"
+    },
     "non_goals": {
       "$ref": "#/$defs/string_array"
     },
@@ -105,11 +108,49 @@
         "proof": {
           "type": "string"
         },
+        "slice_contribution_to_parent": {
+          "type": "string"
+        },
+        "residual_parent_intent": {
+          "type": "string"
+        },
+        "parent_proof_boundary": {
+          "type": "string"
+        },
+        "human_confirmation_needed": {
+          "$ref": "#/$defs/string_array"
+        },
         "depends_on": {
           "$ref": "#/$defs/string_array"
         },
         "parallel_with": {
           "$ref": "#/$defs/string_array"
+        }
+      }
+    },
+    "parent_acceptance": {
+      "type": "object",
+      "required": [
+        "original_intent",
+        "acceptance_target",
+        "parent_proof_required"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "original_intent": {
+          "type": "string"
+        },
+        "acceptance_target": {
+          "type": "string"
+        },
+        "parent_proof_required": {
+          "type": "string"
+        },
+        "residual_intent_rule": {
+          "type": "string"
+        },
+        "clarification_needed_when": {
+          "type": "string"
         }
       }
     },

--- a/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -193,6 +193,7 @@
     "anti_overfitting_review": { "type": "object" },
     "direct_cli_edit_review": { "type": "object" },
     "cost_assessment": { "type": "object" },
+    "parent_acceptance": { "$ref": "#/$defs/string_map" },
     "parent_acceptance_map": {
       "anyOf": [
         { "type": "object" },

--- a/.agentic-workspace/planning/state.toml
+++ b/.agentic-workspace/planning/state.toml
@@ -9,12 +9,12 @@ schema_version = "planning-state/v1"
 work_items = []
 
 [active]
-execplans = [
-  { id = "github-1309-workspace-replace-prompt-keyword-semantic-routin", maturity = "active", status = "active", priority = "P1", refs = "GitHub #1309", title = "[Workspace]: Replace prompt keyword semantic routing with agent judgment and learned guidance", outcome = "Route the upstream issue into a bounded Agentic Workspace slice before implementation.", reason = "Open upstream issue from refreshed external intent evidence; priority P1 inferred from inferred-lane.", suggested_first_slice = "Inspect the issue body, choose the smallest workflow shape, and record exact proof before closeout.", path = ".agentic-workspace/planning/execplans/github-1309-workspace-replace-prompt-keyword-semantic-routin.plan.json" },
-]
+execplans = []
 
 [todo]
-active_items = []
+active_items = [
+  { id = "github-1318-preserve-original-intent", title = "Preserve full original intent across planning slices", maturity = "active", status = "active", surface = ".agentic-workspace/planning/execplans/github-1318-preserve-original-intent.plan.json", why_now = "PR creation and review", owner_role = "implementation", review_role = "validation", handoff_ready = true, next_action = "Create the PR with closure matrix and proof summary.", done_when = "PR body maps #1318-#1325 to concrete evidence and leaves #1326 open.", proof = "Focused tests, workspace/planning validation, contract checks, structured inventory, generated command package check, AW summary, and Planning doctor passed.", refs = ["GitHub #1318 and child issues #1319-#1325"] },
+]
 queued_items = []
 
 [roadmap]

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -87,6 +87,12 @@ Cheap implementer context for a bounded changed-path scope.
 | `acceptance_reconciliation.task_carry_forward_hint` | string | yes |  | Short reminder to preserve task text across start and implement calls. |  |  |
 | `intent_acknowledgement` | object | yes |  | Guidance for stating inferred intent, first slice, non-goals, and correction point before non-direct implementation. |  |  |
 | `intent_evidence` | object | yes |  | Compact provenance and assumption evidence for the task intent being implemented, including source chain, correction point, and clarification/proceed posture. |  |  |
+| `parent_intent_status` | object | no |  | Parent/original-intent status preserving larger intent across bounded slices. |  |  |
+| `parent_intent_status.kind` | const `"agentic-workspace/parent-intent-status/v1"` | yes |  | Discriminator for the parent/original-intent status packet. |  |  |
+| `parent_intent_status.status` | string | yes |  | Whether the recorded parent/original intent is satisfied, open, or only guidance. |  |  |
+| `applicable_intent_status` | object | no |  | Applicable-intent evidence, conflicts, missing authority, and manual-verification obligations. |  |  |
+| `applicable_intent_status.kind` | const `"agentic-workspace/applicable-intent-status/v1"` | yes |  | Discriminator for the applicable-intent status packet. |  |  |
+| `applicable_intent_status.status` | string | yes |  | Whether applicable-intent evidence is present, guidance-only, or requires attention. |  |  |
 | `reuse_pressure` | object | yes |  | Changed-path reuse and abstraction-pressure facts that help the agent decide whether to reuse, accept duplication, or route extraction follow-up. |  |  |
 | `assurance_requirements` | object | yes |  | Repo-declared assurance requirements matched to the task or changed paths, with evidence status and claim-boundary facts; task-marker matches cite explicit config while semantic acceptance remains agent/human owned. |  |  |
 | `verification` | object | yes |  | Matched repo-native verification protocols and bounded evidence status for the task or changed paths; task-marker matches are configured protocol evidence, not AW-owned intent classification. |  |  |

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -123,6 +123,8 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `next_safe_action.source_fields` | array of enum `"immediate_next_allowed_action"`, `"workflow_sufficiency"`, `"skill_routing"`, `"memory_consult"`, `"planning_safety_gate"`, `"proof"`, `"closeout_trust_inspection"`, `"continuation_state"` | yes |  | Startup fields used to derive the packet. |  |  |
 | `skills` | object | no |  | Compact startup projection over skill routing, required skill, recommendations, and catalog drill-down. |  |  |
 | `context` | object | no |  | Supporting startup context for the primary next-safe-action decision, including compatibility projections for detail fields. |  |  |
+| `parent_intent_status` | object | no |  | Parent/original-intent status preserving larger intent across bounded startup and implementation slices. |  |  |
+| `applicable_intent_status` | object | no |  | Applicable-intent evidence, conflicts, missing authority, and manual-verification obligations for startup closeout safety. |  |  |
 | `planning_safety_gate` | object | no |  | Planning ownership guard for broad, high-assurance, decomposed, or scope-widened work. |  |  |
 | `planning_revision` | object | no |  | Optimistic Planning state revision observed by this read surface. |  |  |
 | `active_plan_reliance` | object | no |  | Permission signal separating command-written integrity, planning freshness, and active-plan reliance. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -83,6 +83,12 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `operational_compression` | object | yes |  | Compression signals that keep ordinary agent startup and reporting cheap. |  |  |
 | `successful_completion_cost` | object | yes |  | Recent model CLI evaluation cost, package-read overhead, and rework signals for advisory optimization decisions. |  |  |
 | `completion_contract` | object | yes |  | Derived Planning completion-contract lens for done, partial, blocked, and continuation-required decisions. |  |  |
+| `parent_intent_status` | ref `#/$defs/parent_intent_status` | no |  | Derived parent/original-intent status packet used to prevent slice proof from being reported as parent completion. |  |  |
+| `parent_intent_status.kind` | const `"agentic-workspace/parent-intent-status/v1"` | yes |  | Discriminator for the parent/original-intent status packet. |  |  |
+| `parent_intent_status.status` | string | yes |  | Whether the recorded parent/original intent is satisfied, open, or only guidance. |  |  |
+| `applicable_intent_status` | ref `#/$defs/applicable_intent_status` | no |  | Derived applicable-intent evidence and conflict packet used to keep user, system, subsystem, and soft-intent obligations visible before broad closeout. |  |  |
+| `applicable_intent_status.kind` | const `"agentic-workspace/applicable-intent-status/v1"` | yes |  | Discriminator for the applicable-intent status packet. |  |  |
+| `applicable_intent_status.status` | string | yes |  | Whether applicable-intent evidence is present, guidance-only, or requires attention. |  |  |
 | `repair_loop_residue` | object | yes |  | Derived validation-driven repair residue across Planning and Verification. |  |  |
 | `structured_findings` | object | yes |  | Structured finding residue shape for review and promotion routing. |  |  |
 | `external_evidence_safety` | object | yes |  | External evidence freshness, divergence, stale-after, and closeout-safety projection. |  |  |

--- a/generated/planning/python/_payload/.agentic-workspace/planning/decompositions/README.md
+++ b/generated/planning/python/_payload/.agentic-workspace/planning/decompositions/README.md
@@ -2,6 +2,8 @@
 
 Use decomposition records for epic-shaped requests before implementation lanes exist.
 
-An epic is a work-shape classification, not a freehand artifact type. A `planning-decomposition/v1` record captures the larger intended outcome, candidate lanes, dependency and parallelization assumptions, and high-level proof expectations. Ready implementation slices move into `.agentic-workspace/planning/execplans/*.plan.json`; this directory should not carry lane execution journals.
+An epic is a work-shape classification, not a freehand artifact type. A `planning-decomposition/v1` record captures the larger intended outcome, parent acceptance target, candidate lanes, dependency and parallelization assumptions, and high-level proof expectations. Ready implementation slices move into `.agentic-workspace/planning/execplans/*.plan.json`; this directory should not carry lane execution journals.
+
+Use `parent_acceptance` to keep the user's full original intent separate from slice mechanics. Each lane should state how it advances the parent, what parent intent remains, and whether its proof is slice-only, parent-closing, or requires human confirmation.
 
 Create records by copying `TEMPLATE.decomposition.json` when a request needs product shaping before a lane can be promoted. After editing, run `agentic-workspace summary --format json` or the planning surface checker.

--- a/generated/planning/python/_payload/.agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json
+++ b/generated/planning/python/_payload/.agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json
@@ -3,6 +3,13 @@
   "title": "Epic-shaped request decomposition",
   "status": "shaping",
   "larger_intended_outcome": "Describe the larger outcome before choosing implementation lanes.",
+  "parent_acceptance": {
+    "original_intent": "State the full user/request parent intent before decomposition.",
+    "acceptance_target": "State what must be true before the parent can be called complete.",
+    "parent_proof_required": "State the evidence needed for parent closure, not only slice proof.",
+    "residual_intent_rule": "Each promoted lane must name what parent intent remains unsatisfied.",
+    "clarification_needed_when": "Ask or keep the parent open when clear broad intent would otherwise be narrowed."
+  },
   "non_goals": [
     "Do not put milestone execution detail here; promote ready slices into execplans."
   ],
@@ -14,6 +21,10 @@
       "outcome": "The bounded result this lane would deliver.",
       "owner_surface": "",
       "proof": "High-level proof expectation; exact commands belong in the execplan.",
+      "slice_contribution_to_parent": "How this lane advances the parent acceptance target.",
+      "residual_parent_intent": "What parent intent remains after this lane if it lands.",
+      "parent_proof_boundary": "slice-only|parent-closure|manual-confirmation-needed",
+      "human_confirmation_needed": [],
       "depends_on": [],
       "parallel_with": []
     }

--- a/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-decomposition.schema.json
+++ b/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-decomposition.schema.json
@@ -32,6 +32,9 @@
     "larger_intended_outcome": {
       "type": "string"
     },
+    "parent_acceptance": {
+      "$ref": "#/$defs/parent_acceptance"
+    },
     "non_goals": {
       "$ref": "#/$defs/string_array"
     },
@@ -105,11 +108,49 @@
         "proof": {
           "type": "string"
         },
+        "slice_contribution_to_parent": {
+          "type": "string"
+        },
+        "residual_parent_intent": {
+          "type": "string"
+        },
+        "parent_proof_boundary": {
+          "type": "string"
+        },
+        "human_confirmation_needed": {
+          "$ref": "#/$defs/string_array"
+        },
         "depends_on": {
           "$ref": "#/$defs/string_array"
         },
         "parallel_with": {
           "$ref": "#/$defs/string_array"
+        }
+      }
+    },
+    "parent_acceptance": {
+      "type": "object",
+      "required": [
+        "original_intent",
+        "acceptance_target",
+        "parent_proof_required"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "original_intent": {
+          "type": "string"
+        },
+        "acceptance_target": {
+          "type": "string"
+        },
+        "parent_proof_required": {
+          "type": "string"
+        },
+        "residual_intent_rule": {
+          "type": "string"
+        },
+        "clarification_needed_when": {
+          "type": "string"
         }
       }
     },

--- a/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -193,6 +193,7 @@
     "anti_overfitting_review": { "type": "object" },
     "direct_cli_edit_review": { "type": "object" },
     "cost_assessment": { "type": "object" },
+    "parent_acceptance": { "$ref": "#/$defs/string_map" },
     "parent_acceptance_map": {
       "anyOf": [
         { "type": "object" },

--- a/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/decompositions/README.md
+++ b/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/decompositions/README.md
@@ -2,6 +2,8 @@
 
 Use decomposition records for epic-shaped requests before implementation lanes exist.
 
-An epic is a work-shape classification, not a freehand artifact type. A `planning-decomposition/v1` record captures the larger intended outcome, candidate lanes, dependency and parallelization assumptions, and high-level proof expectations. Ready implementation slices move into `.agentic-workspace/planning/execplans/*.plan.json`; this directory should not carry lane execution journals.
+An epic is a work-shape classification, not a freehand artifact type. A `planning-decomposition/v1` record captures the larger intended outcome, parent acceptance target, candidate lanes, dependency and parallelization assumptions, and high-level proof expectations. Ready implementation slices move into `.agentic-workspace/planning/execplans/*.plan.json`; this directory should not carry lane execution journals.
+
+Use `parent_acceptance` to keep the user's full original intent separate from slice mechanics. Each lane should state how it advances the parent, what parent intent remains, and whether its proof is slice-only, parent-closing, or requires human confirmation.
 
 Create records by copying `TEMPLATE.decomposition.json` when a request needs product shaping before a lane can be promoted. After editing, run `agentic-workspace summary --format json` or the planning surface checker.

--- a/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json
+++ b/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json
@@ -3,6 +3,13 @@
   "title": "Epic-shaped request decomposition",
   "status": "shaping",
   "larger_intended_outcome": "Describe the larger outcome before choosing implementation lanes.",
+  "parent_acceptance": {
+    "original_intent": "State the full user/request parent intent before decomposition.",
+    "acceptance_target": "State what must be true before the parent can be called complete.",
+    "parent_proof_required": "State the evidence needed for parent closure, not only slice proof.",
+    "residual_intent_rule": "Each promoted lane must name what parent intent remains unsatisfied.",
+    "clarification_needed_when": "Ask or keep the parent open when clear broad intent would otherwise be narrowed."
+  },
   "non_goals": [
     "Do not put milestone execution detail here; promote ready slices into execplans."
   ],
@@ -14,6 +21,10 @@
       "outcome": "The bounded result this lane would deliver.",
       "owner_surface": "",
       "proof": "High-level proof expectation; exact commands belong in the execplan.",
+      "slice_contribution_to_parent": "How this lane advances the parent acceptance target.",
+      "residual_parent_intent": "What parent intent remains after this lane if it lands.",
+      "parent_proof_boundary": "slice-only|parent-closure|manual-confirmation-needed",
+      "human_confirmation_needed": [],
       "depends_on": [],
       "parallel_with": []
     }

--- a/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-decomposition.schema.json
+++ b/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-decomposition.schema.json
@@ -32,6 +32,9 @@
     "larger_intended_outcome": {
       "type": "string"
     },
+    "parent_acceptance": {
+      "$ref": "#/$defs/parent_acceptance"
+    },
     "non_goals": {
       "$ref": "#/$defs/string_array"
     },
@@ -105,11 +108,49 @@
         "proof": {
           "type": "string"
         },
+        "slice_contribution_to_parent": {
+          "type": "string"
+        },
+        "residual_parent_intent": {
+          "type": "string"
+        },
+        "parent_proof_boundary": {
+          "type": "string"
+        },
+        "human_confirmation_needed": {
+          "$ref": "#/$defs/string_array"
+        },
         "depends_on": {
           "$ref": "#/$defs/string_array"
         },
         "parallel_with": {
           "$ref": "#/$defs/string_array"
+        }
+      }
+    },
+    "parent_acceptance": {
+      "type": "object",
+      "required": [
+        "original_intent",
+        "acceptance_target",
+        "parent_proof_required"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "original_intent": {
+          "type": "string"
+        },
+        "acceptance_target": {
+          "type": "string"
+        },
+        "parent_proof_required": {
+          "type": "string"
+        },
+        "residual_intent_rule": {
+          "type": "string"
+        },
+        "clarification_needed_when": {
+          "type": "string"
         }
       }
     },

--- a/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -193,6 +193,7 @@
     "anti_overfitting_review": { "type": "object" },
     "direct_cli_edit_review": { "type": "object" },
     "cost_assessment": { "type": "object" },
+    "parent_acceptance": { "$ref": "#/$defs/string_map" },
     "parent_acceptance_map": {
       "anyOf": [
         { "type": "object" },

--- a/packages/planning/bootstrap/.agentic-workspace/planning/decompositions/README.md
+++ b/packages/planning/bootstrap/.agentic-workspace/planning/decompositions/README.md
@@ -2,6 +2,8 @@
 
 Use decomposition records for epic-shaped requests before implementation lanes exist.
 
-An epic is a work-shape classification, not a freehand artifact type. A `planning-decomposition/v1` record captures the larger intended outcome, candidate lanes, dependency and parallelization assumptions, and high-level proof expectations. Ready implementation slices move into `.agentic-workspace/planning/execplans/*.plan.json`; this directory should not carry lane execution journals.
+An epic is a work-shape classification, not a freehand artifact type. A `planning-decomposition/v1` record captures the larger intended outcome, parent acceptance target, candidate lanes, dependency and parallelization assumptions, and high-level proof expectations. Ready implementation slices move into `.agentic-workspace/planning/execplans/*.plan.json`; this directory should not carry lane execution journals.
+
+Use `parent_acceptance` to keep the user's full original intent separate from slice mechanics. Each lane should state how it advances the parent, what parent intent remains, and whether its proof is slice-only, parent-closing, or requires human confirmation.
 
 Create records by copying `TEMPLATE.decomposition.json` when a request needs product shaping before a lane can be promoted. After editing, run `agentic-workspace summary --format json` or the planning surface checker.

--- a/packages/planning/bootstrap/.agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json
+++ b/packages/planning/bootstrap/.agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json
@@ -3,6 +3,13 @@
   "title": "Epic-shaped request decomposition",
   "status": "shaping",
   "larger_intended_outcome": "Describe the larger outcome before choosing implementation lanes.",
+  "parent_acceptance": {
+    "original_intent": "State the full user/request parent intent before decomposition.",
+    "acceptance_target": "State what must be true before the parent can be called complete.",
+    "parent_proof_required": "State the evidence needed for parent closure, not only slice proof.",
+    "residual_intent_rule": "Each promoted lane must name what parent intent remains unsatisfied.",
+    "clarification_needed_when": "Ask or keep the parent open when clear broad intent would otherwise be narrowed."
+  },
   "non_goals": [
     "Do not put milestone execution detail here; promote ready slices into execplans."
   ],
@@ -14,6 +21,10 @@
       "outcome": "The bounded result this lane would deliver.",
       "owner_surface": "",
       "proof": "High-level proof expectation; exact commands belong in the execplan.",
+      "slice_contribution_to_parent": "How this lane advances the parent acceptance target.",
+      "residual_parent_intent": "What parent intent remains after this lane if it lands.",
+      "parent_proof_boundary": "slice-only|parent-closure|manual-confirmation-needed",
+      "human_confirmation_needed": [],
       "depends_on": [],
       "parallel_with": []
     }

--- a/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-decomposition.schema.json
+++ b/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-decomposition.schema.json
@@ -32,6 +32,9 @@
     "larger_intended_outcome": {
       "type": "string"
     },
+    "parent_acceptance": {
+      "$ref": "#/$defs/parent_acceptance"
+    },
     "non_goals": {
       "$ref": "#/$defs/string_array"
     },
@@ -105,11 +108,49 @@
         "proof": {
           "type": "string"
         },
+        "slice_contribution_to_parent": {
+          "type": "string"
+        },
+        "residual_parent_intent": {
+          "type": "string"
+        },
+        "parent_proof_boundary": {
+          "type": "string"
+        },
+        "human_confirmation_needed": {
+          "$ref": "#/$defs/string_array"
+        },
         "depends_on": {
           "$ref": "#/$defs/string_array"
         },
         "parallel_with": {
           "$ref": "#/$defs/string_array"
+        }
+      }
+    },
+    "parent_acceptance": {
+      "type": "object",
+      "required": [
+        "original_intent",
+        "acceptance_target",
+        "parent_proof_required"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "original_intent": {
+          "type": "string"
+        },
+        "acceptance_target": {
+          "type": "string"
+        },
+        "parent_proof_required": {
+          "type": "string"
+        },
+        "residual_intent_rule": {
+          "type": "string"
+        },
+        "clarification_needed_when": {
+          "type": "string"
         }
       }
     },

--- a/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -193,6 +193,7 @@
     "anti_overfitting_review": { "type": "object" },
     "direct_cli_edit_review": { "type": "object" },
     "cost_assessment": { "type": "object" },
+    "parent_acceptance": { "$ref": "#/$defs/string_map" },
     "parent_acceptance_map": {
       "anyOf": [
         { "type": "object" },

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -3247,6 +3247,9 @@ def _planning_decomposition_projection(*, target_root: Path, decomposition_dir: 
             if not isinstance(payload, dict) or payload.get("kind") != "planning-decomposition/v1":
                 continue
             lanes = payload.get("candidate_lanes", [])
+            parent_acceptance = payload.get("parent_acceptance", {})
+            if not isinstance(parent_acceptance, dict):
+                parent_acceptance = {}
             lane_summaries: list[dict[str, str]] = []
             if isinstance(lanes, list):
                 for raw in lanes:
@@ -3257,6 +3260,9 @@ def _planning_decomposition_projection(*, target_root: Path, decomposition_dir: 
                         "title": str(raw.get("title", "")).strip(),
                         "readiness": str(raw.get("readiness", "")).strip(),
                         "owner_surface": str(raw.get("owner_surface", "")).strip(),
+                        "slice_contribution_to_parent": str(raw.get("slice_contribution_to_parent", "")).strip(),
+                        "residual_parent_intent": str(raw.get("residual_parent_intent", "")).strip(),
+                        "parent_proof_boundary": str(raw.get("parent_proof_boundary", "")).strip(),
                     }
                     if lane["readiness"] == "ready":
                         ready_lane_count += 1
@@ -3268,6 +3274,17 @@ def _planning_decomposition_projection(*, target_root: Path, decomposition_dir: 
                     "path": path.relative_to(target_root).as_posix(),
                     "title": str(payload.get("title", "")).strip(),
                     "outcome": str(payload.get("larger_intended_outcome", "")).strip(),
+                    "parent_acceptance": {
+                        key: str(parent_acceptance.get(key, "")).strip()
+                        for key in (
+                            "original_intent",
+                            "acceptance_target",
+                            "parent_proof_required",
+                            "residual_intent_rule",
+                            "clarification_needed_when",
+                        )
+                        if str(parent_acceptance.get(key, "")).strip()
+                    },
                     "status": str(payload.get("status", "")).strip(),
                     "lane_count": len(lane_summaries),
                     "candidate_lanes": lane_summaries,
@@ -9012,6 +9029,51 @@ def _promote_decomposition_lane_to_execplan(
         done_when=proof or outcome or f"{title} is implemented, validated, and closed out honestly.",
         source_fields=source_fields,
     )
+    parent_acceptance = matched_record.get("parent_acceptance", {})
+    if not isinstance(parent_acceptance, dict):
+        parent_acceptance = {}
+    if parent_acceptance or any(
+        str(matched_lane.get(key, "")).strip()
+        for key in ("slice_contribution_to_parent", "residual_parent_intent", "parent_proof_boundary")
+    ):
+        original_intent = str(parent_acceptance.get("original_intent") or matched_record.get("larger_intended_outcome") or "").strip()
+        acceptance_target = str(parent_acceptance.get("acceptance_target") or matched_record.get("larger_intended_outcome") or "").strip()
+        residual_parent_intent = str(
+            matched_lane.get("residual_parent_intent") or parent_acceptance.get("residual_intent_rule") or ""
+        ).strip()
+        raw_human_confirmation = matched_lane.get("human_confirmation_needed")
+        if isinstance(raw_human_confirmation, list):
+            human_confirmation_needed = [str(item).strip() for item in raw_human_confirmation if str(item).strip()]
+        elif raw_human_confirmation:
+            human_confirmation_needed = [str(raw_human_confirmation).strip()]
+        else:
+            human_confirmation_needed = []
+        plan_record["parent_acceptance"] = {
+            "original_intent": original_intent,
+            "parent_intent": original_intent,
+            "parent_acceptance": acceptance_target,
+            "acceptance_target": acceptance_target,
+            "current_slice": outcome,
+            "slice_contribution": str(matched_lane.get("slice_contribution_to_parent") or outcome).strip(),
+            "residual_parent_intent": residual_parent_intent,
+            "proof_boundary": str(matched_lane.get("parent_proof_boundary") or "slice-only").strip(),
+            "parent_proof_required": str(parent_acceptance.get("parent_proof_required") or proof).strip(),
+            "human_confirmation_needed": human_confirmation_needed,
+            "clarification_needed_when": str(parent_acceptance.get("clarification_needed_when") or "").strip(),
+        }
+        plan_record["completion_criteria"].append(
+            "Parent acceptance: prove this slice's contribution and explicitly route residual parent intent before closeout."
+        )
+        plan_record["intent_satisfaction"]["original intent"] = original_intent or plan_record["intent_satisfaction"]["original intent"]
+        if residual_parent_intent:
+            plan_record["intent_continuity"]["this slice completes the larger intended outcome"] = "no"
+            plan_record["intent_continuity"]["continuation surface"] = str(
+                parent_acceptance.get("continuation_owner") or "parent lane"
+            ).strip()
+            plan_record["required_continuation"]["required follow-on for the larger intended outcome"] = "yes"
+            plan_record["required_continuation"]["owner surface"] = str(
+                parent_acceptance.get("continuation_owner") or "parent lane"
+            ).strip()
     plan_record["references"] = [
         {
             "kind": "source",

--- a/packages/planning/tests/test_promote.py
+++ b/packages/planning/tests/test_promote.py
@@ -342,6 +342,13 @@ def test_promote_to_plan_supports_decomposition_lane(tmp_path: Path) -> None:
                 "title": "Dogfood planning safety",
                 "status": "ready-for-lane-promotion",
                 "larger_intended_outcome": "Prevent broad work from bypassing planning.",
+                "parent_acceptance": {
+                    "original_intent": "Prevent broad work from bypassing planning.",
+                    "acceptance_target": "Broad work keeps parent acceptance, residual intent, and proof boundary visible across slices.",
+                    "parent_proof_required": "Focused workspace and Planning tests prove parent acceptance is preserved.",
+                    "residual_intent_rule": "Promoted lanes must name residual parent intent before closeout.",
+                    "clarification_needed_when": "A child slice would otherwise claim parent completion from local proof.",
+                },
                 "non_goals": [],
                 "candidate_lanes": [
                     {
@@ -351,6 +358,10 @@ def test_promote_to_plan_supports_decomposition_lane(tmp_path: Path) -> None:
                         "outcome": "Represent JSON/text planning behavior in schema-valid promoted work.",
                         "owner_surface": "",
                         "proof": "Focused workspace tests pass.",
+                        "slice_contribution_to_parent": "Adds schema-valid promoted work behavior.",
+                        "residual_parent_intent": "runtime closeout proof remains.",
+                        "parent_proof_boundary": "slice-only",
+                        "human_confirmation_needed": ["maintainer accepts parent closure proof before closing parent"],
                         "depends_on": [],
                         "parallel_with": [],
                     }
@@ -379,6 +390,12 @@ def test_promote_to_plan_supports_decomposition_lane(tmp_path: Path) -> None:
 
     plan = json.loads((tmp_path / ".agentic-workspace" / "planning" / "execplans" / "safety-slice.plan.json").read_text(encoding="utf-8"))
     assert "JSON/text" in plan["canonical_core"]["next_action"]
+    assert plan["parent_acceptance"]["original_intent"] == "Prevent broad work from bypassing planning."
+    assert plan["parent_acceptance"]["current_slice"] == "Represent JSON/text planning behavior in schema-valid promoted work."
+    assert plan["parent_acceptance"]["residual_parent_intent"] == "runtime closeout proof remains."
+    assert plan["parent_acceptance"]["proof_boundary"] == "slice-only"
+    assert plan["intent_continuity"]["this slice completes the larger intended outcome"] == "no"
+    assert plan["required_continuation"]["required follow-on for the larger intended outcome"] == "yes"
 
     decomposition = json.loads(decomposition_path.read_text(encoding="utf-8"))
     schema_path = (

--- a/packages/planning/tests/test_summary.py
+++ b/packages/planning/tests/test_summary.py
@@ -226,6 +226,13 @@ def test_planning_summary_projects_decomposition_records(tmp_path: Path) -> None
                 "title": "Shop build",
                 "status": "ready-for-lane-promotion",
                 "larger_intended_outcome": "Build the shop.",
+                "parent_acceptance": {
+                    "original_intent": "Build the complete shop.",
+                    "acceptance_target": "Storefront, checkout, and fulfillment lanes are complete.",
+                    "parent_proof_required": "Parent acceptance map proves all lanes.",
+                    "residual_intent_rule": "Each lane names remaining parent intent.",
+                    "clarification_needed_when": "A lane tries to close the parent with slice-only proof.",
+                },
                 "non_goals": ["Do not implement everything in one lane."],
                 "candidate_lanes": [
                     {
@@ -235,6 +242,10 @@ def test_planning_summary_projects_decomposition_records(tmp_path: Path) -> None
                         "outcome": "Browsable storefront.",
                         "owner_surface": ".agentic-workspace/planning/execplans/storefront.plan.json",
                         "proof": "Build and smoke test.",
+                        "slice_contribution_to_parent": "Provides the browsing lane.",
+                        "residual_parent_intent": "checkout and fulfillment remain.",
+                        "parent_proof_boundary": "slice-only",
+                        "human_confirmation_needed": [],
                         "depends_on": [],
                         "parallel_with": [],
                     }
@@ -255,7 +266,14 @@ def test_planning_summary_projects_decomposition_records(tmp_path: Path) -> None
     assert summary["decomposition"]["status"] == "present"
     assert summary["decomposition"]["record_count"] == 1
     assert summary["decomposition"]["ready_lane_count"] == 1
+    record = summary["decomposition"]["records"][0]
+    assert record["parent_acceptance"]["original_intent"] == "Build the complete shop."
+    assert record["parent_acceptance"]["acceptance_target"] == "Storefront, checkout, and fulfillment lanes are complete."
     assert summary["decomposition"]["records"][0]["candidate_lanes"][0]["id"] == "storefront"
+    lane = summary["decomposition"]["records"][0]["candidate_lanes"][0]
+    assert lane["slice_contribution_to_parent"] == "Provides the browsing lane."
+    assert lane["residual_parent_intent"] == "checkout and fulfillment remain."
+    assert lane["parent_proof_boundary"] == "slice-only"
 
 
 def test_planning_summary_warns_for_misplaced_decomposition_records(tmp_path: Path) -> None:

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -162,6 +162,14 @@
       "description": "Compact provenance and assumption evidence for the task intent being implemented, including source chain, correction point, and clarification/proceed posture.",
       "additionalProperties": true
     },
+    "parent_intent_status": {
+      "$ref": "#/$defs/parent_intent_status",
+      "description": "Compact parent/original-intent status preserving larger intent across bounded implementation slices."
+    },
+    "applicable_intent_status": {
+      "$ref": "#/$defs/applicable_intent_status",
+      "description": "Compact applicable-intent evidence and conflict packet for broad closeout safety."
+    },
     "reuse_pressure": {
       "type": "object",
       "description": "Changed-path reuse and abstraction-pressure facts that help the agent decide whether to reuse, accept duplication, or route extraction follow-up.",
@@ -353,6 +361,44 @@
       "type": "object",
       "description": "Compact durable system or subsystem intent pressure that may affect scope, proof, delegation, or closeout.",
       "additionalProperties": true
+    },
+    "parent_intent_status": {
+      "type": "object",
+      "required": [
+        "kind",
+        "status"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/parent-intent-status/v1",
+          "description": "Discriminator for the parent/original-intent status packet."
+        },
+        "status": {
+          "type": "string",
+          "description": "Whether the recorded parent/original intent is satisfied, open, or only guidance."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Parent/original-intent status preserving larger intent across bounded slices."
+    },
+    "applicable_intent_status": {
+      "type": "object",
+      "required": [
+        "kind",
+        "status"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/applicable-intent-status/v1",
+          "description": "Discriminator for the applicable-intent status packet."
+        },
+        "status": {
+          "type": "string",
+          "description": "Whether applicable-intent evidence is present, guidance-only, or requires attention."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Applicable-intent evidence, conflicts, missing authority, and manual-verification obligations."
     },
     "durable_intent_promotion": {
       "$ref": "#/$defs/task_intent_promotion_guidance",

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -280,6 +280,16 @@
       "description": "Supporting startup context for the primary next-safe-action decision, including compatibility projections for detail fields.",
       "additionalProperties": true
     },
+    "parent_intent_status": {
+      "type": "object",
+      "description": "Parent/original-intent status preserving larger intent across bounded startup and implementation slices.",
+      "additionalProperties": true
+    },
+    "applicable_intent_status": {
+      "type": "object",
+      "description": "Applicable-intent evidence, conflicts, missing authority, and manual-verification obligations for startup closeout safety.",
+      "additionalProperties": true
+    },
     "planning_safety_gate": {
       "type": "object",
       "description": "Planning ownership guard for broad, high-assurance, decomposed, or scope-widened work.",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -272,6 +272,14 @@
       "type": "object",
       "description": "Derived Planning completion-contract lens for done, partial, blocked, and continuation-required decisions."
     },
+    "parent_intent_status": {
+      "$ref": "#/$defs/parent_intent_status",
+      "description": "Derived parent/original-intent status packet used to prevent slice proof from being reported as parent completion."
+    },
+    "applicable_intent_status": {
+      "$ref": "#/$defs/applicable_intent_status",
+      "description": "Derived applicable-intent evidence and conflict packet used to keep user, system, subsystem, and soft-intent obligations visible before broad closeout."
+    },
     "repair_loop_residue": {
       "type": "object",
       "description": "Derived validation-driven repair residue across Planning and Verification."
@@ -405,6 +413,44 @@
   },
   "additionalProperties": false,
   "$defs": {
+    "parent_intent_status": {
+      "type": "object",
+      "required": [
+        "kind",
+        "status"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/parent-intent-status/v1",
+          "description": "Discriminator for the parent/original-intent status packet."
+        },
+        "status": {
+          "type": "string",
+          "description": "Whether the recorded parent/original intent is satisfied, open, or only guidance."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Parent/original-intent status preserving larger intent across bounded slices."
+    },
+    "applicable_intent_status": {
+      "type": "object",
+      "required": [
+        "kind",
+        "status"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/applicable-intent-status/v1",
+          "description": "Discriminator for the applicable-intent status packet."
+        },
+        "status": {
+          "type": "string",
+          "description": "Whether applicable-intent evidence is present, guidance-only, or requires attention."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Applicable-intent evidence, conflicts, missing authority, and manual-verification obligations."
+    },
     "authority_boundary": {
       "type": "object",
       "required": [

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -19308,6 +19308,78 @@ def _parent_intent_status_payload(
     }
 
 
+def _unplanned_parent_intent_status_payload(
+    *,
+    parent_intent_status: dict[str, Any],
+    task_text: str | None,
+    changed_paths: list[str],
+    generated_surface_trust: dict[str, Any],
+) -> dict[str, Any]:
+    parent_intent_status = _as_dict(parent_intent_status)
+    task = " ".join(str(task_text or "").split())
+    if parent_intent_status.get("status") != "guidance-only" or not task or not changed_paths:
+        return parent_intent_status
+
+    generated_surface_trust = _as_dict(generated_surface_trust)
+    generated_items = [item for item in _list_payload(generated_surface_trust.get("items")) if isinstance(item, dict)]
+    if generated_surface_trust.get("status") != "present" or not generated_items:
+        return parent_intent_status
+
+    generated_paths = [str(item.get("path") or "").strip() for item in generated_items if str(item.get("path") or "").strip()]
+    path_summary = ", ".join(generated_paths[:3])
+    if len(generated_paths) > 3:
+        path_summary = f"{path_summary}, ..."
+
+    must_not_claim = [
+        "Do not claim the parent/original intent is satisfied from generated-surface freshness or changed-path proof.",
+        "Do not silently narrow the explicit task text into a generated-surface slice without Planning/decomposition evidence when agent judgment says the task is broad.",
+    ]
+    return {
+        "kind": "agentic-workspace/parent-intent-status/v1",
+        "status": "needs-planning",
+        "original_intent": task,
+        "parent_acceptance_target": task,
+        "current_slice": f"changed generated surface(s): {path_summary}" if path_summary else "changed generated surface(s)",
+        "proof_boundary": "changed-path/generated-surface proof only",
+        "proof_is_slice_only": True,
+        "residual_parent_intent": (
+            "Parent/original intent has not been recorded in Planning; preserve it before treating this generated-surface "
+            "slice as the whole request."
+        ),
+        "continuation_owner": "Planning",
+        "parent_proof_required": "Create or select Planning/decomposition/execplan evidence before claiming parent completion.",
+        "required_next_action": "Preserve the raw task as parent/original-intent evidence in Planning before narrowing or claiming completion.",
+        "closure_decision": "not-recorded",
+        "larger_intent_status": "not-recorded",
+        "must_not_claim": must_not_claim,
+        "source_fields": [
+            "task_intent.task_excerpt",
+            "changed_paths",
+            "generated_surface_trust",
+            "planning.active.planning_record.parent_acceptance",
+        ],
+        "authority_boundary": _authority_boundary_payload(
+            surface="parent_intent_status",
+            observed_by_aw=[
+                "task_text_available=True",
+                "active_parent_acceptance=False",
+                f"generated_surface_count={len(generated_items)}",
+            ],
+            recommended_by_aw=["preserve raw task text in Planning/decomposition before parent-completion claims"],
+            agent_owned_decisions=[
+                "whether the explicit task is broad enough to require decomposition before implementation",
+                "the concrete first slice and proof boundary",
+            ],
+            human_owned_decisions=["acceptance of parent intent, decomposition, and completion"],
+            rule="AW preserves explicit task text and mechanical changed-path facts; it does not semantically classify the prompt.",
+        ),
+        "rule": (
+            "When changed paths narrow explicit task text before Planning records parent acceptance, AW preserves the raw task "
+            "as candidate parent intent; the agent owns semantic work-shape judgment."
+        ),
+    }
+
+
 def _applicable_intent_status_payload(
     *,
     active_planning_record: dict[str, Any],
@@ -20721,12 +20793,24 @@ def _implement_payload(
         intent_discovery=intent_discovery,
         intent_acknowledgement=intent_acknowledgement,
     )
+    generated_surface_trust = _generated_surface_trust_payload(
+        target_root=target_root,
+        changed_paths=normalized_paths,
+        proof=proof,
+        cli_invoke=config.cli_invoke,
+    )
     active_planning_record_for_intent = _active_planning_record_for_report_section(target_root=target_root)
     parent_completion_boundary = _completion_boundary_payload(active_planning_record=active_planning_record_for_intent)
     parent_intent_status = _parent_intent_status_payload(
         active_planning_record=active_planning_record_for_intent,
         intent_check={},
         completion_boundary=parent_completion_boundary,
+    )
+    parent_intent_status = _unplanned_parent_intent_status_payload(
+        parent_intent_status=parent_intent_status,
+        task_text=task_text,
+        changed_paths=normalized_paths,
+        generated_surface_trust=generated_surface_trust,
     )
     applicable_intent_status = _applicable_intent_status_payload(active_planning_record=active_planning_record_for_intent)
     implement_current_need = "changed-path-implementation" if normalized_paths else "unknown-scope-routing"
@@ -20818,12 +20902,7 @@ def _implement_payload(
         "parent_intent_status": parent_intent_status,
         "applicable_intent_status": applicable_intent_status,
         "objective_drift": _objective_drift_payload(target_root=target_root, changed_paths=normalized_paths, task_text=task_text),
-        "generated_surface_trust": _generated_surface_trust_payload(
-            target_root=target_root,
-            changed_paths=normalized_paths,
-            proof=proof,
-            cli_invoke=config.cli_invoke,
-        ),
+        "generated_surface_trust": generated_surface_trust,
         "reuse_pressure": _reuse_pressure_payload(
             target_root=target_root, changed_paths=normalized_paths, cli_invoke=config.cli_invoke, compact=False
         ),
@@ -21190,7 +21269,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     if isinstance(tiny_context, dict):
         parent_packet = tiny_context.get("parent_intent_status", {})
         parent_status = str(parent_packet.get("status") or "").strip() if isinstance(parent_packet, dict) else ""
-        if parent_status in {"", "guidance-only", "not-recorded"}:
+        if parent_status in {"", "guidance-only", "not-recorded", "needs-planning"}:
             tiny_context.pop("parent_intent_status", None)
             selectors = projected.get("drill_down", {}).get("available_selectors", [])
             if isinstance(selectors, list):

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -7757,6 +7757,16 @@ def _closeout_report_traceability_rows(
     behavior_preservation = _as_dict(proof_confidence.get("behavior_preservation"))
     intent_check = _as_dict(closeout_trust.get("intent_satisfaction_check"))
     assurance = _as_dict(closeout_trust.get("assurance_requirements"))
+    parent_intent = _parent_intent_status_payload(
+        active_planning_record=active_planning_record,
+        intent_check=intent_check,
+        completion_boundary=completion_boundary,
+    )
+    applicable_intents = _applicable_intent_status_payload(
+        active_planning_record=active_planning_record,
+        verification=verification,
+        assurance_requirements=assurance,
+    )
     evidence_status = [item for item in _list_payload(assurance.get("evidence_status")) if isinstance(item, dict)]
     verification_evidence = [item for item in _list_payload(verification.get("evidence_status")) if isinstance(item, dict)]
     if not verification_evidence:
@@ -7833,6 +7843,29 @@ def _closeout_report_traceability_rows(
             "residual_risk_or_follow_up": text_from(completion_boundary.get("required_residual_intent")),
         },
         {
+            "id": "parent-intent",
+            "intent_or_requirement": "parent/original intent status",
+            "evidence_surface": "planning.active.planning_record.intent_satisfaction + parent_acceptance",
+            "evidence": text_from(parent_intent.get("original_intent"), fallback=text_from(parent_intent.get("parent_acceptance_target"))),
+            "status": "present" if parent_intent.get("original_intent") or parent_intent.get("parent_acceptance_target") else "missing",
+            "residual_risk_or_follow_up": text_from(parent_intent.get("residual_parent_intent"), fallback=parent_intent.get("status")),
+        },
+        {
+            "id": "applicable-intents",
+            "intent_or_requirement": "applicable user/system/subsystem/soft intent evidence",
+            "evidence_surface": "planning.active.planning_record.applicable_intents + verification + assurance",
+            "evidence": text_from(
+                f"{len(_list_payload(applicable_intents.get('sources')))} source(s); "
+                f"{len(_list_payload(applicable_intents.get('conflicts')))} conflict(s); "
+                f"{len(_list_payload(applicable_intents.get('manual_verification_needed')))} manual verification item(s)"
+            ),
+            "status": "missing" if applicable_intents.get("status") == "attention" else "present",
+            "residual_risk_or_follow_up": text_from(
+                "; ".join(_list_payload(applicable_intents.get("conflicts"))),
+                fallback=text_from("; ".join(_list_payload(applicable_intents.get("manual_verification_needed")))),
+            ),
+        },
+        {
             "id": "assurance-verification",
             "intent_or_requirement": "assurance and verification evidence",
             "evidence_surface": "closeout_trust.assurance_requirements + verification",
@@ -7860,6 +7893,12 @@ def _closeout_report_completeness_payload(
     proof_confidence = _as_dict(closeout_trust.get("proof_confidence"))
     behavior_preservation = _as_dict(proof_confidence.get("behavior_preservation"))
     intent_check = _as_dict(closeout_trust.get("intent_satisfaction_check"))
+    parent_intent = _parent_intent_status_payload(
+        active_planning_record=active_planning_record,
+        intent_check=intent_check,
+        completion_boundary=completion_boundary,
+    )
+    applicable_intents = _applicable_intent_status_payload(active_planning_record=active_planning_record)
     options = {str(item.get("id", "")): item for item in _list_payload(closeout_trust.get("completion_options")) if isinstance(item, dict)}
     keep_parent_open = _as_dict(options.get("keep-parent-open"))
     route_residue = _as_dict(options.get("route-residue"))
@@ -7940,6 +7979,26 @@ def _closeout_report_completeness_payload(
         "complete" if residual else "partial",
         residual or "no residual risk explicitly recorded",
         "residual risk statement is not explicit",
+    )
+    parent_open = parent_intent.get("status") != "satisfied"
+    add_check(
+        "parent-intent-status",
+        "incomplete" if parent_open and parent_intent.get("proof_is_slice_only") else "partial" if parent_open else "complete",
+        evidence_text(parent_intent.get("original_intent"), parent_intent.get("parent_acceptance_target")),
+        evidence_text(parent_intent.get("residual_parent_intent"), parent_intent.get("parent_proof_required"))
+        or "parent/original intent is not explicitly satisfied",
+    )
+    applicable_blocked = bool(applicable_intents.get("closeout_blocked"))
+    add_check(
+        "applicable-intent-status",
+        "incomplete" if applicable_blocked else "complete",
+        evidence_text(
+            applicable_intents.get("conflicts"),
+            applicable_intents.get("manual_verification_needed"),
+            applicable_intents.get("sources"),
+            "no applicable-intent conflicts recorded",
+        ),
+        "applicable intent conflict, missing authority, or manual verification remains" if applicable_blocked else "",
     )
     preservation_status = str(behavior_preservation.get("status") or "").strip()
     preservation_claims = _list_payload(behavior_preservation.get("claims"))
@@ -8542,6 +8601,8 @@ def _closeout_report_final_response_rendering_payload(
     next_action: str,
     decision_review: dict[str, Any] | None = None,
     behavior_preservation: dict[str, Any] | None = None,
+    parent_intent_status: dict[str, Any] | None = None,
+    applicable_intent_status: dict[str, Any] | None = None,
     review_mode: str = "",
 ) -> dict[str, Any]:
     profile = str(profile_policy.get("selected_profile") or "minimal")
@@ -8556,6 +8617,8 @@ def _closeout_report_final_response_rendering_payload(
     must_not_claim: list[str] = ["Do not dump raw closeout_report JSON into the final user-facing response."]
     decision_review = _as_dict(decision_review)
     behavior_preservation = _as_dict(behavior_preservation)
+    parent_intent_status = _as_dict(parent_intent_status)
+    applicable_intent_status = _as_dict(applicable_intent_status)
     review_contract = _closeout_report_review_mode_contract(review_mode or "small-direct-edit")
 
     def present(text: str) -> str:
@@ -8592,6 +8655,8 @@ def _closeout_report_final_response_rendering_payload(
             "behavior preservation proof": ("behavior proof:",),
             "behavior preservation caveat": ("behavior caveat:",),
             "review focus": ("review focus:",),
+            "parent intent status": ("parent intent:",),
+            "applicable intent status": ("applicable intent:",),
         }
         for fact in must_include:
             markers = fact_markers.get(fact, (fact,))
@@ -8649,7 +8714,16 @@ def _closeout_report_final_response_rendering_payload(
         caveat_lines: list[str] = []
         for line in summary_lines:
             if line.startswith(
-                ("Closeout caveat:", "Closure boundary:", "Residue:", "Evidence caveat:", "Decision gap:", "Behavior caveat:")
+                (
+                    "Closeout caveat:",
+                    "Closure boundary:",
+                    "Residue:",
+                    "Evidence caveat:",
+                    "Decision gap:",
+                    "Behavior caveat:",
+                    "Parent intent:",
+                    "Applicable intent:",
+                )
             ):
                 caveat_lines.append(line)
         if not caveat_lines and not plain_done_allowed:
@@ -8837,6 +8911,40 @@ def _closeout_report_final_response_rendering_payload(
             "Do not claim no behavior changed, business logic preserved, migration complete, or compatibility proved unless behavior_preservation evidence supports that claim or the caveat is rendered."
         )
 
+    parent_status = present(str(parent_intent_status.get("status") or ""))
+    if parent_status and parent_status not in {"satisfied", "guidance-only", "not-recorded"}:
+        must_include.append("parent intent status")
+        parent_line_parts = [parent_status]
+        original_intent = present(str(parent_intent_status.get("original_intent") or ""))
+        current_slice = present(str(parent_intent_status.get("current_slice") or ""))
+        residual_parent = present(str(parent_intent_status.get("residual_parent_intent") or ""))
+        proof_boundary = present(str(parent_intent_status.get("proof_boundary") or ""))
+        if original_intent:
+            parent_line_parts.append(f"original: {original_intent}")
+        if current_slice:
+            parent_line_parts.append(f"current slice: {current_slice}")
+        if proof_boundary:
+            parent_line_parts.append(f"proof boundary: {proof_boundary}")
+        if residual_parent:
+            parent_line_parts.append(f"residual: {residual_parent}")
+        summary_lines.append(f"Parent intent: {'; '.join(parent_line_parts[:5])}")
+        must_not_claim.extend(str(item) for item in _list_payload(parent_intent_status.get("must_not_claim")) if str(item).strip())
+
+    if applicable_intent_status.get("closeout_blocked"):
+        must_include.append("applicable intent status")
+        conflicts = [str(item) for item in _list_payload(applicable_intent_status.get("conflicts")) if str(item).strip()]
+        manual = [str(item) for item in _list_payload(applicable_intent_status.get("manual_verification_needed")) if str(item).strip()]
+        missing = [str(item) for item in _list_payload(applicable_intent_status.get("missing_authority")) if str(item).strip()]
+        fragments = []
+        if conflicts:
+            fragments.append("conflict: " + "; ".join(conflicts[:2]))
+        if manual:
+            fragments.append("manual verification: " + "; ".join(manual[:2]))
+        if missing:
+            fragments.append("missing authority: " + "; ".join(missing[:2]))
+        summary_lines.append("Applicable intent: " + ("; ".join(fragments) if fragments else "unresolved applicable-intent obligation"))
+        must_not_claim.extend(str(item) for item in _list_payload(applicable_intent_status.get("must_not_claim")) if str(item).strip())
+
     boundary_text = present(completion_decision)
     completion_boundary_text = present(
         str(
@@ -8863,7 +8971,13 @@ def _closeout_report_final_response_rendering_payload(
     elif profile_requires_detail:
         summary_lines.append("Residue: none recorded.")
 
-    if lower_trust or incomplete_or_partial or has_material_guidance_signal:
+    parent_status_blocks_done = str(parent_intent_status.get("status") or "").strip() not in {
+        "",
+        "satisfied",
+        "guidance-only",
+        "not-recorded",
+    }
+    if lower_trust or incomplete_or_partial or has_material_guidance_signal or parent_status_blocks_done:
         must_not_claim.append("Do not render this closeout as a plain done summary without the lower-trust or incomplete-evidence caveat.")
     if incomplete_or_partial:
         must_include.append("missing or partial evidence caveat")
@@ -8873,9 +8987,24 @@ def _closeout_report_final_response_rendering_payload(
 
     rendering_mode = "compact" if guidance_only else "evidence-backed" if profile_requires_detail else "compact"
     status_value = (
-        "required" if profile_requires_detail or lower_trust or incomplete_or_partial or has_material_guidance_signal else "available"
+        "required"
+        if (
+            profile_requires_detail
+            or lower_trust
+            or incomplete_or_partial
+            or has_material_guidance_signal
+            or parent_status_blocks_done
+            or applicable_intent_status.get("closeout_blocked")
+        )
+        else "available"
     )
-    plain_done_allowed = not (lower_trust or incomplete_or_partial or has_material_guidance_signal)
+    plain_done_allowed = not (
+        lower_trust
+        or incomplete_or_partial
+        or has_material_guidance_signal
+        or parent_status_blocks_done
+        or applicable_intent_status.get("closeout_blocked")
+    )
     summary_lines = summary_lines[:8]
     unique_must_include = list(dict.fromkeys(must_include))
     chat_report_template = chat_report_template_payload(
@@ -8984,6 +9113,16 @@ def _closeout_report_payload(
         requested_outcome=requested_outcome,
         intent_check=intent_check,
     )
+    parent_intent_status = _parent_intent_status_payload(
+        active_planning_record=active_planning_record,
+        intent_check=intent_check,
+        completion_boundary=completion_boundary,
+    )
+    applicable_intent_status = _applicable_intent_status_payload(
+        active_planning_record=active_planning_record,
+        verification=verification,
+        assurance_requirements=_as_dict(closeout_trust.get("assurance_requirements")),
+    )
     changed_surfaces = str(execution.get("changed surfaces") or "").strip()
     validation_proof = str(proof_report.get("validation proof") or execution.get("validations run") or "").strip()
     completion_decision = str(completion_contract.get("completion_decision", "unknown"))
@@ -9019,6 +9158,8 @@ def _closeout_report_payload(
         next_action=str(next_action),
         decision_review=decision_review,
         behavior_preservation=behavior_preservation,
+        parent_intent_status=parent_intent_status,
+        applicable_intent_status=applicable_intent_status,
         review_mode=selected_review_mode,
     )
     detail_commands = {
@@ -9103,6 +9244,8 @@ def _closeout_report_payload(
             "closure_decision": str(closure_check.get("closure decision") or closure_check.get("closure_decision") or "").strip(),
         },
         "intent_evidence": intent_evidence,
+        "parent_intent_status": parent_intent_status,
+        "applicable_intent_status": applicable_intent_status,
         "changes": {
             "changed_surfaces": changed_surfaces,
             "scope_touched": str(execution.get("scope touched") or "").strip(),
@@ -9259,6 +9402,8 @@ def _derived_continuation_projection_payloads(
         "external_evidence_safety": external_evidence_safety,
         "workflow_compliance_summary": workflow_compliance_summary,
         "closeout_report": closeout_report,
+        "parent_intent_status": closeout_report.get("parent_intent_status", {}),
+        "applicable_intent_status": closeout_report.get("applicable_intent_status", {}),
         "continuation_next_actions": continuation_next_actions,
         "migration_pilot_template": _migration_pilot_template_payload(cli_invoke=config.cli_invoke),
         "compact_output_criteria": _compact_output_criteria_payload(cli_invoke=config.cli_invoke),
@@ -13324,6 +13469,7 @@ def _intent_satisfaction_check_payload(*, planning_report: dict[str, Any], targe
     completes = str(intent_continuity.get("this slice completes the larger intended outcome", "")).strip().lower()
     continuation = str(required_continuation.get("required follow-on for the larger intended outcome", "")).strip().lower()
     external_closeout = _external_intent_closeout_check(target_root=target_root, planning_record=planning_record)
+    applicable_intents = _applicable_intent_status_payload(active_planning_record=raw_planning_record or planning_record)
     if completes in {"yes", "true"} and continuation in {"no", "false", "none"}:
         trust = "satisfied"
         recommended_next_action = "Closeout may claim intent satisfaction if proof also passed."
@@ -13336,6 +13482,9 @@ def _intent_satisfaction_check_payload(*, planning_report: dict[str, Any], targe
     if trust == "satisfied" and external_closeout.get("trust") != "normal":
         trust = "follow-up-required"
         recommended_next_action = str(external_closeout.get("recommended_next_action") or recommended_next_action)
+    if applicable_intents.get("closeout_blocked"):
+        trust = "needs-review"
+        recommended_next_action = "Resolve applicable-intent conflict, missing authority, or manual verification before broad closeout."
     completion_boundary = _completion_boundary_payload(
         active_planning_record=planning_record,
         raw_planning_record=raw_planning_record,
@@ -13395,9 +13544,11 @@ def _intent_satisfaction_check_payload(*, planning_report: dict[str, Any], targe
             },
             "completion_boundary": completion_boundary,
             "external_intent_evidence": external_closeout,
+            "applicable_intent_status": applicable_intents,
             "non_substitution_rule": "Validation success alone is not closure evidence.",
         },
         "external_intent_evidence": external_closeout,
+        "applicable_intent_status": applicable_intents,
         "recommended_next_action": recommended_next_action,
     }
 
@@ -14929,6 +15080,14 @@ def _run_preflight_command(
         task_text=task_text,
         execution_posture=execution_posture,
     )
+    active_parent_record = _active_planning_record_for_report_section(target_root=target_root)
+    active_parent_boundary = _completion_boundary_payload(active_planning_record=active_parent_record)
+    parent_intent_status = _parent_intent_status_payload(
+        active_planning_record=active_parent_record,
+        intent_check={},
+        completion_boundary=active_parent_boundary,
+    )
+    applicable_intent_status = _applicable_intent_status_payload(active_planning_record=active_parent_record)
     if active_only:
         active_payload = {
             "kind": "preflight-response/v1",
@@ -14949,6 +15108,8 @@ def _run_preflight_command(
             "skill_routing": _startup_skill_routing_payload(target_root=target_root, cli_invoke=config.cli_invoke),
             "active_planning_state": active_state,
             "planning_record": planning_record if isinstance(planning_record, dict) else {"status": "unavailable"},
+            "parent_intent_status": parent_intent_status,
+            "applicable_intent_status": applicable_intent_status,
         }
         return active_payload
     startup_payload = _defaults_payload().get("startup", {})
@@ -15021,6 +15182,8 @@ def _run_preflight_command(
         "operating_posture": _operating_posture_payload(config=config, surface="preflight"),
         "durable_intent": durable_intent,
         "active_planning_state": active_state,
+        "parent_intent_status": parent_intent_status,
+        "applicable_intent_status": applicable_intent_status,
     }
     vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
     if vague_orientation["applies_to_current_task"]:
@@ -15779,6 +15942,33 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
             **({"task_search": skill_routing["task_search"]} if isinstance(skill_routing, dict) and "task_search" in skill_routing else {}),
         },
     }
+    if isinstance(payload.get("parent_intent_status"), dict):
+        projected["parent_intent_status"] = {
+            key: payload["parent_intent_status"].get(key)
+            for key in (
+                "status",
+                "original_intent",
+                "current_slice",
+                "proof_boundary",
+                "proof_is_slice_only",
+                "residual_parent_intent",
+                "parent_proof_required",
+            )
+            if key in payload["parent_intent_status"]
+        }
+    if isinstance(payload.get("applicable_intent_status"), dict):
+        projected["applicable_intent_status"] = {
+            key: payload["applicable_intent_status"].get(key)
+            for key in (
+                "status",
+                "conflicts",
+                "missing_authority",
+                "manual_verification_needed",
+                "blocked_claims",
+                "closeout_blocked",
+            )
+            if key in payload["applicable_intent_status"]
+        }
     assurance_requirements = payload.get("assurance_requirements", {})
     if isinstance(assurance_requirements, dict) and int(assurance_requirements.get("active_count", 0) or 0) > 0:
         projected["assurance_requirements"] = _compact_assurance_requirements(assurance_requirements)
@@ -16383,6 +16573,22 @@ def _start_payload(
         task_text=task_text,
         changed_paths=changed_paths,
     )
+    raw_planning_record = (
+        _raw_active_planning_record_for_closeout(planning_record=planning_record, target_root=target_root)
+        if active_planning_present and isinstance(planning_record, dict)
+        else {}
+    )
+    active_parent_record = raw_planning_record or (planning_record if isinstance(planning_record, dict) else {})
+    completion_boundary = _completion_boundary_payload(active_planning_record=active_parent_record)
+    parent_intent_status = _parent_intent_status_payload(
+        active_planning_record=active_parent_record,
+        intent_check={},
+        completion_boundary=completion_boundary,
+    )
+    applicable_intent_status = _applicable_intent_status_payload(
+        active_planning_record=active_parent_record,
+        assurance_requirements=assurance_requirements,
+    )
     current_need = "continue-active-planning" if active_planning_present else "first-contact-routing"
     if changed_paths:
         current_need = "changed-path-startup"
@@ -16466,6 +16672,10 @@ def _start_payload(
             cli_invoke=config.cli_invoke,
         ),
     }
+    if parent_intent_status.get("status") != "guidance-only":
+        payload["parent_intent_status"] = parent_intent_status
+    if applicable_intent_status.get("status") != "guidance-only":
+        payload["applicable_intent_status"] = applicable_intent_status
     if int(assurance_requirements.get("configured_count", 0) or 0) > 0:
         payload["assurance_requirements"] = assurance_requirements
     startup_review = _workspace_absence_startup_review(target_root=target_root, config=config)
@@ -17175,6 +17385,33 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         },
         "memory": payload.get("memory_consult", {}),
     }
+    if isinstance(payload.get("parent_intent_status"), dict):
+        context["parent_intent_status"] = {
+            key: payload["parent_intent_status"].get(key)
+            for key in (
+                "status",
+                "original_intent",
+                "current_slice",
+                "proof_boundary",
+                "proof_is_slice_only",
+                "residual_parent_intent",
+                "parent_proof_required",
+            )
+            if key in payload["parent_intent_status"]
+        }
+    if isinstance(payload.get("applicable_intent_status"), dict):
+        context["applicable_intent_status"] = {
+            key: payload["applicable_intent_status"].get(key)
+            for key in (
+                "status",
+                "conflicts",
+                "missing_authority",
+                "manual_verification_needed",
+                "blocked_claims",
+                "closeout_blocked",
+            )
+            if key in payload["applicable_intent_status"]
+        }
     uv_guidance = payload.get("uv_cache_guidance", {})
     if not (isinstance(uv_guidance, dict) and uv_guidance.get("status") == "available"):
         cli_invocation = payload.get("cli_invocation", {})
@@ -17463,6 +17700,20 @@ def _start_tiny_payload_fast(
             cli_invoke=config.cli_invoke,
         ),
     }
+    active_parent_record = (
+        _raw_active_planning_record_for_closeout(planning_record={}, target_root=target_root) if active_planning_present else {}
+    )
+    completion_boundary = _completion_boundary_payload(active_planning_record=active_parent_record)
+    parent_intent_status = _parent_intent_status_payload(
+        active_planning_record=active_parent_record,
+        intent_check={},
+        completion_boundary=completion_boundary,
+    )
+    applicable_intent_status = _applicable_intent_status_payload(active_planning_record=active_parent_record)
+    if parent_intent_status.get("status") != "guidance-only":
+        payload["parent_intent_status"] = parent_intent_status
+    if applicable_intent_status.get("status") != "guidance-only":
+        payload["applicable_intent_status"] = applicable_intent_status
     startup_review = _workspace_absence_startup_review(target_root=target_root, config=config)
     if startup_review["status"] == "attention":
         payload["startup_review"] = startup_review
@@ -18877,6 +19128,275 @@ def _closeout_intent_evidence_payload(
     }
 
 
+def _parent_intent_status_payload(
+    *,
+    active_planning_record: dict[str, Any],
+    intent_check: dict[str, Any],
+    completion_boundary: dict[str, Any],
+) -> dict[str, Any]:
+    active_planning_record = _as_dict(active_planning_record)
+    intent_check = _as_dict(intent_check)
+    completion_boundary = _as_dict(completion_boundary)
+    intent_satisfaction = _as_dict(active_planning_record.get("intent_satisfaction"))
+    intent_continuity = _as_dict(active_planning_record.get("intent_continuity"))
+    required_continuation = _as_dict(active_planning_record.get("required_continuation"))
+    closure_check = _as_dict(active_planning_record.get("closure_check"))
+    proof_report = _as_dict(active_planning_record.get("proof_report"))
+    intent_proof = _as_dict(proof_report.get("intent_proof"))
+    parent_acceptance = _as_dict(active_planning_record.get("parent_acceptance"))
+    active_milestone = _as_dict(active_planning_record.get("active_milestone"))
+    delegated = _as_dict(active_planning_record.get("delegated_judgment"))
+    execution = _as_dict(active_planning_record.get("execution_run"))
+
+    def present(*values: Any) -> str:
+        for value in values:
+            text = str(value or "").strip()
+            if text and text.lower() not in {"none", "null", "unknown", "pending", "not recorded"}:
+                return text
+        return ""
+
+    def truthy_yes(value: Any) -> bool:
+        return str(value or "").strip().lower() in {"yes", "true", "satisfied", "complete", "completed", "closed"}
+
+    original_intent = present(
+        intent_satisfaction.get("original intent"),
+        parent_acceptance.get("original_intent"),
+        parent_acceptance.get("parent_intent"),
+        intent_continuity.get("larger intended outcome"),
+        intent_check.get("larger_intent"),
+        completion_boundary.get("final_satisfaction"),
+    )
+    current_slice = present(
+        parent_acceptance.get("current_slice"),
+        parent_acceptance.get("slice_intent"),
+        delegated.get("requested outcome"),
+        delegated.get("requested_outcome"),
+        active_milestone.get("scope"),
+        execution.get("what happened"),
+    )
+    residual_intent = present(
+        parent_acceptance.get("residual_parent_intent"),
+        parent_acceptance.get("residual_intent"),
+        completion_boundary.get("required_residual_intent"),
+        required_continuation.get("required follow-on for the larger intended outcome"),
+        intent_satisfaction.get("unsolved intent passed to"),
+    )
+    continuation_owner = present(
+        parent_acceptance.get("continuation_owner"),
+        completion_boundary.get("required_follow_up_owner"),
+        required_continuation.get("owner surface"),
+        intent_continuity.get("continuation surface"),
+        intent_check.get("continuation_surface"),
+    )
+    proof_boundary = present(
+        parent_acceptance.get("proof_boundary"),
+        intent_proof.get("claim_boundary"),
+        intent_proof.get("claim boundary"),
+        completion_boundary.get("bounded_slice_success"),
+    )
+    parent_acceptance_target = present(
+        parent_acceptance.get("parent_acceptance"),
+        parent_acceptance.get("acceptance_target"),
+        parent_acceptance.get("final_satisfaction"),
+        completion_boundary.get("final_satisfaction"),
+        original_intent,
+    )
+    parent_proof_required = present(
+        parent_acceptance.get("parent_proof_required"),
+        parent_acceptance.get("evidence_required_for_parent_completion"),
+        completion_boundary.get("evidence_required_for_final_completion"),
+    )
+    required_continuation_signal = _required_continuation_present(required_continuation)
+    has_parent_signal = bool(
+        original_intent
+        or residual_intent
+        or continuation_owner
+        or parent_acceptance
+        or intent_satisfaction
+        or intent_continuity
+        or required_continuation_signal
+    )
+    if not has_parent_signal:
+        return {
+            "kind": "agentic-workspace/parent-intent-status/v1",
+            "status": "guidance-only",
+            "original_intent": "",
+            "parent_acceptance_target": "",
+            "current_slice": "",
+            "proof_boundary": "not-recorded",
+            "proof_is_slice_only": False,
+            "residual_parent_intent": "",
+            "continuation_owner": "",
+            "parent_proof_required": "",
+            "closure_decision": "not-recorded",
+            "larger_intent_status": "not-recorded",
+            "must_not_claim": [],
+            "source_fields": [
+                "planning.active.planning_record.intent_satisfaction",
+                "planning.active.planning_record.intent_continuity",
+                "planning.active.planning_record.required_continuation",
+                "planning.active.planning_record.parent_acceptance",
+                "planning.active.planning_record.proof_report.intent_proof",
+                "planning.active.planning_record.closure_check",
+                "report.closeout_trust.intent_satisfaction_check",
+                "report.completion_contract.completion_boundary",
+            ],
+            "rule": "No explicit parent/original intent boundary was recorded for this surface.",
+        }
+
+    closure_status = str(closure_check.get("larger-intent status") or closure_check.get("larger_intent_status") or "").strip().lower()
+    closure_decision = str(closure_check.get("closure decision") or closure_check.get("closure_decision") or "").strip().lower()
+    intent_satisfied = (
+        truthy_yes(intent_satisfaction.get("was original intent fully satisfied?"))
+        or truthy_yes(intent_continuity.get("this slice completes the larger intended outcome"))
+        or truthy_yes(intent_continuity.get("this_slice_completes_the_larger_intended_outcome"))
+    )
+    intent_trust = str(intent_check.get("trust") or "").strip().lower()
+    required_follow_on = (
+        str(required_continuation.get("required follow-on for the larger intended outcome") or intent_check.get("required_follow_on") or "")
+        .strip()
+        .lower()
+    )
+    parent_closed = (
+        intent_satisfied
+        and closure_status in {"closed", "complete", "completed", "done", ""}
+        and closure_decision in {"archive-and-close", "close", "closed", ""}
+        and required_follow_on not in {"yes", "true"}
+        and intent_trust not in {"follow-up-required", "needs-review"}
+    )
+    parent_open = (
+        not parent_closed
+        or closure_status in {"open", "partial", "unfinished", "follow-up-required"}
+        or required_follow_on in {"yes", "true"}
+        or intent_trust in {"follow-up-required", "needs-review"}
+    )
+    proof_boundary_lower = proof_boundary.lower()
+    proof_is_slice_only = any(token in proof_boundary_lower for token in ("slice", "work", "current", "bounded"))
+    narrowed_proof = proof_is_slice_only and parent_open
+    status = "satisfied" if parent_closed else "open" if parent_open else "needs-review"
+    must_not_claim = [
+        "Do not claim the parent/original intent is complete unless parent_intent_status.status is satisfied.",
+        "Do not collapse current slice proof into parent completion proof.",
+    ]
+    if narrowed_proof:
+        must_not_claim.append("Do not report the work as fully done when proof only covers the current slice.")
+    return {
+        "kind": "agentic-workspace/parent-intent-status/v1",
+        "status": status,
+        "original_intent": original_intent,
+        "parent_acceptance_target": parent_acceptance_target,
+        "current_slice": current_slice,
+        "proof_boundary": proof_boundary or "not-recorded",
+        "proof_is_slice_only": narrowed_proof,
+        "residual_parent_intent": residual_intent,
+        "continuation_owner": continuation_owner,
+        "parent_proof_required": parent_proof_required,
+        "closure_decision": closure_decision or "not-recorded",
+        "larger_intent_status": closure_status or "not-recorded",
+        "must_not_claim": must_not_claim,
+        "source_fields": [
+            "planning.active.planning_record.intent_satisfaction",
+            "planning.active.planning_record.intent_continuity",
+            "planning.active.planning_record.required_continuation",
+            "planning.active.planning_record.parent_acceptance",
+            "planning.active.planning_record.proof_report.intent_proof",
+            "planning.active.planning_record.closure_check",
+            "report.closeout_trust.intent_satisfaction_check",
+            "report.completion_contract.completion_boundary",
+        ],
+        "rule": "Slices are execution mechanics; parent/original intent is complete only when explicit parent acceptance and closeout evidence say so.",
+    }
+
+
+def _applicable_intent_status_payload(
+    *,
+    active_planning_record: dict[str, Any],
+    verification: dict[str, Any] | None = None,
+    assurance_requirements: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    active_planning_record = _as_dict(active_planning_record)
+    verification = _as_dict(verification)
+    assurance_requirements = _as_dict(assurance_requirements)
+    raw = active_planning_record.get("applicable_intents")
+    if not isinstance(raw, dict):
+        raw = active_planning_record.get("applicable_intent")
+    applicable = _as_dict(raw)
+
+    sources = [item for item in _list_payload(applicable.get("sources")) if isinstance(item, dict)]
+    conflicts = [str(item).strip() for item in _list_payload(applicable.get("conflicts")) if str(item).strip()]
+    missing_authority = [str(item).strip() for item in _list_payload(applicable.get("missing_authority")) if str(item).strip()]
+    manual_verification = [
+        str(item).strip()
+        for item in _list_payload(applicable.get("manual_verification_needed") or applicable.get("manual_verification"))
+        if str(item).strip()
+    ]
+    soft_intents = [str(item).strip() for item in _list_payload(applicable.get("soft_intents")) if str(item).strip()]
+    system_intents = [str(item).strip() for item in _list_payload(applicable.get("system_intents")) if str(item).strip()]
+    subsystem_intents = [str(item).strip() for item in _list_payload(applicable.get("subsystem_intents")) if str(item).strip()]
+    user_intents = [str(item).strip() for item in _list_payload(applicable.get("user_intents")) if str(item).strip()]
+
+    for status in _list_payload(assurance_requirements.get("evidence_status")):
+        if not isinstance(status, dict):
+            continue
+        state = str(status.get("state") or "").strip()
+        requirement = str(status.get("requirement_id") or status.get("id") or "assurance requirement").strip()
+        if state in {"missing-evidence", "review-required"}:
+            manual_verification.append(f"{requirement}: {state}")
+    for gap in _list_payload(verification.get("known_gaps")) + _list_payload(verification.get("active_known_gaps")):
+        if not isinstance(gap, dict):
+            continue
+        gap_id = str(gap.get("id") or "verification-gap").strip()
+        reason = str(gap.get("reason") or gap.get("residual_risk") or "").strip()
+        blocked_claims = [str(item).strip() for item in _list_payload(gap.get("blocked_claims")) if str(item).strip()]
+        if blocked_claims:
+            manual_verification.append(f"{gap_id}: blocks {', '.join(blocked_claims)}")
+        elif reason:
+            manual_verification.append(f"{gap_id}: {reason}")
+
+    manual_verification = _dedupe(manual_verification)
+    evidence_count = len(sources) + len(user_intents) + len(system_intents) + len(subsystem_intents) + len(soft_intents)
+    blocking = bool(conflicts or missing_authority or manual_verification)
+    status = "attention" if blocking else "present" if evidence_count else "guidance-only"
+    blocked_claims = _dedupe(
+        [str(item).strip() for item in _list_payload(applicable.get("blocked_claims")) if str(item).strip()]
+        or (["claim-work-complete", "close-parent-lane"] if blocking else [])
+    )
+    return {
+        "kind": "agentic-workspace/applicable-intent-status/v1",
+        "status": status,
+        "user_intents": user_intents,
+        "system_intents": system_intents,
+        "subsystem_intents": subsystem_intents,
+        "soft_intents": soft_intents,
+        "sources": sources,
+        "conflicts": conflicts,
+        "missing_authority": missing_authority,
+        "manual_verification_needed": manual_verification,
+        "blocked_claims": blocked_claims,
+        "closeout_blocked": blocking,
+        "authority_boundary": _authority_boundary_payload(
+            surface="applicable_intent_status",
+            observed_by_aw=[
+                f"intent_source_count={evidence_count}",
+                f"conflict_count={len(conflicts)}",
+                f"manual_verification_count={len(manual_verification)}",
+            ],
+            recommended_by_aw=["ask for clarification or keep closeout partial when conflicts or manual verification remain"]
+            if blocking
+            else [],
+            agent_owned_decisions=["semantic reconciliation of applicable intents"],
+            human_owned_decisions=["acceptance, waiver, or clarification when applicable intents conflict or require manual verification"],
+            rule="AW surfaces applicable-intent evidence and conflicts; it does not decide which intent wins.",
+        ),
+        "must_not_claim": [
+            "Do not claim full closeout while applicable intent conflicts, missing authority, or manual verification obligations remain unresolved."
+        ]
+        if blocking
+        else [],
+        "rule": "Applicable user, system, subsystem, and soft intents must remain visible for broad or high-assurance work; unresolved conflicts block or caveat closeout.",
+    }
+
+
 def _read_task_text_from_file(*, target_root: Path, task_file: str | None) -> str | None:
     if not task_file:
         return None
@@ -20201,6 +20721,14 @@ def _implement_payload(
         intent_discovery=intent_discovery,
         intent_acknowledgement=intent_acknowledgement,
     )
+    active_planning_record_for_intent = _active_planning_record_for_report_section(target_root=target_root)
+    parent_completion_boundary = _completion_boundary_payload(active_planning_record=active_planning_record_for_intent)
+    parent_intent_status = _parent_intent_status_payload(
+        active_planning_record=active_planning_record_for_intent,
+        intent_check={},
+        completion_boundary=parent_completion_boundary,
+    )
+    applicable_intent_status = _applicable_intent_status_payload(active_planning_record=active_planning_record_for_intent)
     implement_current_need = "changed-path-implementation" if normalized_paths else "unknown-scope-routing"
     payload = {
         "kind": "implementer-context/v1",
@@ -20287,6 +20815,8 @@ def _implement_payload(
         "acceptance_reconciliation": _acceptance_reconciliation_prompt_payload(task_text=task_text, acceptance=acceptance),
         "intent_acknowledgement": intent_acknowledgement,
         "intent_evidence": intent_evidence,
+        "parent_intent_status": parent_intent_status,
+        "applicable_intent_status": applicable_intent_status,
         "objective_drift": _objective_drift_payload(target_root=target_root, changed_paths=normalized_paths, task_text=task_text),
         "generated_surface_trust": _generated_surface_trust_payload(
             target_root=target_root,
@@ -20576,6 +21106,33 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 else [],
             },
             "intent_evidence": _compact_intent_evidence(payload.get("intent_evidence", {})),
+            "parent_intent_status": {
+                key: payload.get("parent_intent_status", {}).get(key)
+                for key in (
+                    "kind",
+                    "status",
+                    "original_intent",
+                    "current_slice",
+                    "proof_boundary",
+                    "proof_is_slice_only",
+                    "residual_parent_intent",
+                    "continuation_owner",
+                )
+                if isinstance(payload.get("parent_intent_status"), dict) and key in payload.get("parent_intent_status", {})
+            },
+            "applicable_intent_status": {
+                key: payload.get("applicable_intent_status", {}).get(key)
+                for key in (
+                    "kind",
+                    "status",
+                    "conflicts",
+                    "missing_authority",
+                    "manual_verification_needed",
+                    "blocked_claims",
+                    "closeout_blocked",
+                )
+                if isinstance(payload.get("applicable_intent_status"), dict) and key in payload.get("applicable_intent_status", {})
+            },
             "acceptance": _tiny_acceptance_payload(payload.get("acceptance", {})),
             "acceptance_reconciliation": _tiny_acceptance_reconciliation(payload.get("acceptance_reconciliation", {})),
             "objective_drift": _tiny_objective_drift(payload.get("objective_drift", {})),
@@ -20612,6 +21169,8 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "context.workflow_sufficiency",
                 "context.acceptance",
                 "context.intent_evidence",
+                "context.parent_intent_status",
+                "context.applicable_intent_status",
                 "context.acceptance_reconciliation",
                 "context.objective_drift",
                 "context.reuse_pressure",
@@ -20627,6 +21186,22 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             ],
         },
     }
+    tiny_context = projected.get("context", {})
+    if isinstance(tiny_context, dict):
+        parent_packet = tiny_context.get("parent_intent_status", {})
+        parent_status = str(parent_packet.get("status") or "").strip() if isinstance(parent_packet, dict) else ""
+        if parent_status in {"", "guidance-only", "not-recorded"}:
+            tiny_context.pop("parent_intent_status", None)
+            selectors = projected.get("drill_down", {}).get("available_selectors", [])
+            if isinstance(selectors, list):
+                projected["drill_down"]["available_selectors"] = [item for item in selectors if item != "context.parent_intent_status"]
+        applicable_packet = tiny_context.get("applicable_intent_status", {})
+        applicable_status = str(applicable_packet.get("status") or "").strip() if isinstance(applicable_packet, dict) else ""
+        if applicable_status in {"", "guidance-only", "not-recorded"}:
+            tiny_context.pop("applicable_intent_status", None)
+            selectors = projected.get("drill_down", {}).get("available_selectors", [])
+            if isinstance(selectors, list):
+                projected["drill_down"]["available_selectors"] = [item for item in selectors if item != "context.applicable_intent_status"]
     generated_surface_trust = payload.get("generated_surface_trust", {})
     if isinstance(generated_surface_trust, dict) and generated_surface_trust.get("status") == "present":
         projected["generated_surface_trust"] = _tiny_generated_surface_trust(generated_surface_trust)

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1520,6 +1520,57 @@ def test_implement_context_surfaces_parent_intent_for_active_slice(tmp_path: Pat
     assert "runtime behavior can still be changed outside generated IR" in parent["residual_parent_intent"]
 
 
+def test_implement_preserves_unplanned_parent_intent_for_generated_surface_slice(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "agentic_workspace" / "contracts" / "command_package_ir.json", "{}\n")
+    _write(tmp_path / "generated" / "workspace" / "python" / "parser_adapter.py", "# generated\n")
+    task = "all runtime code should be generated from IR representations as a single source of truth"
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "generated/workspace/python/parser_adapter.py",
+                "--task",
+                task,
+                "--verbose",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    parent = payload["parent_intent_status"]
+    assert parent["status"] == "needs-planning"
+    assert parent["original_intent"] == task
+    assert parent["parent_acceptance_target"] == task
+    assert parent["current_slice"] == "changed generated surface(s): generated/workspace/python/parser_adapter.py"
+    assert parent["proof_boundary"] == "changed-path/generated-surface proof only"
+    assert parent["proof_is_slice_only"] is True
+    assert parent["larger_intent_status"] == "not-recorded"
+    assert parent["closure_decision"] == "not-recorded"
+    assert parent["required_next_action"].startswith("Preserve the raw task")
+    assert "generated-surface freshness" in parent["must_not_claim"][0]
+    assert parent["source_fields"] == [
+        "task_intent.task_excerpt",
+        "changed_paths",
+        "generated_surface_trust",
+        "planning.active.planning_record.parent_acceptance",
+    ]
+    authority = parent["authority_boundary"]
+    assert authority["surface"] == "parent_intent_status"
+    assert "active_parent_acceptance=False" in authority["observed_by_aw"]
+    assert "semantic work-shape judgment" in parent["rule"]
+    assert "does not semantically classify the prompt" in authority["reporting_rule"]
+    assert payload["generated_surface_trust"]["status"] == "present"
+
+
 def test_implement_rejects_archived_plan_residue_with_only_activation_trigger(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1443,6 +1443,83 @@ def test_implement_allows_completed_archived_plan_residue_with_routed_continuati
     assert facts["archived_planning_residue"]["records"][0]["closure_decision"] == "archive-but-keep-lane-open"
 
 
+def test_implement_context_surfaces_parent_intent_for_active_slice(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    plan = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "generated-runtime-boundary.plan.json"
+    _write(
+        plan,
+        json.dumps(
+            {
+                "kind": "planning-execplan/v1",
+                "title": "Generated Runtime Boundary",
+                "active_milestone": {
+                    "id": "generated-runtime-boundary",
+                    "status": "active",
+                    "scope": "Refresh one generated adapter.",
+                },
+                "delegated_judgment": {"requested outcome": "Refresh one generated adapter."},
+                "parent_acceptance": {
+                    "original_intent": "all runtime code should be generated from IR representations as a single source of truth",
+                    "parent_acceptance": "runtime behavior cannot be changed outside generated IR or declared primitive implementation boundaries",
+                    "current_slice": "generated parser adapter freshness",
+                    "residual_parent_intent": "runtime behavior can still be changed outside generated IR/primitive implementation boundaries",
+                    "proof_boundary": "slice-only",
+                },
+                "intent_continuity": {
+                    "larger intended outcome": "all runtime code should be generated from IR representations as a single source of truth",
+                    "this slice completes the larger intended outcome": "no",
+                    "continuation surface": "#1318",
+                },
+                "required_continuation": {
+                    "required follow-on for the larger intended outcome": "yes",
+                    "owner surface": "#1318",
+                },
+                "proof_report": {
+                    "validation proof": "pending",
+                    "intent_proof": {"status": "needs_review", "claim_boundary": "slice"},
+                },
+            },
+            indent=2,
+        ),
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'generated-runtime-boundary', title = 'Generated runtime boundary', surface = '.agentic-workspace/planning/execplans/generated-runtime-boundary.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+    _write(tmp_path / "generated" / "workspace" / "python" / "parser_adapter.py", "# generated\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "generated/workspace/python/parser_adapter.py",
+                "--task",
+                "Refresh the generated parser adapter without closing the full runtime-generation boundary.",
+                "--verbose",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    parent = payload["parent_intent_status"]
+    assert parent["status"] == "open"
+    assert parent["original_intent"] == "all runtime code should be generated from IR representations as a single source of truth"
+    assert parent["current_slice"] == "generated parser adapter freshness"
+    assert parent["proof_is_slice_only"] is True
+    assert "runtime behavior can still be changed outside generated IR" in parent["residual_parent_intent"]
+
+
 def test_implement_rejects_archived_plan_residue_with_only_activation_trigger(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -3838,6 +3838,135 @@ reopen_trigger = "parent lane asks for full parser behavior-preservation closure
     assert "1 verification evidence row(s)" in traceability["assurance-verification"]["evidence"]
 
 
+def test_report_closeout_report_represents_generated_code_parent_intent_boundary(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    plan = target / ".agentic-workspace" / "planning" / "execplans" / "generated-runtime-boundary.plan.json"
+    _write_json(
+        plan,
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Generated Runtime Boundary",
+            "active_milestone": {
+                "id": "generated-runtime-boundary",
+                "status": "complete",
+                "scope": "Refresh generated parser adapter and prove the generated target is current.",
+            },
+            "delegated_judgment": {
+                "requested outcome": "Refresh the generated parser adapter without losing the parent runtime-generation boundary.",
+                "hard constraints": "Do not claim the full runtime boundary is satisfied by one freshness slice.",
+            },
+            "parent_acceptance": {
+                "original_intent": "all runtime code should be generated from IR representations as a single source of truth",
+                "parent_acceptance": "runtime behavior cannot be changed outside generated IR or declared primitive implementation boundaries",
+                "current_slice": "generated parser adapter freshness",
+                "slice_contribution": "parser adapter output is current",
+                "residual_parent_intent": "runtime behavior can still be changed outside generated IR/primitive implementation boundaries",
+                "proof_boundary": "slice-only",
+                "parent_proof_required": "runtime primitive boundary audit plus generated package conformance",
+                "human_confirmation_needed": ["maintainer confirms any direct runtime primitive implementation is intentionally declared"],
+            },
+            "intent_continuity": {
+                "larger intended outcome": "all runtime code should be generated from IR representations as a single source of truth",
+                "this slice completes the larger intended outcome": "no",
+                "continuation surface": "#1318",
+            },
+            "required_continuation": {
+                "required follow-on for the larger intended outcome": "yes",
+                "owner surface": "#1318",
+                "activation trigger": "runtime code remains directly editable outside generated IR or primitive implementation declarations",
+            },
+            "applicable_intents": {
+                "user_intents": ["all runtime code should be generated from IR representations as a single source of truth"],
+                "system_intents": [
+                    "AW must remain repo- and agent-agnostic and should surface evidence instead of deciding semantic closure."
+                ],
+                "subsystem_intents": ["Generated command package runtime targets must be refreshed from IR before use."],
+                "soft_intents": ["Direct runtime primitive edits require maintainer-visible justification."],
+                "sources": [
+                    {"source": "GitHub #1318", "intent": "preserve full original intent across slices"},
+                    {"source": "generated package contract", "intent": "generated targets are current"},
+                ],
+                "conflicts": ["current slice proves generated parser freshness, not full runtime-generation source-of-truth"],
+                "manual_verification_needed": [
+                    "maintainer must confirm whether remaining direct runtime primitive implementations are declared primitives"
+                ],
+                "blocked_claims": ["claim-work-complete", "close-parent-lane"],
+            },
+            "execution_run": {
+                "run status": "complete",
+                "what happened": "Regenerated parser adapter and checked generated package freshness.",
+                "scope touched": "generated parser adapter",
+                "changed surfaces": "generated/workspace/python/parser_adapter.py; generated/workspace/typescript/parser_adapter.mjs",
+                "validations run": "uv run python scripts/generate/generate_command_packages.py --check",
+                "result for continuation": "slice complete; parent runtime boundary remains open",
+            },
+            "proof_report": {
+                "validation proof": "uv run python scripts/generate/generate_command_packages.py --check passed",
+                "proof achieved now": "yes, for generated parser adapter freshness only",
+                "intent_proof": {
+                    "status": "sufficient_for_claim",
+                    "claim_boundary": "slice",
+                    "proof_dimensions": ["generated target freshness"],
+                    "unproven_after_tests": ["full runtime-generation source-of-truth boundary"],
+                },
+            },
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": "open",
+                "closure decision": "archive-but-keep-lane-open",
+                "why this decision is honest": "The slice proof is real, but the parent runtime-generation boundary remains unproven.",
+                "evidence carried forward": "generated parser freshness proof",
+                "reopen trigger": "parent completion is claimed from generated freshness proof alone",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'generated-runtime-boundary', title = 'Generated runtime boundary', surface = '.agentic-workspace/planning/execplans/generated-runtime-boundary.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_report", "--format", "json"]) == 0
+
+    report = json.loads(capsys.readouterr().out)["answer"]
+    parent = report["parent_intent_status"]
+    assert parent["status"] == "open"
+    assert parent["original_intent"] == "all runtime code should be generated from IR representations as a single source of truth"
+    assert parent["current_slice"] == "generated parser adapter freshness"
+    assert parent["proof_is_slice_only"] is True
+    assert "runtime behavior can still be changed outside generated IR" in parent["residual_parent_intent"]
+    applicable = report["applicable_intent_status"]
+    assert applicable["status"] == "attention"
+    assert applicable["closeout_blocked"] is True
+    assert applicable["conflicts"]
+    options = {option["id"]: option for option in report["closure_boundary"]["completion_options"]}
+    assert options["claim-work-complete"]["allowed"] is False
+    assert options["claim-work-complete"]["blocking_fields"]
+    assert options["close-parent-lane"]["allowed"] is False
+    rendering = report["final_response_rendering"]
+    assert rendering["plain_done_allowed"] is False
+    assert "parent intent status" in rendering["must_include"]
+    assert "applicable intent status" in rendering["must_include"]
+    rendered_text = rendering["rendered_summary"]["rendered_text"]
+    assert "Parent intent: open" in rendered_text
+    assert "Applicable intent:" in rendered_text
+    assert "Do not collapse current slice proof into parent completion proof." in rendering["must_not_claim"]
+    traceability = {row["id"]: row for row in report["traceability"]["rows"]}
+    assert traceability["parent-intent"]["status"] == "present"
+    assert traceability["applicable-intents"]["status"] == "missing"
+    checks = {check["id"]: check for check in report["completeness"]["checks"]}
+    assert checks["parent-intent-status"]["status"] == "incomplete"
+    assert checks["applicable-intent-status"]["status"] == "incomplete"
+
+
 def test_report_closeout_trust_blocks_broad_claim_for_missing_assurance_evidence(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -1606,6 +1606,80 @@ def test_start_surfaces_decomposed_active_work_delegation_candidates_and_auto_sk
     assert "safe_to_auto_run_commands" in audit["skipped_targets"][0]["reasons"][0]
 
 
+def test_start_surfaces_parent_intent_status_for_active_generated_code_slice(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    plan_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "generated-code-slice.plan.json"
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        "\n".join(
+            [
+                'kind = "agentic-planning-state"',
+                'schema_version = "planning-state/v1"',
+                "",
+                "[todo]",
+                'active_items = [{ id = "generated-code-slice", surface = ".agentic-workspace/planning/execplans/generated-code-slice.plan.json", next_action = "Continue the bounded generated-code slice." }]',
+            ]
+        ),
+    )
+    _write(
+        plan_path,
+        json.dumps(
+            {
+                "kind": "planning-execplan/v1",
+                "id": "generated-code-slice",
+                "title": "Generated code freshness slice",
+                "status": "in_progress",
+                "active_milestone": {
+                    "id": "slice",
+                    "scope": "Refresh generated adapters after primitive changes.",
+                },
+                "parent_acceptance": {
+                    "original_intent": "all runtime code should be generated from IR representations as a single source of truth",
+                    "acceptance_target": "No runtime target contains hand-maintained behavior that belongs in generated IR.",
+                    "current_slice": "hash-gated freshness checks for generated CLI targets",
+                    "proof_boundary": "current slice only",
+                    "residual_parent_intent": "Audit remaining runtime primitives and move non-primitive behavior into command-generation IR.",
+                    "parent_proof_required": "Generated targets and runtime behavior must be traced back to IR or explicit primitive exceptions.",
+                },
+                "applicable_intents": {
+                    "sources": [{"kind": "user", "ref": "#1318"}],
+                    "user_intents": ["Preserve full original generated-code intent across slices."],
+                    "manual_verification_needed": ["Confirm this slice is not treated as closing the parent lane."],
+                },
+            },
+            indent=2,
+        ),
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue implementation of the generated-code freshness slice",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    context = _start_context(payload)
+    parent = context["parent_intent_status"]
+    assert parent["status"] == "open"
+    assert parent["original_intent"] == "all runtime code should be generated from IR representations as a single source of truth"
+    assert parent["current_slice"] == "hash-gated freshness checks for generated CLI targets"
+    assert parent["proof_is_slice_only"] is True
+    assert "Audit remaining runtime primitives" in parent["residual_parent_intent"]
+    applicable = context["applicable_intent_status"]
+    assert applicable["status"] == "attention"
+    assert applicable["closeout_blocked"] is True
+    assert "claim-work-complete" in applicable["blocked_claims"]
+
+
 def test_start_decomposition_only_delegation_requires_lane_promotion_before_handoff(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(


### PR DESCRIPTION
## What landed

- Added parent/original-intent status and applicable-intent status packets to the existing startup, implement, closeout_report, completion-option, final-response, and report projection surfaces.
- Added Planning decomposition/execplan support for parent acceptance, slice contribution, residual parent intent, proof boundary, and human confirmation needs.
- Added a #1319 grounding review, #1318 decomposition, and #1318 execplan closeout evidence.
- Added fixtures for the generated-code/runtime-boundary under-scoping failure, including the unplanned broad-entry case where no active execplan has recorded `parent_acceptance` yet.
- Refreshed schema/reference docs and Planning generated payloads for Python and TypeScript package targets.

## Closure matrix

Issue | Closure evidence
--- | ---
#1318 | Representative end-to-end path now covers Planning decomposition and promoted slice parent acceptance, startup/implement parent-intent packets, closeout_report parent/applicable status, completion-option blocking, final-response rendering, and generated-code under-scoping fixtures for both planned and unplanned entry. The PR body leaves #1326 open as sibling residual scope.
#1319 | `.agentic-workspace/planning/reviews/2026-06-05-issue-1318-original-intent-preservation-grounding.review.json` grounds the lane in existing AW surfaces and maps findings to implementation evidence.
#1320 | `test_implement_preserves_unplanned_parent_intent_for_generated_surface_slice` proves that, with no active execplan/`parent_acceptance`, implement preserves the raw task text as candidate parent/original-intent evidence, reports `parent_intent_status.status = needs-planning`, keeps larger-intent closure `not-recorded`, and names Planning/decomposition as the next preservation action before narrowing or claiming completion. `test_start_surfaces_parent_intent_status_for_active_generated_code_slice` and `test_implement_context_surfaces_parent_intent_for_active_slice` prove the same surfaces carry parent intent, current slice, proof boundary, and residual parent intent once Planning has recorded parent acceptance.
#1321 | Planning decomposition schemas/templates/projections and `test_planning_summary_projects_decomposition_records` plus `test_promote_to_plan_supports_decomposition_lane` prove parent acceptance fields survive decomposition summary and lane promotion.
#1322 | `test_report_closeout_report_represents_generated_code_parent_intent_boundary` proves closeout_report and completion_options block broad/full-work claims when proof only covers a narrower slice.
#1323 | The generated-code fixtures use `all runtime code should be generated from IR representations as a single source of truth` and prove freshness of a generated target cannot close the parent runtime-boundary intent, whether the parent intent is already recorded in Planning or only preserved from the current explicit task text.
#1324 | Final-response rendering now must include parent intent/applicable intent status when they affect closeout, blocks plain-done claims, and renders current slice, proof boundary, residual parent intent, and blocked claims.
#1325 | Applicable-intent status carries source/conflict/missing-authority/manual-verification evidence and blocks or caveats closeout/final response when unresolved.

## Sibling scope

#1326 and its children are not closed by this PR. They remain the broader durable applicable-intent source discovery/precedence lane.

## Why parent closure is honest

This is not just wording. The PR adds runtime packets, Planning schema/template/promotion support, generated package payload updates, schema docs, and tests that exercise the full failure mode: an epic-shaped intent can be decomposed into slices without losing the original parent acceptance target or allowing a slice proof to masquerade as parent completion. It now also covers the earlier entry point before Planning has recorded parent acceptance: implement preserves the explicit task text as candidate parent/original intent, reports that parent status is not recorded/needs Planning, and keeps the authority boundary clear that AW observed task text and generated-path facts while the agent/human own semantic work-shape and acceptance judgment.

## Proof

- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_preserves_unplanned_parent_intent_for_generated_surface_slice tests/test_workspace_implement_cli.py::test_implement_context_surfaces_parent_intent_for_active_slice tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q`
- `uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_surfaces_parent_intent_status_for_active_generated_code_slice -q`
- `uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_report_represents_generated_code_parent_intent_boundary -q`
- `uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_surfaces_parent_intent_status_for_active_generated_code_slice tests/test_workspace_implement_cli.py::test_implement_context_surfaces_parent_intent_for_active_slice tests/test_workspace_report_cli.py::test_report_closeout_report_represents_generated_code_parent_intent_boundary tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unsupported_behavior_preservation_claim packages/planning/tests/test_summary.py::test_planning_summary_projects_decomposition_records packages/planning/tests/test_promote.py::test_promote_to_plan_supports_decomposition_lane -q`
- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_workspace_implement_cli.py::test_implement_context_surfaces_parent_intent_for_active_slice tests/test_workspace_report_cli.py::test_report_closeout_report_renders_planned_slice_first_inspection_contract tests/test_workspace_report_cli.py::test_report_closeout_report_uses_audit_profile_for_strict_closeout tests/test_workspace_report_cli.py::test_report_closeout_report_represents_generated_code_parent_intent_boundary -q`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `make maintainer-surfaces`
- `make test-workspace`
- `make lint-workspace`
- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`
- `make schema-reference-docs`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`

## Limitations

- This does not implement #1326 durable source discovery/precedence. It only ensures #1318 cannot hide that sibling residual scope.
- Parent/applicable packets are compact and evidence-oriented; AW still does not decide semantic intent precedence. Agent/human judgment owns reconciliation and acceptance.

Closes #1318
Closes #1319
Closes #1320
Closes #1321
Closes #1322
Closes #1323
Closes #1324
Closes #1325