### PR TITLE
Audit runtime boundary minimization inventory

### DIFF
--- a/.agentic-workspace/planning/closeout-evidence/issue-1357-runtime-boundary-inventory.closeout.json
+++ b/.agentic-workspace/planning/closeout-evidence/issue-1357-runtime-boundary-inventory.closeout.json
@@ -1,0 +1,128 @@
+{
+  "kind": "planning-closeout-evidence/v1",
+  "title": "Audit runtime boundary inventory for #1357",
+  "plan_id": "issue-1357-runtime-boundary-inventory",
+  "created_at": "2026-06-06T16:22:20.650896+00:00",
+  "source_plan": ".agentic-workspace/planning/execplans/issue-1357-runtime-boundary-inventory.plan.json",
+  "intended_archive": ".agentic-workspace/planning/execplans/archive/issue-1357-runtime-boundary-inventory.plan.json",
+  "retention": {
+    "state": "archive-retention-skipped",
+    "reason": "retained archive would exceed the structured-file inventory max_bytes guardrail; closing after distillation instead",
+    "rule": "Retained closeout evidence preserves reportable closeout facts when the full execplan archive exceeds inventory size guardrails."
+  },
+  "active_milestone": {
+    "id": "issue-1357-runtime-boundary-inventory",
+    "status": "completed",
+    "scope": "#1357 audit/minimization evidence only.",
+    "ready": "ready",
+    "blocked": "none after execplan activation; proof pending",
+    "optional_deps": "none"
+  },
+  "delegated_judgment": {
+    "requested outcome": "Make #1357 honestly supportable by turning the accepted Python runtime boundary inventory into exact per-symbol minimization evidence.",
+    "hard constraints": "Keep scope to #1357 audit/report evidence; do not claim #1364 generated CLI migration or #1367 compositional IR implementation is complete.",
+    "agent may decide locally": "May add schema fields, inventory metadata, checker report output, tests, and generated reference docs needed to prove exact ownership and minimization routing.",
+    "escalate when": "Escalate if satisfying #1357 requires actually migrating runtime command behavior or changing command-generation architecture."
+  },
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added exact minimization metadata to every accepted runtime boundary, enforced it in the generated-package checker, exposed it in python-completion-blockers output, and covered it with focused tests.",
+    "scope touched": "scripts/check/check_generated_command_packages.py; src/agentic_workspace/contracts/python_runtime_projection_inventory.json; src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json; tests/test_contract_tooling.py; tests/test_generated_command_package_proof_runner.py; .agentic-workspace/planning/state.toml; .agentic-workspace/planning/execplans/issue-1357-runtime-boundary-inventory.plan.json",
+    "changed surfaces": "runtime boundary inventory schema/data, generated command package proof report, focused tests, planning execplan/state",
+    "validations run": "uv run pytest tests/test_generated_command_package_proof_runner.py::test_full_python_completion_rejects_weak_runtime_boundary_minimization_metadata tests/test_generated_command_package_proof_runner.py::test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundaries tests/test_generated_command_package_proof_runner.py::test_python_completion_blocker_report_has_json_cli_mode tests/test_contract_tooling.py::test_python_runtime_projection_inventory_tracks_generated_output_debt -q -> 4 passed; uv run python scripts/check/check_generated_command_packages.py -> ok; uv run python scripts/generate/generate_command_packages.py --check -> ok; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -> passed; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success -> ok; uv run python scripts/check/check_structured_file_inventory.py --quiet-success -> passed; uv run python scripts/run_agentic_workspace.py summary --target . --format json -> warning_count 0; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json -> healthy; make schema-reference-docs -> ok; make test-workspace -> ok; make lint-workspace -> ok",
+    "result for continuation": "#1357 slice complete; #1364 generated CLI migration and #1367 compositional IR remain open",
+    "next step": "Create PR for #1357 and continue issue priority order after merge."
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "yes; no runtime behavior migration or command-generation architecture changes were made",
+    "proof status": "passed",
+    "intent served": "yes for #1357 audit/minimization evidence; no claim that #1364/#1367 are complete",
+    "config compliance": "AW start/implement used; active execplan created when AW required planning ownership",
+    "misinterpretation risk": "low; report explicitly distinguishes fresh/inventoried from minimized",
+    "follow-on decision": "continue with #1367/#1364 in priority order after this PR merges"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_generated_command_package_proof_runner.py::test_full_python_completion_rejects_weak_runtime_boundary_minimization_metadata tests/test_generated_command_package_proof_runner.py::test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundaries tests/test_generated_command_package_proof_runner.py::test_python_completion_blocker_report_has_json_cli_mode tests/test_contract_tooling.py::test_python_runtime_projection_inventory_tracks_generated_output_debt -q -> 4 passed; uv run python scripts/check/check_generated_command_packages.py -> ok; uv run python scripts/generate/generate_command_packages.py --check -> ok; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -> passed; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success -> ok; uv run python scripts/check/check_structured_file_inventory.py --quiet-success -> passed; uv run python scripts/run_agentic_workspace.py summary --target . --format json -> warning_count 0; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json -> healthy; make schema-reference-docs -> ok; make test-workspace -> ok; make lint-workspace -> ok",
+    "proof achieved now": "passed",
+    "evidence for \"proof achieved\" state": "uv run pytest tests/test_generated_command_package_proof_runner.py::test_full_python_completion_rejects_weak_runtime_boundary_minimization_metadata tests/test_generated_command_package_proof_runner.py::test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundaries tests/test_generated_command_package_proof_runner.py::test_python_completion_blocker_report_has_json_cli_mode tests/test_contract_tooling.py::test_python_runtime_projection_inventory_tracks_generated_output_debt -q -> 4 passed; uv run python scripts/check/check_generated_command_packages.py -> ok; uv run python scripts/generate/generate_command_packages.py --check -> ok; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -> passed; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success -> ok; uv run python scripts/check/check_structured_file_inventory.py --quiet-success -> passed; uv run python scripts/run_agentic_workspace.py summary --target . --format json -> warning_count 0; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json -> healthy; make schema-reference-docs -> ok; make test-workspace -> ok; make lint-workspace -> ok"
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1357 audit and shrink accepted runtime primitive inventory for generated CLI completion.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "#1357 audit evidence is satisfied: every accepted runtime boundary has exact minimization metadata; checker/report/tests enforce category, route, owner, tracking issue, edit reasons, and stale-when evidence.",
+    "unsolved intent passed to": "#1364 and #1367 remain open for actual migration/compositional IR"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "complete",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "This bounded #1357 slice is complete, but the larger generated CLI migration/compositional IR intent remains open.",
+    "evidence carried forward": "focused tests, generated command package check, generated freshness check, contract tooling, structured inventory, workspace tests/lint, summary, and doctor passed.",
+    "reopen trigger": "A runtime boundary can be accepted without exact minimization metadata or the blocker report again conflates fresh/inventoried with minimized."
+  },
+  "durable_residue": {
+    "status": "contract",
+    "learned constraint": "accepted runtime boundary inventory is not the same as minimized runtime boundary",
+    "motivation worth preserving": "Already encoded in python_runtime_projection_inventory schema/data and checker report; no separate Memory note needed.",
+    "canonical owner now": "src/agentic_workspace/contracts/python_runtime_projection_inventory.json and scripts/check/check_generated_command_packages.py",
+    "promotion trigger": "Promote only if future agents miss this distinction outside generated CLI work.",
+    "retention after promotion": "retain"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1357 audit/minimization evidence implemented",
+    "validation confirmed": "uv run pytest tests/test_generated_command_package_proof_runner.py::test_full_python_completion_rejects_weak_runtime_boundary_minimization_metadata tests/test_generated_command_package_proof_runner.py::test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundaries tests/test_generated_command_package_proof_runner.py::test_python_completion_blocker_report_has_json_cli_mode tests/test_contract_tooling.py::test_python_runtime_projection_inventory_tracks_generated_output_debt -q -> 4 passed; uv run python scripts/check/check_generated_command_packages.py -> ok; uv run python scripts/generate/generate_command_packages.py --check -> ok; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py -> passed; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success -> ok; uv run python scripts/check/check_structured_file_inventory.py --quiet-success -> passed; uv run python scripts/run_agentic_workspace.py summary --target . --format json -> warning_count 0; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json -> healthy; make schema-reference-docs -> ok; make test-workspace -> ok; make lint-workspace -> ok",
+    "follow-on routed to": "#1364 and #1367",
+    "post-work posterity capture": "PR body and this execplan",
+    "resume from": "next prioritized issue after #1357 PR",
+    "knowledge promoted (Memory/Docs/Config)": "none; this is contract/checker evidence, not durable repo memory"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "Existing planning workflow follow-ups; no new issue filed from this slice.",
+          "owner": "",
+          "source": "improvement_signal_review.signals routed"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "#1364 remains the full generated CLI migration owner.",
+          "owner": "",
+          "source": "closeout_distillation"
+        },
+        {
+          "summary": "#1367 owns compositional operation IR/modular primitive architecture.",
+          "owner": "",
+          "source": "closeout_distillation"
+        }
+      ],
+      "memory": [
+        {
+          "summary": "none; this is contract/checker evidence, not durable repo memory",
+          "owner": "Memory",
+          "source": "execution_summary"
+        }
+      ],
+      "config_check": [
+        {
+          "summary": "none; this is contract/checker evidence, not durable repo memory",
+          "owner": "config/check",
+          "source": "execution_summary"
+        }
+      ],
+      "docs": [],
+      "issue_follow_up": [
+        {
+          "summary": "No new issue needed; follow-ons already exist as #1364 and #1367.",
+          "owner": "",
+          "source": "closeout_distillation"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -151,6 +151,32 @@ PYTHON_RUNTIME_BOUNDARY_MINIMIZATION_HAND_OWNED_CLASSES = {
     "package-specific-judgment",
     "provider-integration",
 }
+PYTHON_RUNTIME_BOUNDARY_EXPECTED_MINIMIZATION = {
+    "front-door-dispatch": {
+        "minimization_category": "front-door-dispatch-extraction-candidate",
+        "minimization_route": "candidate-extract-when-contract-stable",
+    },
+    "live-workspace-inspection": {
+        "minimization_category": "live-workspace-inspection",
+        "minimization_route": "keep-as-hand-owned-primitive",
+    },
+    "mutation-orchestration": {
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+    },
+    "package-specific-judgment": {
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+    },
+    "provider-integration": {
+        "minimization_category": "provider-integration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+    },
+    "generic-deterministic-runtime-debt": {
+        "minimization_category": "generated-command-behavior-move-required",
+        "minimization_route": "move-to-command-generation-or-ir",
+    },
+}
 PYTHON_OUTPUT_BOUNDARY_AUDIT_REQUIRED_PHRASES = (
     "generated-owned output coverage:",
     "accepted source fallback:",
@@ -1795,10 +1821,16 @@ def _validate_python_completion_accepted_runtime_boundaries(*, require_exact: bo
             "operation_ids",
             "primitive_refs",
             "runtime_boundary_class",
+            "minimization_category",
+            "minimization_route",
+            "minimization_owner",
+            "minimization_tracking_issue",
+            "direct_edit_reasons_allowed",
             "why_not_generic_deterministic",
             "conformance_ref",
             "status",
             "generic_behavior_audit",
+            "stale_when",
         ):
             value = entry.get(field)
             if isinstance(value, list):
@@ -1808,6 +1840,19 @@ def _validate_python_completion_accepted_runtime_boundaries(*, require_exact: bo
             if missing:
                 errors.append(f"{location} must include non-empty {field}")
         boundary_class = str(entry.get("runtime_boundary_class", ""))
+        expected_minimization = PYTHON_RUNTIME_BOUNDARY_EXPECTED_MINIMIZATION.get(boundary_class)
+        if expected_minimization is None:
+            errors.append(f"{location} has unsupported runtime_boundary_class {boundary_class!r}")
+        else:
+            for field, expected_value in expected_minimization.items():
+                if str(entry.get(field, "")) != expected_value:
+                    errors.append(f"{location} must declare {field}={expected_value!r} for {boundary_class!r}")
+        edit_reasons = entry.get("direct_edit_reasons_allowed", [])
+        if edit_reasons != list(RUNTIME_SOURCE_EDIT_ACCEPTED_REASONS):
+            errors.append(
+                f"{location} direct_edit_reasons_allowed must be {list(RUNTIME_SOURCE_EDIT_ACCEPTED_REASONS)!r} "
+                "so broad runtime edits cannot be justified by vague package-domain wording"
+            )
         if boundary_class in PYTHON_OPERATION_FULL_COMPLETION_BLOCKING_BOUNDARY_CLASSES:
             errors.append(f"{location} cannot accept generic deterministic runtime debt")
         if str(entry.get("status", "")) != PYTHON_ACCEPTED_RUNTIME_BOUNDARY_PERMANENCE_STATUS:
@@ -1874,18 +1919,31 @@ def _python_runtime_boundary_metrics() -> dict[str, object]:
     if not isinstance(entries, list):
         return {"status": "unavailable", "error": "accepted_runtime_boundaries.entries is not a list"}
     class_counts: dict[str, int] = {}
+    minimization_category_counts: dict[str, int] = {}
+    minimization_route_counts: dict[str, int] = {}
+    minimization_tracking_issue_counts: dict[str, int] = {}
     package_counts: dict[str, int] = {}
     binding_kind_counts: dict[str, int] = {}
     output_emission_symbols: list[dict[str, str]] = []
     python_bridge_symbols: list[dict[str, str]] = []
     generic_debt_symbols: list[dict[str, str]] = []
+    exact_minimization_inventory: list[dict[str, str]] = []
     current_symbol_ids: set[str] = set()
     for entry in entries:
         if not isinstance(entry, dict):
             continue
-        current_symbol_ids.add(_accepted_runtime_symbol_id(entry))
+        symbol_id = _accepted_runtime_symbol_id(entry)
+        current_symbol_ids.add(symbol_id)
         boundary_class = str(entry.get("runtime_boundary_class", "unknown") or "unknown")
         class_counts[boundary_class] = class_counts.get(boundary_class, 0) + 1
+        minimization_category = str(entry.get("minimization_category", "unknown") or "unknown")
+        minimization_category_counts[minimization_category] = minimization_category_counts.get(minimization_category, 0) + 1
+        minimization_route = str(entry.get("minimization_route", "unknown") or "unknown")
+        minimization_route_counts[minimization_route] = minimization_route_counts.get(minimization_route, 0) + 1
+        minimization_tracking_issue = str(entry.get("minimization_tracking_issue", "unknown") or "unknown")
+        minimization_tracking_issue_counts[minimization_tracking_issue] = (
+            minimization_tracking_issue_counts.get(minimization_tracking_issue, 0) + 1
+        )
         owner_package = str(entry.get("owner_package", "unknown") or "unknown")
         package_counts[owner_package] = package_counts.get(owner_package, 0) + 1
         binding_kind = str(entry.get("binding_kind", "unknown") or "unknown")
@@ -1895,6 +1953,21 @@ def _python_runtime_boundary_metrics() -> dict[str, object]:
         source_module = str(entry.get("source_module", ""))
         primitive_refs = entry.get("primitive_refs", [])
         primitive_ref_strings = [str(ref) for ref in primitive_refs] if isinstance(primitive_refs, list) else []
+        exact_minimization_inventory.append(
+            {
+                "symbol_id": symbol_id,
+                "binding_kind": binding_kind,
+                "source_module": source_module,
+                "source_symbol": source_symbol,
+                "owner_package": owner_package,
+                "runtime_boundary_class": boundary_class,
+                "minimization_category": minimization_category,
+                "minimization_route": minimization_route,
+                "minimization_owner": str(entry.get("minimization_owner", "")),
+                "minimization_tracking_issue": minimization_tracking_issue,
+                "stale_when": str(entry.get("stale_when", "")),
+            }
+        )
         if "emit" in source_symbol:
             output_emission_symbols.append(
                 {
@@ -1931,6 +2004,9 @@ def _python_runtime_boundary_metrics() -> dict[str, object]:
         "accepted_runtime_symbol_count_by_package": dict(sorted(package_counts.items())),
         "accepted_runtime_symbol_count_by_class": dict(sorted(class_counts.items())),
         "accepted_runtime_symbol_count_by_binding_kind": dict(sorted(binding_kind_counts.items())),
+        "accepted_runtime_symbol_count_by_minimization_category": dict(sorted(minimization_category_counts.items())),
+        "accepted_runtime_symbol_count_by_minimization_route": dict(sorted(minimization_route_counts.items())),
+        "accepted_runtime_symbol_count_by_minimization_tracking_issue": dict(sorted(minimization_tracking_issue_counts.items())),
         "output_fallback_symbol_count": len(output_emission_symbols),
         "python_bridge_step_count": len(python_bridge_symbols),
         "generic_debt_symbol_count": len(generic_debt_symbols),
@@ -1941,6 +2017,7 @@ def _python_runtime_boundary_metrics() -> dict[str, object]:
         "accepted_output_emission_symbols": output_emission_symbols,
         "python_bridge_symbols": python_bridge_symbols,
         "generic_debt_symbols": generic_debt_symbols,
+        "exact_minimization_inventory": sorted(exact_minimization_inventory, key=lambda item: item["symbol_id"]),
     }
 
 
@@ -1958,8 +2035,22 @@ def _runtime_boundary_minimization_report(metrics: dict[str, object]) -> dict[st
     generic_debt_symbols = metrics.get("generic_debt_symbols", [])
     if not isinstance(generic_debt_symbols, list):
         generic_debt_symbols = []
+    category_counts_obj = metrics.get("accepted_runtime_symbol_count_by_minimization_category", {})
+    category_counts = {str(key): int(value) for key, value in category_counts_obj.items()} if isinstance(category_counts_obj, dict) else {}
+    route_counts_obj = metrics.get("accepted_runtime_symbol_count_by_minimization_route", {})
+    route_counts = {str(key): int(value) for key, value in route_counts_obj.items()} if isinstance(route_counts_obj, dict) else {}
+    tracking_issue_counts_obj = metrics.get("accepted_runtime_symbol_count_by_minimization_tracking_issue", {})
+    tracking_issue_counts = (
+        {str(key): int(value) for key, value in tracking_issue_counts_obj.items()}
+        if isinstance(tracking_issue_counts_obj, dict)
+        else {}
+    )
+    exact_inventory = metrics.get("exact_minimization_inventory", [])
+    if not isinstance(exact_inventory, list):
+        exact_inventory = []
     hand_owned_count = sum(class_counts.get(boundary_class, 0) for boundary_class in PYTHON_RUNTIME_BOUNDARY_MINIMIZATION_HAND_OWNED_CLASSES)
     move_candidate_count = class_counts.get("generic-deterministic-runtime-debt", 0)
+    extraction_candidate_count = route_counts.get("candidate-extract-when-contract-stable", 0)
     minimization_claim_allowed = accepted_symbol_count == 0
     status = "minimized" if minimization_claim_allowed else "not-minimized-hand-owned-boundaries-remain"
     return {
@@ -1974,12 +2065,17 @@ def _runtime_boundary_minimization_report(metrics: dict[str, object]) -> dict[st
         "accepted_symbol_count": accepted_symbol_count,
         "remaining_hand_owned_symbol_count": hand_owned_count,
         "move_to_command_generation_candidate_count": move_candidate_count,
+        "contract_stable_extraction_candidate_count": extraction_candidate_count,
         "remaining_by_runtime_boundary_class": dict(sorted(class_counts.items())),
+        "remaining_by_minimization_category": dict(sorted(category_counts.items())),
+        "remaining_by_minimization_route": dict(sorted(route_counts.items())),
+        "remaining_by_minimization_tracking_issue": dict(sorted(tracking_issue_counts.items())),
         "route_by_runtime_boundary_class": {
             key: PYTHON_RUNTIME_BOUNDARY_MINIMIZATION_ROUTES[key]
             for key in sorted(PYTHON_RUNTIME_BOUNDARY_MINIMIZATION_ROUTES)
         },
         "move_to_command_generation_candidates": generic_debt_symbols,
+        "exact_runtime_boundary_inventory": exact_inventory,
         "required_evidence_for_remaining_boundaries": [
             "binding_kind",
             "source_module",
@@ -1988,9 +2084,15 @@ def _runtime_boundary_minimization_report(metrics: dict[str, object]) -> dict[st
             "primitive_refs",
             "owner_package",
             "runtime_boundary_class",
+            "minimization_category",
+            "minimization_route",
+            "minimization_owner",
+            "minimization_tracking_issue",
+            "direct_edit_reasons_allowed",
             "why_not_generic_deterministic",
             "conformance_ref",
             "generic_behavior_audit",
+            "stale_when",
         ],
         "shrink_next_when": [
             "a boundary's deterministic dataflow can be expressed as shared primitive IR",

--- a/src/agentic_workspace/contracts/python_runtime_projection_inventory.json
+++ b/src/agentic_workspace/contracts/python_runtime_projection_inventory.json
@@ -119,7 +119,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "memory.adopt.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Default dry-run behavior is no longer generic deterministic runtime debt: it uses path.target_root.resolve, payload.lifecycle-plan, and output.emit.install-result. The remaining package-domain primitive is a mutation/custom-policy fallback and is not counted as portable codegen coverage."
+        "generic_behavior_audit": "Default dry-run behavior is no longer generic deterministic runtime debt: it uses path.target_root.resolve, payload.lifecycle-plan, and output.emit.install-result. The remaining package-domain primitive is a mutation/custom-policy fallback and is not counted as portable codegen coverage.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -138,7 +147,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "memory.bootstrap-cleanup.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.bootstrap.cleanup) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.bootstrap.cleanup) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -157,7 +175,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "memory.capture-note.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.capture_note.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.capture_note.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -176,7 +203,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "memory.create-note.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.note.create) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.note.create) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -198,7 +234,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "memory.init.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Default dry-run behavior is no longer generic deterministic runtime debt: it uses path.target_root.resolve, payload.lifecycle-plan, and output.emit.install-result. The remaining package-domain primitive is a mutation/custom-policy fallback and is not counted as portable codegen coverage."
+        "generic_behavior_audit": "Default dry-run behavior is no longer generic deterministic runtime debt: it uses path.target_root.resolve, payload.lifecycle-plan, and output.emit.install-result. The remaining package-domain primitive is a mutation/custom-policy fallback and is not counted as portable codegen coverage.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -220,7 +265,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "memory.install.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Default dry-run behavior is no longer generic deterministic runtime debt: it uses path.target_root.resolve, payload.lifecycle-plan, and output.emit.install-result. The remaining package-domain primitive is a mutation/custom-policy fallback and is not counted as portable codegen coverage."
+        "generic_behavior_audit": "Default dry-run behavior is no longer generic deterministic runtime debt: it uses path.target_root.resolve, payload.lifecycle-plan, and output.emit.install-result. The remaining package-domain primitive is a mutation/custom-policy fallback and is not counted as portable codegen coverage.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -239,7 +293,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "memory.migrate-layout.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.migrate_layout.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.migrate_layout.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -258,7 +321,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "memory.promotion-report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while memory.promotion_report.load names the Memory package-domain promotion report boundary. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while memory.promotion_report.load names the Memory package-domain promotion report boundary. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -277,7 +349,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "memory.route-review.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.route_review.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.route_review.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -296,7 +377,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "memory.route.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.route.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.route.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -315,7 +405,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "memory.search.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.search.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.search.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -334,7 +433,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "memory.sync-memory.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.sync_memory.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.sync_memory.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -353,7 +461,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "memory.uninstall.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.uninstall.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.uninstall.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -372,7 +489,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "memory.upgrade.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.upgrade.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.upgrade.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -391,7 +517,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.adopt.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.adopt.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.adopt.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -410,7 +545,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.close-item.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.close-item.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.close-item.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -429,7 +573,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.create-review.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.create-review.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.create-review.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -448,7 +601,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.doctor.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.bootstrap.doctor.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.bootstrap.doctor.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -467,7 +629,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.handoff.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.handoff.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.handoff.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -486,7 +657,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.init.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.init.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.init.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -505,7 +685,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.install.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.install.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.install.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -524,7 +713,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.status.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.bootstrap.status.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.bootstrap.status.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -543,7 +741,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.uninstall.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.uninstall.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.uninstall.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -562,7 +769,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.upgrade.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.upgrade.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.upgrade.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -581,7 +797,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.verify-payload.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.verify-payload.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.verify-payload.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -616,7 +841,16 @@
         "why_not_generic_deterministic": "Generated JSON dict emission and common compact/tiny text forms are emitted before source fallback. The accepted source fallback is remaining package-specific output judgment for memory capture-note, current, prompt, promotion, install/adopt/init result, route review, and Memory report compatibility text whose wording is coupled to Memory package semantics.",
         "conformance_ref": "memory.bootstrap-cleanup.process, memory.capture-note.process, memory.create-note.dry-run.process, memory.current-show.process, memory.list-files.process, memory.list-skills.process, memory.migrate-layout.lifecycle.dry-run.process, memory.promotion-report.process, memory.prompt.process, memory.report.process, memory.route-report.process, memory.route-review.process, memory.route.process, memory.search.process, memory.sync-memory.process, memory.uninstall.lifecycle.dry-run.process, memory.upgrade.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "generated-owned output coverage: JSON dict emission, compact-answer text, selected-output text, delegation-outcomes text, memory route/report text, and planning-module tiny text are handled before source fallback; planning-module tiny text is now owned by the codegen output primitive. accepted source fallback: memory capture-note, current, prompt, promotion, install/adopt/init result, route review, and Memory report compatibility text remain in Memory runtime because they encode Memory package semantics and compatibility wording. not accepted as generic output: generic JSON/text dict emission is already generated-owned and this exact symbol is accepted only for the named Memory-specific fallback cases."
+        "generic_behavior_audit": "generated-owned output coverage: JSON dict emission, compact-answer text, selected-output text, delegation-outcomes text, memory route/report text, and planning-module tiny text are handled before source fallback; planning-module tiny text is now owned by the codegen output primitive. accepted source fallback: memory capture-note, current, prompt, promotion, install/adopt/init result, route review, and Memory report compatibility text remain in Memory runtime because they encode Memory package semantics and compatibility wording. not accepted as generic output: generic JSON/text dict emission is already generated-owned and this exact symbol is accepted only for the named Memory-specific fallback cases.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -635,7 +869,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "memory.doctor.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Non-strict, non-verbose text and JSON behavior is no longer generic deterministic runtime debt: it uses path.target_root.resolve, payload.status, and output.emit.install-result over schema-backed Memory payload policy. The remaining package-domain primitive is a verbose/strict-policy fallback and is not counted as portable codegen coverage."
+        "generic_behavior_audit": "Non-strict, non-verbose text and JSON behavior is no longer generic deterministic runtime debt: it uses path.target_root.resolve, payload.status, and output.emit.install-result over schema-backed Memory payload policy. The remaining package-domain primitive is a verbose/strict-policy fallback and is not counted as portable codegen coverage.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -654,7 +897,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "memory.current-show.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.current.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.current.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -673,7 +925,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "memory.prompt.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.prompt.render) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (memory.prompt.render) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -692,7 +953,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "memory.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Non-verbose text/JSON behavior is no longer generic deterministic runtime debt: it uses path.target_root.resolve, toml.table.counts, payload.assemble, and output.emit. The remaining memory.report.load fallback is still explicit package-domain debt for verbose behavior, not portable codegen completion."
+        "generic_behavior_audit": "Non-verbose text/JSON behavior is no longer generic deterministic runtime debt: it uses path.target_root.resolve, toml.table.counts, payload.assemble, and output.emit. The remaining memory.report.load fallback is still explicit package-domain debt for verbose behavior, not portable codegen completion.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -711,7 +981,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "memory.route-report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment for the remaining verbose fallback; generated operation IR now builds the non-verbose text/JSON tiny route snapshot from target-local files with path.target_root.resolve, filesystem.exists, filesystem.glob, payload.assemble, and output.emit. The remaining memory.route_report.load fallback is still explicit package-domain debt for verbose behavior, not portable codegen completion."
+        "generic_behavior_audit": "Classified as package-specific-judgment for the remaining verbose fallback; generated operation IR now builds the non-verbose text/JSON tiny route snapshot from target-local files with path.target_root.resolve, filesystem.exists, filesystem.glob, payload.assemble, and output.emit. The remaining memory.route_report.load fallback is still explicit package-domain debt for verbose behavior, not portable codegen completion.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -730,7 +1009,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR, codegen-owned run_operation_steps, and generated output own deterministic tiny report text, while planning.report.load remains an explicit package-boundary call for report payload construction and verbose detail. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR, codegen-owned run_operation_steps, and generated output own deterministic tiny report text, while planning.report.load remains an explicit package-boundary call for report payload construction and verbose detail. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -749,7 +1037,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR, codegen-owned run_operation_steps, and generated output own deterministic tiny report text, while planning.report.load remains an explicit package-boundary call for report payload construction and verbose detail. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR, codegen-owned run_operation_steps, and generated output own deterministic tiny report text, while planning.report.load remains an explicit package-boundary call for report payload construction and verbose detail. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -768,7 +1065,16 @@
         "runtime_boundary_class": "mutation-orchestration",
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.adopt.lifecycle.dry-run.process",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.adopt.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.adopt.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -787,7 +1093,16 @@
         "runtime_boundary_class": "package-specific-judgment",
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.close-item.process",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.close-item.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.close-item.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -806,7 +1121,16 @@
         "runtime_boundary_class": "package-specific-judgment",
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.status.process",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.bootstrap.status.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.bootstrap.status.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -825,7 +1149,16 @@
         "runtime_boundary_class": "package-specific-judgment",
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.create-review.process",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.create-review.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.create-review.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -844,7 +1177,16 @@
         "runtime_boundary_class": "package-specific-judgment",
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.doctor.process",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.bootstrap.doctor.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.bootstrap.doctor.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -865,7 +1207,16 @@
         "runtime_boundary_class": "mutation-orchestration",
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.init.lifecycle.dry-run.process, planning.install.lifecycle.dry-run.process",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.init.apply, planning.install.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.init.apply, planning.install.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -884,7 +1235,16 @@
         "runtime_boundary_class": "package-specific-judgment",
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.handoff.process",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.handoff.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.handoff.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -903,7 +1263,16 @@
         "runtime_boundary_class": "mutation-orchestration",
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.uninstall.lifecycle.dry-run.process",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.uninstall.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.uninstall.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -922,7 +1291,16 @@
         "runtime_boundary_class": "mutation-orchestration",
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.upgrade.lifecycle.dry-run.process",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.upgrade.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.upgrade.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -941,7 +1319,16 @@
         "runtime_boundary_class": "package-specific-judgment",
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.verify-payload.process",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.verify-payload.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.verify-payload.load) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -960,7 +1347,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.archive-plan.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.archive-plan.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.archive-plan.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -979,7 +1375,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.closeout.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.closeout.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.closeout.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -998,7 +1403,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.delegation-decision.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.delegation-decision.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.delegation-decision.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1017,7 +1431,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.intake-artifact.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.intake-artifact.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.intake-artifact.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1036,7 +1459,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.new-plan.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.new-plan.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.new-plan.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1055,7 +1487,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.promote-to-plan.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.promote-to-plan.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.promote-to-plan.apply) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1064,13 +1505,26 @@
         "source_module": "repo_planning_bootstrap.runtime_projection",
         "source_symbol": "apply_planning_lane_create_operation",
         "owner_package": "planning package runtime boundary",
-        "operation_ids": ["planning.lane-create.lifecycle"],
-        "primitive_refs": ["planning.lane-create.apply"],
+        "operation_ids": [
+          "planning.lane-create.lifecycle"
+        ],
+        "primitive_refs": [
+          "planning.lane-create.apply"
+        ],
         "runtime_boundary_class": "mutation-orchestration",
         "why_not_generic_deterministic": "The symbol owns Planning lane lifecycle state mutation policy, validation, conflict handling, and provenance updates.",
         "conformance_ref": "planning.lane-create.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR owns dataflow while planning.lane-create.apply remains an explicit package-boundary call."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR owns dataflow while planning.lane-create.apply remains an explicit package-boundary call.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1079,13 +1533,26 @@
         "source_module": "repo_planning_bootstrap.runtime_projection",
         "source_symbol": "apply_planning_lane_promote_operation",
         "owner_package": "planning package runtime boundary",
-        "operation_ids": ["planning.lane-promote.lifecycle"],
-        "primitive_refs": ["planning.lane-promote.apply"],
+        "operation_ids": [
+          "planning.lane-promote.lifecycle"
+        ],
+        "primitive_refs": [
+          "planning.lane-promote.apply"
+        ],
         "runtime_boundary_class": "mutation-orchestration",
         "why_not_generic_deterministic": "The symbol owns Planning lane lifecycle state mutation policy, validation, conflict handling, and provenance updates.",
         "conformance_ref": "planning.lane-promote.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR owns dataflow while planning.lane-promote.apply remains an explicit package-boundary call."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR owns dataflow while planning.lane-promote.apply remains an explicit package-boundary call.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1094,13 +1561,26 @@
         "source_module": "repo_planning_bootstrap.runtime_projection",
         "source_symbol": "apply_planning_lane_activate_operation",
         "owner_package": "planning package runtime boundary",
-        "operation_ids": ["planning.lane-activate.lifecycle"],
-        "primitive_refs": ["planning.lane-activate.apply"],
+        "operation_ids": [
+          "planning.lane-activate.lifecycle"
+        ],
+        "primitive_refs": [
+          "planning.lane-activate.apply"
+        ],
         "runtime_boundary_class": "mutation-orchestration",
         "why_not_generic_deterministic": "The symbol owns Planning lane lifecycle state mutation policy, validation, conflict handling, and provenance updates.",
         "conformance_ref": "planning.lane-activate.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR owns dataflow while planning.lane-activate.apply remains an explicit package-boundary call."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR owns dataflow while planning.lane-activate.apply remains an explicit package-boundary call.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1109,13 +1589,26 @@
         "source_module": "repo_planning_bootstrap.runtime_projection",
         "source_symbol": "apply_planning_lane_close_operation",
         "owner_package": "planning package runtime boundary",
-        "operation_ids": ["planning.lane-close.lifecycle"],
-        "primitive_refs": ["planning.lane-close.apply"],
+        "operation_ids": [
+          "planning.lane-close.lifecycle"
+        ],
+        "primitive_refs": [
+          "planning.lane-close.apply"
+        ],
         "runtime_boundary_class": "mutation-orchestration",
         "why_not_generic_deterministic": "The symbol owns Planning lane lifecycle state mutation policy, validation, conflict handling, and provenance updates.",
         "conformance_ref": "planning.lane-close.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR owns dataflow while planning.lane-close.apply remains an explicit package-boundary call."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR owns dataflow while planning.lane-close.apply remains an explicit package-boundary call.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1124,13 +1617,26 @@
         "source_module": "repo_planning_bootstrap.runtime_projection",
         "source_symbol": "apply_planning_lane_archive_operation",
         "owner_package": "planning package runtime boundary",
-        "operation_ids": ["planning.lane-archive.lifecycle"],
-        "primitive_refs": ["planning.lane-archive.apply"],
+        "operation_ids": [
+          "planning.lane-archive.lifecycle"
+        ],
+        "primitive_refs": [
+          "planning.lane-archive.apply"
+        ],
         "runtime_boundary_class": "mutation-orchestration",
         "why_not_generic_deterministic": "The symbol owns Planning lane lifecycle state mutation policy, validation, conflict handling, and provenance updates.",
         "conformance_ref": "planning.lane-archive.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR owns dataflow while planning.lane-archive.apply remains an explicit package-boundary call."
+        "generic_behavior_audit": "Classified as mutation-orchestration; generated operation IR owns dataflow while planning.lane-archive.apply remains an explicit package-boundary call.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1175,7 +1681,16 @@
         "why_not_generic_deterministic": "Generated JSON dict emission and common compact/tiny text forms are emitted before source fallback. The accepted source fallback is remaining package-specific output judgment for planning summary, reconcile, handoff, prompt, list-files, and Planning lifecycle result compatibility text whose wording is coupled to Planning state semantics.",
         "conformance_ref": "planning.adopt.lifecycle.dry-run.process, planning.archive-plan.lifecycle.dry-run.process, planning.close-item.process, planning.closeout.lifecycle.dry-run.process, planning.create-review.process, planning.delegation-decision.lifecycle.dry-run.process, planning.doctor.process, planning.handoff.process, planning.init.lifecycle.dry-run.process, planning.install.lifecycle.dry-run.process, planning.intake-artifact.lifecycle.dry-run.process, planning.list-files.process, planning.new-plan.lifecycle.dry-run.process, planning.promote-to-plan.lifecycle.dry-run.process, planning.prompt.process, planning.reconcile.process, planning.report.process, planning.status.process, planning.summary.process, planning.uninstall.lifecycle.dry-run.process, planning.upgrade.lifecycle.dry-run.process, planning.verify-payload.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "generated-owned output coverage: JSON dict emission, compact-answer text, selected-output text, delegation-outcomes text, memory route/report text, and planning-module tiny text are handled before source fallback; planning-module tiny text is now owned by the codegen output primitive. accepted source fallback: planning summary, reconcile, handoff, prompt, list-files, and Planning lifecycle result compatibility text remain in Planning runtime because they encode Planning state view semantics and package compatibility wording. not accepted as generic output: generic JSON/text dict emission is already generated-owned and this exact symbol is accepted only for the named Planning-specific fallback cases."
+        "generic_behavior_audit": "generated-owned output coverage: JSON dict emission, compact-answer text, selected-output text, delegation-outcomes text, memory route/report text, and planning-module tiny text are handled before source fallback; planning-module tiny text is now owned by the codegen output primitive. accepted source fallback: planning summary, reconcile, handoff, prompt, list-files, and Planning lifecycle result compatibility text remain in Planning runtime because they encode Planning state view semantics and package compatibility wording. not accepted as generic output: generic JSON/text dict emission is already generated-owned and this exact symbol is accepted only for the named Planning-specific fallback cases.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1194,7 +1709,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "planning.reconcile.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as mutation-orchestration; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1213,7 +1737,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.summary.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1232,7 +1765,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "planning.prompt.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.prompt.render) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (planning.prompt.render) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1251,7 +1793,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "delegation-outcome.append.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR, codegen-owned run_operation_steps, and generated output own the deterministic command result text, while workspace.root.resolve and delegation.outcome.append remain explicit package-boundary calls for target validation and local-only record append. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR, codegen-owned run_operation_steps, and generated output own the deterministic command result text, while workspace.root.resolve and delegation.outcome.append remain explicit package-boundary calls for target validation and local-only record append. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1278,7 +1829,16 @@
         "why_not_generic_deterministic": "Generated JSON, selected-output, compact-answer, defaults-router, delegation-outcome, memory route/report text, and codegen-owned planning-module tiny text are emitted before source fallback. The accepted source fallback is remaining package-specific output judgment for prompt payload text, workspace-system-intent text, and config/defaults compatibility surfaces whose wording depends on workspace package policy.",
         "conformance_ref": "config.report.process, defaults.report.process, delegation-outcome.append.process, prompt.init.process, prompt.uninstall.process, prompt.upgrade.process, system-intent.sync.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "generated-owned output coverage: JSON dict emission, selected-output text, compact-answer text, defaults-router text, delegation-outcomes text, memory route/report text, and planning-module tiny text are handled before source fallback; planning-module tiny text is now owned by the codegen output primitive. accepted source fallback: prompt payload text, workspace-system-intent text, and config/defaults compatibility emitters remain in workspace runtime because their wording is coupled to workspace policy and compatibility contracts. not accepted as generic output: generic JSON/text dict emission is already generated-owned and this exact symbol is accepted only for the named package-specific fallback cases."
+        "generic_behavior_audit": "generated-owned output coverage: JSON dict emission, selected-output text, compact-answer text, defaults-router text, delegation-outcomes text, memory route/report text, and planning-module tiny text are handled before source fallback; planning-module tiny text is now owned by the codegen output primitive. accepted source fallback: prompt payload text, workspace-system-intent text, and config/defaults compatibility emitters remain in workspace runtime because their wording is coupled to workspace policy and compatibility contracts. not accepted as generic output: generic JSON/text dict emission is already generated-owned and this exact symbol is accepted only for the named package-specific fallback cases.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1297,7 +1857,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "config.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, and generated output owns selected-output text. Domain primitive refs (workspace.root.resolve, workspace.config.load, output.fields.select, workspace.config.emit) remain explicit package-boundary calls for config loading, profile projection, and tiny/full text. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, and generated output owns selected-output text. Domain primitive refs (workspace.root.resolve, workspace.config.load, output.fields.select, workspace.config.emit) remain explicit package-boundary calls for config loading, profile projection, and tiny/full text. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1316,7 +1885,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "system-intent.sync.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (workspace.root.resolve, system_intent.config.resolve, system_intent.source_metadata.refresh, system_intent.mirror.read_or_create, system_intent.result.emit) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (workspace.root.resolve, system_intent.config.resolve, system_intent.source_metadata.refresh, system_intent.mirror.read_or_create, system_intent.result.emit) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1335,7 +1913,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "system-intent.sync.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (workspace.root.resolve, system_intent.config.resolve, system_intent.source_metadata.refresh, system_intent.mirror.read_or_create, system_intent.result.emit) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (workspace.root.resolve, system_intent.config.resolve, system_intent.source_metadata.refresh, system_intent.mirror.read_or_create, system_intent.result.emit) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1354,7 +1941,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "system-intent.sync.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (workspace.root.resolve, system_intent.config.resolve, system_intent.source_metadata.refresh, system_intent.mirror.read_or_create, system_intent.result.emit) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (workspace.root.resolve, system_intent.config.resolve, system_intent.source_metadata.refresh, system_intent.mirror.read_or_create, system_intent.result.emit) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1375,7 +1971,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "prompt.init.process, prompt.uninstall.process, prompt.upgrade.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (workspace.selection.resolve, prompt.render) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (workspace.selection.resolve, prompt.render) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1396,7 +2001,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "prompt.init.process, prompt.uninstall.process, prompt.upgrade.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (workspace.selection.resolve, prompt.render) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, while domain primitive refs (workspace.selection.resolve, prompt.render) remain explicit package-boundary calls. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1415,7 +2029,16 @@
         "why_not_generic_deterministic": "The symbol owns provider-specific integration or external-tool behavior rather than deterministic target-executor logic.",
         "conformance_ref": "external-intent.refresh-github.help.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as provider-integration; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as provider-integration; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "provider-integration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for provider or subprocess integration",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the provider interaction has a generic adapter contract owned by command-generation or shared runtime primitives.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1434,7 +2057,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "implement.context.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1455,7 +2087,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "init.lifecycle.dry-run.process, install.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as mutation-orchestration; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1476,7 +2117,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "uninstall.lifecycle.destructive-refusal.process, upgrade.lifecycle.dry-run.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as mutation-orchestration; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1497,7 +2147,16 @@
         "why_not_generic_deterministic": "The symbol owns live workspace inspection and policy interpretation over target state rather than deterministic target-executor logic.",
         "conformance_ref": "doctor.report.process, status.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as live-workspace-inspection; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as live-workspace-inspection; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "live-workspace-inspection",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for live repository inspection semantics",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the live inspection can be expressed as stable IR inputs plus portable filesystem/schema primitives without losing current-checkout semantics.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1516,7 +2175,16 @@
         "why_not_generic_deterministic": "The symbol owns module front-door dispatch across installed package boundaries rather than deterministic target-executor logic.",
         "conformance_ref": "memory.front-door.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as front-door-dispatch; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as front-door-dispatch; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "front-door-dispatch-extraction-candidate",
+        "minimization_route": "candidate-extract-when-contract-stable",
+        "minimization_owner": "workspace package runtime boundary with command-generation architecture follow-up",
+        "minimization_tracking_issue": "#1367",
+        "stale_when": "Stale when module front-door dispatch can be represented as generated command composition or a stable cross-package dispatch primitive without package runtime policy.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1535,7 +2203,16 @@
         "why_not_generic_deterministic": "The symbol owns live workspace inspection and policy interpretation over target state rather than deterministic target-executor logic.",
         "conformance_ref": "modules.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as live-workspace-inspection; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as live-workspace-inspection; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "live-workspace-inspection",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for live repository inspection semantics",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the live inspection can be expressed as stable IR inputs plus portable filesystem/schema primitives without losing current-checkout semantics.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1554,7 +2231,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "ownership.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1573,7 +2259,16 @@
         "why_not_generic_deterministic": "The symbol owns module front-door dispatch across installed package boundaries rather than deterministic target-executor logic.",
         "conformance_ref": "planning.front-door.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as front-door-dispatch; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as front-door-dispatch; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "front-door-dispatch-extraction-candidate",
+        "minimization_route": "candidate-extract-when-contract-stable",
+        "minimization_owner": "workspace package runtime boundary with command-generation architecture follow-up",
+        "minimization_tracking_issue": "#1367",
+        "stale_when": "Stale when module front-door dispatch can be represented as generated command composition or a stable cross-package dispatch primitive without package runtime policy.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1592,7 +2287,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "preflight.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1611,7 +2315,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "proof.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1630,7 +2343,16 @@
         "why_not_generic_deterministic": "The symbol owns package lifecycle or planning-state mutation policy, validation, conflict handling, or provenance updates that are not portable target-executor behavior.",
         "conformance_ref": "reconcile.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as mutation-orchestration; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as mutation-orchestration; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "mutation-safety-orchestration",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for mutation, safety, conflict, and provenance policy",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the mutation can be decomposed into generated composition plus smaller package primitives with equivalent safety and provenance proof.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1649,7 +2371,16 @@
         "why_not_generic_deterministic": "The symbol owns live workspace inspection and policy interpretation over target state rather than deterministic target-executor logic.",
         "conformance_ref": "report.combined.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as live-workspace-inspection; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as live-workspace-inspection; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "live-workspace-inspection",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for live repository inspection semantics",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the live inspection can be expressed as stable IR inputs plus portable filesystem/schema primitives without losing current-checkout semantics.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1668,7 +2399,16 @@
         "why_not_generic_deterministic": "The symbol owns live workspace inspection and policy interpretation over target state rather than deterministic target-executor logic.",
         "conformance_ref": "setup.guidance.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as live-workspace-inspection; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as live-workspace-inspection; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "live-workspace-inspection",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for live repository inspection semantics",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the live inspection can be expressed as stable IR inputs plus portable filesystem/schema primitives without losing current-checkout semantics.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1687,7 +2427,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "skills.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1706,7 +2455,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "start.context.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1725,7 +2483,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "summary.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "runtime-facade-call",
@@ -1744,7 +2511,16 @@
         "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "config.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, and generated output owns selected-output text. Domain primitive refs (workspace.root.resolve, workspace.config.load, output.fields.select, workspace.config.emit) remain explicit package-boundary calls for config loading, profile projection, and tiny/full text. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own the dataflow, and generated output owns selected-output text. Domain primitive refs (workspace.root.resolve, workspace.config.load, output.fields.select, workspace.config.emit) remain explicit package-boundary calls for config loading, profile projection, and tiny/full text. This entry is not accepted as portable codegen coverage, and full-completion proof rejects it if the boundary class is generic-deterministic-runtime-debt.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       },
       {
         "binding_kind": "operation-function-call",
@@ -1765,7 +2541,16 @@
         "why_not_generic_deterministic": "Verification report semantics classify repo-specific protocol activation, bounded evidence, stale conditions, and known gaps behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
         "conformance_ref": "verification.report.process",
         "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own target resolution, dataflow, and emission, while verification.report.load names the Verification package-domain report boundary. This entry is not accepted as portable codegen coverage."
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated operation IR and codegen-owned run_operation_steps own target resolution, dataflow, and emission, while verification.report.load names the Verification package-domain report boundary. This entry is not accepted as portable codegen coverage.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#1364",
+        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
       }
     ]
   },

--- a/src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json
+++ b/src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json
@@ -194,10 +194,16 @@
         "operation_ids",
         "primitive_refs",
         "runtime_boundary_class",
+        "minimization_category",
+        "minimization_route",
+        "minimization_owner",
+        "minimization_tracking_issue",
+        "direct_edit_reasons_allowed",
         "why_not_generic_deterministic",
         "conformance_ref",
         "status",
-        "generic_behavior_audit"
+        "generic_behavior_audit",
+        "stale_when"
       ],
       "properties": {
         "binding_kind": {
@@ -277,6 +283,49 @@
           ],
           "description": "Non-generic package-domain runtime classification."
         },
+        "minimization_category": {
+          "enum": [
+            "primitive-bugfix-or-new-primitive-eligible",
+            "package-specific-judgment",
+            "mutation-safety-orchestration",
+            "live-workspace-inspection",
+            "provider-integration",
+            "generated-command-behavior-move-required",
+            "front-door-dispatch-extraction-candidate"
+          ],
+          "description": "Issue #1357 minimization classification used to distinguish true primitive ownership from generated-command behavior that must move."
+        },
+        "minimization_route": {
+          "enum": [
+            "keep-as-hand-owned-primitive",
+            "candidate-extract-when-contract-stable",
+            "move-to-command-generation-or-ir"
+          ],
+          "description": "Implementation route for shrinking or retaining this exact runtime boundary."
+        },
+        "minimization_owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Reviewable owner for the current boundary and the next minimization decision."
+        },
+        "minimization_tracking_issue": {
+          "type": "string",
+          "pattern": "^#\\d+$",
+          "description": "Issue that owns future extraction, migration, or acceptance of this boundary."
+        },
+        "direct_edit_reasons_allowed": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "existing-primitive-bugfix",
+              "new-primitive-implementation"
+            ]
+          },
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "description": "The only direct runtime-source edit reasons allowed for this boundary."
+        },
         "why_not_generic_deterministic": {
           "type": "string",
           "minLength": 1
@@ -295,6 +344,11 @@
         "generic_behavior_audit": {
           "type": "string",
           "minLength": 1
+        },
+        "stale_when": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Condition that makes this accepted runtime boundary stale or no longer acceptable."
         }
       },
       "allOf": [

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -1771,6 +1771,19 @@ def test_python_runtime_projection_inventory_tracks_generated_output_debt() -> N
     assert {"runtime-facade-call", "operation-function-call"} <= binding_kinds
     assert all(entry["status"] == "accepted-permanent-package-domain-boundary" for entry in accepted_boundaries["entries"])
     assert all(entry["operation_ids"] and entry["primitive_refs"] for entry in accepted_boundaries["entries"])
+    assert all(entry["minimization_category"] for entry in accepted_boundaries["entries"])
+    assert all(entry["minimization_route"] for entry in accepted_boundaries["entries"])
+    assert all(entry["minimization_owner"] for entry in accepted_boundaries["entries"])
+    assert all(entry["minimization_tracking_issue"].startswith("#") for entry in accepted_boundaries["entries"])
+    assert all(
+        entry["direct_edit_reasons_allowed"] == ["existing-primitive-bugfix", "new-primitive-implementation"]
+        for entry in accepted_boundaries["entries"]
+    )
+    assert all(entry["stale_when"] for entry in accepted_boundaries["entries"])
+    front_door_entries = [entry for entry in accepted_boundaries["entries"] if entry["runtime_boundary_class"] == "front-door-dispatch"]
+    assert front_door_entries
+    assert all(entry["minimization_route"] == "candidate-extract-when-contract-stable" for entry in front_door_entries)
+    assert all(entry["minimization_tracking_issue"] == "#1367" for entry in front_door_entries)
     output_entries = [
         entry
         for entry in accepted_boundaries["entries"]

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -222,6 +222,24 @@ def test_full_python_completion_rejects_wrong_operation_function_call_metadata()
     assert any("must declare operation_ids" in error for error in errors)
 
 
+def test_full_python_completion_rejects_weak_runtime_boundary_minimization_metadata() -> None:
+    errors = _checker_case_errors(
+        """
+        inventory = copy.deepcopy(checker.python_runtime_projection_inventory_manifest())
+        entry = next(item for item in inventory["accepted_runtime_boundaries"]["entries"] if item["binding_kind"] == "operation-function-call")
+        entry["minimization_route"] = "move-to-command-generation-or-ir"
+        entry["direct_edit_reasons_allowed"] = ["implementation detail"]
+        entry.pop("stale_when", None)
+        checker.python_runtime_projection_inventory_manifest = lambda: inventory
+        _emit({"errors": checker._validate_python_completion_accepted_runtime_boundaries()[0]})
+        """
+    )
+
+    assert any("must declare minimization_route=" in error for error in errors)
+    assert any("direct_edit_reasons_allowed must be" in error for error in errors)
+    assert any("must include non-empty stale_when" in error for error in errors)
+
+
 def test_full_python_completion_rejects_weak_output_boundary_audit() -> None:
     errors = _checker_case_errors(
         """
@@ -326,6 +344,14 @@ def test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundarie
     assert runtime_metrics["status"] == "available"
     assert runtime_metrics["accepted_runtime_symbol_count"] == sum(runtime_metrics["accepted_runtime_symbol_count_by_package"].values())
     assert runtime_metrics["accepted_runtime_symbol_count"] == sum(runtime_metrics["accepted_runtime_symbol_count_by_class"].values())
+    assert runtime_metrics["accepted_runtime_symbol_count"] == sum(
+        runtime_metrics["accepted_runtime_symbol_count_by_minimization_category"].values()
+    )
+    assert runtime_metrics["accepted_runtime_symbol_count"] == sum(
+        runtime_metrics["accepted_runtime_symbol_count_by_minimization_route"].values()
+    )
+    assert runtime_metrics["accepted_runtime_symbol_count_by_minimization_route"]["keep-as-hand-owned-primitive"] > 0
+    assert runtime_metrics["accepted_runtime_symbol_count_by_minimization_tracking_issue"]["#1364"] > 0
     assert runtime_metrics["python_bridge_step_count"] == 0
     assert runtime_metrics["python_bridge_symbols"] == []
     assert runtime_metrics["generic_debt_symbol_count"] == 0
@@ -339,6 +365,21 @@ def test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundarie
     assert minimization["whole_category_acceptance_allowed"] is False
     assert minimization["accepted_symbol_count"] == runtime_metrics["accepted_runtime_symbol_count"]
     assert minimization["remaining_hand_owned_symbol_count"] == runtime_metrics["accepted_runtime_symbol_count"]
+    assert minimization["remaining_by_minimization_route"]["keep-as-hand-owned-primitive"] > 0
+    assert minimization["remaining_by_minimization_tracking_issue"]["#1364"] > 0
+    assert minimization["contract_stable_extraction_candidate_count"] == runtime_metrics[
+        "accepted_runtime_symbol_count_by_minimization_route"
+    ].get("candidate-extract-when-contract-stable", 0)
+    assert minimization["exact_runtime_boundary_inventory"]
+    exact_entry = minimization["exact_runtime_boundary_inventory"][0]
+    assert {
+        "symbol_id",
+        "minimization_category",
+        "minimization_route",
+        "minimization_owner",
+        "minimization_tracking_issue",
+        "stale_when",
+    } <= set(exact_entry)
     assert "not a claim that runtime boundaries are minimized" in minimization["freshness_claim_boundary"]
     assert "generic-deterministic-runtime-debt" in minimization["route_by_runtime_boundary_class"]
     assert "agent_owns" in minimization["authority_boundary"]
@@ -468,6 +509,8 @@ def test_python_completion_blocker_report_has_json_cli_mode(capsys) -> None:
     assert payload["next_owner"] == "none"
     runtime_metrics = payload["accepted_runtime_boundary_metrics"]
     assert runtime_metrics["accepted_runtime_symbol_count_by_package"]
+    assert runtime_metrics["accepted_runtime_symbol_count_by_minimization_category"]
+    assert runtime_metrics["accepted_runtime_symbol_count_by_minimization_route"]["keep-as-hand-owned-primitive"] > 0
     assert runtime_metrics["output_fallback_symbol_count"] == runtime_metrics["accepted_output_emission_symbol_count"]
     assert runtime_metrics["python_bridge_step_count"] == 0
     assert runtime_metrics["python_bridge_symbols"] == []
@@ -476,6 +519,8 @@ def test_python_completion_blocker_report_has_json_cli_mode(capsys) -> None:
     assert minimization["status"] == "not-minimized-hand-owned-boundaries-remain"
     assert minimization["minimization_claim_allowed"] is False
     assert minimization["remaining_hand_owned_symbol_count"] == runtime_metrics["accepted_runtime_symbol_count"]
+    assert minimization["exact_runtime_boundary_inventory"]
+    assert minimization["remaining_by_minimization_tracking_issue"]["#1364"] > 0
     target_freshness = payload["generated_target_freshness"]
     assert target_freshness["status"] == "fresh"
     assert target_freshness["target_families"] == ["python", "typescript"]


### PR DESCRIPTION
## What landed

- Added exact #1357 minimization metadata to every accepted Python runtime boundary: category, route, owner, tracking issue, allowed direct-edit reasons, and stale-when condition.
- Tightened `check_generated_command_packages.py` so accepted boundaries must carry that metadata and class-to-route claims must match the declared runtime boundary class.
- Extended `--python-completion-blockers` output with minimization category/route/tracking issue counts and an exact per-symbol minimization inventory.
- Added focused tests proving weak minimization metadata is rejected and the report exposes the new evidence.
- Retained compact Planning closeout evidence for the bounded #1357 slice.

## Closure boundary

Closes #1357.

This does not close #1364 or #1367. The report now shows the distinction clearly: generated Python output can be fresh/inventoried while the runtime boundary is still not minimized. Current report evidence shows 83 keep-as-hand-owned primitive boundaries and 2 front-door dispatch extraction candidates routed to #1367.

## Proof

- `uv run pytest tests/test_generated_command_package_proof_runner.py::test_full_python_completion_rejects_weak_runtime_boundary_minimization_metadata tests/test_generated_command_package_proof_runner.py::test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundaries tests/test_generated_command_package_proof_runner.py::test_python_completion_blocker_report_has_json_cli_mode tests/test_contract_tooling.py::test_python_runtime_projection_inventory_tracks_generated_output_debt -q` -> 4 passed
- `uv run python scripts/check/check_generated_command_packages.py` -> ok
- `uv run python scripts/generate/generate_command_packages.py --check` -> ok
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py tests/test_generated_command_package_proof_runner.py tests/test_contract_tooling.py` -> passed
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success` -> ok
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success` -> passed
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json` -> warning_count 0
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` -> healthy
- `make schema-reference-docs` -> ok
- `make test-workspace` -> ok
- `make lint-workspace` -> ok

## Dogfooding

AW helped catch that this had become multi-surface lane-shaped work and required an active execplan before closeout. That happened after initial edits rather than before them, but the gate did improve residue handling and prevented leaving active Planning state behind.