### PR TITLE
Implement applicable intent reporting lane

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/github-1326-applicable-intent-implementation.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1326-applicable-intent-implementation.plan.json
@@ -1,0 +1,347 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1326 applicable-intent lane",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement the #1326 applicable-intent lane in full, including children #1327-#1332.",
+    "hard_constraints": "Use existing AW surfaces; do not add a policy engine, broad intent registry, hidden keyword classifier, or automatic semantic conflict resolver.",
+    "agent_may_decide": "Exact projection placement, compact schema shape, fixture organization, and whether child closure evidence is code, docs, or tests.",
+    "escalate_when": "A correct implementation requires a new global state store, changes who owns semantic acceptance, or cannot honestly satisfy one child issue.",
+    "next_action": "Map current intent-source surfaces, then implement the smallest compact projection and fixtures that satisfy #1326 and #1327-#1332.",
+    "proof_expectations": [
+      "Focused tests for applicable-intent projection and closeout/final-response caveats.",
+      "Workspace report/start/implement tests covering authority boundaries and issue-sourced intent evidence.",
+      "Verification or assurance tests showing manual verification/waiver/known-gap representation.",
+      "Maintainer surface and schema checks if contracts or structured inventory change."
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/reporting_support.py",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_workspace_report_cli.py",
+      "tests/test_workspace_start_preflight_cli.py",
+      "tests/test_workspace_implement_cli.py",
+      "packages/verification/tests/test_runtime_primitives.py",
+      ".agentic-workspace/planning/reviews/",
+      ".agentic-workspace/memory/repo/"
+    ],
+    "completion_criteria": [
+      "#1327 has a grounded review artifact or equivalent evidence map.",
+      "#1328 exposes compact applicable-intent sources for multiple source types without semantic keyword classification.",
+      "#1329 defines stable authority, precedence, freshness, and conflict states with authority-safe wording.",
+      "#1330 routes clarification, waiver, acceptance, and deferral outcomes to durable owner evidence.",
+      "#1331 represents manual soft-intent verification status and closeout effect.",
+      "#1332 has regression fixtures preventing unresolved conflicts or soft-intent obligations from being hidden in closeout/final response."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "GitHub #1326; children #1327 #1328 #1329 #1330 #1331 #1332"
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement the #1326 applicable-intent lane in full, including children #1327-#1332.",
+      "constraints": "Use existing AW surfaces; do not add a policy engine, broad intent registry, hidden keyword classifier, or automatic semantic conflict resolver.",
+      "latitude": "Exact projection placement, compact schema shape, fixture organization, and whether child closure evidence is code, docs, or tests.",
+      "escalation": "A correct implementation requires a new global state store, changes who owns semantic acceptance, or cannot honestly satisfy one child issue.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "github-1326-applicable-intent-implementation",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/reporting_support.py",
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_workspace_report_cli.py",
+        "tests/test_workspace_start_preflight_cli.py",
+        "tests/test_workspace_implement_cli.py",
+        "packages/verification/tests/test_runtime_primitives.py",
+        ".agentic-workspace/planning/reviews/",
+        ".agentic-workspace/memory/repo/"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "GitHub #1326; children #1327 #1328 #1329 #1330 #1331 #1332",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1326 applicable-intent lane",
+    "inferred intended outcome": "GitHub #1326; children #1327 #1328 #1329 #1330 #1331 #1332",
+    "chosen concrete what": "#1326 and children #1327-#1332 have representative review, projection, authority/freshness/conflict vocabulary, durable outcome routing, manual verification closeout effect, and regression fixture coverage.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "GitHub #1326; children #1327 #1328 #1329 #1330 #1331 #1332",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "Local implementation is safer for this lane because the report projection, closeout completeness, and regression fixtures need tight iteration in one workspace; delegation would not reduce proof burden or semantic acceptance risk.",
+    "decision command": "agentic-planning delegation-decision",
+    "planning revision observed": "8aa237f52f144cd6",
+    "recorded at": "2026-06-05T16:43:03+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": "GitHub #1326; children #1327 #1328 #1329 #1330 #1331 #1332",
+      "label": "GitHub #1326; children #1327 #1328 #1329 #1330 #1331 #1332",
+      "role": "intake",
+      "locator": ""
+    }
+  ],
+  "active_milestone": {
+    "id": "github-1326-applicable-intent-implementation",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement #1326 applicable-intent lane is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented the #1326 applicable-intent lane across report projection, report router, closeout completeness, schema/reference docs, and regression fixtures.",
+    "scope touched": "Workspace report runtime projection, reporting router, workspace report schema/reference docs, report CLI tests, and Planning lane/review artifacts.",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; src/agentic_workspace/contracts/report_contract.json; docs/reference/workspace-report.md; tests/test_workspace_report_cli.py; .agentic-workspace/planning lane/review/execplan state.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within existing AW surfaces. AW assembles structural/configured applicable-intent evidence and explicitly leaves semantic applicability, conflict resolution, waiver, and acceptance to agent/human/domain owners. Dogfooding found Planning lane lifecycle follow-ups routed to #1349 and #1350.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "Local implementation is safer for this lane because the report projection, closeout completeness, and regression fixtures need tight iteration in one workspace; delegation would not reduce proof burden or semantic acceptance risk.",
+    "expected savings": "unknown",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_report_cli.py::test_report_applicable_intent_section_projects_sources_authority_and_durable_outcomes tests/test_workspace_report_cli.py::test_report_router_surfaces_applicable_intent_compactly tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unresolved_soft_applicable_intent_from_verification tests/test_workspace_report_cli.py::test_report_closeout_report_represents_generated_code_parent_intent_boundary -q passed; make test-workspace passed; make lint-workspace passed; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success passed; uv run python scripts/check/check_structured_file_inventory.py --quiet-success passed; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py passed; make maintainer-surfaces passed; make schema-reference-docs passed; uv run python scripts/generate/generate_command_packages.py --check passed; uv run python scripts/check/check_generated_command_packages.py passed; uv run python scripts/run_agentic_workspace.py summary --target . --format json passed; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json passed; uv run python scripts/run_agentic_workspace.py report --target . --section applicable_intent --format json dogfooded successfully.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "GitHub #1326; children #1327 #1328 #1329 #1330 #1331 #1332",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1326 and children #1327-#1332 have representative review, projection, authority/freshness/conflict vocabulary, durable outcome routing, manual verification closeout effect, and regression fixture coverage.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed issue residue to GitHub #1349 and #1350.",
+    "motivation worth preserving": "Future agents should continue from GitHub #1349 and #1350 rather than rediscover this closeout residue.",
+    "canonical owner now": "GitHub #1349 and #1350",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "GitHub #1349 and #1350",
+    "proposed durable intent": "Future agents should continue from GitHub #1349 and #1350 rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "GitHub #1349 and #1350"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a lane claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      {
+        "summary": "Closeout routed issue residue to GitHub #1349 and #1350.",
+        "owner": "GitHub #1349 and #1350",
+        "source": "durable_residue"
+      }
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      {
+        "summary": "Closeout routed issue residue to GitHub #1349 and #1350.",
+        "owner": "GitHub #1349 and #1350",
+        "source": "durable_residue"
+      }
+    ],
+    "signals dismissed": [],
+    "next owner": "see routed signal owner"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-05: Scaffolded by agentic-planning new-plan.",
+    "2026-06-05: Recorded delegation decision route=keep-local."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "GitHub #1349 and #1350",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: GitHub #1326; children #1327 #1328 #1329 #1330 #1331 #1332\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_report_cli.py::test_report_applicable_intent_section_projects_sources_authority_and_durable_outcomes tests/test_workspace_report_cli.py::test_report_router_surfaces_applicable_intent_compactly tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unresolved_soft_applicable_intent_from_verification tests/test_workspace_report_cli.py::test_report_closeout_report_represents_generated_code_parent_intent_boundary -q passed; make test-workspace passed; make lint-workspace passed; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success passed; uv run python scripts/check/check_structured_file_inventory.py --quiet-success passed; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py passed; make maintainer-surfaces passed; make schema-reference-docs passed; uv run python scripts/generate/generate_command_packages.py --check passed; uv run python scripts/check/check_generated_command_packages.py passed; uv run python scripts/run_agentic_workspace.py summary --target . --format json passed; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json passed; uv run python scripts/run_agentic_workspace.py report --target . --section applicable_intent --format json dogfooded successfully.\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; src/agentic_workspace/contracts/report_contract.json; docs/reference/workspace-report.md; tests/test_workspace_report_cli.py; .agentic-workspace/planning lane/review/execplan state.\nDurable residue: planning (GitHub #1349 and #1350)\nMemory learning: route_to_planning\nFollow-up: none"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/github-1351-durable-outcome-review.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1351-durable-outcome-review.plan.json
@@ -1,0 +1,299 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Address PR #1351 durable outcome review",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for Address PR #1351 durable outcome review.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Address PR #1351 durable outcome review is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Address PR #1351 durable outcome review."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Address PR #1351 durable outcome review.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "github-1351-durable-outcome-review",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Address PR #1351 durable outcome review.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Address PR #1351 durable outcome review",
+    "inferred intended outcome": "Create a bounded plan for Address PR #1351 durable outcome review.",
+    "chosen concrete what": "Resolved-outcome fixture proves accepted interpretation evidence clears applicable-intent conflict/manual/missing-authority pressure and is rendered in closeout.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Address PR #1351 durable outcome review.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1351-durable-outcome-review",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Address PR #1351 durable outcome review is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Addressed PR #1351 review by adding a compact resolved durable applicable-intent outcome path and fixture.",
+    "scope touched": "Workspace report applicable-intent projection, closeout rendering/completeness, workspace report schema/reference docs, structured inventory, and report CLI tests.",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; src/agentic_workspace/contracts/structured_file_inventory.json; docs/reference/workspace-report.md; tests/test_workspace_report_cli.py; .agentic-workspace/planning execplan/state.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "The review comment asked for concrete durable outcome evidence for #1326/#1330. The change records applicable_intents.durable_outcomes with owner, evidence anchor, stale condition, reopen trigger, affected claims, and resolves list; report and closeout now consume that record so the same obligation is not treated as unresolved.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Focused applicable-intent tests passed; make test-workspace passed; make lint-workspace passed; contract tooling passed; structured inventory passed; ruff scoped check passed; make maintainer-surfaces passed; make schema-reference-docs passed; generated command package checks passed; summary and doctor passed.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Address PR #1351 durable outcome review.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Resolved-outcome fixture proves accepted interpretation evidence clears applicable-intent conflict/manual/missing-authority pressure and is rendered in closeout.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-05: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Address PR #1351 durable outcome review.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Focused applicable-intent tests passed; make test-workspace passed; make lint-workspace passed; contract tooling passed; structured inventory passed; ruff scoped check passed; make maintainer-surfaces passed; make schema-reference-docs passed; generated command package checks passed; summary and doctor passed.\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; src/agentic_workspace/contracts/structured_file_inventory.json; docs/reference/workspace-report.md; tests/test_workspace_report_cli.py; .agentic-workspace/planning execplan/state.\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/.agentic-workspace/planning/lanes/archive/github-1326-applicable-intent.lane.json
+++ b/.agentic-workspace/planning/lanes/archive/github-1326-applicable-intent.lane.json
@@ -1,0 +1,69 @@
+{
+  "kind": "planning-lane/v1",
+  "id": "github-1326-applicable-intent",
+  "title": "Implement applicable-intent operating model",
+  "status": "archived",
+  "parent_decomposition_ref": "",
+  "lane_outcome": "AW can surface applicable intent sources, authority and freshness posture, durable clarification or waiver outcomes, manual verification status, and closeout caveats without becoming a semantic policy engine.",
+  "purpose_for_parent": "Close #1326 and child issues #1327-#1332 through compact evidence across existing Planning, Memory, Verification, assurance, closeout, and final-response surfaces.",
+  "subsystems": [
+    "workspace reporting",
+    "Planning",
+    "Verification",
+    "Memory",
+    "assurance",
+    "closeout/final-response rendering"
+  ],
+  "technical_strategy": "Reuse existing report/start/implement, Verification, assurance, Planning, Memory guidance, and closeout surfaces. Add a compact applicable-intent projection and representative fixtures rather than a policy engine or broad intent registry.",
+  "technology_choices": [],
+  "slice_sequence": [
+    {
+      "id": "github-1326-applicable-intent-implementation",
+      "title": "Implement #1326 applicable-intent lane",
+      "status": "active",
+      "execplan_ref": ".agentic-workspace/planning/execplans/github-1326-applicable-intent-implementation.plan.json",
+      "depends_on": [],
+      "purpose_for_lane": "Deliver the compact applicable-intent projection, durable outcome routing, manual verification closeout behavior, and representative regression fixtures.",
+      "proof": "Focused applicable-intent report/closeout tests plus workspace proof checks.",
+      "residual_after_slice": "none if #1326 and children #1327-#1332 are honestly satisfied"
+    }
+  ],
+  "current_slice": "github-1326-applicable-intent-implementation",
+  "acceptance_boundary": "All lane slices have landed, lane proof aggregation is satisfied, and residual work is routed.",
+  "proof_strategy": "Representative fixtures must cover source discovery, authority/conflict vocabulary, durable outcome routing, manual soft-intent verification, and closeout/final-response caveats.",
+  "proof_aggregation": {
+    "status": "partial",
+    "evidence": [
+      "Focused applicable-intent tests passed; make test-workspace and make lint-workspace passed; contract tooling, structured inventory, maintainer surfaces, schema docs, generated package checks, summary, doctor, and applicable_intent dogfooding passed."
+    ],
+    "known_gaps": [
+      "No residual #1326 lane work. Dogfooding follow-ups are routed to GitHub #1349 and #1350."
+    ]
+  },
+  "residual_lane_work": "No residual #1326 lane work. Dogfooding follow-ups are routed to GitHub #1349 and #1350.",
+  "lane_to_epic_contribution": "Closes #1326 and children #1327-#1332 by adding compact applicable-intent source projection, authority/freshness/conflict vocabulary, durable outcome routing, manual verification closeout effects, schema/reference docs, and regression fixtures across existing AW surfaces.",
+  "parent_close_permission": "may-close-parent",
+  "closeout_state": {
+    "status": "blocked",
+    "summary": "Closes #1326 and children #1327-#1332 by adding compact applicable-intent source projection, authority/freshness/conflict vocabulary, durable outcome routing, manual verification closeout effects, schema/reference docs, and regression fixtures across existing AW surfaces.",
+    "residual_work": "No residual #1326 lane work. Dogfooding follow-ups are routed to GitHub #1349 and #1350.",
+    "next_owner": "GitHub #1349 and #1350 for dogfooding follow-ups only"
+  },
+  "references": [
+    {
+      "kind": "issue",
+      "target": "GitHub #1326",
+      "label": "Parent applicable-intent lane",
+      "role": "parent-intent",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1326"
+    },
+    {
+      "kind": "issue",
+      "target": "GitHub #1327-#1332",
+      "label": "Review and implementation children",
+      "role": "closure-set",
+      "locator": ""
+    }
+  ],
+  "notes": "Keep AW authority language explicit: AW exposes structural/configured evidence and recommended owners; the agent, human, domain, or compliance owner decides semantic applicability and acceptance."
+}

--- a/.agentic-workspace/planning/reviews/2026-06-05-issue-1326-applicable-intent-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-05-issue-1326-applicable-intent-grounding.review.json
@@ -1,0 +1,155 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Applicable intent source surfaces and gaps grounding",
+  "date": "2026-06-05",
+  "scope": [
+    "#1326 parent lane and #1327 review child"
+  ],
+  "classification": "applicable-intent-grounding",
+  "goal": [
+    "Map current applicable-intent source surfaces before implementing #1326.",
+    "Identify the smallest existing AW surfaces that can represent source discovery, authority/freshness, conflicts, durable clarification or waiver outcomes, manual verification, and closeout caveats."
+  ],
+  "non_goals": [
+    "Do not add a policy engine or global intent registry.",
+    "Do not make AW decide semantic applicability or choose which source wins a conflict.",
+    "Do not force applicable-intent machinery onto small direct work."
+  ],
+  "review_mode": {
+    "mode": "applicable-intent-grounding",
+    "review question": "Which existing surfaces can carry applicable-intent evidence for #1326 without a new broad state store?",
+    "default finding cap": "bounded",
+    "inputs inspected first": "GitHub #1326-#1332, report/closeout code, Verification manifest/runtime, assurance requirement projection, Memory index/manifest, Planning active records"
+  },
+  "review_method": {
+    "commands used": [
+      "uv run python scripts/run_agentic_workspace.py start --task \"Implement the #1326 lane\" --format json",
+      "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+      "gh issue view 1326 --json number,title,state,body,comments,url,labels",
+      "gh issue view 1327..1332 --json number,title,state,body,comments,url",
+      "rg -n \"applicable_intents|assurance_requirements|verification|standing_intent|closeout_report\" src tests packages .agentic-workspace"
+    ],
+    "evidence sources": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "src/agentic_workspace/reporting_support.py",
+      "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py",
+      ".agentic-workspace/memory/repo/index.md",
+      ".agentic-workspace/memory/repo/manifest.toml",
+      "tests/test_workspace_report_cli.py",
+      "GitHub #1326",
+      "GitHub #1327",
+      "GitHub #1328",
+      "GitHub #1329",
+      "GitHub #1330",
+      "GitHub #1331",
+      "GitHub #1332"
+    ]
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1326",
+      "label": "parent applicable-intent lane",
+      "role": "parent_intent",
+      "locator": "issue"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1327",
+      "label": "grounding review child",
+      "role": "review_slice",
+      "locator": "issue"
+    }
+  ],
+  "findings": [
+    {
+      "title": "F1: Applicable-intent evidence already exists, but it is split across Planning, Memory, Verification, assurance, standing intent, and external issue evidence.",
+      "summary": "No single compact report tells an agent which intent sources may matter before broad or soft-intent closeout.",
+      "evidence": "report already builds durable_intent, standing_intent, assurance_requirements, verification, memory_consult, external_work_reconciliation, and closeout_report; closeout also has a Planning-backed applicable_intents status packet.",
+      "risk if unchanged": "Agents either over-read raw surfaces or miss subsystem/system/soft intents and resolve conflicts only in chat.",
+      "suggested action": "Add a compact report section that assembles structural/configured source evidence while preserving agent/human semantic ownership.",
+      "promotion target": "#1328"
+    },
+    {
+      "title": "F2: Authority and freshness need a stable vocabulary that does not imply AW semantic resolution.",
+      "summary": "Existing authority_boundary packets are the right model, but applicable-intent sources need small enumerations for authority class, freshness/trust, and conflict status.",
+      "evidence": "assurance and Verification already say AW reports configured match facts and does not decide semantic intent; #1329 asks for authoritative/advisory/stale/conflicting/manual-owner wording.",
+      "risk if unchanged": "Agents can describe AW as having classified or resolved an intent conflict when it only exposed evidence.",
+      "suggested action": "Expose a stable vocabulary and authority_boundary in applicable_intent output.",
+      "promotion target": "#1329"
+    },
+    {
+      "title": "F3: Durable clarification and waiver outcomes fit existing owner surfaces.",
+      "summary": "Planning parent acceptance, decision facts, Memory, Verification known gaps, assurance waivers, issue comments, docs/config, and closeout evidence can own outcomes without a new approval log.",
+      "evidence": "#1330 explicitly names those owners; current closeout and Verification surfaces already retain summaries, evidence labels, known gaps, blocked claims, and reopen triggers.",
+      "risk if unchanged": "Clarifications or waivers remain chat-only and future sessions rediscover the same conflict.",
+      "suggested action": "Add owner-routing guidance to applicable_intent output and fixtures.",
+      "promotion target": "#1330"
+    },
+    {
+      "title": "F4: Manual soft-intent verification must affect closeout, not only proof selection.",
+      "summary": "Verification and assurance can represent manual evidence requirements and known gaps, but closeout completeness must treat unresolved manual requirements as caveats/blockers.",
+      "evidence": "Verification manifests support scenarios, expected_evidence, evidence_bundles, known_gaps, blocked_claims, and review_owner; closeout_report already blocks Planning.applicable_intents but its completeness path needs assurance/Verification enrichment.",
+      "risk if unchanged": "Ordinary tests can pass while final reports hide unresolved domain or compliance acceptance.",
+      "suggested action": "Feed assurance/Verification manual obligations into applicable-intent closeout status and final-response rendering.",
+      "promotion target": "#1331 and #1332"
+    }
+  ],
+  "recommendation": {
+    "promote": "Implement #1328-#1332 in one bounded lane because the children share one representative fixture and one compact report surface.",
+    "defer": "Do not build a global policy engine, automated business-risk classifier, or new intent state store.",
+    "dismiss": "Do not duplicate Memory, Planning, Verification, or assurance ownership; assemble their evidence through report surfaces."
+  },
+  "retention": {
+    "closeout shape": "shrink",
+    "trigger": "findings promoted, dismissed, or superseded",
+    "proof surface": "routed issues, planning state, docs, checks, Memory, or a compact retained review stub"
+  },
+  "prose_templates": {
+    "review_finding": {
+      "sections": [
+        "Finding",
+        "Evidence",
+        "Impact",
+        "Recommendation",
+        "Owner",
+        "Status"
+      ],
+      "field_map": {
+        "Finding": "findings[].title + findings[].summary",
+        "Evidence": "findings[].evidence + findings[].source",
+        "Impact": "findings[].risk if unchanged",
+        "Recommendation": "findings[].suggested action + findings[].promotion target",
+        "Owner": "findings[].promotion target",
+        "Status": "recommendation/promote|defer|dismiss"
+      },
+      "rule": "Use only these headings when a prose finding is needed; keep the canonical fields structured."
+    },
+    "handoff_or_closeout": {
+      "sections": [
+        "Intent",
+        "What changed",
+        "Proof",
+        "Remaining risk",
+        "Durable residue",
+        "Next owner"
+      ],
+      "field_map": {
+        "Intent": "intent/outcome or requested_outcome",
+        "What changed": "execution_summary/outcome delivered",
+        "Proof": "proof_report/validation proof",
+        "Remaining risk": "finished_run_review/misinterpretation risk or follow-on decision",
+        "Durable residue": "durable_residue + closeout_distillation",
+        "Next owner": "execution_summary/follow-on routed to or required_continuation/owner surface"
+      },
+      "rule": "Prefer structured fields; use this shape only for short human-readable summaries."
+    }
+  },
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_report_cli.py::test_report_applicable_intent_section_projects_sources_authority_and_durable_outcomes tests/test_workspace_report_cli.py::test_report_router_surfaces_applicable_intent_compactly tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unresolved_soft_applicable_intent_from_verification -q"
+  ],
+  "drift_log": [
+    "2026-06-05: Review record created by create-review.",
+    "2026-06-05: Filled with #1326/#1327 source-surface grounding and implementation recommendation."
+  ]
+}

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -69,6 +69,37 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `agent_configuration_queries` | object | yes |  | Compact queries agents should ask before opening broader configuration docs. |  |  |
 | `system_intent_mirror` | object | no |  | Compiled system-intent mirror status and source metadata. |  |  |
 | `durable_intent` | object | yes |  | Compact decision projection for durable task, subsystem, and system intent pressure. |  |  |
+| `applicable_intent` | ref `#/$defs/applicable_intent` | yes |  | Compact applicable-intent source, authority, freshness, conflict, durable-outcome, and manual-verification evidence. |  |  |
+| `applicable_intent.kind` | const `"agentic-workspace/applicable-intent-sources/v1"` | yes |  | Discriminator for the applicable-intent source projection. |  |  |
+| `applicable_intent.status` | string | yes |  | Whether source evidence is present, guidance-only, or requires attention. |  |  |
+| `applicable_intent.source_count` | integer | yes |  | Number of applicable-intent source records surfaced in this projection. |  |  |
+| `applicable_intent.sources` | array of object | yes |  | Structural or configured source records from Planning, Memory, assurance, Verification, standing intent, durable intent, or external work evidence. |  |  |
+| `applicable_intent.authority_vocabulary` | object | yes |  | Stable vocabulary for authority classes, freshness/trust states, conflict states, and manual-verification states. |  |  |
+| `applicable_intent.conflict_status` | string | yes |  | Compact status for whether the projection has no conflict, a possible conflict, a closeout-blocking conflict, or a clarification requirement. |  |  |
+| `applicable_intent.conflicts` | array of string | no |  | Recorded conflict statements from existing owner surfaces. |  |  |
+| `applicable_intent.missing_authority` | array of string | no |  | Recorded missing authority or acceptance evidence. |  |  |
+| `applicable_intent.stale_or_superseded` | array of object | no |  | Sources whose freshness state indicates stale or superseded evidence. |  |  |
+| `applicable_intent.manual_verification` | array of object | yes |  | Manual/domain/compliance verification obligations that must remain visible before broad closeout. |  |  |
+| `applicable_intent.durable_outcome_routing` | array of object | yes |  | Owner-surface guidance for clarifications, accepted interpretations, waivers, and deferred outcomes. |  |  |
+| `applicable_intent.blocked_claims` | array of string | yes |  | Completion claims that should not be made while applicable-intent conflicts or missing verification remain. |  |  |
+| `applicable_intent.closeout_blocked` | boolean | yes |  | Whether applicable-intent evidence blocks broad/plain closeout claims. |  |  |
+| `applicable_intent.closeout_status` | ref `#/$defs/applicable_intent_status` | no |  | Closeout-oriented applicable-intent status summary. |  |  |
+| `applicable_intent.closeout_status.kind` | const `"agentic-workspace/applicable-intent-status/v1"` | yes |  | Discriminator for the applicable-intent status packet. |  |  |
+| `applicable_intent.closeout_status.status` | string | yes |  | Whether applicable-intent evidence is present, guidance-only, or requires attention. |  |  |
+| `applicable_intent.next_actions` | array of string | no |  | Suggested next inspection or resolution actions. |  |  |
+| `applicable_intent.authority_boundary` | ref `#/$defs/authority_boundary` | yes |  | Authority boundary showing that AW assembles structural/configured evidence while agent and human owners decide semantic applicability and acceptance. |  |  |
+| `applicable_intent.authority_boundary.kind` | const `"agentic-workspace/authority-boundary/v1"` | yes |  | Discriminator for the authority-boundary packet. |  |  |
+| `applicable_intent.authority_boundary.surface` | string | yes |  | Payload surface whose authority categories are being described. |  |  |
+| `applicable_intent.authority_boundary.authority_class` | enum `"hard-gate"`, `"advisory-support"`, `"observed-facts"`, `"agent-owned"` | yes |  | Dominant authority class for the surface. |  |  |
+| `applicable_intent.authority_boundary.enforced_by_aw` | array of string | yes |  | Hard gates or constraints AW enforces for this surface. |  |  |
+| `applicable_intent.authority_boundary.observed_by_aw` | array of string | yes |  | Mechanical facts, evidence, path state, or configuration AW observed. |  |  |
+| `applicable_intent.authority_boundary.recommended_by_aw` | array of string | yes |  | Advisory next actions or support signals AW recommends without owning semantic judgment. |  |  |
+| `applicable_intent.authority_boundary.candidate_routes` | array of string | yes |  | Possible routes AW surfaced for the agent to evaluate. |  |  |
+| `applicable_intent.authority_boundary.proof_hints` | array of string | yes |  | Proof burden or validation hints relevant to the surface. |  |  |
+| `applicable_intent.authority_boundary.agent_owned_decisions` | array of string | yes |  | Semantic, route, proof-proportionality, or completion judgments the agent owns. |  |  |
+| `applicable_intent.authority_boundary.human_owned_decisions` | array of string | yes |  | Intent, acceptance, or handoff decisions requiring human ownership when present. |  |  |
+| `applicable_intent.authority_boundary.reporting_rule` | string | yes |  | How agents should report the boundary without overstating AW authority. |  |  |
+| `applicable_intent.rule` | string | no |  | Usage rule for when this projection should be consulted. |  |  |
 | `workflow_obligations` | object | yes |  | Repo-configured workflow obligations surfaced for report consumers. |  |  |
 | `assurance_requirements` | object | yes |  | Repo-declared assurance requirements, active matches, and evidence status projection; task-marker matches cite explicit config while semantic acceptance remains agent/human owned. |  |  |
 | `verification` | object | yes |  | Repo-native verification protocols, scenarios, bounded evidence bundles, and soft verification routing projection; task-marker matches are configured protocol evidence, not AW-owned intent classification. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -80,6 +80,8 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `applicable_intent.missing_authority` | array of string | no |  | Recorded missing authority or acceptance evidence. |  |  |
 | `applicable_intent.stale_or_superseded` | array of object | no |  | Sources whose freshness state indicates stale or superseded evidence. |  |  |
 | `applicable_intent.manual_verification` | array of object | yes |  | Manual/domain/compliance verification obligations that must remain visible before broad closeout. |  |  |
+| `applicable_intent.durable_outcomes` | array of object | no |  | Recorded clarification, accepted-interpretation, waiver, or deferral outcomes with owner, evidence anchor, stale condition, reopen trigger, affected claims, and resolved items. |  |  |
+| `applicable_intent.resolved_outcome_count` | integer | no |  | Number of durable applicable-intent outcome records surfaced by this projection. |  |  |
 | `applicable_intent.durable_outcome_routing` | array of object | yes |  | Owner-surface guidance for clarifications, accepted interpretations, waivers, and deferred outcomes. |  |  |
 | `applicable_intent.blocked_claims` | array of string | yes |  | Completion claims that should not be made while applicable-intent conflicts or missing verification remain. |  |  |
 | `applicable_intent.closeout_blocked` | boolean | yes |  | Whether applicable-intent evidence blocks broad/plain closeout claims. |  |  |

--- a/src/agentic_workspace/contracts/report_contract.json
+++ b/src/agentic_workspace/contracts/report_contract.json
@@ -26,6 +26,7 @@
     "agent_configuration_queries",
     "system_intent_mirror",
     "durable_intent",
+    "applicable_intent",
     "workflow_obligations",
     "assurance_requirements",
     "product_managed_enclave",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -33,6 +33,7 @@
     "assurance_requirements",
     "verification",
     "durable_intent",
+    "applicable_intent",
     "product_managed_enclave",
     "ownership_diagnostics",
     "surface_value_guardrail",
@@ -215,6 +216,10 @@
     "durable_intent": {
       "type": "object",
       "description": "Compact decision projection for durable task, subsystem, and system intent pressure."
+    },
+    "applicable_intent": {
+      "$ref": "#/$defs/applicable_intent",
+      "description": "Compact applicable-intent source, authority, freshness, conflict, durable-outcome, and manual-verification evidence."
     },
     "workflow_obligations": {
       "type": "object",
@@ -450,6 +455,124 @@
       },
       "additionalProperties": true,
       "description": "Applicable-intent evidence, conflicts, missing authority, and manual-verification obligations."
+    },
+    "applicable_intent": {
+      "type": "object",
+      "required": [
+        "kind",
+        "status",
+        "source_count",
+        "sources",
+        "authority_vocabulary",
+        "conflict_status",
+        "manual_verification",
+        "durable_outcome_routing",
+        "blocked_claims",
+        "closeout_blocked",
+        "authority_boundary"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/applicable-intent-sources/v1",
+          "description": "Discriminator for the applicable-intent source projection."
+        },
+        "status": {
+          "type": "string",
+          "description": "Whether source evidence is present, guidance-only, or requires attention."
+        },
+        "source_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of applicable-intent source records surfaced in this projection."
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Structural or configured source records from Planning, Memory, assurance, Verification, standing intent, durable intent, or external work evidence."
+        },
+        "authority_vocabulary": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Stable vocabulary for authority classes, freshness/trust states, conflict states, and manual-verification states."
+        },
+        "conflict_status": {
+          "type": "string",
+          "description": "Compact status for whether the projection has no conflict, a possible conflict, a closeout-blocking conflict, or a clarification requirement."
+        },
+        "conflicts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Recorded conflict statements from existing owner surfaces."
+        },
+        "missing_authority": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Recorded missing authority or acceptance evidence."
+        },
+        "stale_or_superseded": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Sources whose freshness state indicates stale or superseded evidence."
+        },
+        "manual_verification": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Manual/domain/compliance verification obligations that must remain visible before broad closeout."
+        },
+        "durable_outcome_routing": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Owner-surface guidance for clarifications, accepted interpretations, waivers, and deferred outcomes."
+        },
+        "blocked_claims": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Completion claims that should not be made while applicable-intent conflicts or missing verification remain."
+        },
+        "closeout_blocked": {
+          "type": "boolean",
+          "description": "Whether applicable-intent evidence blocks broad/plain closeout claims."
+        },
+        "closeout_status": {
+          "$ref": "#/$defs/applicable_intent_status",
+          "description": "Closeout-oriented applicable-intent status summary."
+        },
+        "next_actions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Suggested next inspection or resolution actions."
+        },
+        "authority_boundary": {
+          "$ref": "#/$defs/authority_boundary",
+          "description": "Authority boundary showing that AW assembles structural/configured evidence while agent and human owners decide semantic applicability and acceptance."
+        },
+        "rule": {
+          "type": "string",
+          "description": "Usage rule for when this projection should be consulted."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Applicable-intent source projection across existing AW surfaces without semantic conflict resolution."
     },
     "authority_boundary": {
       "type": "object",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -532,6 +532,19 @@
           },
           "description": "Manual/domain/compliance verification obligations that must remain visible before broad closeout."
         },
+        "durable_outcomes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Recorded clarification, accepted-interpretation, waiver, or deferral outcomes with owner, evidence anchor, stale condition, reopen trigger, affected claims, and resolved items."
+        },
+        "resolved_outcome_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of durable applicable-intent outcome records surfaced by this projection."
+        },
         "durable_outcome_routing": {
           "type": "array",
           "items": {

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -361,6 +361,32 @@
       "checked_in_justification": "Canonical checked-in structured input used by package behavior, validation, packaging, or repo policy."
     },
     {
+      "pattern": ".agentic-workspace/planning/lanes/archive/*.lane.json",
+      "format": "json",
+      "owner": "planning",
+      "status": "schema-backed",
+      "schema_or_validator": ".agentic-workspace/planning/schemas/planning-lane.schema.json",
+      "editable_by_agents": false,
+      "generated": false,
+      "notes": "Archived lane records validate against the planning lane schema while remaining historical audit evidence.",
+      "storage_class": "historical-audit-distillation",
+      "checked_in_justification": "Historical proof or review residue retained as distilled audit evidence rather than ordinary startup input.",
+      "reconstructable_from": [
+        "git history",
+        "issue or PR references embedded in the archive record",
+        "commit history around the closeout"
+      ],
+      "guardrails": {
+        "max_bytes": 25000,
+        "preferred_refs": [
+          "issue ids",
+          "commit SHAs",
+          "validation command names"
+        ],
+        "routed_to": "#538"
+      }
+    },
+    {
       "pattern": ".agentic-workspace/planning/external-intent-evidence.json",
       "format": "json",
       "owner": "planning-evidence",

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -610,6 +610,9 @@ def report_router_payload(
             "omitted_section_hint_count": max(0, len(section_hints) - len(compact_section_hints)),
         },
     }
+    applicable_intent = _report_router_applicable_intent(payload.get("applicable_intent", {}))
+    if applicable_intent.get("attention_required"):
+        router_payload["applicable_intent"] = applicable_intent
     maintainer_mode = router_payload.get("maintainer_mode", {})
     if not (isinstance(maintainer_mode, dict) and maintainer_mode.get("status") == "enabled"):
         router_payload.pop("maintainer_mode", None)
@@ -705,11 +708,12 @@ def _compact_report_section_hints(hints: list[dict[str, Any]]) -> list[dict[str,
         "execution_shape": 1,
         "routine_work_context": 2,
         "improvement_intake": 3,
-        "operating_posture": 4,
-        "external_work_reconciliation": 5,
-        "module_reports": 6,
-        "successful_completion_cost": 7,
-        "findings": 8,
+        "applicable_intent": 4,
+        "operating_posture": 5,
+        "external_work_reconciliation": 6,
+        "module_reports": 7,
+        "successful_completion_cost": 8,
+        "findings": 9,
     }
     ordered = sorted(
         hints,
@@ -855,6 +859,41 @@ def _report_router_external_work_reconciliation(value: Any) -> dict[str, Any]:
         "recommended_next_action": value.get("recommended_next_action", ""),
         "section_command": "agentic-workspace report --target ./repo --section external_work_reconciliation --format json",
     }
+
+
+def _report_router_applicable_intent(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"status": "unavailable", "source_count": 0}
+    manual = value.get("manual_verification", [])
+    manual = manual if isinstance(manual, list) else []
+    conflicts = _support_list_payload(value.get("conflicts"))
+    missing_authority = _support_list_payload(value.get("missing_authority"))
+    authority_boundary = value.get("authority_boundary", {})
+    if isinstance(authority_boundary, dict):
+        authority_boundary = {
+            "surface": authority_boundary.get("surface", "applicable_intent"),
+            "authority_class": authority_boundary.get("authority_class", "advisory-support"),
+            "rule": authority_boundary.get("reporting_rule") or authority_boundary.get("rule", ""),
+        }
+    else:
+        authority_boundary = {}
+    compact = {
+        "status": value.get("status", "unavailable"),
+        "source_count": value.get("source_count", 0),
+        "conflict_status": value.get("conflict_status", "unknown"),
+    }
+    attention_required = bool(value.get("closeout_blocked", False) or conflicts or missing_authority or manual)
+    if attention_required:
+        compact["attention_required"] = True
+        compact["conflict_count"] = len(conflicts)
+        compact["missing_authority_count"] = len(missing_authority)
+        compact["manual_verification_count"] = len(manual)
+        compact["closeout_blocked"] = bool(value.get("closeout_blocked", False))
+        compact["kind"] = value.get("kind", "agentic-workspace/applicable-intent-sources/v1")
+        compact["detail_command"] = "agentic-workspace report --target ./repo --section applicable_intent --format json"
+        compact["blocked_claims"] = value.get("blocked_claims", [])
+        compact["authority_boundary"] = authority_boundary
+    return compact
 
 
 def _report_router_closeout_report(value: Any, *, cli_invoke: str = DEFAULT_CLI_INVOKE, target_arg: str = "./repo") -> dict[str, Any]:
@@ -1054,6 +1093,7 @@ def report_section_hints(
         "effective_authority": "authority, current work, system-intent pressure, idle context, and unresolved gaps",
         "execution_shape": "default execution posture and planning-backed work guidance",
         "durable_intent": "task, subsystem, and system intent pressure relevant to decisions before implementation or closeout",
+        "applicable_intent": "compact applicable-intent source, authority, conflict, durable-outcome, and manual-verification evidence",
         "maintenance_pressure": "one compact router for audit, retention, footprint, external-evidence, and closeout residue",
         "reuse_pressure": "changed-path reuse and abstraction-pressure facts before adding local code",
         "operational_compression": "falsifiable advisory measures for whether surfaces reduce total operational cost",
@@ -1094,6 +1134,7 @@ def report_section_hints(
         "effective_authority": ("inspect now if authority, idle state, or unresolved intent pressure affects whether work can proceed"),
         "execution_shape": "inspect now to choose direct work, light planning, or checked-in execplan promotion",
         "durable_intent": "inspect now when task intent may generalize into durable system or subsystem direction",
+        "applicable_intent": "inspect before broad, subsystem-affecting, compliance-relevant, or soft-intent closeout decisions",
         "maintenance_pressure": "inspect now only when residue, retention, or closeout pressure affects the active lane",
         "reuse_pressure": "inspect before implementation when deciding whether to reuse, accept duplication, or route extraction follow-up",
         "operational_compression": "inspect now when assessing whether package surfaces are reducing total work",
@@ -1141,6 +1182,10 @@ def report_section_hints(
     hints: list[dict[str, Any]] = []
     for section, purpose in section_purposes.items():
         if section in payload:
+            if section == "applicable_intent":
+                applicable_compact = _report_router_applicable_intent(payload.get("applicable_intent", {}))
+                if not applicable_compact.get("attention_required"):
+                    continue
             advanced_feature = advanced_sections.get(section)
             relevant_advanced_section = section == "maintenance_pressure" and maintenance_pressure_status == "attention"
             if advanced_feature and advanced_feature not in enabled_advanced_features and not relevant_advanced_section:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -987,6 +987,70 @@ def _compact_verification(value: Any) -> dict[str, Any]:
     }
 
 
+def _applicable_intent_durable_outcomes_payload(applicable: dict[str, Any]) -> list[dict[str, Any]]:
+    outcomes: list[dict[str, Any]] = []
+    raw_outcomes = _list_payload(
+        applicable.get("durable_outcomes") or applicable.get("resolved_outcomes") or applicable.get("durable_outcome_evidence")
+    )
+    for index, raw in enumerate(raw_outcomes, start=1):
+        if not isinstance(raw, dict):
+            continue
+        outcome = str(raw.get("outcome") or raw.get("type") or raw.get("status") or "accepted-interpretation").strip()
+        summary = str(raw.get("summary") or raw.get("decision") or raw.get("reason") or "").strip()
+        owner = str(raw.get("owner") or raw.get("accepted_by") or raw.get("waived_by") or raw.get("review_owner") or "").strip()
+        owner_surface = str(raw.get("owner_surface") or raw.get("surface") or raw.get("source") or "").strip()
+        evidence_anchor = str(raw.get("evidence_anchor") or raw.get("evidence") or raw.get("locator") or "").strip()
+        status = str(raw.get("record_status") or raw.get("state") or "recorded").strip()
+        resolves = _dedupe(
+            [
+                str(item).strip()
+                for item in (
+                    _list_payload(raw.get("resolves"))
+                    + _list_payload(raw.get("resolves_conflicts"))
+                    + _list_payload(raw.get("resolves_missing_authority"))
+                    + _list_payload(raw.get("resolves_manual_verification"))
+                )
+                if str(item).strip()
+            ]
+        )
+        outcomes.append(
+            {
+                "id": str(raw.get("id") or f"durable-outcome-{index}"),
+                "outcome": outcome,
+                "status": status,
+                "summary": summary,
+                "owner": owner or "human/domain owner",
+                "owner_surface": owner_surface or "Planning, Verification, assurance, docs/config, or issue evidence",
+                "evidence_anchor": evidence_anchor or "durable outcome record",
+                "stale_when": str(raw.get("stale_when") or raw.get("stale") or "owner surface changes or later evidence supersedes it"),
+                "reopen_trigger": str(raw.get("reopen_trigger") or raw.get("reopen_when") or "affected intent, owner, or evidence changes"),
+                "affected_claims": _dedupe([str(item).strip() for item in _list_payload(raw.get("affected_claims")) if str(item).strip()]),
+                "resolves": resolves,
+                "closeout_effect": str(
+                    raw.get("closeout_effect")
+                    or (
+                        "deferred-with-owner"
+                        if outcome == "deferred-with-owner"
+                        else "satisfies recorded applicable-intent obligation for resolved items"
+                    )
+                ),
+            }
+        )
+    return outcomes
+
+
+def _applicable_intent_resolved_items(durable_outcomes: list[dict[str, Any]]) -> set[str]:
+    resolved: set[str] = set()
+    unresolved_states = {"", "pending", "missing", "rejected", "stale", "superseded"}
+    for outcome in durable_outcomes:
+        if not isinstance(outcome, dict):
+            continue
+        if str(outcome.get("status") or "").strip() in unresolved_states:
+            continue
+        resolved.update(str(item).strip() for item in _list_payload(outcome.get("resolves")) if str(item).strip())
+    return resolved
+
+
 def _applicable_intent_source_projection_payload(
     *,
     target_root: Path,
@@ -1178,6 +1242,7 @@ def _applicable_intent_source_projection_payload(
         verification=verification,
         assurance_requirements=assurance_requirements,
     )
+    durable_outcomes = [item for item in _list_payload(planning_applicable.get("durable_outcomes")) if isinstance(item, dict)]
     conflicts = [str(item) for item in _list_payload(planning_applicable.get("conflicts")) if str(item).strip()]
     missing_authority = [str(item) for item in _list_payload(planning_applicable.get("missing_authority")) if str(item).strip()]
     manual_required = [str(item) for item in _list_payload(planning_applicable.get("manual_verification_needed")) if str(item).strip()]
@@ -1276,6 +1341,8 @@ def _applicable_intent_source_projection_payload(
         "missing_authority": missing_authority,
         "stale_or_superseded": stale_or_superseded,
         "manual_verification": manual_verification,
+        "durable_outcomes": durable_outcomes,
+        "resolved_outcome_count": len(durable_outcomes),
         "durable_outcome_routing": durable_outcome_routing,
         "blocked_claims": blocked_claims,
         "closeout_blocked": conflict_status != "none",
@@ -8384,6 +8451,7 @@ def _closeout_report_completeness_payload(
         evidence_text(
             applicable_intents.get("conflicts"),
             applicable_intents.get("manual_verification_needed"),
+            applicable_intents.get("durable_outcomes"),
             applicable_intents.get("sources"),
             "no applicable-intent conflicts recorded",
         ),
@@ -9333,6 +9401,22 @@ def _closeout_report_final_response_rendering_payload(
             fragments.append("missing authority: " + "; ".join(missing[:2]))
         summary_lines.append("Applicable intent: " + ("; ".join(fragments) if fragments else "unresolved applicable-intent obligation"))
         must_not_claim.extend(str(item) for item in _list_payload(applicable_intent_status.get("must_not_claim")) if str(item).strip())
+
+    durable_outcomes = [item for item in _list_payload(applicable_intent_status.get("durable_outcomes")) if isinstance(item, dict)]
+    if durable_outcomes:
+        must_include.append("applicable intent outcome")
+        outcome = durable_outcomes[0]
+        fragments = [
+            str(outcome.get("outcome") or "recorded-outcome"),
+            f"owner: {outcome.get('owner')}",
+            f"evidence: {outcome.get('evidence_anchor')}",
+        ]
+        stale_when = str(outcome.get("stale_when") or "").strip()
+        if stale_when:
+            fragments.append(f"stale when: {stale_when}")
+        summary_lines.append(
+            "Applicable intent outcome: " + "; ".join(fragment for fragment in fragments if fragment and fragment != "owner: None")
+        )
 
     boundary_text = present(completion_decision)
     completion_boundary_text = present(
@@ -20111,6 +20195,7 @@ def _applicable_intent_status_payload(
     system_intents = [str(item).strip() for item in _list_payload(applicable.get("system_intents")) if str(item).strip()]
     subsystem_intents = [str(item).strip() for item in _list_payload(applicable.get("subsystem_intents")) if str(item).strip()]
     user_intents = [str(item).strip() for item in _list_payload(applicable.get("user_intents")) if str(item).strip()]
+    durable_outcomes = _applicable_intent_durable_outcomes_payload(applicable)
 
     for status in _list_payload(assurance_requirements.get("evidence_status")):
         if not isinstance(status, dict):
@@ -20130,14 +20215,16 @@ def _applicable_intent_status_payload(
         elif reason:
             manual_verification.append(f"{gap_id}: {reason}")
 
+    resolved_items = _applicable_intent_resolved_items(durable_outcomes)
+    conflicts = [item for item in conflicts if item not in resolved_items]
+    missing_authority = [item for item in missing_authority if item not in resolved_items]
+    manual_verification = [item for item in manual_verification if item not in resolved_items]
     manual_verification = _dedupe(manual_verification)
     evidence_count = len(sources) + len(user_intents) + len(system_intents) + len(subsystem_intents) + len(soft_intents)
     blocking = bool(conflicts or missing_authority or manual_verification)
     status = "attention" if blocking else "present" if evidence_count else "guidance-only"
-    blocked_claims = _dedupe(
-        [str(item).strip() for item in _list_payload(applicable.get("blocked_claims")) if str(item).strip()]
-        or (["claim-work-complete", "close-parent-lane"] if blocking else [])
-    )
+    raw_blocked_claims = [str(item).strip() for item in _list_payload(applicable.get("blocked_claims")) if str(item).strip()]
+    blocked_claims = _dedupe((raw_blocked_claims if blocking else []) or (["claim-work-complete", "close-parent-lane"] if blocking else []))
     return {
         "kind": "agentic-workspace/applicable-intent-status/v1",
         "status": status,
@@ -20149,6 +20236,8 @@ def _applicable_intent_status_payload(
         "conflicts": conflicts,
         "missing_authority": missing_authority,
         "manual_verification_needed": manual_verification,
+        "durable_outcomes": durable_outcomes,
+        "resolved_outcome_count": len(durable_outcomes),
         "blocked_claims": blocked_claims,
         "closeout_blocked": blocking,
         "authority_boundary": _authority_boundary_payload(

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -987,6 +987,327 @@ def _compact_verification(value: Any) -> dict[str, Any]:
     }
 
 
+def _applicable_intent_source_projection_payload(
+    *,
+    target_root: Path,
+    active_planning_record: dict[str, Any] | None = None,
+    assurance_requirements: dict[str, Any] | None = None,
+    verification: dict[str, Any] | None = None,
+    standing_intent: dict[str, Any] | None = None,
+    durable_intent: dict[str, Any] | None = None,
+    external_work_reconciliation: dict[str, Any] | None = None,
+    memory_consult: dict[str, Any] | None = None,
+    cli_invoke: str = DEFAULT_CLI_INVOKE,
+) -> dict[str, Any]:
+    active_planning_record = _as_dict(active_planning_record)
+    assurance_requirements = _as_dict(assurance_requirements)
+    verification = _as_dict(verification)
+    standing_intent = _as_dict(standing_intent)
+    durable_intent = _as_dict(durable_intent)
+    external_work_reconciliation = _as_dict(external_work_reconciliation)
+    memory_consult = _as_dict(memory_consult)
+    sources: list[dict[str, Any]] = []
+
+    def add_source(
+        *,
+        source_id: str,
+        source_type: str,
+        owner_surface: str,
+        authority_class: str,
+        evidence_anchor: str,
+        match_evidence: list[str] | None = None,
+        freshness: str = "current",
+        trust: str = "unverified",
+        next_read: str = "",
+        owner: str = "agent",
+        status: str = "present",
+    ) -> None:
+        if not source_id or any(item.get("id") == source_id for item in sources):
+            return
+        sources.append(
+            {
+                "id": source_id,
+                "source_type": source_type,
+                "owner_surface": owner_surface,
+                "authority_class": authority_class,
+                "freshness": freshness,
+                "trust": trust,
+                "status": status,
+                "structural_match_evidence": _dedupe([str(item) for item in (match_evidence or []) if str(item).strip()]),
+                "evidence_anchor": evidence_anchor,
+                "next_read": next_read,
+                "resolution_owner": owner,
+            }
+        )
+
+    requested_outcome = str(
+        active_planning_record.get("requested_outcome")
+        or _as_dict(active_planning_record.get("canonical_core")).get("requested_outcome")
+        or _as_dict(active_planning_record.get("delegated_judgment")).get("requested outcome")
+        or _as_dict(active_planning_record.get("delegated_judgment")).get("requested_outcome")
+        or ""
+    ).strip()
+    active_plan_path = str(active_planning_record.get("source_path") or active_planning_record.get("path") or "").strip()
+    if requested_outcome or active_planning_record:
+        add_source(
+            source_id="planning.active",
+            source_type="Planning",
+            owner_surface=active_plan_path or ".agentic-workspace/planning/state.toml",
+            authority_class="authoritative",
+            freshness="current",
+            trust="current",
+            evidence_anchor=requested_outcome or "active Planning record",
+            match_evidence=["active Planning record selected for current work"],
+            next_read="agentic-workspace summary --target ./repo --format json",
+            owner="agent",
+        )
+    for ref in _list_payload(active_planning_record.get("references")):
+        if not isinstance(ref, dict):
+            continue
+        target = str(ref.get("target") or ref.get("label") or "").strip()
+        if not target:
+            continue
+        add_source(
+            source_id=f"planning.reference.{_decision_slug(target)}",
+            source_type="issue" if "github" in target.lower() or "#" in target else "Planning",
+            owner_surface=active_plan_path or ".agentic-workspace/planning/execplans",
+            authority_class="authoritative",
+            freshness="current",
+            trust="current",
+            evidence_anchor=target,
+            match_evidence=[str(ref.get("role") or "active Planning reference")],
+            next_read=str(ref.get("locator") or "agentic-workspace summary --target ./repo --format json"),
+            owner="agent",
+        )
+
+    memory_index = target_root / ".agentic-workspace" / "memory" / "repo" / "index.md"
+    memory_manifest = target_root / ".agentic-workspace" / "memory" / "repo" / "manifest.toml"
+    if memory_index.exists():
+        add_source(
+            source_id="memory.repo.index",
+            source_type="Memory",
+            owner_surface=".agentic-workspace/memory/repo/index.md",
+            authority_class="learned",
+            freshness="current" if memory_manifest.exists() else "unverified",
+            trust="advisory",
+            evidence_anchor="repo Memory index is present",
+            match_evidence=_list_payload(memory_consult.get("read_first")) or ["Memory index route is available"],
+            next_read=".agentic-workspace/memory/repo/index.md",
+            owner="agent",
+        )
+
+    if standing_intent:
+        add_source(
+            source_id="standing_intent.effective",
+            source_type="docs/contracts",
+            owner_surface=".agentic-workspace/docs/standing-intent-contract.md",
+            authority_class="advisory",
+            freshness="current",
+            trust="advisory",
+            evidence_anchor=str(
+                _as_dict(standing_intent.get("effective_view")).get("rule") or standing_intent.get("status") or "standing intent available"
+            ),
+            match_evidence=["standing intent report is available"],
+            next_read="agentic-workspace report --target ./repo --section standing_intent --format json",
+            owner="agent",
+        )
+    if durable_intent and durable_intent.get("status") not in {None, "", "absent"}:
+        add_source(
+            source_id="durable_intent.projection",
+            source_type="docs/contracts",
+            owner_surface=".agentic-workspace/system-intent/",
+            authority_class="authoritative",
+            freshness="current",
+            trust="current",
+            evidence_anchor=str(durable_intent.get("status")),
+            match_evidence=["durable intent projection is present"],
+            next_read="agentic-workspace report --target ./repo --section durable_intent --format json",
+            owner="agent",
+        )
+
+    for requirement in _list_payload(assurance_requirements.get("active")):
+        if not isinstance(requirement, dict):
+            continue
+        requirement_id = str(requirement.get("id") or "assurance-requirement").strip()
+        add_source(
+            source_id=f"assurance.{requirement_id}",
+            source_type="assurance",
+            owner_surface=".agentic-workspace/config.toml [assurance.requirements]",
+            authority_class="configured",
+            freshness="current",
+            trust="configured",
+            evidence_anchor=requirement_id,
+            match_evidence=_list_payload(requirement.get("applies_because")),
+            next_read="agentic-workspace report --target ./repo --section assurance_requirements --format json",
+            owner=str(requirement.get("review_owner") or "human/domain owner"),
+        )
+    for protocol in _list_payload(verification.get("active_protocols")):
+        if not isinstance(protocol, dict):
+            continue
+        protocol_id = str(protocol.get("id") or "verification-protocol").strip()
+        add_source(
+            source_id=f"verification.{protocol_id}",
+            source_type="Verification",
+            owner_surface=".agentic-workspace/verification/manifest.toml",
+            authority_class="verification-owned",
+            freshness="current",
+            trust="configured",
+            evidence_anchor=protocol_id,
+            match_evidence=_list_payload(protocol.get("applies_because")),
+            next_read="agentic-workspace report --target ./repo --section verification --format json",
+            owner=str(protocol.get("review_owner") or "agent"),
+        )
+
+    external_state = _as_dict(external_work_reconciliation.get("external_work_state"))
+    if external_work_reconciliation and external_work_reconciliation.get("status") not in {None, "", "absent", "unavailable"}:
+        add_source(
+            source_id="external_work.reconciliation",
+            source_type="issue",
+            owner_surface=".agentic-workspace/local/cache/external-intent-evidence.json",
+            authority_class="configured",
+            freshness=str(external_state.get("freshness") or "current"),
+            trust=str(external_work_reconciliation.get("trust") or "unverified"),
+            evidence_anchor=str(external_work_reconciliation.get("status")),
+            match_evidence=["external work cache/reconciliation is available"],
+            next_read="agentic-workspace report --target ./repo --section external_work_reconciliation --format json",
+            owner="agent",
+        )
+
+    planning_applicable = _applicable_intent_status_payload(
+        active_planning_record=active_planning_record,
+        verification=verification,
+        assurance_requirements=assurance_requirements,
+    )
+    conflicts = [str(item) for item in _list_payload(planning_applicable.get("conflicts")) if str(item).strip()]
+    missing_authority = [str(item) for item in _list_payload(planning_applicable.get("missing_authority")) if str(item).strip()]
+    manual_required = [str(item) for item in _list_payload(planning_applicable.get("manual_verification_needed")) if str(item).strip()]
+    stale_or_superseded: list[dict[str, str]] = []
+    for source in sources:
+        if source.get("freshness") in {"stale", "superseded"}:
+            stale_or_superseded.append(
+                {
+                    "source_id": str(source.get("id")),
+                    "freshness": str(source.get("freshness")),
+                    "owner_surface": str(source.get("owner_surface")),
+                }
+            )
+
+    conflict_status = (
+        "conflict-blocking-closeout"
+        if conflicts
+        else "clarification-required"
+        if missing_authority or manual_required
+        else "possible-conflict"
+        if stale_or_superseded
+        else "none"
+    )
+    manual_verification = [
+        {
+            "id": f"manual-{index}",
+            "status": "required",
+            "summary": item,
+            "owner": "human/domain owner",
+            "evidence_anchor": "assurance, Verification, or Planning applicable_intents",
+            "closeout_effect": "blocks or caveats broad/full closeout until verified, accepted, waived, or deferred",
+        }
+        for index, item in enumerate(manual_required, start=1)
+    ]
+    durable_outcome_routing = [
+        {
+            "outcome": "clarified-intent",
+            "owner_surface": "Planning parent acceptance, decision fact, docs/config, or issue comment",
+            "retain": "summary plus evidence anchor; no raw transcript",
+            "stale_when": "the clarified owner surface changes or a later human instruction supersedes it",
+        },
+        {
+            "outcome": "accepted-interpretation",
+            "owner_surface": "Planning closeout evidence or decision record",
+            "retain": "accepted interpretation, owner, evidence, and scope",
+            "stale_when": "acceptance owner, subsystem contract, or proof boundary changes",
+        },
+        {
+            "outcome": "waiver",
+            "owner_surface": "assurance waiver, Verification known gap, closeout evidence, or issue comment",
+            "retain": "waiver reason, owner, affected claims, and reopen trigger",
+            "stale_when": "waived requirement changes or evidence becomes available",
+        },
+        {
+            "outcome": "deferred-with-owner",
+            "owner_surface": "Planning residual work, issue follow-up, or Verification known gap",
+            "retain": "owner, trigger, blocked claims, and next inspection route",
+            "stale_when": "owner accepts, rejects, or supersedes the deferred outcome",
+        },
+    ]
+    blocked_claims = _dedupe(
+        [str(item) for item in _list_payload(planning_applicable.get("blocked_claims")) if str(item).strip()]
+        or (["claim-work-complete", "close-parent-lane"] if conflict_status != "none" else [])
+    )
+    return {
+        "kind": "agentic-workspace/applicable-intent-sources/v1",
+        "status": "attention" if conflict_status != "none" else "present" if sources else "guidance-only",
+        "source_count": len(sources),
+        "sources": sources,
+        "authority_vocabulary": {
+            "authority_classes": [
+                "authoritative",
+                "configured",
+                "learned",
+                "advisory",
+                "human-owned",
+                "compliance-owned",
+                "verification-owned",
+                "unknown",
+            ],
+            "freshness_trust_states": ["current", "stale", "superseded", "unverified", "conflicting", "absent-required"],
+            "conflict_states": ["none", "possible-conflict", "conflict-blocking-closeout", "clarification-required"],
+            "manual_verification_states": [
+                "not-applicable",
+                "required",
+                "verified",
+                "accepted-by-owner",
+                "waived-with-reason",
+                "deferred-with-owner",
+                "blocked-pending-clarification",
+                "stale-or-needs-reverification",
+            ],
+        },
+        "conflict_status": conflict_status,
+        "conflicts": conflicts,
+        "missing_authority": missing_authority,
+        "stale_or_superseded": stale_or_superseded,
+        "manual_verification": manual_verification,
+        "durable_outcome_routing": durable_outcome_routing,
+        "blocked_claims": blocked_claims,
+        "closeout_blocked": conflict_status != "none",
+        "closeout_status": planning_applicable,
+        "next_actions": [
+            "Resolve conflicts through the smallest durable owner before broad closeout."
+            if conflict_status != "none"
+            else "Use sources as read-first evidence when agent judgment finds them relevant.",
+            _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section closeout_report --format json",
+                cli_invoke=cli_invoke,
+            ),
+        ],
+        "authority_boundary": _authority_boundary_payload(
+            surface="applicable_intent",
+            observed_by_aw=[
+                "active Planning records",
+                "Memory index/manifest presence",
+                "standing and durable intent projections",
+                "assurance requirement matches",
+                "Verification protocol/gap matches",
+                "external work reconciliation availability",
+            ],
+            recommended_by_aw=["read structurally matched sources and route durable clarification or waiver outcomes"],
+            agent_owned_decisions=["semantic applicability of each source", "which source governs when meanings conflict"],
+            human_owned_decisions=["domain/compliance acceptance, waiver, or clarification"],
+            rule="AW assembles structural/configured evidence; it does not infer or resolve semantic intent.",
+        ),
+        "rule": "Use this projection for broad, architectural, compliance-relevant, or subsystem-affecting work; do not force it onto small direct work.",
+    }
+
+
 def _assurance_requirements_with_verification(assurance_requirements: dict[str, Any], verification: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(assurance_requirements, dict) or not isinstance(verification, dict):
         return assurance_requirements
@@ -6270,6 +6591,18 @@ def _run_report_command(
         assurance_requirements=assurance_requirements,
     )
     assurance_requirements = _assurance_requirements_with_verification(assurance_requirements, verification)
+    memory_consult = _memory_consult_payload(target_root=target_root, cli_invoke=config.cli_invoke)
+    applicable_intent = _applicable_intent_source_projection_payload(
+        target_root=target_root,
+        active_planning_record=raw_active_planning_record or active_planning_record,
+        assurance_requirements=assurance_requirements,
+        verification=verification,
+        standing_intent=standing_intent,
+        durable_intent=durable_intent,
+        external_work_reconciliation=external_work_reconciliation,
+        memory_consult=memory_consult,
+        cli_invoke=config.cli_invoke,
+    )
     payload = {
         "kind": "workspace-report/v1",
         "schema": _reporting_schema_payload(),
@@ -6296,7 +6629,7 @@ def _run_report_command(
         "config_effect_audit": _config_effect_audit_payload(config=config),
         "branch_workflow_posture": branch_workflow_posture,
         "local_memory": local_memory,
-        "memory_consult": _memory_consult_payload(target_root=target_root, cli_invoke=config.cli_invoke),
+        "memory_consult": memory_consult,
         "reuse_pressure": _reuse_pressure_payload(target_root=target_root, cli_invoke=config.cli_invoke),
         "agent_aids": _agent_aids_report_payload(target_root=target_root, cli_invoke=config.cli_invoke),
         "execution_shape": execution_shape,
@@ -6307,6 +6640,7 @@ def _run_report_command(
         ),
         "system_intent_mirror": _system_intent_report_payload(target_root=target_root, config=config),
         "workflow_obligations": _workflow_obligations_report_payload(config=config, active_planning_record=active_planning_record),
+        "applicable_intent": applicable_intent,
         "assurance_requirements": assurance_requirements,
         "verification": verification,
         "product_managed_enclave": _product_managed_enclave_payload(target_root=target_root, ownership_payload=ownership_payload),
@@ -7247,6 +7581,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "when evidence production or review provenance matters more than ordinary proof selection",
     },
     {
+        "section": "applicable_intent",
+        "kind": "agentic-workspace/applicable-intent-sources/v1",
+        "purpose": "compact applicable intent source, authority, conflict, durable-outcome, and manual-verification evidence",
+        "when_to_use": "before broad, subsystem-affecting, architectural, compliance-relevant, or soft-intent closeout decisions",
+    },
+    {
         "section": "successful_completion_cost",
         "kind": "agentic-workspace/successful-completion-cost/v1",
         "purpose": "recent model CLI evaluation cost, package-read overhead, and first-pass versus rework evidence",
@@ -7928,6 +8268,8 @@ def _closeout_report_completeness_payload(
     closeout_trust: dict[str, Any],
     completion_contract: dict[str, Any],
     traceability_rows: list[dict[str, Any]],
+    verification: dict[str, Any] | None = None,
+    assurance_requirements: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     execution = _as_dict(active_planning_record.get("execution_run"))
     closure_check = _as_dict(active_planning_record.get("closure_check"))
@@ -7941,7 +8283,11 @@ def _closeout_report_completeness_payload(
         intent_check=intent_check,
         completion_boundary=completion_boundary,
     )
-    applicable_intents = _applicable_intent_status_payload(active_planning_record=active_planning_record)
+    applicable_intents = _applicable_intent_status_payload(
+        active_planning_record=active_planning_record,
+        verification=verification,
+        assurance_requirements=assurance_requirements,
+    )
     options = {str(item.get("id", "")): item for item in _list_payload(closeout_trust.get("completion_options")) if isinstance(item, dict)}
     keep_parent_open = _as_dict(options.get("keep-parent-open"))
     route_residue = _as_dict(options.get("route-residue"))
@@ -9127,6 +9473,8 @@ def _closeout_report_payload(
         closeout_trust=closeout_trust,
         completion_contract=completion_contract,
         traceability_rows=traceability_rows,
+        verification=verification,
+        assurance_requirements=_as_dict(closeout_trust.get("assurance_requirements")),
     )
     profile_policy = _closeout_report_profile_policy_payload(
         closeout_trust=closeout_trust,
@@ -9480,7 +9828,7 @@ def _run_lazy_report_section_command(
 
     active_planning_record = _active_planning_record_for_report_section(target_root=target_root)
 
-    if normalized in {"assurance_requirements", "verification"}:
+    if normalized in {"assurance_requirements", "verification", "applicable_intent"}:
         assurance_requirements = _assurance_requirements_report_payload(
             config=config,
             active_planning_record=active_planning_record,
@@ -9492,6 +9840,38 @@ def _run_lazy_report_section_command(
         )
         payload["verification"] = verification
         payload["assurance_requirements"] = _assurance_requirements_with_verification(assurance_requirements, verification)
+        if normalized == "applicable_intent":
+            payload["memory_consult"] = _memory_consult_payload(target_root=target_root, cli_invoke=config.cli_invoke)
+            payload["standing_intent"] = standing_intent_payload(
+                target_root=target_root,
+                config_policy={
+                    "improvement_latitude": config.improvement_latitude,
+                    "improvement_latitude_source": config.improvement_latitude_source,
+                    "optimization_bias": config.optimization_bias,
+                    "optimization_bias_source": config.optimization_bias_source,
+                    "workflow_artifact_profile": config.workflow_artifact_profile,
+                    "workflow_artifact_profile_source": config.workflow_artifact_profile_source,
+                },
+                active_planning=active_planning_record,
+                memory_installed="memory" in payload.get("installed_modules", []),
+            )
+            payload["durable_intent"] = _intent_decision_projection(target_root=target_root, config=config, compact=True)
+            payload["external_work_reconciliation"] = _external_work_reconciliation_payload(
+                module_reports=[],
+                external_work_delta=_external_work_delta_payload(target_root=target_root),
+                cli_invoke=config.cli_invoke,
+            )
+            payload["applicable_intent"] = _applicable_intent_source_projection_payload(
+                target_root=target_root,
+                active_planning_record=active_planning_record,
+                assurance_requirements=payload["assurance_requirements"],
+                verification=verification,
+                standing_intent=payload["standing_intent"],
+                durable_intent=payload["durable_intent"],
+                external_work_reconciliation=payload["external_work_reconciliation"],
+                memory_consult=payload["memory_consult"],
+                cli_invoke=config.cli_invoke,
+            )
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "successful_completion_cost":
@@ -9871,6 +10251,28 @@ def _run_report_router_command(
         external_evidence_safety=external_evidence_safety,
         cli_invoke=config.cli_invoke,
     )
+    assurance_requirements = _assurance_requirements_report_payload(
+        config=config,
+        active_planning_record=active_planning_record,
+    )
+    verification = _verification_report_payload(
+        target_root=target_root,
+        active_planning_record=active_planning_record,
+        assurance_requirements=assurance_requirements,
+    )
+    assurance_requirements = _assurance_requirements_with_verification(assurance_requirements, verification)
+    memory_consult = _tiny_memory_consult_payload(config=config)
+    durable_intent = _intent_decision_projection(target_root=target_root, config=config, compact=True)
+    applicable_intent = _applicable_intent_source_projection_payload(
+        target_root=target_root,
+        active_planning_record=active_planning_record,
+        assurance_requirements=assurance_requirements,
+        verification=verification,
+        durable_intent=durable_intent,
+        external_work_reconciliation=external_work_reconciliation,
+        memory_consult=memory_consult,
+        cli_invoke=config.cli_invoke,
+    )
     closeout_report_route = _closeout_report_route_payload(
         completion_contract=completion_contract,
         config=config,
@@ -9908,10 +10310,11 @@ def _run_report_router_command(
         "report_profile": _report_profile_payload(cli_invoke=config.cli_invoke),
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
-        "memory_consult": _tiny_memory_consult_payload(config=config),
+        "memory_consult": memory_consult,
         "reuse_pressure": _reuse_pressure_payload(target_root=target_root, cli_invoke=config.cli_invoke, compact=True),
         "execution_shape": _report_router_execution_shape_fast(config=config),
-        "durable_intent": _intent_decision_projection(target_root=target_root, config=config, compact=True),
+        "durable_intent": durable_intent,
+        "applicable_intent": applicable_intent,
         "effective_authority": _effective_authority_payload(
             target_root=target_root, config=config, installed_modules=installed_modules, module_reports=[]
         ),

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -3974,6 +3974,189 @@ def test_report_closeout_report_represents_generated_code_parent_intent_boundary
     assert checks["applicable-intent-status"]["status"] == "incomplete"
 
 
+def _write_applicable_intent_fixture(target: Path) -> None:
+    _write(
+        target / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[workspace]
+default_preset = "full"
+
+[assurance.requirements.privacy_soft_intent]
+level = "high"
+applies_to_planning_refs = ["privacy-soft-intent"]
+authority_refs = ["docs/privacy-contract.md"]
+required_evidence = ["privacy_owner_acceptance"]
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+review_owner = "privacy-owner"
+""",
+    )
+    _write(
+        target / ".agentic-workspace" / "verification" / "manifest.toml",
+        """
+schema_version = "agentic-workspace/verification-manifest/v1"
+
+[scenarios.privacy_owner_review]
+protocol_id = "privacy_soft_review"
+title = "Privacy owner review"
+steps = ["Review the privacy contract against the changed behavior"]
+expected_observations = ["Privacy owner acceptance is recorded"]
+pass_evidence_labels = ["privacy_owner_acceptance"]
+fail_evidence_labels = ["privacy_owner_gap"]
+manual_boundary = "Human/domain owner acceptance is required."
+
+[protocols.privacy_soft_review]
+title = "Privacy soft-intent verification"
+purpose = "Represent the manual privacy review obligation."
+planning_refs = ["privacy-soft-intent"]
+scenario_refs = ["privacy_owner_review"]
+expected_evidence = ["privacy_owner_acceptance"]
+review_owner = "privacy-owner"
+authority_refs = ["docs/privacy-contract.md"]
+retention = "retain-summary"
+
+[known_gaps.privacy_owner_not_recorded]
+protocol_id = "privacy_soft_review"
+scenario_id = "privacy_owner_review"
+reason = "Privacy owner acceptance has not been recorded."
+owner = "privacy-owner"
+status = "open"
+evidence_labels = ["privacy_owner_acceptance"]
+blocked_claims = ["claim-work-complete", "close-parent-lane"]
+residual_risk = "Manual privacy acceptance remains unresolved."
+reopen_trigger = "privacy-sensitive behavior changes"
+""",
+    )
+    _write_json(
+        target / ".agentic-workspace" / "planning" / "execplans" / "privacy-soft-intent.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Privacy soft intent fixture",
+            "active_milestone": {"id": "privacy-soft-intent", "status": "complete", "scope": "Privacy-sensitive change."},
+            "delegated_judgment": {
+                "requested outcome": "Change privacy-sensitive behavior while preserving required privacy-owner acceptance.",
+                "hard constraints": "Do not claim broad completion before manual privacy verification is accepted or waived.",
+            },
+            "assurance_requirement_refs": ["privacy-soft-intent"],
+            "verification_protocol_refs": ["privacy_soft_review"],
+            "applicable_intents": {
+                "user_intents": ["ship the privacy-sensitive change"],
+                "system_intents": ["manual privacy acceptance must stay visible when required"],
+                "subsystem_intents": ["privacy contract governs this subsystem"],
+                "soft_intents": ["privacy-owner acceptance is required"],
+                "sources": [
+                    {"source": "GitHub #1326", "intent": "preserve applicable soft/system/subsystem intents"},
+                    {"source": "docs/privacy-contract.md", "intent": "privacy owner acceptance required"},
+                ],
+                "conflicts": ["ordinary tests passed but privacy-owner acceptance is missing"],
+                "missing_authority": ["privacy-owner acceptance"],
+                "manual_verification_needed": ["privacy_soft_intent: privacy_owner_acceptance"],
+                "blocked_claims": ["claim-work-complete", "close-parent-lane"],
+            },
+            "execution_run": {
+                "run status": "complete",
+                "what happened": "Changed privacy-sensitive behavior.",
+                "scope touched": "privacy subsystem",
+                "changed surfaces": "src/privacy.py",
+                "validations run": "ordinary tests passed",
+                "result for continuation": "manual privacy acceptance remains unresolved",
+            },
+            "proof_report": {
+                "validation proof": "ordinary tests passed",
+                "proof achieved now": "yes for ordinary tests; no for privacy-owner acceptance",
+            },
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": "open",
+                "closure decision": "archive-but-keep-lane-open",
+                "why this decision is honest": "Manual privacy acceptance remains unresolved.",
+                "evidence carried forward": "ordinary tests plus missing privacy-owner acceptance",
+                "reopen trigger": "plain completion is claimed without privacy-owner acceptance",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'privacy-soft-intent', title = 'Privacy soft intent fixture', surface = '.agentic-workspace/planning/execplans/privacy-soft-intent.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+
+def test_report_applicable_intent_section_projects_sources_authority_and_durable_outcomes(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--preset", "full"]) == 0
+    capsys.readouterr()
+    _write_applicable_intent_fixture(target)
+
+    assert cli.main(["report", "--target", str(target), "--section", "applicable_intent", "--format", "json"]) == 0
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    assert answer["kind"] == "agentic-workspace/applicable-intent-sources/v1"
+    assert answer["status"] == "attention"
+    assert answer["conflict_status"] == "conflict-blocking-closeout"
+    source_types = {source["source_type"] for source in answer["sources"]}
+    assert {"Planning", "Memory", "assurance", "Verification"} <= source_types
+    assert "configured" in answer["authority_vocabulary"]["authority_classes"]
+    assert "stale" in answer["authority_vocabulary"]["freshness_trust_states"]
+    assert "waived-with-reason" in answer["authority_vocabulary"]["manual_verification_states"]
+    assert answer["manual_verification"][0]["status"] == "required"
+    assert answer["durable_outcome_routing"][0]["outcome"] == "clarified-intent"
+    assert "claim-work-complete" in answer["blocked_claims"]
+    assert answer["authority_boundary"]["surface"] == "applicable_intent"
+    assert "semantic applicability of each source" in answer["authority_boundary"]["agent_owned_decisions"]
+
+
+def test_report_router_surfaces_applicable_intent_compactly(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--preset", "full"]) == 0
+    capsys.readouterr()
+    _write_applicable_intent_fixture(target)
+
+    assert cli.main(["report", "--target", str(target), "--format", "json"]) == 0
+
+    context = _report_context(json.loads(capsys.readouterr().out))
+    applicable = context["applicable_intent"]
+    assert applicable["status"] == "attention"
+    assert applicable["source_count"] >= 4
+    assert applicable["conflict_status"] == "conflict-blocking-closeout"
+    assert applicable["manual_verification_count"] >= 1
+    assert applicable["closeout_blocked"] is True
+    assert applicable["detail_command"].endswith("--section applicable_intent --format json")
+    assert applicable["attention_required"] is True
+
+
+def test_report_closeout_report_caveats_unresolved_soft_applicable_intent_from_verification(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--preset", "full"]) == 0
+    capsys.readouterr()
+    _write_applicable_intent_fixture(target)
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_report", "--format", "json"]) == 0
+
+    report = json.loads(capsys.readouterr().out)["answer"]
+    applicable = report["applicable_intent_status"]
+    assert applicable["closeout_blocked"] is True
+    assert "privacy_soft_intent: privacy_owner_acceptance" in applicable["manual_verification_needed"]
+    checks = {check["id"]: check for check in report["completeness"]["checks"]}
+    assert checks["applicable-intent-status"]["status"] == "incomplete"
+    rendering = report["final_response_rendering"]
+    assert rendering["plain_done_allowed"] is False
+    assert "applicable intent status" in rendering["must_include"]
+    assert any("applicable intent conflicts" in claim for claim in rendering["must_not_claim"])
+
+
 def test_report_closeout_report_uses_lane_owner_proof_aggregation(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -4088,6 +4088,127 @@ reopen_trigger = "privacy-sensitive behavior changes"
     )
 
 
+def _write_resolved_applicable_intent_fixture(target: Path) -> None:
+    _write(
+        target / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[workspace]
+default_preset = "full"
+
+[assurance.requirements.privacy_soft_intent]
+level = "high"
+applies_to_planning_refs = ["privacy-soft-intent"]
+authority_refs = ["docs/privacy-contract.md"]
+required_evidence = ["privacy_owner_acceptance"]
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+review_owner = "privacy-owner"
+""",
+    )
+    _write(
+        target / ".agentic-workspace" / "verification" / "manifest.toml",
+        """
+schema_version = "agentic-workspace/verification-manifest/v1"
+
+[scenarios.privacy_owner_review]
+protocol_id = "privacy_soft_review"
+title = "Privacy owner review"
+steps = ["Review the privacy contract against the changed behavior"]
+expected_observations = ["Privacy owner acceptance is recorded"]
+pass_evidence_labels = ["privacy_owner_acceptance"]
+manual_boundary = "Human/domain owner acceptance is required."
+
+[protocols.privacy_soft_review]
+title = "Privacy soft-intent verification"
+purpose = "Represent the manual privacy review obligation."
+planning_refs = ["privacy-soft-intent"]
+scenario_refs = ["privacy_owner_review"]
+expected_evidence = ["privacy_owner_acceptance"]
+review_owner = "privacy-owner"
+authority_refs = ["docs/privacy-contract.md"]
+retention = "retain-summary"
+""",
+    )
+    _write_json(
+        target / ".agentic-workspace" / "planning" / "execplans" / "privacy-soft-intent.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Privacy soft intent accepted fixture",
+            "active_milestone": {"id": "privacy-soft-intent", "status": "complete", "scope": "Privacy-sensitive change."},
+            "delegated_judgment": {
+                "requested outcome": "Change privacy-sensitive behavior while preserving required privacy-owner acceptance.",
+                "hard constraints": "Do not claim broad completion before manual privacy verification is accepted or waived.",
+            },
+            "assurance_requirement_refs": ["privacy-soft-intent"],
+            "verification_protocol_refs": ["privacy_soft_review"],
+            "assurance_evidence": {"privacy_soft_intent": {"evidence_present": ["privacy_owner_acceptance"]}},
+            "applicable_intents": {
+                "user_intents": ["ship the privacy-sensitive change"],
+                "system_intents": ["manual privacy acceptance must stay visible when required"],
+                "subsystem_intents": ["privacy contract governs this subsystem"],
+                "soft_intents": ["privacy-owner acceptance is required"],
+                "sources": [
+                    {"source": "GitHub #1326", "intent": "preserve applicable soft/system/subsystem intents"},
+                    {"source": "docs/privacy-contract.md", "intent": "privacy owner acceptance required"},
+                ],
+                "conflicts": ["ordinary tests passed but privacy-owner acceptance is missing"],
+                "missing_authority": ["privacy-owner acceptance"],
+                "manual_verification_needed": ["privacy_soft_intent: privacy_owner_acceptance"],
+                "blocked_claims": ["claim-work-complete", "close-parent-lane"],
+                "durable_outcomes": [
+                    {
+                        "id": "privacy-owner-accepted-interpretation",
+                        "outcome": "accepted-interpretation",
+                        "summary": "Privacy owner accepted the manual review evidence as satisfying the privacy soft intent.",
+                        "owner": "privacy-owner",
+                        "owner_surface": "GitHub issue comment",
+                        "evidence_anchor": "privacy_owner_acceptance in GitHub #1330 comment",
+                        "stale_when": "privacy contract or privacy-sensitive behavior changes",
+                        "reopen_trigger": "privacy-sensitive behavior changes",
+                        "affected_claims": ["claim-work-complete", "close-parent-lane"],
+                        "resolves": [
+                            "ordinary tests passed but privacy-owner acceptance is missing",
+                            "privacy-owner acceptance",
+                            "privacy_soft_intent: privacy_owner_acceptance",
+                        ],
+                    }
+                ],
+            },
+            "execution_run": {
+                "run status": "complete",
+                "what happened": "Changed privacy-sensitive behavior.",
+                "scope touched": "privacy subsystem",
+                "changed surfaces": "src/privacy.py",
+                "validations run": "ordinary tests and privacy owner review passed",
+                "result for continuation": "privacy owner acceptance recorded",
+            },
+            "proof_report": {
+                "validation proof": "ordinary tests passed; privacy_owner_acceptance recorded",
+                "proof achieved now": "yes for ordinary tests and privacy-owner acceptance",
+            },
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": "closed",
+                "closure decision": "archive-and-close",
+                "why this decision is honest": "Privacy owner acceptance is recorded as durable outcome evidence.",
+                "evidence carried forward": "ordinary tests plus privacy_owner_acceptance",
+                "reopen trigger": "privacy-sensitive behavior changes",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        "  { id = 'privacy-soft-intent', title = 'Privacy soft intent accepted fixture', surface = '.agentic-workspace/planning/execplans/privacy-soft-intent.plan.json' },\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+
 def test_report_applicable_intent_section_projects_sources_authority_and_durable_outcomes(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
@@ -4155,6 +4276,45 @@ def test_report_closeout_report_caveats_unresolved_soft_applicable_intent_from_v
     assert rendering["plain_done_allowed"] is False
     assert "applicable intent status" in rendering["must_include"]
     assert any("applicable intent conflicts" in claim for claim in rendering["must_not_claim"])
+
+
+def test_report_applicable_intent_resolved_outcome_is_durable_closeout_evidence(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--preset", "full"]) == 0
+    capsys.readouterr()
+    _write_resolved_applicable_intent_fixture(target)
+
+    assert cli.main(["report", "--target", str(target), "--section", "applicable_intent", "--format", "json"]) == 0
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    assert answer["conflict_status"] == "none"
+    assert answer["closeout_blocked"] is False
+    assert answer["conflicts"] == []
+    assert answer["manual_verification"] == []
+    assert answer["blocked_claims"] == []
+    outcome = answer["durable_outcomes"][0]
+    assert outcome["outcome"] == "accepted-interpretation"
+    assert outcome["owner"] == "privacy-owner"
+    assert outcome["evidence_anchor"] == "privacy_owner_acceptance in GitHub #1330 comment"
+    assert outcome["stale_when"] == "privacy contract or privacy-sensitive behavior changes"
+    assert outcome["affected_claims"] == ["claim-work-complete", "close-parent-lane"]
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_report", "--format", "json"]) == 0
+
+    report = json.loads(capsys.readouterr().out)["answer"]
+    applicable = report["applicable_intent_status"]
+    assert applicable["closeout_blocked"] is False
+    assert applicable["manual_verification_needed"] == []
+    checks = {check["id"]: check for check in report["completeness"]["checks"]}
+    assert checks["applicable-intent-status"]["status"] == "complete"
+    rendering = report["final_response_rendering"]
+    assert "applicable intent outcome" in rendering["must_include"]
+    rendered = rendering["rendered_summary"]["rendered_text"]
+    assert "Applicable intent outcome: accepted-interpretation" in rendered
+    assert "privacy_owner_acceptance in GitHub #1330 comment" in rendered
+    assert not any("applicable intent conflicts" in claim for claim in rendering["must_not_claim"])
 
 
 def test_report_closeout_report_uses_lane_owner_proof_aggregation(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## What landed

- Added `applicable_intent` as a selected/full workspace report surface that assembles structural or configured intent-source evidence from Planning, Memory, standing/durable intent, assurance, Verification, and external work reconciliation.
- Kept the authority boundary explicit: AW observes and recommends routes; the agent and human/domain owners decide semantic applicability, conflict resolution, waiver, and acceptance.
- Wired applicable-intent status into closeout completeness so unresolved conflicts, missing authority, or manual verification block plain/broad done claims.
- Added router behavior that stays quiet on clean default reports and exposes `context.applicable_intent` only when attention is required; full detail remains behind `report --section applicable_intent`.
- Updated the workspace report schema/reference docs and added representative report/closeout regression fixtures.
- Added archived Planning evidence for the lane and grounding review.

## Closure matrix

| Issue | Closure evidence |
| --- | --- |
| Closes #1326 | Representative lane implementation across existing AW surfaces: Planning/review evidence, compact applicable-intent source projection, authority/freshness/conflict vocabulary, durable outcome routing, manual-verification closeout effect, schema/reference docs, and regression fixtures. |
| Closes #1327 | Added `.agentic-workspace/planning/reviews/2026-06-05-issue-1326-applicable-intent-grounding.review.json` mapping current source surfaces and gaps before implementation. |
| Closes #1328 | `report --section applicable_intent` projects Planning, Memory, standing/durable intent, assurance, Verification, and external work sources without semantic keyword classification. |
| Closes #1329 | Added stable authority classes, freshness/trust states, conflict states, manual-verification states, and an authority boundary saying AW assembles evidence but does not resolve semantic intent. |
| Closes #1330 | Added durable outcome routing for clarified intent, accepted interpretation, waiver, and deferred-with-owner outcomes, including owner surfaces and stale conditions. |
| Closes #1331 | Manual Verification/assurance gaps now feed applicable-intent status and closeout completeness, blocking broad/plain done claims until resolved, waived, or owned. |
| Closes #1332 | Added regression fixtures for selected/full report projection, actionable router surfacing, and closeout/final-response caveats for unresolved soft applicable intent. |

## Proof

- `uv run pytest tests/test_workspace_report_cli.py::test_report_applicable_intent_section_projects_sources_authority_and_durable_outcomes tests/test_workspace_report_cli.py::test_report_router_surfaces_applicable_intent_compactly tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unresolved_soft_applicable_intent_from_verification tests/test_workspace_report_cli.py::test_report_closeout_report_represents_generated_code_parent_intent_boundary -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make maintainer-surfaces`
- `make schema-reference-docs`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `uv run python scripts/run_agentic_workspace.py report --target . --section applicable_intent --format json`

## Dogfooding follow-ups

- Filed #1349 for active lane projection needing schema-valid execplan references after lane activation.
- Filed #1350 for workspace front-door forwarding failures across Planning lane lifecycle commands (`lane-activate`, `lane-close`, `lane-archive`).

## Remaining limitation

This does not add a semantic policy engine or automated business-intent resolver. That is intentional: the lane preserves AW as repo- and agent-agnostic support for evidence, authority boundaries, and closeout caveats.

## Review update

Addressed the PR comment about #1326/#1330 durable outcome evidence in commit `b6e42c57`.

- Added a resolved-outcome fixture that starts with a privacy soft-intent conflict/manual-verification requirement, records `applicable_intents.durable_outcomes`, and asserts the report surfaces owner, owner surface, evidence anchor, stale condition, reopen trigger, affected claims, and resolved items.
- Closeout now consumes that durable outcome: the same conflict/manual/missing-authority items are no longer treated as unresolved, the applicable-intent completeness check is complete, and final-response rendering includes the applicable-intent outcome evidence.
- Also classified archived lane records in the structured file inventory after the check exposed the missing archived-lane pattern.

Additional proof after review update:

- `uv run pytest tests/test_workspace_report_cli.py::test_report_applicable_intent_section_projects_sources_authority_and_durable_outcomes tests/test_workspace_report_cli.py::test_report_applicable_intent_resolved_outcome_is_durable_closeout_evidence tests/test_workspace_report_cli.py::test_report_closeout_report_caveats_unresolved_soft_applicable_intent_from_verification tests/test_workspace_report_cli.py::test_report_router_surfaces_applicable_intent_compactly -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make maintainer-surfaces`
- `make schema-reference-docs`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
