### PR TITLE
Add test suite strategy grounding

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1366-test-suite-strategy.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1366-test-suite-strategy.plan.json
@@ -1,0 +1,330 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1366 test suite inventory and simplification strategy",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1366 by grounding the current test-suite shape and shipping future-agent guidance for consolidation, pruning, and contract-owned conformance migration.",
+    "hard_constraints": "Do not broadly delete or rewrite tests before equivalent coverage exists. Keep this lane to inventory, review evidence, guidance, and minimal maintainer-surface proof.",
+    "agent_may_decide": "Which clusters to name, which follow-up issues own replacement work, and the smallest documentation/test surface that prevents more one-off regression sprawl.",
+    "escalate_when": "The work requires deleting substantial tests, changing runtime behavior, or completing #1373/#1374/command-generation#9 instead of grounding #1366.",
+    "next_action": "Add the grounding review, maintainer testing-strategy guide, playbook/index links, and focused proof.",
+    "proof_expectations": [
+      "uv run pytest tests/test_maintainer_surfaces.py -q",
+      "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+      "make maintainer-surfaces",
+      "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+      "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+    ],
+    "touched_scope": [
+      "docs/maintainer/testing-strategy.md",
+      "docs/maintainer/contributor-playbook.md",
+      "docs/maintainer/index.md",
+      "tests/test_maintainer_surfaces.py",
+      ".agentic-workspace/planning/reviews/2026-06-06-issue-1366-test-suite-strategy.review.json"
+    ],
+    "completion_criteria": [
+      "Test inventory and consolidation strategy are captured in a planning review.",
+      "Future-agent guidance explains when to add, merge, convert, or prune tests.",
+      "The strategy is linked from maintainer surfaces and protected by focused proof.",
+      "Broad test replacement is explicitly routed to #1373, #1374, and command-generation#9."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Implement #1366 by grounding the current test-suite shape and shipping future-agent guidance for consolidation, pruning, and contract-owned conformance migration."
+  ],
+  "non_goals": [
+    "Do not broadly delete tests in this lane.",
+    "Do not migrate all behavior tests into contract-owned cases before #1373/#1374/command-generation#9.",
+    "Do not change runtime behavior."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1366 by grounding the current test-suite shape and shipping future-agent guidance for consolidation, pruning, and contract-owned conformance migration.",
+      "constraints": "Do not broadly delete or rewrite tests before equivalent coverage exists. Keep this lane to inventory, review evidence, guidance, and minimal maintainer-surface proof.",
+      "latitude": "Which clusters to name, which follow-up issues own replacement work, and the smallest documentation/test surface that prevents more one-off regression sprawl.",
+      "escalation": "Escalate when the work requires deleting substantial tests, changing runtime behavior, or completing #1373/#1374/command-generation#9 instead of grounding #1366.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1366-test-suite-strategy",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "docs/maintainer/testing-strategy.md",
+        "docs/maintainer/contributor-playbook.md",
+        "docs/maintainer/index.md",
+        "tests/test_maintainer_surfaces.py",
+        ".agentic-workspace/planning/reviews/2026-06-06-issue-1366-test-suite-strategy.review.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Implement #1366 by grounding the current test-suite shape and shipping future-agent guidance for consolidation, pruning, and contract-owned conformance migration.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Future agents have a checked-in strategy for adding, merging, converting, and pruning tests without adding narrow regressions by default.",
+    "intentionally deferred": "Broad conversion of existing behavior tests into contract-owned conformance cases remains owned by #1373, #1374, and command-generation#9.",
+    "discovered implications": "Collection cost is low; the immediate risk is review/maintenance cost from duplicate intent in broad workflow test surfaces.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1366 test suite inventory and simplification strategy",
+    "inferred intended outcome": "Ground #1366 with inventory evidence and ship enough maintainer guidance to steer future test work toward contract-owned cases and scenario consolidation.",
+    "chosen concrete what": "Add a review record, testing-strategy guide, playbook/index links, and focused maintainer-surface proof.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "docs/maintainer/testing-strategy.md, docs/maintainer/contributor-playbook.md, docs/maintainer/index.md, tests/test_maintainer_surfaces.py, and the #1366 planning review/execplan surfaces.",
+    "max changed files": "7 expected checked-in files plus planning state.",
+    "required validation commands": "uv run pytest tests/test_maintainer_surfaces.py -q; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; make maintainer-surfaces; AW summary and planning doctor.",
+    "ask-before-refactor threshold": "Ask before broad test deletion, runtime changes, or starting #1373/#1374/command-generation#9 replacement work.",
+    "stop before touching": "Generated command runtime behavior, broad test files, package runtime code, or command-generation source."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1366 by grounding the current test-suite shape and shipping future-agent guidance for consolidation, pruning, and contract-owned conformance migration.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "Test strategy inventory and maintainer guidance require repository-local context and proof; no bounded external delegation target reduces risk.",
+    "decision command": "agentic-planning delegation-decision",
+    "planning revision observed": "7cd33de681b98c4d",
+    "recorded at": "2026-06-06T19:23:03+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1366-test-suite-strategy",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Add the grounding review, maintainer testing-strategy guide, playbook/index links, and focused proof."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "docs/maintainer/testing-strategy.md",
+    "docs/maintainer/contributor-playbook.md",
+    "docs/maintainer/index.md",
+    "tests/test_maintainer_surfaces.py",
+    ".agentic-workspace/planning/reviews/2026-06-06-issue-1366-test-suite-strategy.review.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_maintainer_surfaces.py -q",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "make maintainer-surfaces",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement #1366 test suite inventory and simplification strategy is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Inventory data was gathered for root and package tests, a #1366 grounding review was recorded, maintainer testing-strategy guidance was added, and the guidance was linked from maintainer entrypoints.",
+    "scope touched": "Maintainer testing guidance, #1366 planning review/execplan surfaces, and maintainer-surface proof.",
+    "changed surfaces": "docs/maintainer/testing-strategy.md; docs/maintainer/contributor-playbook.md; docs/maintainer/index.md; tests/test_maintainer_surfaces.py; .agentic-workspace/planning/reviews/2026-06-06-issue-1366-test-suite-strategy.review.json",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed inside the strategy/investigation lane. Broad pruning and conformance-case replacement are intentionally deferred to #1373, #1374, and command-generation#9.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "Test strategy inventory and maintainer guidance require repository-local context and proof; no bounded external delegation target reduces risk.",
+    "expected savings": "unknown",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Passed: uv run pytest tests/test_maintainer_surfaces.py -q; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; make maintainer-surfaces; make test-workspace; make lint-workspace; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1366 by grounding the current test-suite shape and shipping future-agent guidance for consolidation, pruning, and contract-owned conformance migration.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1366 is implementation-ready and preventively documented: future agents have a checked-in hierarchy for add/merge/convert/prune decisions and a review record with counts, risks, no-prune areas, and replacement follow-ups.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "docs",
+    "learned constraint": "Closeout routed docs residue to docs/maintainer/testing-strategy.md.",
+    "motivation worth preserving": "Future agents should continue from docs/maintainer/testing-strategy.md rather than rediscover this closeout residue.",
+    "canonical owner now": "docs/maintainer/testing-strategy.md",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "docs/maintainer/testing-strategy.md",
+    "proposed durable intent": "Future agents should continue from docs/maintainer/testing-strategy.md rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "docs/maintainer/testing-strategy.md"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-06: Scaffolded by agentic-planning new-plan.",
+    "2026-06-06: Recorded delegation decision route=keep-local."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "promote_to_docs_contracts_checks_code",
+    "target": "docs/maintainer/testing-strategy.md",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1366 by grounding the current test-suite shape and shipping future-agent guidance for consolidation, pruning, and contract-owned conformance migration.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Passed: uv run pytest tests/test_maintainer_surfaces.py -q; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; make maintainer-surfaces; make test-workspace; make lint-workspace; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json.\nChanged surfaces: docs/maintainer/testing-strategy.md; docs/maintainer/contributor-playbook.md; docs/maintainer/index.md; tests/test_maintainer_surfaces.py; .agentic-workspace/planning/reviews/2026-06-06-issue-1366-test-suite-strategy.review.json\nDurable residue: docs (docs/maintainer/testing-strategy.md)\nMemory learning: promote_to_docs_contracts_checks_code\nFollow-up: none"
+  }
+}

--- a/.agentic-workspace/planning/reviews/2026-06-06-issue-1366-test-suite-strategy.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-06-issue-1366-test-suite-strategy.review.json
@@ -1,0 +1,115 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1366 test suite inventory and simplification strategy",
+  "date": "2026-06-06",
+  "classification": "test-suite-strategy-grounding",
+  "goal": "Inventory current Python test surfaces, identify consolidation pressure, and define an implementation-ready testing strategy aligned with compositional IR and contract-owned conformance cases.",
+  "scope": [
+    "root workspace tests",
+    "packages/memory tests",
+    "packages/planning tests",
+    "packages/verification tests",
+    "interaction with #1367 compositional operation IR",
+    "interaction with #1373, #1374, and command-generation#9 replacement follow-ups"
+  ],
+  "non_goals": [
+    "broad deletion of tests before equivalent coverage exists",
+    "migrating all regressions into contract-owned cases in this lane",
+    "changing runtime behavior",
+    "changing command-generation contracts beyond documenting follow-up ownership"
+  ],
+  "references": [
+    {
+      "kind": "issue",
+      "target": "#1366",
+      "label": "Inventory and simplify test suite strategy"
+    },
+    {
+      "kind": "issue",
+      "target": "#1367",
+      "label": "Compositional operation IR"
+    },
+    {
+      "kind": "issue",
+      "target": "#1373",
+      "label": "Plan post-migration replacement of regression tests with contract-owned conformance cases"
+    },
+    {
+      "kind": "issue",
+      "target": "#1374",
+      "label": "Replace AW generated-command behavior tests with contract-owned conformance cases"
+    },
+    {
+      "kind": "issue",
+      "target": "rickardvh/command-generation#9",
+      "label": "Replace command-generation behavior tests with contract-owned conformance cases"
+    },
+    {
+      "kind": "review",
+      "target": ".agentic-workspace/planning/reviews/2026-06-06-issue-1367-compositional-operation-ir-grounding.review.json",
+      "label": "Compositional IR grounding review"
+    }
+  ],
+  "summary": "The suite collects quickly, but tests are concentrated in broad workflow surfaces where narrow regressions have accumulated. The right near-term move is a documented test hierarchy and follow-up ownership for contract-owned replacements, not broad pruning before primitive/fragment/operation contract cases can carry the behavior.",
+  "summary_counts": {
+    "python_test_files": 64,
+    "ast_test_functions": 1577,
+    "total_test_lines": 53534,
+    "root_workspace_collected_tests": 1098,
+    "planning_collected_tests": 337,
+    "memory_collected_tests": 247,
+    "verification_collected_tests": 6,
+    "root_collect_seconds": 0.67,
+    "planning_collect_seconds": 2.02,
+    "memory_collect_seconds": 1.14,
+    "verification_collect_seconds": 0.26
+  },
+  "review_method": {
+    "collection": "pytest --collect-only was run for root tests and package tests to measure count and collection cost.",
+    "inventory": "AST-based counting through uv run python measured test functions, file count, and largest files by tests and lines.",
+    "issue_review": "Issue #1366 and related follow-ups #1373, #1374, and command-generation#9 were reviewed to separate strategy closure from post-migration replacement work.",
+    "architecture_review": "The #1367 grounding review was used to map tests to primitive, fragment/subflow, operation, and command levels."
+  },
+  "findings": [
+    {
+      "id": "sprawl-pressure-is-readability-not-collection-time",
+      "finding": "Collection is fast enough that immediate optimization pressure is not raw pytest startup. The visible risk is review cost and duplicate intent in broad workflow files.",
+      "evidence": "Root tests collected 1098 tests in 0.67s; planning collected 337 in 2.02s; memory collected 247 in 1.14s; verification collected 6 in 0.26s.",
+      "suggested action": "Avoid deleting tests for count alone. Consolidate when a change touches a cluster and equivalent stronger coverage can be shown.",
+      "confidence": "high"
+    },
+    {
+      "id": "largest-clusters-are-workflow-contract-surfaces",
+      "finding": "The largest files are command/workflow/report/planning surfaces where small regressions can obscure the intended contract.",
+      "evidence": "Top clusters include test_model_cli_harness.py, test_workspace_report_cli.py, packages/planning/tests/test_summary.py, test_workspace_start_preflight_cli.py, test_generated_command_package_proof_runner.py, test_workspace_lifecycle_cli.py, packages/planning/tests/test_archive.py, test_workspace_implement_cli.py, test_contract_tooling.py, and test_workspace_proof_cli.py.",
+      "suggested action": "When touching these areas, prefer scenario matrices, contract-owned conformance cases, or representative black-box tests over more one-off tests.",
+      "confidence": "high"
+    },
+    {
+      "id": "contract-owned-replacement-is-a-separate-lane",
+      "finding": "The suite cannot honestly be converted wholesale before the contract-owned case shape and target adapters are stable.",
+      "evidence": "#1373, #1374, and command-generation#9 already own the replacement work after the #1370/#1367 direction. #1366 should ground and guide that work rather than silently doing a partial migration.",
+      "suggested action": "Ship strategy guidance now; use the replacement follow-ups for broad conversion and pruning.",
+      "confidence": "high"
+    },
+    {
+      "id": "no-prune-surfaces",
+      "finding": "Archive/closeout, startup/preflight, proof/report, generated package freshness, schema/reference docs, and package install boundaries are high-risk areas.",
+      "evidence": "These surfaces have recurring dogfooding failures and broad collaboration effects; no equivalent contract-owned matrix exists yet for many of them.",
+      "suggested action": "Require explicit stronger/equivalent coverage before removing tests in these areas.",
+      "confidence": "medium"
+    }
+  ],
+  "recommendation": {
+    "implementation_now": "Add maintainer testing-strategy guidance, link it from the contributor playbook and maintainer index, preserve this review as grounding evidence, and add a small maintainer-surface test so future agents see the route before adding regressions.",
+    "implementation_later": "Use #1373, #1374, and command-generation#9 to replace existing behavior regressions with contract-owned conformance cases once the contract shape and adapters are stable.",
+    "closeout_boundary": "#1366 can close as an investigation/strategy lane if the PR reports that no broad pruning was attempted and names the concrete replacement follow-ups."
+  },
+  "validation_commands": [
+    "uv run pytest tests/test_maintainer_surfaces.py -q",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "make maintainer-surfaces",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ]
+}

--- a/docs/maintainer/contributor-playbook.md
+++ b/docs/maintainer/contributor-playbook.md
@@ -11,6 +11,7 @@ This playbook is primarily for maintainers operating as coding agents. Human con
 Use `docs/design-principles.md` when a change affects product shape, ownership, lifecycle behavior, or the amount of ceremony the repo imposes on normal work.
 Use `docs/maintainer/operational-affordance-design.md` when a change affects startup, recovery, proof, closeout, lifecycle, Memory, planning, agent-aid, or other operational surfaces that should carry agents to the next correct action.
 Use `docs/maintainer/dogfooding-feedback.md` when the missing judgment is whether repo friction should become product work, how to classify it, or whether it has earned queue entry.
+Use `docs/maintainer/testing-strategy.md` before adding or pruning tests, especially when a narrow regression could instead become a primitive, fragment, operation, or contract-owned conformance case.
 Use `agentic-workspace defaults --section improvement_intake --format json` when the question is how to route setup findings, dogfooding friction, review findings, validation friction, or Memory improvement signals through one shared decision model.
 Use `.agentic-workspace/docs/compatibility-policy.md` when you need to judge whether a surface is stable, mutable, or generated before making the change.
 Use `.agentic-workspace/docs/lifecycle-and-config-contract.md` when you need the canonical root `init` mode matrix, configuration rules, or prompt semantics.

--- a/docs/maintainer/index.md
+++ b/docs/maintainer/index.md
@@ -7,6 +7,7 @@ This section is for source-checkout maintenance of this repository. It is not th
 - [Contributor playbook](contributor-playbook.md): routing, ownership, validation lanes, and maintainer workflow.
 - [Maintainer commands](maintainer-commands.md): literal command index.
 - [Dogfooding feedback](dogfooding-feedback.md): friction classification and admission policy.
+- [Testing strategy](testing-strategy.md): inventory, consolidation, pruning, and contract-owned conformance guidance.
 - [Installed-contract design checklist](installed-contract-design-checklist.md): review bar for collaboration-sensitive installed surfaces.
 - [Operational affordance design](operational-affordance-design.md): design review rubric for operational surfaces.
 

--- a/docs/maintainer/testing-strategy.md
+++ b/docs/maintainer/testing-strategy.md
@@ -1,0 +1,83 @@
+# Testing Strategy
+
+Use this guide before adding or pruning tests in this repository. The goal is to preserve behavior contracts with fewer one-off regressions and less implementation-shape lock-in.
+
+## Current Inventory
+
+The June 2026 inventory for #1366 found 64 Python test files and 1,577 test functions across the root workspace and package suites:
+
+- root workspace: 1,098 collected tests
+- planning package: 337 collected tests
+- memory package: 247 collected tests
+- verification package: 6 collected tests
+
+Collection is fast, so the immediate problem is not raw collection time. The pressure is readability, duplicate intent, and a growing pile of narrow regression tests around broad workflow surfaces.
+
+The largest clusters by test count are:
+
+- `tests/test_model_cli_harness.py`
+- `tests/test_workspace_report_cli.py`
+- `packages/planning/tests/test_summary.py`
+- `tests/test_workspace_start_preflight_cli.py`
+- `tests/test_generated_command_package_proof_runner.py`
+- `tests/test_workspace_lifecycle_cli.py`
+- `packages/planning/tests/test_archive.py`
+- `tests/test_workspace_implement_cli.py`
+- `tests/test_contract_tooling.py`
+- `tests/test_workspace_proof_cli.py`
+
+These clusters are not automatically bad. Treat them as the first places to look for scenario consolidation, table-driven structure, or contract-owned conformance cases when related work changes them.
+
+## Contract Ladder
+
+Prefer testing behavior at the lowest level that proves the intended contract without preserving accidental implementation shape:
+
+- Primitive conformance: deterministic execution units and target parity.
+- Fragment or subflow behavior: reusable workflow patterns such as lifecycle mutation, validation, report shaping, and output rendering.
+- Operation composition: command-facing contracts assembled from primitives and fragments.
+- Representative command black-box behavior: user-visible compatibility, high-risk workflows, and transport behavior.
+
+When a bug belongs to a reusable fragment, add or extend a fragment or operation case before adding several command-specific regressions. When the behavior is transport-specific, keep the target adapter test small and point behavior truth back to the operation contract.
+
+## Contract-Owned Cases
+
+The preferred long-term direction is contract-owned conformance:
+
+- Operational contracts own canonical input/output or input/error cases.
+- Python owns the single authoritative conformance runner.
+- CLI, generated package, MCP, and future targets provide thin adapters.
+- Adapters normalize invocation, result extraction, exit or error shape, and capability reporting.
+
+The runner should remain simple: load contract cases, select a target adapter, run the declared operation with declared input and fixtures, normalize the result, and compare it with expected output or expected error.
+
+## Add, Merge, Convert, Or Prune
+
+Add a new test when the behavior is new, the failure mode is not already represented, and the right contract surface does not yet have an equivalent case.
+
+Merge tests when several narrow regressions assert the same contract through slightly different fixtures. Prefer table-driven scenarios when the setup is shared and the expected behavior is easy to compare.
+
+Convert tests when a command-level regression really belongs to a primitive, fragment, operation, or contract-owned conformance case. Keep one representative command black-box test if user-visible behavior or transport compatibility is the risk.
+
+Prune only when stronger or equivalent coverage remains and the removed test preserves implementation detail, duplicate fixture shape, or obsolete behavior rather than a meaningful contract.
+
+Do not prune coverage for historically fragile lifecycle, planning, archive, proof, generated-package freshness, or report/closeout behavior until an equivalent contract-owned case or scenario matrix exists.
+
+## No-Prune Areas
+
+Treat these areas as high-risk until a stronger replacement exists:
+
+- Planning archive, closeout, and active-state mutation safety.
+- Startup, preflight, implementation, proof, and report routing.
+- Generated command package freshness, conformance, and target parity.
+- Schema/reference docs and structured inventory checks.
+- Package install and payload boundary behavior.
+
+High-risk does not mean "add another one-off test by default." It means the replacement must be explicit, equivalent or stronger, and easy to review.
+
+## Future Work
+
+#1373 owns the plan for replacing existing regressions with contract-owned conformance cases after the migration shape is stable.
+
+#1374 owns replacing AW generated-command behavior tests with contract-owned conformance cases.
+
+rickardvh/command-generation#9 owns the matching replacement work in the command-generation repository.

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -452,6 +452,22 @@ def test_contributor_playbook_requires_operational_affordance_review() -> None:
     assert "weak agents can proceed without learning package internals" in text
 
 
+def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
+    playbook = (WORKSPACE_ROOT / "docs" / "maintainer" / "contributor-playbook.md").read_text(encoding="utf-8")
+    strategy = (WORKSPACE_ROOT / "docs" / "maintainer" / "testing-strategy.md").read_text(encoding="utf-8")
+
+    assert "docs/maintainer/testing-strategy.md" in playbook
+    assert "Primitive conformance" in strategy
+    assert "Fragment or subflow behavior" in strategy
+    assert "Operation composition" in strategy
+    assert "Representative command black-box behavior" in strategy
+    assert "Contract-Owned Cases" in strategy
+    assert "Prune only when stronger or equivalent coverage remains" in strategy
+    assert "#1373 owns the plan" in strategy
+    assert "#1374 owns replacing AW generated-command behavior tests" in strategy
+    assert "rickardvh/command-generation#9" in strategy
+
+
 def test_maintainer_surface_role_guidance_passes_when_docs_are_scoped(tmp_path: Path) -> None:
     mod = _load_module(_checker_script_path(), "maintainer_surfaces_valid")
     _write_planning_surfaces(tmp_path)


### PR DESCRIPTION
## What landed

- Added `docs/maintainer/testing-strategy.md` with the June 2026 inventory, contract ladder, add/merge/convert/prune rules, no-prune areas, and ownership for post-migration replacement work.
- Added the #1366 grounding review at `.agentic-workspace/planning/reviews/2026-06-06-issue-1366-test-suite-strategy.review.json` with counts, timings, findings, risks, and follow-up boundaries.
- Linked the testing strategy from the contributor playbook and maintainer index, and added a maintainer-surface test so future agents see the route before adding one-off regressions.
- Archived the active #1366 execplan with proof and closeout evidence.

## Closure boundary

Closes #1366 as an investigation/strategy lane. This PR does not broadly prune or rewrite the test suite, because the review found that the stronger replacement path depends on stable contract-owned conformance cases and adapters. That follow-on work remains owned by #1373, #1374, and rickardvh/command-generation#9.

## Proof

- `uv run pytest tests/test_maintainer_surfaces.py -q`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `make maintainer-surfaces`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`

The commit hook also reran sync/lint/absolute-path checks successfully.