### PR TITLE
Add generated CLI migration guardrails

### DIFF
--- a/.agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json
@@ -1,0 +1,170 @@
+{
+  "kind": "planning-decomposition/v1",
+  "title": "Generated CLI single-source runtime boundary",
+  "status": "shaping",
+  "larger_intended_outcome": "Finish #1354 as an end-to-end system lane: command behavior should be generated from canonical IR and command-generation sources wherever applicable, direct runtime edits should be limited to existing primitive bugfixes or genuinely new primitive implementations, Python and TypeScript generated targets should stay current together, and any remaining hand-owned runtime primitive inventory should be explicit, small, justified, and reviewable.",
+  "parent_acceptance": {
+    "original_intent": "All runtime command behavior should be generated from IR representations as a single source of truth unless the edit is a bugfix in an existing primitive implementation or a genuinely new primitive implementation.",
+    "acceptance_target": "Runtime command behavior edits outside primitive bugfix/new primitive work are visibly suspect or rejected by proof/review gates; generated Python and TypeScript targets have symmetric freshness guarantees; accepted runtime boundaries are classified and minimized; generic generation/conformance support lives in command-generation where appropriate; closeout reports full-intent satisfaction and residual gaps honestly.",
+    "parent_proof_required": "Issue-linked lane closeouts for #1355-#1358 plus command-generation support, generated-package freshness/static proof, changed-path proof for runtime-source gates, inventory/minimization evidence, Python/TypeScript parity proof, and dogfooding report covering epic/lane/slice intent preservation.",
+    "residual_intent_rule": "Each lane closeout must state which #1354 parent acceptance target remains unsatisfied and whether parent closure is still blocked.",
+    "clarification_needed_when": "Ask or keep the parent open if a lane can only land a guard, audit, or transitional inventory without satisfying the stricter generated-from-IR end state."
+  },
+  "non_goals": [
+    "Do not claim #1354 complete from generated-output freshness alone.",
+    "Do not replace direct runtime edits with another hand-owned runtime workaround.",
+    "Do not move product-specific AW behavior into command-generation; command-generation should own only generic generator, renderer, primitive execution, freshness, and conformance machinery.",
+    "Do not close parent #1354 from wording-only changes or first-slice proof."
+  ],
+  "candidate_lanes": [
+    {
+      "id": "lane-1356-runtime-source-edit-gate",
+      "title": "Gate direct runtime-source edits",
+      "readiness": "promoted",
+      "outcome": "Generated-CLI-adjacent runtime source edits are flagged by proof/check surfaces unless they provide an explicit primitive bugfix, new primitive, or accepted/suspect generated-command behavior classification with owner, symbol, and proof.",
+      "owner_surface": ".agentic-workspace/planning/lanes/lane-1356-runtime-source-edit-gate.lane.json",
+      "proof": "Focused check/proof tests demonstrate runtime source edits require explicit primitive-edit classification and vague package-domain boundary wording is insufficient.",
+      "slice_contribution_to_parent": "Prevents agents from silently treating runtime code as a relaxed command behavior implementation surface.",
+      "residual_parent_intent": "Runtime inventory minimization, Python/TypeScript freshness parity, and command-generation ownership support still remain after this lane.",
+      "parent_proof_boundary": "slice-only",
+      "human_confirmation_needed": [],
+      "depends_on": [],
+      "parallel_with": [
+        "lane-1357-runtime-inventory-minimization"
+      ]
+    },
+    {
+      "id": "lane-1357-runtime-inventory-minimization",
+      "title": "Audit and shrink runtime primitive inventory",
+      "readiness": "promoted",
+      "outcome": "Accepted runtime boundaries are classified into reviewable owner/reason categories, whole-category acceptance is reduced or justified, and the blocker report distinguishes freshness from minimized runtime boundary status.",
+      "owner_surface": ".agentic-workspace/planning/lanes/lane-1357-runtime-inventory-minimization.lane.json",
+      "proof": "Inventory/check tests show accepted boundaries carry exact owner/reason/minimization evidence and route move-to-command-generation candidates explicitly.",
+      "slice_contribution_to_parent": "Makes remaining hand-owned runtime primitive inventory explicit, justified, and smaller or at least visibly transitional.",
+      "residual_parent_intent": "Runtime edit gates, target parity/freshness, external command-generation support, and dogfooding closeout still remain unless completed separately.",
+      "parent_proof_boundary": "slice-only",
+      "human_confirmation_needed": [],
+      "depends_on": [],
+      "parallel_with": [
+        "lane-1356-runtime-source-edit-gate"
+      ]
+    },
+    {
+      "id": "lane-1358-generated-target-parity-freshness",
+      "title": "Guarantee generated target parity and freshness",
+      "readiness": "promoted",
+      "outcome": "Relevant command-generation, IR, primitive, runtime support, and generated-package proof changes require cheap freshness/parity evidence for both Python and TypeScript generated targets.",
+      "owner_surface": ".agentic-workspace/planning/lanes/lane-1358-generated-target-parity-freshness.lane.json",
+      "proof": "Freshness/hash/check tests fail stale Python or TypeScript output after relevant source changes and remain cheap for unrelated edits.",
+      "slice_contribution_to_parent": "Prevents agents from editing Python-facing runtime/generation surfaces while leaving TypeScript stale or unproven.",
+      "residual_parent_intent": "Inventory minimization and command-generation ownership may still remain after parity proof lands.",
+      "parent_proof_boundary": "slice-only",
+      "human_confirmation_needed": [],
+      "depends_on": [
+        "lane-1356-runtime-source-edit-gate"
+      ],
+      "parallel_with": []
+    },
+    {
+      "id": "lane-command-generation-support",
+      "title": "Route generic support into command-generation",
+      "readiness": "promoted",
+      "outcome": "Any generic freshness/hash, primitive execution, target rendering, conformance, or host-manifest support needed by #1354 is implemented in rickardvh/command-generation or explicitly deferred there, while AW keeps only host-specific contracts and product primitive implementations.",
+      "owner_surface": ".agentic-workspace/planning/lanes/lane-command-generation-support.lane.json",
+      "proof": "External package tests and AW integration checks pass; any remaining AW-local wrapper policy is documented as host-specific.",
+      "slice_contribution_to_parent": "Keeps the single-source boundary from becoming another AW-local runtime workaround.",
+      "residual_parent_intent": "Parent closure remains blocked if generic support is needed but only patched locally in AW.",
+      "parent_proof_boundary": "manual-confirmation-needed",
+      "human_confirmation_needed": [
+        "Confirm whether command-generation#5 is sufficient or needs additional subissues before moving generic APIs."
+      ],
+      "depends_on": [
+        "lane-1356-runtime-source-edit-gate",
+        "lane-1357-runtime-inventory-minimization",
+        "lane-1358-generated-target-parity-freshness"
+      ],
+      "parallel_with": []
+    },
+    {
+      "id": "lane-dogfooding-intent-closeout",
+      "title": "Dogfood epic/lane/slice preservation and closeout",
+      "readiness": "promoted",
+      "outcome": "The final PR closeout reports whether AW preserved #1354 intent across epic, lane, and slice levels, names remaining parent gaps, and routes any dogfooding findings to concrete issues or fixes.",
+      "owner_surface": ".agentic-workspace/planning/lanes/lane-dogfooding-intent-closeout.lane.json",
+      "proof": "Closeout report maps each #1354 dogfooding requirement to observed evidence, fixed/routed findings, and remaining limitations.",
+      "slice_contribution_to_parent": "Prevents narrow slice completion from being misreported as full parent intent satisfaction.",
+      "residual_parent_intent": "None only if all parent acceptance targets have proof; otherwise parent #1354 stays open with explicit owner.",
+      "parent_proof_boundary": "parent-closure",
+      "human_confirmation_needed": [],
+      "depends_on": [
+        "lane-1356-runtime-source-edit-gate",
+        "lane-1357-runtime-inventory-minimization",
+        "lane-1358-generated-target-parity-freshness"
+      ],
+      "parallel_with": []
+    }
+  ],
+  "dependency_assumptions": [
+    "Runtime edit gates should land before parity/freshness proof so later changed-path proof can classify runtime edits correctly.",
+    "Runtime inventory minimization can proceed in parallel with the edit gate, but parent closeout needs both.",
+    "Command-generation package changes should be made only for generic support; host-specific AW contracts remain in this repo.",
+    "Parent #1354 closure is blocked until the dogfooding closeout maps full-intent satisfaction, not just slice completion."
+  ],
+  "parallelization_assumptions": [
+    "Runtime-source edit gating and inventory audit can be separate PRs or stacked PRs if their proof surfaces remain independent.",
+    "Freshness/parity depends on the edit gate only where changed-path proof selection consumes the gate output.",
+    "External command-generation work can be shaped after the first AW-side gates clarify what generic support is actually missing."
+  ],
+  "proof_expectations": [
+    "Every lane must run generated command package freshness/static proof when command-generation, IR, operation contracts, primitive inventories, or generated targets change.",
+    "Every runtime-source lane must run changed-path proof and demonstrate primitive-edit classification in the user-facing proof surface.",
+    "Freshness/parity work must include both Python and TypeScript generated targets and fail stale output early.",
+    "Parent closeout must include dogfooding evidence for epic/lane/slice preservation, AW terminology, residual full-intent gaps, and proof selection parity."
+  ],
+  "promotion_rule": "Promote only one ready lane at a time into a first-class lane and execplan-backed slice. A lane may close without closing #1354; parent closure requires all acceptance targets and dogfooding requirements to be satisfied or explicitly deferred with owner.",
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1354",
+      "label": "parent generated-CLI single-source boundary",
+      "role": "parent_intent"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1355",
+      "label": "fresh decomposition requirement",
+      "role": "this decomposition"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1356",
+      "label": "runtime edit gate lane",
+      "role": "implementation_lane"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1357",
+      "label": "runtime inventory minimization lane",
+      "role": "implementation_lane"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1358",
+      "label": "generated target parity/freshness lane",
+      "role": "implementation_lane"
+    },
+    {
+      "kind": "github-issue",
+      "target": "rickardvh/command-generation#5",
+      "label": "generic command-generation support",
+      "role": "external_lane"
+    },
+    {
+      "kind": "planning-review",
+      "target": ".agentic-workspace/planning/reviews/2026-06-06-issue-1354-generated-cli-single-source-boundary-grounding.review.json",
+      "label": "grounding review",
+      "role": "grounding"
+    }
+  ],
+  "notes": "Created after #1359 fixed AW task-shape ownership so #1354 could resume without dogfooding known-bad routing. This decomposition is fresh #1354 authority; the older python-generated-cli decomposition is background only."
+}

--- a/.agentic-workspace/planning/execplans/archive/command-generation-output-freshness-support.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/command-generation-output-freshness-support.plan.json
@@ -1,0 +1,305 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Use command-generation freshness support",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for Use command-generation freshness support.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Use command-generation freshness support is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Use command-generation freshness support."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Use command-generation freshness support.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "command-generation-output-freshness-support",
+      "status": "completed",
+      "next_step": "Continue via .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Use command-generation freshness support.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "activation trigger": "when the continuation owner promotes the next slice"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json."
+  },
+  "intent_interpretation": {
+    "literal request": "Use command-generation freshness support",
+    "inferred intended outcome": "Create a bounded plan for Use command-generation freshness support.",
+    "chosen concrete what": "Command-generation support lane is satisfied for generated output freshness fingerprints.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Use command-generation freshness support.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "command-generation-output-freshness-support",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Use command-generation freshness support is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Moved generic rendered-output freshness compare/count/digest mechanics into command-generation and updated AW to keep only host-specific target-family classification and policy wording.",
+    "scope touched": "../command-generation/src/command_generation/generator.py; ../command-generation/src/command_generation/__init__.py; ../command-generation/tests/test_public_api.py; pyproject.toml; uv.lock; scripts/check/check_generated_command_packages.py",
+    "changed surfaces": "command-generation public API; AW dependency pin; AW generated-package blocker report.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope respected: generic freshness/hash mechanics are command-generation-owned; AW retains host-specific classification. Parent #1354 still needs final dogfooding closeout.",
+    "proof status": "passed",
+    "intent served": "no; intent-status=partial keeps continuation explicit.",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "command-generation PR #6 opened at ae8fd35cb867db9e69e6d728219a960e458d9139; command-generation uv run pytest passed (29 tests). AW pins that commit in pyproject/uv.lock and consumes command_generation.generated_output_freshness_report; AW summary/doctor, check_generated_command_packages.py, make test-workspace, and make lint-workspace passed.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Use command-generation freshness support.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "execution_summary": {
+    "outcome delivered": "Command-generation support lane is satisfied for generated output freshness fingerprints.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "proposed durable intent": "Future agents should continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status partial.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+          "owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-06: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Use command-generation freshness support.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: command-generation PR #6 opened at ae8fd35cb867db9e69e6d728219a960e458d9139; command-generation uv run pytest passed (29 tests). AW pins that commit in pyproject/uv.lock and consumes command_generation.generated_output_freshness_report; AW summary/doctor, check_generated_command_packages.py, make test-workspace, and make lint-workspace passed.\nChanged surfaces: command-generation public API; AW dependency pin; AW generated-package blocker report.\nDurable residue: planning (.agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json)\nMemory learning: route_to_planning\nFollow-up: .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/generated-cli-boundary-dogfooding-closeout.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/generated-cli-boundary-dogfooding-closeout.plan.json
@@ -1,0 +1,311 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Close #1354 with dogfooding evidence",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for Close #1354 with dogfooding evidence.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Close #1354 with dogfooding evidence is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Close #1354 with dogfooding evidence."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Close #1354 with dogfooding evidence.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "generated-cli-boundary-dogfooding-closeout",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Close #1354 with dogfooding evidence.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Close #1354 with dogfooding evidence",
+    "inferred intended outcome": "Create a bounded plan for Close #1354 with dogfooding evidence.",
+    "chosen concrete what": "#1354 full-intent closure evidence is ready for PR review.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Close #1354 with dogfooding evidence.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "generated-cli-boundary-dogfooding-closeout",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Close #1354 with dogfooding evidence is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Completed the #1354 lane end-to-end and prepared PR closure evidence across epic, lane, and slice levels.",
+    "scope touched": "Planning decomposition/lane archives, AW checker/proof surfaces, command-generation support PR, dependency pin, tests, PR body.",
+    "changed surfaces": "AW proof/check UX; command-generation public helper; Planning closeout evidence; dogfooding issue links.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Parent #1354 closure is supportable: all planned lanes have proof; dogfooding findings were filed as #1361 and #1362; remaining limitation is that command-generation PR #6 must merge before the AW dependency pin can be merged safely.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Closure evidence: #1356 runtime-source edit gate closed; #1357 runtime inventory minimization closed; #1358 generated target parity/freshness closed; command-generation support implemented in command-generation PR #6 and pinned in AW; AW selected proof passed including summary, doctor, check_generated_command_packages.py, make test-workspace, make lint-workspace; command-generation uv run pytest passed.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Close #1354 with dogfooding evidence.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1354 full-intent closure evidence is ready for PR review.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed issue residue to GitHub PR body and dogfooding issues #1361/#1362.",
+    "motivation worth preserving": "Future agents should continue from GitHub PR body and dogfooding issues #1361/#1362 rather than rediscover this closeout residue.",
+    "canonical owner now": "GitHub PR body and dogfooding issues #1361/#1362",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "GitHub PR body and dogfooding issues #1361/#1362",
+    "proposed durable intent": "Future agents should continue from GitHub PR body and dogfooding issues #1361/#1362 rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "GitHub PR body and dogfooding issues #1361/#1362"
+  },
+  "closure_check": {
+    "closeout scope": "epic",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a epic claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      {
+        "summary": "Closeout routed issue residue to GitHub PR body and dogfooding issues #1361/#1362.",
+        "owner": "GitHub PR body and dogfooding issues #1361/#1362",
+        "source": "durable_residue"
+      }
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      {
+        "summary": "Closeout routed issue residue to GitHub PR body and dogfooding issues #1361/#1362.",
+        "owner": "GitHub PR body and dogfooding issues #1361/#1362",
+        "source": "durable_residue"
+      }
+    ],
+    "signals dismissed": [],
+    "next owner": "see routed signal owner"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-06: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "GitHub PR body and dogfooding issues #1361/#1362",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Close #1354 with dogfooding evidence.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Closure evidence: #1356 runtime-source edit gate closed; #1357 runtime inventory minimization closed; #1358 generated target parity/freshness closed; command-generation support implemented in command-generation PR #6 and pinned in AW; AW selected proof passed including summary, doctor, check_generated_command_packages.py, make test-workspace, make lint-workspace; command-generation uv run pytest passed.\nChanged surfaces: AW proof/check UX; command-generation public helper; Planning closeout evidence; dogfooding issue links.\nDurable residue: planning (GitHub PR body and dogfooding issues #1361/#1362)\nMemory learning: route_to_planning\nFollow-up: none"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/issue-1356-runtime-source-edit-gate.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1356-runtime-source-edit-gate.plan.json
@@ -1,0 +1,332 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Gate direct runtime-source edits",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1356: make direct edits to generated-CLI-adjacent runtime source visibly suspect unless explicitly classified as an existing primitive bugfix, a genuinely new primitive, or an accepted/suspect generated-command behavior boundary with owner, symbol, and proof evidence.",
+    "hard_constraints": "Do not make vague package-domain boundary wording sufficient. Do not add a new hand-owned runtime workaround. Keep this slice to proof/check/report surfaces for runtime-source edit classification; do not perform the #1357 inventory shrink or #1358 freshness parity lanes here.",
+    "agent_may_decide": "Exact payload shape and test placement, provided the user-facing proof surface distinguishes observed changed runtime paths, accepted edit reasons, rejected vague reasons, owner/symbol evidence, and residual risk.",
+    "escalate_when": "A correct gate requires command-generation package API changes, broad primitive inventory reclassification, or generated-target freshness/hash behavior outside #1356.",
+    "next_action": "Inspect generated-package proof and changed-path proof/implement surfaces, add the smallest runtime-source edit review packet and tests, then run focused and selected full proof.",
+    "proof_expectations": [
+      "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_workspace_implement_cli.py -q",
+      "uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json",
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run python scripts/run_agentic_workspace.py implement --changed <paths> --task \"Implement #1356 runtime-source edit gate\" --format json"
+    ],
+    "touched_scope": [
+      "scripts/check/check_generated_command_packages.py",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_generated_command_package_proof_runner.py",
+      "tests/test_workspace_implement_cli.py",
+      ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+      ".agentic-workspace/planning/lanes/lane-1356-runtime-source-edit-gate.lane.json",
+      ".agentic-workspace/planning/execplans/issue-1356-runtime-source-edit-gate.plan.json"
+    ],
+    "completion_criteria": [
+      "Runtime-source changed paths participating in generated CLI behavior surface a review packet with observed paths, required classification, accepted reasons, rejected vague reasons, owner/symbol/proof expectations, and residual risk.",
+      "Missing or vague runtime edit classification is visibly insufficient in proof/check output.",
+      "Focused tests cover accepted primitive bugfix/new primitive classification and rejected vague package-domain boundary wording.",
+      "Closeout states that #1356 is slice/lane progress only and parent #1354 remains open for #1357, #1358, command-generation support, and dogfooding closeout."
+    ],
+    "continuation_owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Implement #1356 so direct runtime-source edits are gated by explicit primitive-edit classification."
+  ],
+  "non_goals": [
+    "Do not implement #1357 inventory minimization, #1358 generated target parity/freshness, command-generation#5 generic support, or final #1354 parent closeout in this slice."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1356 runtime-source edit gate.",
+      "constraints": "Runtime edit proof must require concrete primitive-edit classification; vague package-domain wording is insufficient.",
+      "latitude": "Choose compact packet shape, checks, and tests within existing proof/report surfaces.",
+      "escalation": "Escalate if generic command-generation APIs or broad inventory minimization are needed.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1356-runtime-source-edit-gate",
+      "status": "completed",
+      "next_step": "Continue via .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "scripts/check/check_generated_command_packages.py",
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_generated_command_package_proof_runner.py",
+        "tests/test_workspace_implement_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "#1354 generated-CLI single-source runtime boundary.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "activation trigger": "after #1356 lane closeout"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json."
+  },
+  "intent_interpretation": {
+    "literal request": "Gate direct runtime-source edits under the generated-CLI boundary.",
+    "inferred intended outcome": "Add proof/check/report support that makes runtime-source edits require explicit primitive bugfix/new primitive/suspect generated-command classification.",
+    "chosen concrete what": "Add a compact runtime-source edit review packet to generated-package proof or changed-path proof surfaces and tests that reject vague package-domain classification.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "scripts/check/check_generated_command_packages.py, src/agentic_workspace/workspace_runtime_primitives.py, focused tests, and this lane/decomposition/execplan closeout state.",
+    "max changed files": "about 8 source/test/planning files, excluding generated artifacts only if a contract change unexpectedly requires regeneration.",
+    "required validation commands": "Focused generated-package proof tests, focused implement changed-path tests, generated-package checks, and AW implement/proof selection for changed paths.",
+    "ask-before-refactor threshold": "Ask before moving generic APIs into command-generation, changing the runtime inventory taxonomy broadly, or altering generated target freshness semantics.",
+    "stop before touching": "#1357 inventory minimization, #1358 freshness/hash parity, command-generation package code, broad runtime primitive migration, or parent #1354 closeout."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "#1354/#1356 issues, the #1354 grounding review, generated-package check script, AW implement/proof changed-path surfaces, focused tests, and this lane/execplan.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Resume by inspecting the runtime-source edit review packet/check tests and running implement --changed before closeout.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1356 runtime-source edit gate.",
+    "hard constraints": "Do not make vague package-domain boundary sufficient; do not claim parent #1354 closure.",
+    "agent may decide locally": "Packet names, field shape, and focused test placement.",
+    "escalate when": "The gate needs command-generation API changes, broad inventory minimization, or freshness parity behavior."
+  },
+  "post_decomposition_delegation": {
+    "status": "keep-local",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1356-runtime-source-edit-gate",
+    "status": "completed",
+    "scope": "Implement #1356 runtime-source edit proof gate only.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Inspect existing generated-package proof and changed-path implement/proof surfaces, then implement the smallest runtime-source edit review packet and tests."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "scripts/check/check_generated_command_packages.py",
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "tests/test_generated_command_package_proof_runner.py",
+    "tests/test_workspace_implement_cli.py",
+    ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    ".agentic-workspace/planning/lanes/lane-1356-runtime-source-edit-gate.lane.json",
+    ".agentic-workspace/planning/execplans/issue-1356-runtime-source-edit-gate.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_workspace_implement_cli.py -q",
+    "uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run python scripts/run_agentic_workspace.py implement --changed <paths> --task \"Implement #1356 runtime-source edit gate\" --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Runtime-source edit proof/check output requires explicit primitive bugfix/new primitive/suspect generated-command classification.",
+    "Vague package-domain boundary wording is rejected or marked insufficient.",
+    "Focused tests and generated-package checks pass.",
+    "Lane closeout keeps #1354 parent open for remaining lanes."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented #1356 by adding a generated-CLI runtime-source edit policy to the Python completion blocker report and a changed-path runtime_source_edit_review packet in AW implement/proof output. The packet reports observed runtime source paths, accepted primitive-edit reasons, rejected vague reasons, required evidence, and closeout rules without making AW the semantic classifier.",
+    "scope touched": "Generated-package proof report, AW changed-path proof selection/tiny implement projection, focused tests, #1354 decomposition, #1356 lane and execplan Planning state.",
+    "changed surfaces": "scripts/check/check_generated_command_packages.py; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_generated_command_package_proof_runner.py; tests/test_workspace_implement_cli.py; .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json; .agentic-workspace/planning/lanes/lane-1356-runtime-source-edit-gate.lane.json; .agentic-workspace/planning/execplans/issue-1356-runtime-source-edit-gate.plan.json; .agentic-workspace/planning/state.toml",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed inside #1356. The lane gates direct runtime-source edits but does not shrink the accepted runtime inventory or implement Python/TypeScript freshness parity; those remain explicit #1354 lanes.",
+    "proof status": "passed",
+    "intent served": "no; intent-status=partial keeps continuation explicit.",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "Focused tests passed: uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_workspace_implement_cli.py -q --tb=short (125 passed). Generated package freshness/static proof passed: uv run python scripts/generate/generate_command_packages.py --check and uv run python scripts/check/check_generated_command_packages.py. AW selected proof passed: summary, doctor, make test-workspace, make lint-workspace.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1356 so generated-CLI-adjacent runtime source edits require explicit primitive-edit classification.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1356 is satisfied as a slice/lane contribution. Parent #1354 remains open for #1357, #1358, command-generation support, and final dogfooding closeout.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "proposed durable intent": "Future agents should continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status partial.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+          "owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-06: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1356 so generated-CLI-adjacent runtime source edits require explicit primitive-edit classification.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: Focused tests passed: uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_workspace_implement_cli.py -q --tb=short (125 passed). Generated package freshness/static proof passed: uv run python scripts/generate/generate_command_packages.py --check and uv run python scripts/check/check_generated_command_packages.py. AW selected proof passed: summary, doctor, make test-workspace, make lint-workspace.\nChanged surfaces: scripts/check/check_generated_command_packages.py; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_generated_command_package_proof_runner.py; tests/test_workspace_implement_cli.py; .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json; .agentic-workspace/planning/lanes/lane-1356-runtime-source-edit-gate.lane.json; .agentic-workspace/planning/execplans/issue-1356-runtime-source-edit-gate.plan.json; .agentic-workspace/planning/state.toml\nDurable residue: planning (.agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json)\nMemory learning: route_to_planning\nFollow-up: .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/issue-1357-runtime-inventory-minimization.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1357-runtime-inventory-minimization.plan.json
@@ -1,0 +1,343 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Audit and shrink runtime primitive inventory",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1357 by making the generated-package inventory proof distinguish current/fresh generated targets from minimized runtime boundary status.",
+    "hard_constraints": "Do not relax the generated-from-IR parent intent. Do not treat whole runtime files or packages as acceptable command-behavior implementation surfaces. Keep generic generation support routed to command-generation and keep AW-owned primitive implementations exact and reviewable.",
+    "agent_may_decide": "How to summarize accepted runtime symbols, minimization status, and move-candidate routing inside existing check/proof surfaces.",
+    "escalate_when": "A correct fix requires changing command-generation APIs, adding a new runtime module, or removing a runtime primitive whose behavior is not understood.",
+    "next_action": "Inspect the runtime inventory/check implementation, add compact minimization reporting, and run focused proof.",
+    "proof_expectations": [
+      "uv run pytest tests/test_generated_command_package_proof_runner.py -q --tb=short",
+      "uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json",
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run python scripts/generate/generate_command_packages.py --check"
+    ],
+    "touched_scope": [
+      "scripts/check/check_generated_command_packages.py",
+      "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
+      "src/agentic_workspace/contracts/operation_primitives.json",
+      "tests/test_generated_command_package_proof_runner.py"
+    ],
+    "completion_criteria": [
+      "The generated-package proof distinguishes generated target freshness/completion from runtime-boundary minimization.",
+      "Accepted runtime boundaries are exact and reviewable by symbol/owner/reason rather than accepted as a whole category.",
+      "Move-to-command-generation or generated-command-behavior candidates are surfaced explicitly instead of hidden behind package-domain wording.",
+      "#1354 remains open unless later lanes satisfy parity/freshness and external command-generation support."
+    ],
+    "continuation_owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Audit and shrink runtime primitive inventory."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1357 by making accepted runtime primitive inventory minimization explicit in generated-package proof.",
+      "constraints": "Keep scope inside existing generated-package inventory/check surfaces and do not soften the parent single-source boundary.",
+      "latitude": "Choose compact status fields, exact-symbol summaries, and tests that make the remaining runtime inventory reviewable.",
+      "escalation": "Escalate if the work requires new command-generation APIs, unsafe primitive removal, or a broader generated target migration.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1357-runtime-inventory-minimization",
+      "status": "completed",
+      "next_step": "Continue via .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "scripts/check/check_generated_command_packages.py",
+        "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
+        "src/agentic_workspace/contracts/operation_primitives.json",
+        "tests/test_generated_command_package_proof_runner.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "#1354 generated-CLI single-source boundary: runtime command behavior is generated from canonical IR/command-generation wherever applicable and hand-owned primitive runtime code stays minimal, exact, and justified.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "activation trigger": "After this lane closes, promote #1358 and any command-generation support lane needed for full #1354 satisfaction."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json."
+  },
+  "intent_interpretation": {
+    "literal request": "Audit and shrink runtime primitive inventory",
+    "inferred intended outcome": "Make the remaining AW-owned primitive runtime inventory exact, justified, and visibly transitional where it should later move toward generated/command-generation support.",
+    "chosen concrete what": "Expose minimization status and exact accepted-boundary evidence in the generated-package blocker/proof report.",
+    "interpretation distance": "low",
+    "review guidance": "Check whether the report separates freshness from minimization and whether any accepted runtime boundary is still justified only by vague package-domain wording."
+  },
+  "execution_bounds": {
+    "allowed paths": "scripts/check/check_generated_command_packages.py; src/agentic_workspace/contracts/python_runtime_projection_inventory.json; src/agentic_workspace/contracts/operation_primitives.json; tests/test_generated_command_package_proof_runner.py; planning closeout artifacts for this lane.",
+    "max changed files": "About 6 files; ask before touching generated targets or command-generation in this slice.",
+    "required validation commands": "Focused generated-package proof runner tests, generated package blocker JSON check, generated package static check, and generator --check.",
+    "ask-before-refactor threshold": "Ask before moving primitives, editing generated targets directly, or adding new command-generation APIs.",
+    "stop before touching": "Generated target files, unrelated runtime primitives, broad command dispatch behavior, or TypeScript parity work reserved for #1358."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate exact accepted-boundary inventory and minimization status."
+  },
+  "context_budget": {
+    "live working set": "This execplan, #1357, the #1354 decomposition, the runtime inventory contracts, generated-package check script, and proof-runner tests.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue from #1357: expose runtime-boundary minimization status in generated-package proof without closing #1354.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Make #1357 runtime inventory minimization reviewable in generated-package proof.",
+    "hard constraints": "Do not soften the generated CLI single-source boundary or substitute package-level acceptance for exact primitive evidence.",
+    "agent may decide locally": "The compact field names and exact report layout inside existing proof surfaces.",
+    "escalate when": "The fix requires unsafe primitive removal, new command-generation support, or broader parity/freshness work."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    "#1354",
+    "#1357",
+    ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    ".agentic-workspace/planning/lanes/lane-1357-runtime-inventory-minimization.lane.json"
+  ],
+  "active_milestone": {
+    "id": "issue-1357-runtime-inventory-minimization",
+    "status": "completed",
+    "scope": "Expose exact runtime-boundary minimization evidence in generated-package proof.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Inspect the current runtime inventory metrics and add compact minimization reporting."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "scripts/check/check_generated_command_packages.py",
+    "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
+    "src/agentic_workspace/contracts/operation_primitives.json",
+    "tests/test_generated_command_package_proof_runner.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan.",
+    "Do not directly edit generated targets in this slice.",
+    "Do not claim #1354 complete from inventory reporting alone."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_generated_command_package_proof_runner.py -q --tb=short",
+    "uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run python scripts/generate/generate_command_packages.py --check"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Runtime-boundary minimization status is reported separately from generated target freshness/completion.",
+    "Accepted runtime boundaries are exact-symbol evidence with owner/reason/minimization metadata.",
+    "Generic/generated-command behavior candidates are visible and routed instead of hidden by broad package-domain acceptance.",
+    "Lane closeout keeps #1354 open for #1358 and command-generation support."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "#1357 is complete as a slice: accepted runtime boundaries are exact/inventoried and the proof report blocks minimized-inventory claims while hand-owned symbols remain.",
+    "scope touched": "scripts/check/check_generated_command_packages.py; tests/test_generated_command_package_proof_runner.py; #1357 planning surfaces",
+    "changed surfaces": "Generated-package blocker report JSON/text output and proof-runner tests.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope respected; parent #1354 remains open for #1358 parity/freshness and command-generation support.",
+    "proof status": "passed",
+    "intent served": "no; intent-status=partial keeps continuation explicit.",
+    "config compliance": "AW startup/summary/implement proof routing was used; generated package freshness check passed",
+    "misinterpretation risk": "low for this slice; parent #1354 remains open because inventory reporting does not itself generate or remove runtime behavior",
+    "follow-on decision": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "Focused generated-package proof passed: tests/test_generated_command_package_proof_runner.py 64 passed; check_generated_command_packages.py passed; generate_command_packages.py --check passed. Runtime-boundary minimization report now separates completion/freshness from minimization and reports 85 remaining accepted hand-owned symbols.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1357 by making remaining AW-owned runtime primitive inventory exact, justified, minimized where possible, and visibly separate from generated target freshness.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "execution_summary": {
+    "outcome delivered": "Runtime inventory minimization status is now distinct from generated target freshness/completion.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "proposed durable intent": "Future agents should continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status partial.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      "Planning command-owned lane activation/new-plan/close sequence left compact state needing manual projection repair during #1354 dogfooding."
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      "GitHub #1361"
+    ],
+    "signals dismissed": [],
+    "next owner": "GitHub #1361"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "GitHub #1361",
+          "owner": "",
+          "source": "improvement_signal_review.signals routed"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+          "owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": [
+        {
+          "summary": "GitHub #1361 tracks Planning mutations leaving compact state immediately usable without manual projection edits.",
+          "owner": "",
+          "source": "closeout_distillation"
+        }
+      ]
+    }
+  },
+  "drift_log": [
+    "2026-06-06: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1357 by making remaining AW-owned runtime primitive inventory exact, justified, minimized where possible, and visibly separate from generated target freshness.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: Focused generated-package proof passed: tests/test_generated_command_package_proof_runner.py 64 passed; check_generated_command_packages.py passed; generate_command_packages.py --check passed. Runtime-boundary minimization report now separates completion/freshness from minimization and reports 85 remaining accepted hand-owned symbols.\nChanged surfaces: Generated-package blocker report JSON/text output and proof-runner tests.\nDurable residue: planning (.agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json)\nMemory learning: route_to_planning\nFollow-up: .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/issue-1358-generated-target-parity-freshness.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1358-generated-target-parity-freshness.plan.json
@@ -1,0 +1,358 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Guarantee generated target parity and freshness",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1358 by making generated-target freshness proof cover both Python and TypeScript generated outputs when relevant source or generated surfaces change.",
+    "hard_constraints": "Do not directly edit generated targets as a substitute for generator output. Do not claim generated-CLI single-source satisfaction from Python-only proof. Keep the check cheap: use freshness/hash/check evidence rather than regenerating on every AW call.",
+    "agent_may_decide": "How to expose parity/freshness evidence inside existing generator/check/proof-selection surfaces.",
+    "escalate_when": "A correct fix requires new generic command-generation APIs, cross-repo changes, or broad generated target layout changes.",
+    "next_action": "Inspect generator/check freshness surfaces and add cheap Python/TypeScript parity proof.",
+    "proof_expectations": [
+      "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_workspace_implement_cli.py -q --tb=short",
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run python scripts/generate/generate_command_packages.py --check",
+      "uv run python scripts/run_agentic_workspace.py implement --changed <changed paths> --task \"Implement #1358 generated target parity and freshness\" --format json"
+    ],
+    "touched_scope": [
+      "scripts/check/check_generated_command_packages.py",
+      "scripts/generate/generate_command_packages.py",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_generated_command_package_proof_runner.py",
+      "tests/test_workspace_implement_cli.py"
+    ],
+    "completion_criteria": [
+      "Generated-package proof or proof selection exposes both Python and TypeScript generated target freshness obligations for relevant changes.",
+      "Freshness proof remains cheap and does not require regenerating on every AW call.",
+      "Stale generated outputs remain detectable by generator --check/static proof.",
+      "Parent #1354 remains open unless command-generation support and final dogfooding closeout are also satisfied."
+    ],
+    "continuation_owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Guarantee generated target parity and freshness."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1358 generated target parity/freshness proof.",
+      "constraints": "No generated-target hand edits as substitute for generator output; no Python-only generated freshness claims.",
+      "latitude": "Choose compact parity evidence and focused tests inside existing AW proof/check surfaces.",
+      "escalation": "Escalate if generic support must move to command-generation or if target generation architecture changes are needed.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1358-generated-target-parity-freshness",
+      "status": "completed",
+      "next_step": "Continue via .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "scripts/check/check_generated_command_packages.py",
+        "scripts/generate/generate_command_packages.py",
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_generated_command_package_proof_runner.py",
+        "tests/test_workspace_implement_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "#1354 generated-CLI single-source boundary across Python and TypeScript generated targets.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "activation trigger": "After this lane closes, shape/complete command-generation support and final dogfooding closeout."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json."
+  },
+  "intent_interpretation": {
+    "literal request": "Guarantee generated target parity and freshness",
+    "inferred intended outcome": "Relevant generated-CLI changes should not leave Python and TypeScript generated outputs out of sync or unproven.",
+    "chosen concrete what": "Expose parity/freshness obligations for both generated target families through existing proof/check surfaces.",
+    "interpretation distance": "low",
+    "review guidance": "Check whether the proof output can make a Python-only freshness claim, and whether TypeScript staleness remains cheaply detectable."
+  },
+  "execution_bounds": {
+    "allowed paths": "scripts/check/check_generated_command_packages.py; scripts/generate/generate_command_packages.py; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_generated_command_package_proof_runner.py; tests/test_workspace_implement_cli.py; #1358 planning surfaces.",
+    "max changed files": "About 7 files; ask before touching generated outputs or external command-generation code.",
+    "required validation commands": "Focused tests, check_generated_command_packages.py, generate_command_packages.py --check, AW changed-path implement proof selection.",
+    "ask-before-refactor threshold": "Ask before changing generated target layout, adding cross-repo command-generation APIs, or modifying generated outputs directly.",
+    "stop before touching": "Generated target files, command-generation package internals, unrelated runtime primitives, or parent closeout claims."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, #1358, #1354 decomposition, generator/check scripts, AW proof selection, and focused tests.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue #1358: add cheap Python/TypeScript generated target parity/freshness proof without editing generated targets directly.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1358 generated target parity/freshness proof.",
+    "hard constraints": "No Python-only proof claims; no direct generated-target edits as substitute for generation.",
+    "agent may decide locally": "Compact proof packet shape, tests, and integration into existing check/proof surfaces.",
+    "escalate when": "Generic support must move to command-generation or target architecture changes are needed."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    "#1354",
+    "#1358",
+    ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    ".agentic-workspace/planning/lanes/lane-1358-generated-target-parity-freshness.lane.json"
+  ],
+  "active_milestone": {
+    "id": "issue-1358-generated-target-parity-freshness",
+    "status": "completed",
+    "scope": "Add generated target parity/freshness proof across Python and TypeScript generated outputs.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Inspect generator/check freshness surfaces and add cheap parity proof."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "scripts/check/check_generated_command_packages.py",
+    "scripts/generate/generate_command_packages.py",
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "tests/test_generated_command_package_proof_runner.py",
+    "tests/test_workspace_implement_cli.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan.",
+    "Do not directly edit generated targets.",
+    "Do not claim parent #1354 complete from parity proof alone."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_workspace_implement_cli.py -q --tb=short",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run python scripts/generate/generate_command_packages.py --check",
+    "uv run python scripts/run_agentic_workspace.py implement --changed <changed paths> --task \"Implement #1358 generated target parity and freshness\" --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Proof/check output covers both Python and TypeScript generated target freshness obligations for relevant changes.",
+    "Freshness evidence is cheap and based on check/hash/proof surfaces rather than regenerating on every AW call.",
+    "Stale generated outputs remain detectable.",
+    "Parent #1354 remains open for command-generation support and final dogfooding closeout unless those are also completed."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "#1358 is complete as a slice: AW proof guidance and generated-package checker output now require/name both Python and TypeScript generated target families for freshness claims.",
+    "scope touched": "scripts/check/check_generated_command_packages.py; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_generated_command_package_proof_runner.py; tests/test_workspace_implement_cli.py; #1358 planning surfaces",
+    "changed surfaces": "AW implement generated_cli_freshness payload; generated-package blocker report JSON/text output; focused tests.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope respected; no generated targets hand-edited; parent #1354 remains open for command-generation support decision and final dogfooding closeout.",
+    "proof status": "passed",
+    "intent served": "no; intent-status=partial keeps continuation explicit.",
+    "config compliance": "AW summary/doctor/implement were used; generated package freshness/static proof and workspace tests/lint passed",
+    "misinterpretation risk": "low for #1358; parent #1354 still needs command-generation support decision and final dogfooding closeout",
+    "follow-on decision": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "Required proof passed: 64 generated-package proof-runner tests; 62 implement CLI tests; generated package blocker report showed 296 Python and 221 TypeScript generated outputs fresh; check_generated_command_packages.py passed; generate_command_packages.py --check passed; summary/doctor passed; make test-workspace and make lint-workspace passed.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1358 by ensuring relevant generated-CLI changes require or expose freshness evidence for both Python and TypeScript generated targets.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "execution_summary": {
+    "outcome delivered": "Generated target parity/freshness evidence now covers Python and TypeScript target families.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "proposed durable intent": "Future agents should continue from .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status partial.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      "Planning command-owned lane activation/new-plan/close sequence left compact state needing manual projection repair during #1354 dogfooding.",
+      "Planning summary/doctor did not validate an active lane slice schema before lane-close failed."
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      "GitHub #1361",
+      "GitHub #1362"
+    ],
+    "signals dismissed": [],
+    "next owner": "GitHub #1361 and #1362"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "GitHub #1361",
+          "owner": "",
+          "source": "improvement_signal_review.signals routed"
+        },
+        {
+          "summary": "GitHub #1362",
+          "owner": "",
+          "source": "improvement_signal_review.signals routed"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+          "owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": [
+        {
+          "summary": "GitHub #1361 tracks Planning mutations leaving compact state immediately usable without manual projection edits.",
+          "owner": "",
+          "source": "closeout_distillation"
+        },
+        {
+          "summary": "GitHub #1362 tracks Planning diagnostics validating active lane record schemas before closeout mutation time.",
+          "owner": "",
+          "source": "closeout_distillation"
+        }
+      ]
+    }
+  },
+  "drift_log": [
+    "2026-06-06: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1358 by ensuring relevant generated-CLI changes require or expose freshness evidence for both Python and TypeScript generated targets.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: Required proof passed: 64 generated-package proof-runner tests; 62 implement CLI tests; generated package blocker report showed 296 Python and 221 TypeScript generated outputs fresh; check_generated_command_packages.py passed; generate_command_packages.py --check passed; summary/doctor passed; make test-workspace and make lint-workspace passed.\nChanged surfaces: AW implement generated_cli_freshness payload; generated-package blocker report JSON/text output; focused tests.\nDurable residue: planning (.agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json)\nMemory learning: route_to_planning\nFollow-up: .agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  }
+}

--- a/.agentic-workspace/planning/lanes/archive/lane-1356-runtime-source-edit-gate.lane.json
+++ b/.agentic-workspace/planning/lanes/archive/lane-1356-runtime-source-edit-gate.lane.json
@@ -1,0 +1,66 @@
+{
+  "kind": "planning-lane/v1",
+  "id": "lane-1356-runtime-source-edit-gate",
+  "title": "Gate direct runtime-source edits",
+  "status": "archived",
+  "parent_decomposition_ref": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+  "lane_outcome": "Generated-CLI-adjacent runtime source edits are flagged by proof/check surfaces unless they provide an explicit primitive bugfix, new primitive, or accepted/suspect generated-command behavior classification with owner, symbol, and proof.",
+  "purpose_for_parent": "Prevents agents from silently treating runtime code as a relaxed command behavior implementation surface.",
+  "subsystems": [
+    "generated command package proof/checking",
+    "AW changed-path proof selection",
+    "runtime primitive/source inventory",
+    "user-facing closeout/report evidence"
+  ],
+  "technical_strategy": "Add a compact runtime-source edit review packet to generated-package proof surfaces and changed-path implement/proof output. The packet should be evidence-oriented: observed changed runtime source paths, required edit reason, accepted reasons, rejected vague reasons, owner/symbol/proof expectations, and residual risk. Keep compatibility with existing generated-package checks while making direct runtime source edits visibly suspect when classification is missing.",
+  "technology_choices": [
+    "Python check script and JSON proof payloads",
+    "existing generated-package static proof tests",
+    "existing AW implement/proof changed-path selection"
+  ],
+  "slice_sequence": [
+    {
+      "id": "direct-runtime-edit-proof-gate",
+      "title": "Add changed-path runtime edit proof gate",
+      "status": "active",
+      "execplan_ref": ".agentic-workspace/planning/execplans/issue-1356-runtime-source-edit-gate.plan.json",
+      "depends_on": [],
+      "purpose_for_lane": "Make generated-CLI-adjacent runtime source edits require explicit primitive bugfix/new primitive/suspect generated-command classification.",
+      "proof": "Focused tests plus generated-package checks demonstrate missing/vague runtime edit classification is surfaced and valid primitive reasons carry owner/symbol/proof evidence.",
+      "residual_after_slice": "Runtime inventory minimization (#1357), generated target parity/freshness (#1358), command-generation support, and final dogfooding closeout remain."
+    }
+  ],
+  "current_slice": "direct-runtime-edit-proof-gate",
+  "acceptance_boundary": "Changed-path proof or generated-package checks surface runtime-source edits with required primitive-edit classification; vague package-domain boundary wording is insufficient; user-facing closeout names any direct runtime edit boundary and residual parent #1354 gaps.",
+  "proof_strategy": "Focused check/proof tests demonstrate runtime source edits require explicit primitive-edit classification and vague package-domain boundary wording is insufficient.",
+  "proof_aggregation": {
+    "status": "partial",
+    "evidence": [
+      "#1356 proof passed: focused generated-package/implement tests (125 passed), generated package freshness/static proof, Planning summary/doctor, make test-workspace, and make lint-workspace."
+    ],
+    "known_gaps": [
+      "This lane gates direct runtime edits but does not by itself shrink the accepted runtime inventory.",
+      "This lane does not by itself guarantee Python/TypeScript generated target freshness parity.",
+      "No residual work inside #1356. Parent #1354 still requires #1357 runtime inventory minimization, #1358 Python/TypeScript freshness parity, command-generation support, and dogfooding closeout."
+    ]
+  },
+  "residual_lane_work": "No residual work inside #1356. Parent #1354 still requires #1357 runtime inventory minimization, #1358 Python/TypeScript freshness parity, command-generation support, and dogfooding closeout.",
+  "lane_to_epic_contribution": "Adds generated-CLI runtime-source edit policy and changed-path runtime_source_edit_review so direct runtime edits require explicit primitive-edit classification instead of vague package-domain wording.",
+  "parent_close_permission": "do-not-close-parent",
+  "closeout_state": {
+    "status": "blocked",
+    "summary": "Adds generated-CLI runtime-source edit policy and changed-path runtime_source_edit_review so direct runtime edits require explicit primitive-edit classification instead of vague package-domain wording.",
+    "residual_work": "No residual work inside #1356. Parent #1354 still requires #1357 runtime inventory minimization, #1358 Python/TypeScript freshness parity, command-generation support, and dogfooding closeout.",
+    "next_owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "references": [
+    {
+      "kind": "decomposition",
+      "target": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+      "label": "lane-1356-runtime-source-edit-gate",
+      "role": "parent",
+      "locator": "candidate_lanes[0]"
+    }
+  ],
+  "notes": ""
+}

--- a/.agentic-workspace/planning/lanes/archive/lane-1357-runtime-inventory-minimization.lane.json
+++ b/.agentic-workspace/planning/lanes/archive/lane-1357-runtime-inventory-minimization.lane.json
@@ -1,0 +1,64 @@
+{
+  "kind": "planning-lane/v1",
+  "id": "lane-1357-runtime-inventory-minimization",
+  "title": "Audit and shrink runtime primitive inventory",
+  "status": "archived",
+  "parent_decomposition_ref": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+  "lane_outcome": "Accepted runtime boundaries are classified into reviewable owner/reason categories, whole-category acceptance is reduced or justified, and the blocker report distinguishes freshness from minimized runtime boundary status.",
+  "purpose_for_parent": "Makes remaining hand-owned runtime primitive inventory explicit, justified, and smaller or at least visibly transitional.",
+  "subsystems": [
+    "generated command package static proof",
+    "Python runtime projection inventory",
+    "operation primitive inventory",
+    "workspace proof selection"
+  ],
+  "technical_strategy": "Use the existing generated-package inventory/check surfaces to separate freshness/completeness from runtime-boundary minimization. Keep exact accepted runtime symbols visible, attach reviewable minimization status, and route generic/generated-command behavior candidates without creating a new runtime module.",
+  "technology_choices": [
+    "Python static proof script",
+    "existing JSON inventory contracts",
+    "focused pytest coverage"
+  ],
+  "slice_sequence": [
+    {
+      "id": "runtime-inventory-minimization-proof",
+      "title": "Expose runtime boundary minimization status in generated package proof",
+      "status": "active",
+      "execplan_ref": ".agentic-workspace/planning/execplans/issue-1357-runtime-inventory-minimization.plan.json",
+      "depends_on": [],
+      "purpose_for_lane": "Make generated-package proof distinguish fresh/inventoried generated targets from minimized runtime boundaries.",
+      "proof": "Focused generated-package proof-runner tests and generated-package checks show minimization_claim_allowed remains false while accepted hand-owned runtime symbols remain.",
+      "residual_after_slice": "Generated target parity/freshness (#1358), command-generation support, and final dogfooding closeout remain for parent #1354."
+    }
+  ],
+  "current_slice": "runtime-inventory-minimization-proof",
+  "acceptance_boundary": "All lane slices have landed, lane proof aggregation is satisfied, and residual work is routed.",
+  "proof_strategy": "Inventory/check tests show accepted boundaries carry exact owner/reason/minimization evidence and route move-to-command-generation candidates explicitly.",
+  "proof_aggregation": {
+    "status": "partial",
+    "evidence": [
+      "Focused generated-package proof passed: tests/test_generated_command_package_proof_runner.py 64 passed; check_generated_command_packages.py passed; generate_command_packages.py --check passed. Runtime-boundary minimization report now separates completion/freshness from minimization and reports 85 remaining accepted hand-owned symbols."
+    ],
+    "known_gaps": [
+      "No residual work inside #1357. Parent #1354 still requires #1358 generated target parity/freshness and command-generation support shaping."
+    ]
+  },
+  "residual_lane_work": "No residual work inside #1357. Parent #1354 still requires #1358 generated target parity/freshness and command-generation support shaping.",
+  "lane_to_epic_contribution": "Makes remaining hand-owned runtime primitive inventory exact/inventoried and blocks minimized-inventory claims while accepted runtime symbols remain.",
+  "parent_close_permission": "do-not-close-parent",
+  "closeout_state": {
+    "status": "blocked",
+    "summary": "Makes remaining hand-owned runtime primitive inventory exact/inventoried and blocks minimized-inventory claims while accepted runtime symbols remain.",
+    "residual_work": "No residual work inside #1357. Parent #1354 still requires #1358 generated target parity/freshness and command-generation support shaping.",
+    "next_owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "references": [
+    {
+      "kind": "decomposition",
+      "target": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+      "label": "lane-1357-runtime-inventory-minimization",
+      "role": "parent",
+      "locator": "candidate_lanes[1]"
+    }
+  ],
+  "notes": ""
+}

--- a/.agentic-workspace/planning/lanes/archive/lane-1358-generated-target-parity-freshness.lane.json
+++ b/.agentic-workspace/planning/lanes/archive/lane-1358-generated-target-parity-freshness.lane.json
@@ -1,0 +1,65 @@
+{
+  "kind": "planning-lane/v1",
+  "id": "lane-1358-generated-target-parity-freshness",
+  "title": "Guarantee generated target parity and freshness",
+  "status": "archived",
+  "parent_decomposition_ref": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+  "lane_outcome": "Relevant command-generation, IR, primitive, runtime support, and generated-package proof changes require cheap freshness/parity evidence for both Python and TypeScript generated targets.",
+  "purpose_for_parent": "Prevents agents from editing Python-facing runtime/generation surfaces while leaving TypeScript stale or unproven.",
+  "subsystems": [
+    "generated command package generator",
+    "generated package static proof",
+    "Python generated targets",
+    "TypeScript generated targets",
+    "AW changed-path proof selection"
+  ],
+  "technical_strategy": "Add cheap generated-target freshness evidence that covers both Python and TypeScript outputs. Prefer a manifest/hash or existing generator --check integration over regenerating on every call, and make proof selection surface parity obligations whenever relevant source or generated target paths change.",
+  "technology_choices": [
+    "existing generator --check command",
+    "static generated-package proof script",
+    "focused pytest coverage"
+  ],
+  "slice_sequence": [
+    {
+      "id": "generated-target-parity-freshness-proof",
+      "title": "Require Python and TypeScript generated target freshness proof",
+      "status": "active",
+      "execplan_ref": ".agentic-workspace/planning/execplans/issue-1358-generated-target-parity-freshness.plan.json",
+      "depends_on": [],
+      "purpose_for_lane": "Prevent source/runtime/generator edits from proving only Python generated output while leaving TypeScript stale or unmentioned.",
+      "proof": "Focused tests and generated-package checks demonstrate stale generated targets are detected cheaply and proof guidance names both Python and TypeScript targets.",
+      "residual_after_slice": "Command-generation support and final #1354 dogfooding closeout remain unless this slice proves no external generic support is needed."
+    }
+  ],
+  "current_slice": "generated-target-parity-freshness-proof",
+  "acceptance_boundary": "All lane slices have landed, lane proof aggregation is satisfied, and residual work is routed.",
+  "proof_strategy": "Freshness/hash/check tests fail stale Python or TypeScript output after relevant source changes and remain cheap for unrelated edits.",
+  "proof_aggregation": {
+    "status": "partial",
+    "evidence": [
+      "Required proof passed: 64 generated-package proof-runner tests; 62 implement CLI tests; generated package blocker report showed 296 Python and 221 TypeScript generated outputs fresh; check_generated_command_packages.py passed; generate_command_packages.py --check passed; summary/doctor passed; make test-workspace and make lint-workspace passed."
+    ],
+    "known_gaps": [
+      "No residual work inside #1358. Parent #1354 still requires command-generation support decision and final dogfooding closeout."
+    ]
+  },
+  "residual_lane_work": "No residual work inside #1358. Parent #1354 still requires command-generation support decision and final dogfooding closeout.",
+  "lane_to_epic_contribution": "Prevents Python-only generated freshness claims by making AW proof guidance and generated-package checker output name both Python and TypeScript generated target families.",
+  "parent_close_permission": "do-not-close-parent",
+  "closeout_state": {
+    "status": "blocked",
+    "summary": "Prevents Python-only generated freshness claims by making AW proof guidance and generated-package checker output name both Python and TypeScript generated target families.",
+    "residual_work": "No residual work inside #1358. Parent #1354 still requires command-generation support decision and final dogfooding closeout.",
+    "next_owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "references": [
+    {
+      "kind": "decomposition",
+      "target": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+      "label": "lane-1358-generated-target-parity-freshness",
+      "role": "parent",
+      "locator": "candidate_lanes[2]"
+    }
+  ],
+  "notes": ""
+}

--- a/.agentic-workspace/planning/lanes/archive/lane-command-generation-support.lane.json
+++ b/.agentic-workspace/planning/lanes/archive/lane-command-generation-support.lane.json
@@ -1,0 +1,63 @@
+{
+  "kind": "planning-lane/v1",
+  "id": "lane-command-generation-support",
+  "title": "Route generic support into command-generation",
+  "status": "archived",
+  "parent_decomposition_ref": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+  "lane_outcome": "Any generic freshness/hash, primitive execution, target rendering, conformance, or host-manifest support needed by #1354 is implemented in rickardvh/command-generation or explicitly deferred there, while AW keeps only host-specific contracts and product primitive implementations.",
+  "purpose_for_parent": "Keeps the single-source boundary from becoming another AW-local runtime workaround.",
+  "subsystems": [
+    "command-generation public API",
+    "AW generated-package checker",
+    "AW dependency pin"
+  ],
+  "technical_strategy": "Move generic rendered-output freshness compare/count/digest mechanics into command-generation, while AW keeps only host-specific target-family classification and policy wording.",
+  "technology_choices": [
+    "command_generation.generated_output_freshness_report",
+    "AW git dependency pin",
+    "focused command-generation and AW tests"
+  ],
+  "slice_sequence": [
+    {
+      "id": "generated-output-freshness-api",
+      "title": "Add and consume generic generated output freshness support",
+      "status": "active",
+      "execplan_ref": ".agentic-workspace/planning/execplans/command-generation-output-freshness-support.plan.json",
+      "depends_on": [],
+      "purpose_for_lane": "Ensure generic freshness/hash mechanics live in command-generation instead of AW-local checker code.",
+      "proof": "command-generation `uv run pytest` passed; AW focused/generated/workspace proof passed against the pinned command-generation commit.",
+      "residual_after_slice": "Final dogfooding intent closeout remains for parent #1354."
+    }
+  ],
+  "current_slice": "generated-output-freshness-api",
+  "acceptance_boundary": "All lane slices have landed, lane proof aggregation is satisfied, and residual work is routed.",
+  "proof_strategy": "External package tests and AW integration checks pass; any remaining AW-local wrapper policy is documented as host-specific.",
+  "proof_aggregation": {
+    "status": "partial",
+    "evidence": [
+      "command-generation PR #6 opened at ae8fd35cb867db9e69e6d728219a960e458d9139 with uv run pytest passing; AW pins the commit and full selected AW proof passed."
+    ],
+    "known_gaps": [
+      "No residual command-generation support work discovered for this PR. Final dogfooding intent closeout remains for parent #1354."
+    ]
+  },
+  "residual_lane_work": "No residual command-generation support work discovered for this PR. Final dogfooding intent closeout remains for parent #1354.",
+  "lane_to_epic_contribution": "Moves generic generated-output freshness compare/count/digest mechanics into command-generation while AW keeps host-specific target family classification and policy.",
+  "parent_close_permission": "do-not-close-parent",
+  "closeout_state": {
+    "status": "blocked",
+    "summary": "Moves generic generated-output freshness compare/count/digest mechanics into command-generation while AW keeps host-specific target family classification and policy.",
+    "residual_work": "No residual command-generation support work discovered for this PR. Final dogfooding intent closeout remains for parent #1354.",
+    "next_owner": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json"
+  },
+  "references": [
+    {
+      "kind": "decomposition",
+      "target": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+      "label": "lane-command-generation-support",
+      "role": "parent",
+      "locator": "candidate_lanes[3]"
+    }
+  ],
+  "notes": ""
+}

--- a/.agentic-workspace/planning/lanes/archive/lane-dogfooding-intent-closeout.lane.json
+++ b/.agentic-workspace/planning/lanes/archive/lane-dogfooding-intent-closeout.lane.json
@@ -1,0 +1,63 @@
+{
+  "kind": "planning-lane/v1",
+  "id": "lane-dogfooding-intent-closeout",
+  "title": "Dogfood epic/lane/slice preservation and closeout",
+  "status": "archived",
+  "parent_decomposition_ref": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+  "lane_outcome": "The final PR closeout reports whether AW preserved #1354 intent across epic, lane, and slice levels, names remaining parent gaps, and routes any dogfooding findings to concrete issues or fixes.",
+  "purpose_for_parent": "Prevents narrow slice completion from being misreported as full parent intent satisfaction.",
+  "subsystems": [
+    "Planning closeout evidence",
+    "GitHub PR body",
+    "dogfooding follow-up issues"
+  ],
+  "technical_strategy": "Aggregate lane evidence from #1356, #1357, #1358, and command-generation support into the PR closeout. Close parent #1354 only if every acceptance target has proof or a non-blocking limitation with owner.",
+  "technology_choices": [
+    "GitHub PR body closure matrix",
+    "Planning lane archives",
+    "dogfooding issue links"
+  ],
+  "slice_sequence": [
+    {
+      "id": "parent-closeout-matrix",
+      "title": "Write parent closure and dogfooding matrix",
+      "status": "active",
+      "execplan_ref": ".agentic-workspace/planning/execplans/generated-cli-boundary-dogfooding-closeout.plan.json",
+      "depends_on": [],
+      "purpose_for_lane": "Make #1354 closure evidence explicit across epic/lane/slice work and dogfooding findings.",
+      "proof": "PR body maps each issue/lane to proof, names command-generation PR #6, and records dogfooding issues #1361/#1362.",
+      "residual_after_slice": "None if parent #1354 closure is honestly supportable."
+    }
+  ],
+  "current_slice": "parent-closeout-matrix",
+  "acceptance_boundary": "All lane slices have landed, lane proof aggregation is satisfied, and residual work is routed.",
+  "proof_strategy": "Closeout report maps each #1354 dogfooding requirement to observed evidence, fixed/routed findings, and remaining limitations.",
+  "proof_aggregation": {
+    "status": "partial",
+    "evidence": [
+      "Parent closeout evidence recorded in archived execplan generated-cli-boundary-dogfooding-closeout: #1356 runtime-source edit gate, #1357 runtime inventory minimization, #1358 generated target parity/freshness, command-generation PR #6 support and AW pin, selected AW proof, and dogfooding issues #1361/#1362."
+    ],
+    "known_gaps": [
+      "No remaining lane work. Merge ordering limitation: command-generation PR #6 must land before the AW dependency pin can merge safely."
+    ]
+  },
+  "residual_lane_work": "No remaining lane work. Merge ordering limitation: command-generation PR #6 must land before the AW dependency pin can merge safely.",
+  "lane_to_epic_contribution": "This lane aggregates the #1354 epic evidence across decomposition lanes, explicit child issue proof, command-generation support, and dogfooding findings so parent closure can be reviewed honestly.",
+  "parent_close_permission": "may-close-parent",
+  "closeout_state": {
+    "status": "blocked",
+    "summary": "This lane aggregates the #1354 epic evidence across decomposition lanes, explicit child issue proof, command-generation support, and dogfooding findings so parent closure can be reviewed honestly.",
+    "residual_work": "No remaining lane work. Merge ordering limitation: command-generation PR #6 must land before the AW dependency pin can merge safely.",
+    "next_owner": "PR reviewer; command-generation PR #6 merge ordering"
+  },
+  "references": [
+    {
+      "kind": "decomposition",
+      "target": ".agentic-workspace/planning/decompositions/generated-cli-single-source-boundary.decomposition.json",
+      "label": "lane-dogfooding-intent-closeout",
+      "role": "parent",
+      "locator": "candidate_lanes[4]"
+    }
+  ],
+  "notes": ""
+}

--- a/.agentic-workspace/planning/reviews/2026-06-06-issue-1354-generated-cli-single-source-boundary-grounding.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-06-issue-1354-generated-cli-single-source-boundary-grounding.review.json
@@ -1,0 +1,233 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Generated CLI single-source runtime boundary grounding",
+  "date": "2026-06-06",
+  "scope": [
+    "#1354 generated CLI single-source-of-truth runtime boundary",
+    "Agentic Workspace generated command packages",
+    "sibling rickardvh/command-generation checkout at 5fdfcf6",
+    "current generated-package freshness, proof, primitive, and runtime-boundary checks"
+  ],
+  "classification": "generated-cli-runtime-boundary-investigation",
+  "goal": [
+    "Promote #1354 to implementation-ready without collapsing the full generated-CLI intent to a first slice.",
+    "Identify which work belongs in Agentic Workspace versus command-generation.",
+    "Create implementation issues for the required lanes and dogfooding gaps."
+  ],
+  "non_goals": [
+    "Do not implement the generated-CLI boundary changes in this review.",
+    "Do not declare the full intent satisfied because existing checks say the Python completion gate is satisfied.",
+    "Do not add new hand-owned runtime behavior as a shortcut around command generation.",
+    "Do not require every command behavior to become portable before the inventory is audited and decomposed."
+  ],
+  "review_mode": {
+    "mode": "grounding-review",
+    "promotion_decision": "implementation-ready after subissues are created and linked to #1354",
+    "authority_boundary": "AW can enforce declared generated-output freshness, exact inventories, and explicit proof/check gates. The agent and human own semantic judgment about whether a runtime implementation is a genuine primitive, a bugfix, generated-command behavior, or acceptable transitional debt.",
+    "issue_refs": [
+      "#1354"
+    ]
+  },
+  "review_method": {
+    "commands used": [
+      "uv run python scripts/run_agentic_workspace.py start --task \"Ground #1354 generated-CLI single-source-of-truth runtime boundary and create subissues where necessary\" --format json",
+      "gh issue view 1354 --json number,title,body,url,labels,state",
+      "git checkout master",
+      "git pull --ff-only",
+      "git checkout -b codex/generated-cli-single-source-boundary",
+      "rg --files packages scripts generated tests .agentic-workspace | rg \"command|generated|runtime|primitive|conformance|check_generated|generate_command|workspace_runtime|cli|IR|ir|schema\"",
+      "rg -n \"runtime primitive|runtime_primitives|GENERATED_COMMAND|generated command|single source|command-generation|command_generation|IR|generated package|TypeScript|typescript|Python\" ...",
+      "uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json",
+      "uv run python scripts/generate/generate_command_packages.py --check",
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "git -C ../command-generation status --short --branch",
+      "git -C ../command-generation log --oneline -5",
+      "rg --files ../command-generation",
+      "rg -n \"typescript|python|primitive|runtime|host_manifest|hash|fingerprint|check\" ../command-generation/src ../command-generation/tests ../command-generation/schemas/command_package_ir.schema.json",
+      "uv run python scripts/run_agentic_workspace.py planning create-review --slug issue-1354-generated-cli-single-source-boundary-grounding --title \"Generated CLI single-source runtime boundary grounding\" --scope \"#1354 generated CLI single-source-of-truth runtime boundary\" --classification generated-cli-runtime-boundary-investigation --target . --format json"
+    ],
+    "evidence sources": [
+      "https://github.com/rickardvh/agentic-workspace/issues/1354",
+      "pyproject.toml",
+      "scripts/generate/workspace_command_generation.py",
+      "scripts/check/check_generated_command_packages.py",
+      "src/agentic_workspace/contracts/command_package_ir.json",
+      "src/agentic_workspace/contracts/operation_primitives.json",
+      "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
+      ".agentic-workspace/verification/manifest.toml",
+      ".agentic-workspace/planning/decompositions/command-generation-extraction-epic.decomposition.json",
+      "../command-generation/README.md",
+      "../command-generation/src/command_generation/generator.py",
+      "../command-generation/src/command_generation/primitive_executor.py",
+      "../command-generation/src/command_generation/primitive_registry.py",
+      "../command-generation/src/command_generation/host_manifest.py",
+      "../command-generation/tests/test_public_api.py",
+      "../command-generation/tests/test_primitive_executor.py"
+    ]
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1354",
+      "label": "parent generated-CLI runtime boundary intent",
+      "role": "parent_intent",
+      "locator": "issue"
+    },
+    {
+      "kind": "local-check",
+      "target": "uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json",
+      "label": "current Python completion blocker state",
+      "role": "evidence",
+      "locator": "command"
+    },
+    {
+      "kind": "external-repo",
+      "target": "../command-generation",
+      "label": "command-generation package checkout",
+      "role": "canonical_generic_generator_candidate",
+      "locator": "path"
+    }
+  ],
+  "findings": [
+    {
+      "title": "F1: Current proof says Python completion is satisfied while accepting a large runtime-boundary inventory.",
+      "summary": "The current blocker report has zero blockers and permits the full-generated-cli-complete claim, but the accepted runtime boundary inventory still contains 85 accepted source-symbol boundaries across workspace, planning, memory, and verification.",
+      "evidence": "check_generated_command_packages.py --python-completion-blockers reports completion_claim_allowed=true, blocker_count=0, accepted_runtime_symbol_count=85, operation-function-call=26, runtime-facade-call=59, and package-specific-judgment=46.",
+      "risk if unchanged": "Agents can truthfully cite the current check while still missing the stricter #1354 intent: minimize AW-owned runtime implementations and reject casual runtime edits outside primitive bugfix/new primitive work.",
+      "suggested action": "Create an implementation lane to audit, classify, shrink, and gate accepted runtime boundaries instead of treating exact-symbol inventory alone as sufficient.",
+      "confidence": "high",
+      "source": "#1354; scripts/check/check_generated_command_packages.py; src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
+      "promotion target": "implementation issue: audit and shrink accepted runtime primitive inventory",
+      "promotion trigger": "before any closeout that claims the full #1354 boundary is satisfied"
+    },
+    {
+      "title": "F2: The policy text is stricter than the active edit/proof boundary.",
+      "summary": "command_package_ir.json already says command/interface truth belongs in contracts and generated target files are derived, and that runtime primitives stay hand-owned only as explicit debt. The active workflow does not yet require a direct runtime-source edit reason of primitive bugfix or new primitive.",
+      "evidence": "The issue explicitly allows direct runtime edits only for existing primitive bugfix or genuinely new primitive. Current checks inventory accepted boundaries but do not make every edit to runtime primitive source prove one of those two reasons or fail as suspected generated-command behavior.",
+      "risk if unchanged": "Agents can keep editing runtime modules under the broad label of package-domain boundary, which is the recurring under-interpretation that #1354 is meant to prevent.",
+      "suggested action": "Add changed-path proof/review gating for runtime source paths that requires explicit primitive-edit classification, owner, evidence, and tests; broad phrases such as package-domain boundary should not satisfy the gate by themselves.",
+      "confidence": "high",
+      "source": "#1354; src/agentic_workspace/contracts/command_package_ir.json; scripts/check/check_generated_command_packages.py",
+      "promotion target": "implementation issue: tighten runtime-source edit gates",
+      "promotion trigger": "first implementation slice touching runtime primitive, generated command, generator, or proof surfaces"
+    },
+    {
+      "title": "F3: Generated-output freshness exists, but parity guarantees need to be explicit across Python and TypeScript source changes.",
+      "summary": "generate_command_packages.py --check and check_generated_command_packages.py currently pass and cover generated package freshness. Verification rules already name TypeScript proof lanes, but #1354 needs an explicit cheap hash/freshness workflow that agents cannot skip after relevant source changes, including external command-generation changes.",
+      "evidence": "AW has scripts/generate/workspace_command_generation.py, generated Python and TypeScript targets, .agentic-workspace/verification/manifest.toml generated TypeScript checks, and command-generation render/check APIs. The proof-selection boundary must still explicitly map IR/generator/operation primitive/runtime-support changes to both generated targets and stale-output failure.",
+      "risk if unchanged": "An agent can edit Python runtime primitives or host generation policy, run a local Python-focused check, and leave TypeScript generated targets stale or unproven.",
+      "suggested action": "Add a parity/freshness lane that records source-to-generated fingerprints or equivalent check evidence and makes changed-path proof require Python and TypeScript generated target freshness when command-generation, IR, primitive registry, operation contracts, or runtime support changes.",
+      "confidence": "medium-high",
+      "source": "scripts/generate/workspace_command_generation.py; .agentic-workspace/verification/manifest.toml; command-generation render_outputs/generate_command_packages",
+      "promotion target": "implementation issue: guarantee Python/TypeScript generated target parity and freshness",
+      "promotion trigger": "before generated CLI work can claim both targets are equally current"
+    },
+    {
+      "title": "F4: Some ownership belongs in the external command-generation package, but AW still has host-specific wrapper policy.",
+      "summary": "The command-generation package owns generic rendering, schema loading, primitive registry validation, and portable primitive execution helpers. AW owns product-specific contracts and host manifest assembly. Some #1354 work must land in command-generation if generic primitive execution, target rendering, or freshness/hash APIs are missing.",
+      "evidence": "command-generation README states hosts keep product-specific contracts and primitive implementations while the package owns generic generation and portable primitive execution. AW scripts/generate/workspace_command_generation.py still seeds AW-specific primitive ids and special-cases typescript.domain.execute in host manifest assembly.",
+      "risk if unchanged": "AW may keep growing product-local generator/check work that should be package-owned, weakening the single-source boundary and making cross-target parity depend on AW-specific scripts.",
+      "suggested action": "Create a command-generation issue for generic API/support needed by #1354, and keep AW implementation issues explicit about what remains host-specific.",
+      "confidence": "high",
+      "source": "../command-generation/README.md; ../command-generation/src/command_generation/*; scripts/generate/workspace_command_generation.py",
+      "promotion target": "external implementation issue in rickardvh/command-generation plus AW integration issue",
+      "promotion trigger": "before moving generic runtime, generator, fingerprint, or primitive-conformance behavior"
+    },
+    {
+      "title": "F5: The closed command-generation extraction decomposition is related but insufficient.",
+      "summary": "The existing closed extraction decomposition established command-generation as an independent package while leaving AW host command meaning, generated outputs, and domain primitives in AW. #1354 is stricter and asks whether runtime command behavior edits are still too relaxed.",
+      "evidence": ".agentic-workspace/planning/decompositions/command-generation-extraction-epic.decomposition.json is closed and centers on extraction readiness, no product imports, and package boundaries. #1354 adds runtime edit reasons, minimization of AW-owned primitives, equal Python/TypeScript freshness, and full-intent preservation.",
+      "risk if unchanged": "Implementation may reuse the old closed decomposition and accidentally treat extraction-complete as single-source-boundary-complete.",
+      "suggested action": "Create a fresh decomposition for #1354 with lanes for boundary inventory, edit gates, parity/freshness, command-generation ownership, and AW dogfooding/intent preservation.",
+      "confidence": "high",
+      "source": ".agentic-workspace/planning/decompositions/command-generation-extraction-epic.decomposition.json; #1354",
+      "promotion target": "implementation issue: decomposition and execplans for #1354",
+      "promotion trigger": "before broad implementation starts"
+    },
+    {
+      "title": "F6: Dogfooding found AW under-escalated explicit epic-shaped cross-repo work.",
+      "summary": "Despite #1354 saying the work is likely epic-shaped and may span command-generation, startup guidance still routed the task as bounded/downroute instead of requiring decomposition or a strong shaper escalation.",
+      "evidence": "The start call for grounding #1354 produced a low-tier/downroute shape even after the issue body said this should not be silently collapsed to a first slice and expected grounding review, decomposition, lanes, and execplans.",
+      "risk if unchanged": "AW continues to preserve narrow immediate action while failing the higher-level user intent satisfaction that motivated #1354.",
+      "suggested action": "Create a dogfooding issue to make explicit epic-shaped, cross-repo, or full-intent preservation signals prompt decomposition/shaper escalation instead of bounded implementation routing.",
+      "confidence": "medium-high",
+      "source": "dogfooding during this review lane; #1354 body",
+      "promotion target": "implementation issue: epic/cross-repo shaping escalation",
+      "promotion trigger": "before claiming AW dogfooding obligations were met for #1354"
+    }
+  ],
+  "recommendation": {
+    "promote": "Yes. Promote #1354 to implementation via subissues. The first implementation step should be decomposition/execplans, not code changes.",
+    "defer": "Do not defer the full lane as wording-only. Defer only exact primitive migrations that require command-generation API changes until the external package issue is shaped.",
+    "dismiss": "Do not dismiss the concern because existing generated-package checks pass; those checks prove current policy, not the stricter user intent."
+  },
+  "issue_classifications": [
+    {
+      "owner_repo": "rickardvh/agentic-workspace",
+      "title": "Decompose #1354 generated-CLI runtime boundary into lanes and execplan-backed slices",
+      "reason": "The parent is epic-shaped and must preserve full intent before implementation starts.",
+      "promoted_issue": "#1355"
+    },
+    {
+      "owner_repo": "rickardvh/agentic-workspace",
+      "title": "Gate direct runtime-source edits under the generated-CLI boundary",
+      "reason": "Runtime source edits need explicit primitive bugfix or new primitive evidence, not vague package-domain boundary wording.",
+      "promoted_issue": "#1356"
+    },
+    {
+      "owner_repo": "rickardvh/agentic-workspace",
+      "title": "Audit and shrink accepted runtime primitive inventory for generated CLI completion",
+      "reason": "The current completion proof accepts 85 boundaries and needs stricter classification, minimization, and reviewable residue.",
+      "promoted_issue": "#1357"
+    },
+    {
+      "owner_repo": "rickardvh/agentic-workspace",
+      "title": "Guarantee Python and TypeScript generated target parity and freshness",
+      "reason": "Relevant source changes must prove both generated targets are current through cheap freshness or hash checks.",
+      "promoted_issue": "#1358"
+    },
+    {
+      "owner_repo": "rickardvh/command-generation",
+      "title": "Support generated-CLI single-source boundary needs from AW #1354",
+      "reason": "Generic generator, primitive, conformance, or freshness capabilities should live in command-generation rather than AW host runtime.",
+      "promoted_issue": "rickardvh/command-generation#5"
+    },
+    {
+      "owner_repo": "rickardvh/agentic-workspace",
+      "title": "Escalate explicit epic-shaped or cross-repo work before bounded implementation routing",
+      "reason": "Dogfooding showed AW under-escalated #1354 even though the parent issue explicitly required epic/lane/slice preservation.",
+      "promoted_issue": "#1359"
+    },
+    {
+      "kind": "dogfooding-finding",
+      "finding": "AW did not force decomposition for #1354 despite explicit epic-shaped language.",
+      "action": "Promoted to #1359 for shaping escalation."
+    },
+    {
+      "kind": "dogfooding-finding",
+      "finding": "The phrase package-domain boundary remains too easy for an agent to cite without explaining whether the edit is a primitive bugfix, new primitive, generated-command behavior, or accepted transitional debt.",
+      "action": "Promoted to #1356 and #1357."
+    },
+    {
+      "kind": "dogfooding-finding",
+      "finding": "Current proof surfaces are good at freshness and exact-symbol checking, but the user-facing intent gap is whether accepted boundaries are still too broad.",
+      "action": "Promoted to #1357 and #1358."
+    }
+  ],
+  "validation_commands": [
+    "uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json (passed under current policy; important evidence is zero blockers plus 85 accepted runtime symbols)",
+    "uv run python scripts/generate/generate_command_packages.py --check (passed; generated outputs are fresh under current generator inputs)",
+    "uv run python scripts/check/check_generated_command_packages.py (passed; static generated command package checks pass under current policy)",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json (passed)",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json (initially reported schema drift; fixed by moving data into schema-allowed fields)"
+  ],
+  "retention": {
+    "closeout shape": "retain until subissues are implemented or superseded",
+    "trigger": "all promoted issues have implementation PRs or are explicitly rejected by the user",
+    "proof surface": "linked GitHub issues, PR closeout, generated-package checks, command-generation package issues"
+  },
+  "drift_log": [
+    "2026-06-06: Review record created by create-review.",
+    "2026-06-06: Grounding review filled after inspecting AW generated-package checks and sibling command-generation package."
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
 package = true
 
 [tool.uv.sources]
-command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "5fdfcf6f84ae398f4cebfdb7899f762bb2550f1b" }
+command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "ae8fd35cb867db9e69e6d728219a960e458d9139" }
 agentic-memory = { workspace = true }
 agentic-planning = { workspace = true }
 agentic-verification = { workspace = true }

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -30,7 +30,13 @@ for SOURCE_ROOT in (
         sys.path.insert(0, str(SOURCE_ROOT))
 
 import command_generation  # noqa: E402
-from command_generation import CommandGenerationHostManifest, PrimitiveRegistry, command_package_schema_path, render_outputs  # noqa: E402
+from command_generation import (  # noqa: E402
+    CommandGenerationHostManifest,
+    PrimitiveRegistry,
+    command_package_schema_path,
+    generated_output_freshness_report,
+    render_outputs,
+)
 from command_generation.generated_package_loader import (  # noqa: E402
     load_generated_command_module_for_entrypoint,
     load_generated_command_package_for_entrypoint,
@@ -130,6 +136,21 @@ PYTHON_OPERATION_ACCEPTED_BOUNDARY_CLASSES = {
     "provider-integration",
 }
 PYTHON_OPERATION_FULL_COMPLETION_BLOCKING_BOUNDARY_CLASSES = {"generic-deterministic-runtime-debt"}
+PYTHON_RUNTIME_BOUNDARY_MINIMIZATION_ROUTES = {
+    "front-door-dispatch": "candidate-route: reduce by generated dispatcher support only when the dispatch semantics are contract-stable.",
+    "generic-deterministic-runtime-debt": "move-to-command-generation: generic deterministic command behavior must not remain an accepted runtime boundary.",
+    "live-workspace-inspection": "hand-owned: live repository inspection remains a package/runtime primitive until a stable IR contract exists.",
+    "mutation-orchestration": "hand-owned: mutation, safety, conflict, and provenance policy remains a package/runtime primitive until safely decomposed.",
+    "package-specific-judgment": "hand-owned: semantic package judgment remains a package/runtime primitive unless a smaller stable contract emerges.",
+    "provider-integration": "hand-owned: provider or subprocess integration remains an adapter/runtime primitive unless generic provider support is defined.",
+}
+PYTHON_RUNTIME_BOUNDARY_MINIMIZATION_HAND_OWNED_CLASSES = {
+    "front-door-dispatch",
+    "live-workspace-inspection",
+    "mutation-orchestration",
+    "package-specific-judgment",
+    "provider-integration",
+}
 PYTHON_OUTPUT_BOUNDARY_AUDIT_REQUIRED_PHRASES = (
     "generated-owned output coverage:",
     "accepted source fallback:",
@@ -192,6 +213,19 @@ PYTHON_FULL_COMPLETION_BLOCKING_RUNTIME_SOURCE_PATHS = (
     "packages/memory/src/repo_memory_bootstrap/runtime_search.py",
     "packages/memory/src/repo_memory_bootstrap/runtime_primitives.py",
     "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py",
+)
+RUNTIME_SOURCE_EDIT_ACCEPTED_REASONS = (
+    "existing-primitive-bugfix",
+    "new-primitive-implementation",
+)
+RUNTIME_SOURCE_EDIT_SUSPECT_REASONS = (
+    "generated-command-behavior",
+    "interface-behavior-change",
+)
+RUNTIME_SOURCE_EDIT_REJECTED_VAGUE_REASONS = (
+    "package-domain boundary",
+    "runtime code changed",
+    "implementation detail",
 )
 PYTHON_FULL_COMPLETION_ACCEPTED_RUNTIME_FACADE_PATHS = (
     "generated/workspace/python/primitives/workspace_runtime.py",
@@ -1907,6 +1941,124 @@ def _python_runtime_boundary_metrics() -> dict[str, object]:
         "accepted_output_emission_symbols": output_emission_symbols,
         "python_bridge_symbols": python_bridge_symbols,
         "generic_debt_symbols": generic_debt_symbols,
+    }
+
+
+def _runtime_boundary_minimization_report(metrics: dict[str, object]) -> dict[str, object]:
+    if metrics.get("status") != "available":
+        return {
+            "kind": "python-runtime-boundary-minimization/v1",
+            "status": "unavailable",
+            "minimization_claim_allowed": False,
+            "reason": metrics.get("error", "accepted runtime boundary metrics unavailable"),
+        }
+    class_counts_obj = metrics.get("accepted_runtime_symbol_count_by_class", {})
+    class_counts = {str(key): int(value) for key, value in class_counts_obj.items()} if isinstance(class_counts_obj, dict) else {}
+    accepted_symbol_count = int(metrics.get("accepted_runtime_symbol_count", 0) or 0)
+    generic_debt_symbols = metrics.get("generic_debt_symbols", [])
+    if not isinstance(generic_debt_symbols, list):
+        generic_debt_symbols = []
+    hand_owned_count = sum(class_counts.get(boundary_class, 0) for boundary_class in PYTHON_RUNTIME_BOUNDARY_MINIMIZATION_HAND_OWNED_CLASSES)
+    move_candidate_count = class_counts.get("generic-deterministic-runtime-debt", 0)
+    minimization_claim_allowed = accepted_symbol_count == 0
+    status = "minimized" if minimization_claim_allowed else "not-minimized-hand-owned-boundaries-remain"
+    return {
+        "kind": "python-runtime-boundary-minimization/v1",
+        "status": status,
+        "freshness_claim_boundary": (
+            "completion_claim_allowed only means generated Python output is exact/current and accepted boundaries are inventoried; "
+            "it is not a claim that runtime boundaries are minimized."
+        ),
+        "minimization_claim_allowed": minimization_claim_allowed,
+        "whole_category_acceptance_allowed": False,
+        "accepted_symbol_count": accepted_symbol_count,
+        "remaining_hand_owned_symbol_count": hand_owned_count,
+        "move_to_command_generation_candidate_count": move_candidate_count,
+        "remaining_by_runtime_boundary_class": dict(sorted(class_counts.items())),
+        "route_by_runtime_boundary_class": {
+            key: PYTHON_RUNTIME_BOUNDARY_MINIMIZATION_ROUTES[key]
+            for key in sorted(PYTHON_RUNTIME_BOUNDARY_MINIMIZATION_ROUTES)
+        },
+        "move_to_command_generation_candidates": generic_debt_symbols,
+        "required_evidence_for_remaining_boundaries": [
+            "binding_kind",
+            "source_module",
+            "source_symbol",
+            "operation_ids",
+            "primitive_refs",
+            "owner_package",
+            "runtime_boundary_class",
+            "why_not_generic_deterministic",
+            "conformance_ref",
+            "generic_behavior_audit",
+        ],
+        "shrink_next_when": [
+            "a boundary's deterministic dataflow can be expressed as shared primitive IR",
+            "a front-door dispatch path can be rendered from command-generation without package runtime policy",
+            "a provider/runtime adapter can be split into a generic adapter contract and package-owned semantic judgment",
+        ],
+        "authority_boundary": {
+            "aw_observes": [
+                "exact generated call sites",
+                "declared runtime boundary classes",
+                "accepted symbol counts",
+                "generic debt candidates",
+            ],
+            "agent_owns": [
+                "semantic judgment about whether a boundary is safe to shrink",
+                "choosing the next implementation slice",
+                "claiming parent #1354 satisfaction",
+            ],
+            "human_owns": [
+                "acceptance of remaining hand-owned primitive boundaries",
+                "approval of product behavior changes while shrinking runtime code",
+            ],
+        },
+        "claim_rule": (
+            "Do not report the runtime primitive inventory as minimized while accepted_symbol_count is non-zero; "
+            "report it as exact/inventoried unless the remaining hand-owned symbols are actually removed or moved."
+        ),
+    }
+
+
+def _generated_target_freshness_report(ir: dict[str, object]) -> dict[str, object]:
+    outputs = list(render_workspace_command_package_outputs(ir, repo_root=REPO_ROOT))
+    package_target_counts: dict[str, int] = {}
+
+    def target_family_for_path(path: Path) -> str | None:
+        relative_path = path.relative_to(REPO_ROOT).as_posix()
+        parts = relative_path.split("/")
+        if len(parts) < 3 or parts[0] != "generated":
+            return None
+        package_target = "/".join(parts[:3])
+        package_target_counts[package_target] = package_target_counts.get(package_target, 0) + 1
+        return parts[2]
+
+    generic_report = generated_output_freshness_report(
+        outputs,
+        repo_root=REPO_ROOT,
+        required_target_families=("python", "typescript"),
+        target_family_for_path=target_family_for_path,
+    )
+    target_families = ["python", "typescript"]
+    return {
+        "kind": "generated-target-freshness/v1",
+        "status": generic_report["status"],
+        "target_families": target_families,
+        "rendered_output_count": generic_report["rendered_output_count"],
+        "rendered_output_count_by_family": generic_report["rendered_output_count_by_family"],
+        "rendered_output_count_by_package_target": dict(sorted(package_target_counts.items())),
+        "expected_digest_by_family": generic_report["expected_digest_by_family"],
+        "stale_output_count_by_family": generic_report["stale_output_count_by_family"],
+        "stale_outputs_by_family": generic_report["stale_outputs_by_family"],
+        "missing_target_families": generic_report["missing_target_families"],
+        "freshness_check_command": "uv run python scripts/generate/generate_command_packages.py --check",
+        "refresh_command": "uv run python scripts/generate/generate_command_packages.py",
+        "validation_command": "uv run python scripts/check/check_generated_command_packages.py",
+        "cheap_check_rule": generic_report["cheap_check_rule"],
+        "claim_rule": (
+            "Do not claim generated target freshness from Python-only evidence; generated CLI freshness covers both Python and TypeScript target families."
+        ),
     }
 
 
@@ -4104,6 +4256,8 @@ def _python_completion_blockers_report(ir: dict[str, object]) -> dict[str, objec
     gate = policy.get("completion_gate", {})
     gate_state = str(gate.get("state", "")) if isinstance(gate, dict) else "malformed"
     completion_claim_allowed = current_state == "full-generated-cli-complete" and gate_state == "satisfied" and not blockers
+    runtime_metrics = _python_runtime_boundary_metrics()
+    generated_target_freshness = _generated_target_freshness_report(ir)
     return {
         "kind": "python-completion-blockers/v1",
         "current_state": current_state,
@@ -4112,10 +4266,36 @@ def _python_completion_blockers_report(ir: dict[str, object]) -> dict[str, objec
         "false_completion_claim_would_fail": bool(blockers),
         "blockers": blockers,
         "blocker_count": len(blockers),
-        "accepted_runtime_boundary_metrics": _python_runtime_boundary_metrics(),
+        "accepted_runtime_boundary_metrics": runtime_metrics,
+        "runtime_boundary_minimization": _runtime_boundary_minimization_report(runtime_metrics),
+        "generated_target_freshness": generated_target_freshness,
+        "runtime_source_edit_policy": _runtime_source_edit_policy_payload(),
         "lifecycle_dry_run_metrics": _lifecycle_dry_run_metrics(),
         "remaining_scope": "tier-6-final-python-completion-promotion" if blockers else "none",
         "next_owner": ("#892 / tier-6-final-python-completion-promotion" if blockers else "none"),
+    }
+
+
+def _runtime_source_edit_policy_payload() -> dict[str, object]:
+    return {
+        "kind": "generated-cli-runtime-source-edit-policy/v1",
+        "status": "available",
+        "watched_runtime_source_paths": list(PYTHON_FULL_COMPLETION_BLOCKING_RUNTIME_SOURCE_PATHS),
+        "accepted_direct_edit_reasons": list(RUNTIME_SOURCE_EDIT_ACCEPTED_REASONS),
+        "suspect_reasons": list(RUNTIME_SOURCE_EDIT_SUSPECT_REASONS),
+        "rejected_vague_reasons": list(RUNTIME_SOURCE_EDIT_REJECTED_VAGUE_REASONS),
+        "required_evidence": [
+            "changed_path",
+            "edit_reason",
+            "owner",
+            "source_symbol_or_primitive",
+            "proof",
+            "whether command-generation or AW owns the next change",
+        ],
+        "rule": (
+            "Runtime-source edits adjacent to generated CLI behavior require explicit primitive bugfix/new primitive evidence; "
+            "vague package-domain boundary wording is insufficient."
+        ),
     }
 
 
@@ -4134,6 +4314,25 @@ def _print_python_completion_blockers_report(report: dict[str, object], *, outpu
         print(f"Accepted output-emission symbols: {metrics.get('accepted_output_emission_symbol_count')}")
         print(f"Python bridge steps: {metrics.get('python_bridge_step_count')}")
         print(f"Generic debt symbols: {metrics.get('generic_debt_symbol_count')}")
+    minimization = report.get("runtime_boundary_minimization", {})
+    if isinstance(minimization, dict) and minimization.get("status") not in {None, "unavailable"}:
+        print(f"Runtime boundary minimized: {str(minimization.get('minimization_claim_allowed')).lower()}")
+        print(f"Remaining hand-owned runtime symbols: {minimization.get('remaining_hand_owned_symbol_count')}")
+        print(f"Move-to-command-generation candidate symbols: {minimization.get('move_to_command_generation_candidate_count')}")
+        print(f"Runtime minimization claim rule: {minimization.get('claim_rule')}")
+    target_freshness = report.get("generated_target_freshness", {})
+    if isinstance(target_freshness, dict) and target_freshness.get("status"):
+        print(f"Generated target freshness: {target_freshness.get('status')}")
+        print(f"Generated target families: {target_freshness.get('target_families')}")
+        print(f"Rendered outputs by family: {target_freshness.get('rendered_output_count_by_family')}")
+        print(f"Stale outputs by family: {target_freshness.get('stale_output_count_by_family')}")
+        print(f"Generated target claim rule: {target_freshness.get('claim_rule')}")
+    runtime_edit_policy = report.get("runtime_source_edit_policy", {})
+    if isinstance(runtime_edit_policy, dict) and runtime_edit_policy.get("status") == "available":
+        print(
+            "Runtime source edit policy: explicit primitive bugfix/new primitive evidence required; "
+            "vague package-domain boundary wording is insufficient"
+        )
     lifecycle_metrics = report.get("lifecycle_dry_run_metrics", {})
     if isinstance(lifecycle_metrics, dict) and lifecycle_metrics.get("status") == "available":
         print(f"Lifecycle dry-run operations: {lifecycle_metrics.get('lifecycle_dry_run_operation_count')}")

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -22122,6 +22122,20 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "generated_cli_freshness": _tiny_generated_cli_freshness_payload(payload.get("proof", {}).get("generated_cli_freshness", {}))
             if isinstance(payload.get("proof"), dict) and isinstance(payload.get("proof", {}).get("generated_cli_freshness"), dict)
             else {},
+            "runtime_source_edit_review": {
+                key: payload.get("proof", {}).get("runtime_source_edit_review", {}).get(key)
+                for key in (
+                    "kind",
+                    "status",
+                    "changed_paths",
+                    "accepted_direct_edit_reasons",
+                    "rejected_vague_reasons",
+                    "completion_claim_rule",
+                )
+                if isinstance(payload.get("proof"), dict)
+                and isinstance(payload.get("proof", {}).get("runtime_source_edit_review"), dict)
+                and key in payload.get("proof", {}).get("runtime_source_edit_review", {})
+            },
             "proof_obligations": _tiny_proof_obligations_payload(
                 payload.get("proof", {}).get("proof_obligations", {}), required_commands=proof_commands
             )
@@ -22236,6 +22250,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "task_contract",
                 "change_impact",
                 "generated_surface_trust",
+                "proof.runtime_source_edit_review",
                 "assurance_requirements",
                 "verification",
                 "routine_work_context",
@@ -22272,6 +22287,16 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     generated_cli_freshness = projected["proof"].get("generated_cli_freshness", {})
     if not (isinstance(generated_cli_freshness, dict) and generated_cli_freshness.get("kind")):
         projected["proof"].pop("generated_cli_freshness", None)
+    runtime_source_review = projected["proof"].get("runtime_source_edit_review", {})
+    if not (
+        isinstance(runtime_source_review, dict)
+        and runtime_source_review.get("changed_paths")
+        and runtime_source_review.get("status") != "not-applicable"
+    ):
+        projected["proof"].pop("runtime_source_edit_review", None)
+        selectors = projected.get("drill_down", {}).get("available_selectors", [])
+        if isinstance(selectors, list):
+            projected["drill_down"]["available_selectors"] = [item for item in selectors if item != "proof.runtime_source_edit_review"]
     task_argument_mode = payload.get("task_intent", {}).get("task_argument_mode") if isinstance(payload.get("task_intent"), dict) else ""
     intent_proof = payload.get("proof", {}).get("intent_proof") if isinstance(payload.get("proof"), dict) else None
     acceptance_reconciliation = payload.get("acceptance_reconciliation", {})
@@ -31361,7 +31386,7 @@ def _tiny_proof_obligations_payload(value: dict[str, Any], *, required_commands:
 
 
 def _tiny_generated_cli_freshness_payload(value: dict[str, Any]) -> dict[str, Any]:
-    return {
+    payload = {
         "kind": value.get("kind", "agentic-workspace/generated-cli-freshness/v1"),
         "status": value.get("status", "unknown"),
         "obligation": value.get("obligation", value.get("status", "unknown")),
@@ -31369,6 +31394,14 @@ def _tiny_generated_cli_freshness_payload(value: dict[str, Any]) -> dict[str, An
         "refresh_command": value.get("refresh_command", ""),
         "validation_command": value.get("validation_command", ""),
     }
+    parity = value.get("generated_target_parity")
+    if isinstance(parity, dict):
+        payload["generated_target_parity"] = {
+            "status": parity.get("status", "unknown"),
+            "target_families": parity.get("target_families", []),
+            "claim_rule": parity.get("claim_rule", ""),
+        }
+    return payload
 
 
 def _transient_validation_retry_guidance(*, required_commands: list[str]) -> dict[str, Any]:
@@ -31428,6 +31461,23 @@ def _generated_cli_freshness_payload(
         "validation_command": validation_command,
         "required_commands": related_commands,
         "obligation": obligation,
+        "generated_target_parity": {
+            "kind": "agentic-workspace/generated-target-parity/v1",
+            "status": "required" if obligation == "required" else "advisory",
+            "target_families": ["python", "typescript"],
+            "freshness_evidence": [
+                "scripts/generate/generate_command_packages.py --check compares rendered outputs for all generated Python and TypeScript package targets without writing files",
+                "scripts/check/check_generated_command_packages.py performs static generated-package proof across Python and TypeScript surfaces",
+            ],
+            "stale_detection": {
+                "python": "generated/*/python/** outputs must match command-generation render output",
+                "typescript": "generated/*/typescript/** outputs must match command-generation render output",
+            },
+            "claim_rule": (
+                "Do not claim generated CLI freshness from Python-only proof; relevant generated CLI proof must name "
+                "both Python and TypeScript generated targets or record why one family is not applicable."
+            ),
+        },
         "rule": (
             "Generated CLI freshness is relevant only for generated command package surfaces. "
             "Run the check path before trusting generated CLI output; refresh only when the check reports stale output."
@@ -31462,6 +31512,69 @@ def _tiny_surface_compatibility_review(changed_paths: list[str]) -> dict[str, An
             "size-budget assertions when existing tests define one",
             "selector/full-surface assertion for any new diagnostic field",
         ],
+    }
+
+
+_GENERATED_CLI_RUNTIME_SOURCE_EDIT_PATHS = {
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "packages/planning/src/repo_planning_bootstrap/installer.py",
+    "packages/planning/src/repo_planning_bootstrap/runtime_projection.py",
+    "packages/memory/src/repo_memory_bootstrap/installer.py",
+    "packages/memory/src/repo_memory_bootstrap/runtime_search.py",
+    "packages/memory/src/repo_memory_bootstrap/runtime_primitives.py",
+    "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py",
+}
+
+
+def _runtime_source_edit_review_for_changed_paths(changed_paths: list[str]) -> dict[str, Any]:
+    runtime_paths = [path for path in changed_paths if path in _GENERATED_CLI_RUNTIME_SOURCE_EDIT_PATHS]
+    if not runtime_paths:
+        return {"kind": "agentic-workspace/runtime-source-edit-review/v1", "status": "not-applicable", "changed_paths": []}
+    return {
+        "kind": "agentic-workspace/runtime-source-edit-review/v1",
+        "status": "classification-required",
+        "changed_paths": runtime_paths,
+        "accepted_direct_edit_reasons": [
+            "existing-primitive-bugfix",
+            "new-primitive-implementation",
+        ],
+        "suspect_reasons": [
+            "generated-command-behavior",
+            "interface-behavior-change",
+        ],
+        "rejected_vague_reasons": [
+            "package-domain boundary",
+            "runtime code changed",
+            "implementation detail",
+        ],
+        "required_evidence": [
+            "changed_path",
+            "edit_reason",
+            "owner",
+            "source_symbol_or_primitive",
+            "proof",
+            "whether command-generation or AW owns the next change",
+        ],
+        "review_template": {
+            "changed_path": "<runtime source path>",
+            "edit_reason": "existing-primitive-bugfix|new-primitive-implementation|generated-command-behavior|interface-behavior-change",
+            "owner": "AW primitive implementation|command-generation|deferred issue",
+            "source_symbol_or_primitive": "<function, primitive id, or operation id>",
+            "proof": "<focused test/check proving the boundary>",
+            "residual_risk": "<none or explicit follow-up>",
+        },
+        "completion_claim_rule": (
+            "Do not claim generated-CLI boundary satisfaction from a runtime source edit until the final report states the edit reason, "
+            "owner, symbol/primitive, proof, and residual risk."
+        ),
+        "authority_boundary": _authority_boundary_payload(
+            surface="runtime_source_edit_review",
+            observed_by_aw=["changed runtime source path"],
+            recommended_by_aw=["classify direct runtime edit before closeout"],
+            agent_owned_decisions=["edit reason", "owner judgment", "whether the change belongs in command-generation"],
+            rule="AW reports runtime-source edit evidence and required proof; the agent owns the semantic classification.",
+        ),
+        "rule": "Vague package-domain boundary wording is insufficient for generated-CLI-adjacent runtime source edits.",
     }
 
 
@@ -32191,6 +32304,9 @@ def _proof_selection_for_changed_paths(
     surface_value_review = _surface_value_review_for_changed_paths(changed_paths=changed_paths, target_root=target_root)
     if surface_value_review["durable_surface_count"]:
         proof_selection["surface_value_review"] = surface_value_review
+    runtime_source_review = _runtime_source_edit_review_for_changed_paths(changed_paths)
+    if runtime_source_review["changed_paths"]:
+        proof_selection["runtime_source_edit_review"] = runtime_source_review
     direct_cli_review = _direct_cli_edit_review_for_changed_paths(changed_paths)
     if direct_cli_review["changed_paths"]:
         proof_selection["direct_cli_edit_review"] = direct_cli_review

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -332,6 +332,34 @@ def test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundarie
     assert runtime_metrics["baseline_symbol_count"] == runtime_metrics["accepted_runtime_symbol_count"]
     assert runtime_metrics["new_symbols_since_baseline"] == []
     assert runtime_metrics["removed_symbols_since_baseline"] == []
+    minimization = report["runtime_boundary_minimization"]
+    assert minimization["kind"] == "python-runtime-boundary-minimization/v1"
+    assert minimization["status"] == "not-minimized-hand-owned-boundaries-remain"
+    assert minimization["minimization_claim_allowed"] is False
+    assert minimization["whole_category_acceptance_allowed"] is False
+    assert minimization["accepted_symbol_count"] == runtime_metrics["accepted_runtime_symbol_count"]
+    assert minimization["remaining_hand_owned_symbol_count"] == runtime_metrics["accepted_runtime_symbol_count"]
+    assert "not a claim that runtime boundaries are minimized" in minimization["freshness_claim_boundary"]
+    assert "generic-deterministic-runtime-debt" in minimization["route_by_runtime_boundary_class"]
+    assert "agent_owns" in minimization["authority_boundary"]
+    assert "accepted_symbol_count is non-zero" in minimization["claim_rule"]
+    target_freshness = report["generated_target_freshness"]
+    assert target_freshness["kind"] == "generated-target-freshness/v1"
+    assert target_freshness["status"] == "fresh"
+    assert target_freshness["target_families"] == ["python", "typescript"]
+    assert target_freshness["rendered_output_count_by_family"]["python"] > 0
+    assert target_freshness["rendered_output_count_by_family"]["typescript"] > 0
+    assert target_freshness["stale_output_count_by_family"] == {}
+    assert target_freshness["missing_target_families"] == []
+    assert "do not rewrite generated files" in target_freshness["cheap_check_rule"]
+    assert "Python-only evidence" in target_freshness["claim_rule"]
+    edit_policy = report["runtime_source_edit_policy"]
+    assert edit_policy["kind"] == "generated-cli-runtime-source-edit-policy/v1"
+    assert "src/agentic_workspace/workspace_runtime_primitives.py" in edit_policy["watched_runtime_source_paths"]
+    assert edit_policy["accepted_direct_edit_reasons"] == ["existing-primitive-bugfix", "new-primitive-implementation"]
+    assert "package-domain boundary" in edit_policy["rejected_vague_reasons"]
+    assert "source_symbol_or_primitive" in edit_policy["required_evidence"]
+    assert "vague package-domain boundary wording is insufficient" in edit_policy["rule"]
     lifecycle_metrics = report["lifecycle_dry_run_metrics"]
     assert lifecycle_metrics["status"] == "available"
     assert lifecycle_metrics["codegen_default_dry_run_operation_count"] >= 3
@@ -382,6 +410,38 @@ def test_runtime_budget_metrics_compare_against_recorded_baseline() -> None:
     ]
 
 
+def test_runtime_boundary_minimization_routes_generic_debt_to_command_generation() -> None:
+    payload = _run_checker_case(
+        """
+        metrics = checker._python_runtime_boundary_metrics()
+        metrics["accepted_runtime_symbol_count"] += 1
+        metrics["accepted_runtime_symbol_count_by_class"]["generic-deterministic-runtime-debt"] = 1
+        metrics["generic_debt_symbols"] = [
+            {
+                "operation_id": "workspace.example.report",
+                "source_module": "agentic_workspace.workspace_runtime_primitives",
+                "source_symbol": "_example_generated_command_behavior",
+                "runtime_boundary_class": "generic-deterministic-runtime-debt",
+            }
+        ]
+        _emit({"minimization": checker._runtime_boundary_minimization_report(metrics)})
+        """
+    )
+    minimization = payload["minimization"]
+
+    assert minimization["minimization_claim_allowed"] is False
+    assert minimization["move_to_command_generation_candidate_count"] == 1
+    assert minimization["move_to_command_generation_candidates"] == [
+        {
+            "operation_id": "workspace.example.report",
+            "source_module": "agentic_workspace.workspace_runtime_primitives",
+            "source_symbol": "_example_generated_command_behavior",
+            "runtime_boundary_class": "generic-deterministic-runtime-debt",
+        }
+    ]
+    assert minimization["route_by_runtime_boundary_class"]["generic-deterministic-runtime-debt"].startswith("move-to-command-generation:")
+
+
 def test_declarative_view_specs_match_generated_operations() -> None:
     checker = _load_checker()
 
@@ -412,6 +472,18 @@ def test_python_completion_blocker_report_has_json_cli_mode(capsys) -> None:
     assert runtime_metrics["python_bridge_step_count"] == 0
     assert runtime_metrics["python_bridge_symbols"] == []
     assert runtime_metrics["generic_debt_symbol_count"] == 0
+    minimization = payload["runtime_boundary_minimization"]
+    assert minimization["status"] == "not-minimized-hand-owned-boundaries-remain"
+    assert minimization["minimization_claim_allowed"] is False
+    assert minimization["remaining_hand_owned_symbol_count"] == runtime_metrics["accepted_runtime_symbol_count"]
+    target_freshness = payload["generated_target_freshness"]
+    assert target_freshness["status"] == "fresh"
+    assert target_freshness["target_families"] == ["python", "typescript"]
+    assert target_freshness["rendered_output_count_by_family"]["python"] > 0
+    assert target_freshness["rendered_output_count_by_family"]["typescript"] > 0
+    assert payload["runtime_source_edit_policy"]["status"] == "available"
+    assert "new-primitive-implementation" in payload["runtime_source_edit_policy"]["accepted_direct_edit_reasons"]
+    assert "package-domain boundary" in payload["runtime_source_edit_policy"]["rejected_vague_reasons"]
     assert payload["lifecycle_dry_run_metrics"]["codegen_default_dry_run_operation_count"] >= 3
 
 

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -74,6 +74,10 @@ def test_implement_command_returns_bounded_context_and_boundary_warnings(tmp_pat
     assert freshness["refresh_command"] == "uv run python scripts/generate/generate_command_packages.py"
     assert freshness["validation_command"] == "uv run python scripts/check/check_generated_command_packages.py"
     assert "uv run python scripts/check/check_generated_command_packages.py" in freshness["required_commands"]
+    parity = freshness["generated_target_parity"]
+    assert parity["status"] == "required"
+    assert parity["target_families"] == ["python", "typescript"]
+    assert "Python-only proof" in parity["claim_rule"]
     proof_tiers = {tier["id"]: tier["commands"] for tier in payload["proof"]["proof_command_tiers"]["tiers"]}
     assert proof_tiers["generated_contract"][0]["command"] == "uv run python scripts/check/check_generated_command_packages.py"
     assert any(item["command"].endswith("--require-docker") for item in proof_tiers["environmental"])
@@ -1070,6 +1074,8 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert "uv run python scripts/check/check_generated_command_packages.py" in payload["proof"]["required_commands"]
     assert payload["proof"]["generated_cli_freshness"]["status"] == "required"
     assert payload["proof"]["generated_cli_freshness"]["refresh_command"] == "uv run python scripts/generate/generate_command_packages.py"
+    assert payload["proof"]["generated_cli_freshness"]["generated_target_parity"]["target_families"] == ["python", "typescript"]
+    assert "Python-only proof" in payload["proof"]["generated_cli_freshness"]["generated_target_parity"]["claim_rule"]
     obligations = payload["proof"]["proof_obligations"]
     assert obligations["required_proof"]["commands"] == payload["proof"]["required_commands"]
     assert obligations["recommended_confidence_checks"]["status"] == "available"
@@ -1116,6 +1122,40 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert "generated_surface_trust" in payload["drill_down"]["available_selectors"]
     assert len(json.dumps(payload["generated_surface_trust"])) < 700
     assert len(encoded) < 15500
+
+
+def test_implement_surfaces_runtime_source_edit_review_for_generated_cli_boundary(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "Makefile", "test-workspace:\n\tpytest tests\n\nlint-workspace:\n\truff check src tests\n")
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_primitives.py",
+                "--task",
+                "Fix an existing primitive bug under the generated CLI boundary.",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    review = payload["proof"]["runtime_source_edit_review"]
+    assert review["kind"] == "agentic-workspace/runtime-source-edit-review/v1"
+    assert review["status"] == "classification-required"
+    assert review["changed_paths"] == ["src/agentic_workspace/workspace_runtime_primitives.py"]
+    assert review["accepted_direct_edit_reasons"] == ["existing-primitive-bugfix", "new-primitive-implementation"]
+    assert "package-domain boundary" in review["rejected_vague_reasons"]
+    assert "final report states the edit reason" in review["completion_claim_rule"]
+    assert "proof.runtime_source_edit_review" in payload["drill_down"]["available_selectors"]
 
 
 def test_implement_detail_commands_use_resolved_cli_invoke(tmp_path: Path, capsys) -> None:
@@ -1213,6 +1253,7 @@ def test_implement_package_cli_edits_select_generated_command_package_gate(capsy
     payload = json.loads(capsys.readouterr().out)
     assert "make test-memory" in payload["proof"]["required_commands"]
     assert "uv run python scripts/check/check_generated_command_packages.py" in payload["proof"]["required_commands"]
+    assert payload["proof"]["generated_cli_freshness"]["generated_target_parity"]["target_families"] == ["python", "typescript"]
 
 
 def test_implement_uses_available_target_makefile_targets(tmp_path: Path, capsys) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=5fdfcf6f84ae398f4cebfdb7899f762bb2550f1b" },
+    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=ae8fd35cb867db9e69e6d728219a960e458d9139" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -145,7 +145,7 @@ wheels = [
 [[package]]
 name = "command-generation"
 version = "0.1.0"
-source = { git = "https://github.com/rickardvh/command-generation.git?rev=5fdfcf6f84ae398f4cebfdb7899f762bb2550f1b#5fdfcf6f84ae398f4cebfdb7899f762bb2550f1b" }
+source = { git = "https://github.com/rickardvh/command-generation.git?rev=ae8fd35cb867db9e69e6d728219a960e458d9139#ae8fd35cb867db9e69e6d728219a960e458d9139" }
 dependencies = [
     { name = "jsonschema" },
 ]


### PR DESCRIPTION
## What this PR is now

This PR is **not** the completion of the original generated-CLI migration intent. It is supporting instrumentation/guardrail work discovered while trying to complete #1354.

The stricter original intent remains:

> runtime command behavior should be generated from canonical IR / command-generation sources as the single source of truth wherever it is command behavior, with only true primitive bugfixes or genuinely new primitive implementations edited directly in AW runtime code.

This PR makes the remaining boundary visible, but it does **not** remove all unintended runtime command behavior from inside that boundary. Therefore it must not close #1354.

The actual migration-completion issue is #1364.

## What landed

- Added generated-CLI runtime-source edit review so direct edits to generated-CLI-adjacent runtime primitives require explicit primitive bugfix/new primitive evidence, owner, symbol/primitive, proof, and residual risk.
- Added generated target parity/freshness evidence for both Python and TypeScript generated targets in `implement` proof output and `check_generated_command_packages.py`.
- Added runtime boundary minimization evidence that separates exact/current generated output from the stronger claim that runtime boundaries are minimized.
- Moved generic rendered-output freshness digesting into `rickardvh/command-generation` and pinned AW to command-generation commit `ae8fd35cb867db9e69e6d728219a960e458d9139` from rickardvh/command-generation#6.
- Added decomposition/lane archive evidence from the attempted #1354 work, which should now be read as grounding for #1364 rather than closure of #1354.

## Issue posture

| Issue | Current posture |
| --- | --- |
| #1354 | **Not closed by this PR.** Original end-state intent remains unsatisfied while hand-owned runtime command behavior remains. |
| #1364 | Tracks completing the migration. This PR may be useful support, but #1364 is the issue that must prove actual migration. |
| #1355 | Decomposition/grounding work landed, but the decomposition now points to remaining migration work rather than parent closure. |
| #1356 | Runtime-source edit review support landed. This is guardrail support, not migration completion. |
| #1357 | Runtime boundary minimization reporting landed. The report explicitly says the inventory is not minimized. |
| #1358 | Python/TypeScript generated target freshness/parity evidence landed. |
| command-generation#5/#6 | Generic output freshness report lives in command-generation PR #6; AW consumes that helper and keeps only host-specific policy/check presentation. |
| #1361 | Filed while dogfooding because Planning mutations left compact state unusable without manual projection repair. |
| #1362 | Filed while dogfooding because Planning diagnostics missed malformed active lane projection. |

## Why this is draft

The guardrails are not enough on their own. They are especially weak if the unintended runtime command behavior is still accepted inside the boundary they report. This PR should stay draft unless we intentionally decide to land support machinery before the actual migration, or it should be folded into the #1364 implementation PR.

## Dogfooding report

Good:
- The decomposition/lane/slice ladder eventually exposed that #1354 was stricter than a generated-output freshness patch.
- Closeout fields made the dependency on command-generation#6 and the non-minimized runtime inventory explicit.

Bad:
- I incorrectly treated guardrail/reporting work as enough to close the original architectural intent.
- AW Planning state transitions lost or obscured active planning ownership during lane close/archive transitions.
- `summary`/`doctor` did not catch one malformed lane projection until a mutation failed.

Filed:
- #1361 for Planning mutations leaving compact state immediately usable.
- #1362 for Planning diagnostics failing to validate active lane record schemas.
- #1364 for completing the actual generated CLI runtime migration.

## Proof already run

AW repo:
- `uv run pytest tests/test_generated_command_package_proof_runner.py tests/test_workspace_implement_cli.py -q --tb=short` -> 126 passed
- `uv run python scripts/check/check_generated_command_packages.py` -> ok
- `uv run python scripts/generate/generate_command_packages.py --check` -> ok
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success` -> passed
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success` -> passed
- `make maintainer-surfaces` -> ok
- `make lint-workspace` -> ok
- `make test-workspace` -> ok
- `make schema-reference-docs` -> ok
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json` -> clean
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` -> healthy

command-generation support:
- rickardvh/command-generation#6
- `uv run pytest` -> 29 passed

## Remaining limitation

The remaining hand-owned runtime primitive inventory is explicit and not reported as minimized. That is the blocker for satisfying the original intent, not a non-blocking limitation.

Related to #1354.
Supports #1364.
Does not close #1354.