### PR TITLE
Validate Planning lane state diagnostics

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1361-1362-planning-state-diagnostics.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1361-1362-planning-state-diagnostics.plan.json
@@ -1,0 +1,307 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Fix Planning mutation projection and lane schema diagnostics",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "#1361 #1362 dogfooding findings",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Fix Planning mutation projection and lane schema diagnostics is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "#1361 #1362 dogfooding findings"
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "#1361 #1362 dogfooding findings",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1361-1362-planning-state-diagnostics",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "#1361 #1362 dogfooding findings",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Fix Planning mutation projection and lane schema diagnostics",
+    "inferred intended outcome": "#1361 #1362 dogfooding findings",
+    "chosen concrete what": "Summary and doctor now warn for invalid active lane records; lane close now emits lane-archive as the next safe action and compact summary remains not-clean until archive.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "#1361 #1362 dogfooding findings",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": "#1361 #1362 dogfooding findings",
+      "label": "#1361 #1362 dogfooding findings",
+      "role": "intake",
+      "locator": ""
+    }
+  ],
+  "active_milestone": {
+    "id": "issue-1361-1362-planning-state-diagnostics",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Fix Planning mutation projection and lane schema diagnostics is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented shared Planning lane-surface diagnostics so summary and doctor report invalid lane schemas and closed live lane records before mutation surprises.",
+    "scope touched": "packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_lanes.py",
+    "changed surfaces": "Planning summary, Planning doctor, lane close output, lane diagnostics tests",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1361/#1362 Planning diagnostics and mutation follow-up guidance.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "make test-planning; make lint-planning; make typecheck-planning; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_planning_surfaces.py --strict; make test-workspace",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "#1361 #1362 dogfooding findings",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Summary and doctor now warn for invalid active lane records; lane close now emits lane-archive as the next safe action and compact summary remains not-clean until archive.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-06: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: #1361 #1362 dogfooding findings\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: make test-planning; make lint-planning; make typecheck-planning; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make maintainer-surfaces; uv run python scripts/check/check_planning_surfaces.py --strict; make test-workspace\nChanged surfaces: Planning summary, Planning doctor, lane close output, lane diagnostics tests\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none"
+  }
+}

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -1581,7 +1581,9 @@ def doctor_bootstrap(*, target: str | Path | None = None) -> InstallResult:
             if _has_unresolved_placeholders(text):
                 result.add("manual review", path, "starter placeholders still need custom values")
 
+    lane_projection = _planning_lane_projection(target_root=target_root)
     warnings = _run_planning_checker(target_root)
+    warnings.extend(_planning_lane_surface_warnings(target_root=target_root, lane_projection=lane_projection))
     result.warnings.extend(warnings)
     for warning in warnings:
         result.add("warning", target_root / warning["path"], warning["message"])
@@ -1901,6 +1903,7 @@ def planning_summary(
 
     state = _read_state_from_toml(target_root)
     warnings = _run_planning_checker(target_root)
+    warnings.extend(_planning_lane_surface_warnings(target_root=target_root, lane_projection=lane_projection))
     warnings.extend(_unsupported_planning_state_activation_shape_warnings(target_root=target_root, state=state))
     warnings.extend(_planning_state_v1_warnings(target_root=target_root, state=state))
     warnings.extend(_completed_execplan_warnings(completed_execplans))
@@ -3449,6 +3452,47 @@ def _planning_lane_projection(*, target_root: Path) -> dict[str, Any]:
             "Execplans own concrete implementation slices."
         ),
     }
+
+
+def _planning_lane_surface_warnings(*, target_root: Path, lane_projection: dict[str, Any] | None = None) -> list[dict[str, str]]:
+    projection = lane_projection if lane_projection is not None else _planning_lane_projection(target_root=target_root)
+    warnings: list[dict[str, str]] = []
+    invalid_records = projection.get("invalid_records", []) if isinstance(projection, dict) else []
+    if isinstance(invalid_records, list):
+        for record in invalid_records:
+            if not isinstance(record, dict):
+                continue
+            path = str(record.get("path", "")).strip() or (PLANNING_MANAGED_ROOT / "lanes").as_posix()
+            reason = str(record.get("reason", "")).strip() or "lane record failed schema validation"
+            warnings.append(
+                {
+                    "warning_class": "planning_lane_schema_invalid",
+                    "path": path,
+                    "message": f"Planning lane record is invalid: {reason}",
+                    "suggested_fix": "Repair the lane record against planning-lane.schema.json before relying on summary or lane closeout.",
+                }
+            )
+    records = projection.get("records", []) if isinstance(projection, dict) else []
+    if isinstance(records, list):
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            if str(record.get("status", "")).strip() != "closed":
+                continue
+            path = str(record.get("path", "")).strip() or (PLANNING_MANAGED_ROOT / "lanes").as_posix()
+            lane_id = str(record.get("id", "")).strip() or Path(path).stem.removesuffix(".lane")
+            warnings.append(
+                {
+                    "warning_class": "closed_lane_record_live_state",
+                    "path": path,
+                    "message": (
+                        f"Closed lane '{lane_id}' remains in live Planning state; archive it so compact routing "
+                        "does not treat completed lane evidence as selectable work."
+                    ),
+                    "suggested_fix": f"Run agentic-planning lane-archive {lane_id} --target . --format json.",
+                }
+            )
+    return warnings
 
 
 def _decomposition_issue_refs(payload: dict[str, Any]) -> set[str]:
@@ -9554,6 +9598,7 @@ def close_lane_record(
     _upsert_roadmap_lane_state(target_root, record, lane_relative=lane_relative)
     result.add("updated", record_path, "recorded lane proof aggregation, parent contribution, and closeout state")
     result.add("updated", target_root / PLANNING_STATE_PATH, f"projected closed lane '{slug}'")
+    result.add("next safe action", record_path, f"agentic-planning lane-archive {slug} --target . --format json")
     _add_planning_mutation_proof_actions(result)
     return result
 

--- a/packages/planning/tests/test_lanes.py
+++ b/packages/planning/tests/test_lanes.py
@@ -173,8 +173,11 @@ def test_lane_close_and_archive_preserve_parent_contribution(tmp_path: Path) -> 
         parent_contribution="lane artifacts now own strategy and proof aggregation",
         parent_close_permission="may-advance-parent",
     )
-    assert [action.kind for action in close_result.actions] == ["updated", "updated", "proof", "proof"]
+    assert [action.kind for action in close_result.actions] == ["updated", "updated", "next safe action", "proof", "proof"]
+    assert any("lane-archive closeable-lane" in action.detail for action in close_result.actions if action.kind == "next safe action")
     summary = planning_summary(target=tmp_path, profile="compact")
+    assert summary["planning_surface_health"]["status"] == "not-clean"
+    assert any(warning["warning_class"] == "closed_lane_record_live_state" for warning in summary["planning_surface_health"]["warnings"])
     lane = summary["lanes"]["records"][0]
     assert lane["status"] == "closed"
     assert lane["proof_aggregation"]["status"] == "satisfied"
@@ -186,8 +189,63 @@ def test_lane_close_and_archive_preserve_parent_contribution(tmp_path: Path) -> 
     assert not (tmp_path / ".agentic-workspace/planning/lanes/closeable-lane.lane.json").exists()
     assert (tmp_path / ".agentic-workspace/planning/lanes/archive/closeable-lane.lane.json").exists()
     post_archive = planning_summary(target=tmp_path, profile="compact")
+    assert post_archive["planning_surface_health"]["status"] == "clean"
     assert post_archive["lanes"]["record_count"] == 0
     assert post_archive["lanes"]["archived_count"] == 1
+
+
+def test_summary_and_doctor_validate_invalid_active_lane_schema(tmp_path: Path) -> None:
+    install_bootstrap(target=tmp_path)
+    lane_path = tmp_path / ".agentic-workspace" / "planning" / "lanes" / "invalid-lane.lane.json"
+    lane_path.parent.mkdir(parents=True, exist_ok=True)
+    lane_path.write_text(
+        json.dumps(
+            {
+                "kind": "planning-lane/v1",
+                "id": "invalid-lane",
+                "title": "Invalid Lane",
+                "status": "active",
+                "parent_decomposition_ref": "",
+                "lane_outcome": "Expose schema diagnostics before closeout.",
+                "purpose_for_parent": "Prove diagnostics catch malformed slices.",
+                "subsystems": [],
+                "technical_strategy": "Use an intentionally malformed slice.",
+                "slice_sequence": [
+                    {
+                        "id": "bad-slice",
+                        "title": "Bad Slice",
+                        "status": "active",
+                        "execplan": ".agentic-workspace/planning/execplans/bad-slice.plan.json",
+                        "done_when": "This key is not part of the lane slice schema.",
+                    }
+                ],
+                "acceptance_boundary": "Diagnostics report the schema error.",
+                "proof_strategy": "Summary and doctor warnings name the invalid record.",
+                "proof_aggregation": {"status": "not-started", "evidence": [], "known_gaps": []},
+                "residual_lane_work": "",
+                "lane_to_epic_contribution": "",
+                "parent_close_permission": "do-not-close-parent",
+                "closeout_state": {"status": "open", "summary": "", "residual_work": "", "next_owner": ""},
+                "references": [],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = planning_summary(target=tmp_path, profile="compact")
+    warnings = summary["planning_surface_health"]["warnings"]
+    assert summary["planning_surface_health"]["status"] == "not-clean"
+    schema_warning = next(warning for warning in warnings if warning["warning_class"] == "planning_lane_schema_invalid")
+    assert schema_warning["path"].endswith("invalid-lane.lane.json")
+    assert "slice_sequence.0" in schema_warning["message"]
+    assert "execplan_ref" in schema_warning["message"]
+
+    doctor = doctor_bootstrap(target=tmp_path)
+    doctor_warning = next(warning for warning in doctor.warnings if warning["warning_class"] == "planning_lane_schema_invalid")
+    assert doctor_warning["path"].endswith("invalid-lane.lane.json")
+    assert "done_when" in doctor_warning["message"]
 
 
 def test_planning_report_includes_lane_writer_helper_and_status(tmp_path: Path) -> None:


### PR DESCRIPTION
## What landed

- `summary` and `doctor` now share lane-surface diagnostics for schema-invalid lane records.
- Compact summary marks Planning as not-clean when a live lane record is schema-invalid, so `lane-close` is no longer the first command to reveal malformed `slice_sequence` entries.
- Closed live lane records now produce an explicit `closed_lane_record_live_state` warning until `lane-archive` removes them from live Planning state.
- `lane-close` now emits `agentic-planning lane-archive <lane> --target . --format json` as the next safe action after projecting a closed lane.

## Issue mapping

- Closes #1361 by making closed-lane residue visible immediately and by adding the concrete archive follow-up to the close mutation output. Existing activation coverage already verifies `current_slice`/`execplan` projection stays usable; this PR adds the missing close/archive guidance and clean-after-archive assertion.
- Closes #1362 by validating active/open lane records through the same schema-backed projection consumed by summary and doctor, with a regression for invalid `execplan`/`done_when` slice keys and missing required fields.

## Proof

- `uv run pytest packages/planning/tests/test_lanes.py -q --tb=short`
- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_planning_surfaces.py --strict`
- `make test-workspace`

## Notes

This is an existing Planning primitive implementation bugfix. It does not relax the generated-CLI runtime boundary; it fixes the diagnostics/mutation behavior that failed during #1354 dogfooding.