### PR TITLE
[codex] Make task-shape judgment agent-owned

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1359-agent-owned-task-shape-labels.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1359-agent-owned-task-shape-labels.plan.json
@@ -1,0 +1,352 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Stop AW task-shape label ownership",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1359 so AW startup, implement, delegation, and report surfaces stop presenting semantic task-shape labels as AW-owned decisions.",
+    "hard_constraints": "Do not add better keyword classification. Keep AW-owned outputs to observed facts, hard gates, recommendations, candidate routes, and evidence/guidance with agent-owned semantic judgment.",
+    "agent_may_decide": "How to rename or reshape existing fields while preserving compatibility where necessary and making authority boundaries explicit.",
+    "escalate_when": "A correct fix requires a broad Planning skill taxonomy rewrite, changing hard gate behavior, or removing intentional Planning artifact terms such as execplan/decomposition/lane.",
+    "next_action": "No implementation continuation remains for this archived slice; review and merge the PR, then rebase #1354 onto the fix.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_start_preflight_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py -q",
+      "uv run python scripts/generate/generate_command_packages.py --check",
+      "uv run python scripts/check/check_generated_command_packages.py"
+    ],
+      "touched_scope": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/reporting_support.py",
+        "src/agentic_workspace/workspace_output.py",
+        "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+        "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+        "src/agentic_workspace/contracts/workspace_defaults/payload.json",
+        "generated/workspace/python/_contracts/payload.json",
+        "generated/workspace/typescript/resources/_contracts/payload.json",
+        "docs/reference/implementer-context.md",
+        "tests/test_workspace_start_preflight_cli.py",
+        "tests/test_workspace_implement_cli.py",
+        "tests/test_workspace_report_cli.py"
+    ],
+    "completion_criteria": [
+      "No startup, implement, delegation, or report packet presents task-shape labels as AW-owned semantic decisions.",
+      "Structural/task signals are exposed as evidence or guidance with explicit agent-owned classification.",
+      "Focused tests cover #1359 and the #1354-like under-interpretation failure."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Implement #1359 so AW no longer presents task-shape labels as package-owned decisions."
+  ],
+  "non_goals": [
+    "Do not continue #1354 on this branch; do not rewrite broader Planning artifact terminology in this slice."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1359 so AW stops owning semantic task-shape labels.",
+      "constraints": "Expose facts/guidance only; do not implement keyword-based task classification.",
+      "latitude": "Rename or reshape packet fields and tests to preserve agent-owned judgment.",
+      "escalation": "Escalate if the fix expands into a broad Planning skill or artifact terminology redesign.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1359-agent-owned-task-shape-labels",
+      "status": "completed",
+      "next_step": "Review and merge the PR, then rebase #1354 onto the fix.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/reporting_support.py",
+        "src/agentic_workspace/workspace_output.py",
+        "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+        "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+        "src/agentic_workspace/contracts/workspace_defaults/payload.json",
+        "generated/workspace/python/_contracts/payload.json",
+        "generated/workspace/typescript/resources/_contracts/payload.json",
+        "docs/reference/implementer-context.md",
+        "tests/test_workspace_start_preflight_cli.py",
+        "tests/test_workspace_implement_cli.py",
+        "tests/test_workspace_report_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Fix #1359 before continuing #1354 so later generated-CLI work does not dogfood known-bad task-label ownership.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "#1354 can resume without dogfooding AW-owned semantic task-shape labels.",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "After merge, rebase #1354 and continue the generated-CLI single-source boundary lane."
+  },
+  "intent_interpretation": {
+    "literal request": "Before continuing with #1354, fix the dogfooding findings on another branch.",
+    "inferred intended outcome": "Implement #1359 on a separate branch, then use the fixed behavior before resuming #1354.",
+    "chosen concrete what": "Rename/reshape AW-owned task-label packets into structural evidence and guidance with agent-owned classification.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "runtime packet construction, related JSON schemas/output rendering, focused tests, active Planning closeout fields.",
+    "max changed files": "about 10, excluding generated artifacts if regeneration is required.",
+    "required validation commands": "focused tests, generated command freshness, generated package checks, Planning doctor.",
+    "ask-before-refactor threshold": "Ask before rewriting Planning skills, removing legitimate artifact terms, or changing hard gate semantics.",
+    "stop before touching": "Unrelated #1354 generated-CLI runtime boundary work, broad Planning hierarchy redesign, Memory/Verification behavior."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "#1359, this execplan, workspace_runtime_primitives packet functions, workspace_output report text, focused tests.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1359 on a separate branch before continuing #1354.",
+    "hard constraints": "Do not make AW a task classifier; convert labels to evidence/guidance with authority boundaries.",
+    "agent may decide locally": "Exact compatibility field names and test placement.",
+    "escalate when": "The fix needs broad Planning skill taxonomy or hard gate changes."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1359-agent-owned-task-shape-labels",
+    "status": "completed",
+    "scope": "Fix #1359 task-label authority boundaries only.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "None for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "src/agentic_workspace/reporting_support.py",
+    "src/agentic_workspace/workspace_output.py",
+    "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+    "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+    "src/agentic_workspace/contracts/workspace_defaults/payload.json",
+    "generated/workspace/python/_contracts/payload.json",
+    "generated/workspace/typescript/resources/_contracts/payload.json",
+    "docs/reference/implementer-context.md",
+    "tests/test_workspace_start_preflight_cli.py",
+    "tests/test_workspace_implement_cli.py",
+    "tests/test_workspace_report_cli.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_start_preflight_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py -q",
+    "uv run python scripts/generate/generate_command_packages.py --check",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json",
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py",
+    "uv run pytest tests/test_workspace_cli.py -q",
+    "make test-workspace",
+    "make lint-workspace",
+    "make schema-reference-docs"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "#1359 packet fields no longer imply AW-owned semantic classification.",
+    "Tests demonstrate structural evidence/guidance and agent-owned decision boundaries.",
+    "PR created from this branch; #1354 branch remains paused until this merges."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented #1359 so AW startup, implement, delegation, handoff, and report surfaces expose scope/proof facts, fit signals, route evidence, and authority boundaries instead of AW-owned semantic task-shape labels.",
+    "scope touched": "Workspace runtime report/start/implement packets, output rendering, startup/implementer schemas, workspace defaults, generated Python/TypeScript payload resources, focused tests, and schema reference docs.",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; src/agentic_workspace/workspace_output.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; src/agentic_workspace/contracts/workspace_defaults/payload.json; generated/workspace/python/_contracts/payload.json; generated/workspace/typescript/resources/_contracts/payload.json; docs/reference/implementer-context.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_implement_cli.py; tests/test_workspace_report_cli.py",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "none"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed inside #1359. Compatibility readers remain for old task_shape/task_shape_recommender fields, but emitted packets and schemas use planning context, fit signals, scope evidence, route evidence, and agent-owned classification language.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Focused: 267 start/implement/report tests passed; generated command packages check passed; generated package static proof passed; contract tooling passed; structured inventory passed; workspace CLI tests passed; make test-workspace, make lint-workspace, and make schema-reference-docs passed.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1359 so AW no longer presents task-shape labels as package-owned decisions.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1359 is satisfied on this branch; #1354 remains paused until this PR merges and the #1354 branch can be rebased onto the fix.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "signals_fixed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      "Planning summary exposed stale scaffold wording after implementation; closeout needed to remove active TODO guidance before PR."
+    ],
+    "signals fixed": [
+      "Closed the active execplan through the command-owned closeout writer and verified summary/doctor reported a clean Planning state."
+    ],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-06: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1359 so AW no longer presents task-shape labels as package-owned decisions.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Focused: 267 start/implement/report tests passed; generated command packages check passed; generated package static proof passed; contract tooling passed; structured inventory passed; workspace CLI tests passed; make test-workspace, make lint-workspace, and make schema-reference-docs passed.\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; src/agentic_workspace/workspace_output.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; src/agentic_workspace/contracts/workspace_defaults/payload.json; generated/workspace/python/_contracts/payload.json; generated/workspace/typescript/resources/_contracts/payload.json; docs/reference/implementer-context.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_implement_cli.py; tests/test_workspace_report_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -126,7 +126,7 @@ Cheap implementer context for a bounded changed-path scope.
 | `execution_posture.capability_posture` | ref `#/$defs/capability_posture` | yes |  | Task capability posture inferred from changed paths and optional task text. |  |  |
 | `execution_posture.capability_posture.status` | string | yes |  | Whether capability posture was inferred, configured, or unavailable. |  |  |
 | `execution_posture.capability_posture.posture` | object | yes |  | Human-readable posture details used for review. |  |  |
-| `execution_posture.capability_posture.work_shape_guidance` | object | yes |  | Structural work-shape guidance; the agent owns final work-shape judgment. |  |  |
+| `execution_posture.capability_posture.scope_evidence` | object | yes |  | Observed scope evidence; the agent owns semantic task classification. |  |  |
 | `execution_posture.capability_posture.proof_factors` | object | yes |  | Structural proof factors; the agent owns proof proportionality judgment. |  |  |
 | `execution_posture.capability_posture.risk_flags` | array of string | yes |  | Risk signals inferred from paths or task text. |  |  |
 | `execution_posture.capability_posture.inspection_evidence_required` | array of string | yes |  | Context required before trusting the posture. |  |  |

--- a/generated/workspace/python/_contracts/payload.json
+++ b/generated/workspace/python/_contracts/payload.json
@@ -2082,7 +2082,7 @@
     },
     "capability_handoff_packets": {
       "common_required_fields": [
-        "task_shape: direct, bounded, lane, or epic",
+        "planning_context: observed scope/proof facts and the agent's selected execution frame",
         "route_reason: why this target or escalation route fits better than direct execution",
         "inspected_context: exact files, commands, or planning state already inspected",
         "allowed_write_scope: paths or surfaces the receiver may edit",
@@ -3465,12 +3465,12 @@
         {
           "fallback": "agentic-workspace summary --format json",
           "skill": "planning-reporting",
-          "task_shape": "active planning report, restart, or proof posture"
+          "fit_signal": "active planning report, restart, or proof posture"
         },
         {
           "fallback": "agentic-workspace doctor --target ./repo --modules planning --format json",
           "skill": "bootstrap-upgrade",
-          "task_shape": "managed planning bootstrap upgrade"
+          "fit_signal": "managed planning bootstrap upgrade"
         }
       ],
       "query": "agentic-workspace skills --target ./repo --task \"<task>\" --format json",

--- a/generated/workspace/typescript/resources/_contracts/payload.json
+++ b/generated/workspace/typescript/resources/_contracts/payload.json
@@ -2082,7 +2082,7 @@
     },
     "capability_handoff_packets": {
       "common_required_fields": [
-        "task_shape: direct, bounded, lane, or epic",
+        "planning_context: observed scope/proof facts and the agent's selected execution frame",
         "route_reason: why this target or escalation route fits better than direct execution",
         "inspected_context: exact files, commands, or planning state already inspected",
         "allowed_write_scope: paths or surfaces the receiver may edit",
@@ -3465,12 +3465,12 @@
         {
           "fallback": "agentic-workspace summary --format json",
           "skill": "planning-reporting",
-          "task_shape": "active planning report, restart, or proof posture"
+          "fit_signal": "active planning report, restart, or proof posture"
         },
         {
           "fallback": "agentic-workspace doctor --target ./repo --modules planning --format json",
           "skill": "bootstrap-upgrade",
-          "task_shape": "managed planning bootstrap upgrade"
+          "fit_signal": "managed planning bootstrap upgrade"
         }
       ],
       "query": "agentic-workspace skills --target ./repo --task \"<task>\" --format json",

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -1002,7 +1002,7 @@
       "required": [
         "status",
         "posture",
-        "work_shape_guidance",
+        "scope_evidence",
         "proof_factors",
         "risk_flags",
         "inspection_evidence_required",
@@ -1018,9 +1018,9 @@
           "type": "object",
           "description": "Human-readable posture details used for review."
         },
-        "work_shape_guidance": {
+        "scope_evidence": {
           "type": "object",
-          "description": "Structural work-shape guidance; the agent owns final work-shape judgment."
+          "description": "Observed scope evidence; the agent owns semantic task classification."
         },
         "proof_factors": {
           "type": "object",
@@ -1297,10 +1297,11 @@
         "kind",
         "packet_type",
         "mode",
-        "task_shape",
+        "scope_signal",
         "route_reason",
         "inspected_context",
         "proof_expectations",
+        "authority_boundary",
         "allowed_write_scope",
         "stop_conditions",
         "prompt"
@@ -1329,9 +1330,9 @@
           "type": "object",
           "description": "Template that shaped the packet."
         },
-        "task_shape": {
+        "scope_signal": {
           "type": "string",
-          "description": "Task shape being delegated or escalated."
+          "description": "Observed scope signal used as route evidence; not an AW-owned semantic task classification."
         },
         "route_reason": {
           "type": "string",
@@ -1348,6 +1349,10 @@
         "proof_expectations": {
           "type": "string",
           "description": "Proof burden or commands expected from the receiver."
+        },
+        "authority_boundary": {
+          "type": "object",
+          "description": "Boundary explaining that the packet carries route evidence while the agent owns semantic task classification."
         },
         "allowed_write_scope": {
           "type": "string",

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -786,13 +786,13 @@
           "items": {
             "type": "object",
             "required": [
-              "task_shape",
+              "fit_signal",
               "skill"
             ],
             "properties": {
-              "task_shape": {
+              "fit_signal": {
                 "type": "string",
-                "description": "Task shape text value used by this contract."
+                "description": "Skill-fit signal text; not an AW-owned semantic task classification."
               },
               "skill": {
                 "type": "string",

--- a/src/agentic_workspace/contracts/workspace_defaults/payload.json
+++ b/src/agentic_workspace/contracts/workspace_defaults/payload.json
@@ -2082,7 +2082,7 @@
     },
     "capability_handoff_packets": {
       "common_required_fields": [
-        "task_shape: direct, bounded, lane, or epic",
+        "planning_context: observed scope/proof facts and the agent's selected execution frame",
         "route_reason: why this target or escalation route fits better than direct execution",
         "inspected_context: exact files, commands, or planning state already inspected",
         "allowed_write_scope: paths or surfaces the receiver may edit",
@@ -3465,12 +3465,12 @@
         {
           "fallback": "agentic-workspace summary --format json",
           "skill": "planning-reporting",
-          "task_shape": "active planning report, restart, or proof posture"
+          "fit_signal": "active planning report, restart, or proof posture"
         },
         {
           "fallback": "agentic-workspace doctor --target ./repo --modules planning --format json",
           "skill": "bootstrap-upgrade",
-          "task_shape": "managed planning bootstrap upgrade"
+          "fit_signal": "managed planning bootstrap upgrade"
         }
       ],
       "query": "agentic-workspace skills --target ./repo --task \"<task>\" --format json",

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -498,12 +498,12 @@ def report_router_payload(
         current_work = dict(effective_authority.get("current_work", {}) or {})
     execution_shape = payload.get("execution_shape", {})
     if not current_work and isinstance(execution_shape, dict):
-        task_shape = execution_shape.get("task_shape", {})
-        if isinstance(task_shape, dict):
+        planning_context = execution_shape.get("planning_context", execution_shape.get("task_shape", {}))
+        if isinstance(planning_context, dict):
             current_work = {
-                "status": str(task_shape.get("id", "unknown")),
-                "summary": str(task_shape.get("summary", "")),
-                "source": "execution_shape",
+                "status": str(planning_context.get("id", "unknown")),
+                "summary": str(planning_context.get("summary", "")),
+                "source": "execution_shape.planning_context",
             }
     section_hints = report_section_hints(payload, cli_invoke=cli_invoke, target_arg=target_arg)
     compact_section_hints = _compact_report_section_hints(section_hints)
@@ -969,8 +969,8 @@ def _report_router_execution_shape(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {"status": "unavailable"}
     recommendation = value.get("recommendation", {})
-    task_shape = value.get("task_shape", {})
-    recommender = value.get("task_shape_recommender", {})
+    planning_context = value.get("planning_context", value.get("task_shape", {}))
+    recommender = value.get("workflow_shape_guidance", value.get("task_shape_recommender", {}))
     if isinstance(recommender, dict):
         shapes = recommender.get("shapes", [])
         recommender = {
@@ -993,8 +993,8 @@ def _report_router_execution_shape(value: Any) -> dict[str, Any]:
         fast_path = {}
     return {
         "status": value.get("status", "unknown"),
-        "task_shape": task_shape if isinstance(task_shape, dict) else {},
-        "task_shape_recommender": recommender,
+        "planning_context": planning_context if isinstance(planning_context, dict) else {},
+        "workflow_shape_guidance": recommender,
         "narrow_work_fast_path": fast_path,
         "recommendation": recommendation if isinstance(recommendation, dict) else {},
         "deviation_rule": value.get("deviation_rule", ""),

--- a/src/agentic_workspace/workspace_output.py
+++ b/src/agentic_workspace/workspace_output.py
@@ -130,9 +130,9 @@ def _emit_report_text(payload: dict[str, Any]) -> None:
         if isinstance(recommendation, dict):
             print("Execution shape:")
             print(f"- default: {recommendation.get('summary', '')}")
-            task_shape = execution_shape.get("task_shape", {})
-            if isinstance(task_shape, dict) and task_shape.get("summary"):
-                print(f"  task shape: {task_shape['summary']}")
+            planning_context = execution_shape.get("planning_context", {})
+            if isinstance(planning_context, dict) and planning_context.get("summary"):
+                print(f"  planning context: {planning_context['summary']}")
             for reason in recommendation.get("why", [])[:2]:
                 print(f"  why: {reason}")
             deviation_visibility = recommendation.get("deviation_visibility")

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -10615,12 +10615,13 @@ def _run_report_router_command(
 def _report_router_execution_shape_fast(*, config: WorkspaceConfig) -> dict[str, Any]:
     return {
         "status": "present",
-        "task_shape": {
+        "planning_context": {
             "id": "direct-or-no-active-plan",
-            "summary": "No active planning record is present; direct work can proceed when the task is narrow and proof is obvious.",
+            "summary": "No active plan; direct work is agent-owned when narrow and proof is obvious.",
             "why": "The default report router does not load deep planning reports; run the execution_shape section for active-plan detail.",
+            "authority": "AW reports facts; agent owns classification.",
         },
-        "task_shape_recommender": {
+        "workflow_shape_guidance": {
             "status": "available",
             "rule": "Choose the cheapest workflow shape that preserves proof and continuation honesty.",
             "shapes": [{"id": "direct"}, {"id": "light-plan"}, {"id": "checked-in-execplan"}],
@@ -16566,7 +16567,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         immediate["next_proof"] = "select proof after changed paths are known"
     skill_routing = payload.get("skill_routing", {})
     preferred_routes = [
-        {"task_shape": str(item.get("task_shape", "")), "skill": str(item.get("skill", ""))}
+        {"fit_signal": str(item.get("fit_signal", item.get("task_shape", ""))), "skill": str(item.get("skill", ""))}
         for item in (skill_routing.get("preferred_routes", []) if isinstance(skill_routing, dict) else [])[:2]
         if isinstance(item, dict)
     ]
@@ -16884,7 +16885,7 @@ def _compact_start_delegation_decision(value: Any, *, include_manual_handoff_det
         "clarification_mode",
         "recommended_route",
         "authority_boundary",
-        "quality_factors",
+        "route_evidence",
         "token_savings_guidance",
         "required_next_action",
         "effort_guidance",
@@ -16893,11 +16894,11 @@ def _compact_start_delegation_decision(value: Any, *, include_manual_handoff_det
     compact.setdefault("recommended_route", value.get("recommended_route") or value.get("decision"))
     if "authority_boundary" in compact:
         compact["authority_boundary"] = _compact_authority_boundary(compact["authority_boundary"])
-    if isinstance(compact.get("quality_factors"), dict):
-        factors = compact["quality_factors"]
-        compact["quality_factors"] = {
+    if isinstance(compact.get("route_evidence"), dict):
+        factors = compact["route_evidence"]
+        compact["route_evidence"] = {
             key: factors.get(key)
-            for key in ("tier", "proof_factor_hint", "work_shape_hint", "agent_judgment_required")
+            for key in ("proof_review_pressure", "proof_pressure", "scope_signal", "agent_judgment_required")
             if factors.get(key) not in (None, "")
         }
     if isinstance(compact.get("token_savings_guidance"), dict):
@@ -22819,10 +22820,11 @@ def _work_shape_guidance_payload(
             "issue_refs": issue_refs,
         },
         "proof_factors": [item for item in proof_factors if item],
-        "structural_signals": {
-            "work_shape_hint": work_shape or "unknown",
-            "proof_factor_hint": proof_burden or "unknown",
-            "authority": "structural path/task heuristic only",
+        "structural_evidence": {
+            "scope_signal": work_shape or "unknown",
+            "proof_pressure": proof_burden or "unknown",
+            "authority": "observed path/task signal only; not an AW-owned task classification",
+            "agent_owned_classification": True,
         },
         "authority_boundary": authority_boundary,
         "direct_work_is_reasonable_when": direct_reasons
@@ -22833,7 +22835,7 @@ def _work_shape_guidance_payload(
         "judgment_boundary": {
             "aw_owns": ["hard blockers", "changed-path facts", "active planning state", "proof candidates"],
             "agent_owns": ["user intent", "semantic work shape", "completion judgment when no hard blocker applies"],
-            "rule": "AW exposes factual affordances and blockers; the agent owns engineering judgment over those facts.",
+            "rule": "AW exposes factual affordances and blockers; the agent owns engineering judgment and semantic task classification over those facts.",
         },
         "stop_conditions": [
             "changed paths widen beyond the current bounded roots",
@@ -22848,7 +22850,7 @@ def _work_shape_guidance_payload(
         "status": status,
         "decision": decision,
         "required_next_action": required_next_action,
-        "rule": "AW reports hard blockers, facts, and decision guidelines; the agent owns soft semantic work-shape judgment when no hard blocker applies.",
+        "rule": "AW reports hard blockers, facts, and decision guidelines; the agent owns semantic task classification when no hard blocker applies.",
     }
 
 
@@ -22857,16 +22859,22 @@ def _capability_structural_hints(capability: Any) -> tuple[str, str]:
         return "", ""
     posture = capability.get("posture", {}) if isinstance(capability.get("posture"), dict) else {}
     work_shape_guidance = capability.get("work_shape_guidance", {}) if isinstance(capability.get("work_shape_guidance"), dict) else {}
+    scope_evidence = capability.get("scope_evidence", {}) if isinstance(capability.get("scope_evidence"), dict) else {}
     proof_factors = capability.get("proof_factors", {}) if isinstance(capability.get("proof_factors"), dict) else {}
     work_shape = (
-        work_shape_guidance.get("structural_hint")
+        scope_evidence.get("scope_signal")
+        or work_shape_guidance.get("scope_signal")
+        or work_shape_guidance.get("structural_hint")
+        or posture.get("structural scope signal")
         or posture.get("structural work-shape hint")
         or posture.get("work shape")
         or capability.get("work_shape")
         or ""
     )
     proof_burden = (
-        proof_factors.get("structural_hint")
+        proof_factors.get("proof_pressure")
+        or proof_factors.get("structural_hint")
+        or posture.get("proof pressure")
         or posture.get("proof factor hint")
         or posture.get("proof burden")
         or capability.get("proof_burden")
@@ -23592,52 +23600,53 @@ def _capability_posture_for_implementation(*, changed_paths: list[str], task_tex
     if len(set((path.split("/")[0] for path in changed_paths if path))) >= 3:
         risk_flags.append("cross-surface breadth")
     if len(issue_refs) > 1 or "epic" in combined:
-        work_shape = "epic" if "epic" in combined else "lane"
+        scope_signal = "epic" if "epic" in combined else "lane"
     elif "lane" in combined or len(changed_paths) >= 4:
-        work_shape = "lane"
+        scope_signal = "lane"
     elif changed_paths or task_text:
-        work_shape = "bounded"
+        scope_signal = "bounded"
     else:
-        work_shape = "direct"
+        scope_signal = "direct"
 
     def enrich(posture: dict[str, Any], *, reason: str) -> dict[str, Any]:
         execution_class = posture["execution class"]
-        if execution_class in ("boundary-shaping", "reasoning-heavy") or risk_flags or work_shape in ("lane", "epic"):
+        if execution_class in ("boundary-shaping", "reasoning-heavy") or risk_flags or scope_signal in ("lane", "epic"):
             proof_burden = "high"
         elif execution_class == "mechanical-follow-through":
             proof_burden = "obvious"
         else:
             proof_burden = "non-obvious"
         inspection_evidence = ["changed paths", "task text", "runtime_resolution", "proof route"]
-        if work_shape in ("lane", "epic"):
+        if scope_signal in ("lane", "epic"):
             inspection_evidence.append("active planning state")
         enriched_posture = {
             **posture,
-            "structural work-shape hint": work_shape,
-            "proof factor hint": proof_burden,
+            "structural scope signal": scope_signal,
+            "proof pressure": proof_burden,
             "risk flags": risk_flags,
             "inspection evidence required": inspection_evidence,
-            "guidance authority": "structural task/path signals",
+            "guidance authority": "observed task/path signals only; agent owns semantic task classification",
             "self-assessment authority": "advisory-only",
         }
         return {
             "status": "inferred",
             "posture": enriched_posture,
-            "work_shape_guidance": {
-                "structural_hint": work_shape,
-                "authority": "path/task heuristic only",
+            "scope_evidence": {
+                "scope_signal": scope_signal,
+                "authority": "observed path/task signal only; not an AW-owned task classification",
                 "agent_decision_required": True,
             },
             "proof_factors": {
-                "structural_hint": proof_burden,
+                "proof_pressure": proof_burden,
                 "risk_flags": risk_flags,
                 "inspection_evidence_required": inspection_evidence,
-                "authority": "path/task heuristic only",
+                "authority": "observed path/task signal only; agent owns proof proportionality judgment",
             },
             "risk_flags": risk_flags,
             "inspection_evidence_required": inspection_evidence,
-            "guidance_authority": "structural task/path signals",
+            "guidance_authority": "observed task/path signals only",
             "self_assessment_authority": "advisory-only",
+            "agent_owned_decisions": ["semantic task classification", "route fit", "proof proportionality"],
             "reason": reason,
         }
 
@@ -23979,9 +23988,9 @@ def _delegation_next_action_decision(
     if decision != "delegate-bounded-slice":
         auto_skip_reasons.append(f"delegation decision is {decision}, not delegate-bounded-slice")
     if proof_burden == "high":
-        auto_skip_reasons.append("proof factor hint is high")
+        auto_skip_reasons.append("proof pressure signal is high")
     if work_shape not in {"direct", "bounded"}:
-        auto_skip_reasons.append(f"work-shape hint is {work_shape or 'unknown'}")
+        auto_skip_reasons.append(f"scope signal is {work_shape or 'unknown'}")
     auto_audit_applies = bool(
         configured_auto_targets
         and decision not in {"delegate-bounded-slice", "suggest-delegation"}
@@ -24027,8 +24036,8 @@ def _delegation_next_action_decision(
         observed_by_aw=[
             f"delegation_mode={mode}",
             f"clarification_mode={clarification_mode}",
-            f"work_shape_hint={work_shape or 'unknown'}",
-            f"proof_factor_hint={proof_burden or 'unknown'}",
+            f"scope_signal={work_shape or 'unknown'}",
+            f"proof_pressure={proof_burden or 'unknown'}",
         ],
         recommended_by_aw=[decision, required_next_action],
         candidate_routes=[
@@ -24046,8 +24055,8 @@ def _delegation_next_action_decision(
         if required_next_action in {"prepare-manual-handoff", "stop-and-ask-human"}
         else [],
         rule=(
-            "Delegation output is local posture and candidate routing support unless a human-control or auto-execution gate "
-            "explicitly forbids an action."
+            "Delegation output is local posture, observed evidence, and candidate routing support unless a human-control or auto-execution gate "
+            "explicitly forbids an action; the agent owns semantic route fit."
         ),
     )
     return {
@@ -24059,13 +24068,13 @@ def _delegation_next_action_decision(
         "decision": decision,
         "target": target_name if decision != "stay-local" else None,
         "authority_boundary": delegation_authority_boundary,
-        "quality_factors": {
-            "tier": quality_tier,
-            "proof_factor_hint": proof_burden or "unknown",
-            "work_shape_hint": work_shape or "unknown",
+        "route_evidence": {
+            "proof_review_pressure": quality_tier,
+            "proof_pressure": proof_burden or "unknown",
+            "scope_signal": work_shape or "unknown",
             "risk_flags": capability.get("risk_flags", []) if isinstance(capability, dict) else [],
             "agent_judgment_required": True,
-            "rule": "AW exposes structural factors for delegation posture; the agent owns whether the factors justify delegation.",
+            "rule": "AW exposes structural evidence for delegation posture; the agent owns semantic task classification and whether the evidence justifies delegation.",
         },
         "token_savings_guidance": {
             "signal": token_savings_signal,
@@ -24125,9 +24134,9 @@ def _effort_guidance_payload(
     cost_posture = "balanced"
     escalation_trigger = "escalate only if inspection reveals broader uncertainty, high risk, or proof gaps"
     rationale: list[str] = [
-        f"work_shape_hint={work_shape}",
-        f"proof_factor_hint={proof_burden}",
-        f"quality_factor_tier={quality_tier}",
+        f"scope_signal={work_shape}",
+        f"proof_pressure={proof_burden}",
+        f"proof_review_pressure={quality_tier}",
     ]
     if work_shape == "direct" and proof_burden == "obvious":
         implementer = "low"
@@ -24164,6 +24173,7 @@ def _effort_guidance_payload(
         "kind": "agentic-workspace/effort-guidance/v1",
         "status": "evaluated",
         "principle": "Start with cheap routing, then spend higher reasoning effort only where the agent judges it improves quality or safely saves tokens.",
+        "authority": "effort guidance from observed route evidence; agent owns task classification and final effort choice",
         "orchestrator": orchestrator,
         "planner": planner,
         "implementer": implementer,
@@ -24276,8 +24286,12 @@ def _manual_external_relay_payload(
             ],
             "return_to": "Paste the answer back into the current coding-agent session; the coding agent remains responsible for repo implementation and proof.",
             "source_reason": reason,
-            "proof_factors": {"structural_hint": proof_burden},
-            "work_shape_guidance": {"structural_hint": work_shape, "agent_decision_required": True},
+            "proof_factors": {"proof_pressure": proof_burden},
+            "scope_evidence": {
+                "scope_signal": work_shape,
+                "agent_decision_required": True,
+                "authority": "observed signal only; agent owns semantic classification",
+            },
         },
     }
 
@@ -25673,7 +25687,7 @@ def _execution_shape_payload(*, config: WorkspaceConfig, module_reports: list[di
         "advisory_only": True,
         "status": "present",
         "sources": sources,
-        "task_shape_recommender": _task_shape_recommender_payload(),
+        "workflow_shape_guidance": _workflow_shape_guidance_payload(),
         "default_posture": {
             "planner_executor_pattern": mixed_agent["derived_mode"]["planner_executor_pattern"],
             "handoff_preference": mixed_agent["derived_mode"]["handoff_preference"],
@@ -25700,10 +25714,11 @@ def _execution_shape_payload(*, config: WorkspaceConfig, module_reports: list[di
                     }
                 )
             resolution.sort(key=lambda item: (-int(item["score"]), str(item["name"])))
-        payload["task_shape"] = {
+        payload["planning_context"] = {
             "id": "planning-backed-broad-work",
             "summary": "The current slice is already planning-backed with an active execplan.",
             "why": "The work already needs checked-in planning continuity, so repeating broad direct rediscovery is usually more expensive than deriving a bounded handoff once.",
+            "authority": "AW reports facts; agent owns classification.",
         }
         payload["current_slice"] = {
             "task_id": planning_record.get("task", {}).get("id", ""),
@@ -25746,10 +25761,11 @@ def _execution_shape_payload(*, config: WorkspaceConfig, module_reports: list[di
         )
         return payload
     if roadmap_candidate_count or roadmap_lane_count:
-        payload["task_shape"] = {
+        payload["planning_context"] = {
             "id": "roadmap-backed-no-active-plan",
             "summary": "Roadmap candidates exist, but no active planning-backed slice is present.",
             "why": "Roadmap candidates are not execution authority. Broad planned or autopilot work needs an active TODO item plus execplan before implementation; narrow direct tasks may still proceed.",
+            "authority": "AW reports facts; agent owns classification.",
         }
         payload["recommendation"] = {
             "id": "promote-before-broad-work",
@@ -25767,10 +25783,11 @@ def _execution_shape_payload(*, config: WorkspaceConfig, module_reports: list[di
             "Do not implement roadmap or autopilot lanes from chat or issue context alone; promote active planning first."
         )
         return payload
-    payload["task_shape"] = {
+    payload["planning_context"] = {
         "id": "direct-or-no-active-plan",
         "summary": "No planning-backed broad slice is active right now.",
         "why": "Without roadmap-backed planned work or an active execplan, the cheapest honest default is direct execution.",
+        "authority": "AW reports facts; agent owns classification.",
     }
     payload["narrow_work_fast_path"] = {
         "status": "blessed",
@@ -25801,10 +25818,10 @@ def _execution_shape_payload(*, config: WorkspaceConfig, module_reports: list[di
     return payload
 
 
-def _task_shape_recommender_payload() -> dict[str, Any]:
+def _workflow_shape_guidance_payload() -> dict[str, Any]:
     return {
         "status": "available",
-        "rule": "Choose the cheapest workflow shape that preserves proof and continuation honesty.",
+        "rule": "Workflow shapes are guidance for agent-owned planning judgment; AW does not classify the semantic task shape.",
         "shapes": [
             {
                 "id": "direct",
@@ -27127,7 +27144,7 @@ def _startup_skill_routing_payload(
     if intent_discovery_route_first:
         core_routes.append(
             {
-                "task_shape": "vague, broad, high-stakes, or under-specified human intent before implementation or Planning",
+                "fit_signal": "vague, broad, high-stakes, or under-specified human intent before implementation or Planning",
                 "skill": "workspace-intent-discovery",
                 "fallback": "agentic-workspace start --task <task> --select intent_discovery_dialogue --format json",
             }
@@ -27135,12 +27152,12 @@ def _startup_skill_routing_payload(
     core_routes.extend(
         [
             {
-                "task_shape": "active planning report, restart, or proof posture",
+                "fit_signal": "active planning report, restart, or proof posture",
                 "skill": "planning-reporting",
                 "fallback": "agentic-workspace summary --format json",
             },
             {
-                "task_shape": "managed planning bootstrap upgrade",
+                "fit_signal": "managed planning bootstrap upgrade",
                 "skill": "bootstrap-upgrade",
                 "fallback": "agentic-workspace doctor --target ./repo --modules planning --format json",
             },
@@ -27149,19 +27166,19 @@ def _startup_skill_routing_payload(
     configured_features = set(enabled_advanced_features)
     available_advanced_routes = [
         {
-            "task_shape": "active planned work or autopilot execution",
+            "fit_signal": "active planned work or autopilot execution",
             "skill": "planning-autopilot",
             "feature": "autopilot_loops",
             "fallback": "agentic-workspace summary --format json, then the active execplan",
         },
         {
-            "task_shape": "external issue or tracker intake",
+            "fit_signal": "external issue or tracker intake",
             "skill": "planning-intake-upstream-task",
             "feature": "external_adapters",
             "fallback": ".agentic-workspace/planning/upstream-task-intake.md plus checked-in planning state",
         },
         {
-            "task_shape": "bounded review or finding capture",
+            "fit_signal": "bounded review or finding capture",
             "skill": "planning-review-pass",
             "feature": "review_artifacts",
             "fallback": "agentic-workspace report --target ./repo --format json before selecting any review artifact",
@@ -27202,7 +27219,7 @@ def _startup_skill_routing_payload(
     if compact:
         fallback_items = payload.pop("fallback_when_skills_unavailable", [])
         payload["preferred_routes"] = [
-            {"task_shape": route["task_shape"], "skill": route["skill"]} for route in payload["preferred_routes"] if isinstance(route, dict)
+            {"fit_signal": route["fit_signal"], "skill": route["skill"]} for route in payload["preferred_routes"] if isinstance(route, dict)
         ]
         payload["fallback_when_skills_unavailable_count"] = len(fallback_items) if isinstance(fallback_items, list) else 0
         payload["fallback_detail"] = "Use AGENTS.md and compact CLI routers when skills are unavailable."
@@ -33367,7 +33384,9 @@ def _capability_resolution_for_profile(*, profile: DelegationTargetProfile, capa
         elif profile_reasoning_rank and required_rank and (profile_reasoning_rank > required_rank):
             score += 1
             reasons.append("target reasoning profile exceeds the recommended strength")
-    if profile.context_capacity == "small" and str(capability_posture.get("structural work-shape hint", "")).strip() in (
+    if profile.context_capacity == "small" and str(
+        capability_posture.get("structural scope signal", capability_posture.get("structural work-shape hint", ""))
+    ).strip() in (
         "lane",
         "epic",
     ):
@@ -33735,7 +33754,7 @@ def _downrouting_guardrail_payload(
 
 def _capability_handoff_packet_templates() -> dict[str, Any]:
     common_required = [
-        "task_shape: direct, bounded, lane, or epic",
+        "planning_context: observed scope/proof facts and the agent's selected execution frame",
         "route_reason: why this target or escalation route fits better than direct execution",
         "inspected_context: exact files, commands, or planning state already inspected",
         "allowed_write_scope: paths or surfaces the receiver may edit",
@@ -33788,6 +33807,7 @@ def _ready_capability_handoff_packet(
     packet_template = templates["packet_types"].get(packet_type, {})
     posture_detail = posture.get("posture", {}) if isinstance(posture.get("posture"), dict) else {}
     proof_factors = posture.get("proof_factors", {}) if isinstance(posture.get("proof_factors"), dict) else {}
+    scope_evidence = posture.get("scope_evidence", {}) if isinstance(posture.get("scope_evidence"), dict) else {}
     work_shape_guidance = posture.get("work_shape_guidance", {}) if isinstance(posture.get("work_shape_guidance"), dict) else {}
     return {
         "kind": "agentic-workspace/capability-handoff-packet/v1",
@@ -33795,10 +33815,24 @@ def _ready_capability_handoff_packet(
         "mode": mode,
         "target": target,
         "template": packet_template,
-        "task_shape": work_shape_guidance.get("structural_hint") or posture_detail.get("structural work-shape hint"),
+        "scope_signal": scope_evidence.get("scope_signal")
+        or work_shape_guidance.get("scope_signal")
+        or work_shape_guidance.get("structural_hint")
+        or posture_detail.get("structural scope signal")
+        or posture_detail.get("structural work-shape hint"),
         "route_reason": runtime_resolution.get("guidance"),
         "inspected_context": posture.get("inspection_evidence_required", []),
-        "proof_expectations": proof_factors.get("structural_hint") or posture_detail.get("proof factor hint"),
+        "proof_expectations": proof_factors.get("proof_pressure")
+        or proof_factors.get("structural_hint")
+        or posture_detail.get("proof pressure")
+        or posture_detail.get("proof factor hint"),
+        "authority_boundary": _authority_boundary_payload(
+            surface="capability_handoff_packet",
+            observed_by_aw=["scope_signal", "proof_pressure", "configured delegation posture"],
+            recommended_by_aw=["use packet only as bounded handoff guidance"],
+            agent_owned_decisions=["semantic task classification", "receiver fit", "completion judgment"],
+            rule="The handoff packet carries observed route evidence; AW does not classify the task shape.",
+        ),
         "allowed_write_scope": "Use the active plan or implementer-context path boundaries; do not infer broader ownership.",
         "stop_conditions": [
             "capability mismatch remains unresolved",

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2204,8 +2204,9 @@ def test_implement_command_surfaces_reasoning_heavy_execution_posture(tmp_path: 
     payload = json.loads(capsys.readouterr().out)
     posture = payload["execution_posture"]
     assert posture["capability_posture"]["posture"]["execution class"] == "boundary-shaping"
-    assert posture["capability_posture"]["work_shape_guidance"]["structural_hint"] == "bounded"
-    assert posture["capability_posture"]["proof_factors"]["structural_hint"] == "high"
+    assert posture["capability_posture"]["scope_evidence"]["scope_signal"] == "bounded"
+    assert posture["capability_posture"]["scope_evidence"]["agent_decision_required"] is True
+    assert posture["capability_posture"]["proof_factors"]["proof_pressure"] == "high"
     assert "schema" in posture["capability_posture"]["risk_flags"]
     assert "proof route" in posture["capability_posture"]["inspection_evidence_required"]
     assert posture["capability_posture"]["self_assessment_authority"] == "advisory-only"
@@ -2239,6 +2240,10 @@ def test_implement_command_surfaces_reasoning_heavy_execution_posture(tmp_path: 
     ]
     assert "active execplan" in posture["delegation_decision"]["handoff_surface"]["fallback_when_unavailable"]
     assert payload["delegation_decision"] == posture["delegation_decision"]
+    assert "work_shape_hint" not in json.dumps(posture["delegation_decision"])
+    assert "quality_factors" not in posture["delegation_decision"]
+    assert posture["delegation_decision"]["route_evidence"]["scope_signal"] == "bounded"
+    assert "semantic task classification" in posture["delegation_decision"]["route_evidence"]["rule"]
 
 
 def test_implement_auto_delegation_exposes_bounded_slice_handoff(tmp_path: Path, capsys) -> None:
@@ -2293,6 +2298,8 @@ def test_implement_auto_delegation_exposes_bounded_slice_handoff(tmp_path: Path,
     assert decision["target"] == "mini"
     assert decision["required_next_action"] == "execute-when-safe"
     assert decision["token_savings_guidance"]["signal"] == "likely"
+    assert decision["route_evidence"]["scope_signal"] == "bounded"
+    assert decision["route_evidence"]["agent_judgment_required"] is True
     effort = decision["effort_guidance"]
     assert effort["cost_posture"] == "save-tokens-where-safe"
     assert effort["orchestrator"] == "medium"

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -1104,7 +1104,8 @@ def test_report_real_init_summarizes_combined_workspace_state(tmp_path: Path, ca
     assert enclave["boundary_leaks"] == []
     assert "AGENTS.md managed workflow pointer fence only" in enclave["removability"]["would_affect"]
     assert payload["execution_shape"]["status"] == "present"
-    assert payload["execution_shape"]["task_shape"]["id"] == "direct-or-no-active-plan"
+    assert payload["execution_shape"]["planning_context"]["id"] == "direct-or-no-active-plan"
+    assert "agent owns classification" in payload["execution_shape"]["planning_context"]["authority"]
     assert payload["execution_shape"]["narrow_work_fast_path"]["status"] == "blessed"
     assert payload["execution_shape"]["recommendation"]["id"] == "stay-direct"
     assert payload["execution_shape"]["recommendation"]["consult"] == ["agentic-workspace config --target ./repo --format json"]
@@ -1341,7 +1342,7 @@ def test_report_default_profile_returns_router_before_deep_detail(tmp_path: Path
     assert "closeout_report" in context["report_profile"]["decision_grade_fields"]
     assert context["operating_posture"]["surface"] == "report"
     assert context["operating_posture"]["closeout_nudge"]["field"] == "improvement_signal_review"
-    assert context["execution_shape"]["task_shape_recommender"]["status"] == "available"
+    assert context["execution_shape"]["workflow_shape_guidance"]["status"] == "available"
     assert context["execution_shape"]["narrow_work_fast_path"]["status"] == "blessed"
     intake = context["improvement_intake"]
     assert intake["kind"] == "workspace-improvement-intake/v1"
@@ -2728,8 +2729,8 @@ def test_report_routes_roadmap_backed_work_to_planning_before_broad_execution(tm
 
     payload = json.loads(capsys.readouterr().out)
     execution_shape = payload["execution_shape"]
-    assert execution_shape["task_shape"]["id"] == "roadmap-backed-no-active-plan"
-    assert [shape["id"] for shape in execution_shape["task_shape_recommender"]["shapes"]] == [
+    assert execution_shape["planning_context"]["id"] == "roadmap-backed-no-active-plan"
+    assert [shape["id"] for shape in execution_shape["workflow_shape_guidance"]["shapes"]] == [
         "direct",
         "light-plan",
         "checked-in-execplan",
@@ -6469,7 +6470,7 @@ def test_report_surfaces_combined_execution_shape_for_planning_backed_slice(tmp_
     payload = json.loads(capsys.readouterr().out)
     execution_shape = payload["execution_shape"]
     assert execution_shape["status"] == "present"
-    assert execution_shape["task_shape"]["id"] == "planning-backed-broad-work"
+    assert execution_shape["planning_context"]["id"] == "planning-backed-broad-work"
     assert execution_shape["default_posture"]["planner_executor_pattern"] == "strong-planner-cheap-executor-available"
     assert execution_shape["default_posture"]["handoff_preference"] == "prefer-internal-when-safe"
     assert execution_shape["capability_posture"]["execution class"] == "boundary-shaping"
@@ -6478,7 +6479,7 @@ def test_report_surfaces_combined_execution_shape_for_planning_backed_slice(tmp_
     assert execution_shape["recommendation"]["best_target_fits"] == []
     assert execution_shape["current_slice"]["task_id"] == "execution-shape-slice"
     assert execution_shape["resolved_targets"] == []
-    assert "active execplan" in execution_shape["task_shape"]["summary"]
+    assert "active execplan" in execution_shape["planning_context"]["summary"]
 
 
 def test_report_surfaces_agent_efficiency_output_contract_from_repo_config(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -88,6 +88,20 @@ def _start_planning_safety_gate(payload: dict[str, object]) -> dict[str, object]
     raise KeyError("planning_safety_gate")
 
 
+def _json_keys(value: object) -> set[str]:
+    if isinstance(value, dict):
+        keys = set(value)
+        for child in value.values():
+            keys.update(_json_keys(child))
+        return keys
+    if isinstance(value, list):
+        keys: set[str] = set()
+        for child in value:
+            keys.update(_json_keys(child))
+        return keys
+    return set()
+
+
 def _start_workflow_sufficiency(payload: dict[str, object]) -> dict[str, object]:
     sufficiency = payload.get("workflow_sufficiency")
     if isinstance(sufficiency, dict):
@@ -459,6 +473,27 @@ force = "required-before-closeout"
     assert routine["categories"]["authority"]["signals"]["active_assurance_requirements"] == 1
     assert "owner_surface_inventory" not in routine
     assert "routine_work_context" in payload["drill_down"]["available_selectors"]
+
+
+def test_start_keeps_task_classification_agent_owned_for_epic_like_request(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    task = (
+        "Implement the generated CLI runtime boundary end-to-end. This is likely epic-shaped, cross-repo work; "
+        "do not collapse it to a first slice."
+    )
+
+    assert cli.main(["start", "--target", str(tmp_path), "--task", task, "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    keys = _json_keys(payload)
+    assert "task_shape" not in keys
+    assert "work_shape_hint" not in keys
+    assert "quality_factors" not in keys
+    assert "fit_signal" in keys
+    assert "choose direct, bounded, lane, or epic yourself" in payload["context"]["primary_action"]["summary"].lower()
+    sufficiency_boundary = payload["context"]["planning"]["workflow_sufficiency"]["authority_boundary"]
+    assert "semantic work shape" in sufficiency_boundary["agent_owned_decisions"]
+    assert payload["context"]["skill_routing"]["preferred_routes"][0]["fit_signal"]
 
 
 def test_start_keeps_routine_work_context_quiet_without_active_pressure(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Closes #1359.

This makes AW stop presenting semantic task-shape labels as package-owned decisions on the high-impact startup, implement, delegation, handoff, and report surfaces.

What changed:
- Startup skill routing now emits `fit_signal` instead of `task_shape` in compact/default routing.
- Implement/delegation posture now emits `scope_evidence`, `proof_factors.proof_pressure`, and `route_evidence` instead of `work_shape_hint`, `proof_factor_hint`, and `quality_factors`.
- Report execution-shape output now uses `planning_context` and `workflow_shape_guidance`, with compact authority wording that says AW reports facts and the agent owns classification.
- Capability handoff packet templates now ask for planning context and observed scope/proof facts, not an AW-owned task shape.
- Startup/implementer schemas, workspace defaults, generated Python/TypeScript payload resources, and schema reference docs were refreshed.
- Added a regression for a #1354-like epic/cross-repo request to ensure AW does not expose package-owned `task_shape`, `work_shape_hint`, or `quality_factors` keys.

## Boundary

AW still exposes hard gates, observed facts, candidate routes, proof pressure, and route evidence. The agent/human owns semantic classification, route fit, proof proportionality, and completion judgment.

Compatibility readers remain for older `task_shape` and `task_shape_recommender` payloads, and Planning's internal `execplan_profile.task_shape` terminology is left untouched because that is a separate artifact-model concern, not the runtime presentation bug fixed here.

## Dogfooding / closeout

The active #1359 execplan was closed and archived after proof. The closeout records that #1354 should remain paused until this PR lands, then the #1354 branch should be rebased onto this fix before generated-CLI work continues.

## Validation

- `uv run pytest tests/test_workspace_start_preflight_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_report_cli.py -q --tb=short` -> 267 passed
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run pytest tests/test_workspace_cli.py -q` -> 15 passed
- `make test-workspace`
- `make lint-workspace`
- `make schema-reference-docs`
