### PR TITLE
Plan contract-owned test replacement

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1373-contract-test-replacement-plan.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1373-contract-test-replacement-plan.plan.json
@@ -1,0 +1,333 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1373 contract-owned test replacement plan",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1373 by producing a concrete post-migration replacement plan for ordinary regressions versus contract-owned conformance cases.",
+    "hard_constraints": "Do not convert or delete tests in this lane. Preserve #1374 and command-generation#9 as the implementation owners.",
+    "agent_may_decide": "Inventory categories, sequencing gates, and maintainer documentation shape.",
+    "escalate_when": "The work starts changing test behavior, command contracts, generated targets, or command-generation source.",
+    "next_action": "Add the checked-in replacement plan, grounding review, issue handoff links, and maintainer-surface proof.",
+    "proof_expectations": [
+      "uv run pytest tests/test_maintainer_surfaces.py -q",
+      "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+      "make maintainer-surfaces",
+      "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+      "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+    ],
+    "touched_scope": [
+      "docs/maintainer/contract-test-replacement-plan.md",
+      "docs/maintainer/testing-strategy.md",
+      "docs/maintainer/index.md",
+      "tests/test_maintainer_surfaces.py",
+      ".agentic-workspace/planning/reviews/2026-06-06-issue-1373-contract-test-replacement-plan.review.json"
+    ],
+    "completion_criteria": [
+      "Existing test surfaces are inventoried by keep, convert, merge, or delete categories.",
+      "The sequencing plan avoids preserving temporary implementation seams.",
+      "#1374 and command-generation#9 are linked as implementation owners.",
+      "Maintainer proof validates the shipped guidance and planning state."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Implement #1373 by producing a concrete post-migration replacement plan for ordinary regressions versus contract-owned conformance cases."
+  ],
+  "non_goals": [
+    "Do not convert or delete tests in this lane.",
+    "Do not change command contracts, generated targets, or command-generation source.",
+    "Do not implement #1374 or command-generation#9."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1373 by producing a concrete post-migration replacement plan for ordinary regressions versus contract-owned conformance cases.",
+      "constraints": "Do not convert or delete tests in this lane. Preserve #1374 and command-generation#9 as implementation owners.",
+      "latitude": "Inventory categories, sequencing gates, and maintainer documentation shape.",
+      "escalation": "Escalate when the work starts changing test behavior, command contracts, generated targets, or command-generation source.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1373-contract-test-replacement-plan",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "docs/maintainer/contract-test-replacement-plan.md",
+        "docs/maintainer/testing-strategy.md",
+        "docs/maintainer/index.md",
+        "tests/test_maintainer_surfaces.py",
+        ".agentic-workspace/planning/reviews/2026-06-06-issue-1373-contract-test-replacement-plan.review.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Move stable behavior truth from ordinary regressions into contract-owned conformance cases without preserving transient migration seams.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1373 contract-owned test replacement plan",
+    "inferred intended outcome": "Produce the sequencing and inventory plan that makes #1374 and command-generation#9 safe to implement.",
+    "chosen concrete what": "Add a maintainer replacement plan, grounding review, and issue handoff comments.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "docs/maintainer/contract-test-replacement-plan.md, docs/maintainer/testing-strategy.md, docs/maintainer/index.md, tests/test_maintainer_surfaces.py, and #1373 planning surfaces.",
+    "max changed files": "Maintainer docs/test plus planning review/archive surfaces.",
+    "required validation commands": "uv run pytest tests/test_maintainer_surfaces.py -q; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; make maintainer-surfaces; AW summary and planning doctor.",
+    "ask-before-refactor threshold": "Ask before converting tests, changing command contracts, or touching command-generation source.",
+    "stop before touching": "Generated targets, command-generation repo, #1374 implementation, or broad test pruning."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1373 by producing a concrete post-migration replacement plan for ordinary regressions versus contract-owned conformance cases.",
+    "hard constraints": "Do not convert or delete tests in this lane.",
+    "agent may decide locally": "Inventory categories, sequencing gates, and maintainer documentation shape.",
+    "escalate when": "The work starts changing test behavior, command contracts, generated targets, or command-generation source."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "#1373 is a bounded sequencing and inventory plan across AW #1374 and command-generation#9; local context is cheaper than delegation and no implementation handoff reduces proof.",
+    "decision command": "agentic-planning delegation-decision",
+    "planning revision observed": "0e1da3262202afd7",
+    "recorded at": "2026-06-06T20:25:21+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1373-contract-test-replacement-plan",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Validate the checked-in replacement plan, update issue handoffs, and close out."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "docs/maintainer/contract-test-replacement-plan.md",
+    "docs/maintainer/testing-strategy.md",
+    "docs/maintainer/index.md",
+    "tests/test_maintainer_surfaces.py",
+    ".agentic-workspace/planning/reviews/2026-06-06-issue-1373-contract-test-replacement-plan.review.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_maintainer_surfaces.py -q",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "make maintainer-surfaces",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "The replacement plan is checked in and linked.",
+    "The grounding review records inventory evidence and handoff boundaries.",
+    "#1374 and command-generation#9 are updated with the handoff.",
+    "Maintainer and Planning proof passes."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Produced the #1373 contract-owned test replacement plan, inventory, and handoff guidance without converting or deleting tests.",
+    "scope touched": "Maintainer testing strategy docs, #1373 planning review, and issue handoff surfaces.",
+    "changed surfaces": "docs/maintainer/contract-test-replacement-plan.md; docs/maintainer/testing-strategy.md; docs/maintainer/index.md; tests/test_maintainer_surfaces.py; .agentic-workspace/planning/reviews/2026-06-06-issue-1373-contract-test-replacement-plan.review.json",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "The lane planned and linked the replacement work while preserving #1374 and rickardvh/command-generation#9 as implementation owners.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "#1373 is a bounded sequencing and inventory plan across AW #1374 and command-generation#9; local context is cheaper than delegation and no implementation handoff reduces proof.",
+    "expected savings": "unknown",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_maintainer_surfaces.py -q; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; make maintainer-surfaces; make test-workspace; make lint-workspace; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; git diff --check",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1373 by producing a concrete post-migration replacement plan for ordinary regressions versus contract-owned conformance cases.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "The plan categorizes AW and command-generation tests, sets readiness gates, defines deletion/merge evidence, and hands implementation to #1374 and rickardvh/command-generation#9.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "docs",
+    "learned constraint": "Closeout routed docs residue to docs/maintainer/contract-test-replacement-plan.md.",
+    "motivation worth preserving": "Future agents should continue from docs/maintainer/contract-test-replacement-plan.md rather than rediscover this closeout residue.",
+    "canonical owner now": "docs/maintainer/contract-test-replacement-plan.md",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "docs/maintainer/contract-test-replacement-plan.md",
+    "proposed durable intent": "Future agents should continue from docs/maintainer/contract-test-replacement-plan.md rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "docs/maintainer/contract-test-replacement-plan.md"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-06: Scaffolded by agentic-planning new-plan.",
+    "2026-06-06: Recorded delegation decision route=keep-local."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "promote_to_docs_contracts_checks_code",
+    "target": "docs/maintainer/contract-test-replacement-plan.md",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1373 by producing a concrete post-migration replacement plan for ordinary regressions versus contract-owned conformance cases.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_maintainer_surfaces.py -q; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; make maintainer-surfaces; make test-workspace; make lint-workspace; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; git diff --check\nChanged surfaces: docs/maintainer/contract-test-replacement-plan.md; docs/maintainer/testing-strategy.md; docs/maintainer/index.md; tests/test_maintainer_surfaces.py; .agentic-workspace/planning/reviews/2026-06-06-issue-1373-contract-test-replacement-plan.review.json\nDurable residue: docs (docs/maintainer/contract-test-replacement-plan.md)\nMemory learning: promote_to_docs_contracts_checks_code\nFollow-up: none"
+  }
+}

--- a/.agentic-workspace/planning/reviews/2026-06-06-issue-1373-contract-test-replacement-plan.review.json
+++ b/.agentic-workspace/planning/reviews/2026-06-06-issue-1373-contract-test-replacement-plan.review.json
@@ -1,0 +1,93 @@
+{
+  "kind": "planning-review/v1",
+  "title": "Grounding review for #1373 contract-owned test replacement sequencing",
+  "date": "2026-06-06",
+  "classification": "contract-owned-test-replacement-plan",
+  "goal": "Plan broad replacement of ordinary regression tests with contract-owned conformance cases without preserving transient migration boundaries.",
+  "scope": [
+    "AW generated command, conformance, proof, and command-facing test surfaces",
+    "command-generation primitive, public API, and conformance runner tests",
+    "#1374 AW-side implementation handoff",
+    "rickardvh/command-generation#9 package-side implementation handoff"
+  ],
+  "non_goals": [
+    "deleting or converting tests in this planning lane",
+    "changing primitive or operation contracts",
+    "changing generated Python or TypeScript targets",
+    "settling every remaining primitive migration boundary"
+  ],
+  "references": [
+    {
+      "kind": "issue",
+      "target": "#1373",
+      "label": "Plan post-migration replacement of regression tests with contract-owned conformance cases"
+    },
+    {
+      "kind": "issue",
+      "target": "#1374",
+      "label": "Replace AW generated-command behavior tests with contract-owned conformance cases"
+    },
+    {
+      "kind": "issue",
+      "target": "rickardvh/command-generation#9",
+      "label": "Replace command-generation behavior tests with contract-owned conformance cases"
+    },
+    {
+      "kind": "doc",
+      "target": "docs/maintainer/testing-strategy.md",
+      "label": "Testing strategy"
+    },
+    {
+      "kind": "doc",
+      "target": "docs/maintainer/contract-test-replacement-plan.md",
+      "label": "Replacement plan"
+    }
+  ],
+  "summary": "The current suite already has 80 AW process conformance cases and a shared runner path, but ordinary tests still own many behavior examples. Replacement should be sequenced through owner-boundary readiness, command-generation primitive/composite cases, AW operation/process cases, then deletion or merge only where an equivalent contract case and adapter proof exist.",
+  "summary_counts": {
+    "aw_conformance_case_count": 80,
+    "aw_candidate_test_files_reviewed": 15,
+    "command_generation_candidate_test_files_reviewed": 3,
+    "aw_candidate_test_functions_sampled": 612,
+    "command_generation_candidate_test_functions_sampled": 34
+  },
+  "review_method": {
+    "issue_review": "#1373, #1374, and command-generation#9 were read to preserve scope and cross-repo ownership.",
+    "inventory": "AST inventory sampled relevant AW generated-command/proof/CLI files and command-generation test files.",
+    "contract_surface_review": "Existing AW conformance contracts and maintainer testing strategy were inspected before writing the replacement plan."
+  },
+  "findings": [
+    {
+      "id": "contract-cases-exist-but-do-not-own-all-behavior",
+      "finding": "AW already has 80 process-level conformance cases, but generated package proof, primitive executor, and command-facing tests still encode behavior directly in pytest.",
+      "suggested action": "Use #1374 to move stable command/process examples into AW conformance or operation cases and leave proof/checker mechanics ordinary."
+    },
+    {
+      "id": "portable-primitive-behavior-belongs-upstream",
+      "finding": "AW mirrors portable primitive behavior in tests/test_command_generation_primitive_executor.py while command-generation has matching primitive executor tests.",
+      "suggested action": "Use command-generation#9 to make primitive/composite behavior contract-owned upstream; keep AW tests only for dependency wiring and host integration."
+    },
+    {
+      "id": "high-risk-workflows-need-stable-owners-before-conversion",
+      "finding": "Start/preflight, implement, proof, report, and closeout surfaces include semantic risk that should not be moved into contract cases until primitive, fragment, operation, or command ownership is clear.",
+      "suggested action": "Convert stable command-facing examples first and keep assurance/intent/closeout trust regressions ordinary until owner contracts settle."
+    },
+    {
+      "id": "deletion-needs-equivalent-case-mapping",
+      "finding": "Pruning tests without a replacement map would repeat the failure mode #1366 warned about: either preserving accidental layout or deleting meaningful regression coverage.",
+      "suggested action": "Require old test name, replacement contract id/case id, target adapters, proof command, and remaining adapter test before deletion."
+    }
+  ],
+  "recommendation": {
+    "implementation_now": "Ship docs/maintainer/contract-test-replacement-plan.md, link it from testing strategy, and update #1374 and command-generation#9 with the handoff.",
+    "implementation_later": "Execute #1374 and command-generation#9 after owner-boundary readiness gates are true.",
+    "closeout_boundary": "#1373 is closed by a concrete sequencing and inventory plan, not by broad test conversion."
+  },
+  "validation_commands": [
+    "uv run pytest tests/test_maintainer_surfaces.py -q",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "make maintainer-surfaces",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ]
+}

--- a/docs/maintainer/contract-test-replacement-plan.md
+++ b/docs/maintainer/contract-test-replacement-plan.md
@@ -1,0 +1,96 @@
+# Contract-Owned Test Replacement Plan
+
+This plan sequences the post-migration replacement of ordinary regression tests with contract-owned conformance cases. It is the implementation plan for #1373 and the coordination surface for AW #1374 and `rickardvh/command-generation#9`.
+
+## Target Shape
+
+Operational contracts own canonical behavior examples. Python owns one authoritative runner. Generated CLIs, future MCP targets, and other transports provide thin adapters that execute the same cases and normalize results.
+
+Do not preserve the current test layout by renaming ordinary tests into contract-shaped files. Convert behavior only when the primitive, fragment, operation, or command boundary is stable enough that the case will not encode a temporary implementation seam.
+
+## Readiness Gates
+
+Start broad conversion only when all gates are true:
+
+- Portable primitive migration is stable enough that primitive behavior belongs in command-generation-owned contracts.
+- Fragment or composite operation structure is stable enough that reusable workflow behavior can attach below command-level black-box tests.
+- Generated Python and TypeScript targets are fresh and covered by shared conformance runner proof.
+- A converted case can name one behavior owner: primitive, fragment/subflow, operation, command adapter, runner internals, or host-specific orchestration.
+
+If a behavior cannot name one owner yet, keep the ordinary test and mark the blocker in the inventory.
+
+## AW Inventory
+
+| Surface | Current role | Replacement category | Owner |
+| --- | --- | --- | --- |
+| `src/agentic_workspace/contracts/conformance/*.json` | 80 existing process-level conformance cases | Keep and expand as contract-owned command/process cases | AW contracts |
+| `tests/test_generated_tool_conformance.py` | Harness and registry checks for process conformance | Keep ordinary runner/harness tests; add converted cases under contracts | AW |
+| `tests/test_generated_command_package_proof_runner.py` | Generated package proof orchestration, freshness, boundary checks, and conformance routing | Keep proof/checker internals ordinary; convert stable command behavior assertions to operation conformance cases | AW |
+| `tests/test_workspace_proof_generated_packages_cli.py` | Proof route selection for generated package paths | Keep ordinary proof-routing tests | AW |
+| `tests/test_command_generation_primitive_executor.py` | AW mirror of command-generation portable primitive behavior and operation fragment execution | Convert portable primitive behavior to command-generation contract cases; keep only AW integration tests that prove dependency wiring | command-generation plus AW integration |
+| `tests/test_command_generation_artifacts.py` | Artifact ownership, generated target freshness, operation fragment support | Keep ordinary artifact/freshness checks | AW |
+| `tests/test_workspace_cli_blackbox.py` | Console-script and adapter behavior | Keep minimal representative adapter tests; convert stable command outputs to operation cases | AW |
+| `tests/test_workspace_cli.py` | Mixed CLI compatibility, selectors, and orchestration behavior | Split: convert stable command outputs; keep selector/orchestration/error-route tests ordinary | AW |
+| `tests/test_workspace_config_cli.py`, `tests/test_workspace_defaults_cli.py` | Command behavior and output shaping | Convert stable output examples to operation cases; keep policy edge cases ordinary until fragments own them | AW |
+| `tests/test_workspace_implement_cli.py`, `tests/test_workspace_proof_cli.py`, `tests/test_workspace_report_cli.py`, `tests/test_workspace_start_preflight_cli.py` | High-risk workflow/report/proof surfaces with many semantic edge cases | Convert only stable command-facing examples first; keep assurance, intent, proof, and closeout trust regressions ordinary until owner contracts are settled | AW |
+
+## Command-Generation Inventory
+
+| Surface | Current role | Replacement category | Owner |
+| --- | --- | --- | --- |
+| `tests/test_public_api.py` | Package API, generated package behavior, conformance runner drift examples, registry checks | Keep API/schema/generator mechanics ordinary; convert generated command behavior examples to package-owned contract cases | command-generation |
+| `tests/test_primitive_executor.py` | Portable primitive behavior, fragments, primitive errors, operation dataflow | Convert stable primitive and fragment behavior to primitive/composite contract cases; keep executor internals and narrow bug repros ordinary | command-generation |
+| `tests/primitive_conformance.py` | Python conformance runner support | Keep runner internals ordinary; consume contract cases from package resources | command-generation |
+
+## Conversion Order
+
+1. Stabilize owner boundaries.
+
+   Confirm which primitive and fragment behaviors live in command-generation versus AW. Do this before moving tests so converted cases do not preserve pre-migration runtime seams.
+
+2. Convert portable primitive behavior in command-generation.
+
+   Move stable examples for filesystem, JSON, TOML, payload assembly, payload verification, output emit, fragment execution, and operation dataflow into contract-owned cases. Keep executor error mechanics ordinary where they are testing runner implementation rather than public behavior.
+
+3. Convert AW generated-command behavior.
+
+   Move stable generated command examples into `src/agentic_workspace/contracts/conformance/*.json` or the owning operation/composite contract surface. Execute them through the shared runner for Python and TypeScript generated targets.
+
+4. Collapse duplicated ordinary tests.
+
+   For each converted behavior, delete or merge the old regression only after the contract case proves the same behavior through the shared runner. Leave one representative adapter/black-box test per transport risk.
+
+5. Reclassify remaining tests.
+
+   Remaining ordinary tests must be explicitly one of: runner internals, adapter mechanics, proof/checker orchestration, schema/generator mechanics, high-risk semantic workflow, or temporary bug repro with a named blocker.
+
+## Keep Ordinary
+
+Keep ordinary pytest coverage for:
+
+- runner internals and diff reporting;
+- schema loading and generator mechanics;
+- adapter argument mapping, result extraction, exit/error normalization, and capability reporting;
+- proof/checker orchestration and generated target freshness;
+- high-risk semantic workflow surfaces that do not yet have stable operation or fragment owners;
+- narrow bug repros where the contract boundary is not stable enough yet.
+
+## Delete Or Merge Only With Equivalent Coverage
+
+Before deleting an ordinary regression, record:
+
+- old test name;
+- replacement contract id and case id;
+- target adapters that execute it;
+- proof command that ran it;
+- remaining ordinary test, if any, that still covers adapter mechanics.
+
+If that mapping cannot be written, do not delete the test.
+
+## Issue Handoff
+
+#1374 owns AW-side implementation using this plan.
+
+`rickardvh/command-generation#9` owns command-generation implementation using this plan.
+
+When either issue closes, its PR body should include an inventory table with `keep`, `convert`, `merge`, and `delete` rows plus proof that generated Python and TypeScript conformance remain green.

--- a/docs/maintainer/index.md
+++ b/docs/maintainer/index.md
@@ -8,6 +8,7 @@ This section is for source-checkout maintenance of this repository. It is not th
 - [Maintainer commands](maintainer-commands.md): literal command index.
 - [Dogfooding feedback](dogfooding-feedback.md): friction classification and admission policy.
 - [Testing strategy](testing-strategy.md): inventory, consolidation, pruning, and contract-owned conformance guidance.
+- [Contract-owned test replacement plan](contract-test-replacement-plan.md): sequencing and inventory for replacing regression tests with contract-owned conformance cases.
 - [Installed-contract design checklist](installed-contract-design-checklist.md): review bar for collaboration-sensitive installed surfaces.
 - [Operational affordance design](operational-affordance-design.md): design review rubric for operational surfaces.
 

--- a/docs/maintainer/testing-strategy.md
+++ b/docs/maintainer/testing-strategy.md
@@ -76,7 +76,7 @@ High-risk does not mean "add another one-off test by default." It means the repl
 
 ## Future Work
 
-#1373 owns the plan for replacing existing regressions with contract-owned conformance cases after the migration shape is stable.
+#1373 owns the plan for replacing existing regressions with contract-owned conformance cases after the migration shape is stable. Use [Contract-owned test replacement plan](contract-test-replacement-plan.md) for the current sequencing, inventory, and handoff rules.
 
 #1374 owns replacing AW generated-command behavior tests with contract-owned conformance cases.
 

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -455,6 +455,7 @@ def test_contributor_playbook_requires_operational_affordance_review() -> None:
 def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     playbook = (WORKSPACE_ROOT / "docs" / "maintainer" / "contributor-playbook.md").read_text(encoding="utf-8")
     strategy = (WORKSPACE_ROOT / "docs" / "maintainer" / "testing-strategy.md").read_text(encoding="utf-8")
+    replacement_plan = (WORKSPACE_ROOT / "docs" / "maintainer" / "contract-test-replacement-plan.md").read_text(encoding="utf-8")
 
     assert "docs/maintainer/testing-strategy.md" in playbook
     assert "Primitive conformance" in strategy
@@ -464,8 +465,14 @@ def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     assert "Contract-Owned Cases" in strategy
     assert "Prune only when stronger or equivalent coverage remains" in strategy
     assert "#1373 owns the plan" in strategy
+    assert "contract-test-replacement-plan.md" in strategy
     assert "#1374 owns replacing AW generated-command behavior tests" in strategy
     assert "rickardvh/command-generation#9" in strategy
+    assert "Do not preserve the current test layout" in replacement_plan
+    assert "Delete Or Merge Only With Equivalent Coverage" in replacement_plan
+    assert "old test name" in replacement_plan
+    assert "replacement contract id and case id" in replacement_plan
+    assert "rickardvh/command-generation#9" in replacement_plan
 
 
 def test_maintainer_surface_role_guidance_passes_when_docs_are_scoped(tmp_path: Path) -> None:


### PR DESCRIPTION
## What landed

- Added `docs/maintainer/contract-test-replacement-plan.md` as the concrete #1373 sequencing surface for replacing ordinary regressions with contract-owned conformance cases after the migration shape is stable.
- Added a grounding review with sampled AW and command-generation test inventory and replacement categories.
- Linked the plan from maintainer docs and guarded the critical handoff/deletion rules in `tests/test_maintainer_surfaces.py`.
- Archived the active #1373 execplan after closeout.

## Closure boundary

Closes #1373.

This PR does **not** convert or delete tests. It makes #1373 honest by producing the post-migration replacement plan, inventory categories, readiness gates, and deletion/merge evidence requirements. The actual implementation remains owned by:

- #1374 for AW-side generated-command behavior tests.
- rickardvh/command-generation#9 for command-generation primitive/generated behavior tests.

## Handoff

The new plan tells both implementation issues to include an inventory table with `keep`, `convert`, `merge`, and `delete` rows, plus proof that generated Python and TypeScript conformance remain green.

## Proof

- `uv run pytest tests/test_maintainer_surfaces.py -q`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `make maintainer-surfaces`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `git diff --check`

## Remaining limitation

The plan deliberately keeps high-risk workflow/proof/report tests ordinary until stable operation or fragment owners exist. That is not a blocker for #1373; it is the safety boundary for #1374 and command-generation#9.