### PR TITLE
Enforce intent satisfaction as a completion gate

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1380-active-intent-satisfaction-guard.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1380-active-intent-satisfaction-guard.plan.json
@@ -339,6 +339,25 @@
     "claim_level_requested": "full-intent-complete",
     "claim_level_allowed": "full-intent-complete",
     "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
     "blocked_claims": [],
     "residual_intent": "",
     "self_review": {
@@ -354,7 +373,7 @@
     "authority_boundary": {
       "aw_owns": [
         "forcing the transition rule",
-        "blocking unsupported claim language",
+        "blocking unsupported structured claim classes and closure actions",
         "routing continuation"
       ],
       "agent_owns": [

--- a/.agentic-workspace/planning/execplans/archive/issue-1380-active-intent-satisfaction-guard.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1380-active-intent-satisfaction-guard.plan.json
@@ -358,7 +358,6 @@
         "diagnostic_only": true
       }
     },
-    "blocked_claims": [],
     "residual_intent": "",
     "self_review": {
       "question": "Does the delivered work satisfy the active human intent?",

--- a/.agentic-workspace/planning/execplans/archive/issue-1380-active-intent-satisfaction-guard.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1380-active-intent-satisfaction-guard.plan.json
@@ -54,7 +54,7 @@
       "Final response rendering obeys the gate and includes the gate when full completion is blocked."
     ],
     "continuation_owner": "none",
-    "closeout_decision": "pending"
+    "closeout_decision": "archive-and-close"
   },
   "goal": [
     "Create a bounded plan for Implement #1380 active intent satisfaction guard."
@@ -64,16 +64,17 @@
   ],
   "machine_readable_contract": {
     "intent": {
-    "outcome": "Implement the #1383 completion gate pivot for PR #1382.",
-    "constraints": "Reuse existing closeout and Planning fields; do not make AW the semantic judge.",
-    "latitude": "Derived gate shape, compact rendering, schema/reference docs, and focused tests.",
-    "escalation": "Escalate if enforcement requires a new universal intent ledger or PR-specific closure engine."
+      "outcome": "Implement the #1383 completion gate pivot for PR #1382.",
+      "constraints": "Reuse existing closeout and Planning fields; do not make AW the semantic judge.",
+      "latitude": "Derived gate shape, compact rendering, schema/reference docs, and focused tests.",
+      "escalation": "Escalate if enforcement requires a new universal intent ledger or PR-specific closure engine.",
+      "proof": "See proof_report.validation proof."
     },
     "execution": {
       "milestone": "issue-1380-active-intent-satisfaction-guard",
-      "status": "active",
-      "next_step": "Update PR body and push.",
-      "proof": "Focused gate tests plus full workspace validation passed."
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
     },
     "scope": {
       "touched": [
@@ -142,10 +143,15 @@
     "escalate when": "The gate cannot be made strict without broad new state or PR-specific issue closure machinery."
   },
   "post_decomposition_delegation": {
-    "status": "pending",
+    "status": "recorded",
     "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
     "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
-    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "PR #1382 review fixes are tightly coupled across workspace report, Planning closeout, schemas, and focused regressions; keep-local preserves context and does not reduce required proof.",
+    "decision command": "agentic-planning delegation-decision",
+    "planning revision observed": "16b8fd9f7a72e885",
+    "recorded at": "2026-06-07T13:31:46+00:00"
   },
   "system_intent_alignment": {
     "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
@@ -156,7 +162,7 @@
   "references": [],
   "active_milestone": {
     "id": "issue-1380-active-intent-satisfaction-guard",
-    "status": "active",
+    "status": "completed",
     "scope": "Pivot PR #1382 to the #1383 completion gate design.",
     "ready": "ready",
     "blocked": "none",
@@ -191,76 +197,76 @@
     "run status": "completed",
     "executor": "Codex",
     "handoff source": "uv run python scripts/run_agentic_workspace.py start --task ... --format json; implement --changed ... --format json",
-    "what happened": "Created #1383, marked #1380/#1382 as superseded, and pivoted PR #1382 around a derived completion_gate that blocks unsupported full closeout claims and routes continuation, clarification, explicit partial, or complete closeout.",
-    "scope touched": "workspace closeout/report runtime projection, compact reporting support, workspace_report schema/reference docs, and report CLI regression tests",
-    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/workspace-report.md; tests/test_workspace_report_cli.py",
-    "validations run": "focused completion_gate tests; adjacent closeout tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; make maintainer-surfaces; uv run python scripts/run_agentic_workspace.py summary --target . --format json",
-    "result for continuation": "implementation ready for PR review",
-    "next step": "Update PR #1382 body, commit, and push."
+    "what happened": "Addressed PR #1382 review by expanding completion_gate coverage to Planning closeout and lane closeout surfaces, broadening blocked claim language, requiring proof for full closeout, demoting active-intent packets to explicit selectors, and refreshing generated Python/TypeScript payloads.",
+    "scope touched": "src/agentic_workspace/workspace_runtime_primitives.py; packages/planning/src/repo_planning_bootstrap/installer.py; planning schemas; generated planning payloads; focused workspace and planning tests; PR body",
+    "changed surfaces": "completion_gate runtime; Planning closeout records; lane closeout records; start/implement compact contexts; generated Python/TypeScript planning payloads",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
   },
   "finished_run_review": {
-    "review status": "completed",
-    "scope respected": "yes; no new module, universal ledger, semantic classifier, or PR-specific closure engine was added",
+    "review status": "complete",
+    "scope respected": "yes; the review's material findings are addressed with runtime behavior, Planning closeout coverage, schema-backed records, generated target refresh, and focused regressions.",
     "proof status": "passed",
-    "intent served": "yes; closeout cannot honestly expose full completion when completion_gate records active_intent_satisfied=false without human_accepted_partial",
+    "intent served": "yes",
     "config compliance": "used repo-local AW invocation and selected proof from implement --changed",
     "misinterpretation risk": "low; remaining limitation is that PR/issue closure language is blocked through closeout/final-response claim surfaces rather than a provider-specific PR body generator",
-    "follow-on decision": "dogfooding issue #1381 already covers stale state.toml active-item summary metadata; proof --current manual fallback noted in PR dogfooding"
+    "follow-on decision": "none"
   },
   "delegation_outcome_feedback": {
-    "route chosen": "pending",
-    "route skipped reason": "pending",
-    "expected savings": "pending",
-    "actual friction": "pending",
-    "proof result": "pending",
-    "quality concern": "pending",
-    "decomposition adjustment": "pending"
+    "route chosen": "keep-local",
+    "route skipped reason": "PR #1382 review fixes are tightly coupled across workspace report, Planning closeout, schemas, and focused regressions; keep-local preserves context and does not reduce required proof.",
+    "expected savings": "unknown",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
   },
   "proof_report": {
-    "validation proof": "focused completion_gate tests; adjacent closeout tests; make test-workspace; make lint-workspace; contract tooling; structured inventory; contract/check ruff; schema-reference docs; maintainer surfaces; AW summary",
-    "proof achieved now": "yes",
-    "evidence for \"proof achieved\" state": "All required validation commands selected by implement --changed passed after adding schema descriptions and preserving guidance-only closeout profile behavior."
+    "validation proof": "Focused completion-gate, selector, Planning closeout, and lane tests passed; make test-workspace; make lint-workspace; make test-planning; make lint-planning; make typecheck-planning; maintainer-surfaces; schema-reference-docs; contract tooling; structured inventory; AW summary; AW planning doctor.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
   },
   "intent_satisfaction": {
     "original intent": "Implement #1383 so if the agent knows the active human intent is not satisfied, AW must not let the workflow terminate as done/full-complete.",
     "was original intent fully satisfied?": "yes",
-    "evidence of intent satisfaction": "completion_gate is derived from existing closeout/Planning/proof fields, appears in closeout_trust and closeout_report, blocks done/implemented/Closes/full-complete claims when active_intent_satisfied=false without human_accepted_partial, renders required final-response caveats, and is covered by #1379-style overclosure plus continuation, clarification, explicit partial, and satisfied-intent tests.",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
     "unsolved intent passed to": "none"
   },
   "execution_summary": {
-    "outcome delivered": "completion_gate closeout transition enforcement for #1383",
-    "validation confirmed": "focused and full workspace validation passed",
-    "follow-on routed to": "none yet",
+    "outcome delivered": "PR #1382 now supports honest closure of #1383 across workspace report/final-response and Planning closeout/lane surfaces.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
     "post-work posterity capture": "PR body update pending",
-    "knowledge promoted (Memory/Docs/Config)": "workspace_report schema/reference docs",
-    "resume from": "PR #1382 body update and push"
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "workspace_report schema/reference docs"
   },
   "durable_residue": {
     "status": "none",
-    "learned constraint": "none yet",
-    "motivation worth preserving": "none yet",
-    "canonical owner now": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
     "promotion trigger": "none",
     "retention after promotion": "retain"
   },
   "task_intent_promotion": {
-    "decision": "pending",
+    "decision": "do-not-promote",
     "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
-    "evidence source": "",
-    "target scope": "",
-    "proposed durable intent": "",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
     "confidence": "low",
     "needs review": true,
-    "owner surface": ""
+    "owner surface": "archive"
   },
   "closure_check": {
-    "slice status": "complete",
+    "closeout scope": "slice",
+    "slice status": "completed",
     "larger-intent status": "closed",
-    "closure decision": "archive-and-close-after-pr",
-    "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
-    "why this decision is honest": "The PR demonstrates the stricter transition rule: completion_gate blocks full closeout claims when the agent self-review says active human intent is unsatisfied and no human-accepted partial exists.",
-    "evidence carried forward": "Focused completion_gate tests, closeout_report rendering regression, full workspace validation, schema/reference docs, and dogfooding notes.",
-    "reopen trigger": "Reopen if a closeout/final-response completion claim can still say done/implemented/Closes/full-complete while completion_gate.active_intent_satisfied=false and human_accepted_partial=false."
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
   },
   "improvement_signal_review": {
     "status": "signals_routed",
@@ -292,15 +298,81 @@
   },
   "closeout_distillation": {
     "buckets": {
-      "discard": [],
+      "discard": [
+        {
+          "summary": "GitHub #1381",
+          "owner": "",
+          "source": "improvement_signal_review.signals routed"
+        }
+      ],
       "continuation": [],
       "memory": [],
       "config_check": [],
-      "docs": [],
+      "docs": [
+        {
+          "summary": "workspace_report schema/reference docs",
+          "owner": "docs",
+          "source": "execution_summary"
+        }
+      ],
       "issue_follow_up": []
     }
   },
   "drift_log": [
-    "2026-06-06: Scaffolded by agentic-planning new-plan."
-  ]
+    "2026-06-06: Scaffolded by agentic-planning new-plan.",
+    "2026-06-07: Recorded delegation decision route=keep-local."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "blocked_claims": [],
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported claim language",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1383 so if the agent knows the active human intent is not satisfied, AW must not let the workflow terminate as done/full-complete.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Focused completion-gate, selector, Planning closeout, and lane tests passed; make test-workspace; make lint-workspace; make test-planning; make lint-planning; make typecheck-planning; maintainer-surfaces; schema-reference-docs; contract tooling; structured inventory; AW summary; AW planning doctor.\nChanged surfaces: completion_gate runtime; Planning closeout records; lane closeout records; start/implement compact contexts; generated Python/TypeScript planning payloads\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
 }

--- a/.agentic-workspace/planning/execplans/archive/pr-1382-remove-completion-gate-blocked-claims.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/pr-1382-remove-completion-gate-blocked-claims.plan.json
@@ -1,0 +1,303 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Remove completion-gate blocked_claims",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Remove completion_gate.blocked_claims from canonical runtime, schemas, generated payloads, docs, tests, and current archives.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Archive this completed execplan.",
+    "proof_expectations": [
+      "Focused completion-gate tests pass.",
+      "Workspace/planning full validation passes.",
+      "Schema, generated payload, and structured inventory checks pass."
+    ],
+    "touched_scope": [
+      "completion_gate runtime, report projection, schemas, generated payload schemas, docs, tests, and closeout archive records"
+    ],
+    "completion_criteria": [
+      "Remove completion-gate blocked_claims is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Remove completion_gate.blocked_claims now that claim_authorization is the single canonical enforcement surface."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Remove completion_gate.blocked_claims from canonical surfaces.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    },
+    "execution": {
+      "milestone": "pr-1382-remove-completion-gate-blocked-claims",
+      "status": "completed",
+      "next_step": "Archive this completed execplan.",
+      "proof": "Focused gate tests plus workspace/planning validation passed."
+    },
+    "scope": {
+      "touched": [
+        "completion_gate runtime, report projection, schemas, generated payload schemas, docs, tests, and closeout archive records"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Keep completion_gate centered on claim_authorization without legacy prose-fragment compatibility fields.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "completion_gate now has one clean claim-safety abstraction: claim_authorization.",
+    "intentionally deferred": "none",
+    "discovered implications": "Other blocked_claims fields remain on applicable-intent and verification surfaces and are intentionally outside this cleanup.",
+    "proof achieved now": "yes; focused and full validation passed.",
+    "validation still needed": "none for this slice.",
+    "next likely slice": "No required continuation remains for this PR-comment slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Remove blocked_claims from the canonical completion_gate surface.",
+    "inferred intended outcome": "Make claim_authorization the only completion-gate claim safety surface.",
+    "chosen concrete what": "Remove completion_gate.blocked_claims from runtime output, compact projection, schemas, generated payloads, docs, tests, and current archives.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "completion-gate runtime/projection, workspace and planning schemas, generated planning payload schemas, focused tests, current closeout archives, PR body.",
+    "max changed files": "about 20 including generated payloads and closeout archive",
+    "required validation commands": "Focused gate tests, make test-workspace, make lint-workspace, make test-planning, make lint-planning, make typecheck-planning, contract tooling, structured inventory, schema docs, maintainer surfaces.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Remove completion_gate.blocked_claims from canonical surfaces.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-keep-local",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "pr-1382-remove-completion-gate-blocked-claims",
+    "status": "completed",
+    "scope": "Remove completion_gate.blocked_claims from canonical surfaces.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Archive this completed execplan."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "src/agentic_workspace/reporting_support.py",
+    "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+    ".agentic-workspace/planning/schemas/planning-execplan.schema.json",
+    ".agentic-workspace/planning/schemas/planning-lane.schema.json",
+    "packages/planning/src/repo_planning_bootstrap/installer.py",
+    "packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-execplan.schema.json",
+    "packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-lane.schema.json",
+    "generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json",
+    "generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json",
+    "generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json",
+    "generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json",
+    "tests/test_workspace_report_cli.py",
+    "packages/planning/tests/test_archive.py",
+    "docs/reference/workspace-report.md"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "focused completion-gate tests",
+    "make test-workspace",
+    "make lint-workspace",
+    "make test-planning",
+    "make lint-planning",
+    "make typecheck-planning",
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "rg -n 'completion_gate.*blocked_claims|blocked_claims.*completion_gate|closeout_report\\.completion_gate\\.blocked_claims|\"blocked_claims\"' <completion gate/runtime/schema/test/docs surfaces>",
+    "make schema-reference-docs",
+    "make maintainer-surfaces"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Remove completion-gate blocked_claims is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Removed completion_gate.blocked_claims from canonical runtime output, compact projection, schemas, generated payloads, docs, tests, and current closeout archives.",
+    "scope touched": "completion gate only; unrelated applicable-intent and verification blocked_claims fields remain.",
+    "changed surfaces": "runtime, report projection, workspace/planning schemas, generated planning payload schemas, tests, reference docs, closeout archives, PR body.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "close",
+    "next step": "archive this execplan."
+  },
+  "finished_run_review": {
+    "review status": "completed",
+    "scope respected": "yes",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "passed",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "pending",
+    "route skipped reason": "pending",
+    "expected savings": "pending",
+    "actual friction": "pending",
+    "proof result": "pending",
+    "quality concern": "pending",
+    "decomposition adjustment": "pending"
+  },
+  "proof_report": {
+    "validation proof": "focused gate tests; make test-workspace; make lint-workspace; make test-planning; make lint-planning; make typecheck-planning; contract tooling; structured inventory; schema-reference-docs; maintainer-surfaces; AW summary; AW planning doctor.",
+    "proof achieved now": "yes",
+    "evidence for \"proof achieved\" state": "All listed validation commands passed."
+  },
+  "intent_satisfaction": {
+    "original intent": "Remove completion_gate.blocked_claims from canonical completion-gate surfaces.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "Runtime payloads, compact projection, schemas, generated payloads, docs, tests, and current archived completion gates no longer carry completion_gate.blocked_claims.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "completion_gate.blocked_claims removed from canonical surfaces.",
+    "validation confirmed": "passed",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "PR body updated.",
+    "knowledge promoted (Memory/Docs/Config)": "none",
+    "resume from": "archive"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "pending",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "",
+    "target scope": "",
+    "proposed durable intent": "",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": ""
+  },
+  "closure_check": {
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
+    "why this decision is honest": "The requested cleanup is complete and validated.",
+    "evidence carried forward": "proof_report.validation proof and PR body closure matrix.",
+    "reopen trigger": "completion_gate.blocked_claims reappears in canonical runtime, schema, generated payload, docs, or tests."
+  },
+  "improvement_signal_review": {
+    "status": "no_signal_found",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-07: Scaffolded by agentic-planning new-plan."
+  ]
+}

--- a/.agentic-workspace/planning/execplans/archive/pr-1382-structured-claim-authorization.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/pr-1382-structured-claim-authorization.plan.json
@@ -357,7 +357,6 @@
         "diagnostic_only": true
       }
     },
-    "blocked_claims": [],
     "residual_intent": "",
     "self_review": {
       "question": "Does the delivered work satisfy the active human intent?",

--- a/.agentic-workspace/planning/execplans/archive/pr-1382-structured-claim-authorization.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/pr-1382-structured-claim-authorization.plan.json
@@ -1,0 +1,396 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Structured claim authorization for completion gate",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Follow the new PR #1382 comment by replacing keyword/prose closeout safety with structured completion-gate claim authorization and closure actions.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Finish the structured claim authorization implementation, update tests/schemas, validate, update PR body, and push.",
+    "proof_expectations": [
+      "Focused completion-gate workspace report tests pass.",
+      "Focused planning closeout/lane tests pass.",
+      "Workspace and planning lint/test/check/schema commands required by AW pass."
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "packages/planning/src/repo_planning_bootstrap/installer.py",
+      "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+      ".agentic-workspace/planning/schemas/planning-execplan.schema.json",
+      ".agentic-workspace/planning/schemas/planning-lane.schema.json",
+      "tests/test_workspace_report_cli.py",
+      "packages/planning/tests/test_archive.py",
+      "packages/planning/tests/test_lanes.py"
+    ],
+    "completion_criteria": [
+      "Completion gate exposes allowed/blocked structured claim classes and structured issue-closure actions.",
+      "Renderers and completion options consume claim authorization instead of treating unsafe prose examples as enforcement.",
+      "Unsafe claim examples remain diagnostic-only.",
+      "Regression tests assert unsupported structured claim types and closure targets are blocked."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Replace keyword/prose closeout safety with structured completion-gate claim authorization and closure actions."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Follow PR #1382 comment by making completion safety authorize structured claim classes and closure actions.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "pr-1382-structured-claim-authorization",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "packages/planning/src/repo_planning_bootstrap/installer.py",
+        "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+        ".agentic-workspace/planning/schemas/planning-execplan.schema.json",
+        ".agentic-workspace/planning/schemas/planning-lane.schema.json",
+        "tests/test_workspace_report_cli.py",
+        "packages/planning/tests/test_archive.py",
+        "packages/planning/tests/test_lanes.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "PR #1382 completion gate preserves #1383 without brittle keyword matching.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Completion safety now uses structured claim classes/actions instead of prose keyword matching.",
+    "intentionally deferred": "none",
+    "discovered implications": "Compact closeout projection must preserve newly added gate fields or downstream surfaces cannot consume them.",
+    "proof achieved now": "yes; focused and full workspace/planning validation passed.",
+    "validation still needed": "none for this slice.",
+    "next likely slice": "No required continuation remains for this PR-comment slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Follow the PR comment that completion safety should not rely on keyword matching.",
+    "inferred intended outcome": "Make completion gate authorize structured claim classes and issue closure actions; keep prose examples as diagnostics only.",
+    "chosen concrete what": "Update runtime payloads, renderers/options, schemas, tests, and PR body around claim_authorization.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "workspace runtime primitive, planning runtime primitive, completion gate schemas, focused workspace/planning tests, PR body.",
+    "max changed files": "about 12 including generated schema/reference refreshes if required",
+    "required validation commands": "Focused tests first, then AW-required workspace/planning lint/test/schema/check commands.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue structured claim authorization edits and validate against the PR comment.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Replace keyword/prose closeout enforcement with structured claim authorization for completion gate.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-keep-local",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "pr-1382-structured-claim-authorization",
+    "status": "completed",
+    "scope": "Structured claim authorization for PR #1382 completion gate.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Finish runtime/schema/test edits for structured claim authorization."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "packages/planning/src/repo_planning_bootstrap/installer.py",
+    "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+    ".agentic-workspace/planning/schemas/planning-execplan.schema.json",
+    ".agentic-workspace/planning/schemas/planning-lane.schema.json",
+    "tests/test_workspace_report_cli.py",
+    "packages/planning/tests/test_archive.py",
+    "packages/planning/tests/test_lanes.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_report_cli.py::test_report_completion_gate_blocks_1379_style_overclosure tests/test_workspace_report_cli.py::test_report_completion_gate_blocks_full_closeout_when_proof_missing tests/test_workspace_report_cli.py::test_report_completion_gate_allows_satisfied_intent_full_closeout tests/test_workspace_report_cli.py::test_report_completion_gate_allows_explicit_human_partial_only_as_partial -q",
+    "uv run pytest packages/planning/tests/test_archive.py::test_archive_plan_prepare_closeout_normalizes_scaffold_residue_in_retained_archive packages/planning/tests/test_archive.py::test_archive_plan_prepare_closeout_handles_open_parent_lane packages/planning/tests/test_lanes.py::test_lane_close_and_archive_preserve_parent_contribution -q",
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "make schema-reference-docs",
+    "make maintainer-surfaces",
+    "make test-workspace",
+    "make lint-workspace",
+    "make test-planning",
+    "make lint-planning",
+    "make typecheck-planning"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Structured claim authorization for completion gate is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented structured completion-gate claim authorization, preserved it through compact closeout projection, updated renderers/options/tests/schemas, refreshed generated Python and TypeScript planning payload schemas, and updated the PR body.",
+    "scope touched": "workspace completion gate, closeout rendering/options, reporting projection, planning completion gate, planning schemas, generated planning payload schemas, focused tests, schema reference docs.",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; packages/planning/src/repo_planning_bootstrap/installer.py; planning schemas; generated planning payload schemas; focused tests; docs/reference/workspace-report.md",
+    "validations run": "focused workspace/planning gate tests; make test-workspace; make lint-workspace; make test-planning; make lint-planning; make typecheck-planning; contract tooling; structured inventory; schema-reference-docs; maintainer-surfaces; AW summary; AW planning doctor.",
+    "result for continuation": "close",
+    "next step": "archive this execplan."
+  },
+  "finished_run_review": {
+    "review status": "completed",
+    "scope respected": "yes; changes stayed within completion-gate claim authorization, schemas, tests, generated payloads, and PR body.",
+    "proof status": "passed",
+    "intent served": "yes; the gate now authorizes structured claim classes/actions instead of relying on prose keyword matching.",
+    "config compliance": "passed; AW required planning ownership and proof were followed.",
+    "misinterpretation risk": "low; unsafe prose examples are explicitly diagnostic-only.",
+    "follow-on decision": "none for this comment slice."
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "focused gate tests; make test-workspace; make lint-workspace; make test-planning; make lint-planning; make typecheck-planning; contract tooling; structured inventory; schema-reference-docs; maintainer-surfaces; AW summary; AW planning doctor.",
+    "proof achieved now": "yes",
+    "evidence for \"proof achieved\" state": "All listed validation commands passed after generated planning Python and TypeScript payload schemas were refreshed."
+  },
+  "intent_satisfaction": {
+    "original intent": "Follow PR #1382 comment: completion safety should authorize structured claim classes and closure actions instead of relying on keyword matching.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "Structured claim authorization implemented; tests, schemas, generated payloads, and PR body updated.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "structured completion-gate claim authorization implemented and PR body updated.",
+    "validation confirmed": "passed",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "PR body dogfooding section records the projection bug and state-summary friction.",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "none",
+    "proposed durable intent": "none yet",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "none"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "The PR comment asked to replace keyword/prose enforcement with structured claim authorization; the gate now authorizes claim classes/actions and keeps prose examples diagnostic-only.",
+    "evidence carried forward": "focused gate tests; make test-workspace; make lint-workspace; make test-planning; make lint-planning; make typecheck-planning; contract tooling; structured inventory; schema-reference-docs; maintainer-surfaces; AW summary; AW planning doctor",
+    "reopen trigger": "A renderer or closure surface still treats unsafe prose examples as the enforcement model."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      "Active-item summary retained scaffold next-action wording after the execplan was tightened, making AW state less informative until closeout."
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      "PR body dogfooding limitation; no new issue filed because this PR already exercises completion-gate closeout and the finding is not blocking."
+    ],
+    "signals dismissed": [],
+    "next owner": "none for this slice"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "PR body dogfooding limitation; no new issue filed because this PR already exercises completion-gate closeout and the finding is not blocking.",
+          "owner": "",
+          "source": "improvement_signal_review.signals routed"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-07: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "blocked_claims": [],
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Follow PR #1382 comment: completion safety should authorize structured claim classes and closure actions instead of relying on keyword matching.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: focused gate tests; make test-workspace; make lint-workspace; make test-planning; make lint-planning; make typecheck-planning; contract tooling; structured inventory; schema-reference-docs; maintainer-surfaces; AW summary; AW planning doctor.\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; packages/planning/src/repo_planning_bootstrap/installer.py; planning schemas; generated planning payload schemas; focused tests; docs/reference/workspace-report.md\nDurable residue: none (none)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/.agentic-workspace/planning/execplans/issue-1380-active-intent-satisfaction-guard.plan.json
+++ b/.agentic-workspace/planning/execplans/issue-1380-active-intent-satisfaction-guard.plan.json
@@ -1,0 +1,298 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1380 active intent satisfaction guard",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1380 so live chat, issue-backed, and planning-backed work surfaces an active intent contract plus satisfaction matrix before completion claims.",
+    "hard_constraints": "Do not make AW a semantic intent judge; preserve artifact-agnostic intent sources, leave satisfaction judgment to the agent/human, and keep the solution inside existing startup, implement, report/closeout, schema, and test surfaces.",
+    "agent_may_decide": "Compact packet shape, selector placement, tests, and the narrowest projection points that make completion-claim overreach visible without adding a new module.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Validate the active intent contract and satisfaction matrix across startup, implement, and closeout surfaces.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_surfaces_chat_task_active_intent_contract_and_satisfaction_matrix tests/test_workspace_implement_cli.py::test_implement_surfaces_active_intent_contract_for_refined_chat_instruction tests/test_workspace_report_cli.py::test_report_closeout_trust_surfaces_package_workflow_evidence -q",
+      "make test-workspace",
+      "make lint-workspace",
+      "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+      "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+      "make schema-reference-docs"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+      "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+      "tests/test_workspace_start_preflight_cli.py",
+      "tests/test_workspace_implement_cli.py",
+      "tests/test_workspace_report_cli.py"
+    ],
+    "completion_criteria": [
+      "Startup renders a chat-only active intent contract and satisfaction matrix.",
+      "Implement renders the same contract for changed-path work and exposes later-instruction relationship options.",
+      "Closeout trust renders planning-backed active intent and blocks broad/full completion when intent or parent evidence remains open.",
+      "Schemas and generated reference docs accept the new optional surfaces."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "pending"
+  },
+  "goal": [
+    "Create a bounded plan for Implement #1380 active intent satisfaction guard."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Implement #1380 active intent satisfaction guard.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    },
+    "execution": {
+      "milestone": "issue-1380-active-intent-satisfaction-guard",
+      "status": "active",
+      "next_step": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+      "proof": "Fill in the narrowest command that proves the promoted work."
+    },
+    "scope": {
+      "touched": [
+        "Fill in the concrete files before implementation starts."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Implement #1380 active intent satisfaction guard.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "pending",
+    "validation still needed": "current milestone validation remains pending",
+    "next likely slice": "continue the current milestone until the completion criteria are met"
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1380 active intent satisfaction guard",
+    "inferred intended outcome": "Create a bounded plan for Implement #1380 active intent satisfaction guard.",
+    "chosen concrete what": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "Fill in the concrete write scope before implementation starts.",
+    "max changed files": "Fill in an expected upper bound before implementation starts.",
+    "required validation commands": "Fill in the narrowest command that proves the promoted work.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Implement #1380 active intent satisfaction guard.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "pending",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1380-active-intent-satisfaction-guard",
+    "status": "active",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Fill in execution bounds, touched paths, and validation before implementation starts."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "Fill in the concrete files before implementation starts."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "Fill in the narrowest command that proves the promoted work."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement #1380 active intent satisfaction guard is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added active_intent_contract and intent_satisfaction_matrix packets to startup, implement, and closeout_trust surfaces so agents must state controlling intent, relationship options for later chat, self-review before final claims, and completion-claim blockers before claiming work is done.",
+    "scope touched": "workspace runtime projections, startup/implement schemas, generated schema reference docs, and focused workspace CLI tests",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; docs/reference/startup-context.md; docs/reference/implementer-context.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_implement_cli.py; tests/test_workspace_report_cli.py",
+    "validations run": "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_surfaces_chat_task_active_intent_contract_and_satisfaction_matrix tests/test_workspace_implement_cli.py::test_implement_surfaces_active_intent_contract_for_refined_chat_instruction tests/test_workspace_report_cli.py::test_report_closeout_trust_surfaces_package_workflow_evidence -q; amendment focused/size tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; make schema-reference-docs; make maintainer-surfaces; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json",
+    "result for continuation": "implementation ready for PR review",
+    "next step": "Create PR for #1380."
+  },
+  "finished_run_review": {
+    "review status": "completed",
+    "scope respected": "yes; no new module or semantic classifier was added",
+    "proof status": "passed",
+    "intent served": "yes; the surfaces now force an up-front intent contract and a before-claim satisfaction matrix while leaving semantic judgment to the agent/human",
+    "config compliance": "used repo-local AW invocation and selected proof from implement --changed",
+    "misinterpretation risk": "low; remaining risk is that compact generated-surface implement omits the new guard to preserve tiny budget because generated_surface_trust already carries a stronger completion guard",
+    "follow-on decision": "dogfooding issue #1381 filed for stale state.toml active-item summary metadata"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "pending",
+    "route skipped reason": "pending",
+    "expected savings": "pending",
+    "actual friction": "pending",
+    "proof result": "pending",
+    "quality concern": "pending",
+    "decomposition adjustment": "pending"
+  },
+  "proof_report": {
+    "validation proof": "focused tests; make test-workspace; make lint-workspace; contract tooling; structured inventory; schema-reference docs; maintainer surfaces; AW summary; AW doctor",
+    "proof achieved now": "yes",
+    "evidence for \"proof achieved\" state": "All listed validation commands passed after compact size-budget fixes."
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement #1380 so chat-only, issue-backed, refined-by-chat, and partial-slice work cannot bypass explicit intent satisfaction and claim-level validation.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "Startup default renders chat-task active_intent_contract and intent_satisfaction_matrix; implement default renders active intent and relationship options for refined chat instructions; closeout_trust renders planning-backed active intent and blocks broad completion when intent/parent evidence is open; the matrix now explicitly requires self-review before final claims; tests cover all three paths.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "not completed yet",
+    "validation confirmed": "pending",
+    "follow-on routed to": "none yet",
+    "post-work posterity capture": "pending",
+    "knowledge promoted (Memory/Docs/Config)": "none",
+    "resume from": "current milestone"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "pending",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "",
+    "target scope": "",
+    "proposed durable intent": "",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": ""
+  },
+  "closure_check": {
+    "slice status": "complete",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close-after-pr",
+    "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
+    "why this decision is honest": "The PR demonstrates the requested loop: state intent up front, state the satisfaction standard, and block broad completion claims until matrix evidence supports them.",
+    "evidence carried forward": "Focused tests plus full workspace validation; dogfooding issue #1381 for stale state active-item summary metadata.",
+    "reopen trigger": "Reopen if review finds a supported completion claim can still bypass active intent and matrix evidence on ordinary startup, implement, or closeout surfaces."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      {
+        "summary": "Planning summary active-item metadata can remain stale after tightening the active execplan.",
+        "owner": "issue",
+        "routed_to": "GitHub #1381"
+      }
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      "GitHub #1381"
+    ],
+    "signals dismissed": [],
+    "next owner": "GitHub #1381"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-06: Scaffolded by agentic-planning new-plan."
+  ]
+}

--- a/.agentic-workspace/planning/execplans/issue-1380-active-intent-satisfaction-guard.plan.json
+++ b/.agentic-workspace/planning/execplans/issue-1380-active-intent-satisfaction-guard.plan.json
@@ -1,6 +1,6 @@
 {
   "kind": "planning-execplan/v1",
-  "title": "Implement #1380 active intent satisfaction guard",
+  "title": "Implement #1383 completion gate",
   "execplan_profile": {
     "schema": "execplan-profile/v1",
     "task_shape": "bounded",
@@ -26,32 +26,32 @@
     "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
   },
   "canonical_core": {
-    "requested_outcome": "Implement #1380 so live chat, issue-backed, and planning-backed work surfaces an active intent contract plus satisfaction matrix before completion claims.",
-    "hard_constraints": "Do not make AW a semantic intent judge; preserve artifact-agnostic intent sources, leave satisfaction judgment to the agent/human, and keep the solution inside existing startup, implement, report/closeout, schema, and test surfaces.",
-    "agent_may_decide": "Compact packet shape, selector placement, tests, and the narrowest projection points that make completion-claim overreach visible without adding a new module.",
-    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
-    "next_action": "Validate the active intent contract and satisfaction matrix across startup, implement, and closeout surfaces.",
+    "requested_outcome": "Implement #1383 by pivoting PR #1382 from packet-first intent visibility to a strict completion_gate closeout transition rule.",
+    "hard_constraints": "Do not add a universal intent ledger or semantic classifier; reuse existing Planning, proof, acceptance, closeout, and rendering fields; AW enforces the transition rule while the agent owns semantic satisfaction judgment.",
+    "agent_may_decide": "Compact gate field names, exact derived inputs, and focused regression shape that proves unsupported full completion claims are blocked.",
+    "escalate_when": "A correct implementation cannot block completion claims without broad new state, PR-specific machinery, or AW-owned semantic classification.",
+    "next_action": "Update PR #1382 body for #1383 after validation.",
     "proof_expectations": [
-      "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_surfaces_chat_task_active_intent_contract_and_satisfaction_matrix tests/test_workspace_implement_cli.py::test_implement_surfaces_active_intent_contract_for_refined_chat_instruction tests/test_workspace_report_cli.py::test_report_closeout_trust_surfaces_package_workflow_evidence -q",
+      "uv run pytest tests/test_workspace_report_cli.py::test_report_completion_gate_blocks_1379_style_overclosure tests/test_workspace_report_cli.py::test_report_completion_gate_continuation_possible_requires_follow_on_not_caveat tests/test_workspace_report_cli.py::test_report_completion_gate_ambiguous_intent_requires_clarification tests/test_workspace_report_cli.py::test_report_completion_gate_allows_explicit_human_partial_only_as_partial tests/test_workspace_report_cli.py::test_report_completion_gate_allows_satisfied_intent_full_closeout -q",
       "make test-workspace",
       "make lint-workspace",
       "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
       "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+      "make maintainer-surfaces",
       "make schema-reference-docs"
     ],
     "touched_scope": [
       "src/agentic_workspace/workspace_runtime_primitives.py",
-      "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
-      "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
-      "tests/test_workspace_start_preflight_cli.py",
-      "tests/test_workspace_implement_cli.py",
+      "src/agentic_workspace/reporting_support.py",
+      "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+      "docs/reference/workspace-report.md",
       "tests/test_workspace_report_cli.py"
     ],
     "completion_criteria": [
-      "Startup renders a chat-only active intent contract and satisfaction matrix.",
-      "Implement renders the same contract for changed-path work and exposes later-instruction relationship options.",
-      "Closeout trust renders planning-backed active intent and blocks broad/full completion when intent or parent evidence remains open.",
-      "Schemas and generated reference docs accept the new optional surfaces."
+      "Closeout trust and closeout_report expose completion_gate.",
+      "Full done/implemented/close-keyword claims are blocked when active human intent is unsatisfied and no explicit human partial exists.",
+      "Continuation, clarification, human-accepted partial, and satisfied intent branches are covered by focused regression tests.",
+      "Final response rendering obeys the gate and includes the gate when full completion is blocked."
     ],
     "continuation_owner": "none",
     "closeout_decision": "pending"
@@ -64,28 +64,32 @@
   ],
   "machine_readable_contract": {
     "intent": {
-      "outcome": "Create a bounded plan for Implement #1380 active intent satisfaction guard.",
-      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
-      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
-      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    "outcome": "Implement the #1383 completion gate pivot for PR #1382.",
+    "constraints": "Reuse existing closeout and Planning fields; do not make AW the semantic judge.",
+    "latitude": "Derived gate shape, compact rendering, schema/reference docs, and focused tests.",
+    "escalation": "Escalate if enforcement requires a new universal intent ledger or PR-specific closure engine."
     },
     "execution": {
       "milestone": "issue-1380-active-intent-satisfaction-guard",
       "status": "active",
-      "next_step": "Fill in execution bounds, touched paths, and validation before implementation starts.",
-      "proof": "Fill in the narrowest command that proves the promoted work."
+      "next_step": "Update PR body and push.",
+      "proof": "Focused gate tests plus full workspace validation passed."
     },
     "scope": {
       "touched": [
-        "Fill in the concrete files before implementation starts."
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/reporting_support.py",
+        "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+        "docs/reference/workspace-report.md",
+        "tests/test_workspace_report_cli.py"
       ],
       "invariants": [
-        "Preserve the planning contract and keep the work bounded to this plan."
+        "Completion claims must follow completion_gate claim_level_allowed."
       ]
     }
   },
   "intent_continuity": {
-    "larger intended outcome": "Create a bounded plan for Implement #1380 active intent satisfaction guard.",
+    "larger intended outcome": "Implement #1383 completion-gate enforcement for PR #1382.",
     "this slice completes the larger intended outcome": "yes",
     "continuation surface": "none"
   },
@@ -95,24 +99,24 @@
     "activation trigger": "none"
   },
   "iterative_follow_through": {
-    "what this slice enabled": "none yet",
+    "what this slice enabled": "closeout completion_gate enforcement across closeout_trust, closeout_report, and final-response rendering",
     "intentionally deferred": "none",
-    "discovered implications": "none yet",
-    "proof achieved now": "pending",
-    "validation still needed": "current milestone validation remains pending",
-    "next likely slice": "continue the current milestone until the completion criteria are met"
+    "discovered implications": "proof --current can still fall back to manual verification even after implement --changed selected and passed concrete proof commands",
+    "proof achieved now": "yes",
+    "validation still needed": "PR review and merge",
+    "next likely slice": "none; pivot is ready for PR review"
   },
   "intent_interpretation": {
-    "literal request": "Implement #1380 active intent satisfaction guard",
-    "inferred intended outcome": "Create a bounded plan for Implement #1380 active intent satisfaction guard.",
-    "chosen concrete what": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "literal request": "Pivot PR #1382 to a completion_gate that enforces intent satisfaction before closeout claims.",
+    "inferred intended outcome": "Implement #1383 as the controlling design superseding #1380.",
+    "chosen concrete what": "Derived closeout completion_gate plus final-response and compact closeout_trust enforcement.",
     "interpretation distance": "low",
     "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
   },
   "execution_bounds": {
-    "allowed paths": "Fill in the concrete write scope before implementation starts.",
-    "max changed files": "Fill in an expected upper bound before implementation starts.",
-    "required validation commands": "Fill in the narrowest command that proves the promoted work.",
+    "allowed paths": "workspace runtime/reporting support, workspace_report schema/reference docs, and report CLI tests.",
+    "max changed files": "small closeout/report slice",
+    "required validation commands": "focused completion_gate tests; make test-workspace; make lint-workspace; contract tooling; structured inventory; maintainer surfaces; schema-reference docs.",
     "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
     "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
   },
@@ -128,14 +132,14 @@
     "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
     "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
     "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
-    "tiny resumability note": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "tiny resumability note": "completion_gate is the new center; active_intent_contract/matrix are compatibility inputs, not the closeout authority.",
     "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
   },
   "delegated_judgment": {
-    "requested outcome": "Create a bounded plan for Implement #1380 active intent satisfaction guard.",
-    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
-    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
-    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    "requested outcome": "Implement #1383 completion_gate enforcement for PR #1382.",
+    "hard constraints": "Do not make AW the semantic judge and do not rely on caveated completion when active intent is unsatisfied.",
+    "agent may decide locally": "Exact gate derivation from existing closeout fields, rendering wording, and focused test shape.",
+    "escalate when": "The gate cannot be made strict without broad new state or PR-specific issue closure machinery."
   },
   "post_decomposition_delegation": {
     "status": "pending",
@@ -153,51 +157,55 @@
   "active_milestone": {
     "id": "issue-1380-active-intent-satisfaction-guard",
     "status": "active",
-    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "scope": "Pivot PR #1382 to the #1383 completion gate design.",
     "ready": "ready",
     "blocked": "none",
     "optional_deps": "none"
   },
   "immediate_next_action": [
-    "Fill in execution bounds, touched paths, and validation before implementation starts."
+    "Update PR #1382 body and push the completion_gate pivot."
   ],
   "blockers": [
     "None."
   ],
   "touched_paths": [
-    "Fill in the concrete files before implementation starts."
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "src/agentic_workspace/reporting_support.py",
+    "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+    "docs/reference/workspace-report.md",
+    "tests/test_workspace_report_cli.py"
   ],
   "invariants": [
-    "Preserve the planning contract and keep the work bounded to this plan."
+    "If active_intent_satisfied is false and human_accepted_partial is false, full completion claims must remain blocked."
   ],
   "validation_commands": [
-    "Fill in the narrowest command that proves the promoted work."
+    "focused completion_gate pytest; make test-workspace; make lint-workspace; contract checks; maintainer surfaces; schema-reference docs."
   ],
   "required_tools": [
     "None."
   ],
   "completion_criteria": [
-    "Implement #1380 active intent satisfaction guard is implemented, validated, and closed out honestly."
+    "The #1383 completion gate pivot is implemented, validated, and ready for PR review."
   ],
   "execution_run": {
     "run status": "completed",
     "executor": "Codex",
-    "handoff source": "agentic-planning new-plan",
-    "what happened": "Added active_intent_contract and intent_satisfaction_matrix packets to startup, implement, and closeout_trust surfaces so agents must state controlling intent, relationship options for later chat, self-review before final claims, and completion-claim blockers before claiming work is done.",
-    "scope touched": "workspace runtime projections, startup/implement schemas, generated schema reference docs, and focused workspace CLI tests",
-    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; docs/reference/startup-context.md; docs/reference/implementer-context.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_implement_cli.py; tests/test_workspace_report_cli.py",
-    "validations run": "uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_surfaces_chat_task_active_intent_contract_and_satisfaction_matrix tests/test_workspace_implement_cli.py::test_implement_surfaces_active_intent_contract_for_refined_chat_instruction tests/test_workspace_report_cli.py::test_report_closeout_trust_surfaces_package_workflow_evidence -q; amendment focused/size tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; make schema-reference-docs; make maintainer-surfaces; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json",
+    "handoff source": "uv run python scripts/run_agentic_workspace.py start --task ... --format json; implement --changed ... --format json",
+    "what happened": "Created #1383, marked #1380/#1382 as superseded, and pivoted PR #1382 around a derived completion_gate that blocks unsupported full closeout claims and routes continuation, clarification, explicit partial, or complete closeout.",
+    "scope touched": "workspace closeout/report runtime projection, compact reporting support, workspace_report schema/reference docs, and report CLI regression tests",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; src/agentic_workspace/contracts/schemas/workspace_report.schema.json; docs/reference/workspace-report.md; tests/test_workspace_report_cli.py",
+    "validations run": "focused completion_gate tests; adjacent closeout tests; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make schema-reference-docs; make maintainer-surfaces; uv run python scripts/run_agentic_workspace.py summary --target . --format json",
     "result for continuation": "implementation ready for PR review",
-    "next step": "Create PR for #1380."
+    "next step": "Update PR #1382 body, commit, and push."
   },
   "finished_run_review": {
     "review status": "completed",
-    "scope respected": "yes; no new module or semantic classifier was added",
+    "scope respected": "yes; no new module, universal ledger, semantic classifier, or PR-specific closure engine was added",
     "proof status": "passed",
-    "intent served": "yes; the surfaces now force an up-front intent contract and a before-claim satisfaction matrix while leaving semantic judgment to the agent/human",
+    "intent served": "yes; closeout cannot honestly expose full completion when completion_gate records active_intent_satisfied=false without human_accepted_partial",
     "config compliance": "used repo-local AW invocation and selected proof from implement --changed",
-    "misinterpretation risk": "low; remaining risk is that compact generated-surface implement omits the new guard to preserve tiny budget because generated_surface_trust already carries a stronger completion guard",
-    "follow-on decision": "dogfooding issue #1381 filed for stale state.toml active-item summary metadata"
+    "misinterpretation risk": "low; remaining limitation is that PR/issue closure language is blocked through closeout/final-response claim surfaces rather than a provider-specific PR body generator",
+    "follow-on decision": "dogfooding issue #1381 already covers stale state.toml active-item summary metadata; proof --current manual fallback noted in PR dogfooding"
   },
   "delegation_outcome_feedback": {
     "route chosen": "pending",
@@ -209,23 +217,23 @@
     "decomposition adjustment": "pending"
   },
   "proof_report": {
-    "validation proof": "focused tests; make test-workspace; make lint-workspace; contract tooling; structured inventory; schema-reference docs; maintainer surfaces; AW summary; AW doctor",
+    "validation proof": "focused completion_gate tests; adjacent closeout tests; make test-workspace; make lint-workspace; contract tooling; structured inventory; contract/check ruff; schema-reference docs; maintainer surfaces; AW summary",
     "proof achieved now": "yes",
-    "evidence for \"proof achieved\" state": "All listed validation commands passed after compact size-budget fixes."
+    "evidence for \"proof achieved\" state": "All required validation commands selected by implement --changed passed after adding schema descriptions and preserving guidance-only closeout profile behavior."
   },
   "intent_satisfaction": {
-    "original intent": "Implement #1380 so chat-only, issue-backed, refined-by-chat, and partial-slice work cannot bypass explicit intent satisfaction and claim-level validation.",
+    "original intent": "Implement #1383 so if the agent knows the active human intent is not satisfied, AW must not let the workflow terminate as done/full-complete.",
     "was original intent fully satisfied?": "yes",
-    "evidence of intent satisfaction": "Startup default renders chat-task active_intent_contract and intent_satisfaction_matrix; implement default renders active intent and relationship options for refined chat instructions; closeout_trust renders planning-backed active intent and blocks broad completion when intent/parent evidence is open; the matrix now explicitly requires self-review before final claims; tests cover all three paths.",
+    "evidence of intent satisfaction": "completion_gate is derived from existing closeout/Planning/proof fields, appears in closeout_trust and closeout_report, blocks done/implemented/Closes/full-complete claims when active_intent_satisfied=false without human_accepted_partial, renders required final-response caveats, and is covered by #1379-style overclosure plus continuation, clarification, explicit partial, and satisfied-intent tests.",
     "unsolved intent passed to": "none"
   },
   "execution_summary": {
-    "outcome delivered": "not completed yet",
-    "validation confirmed": "pending",
+    "outcome delivered": "completion_gate closeout transition enforcement for #1383",
+    "validation confirmed": "focused and full workspace validation passed",
     "follow-on routed to": "none yet",
-    "post-work posterity capture": "pending",
-    "knowledge promoted (Memory/Docs/Config)": "none",
-    "resume from": "current milestone"
+    "post-work posterity capture": "PR body update pending",
+    "knowledge promoted (Memory/Docs/Config)": "workspace_report schema/reference docs",
+    "resume from": "PR #1382 body update and push"
   },
   "durable_residue": {
     "status": "none",
@@ -250,9 +258,9 @@
     "larger-intent status": "closed",
     "closure decision": "archive-and-close-after-pr",
     "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
-    "why this decision is honest": "The PR demonstrates the requested loop: state intent up front, state the satisfaction standard, and block broad completion claims until matrix evidence supports them.",
-    "evidence carried forward": "Focused tests plus full workspace validation; dogfooding issue #1381 for stale state active-item summary metadata.",
-    "reopen trigger": "Reopen if review finds a supported completion claim can still bypass active intent and matrix evidence on ordinary startup, implement, or closeout surfaces."
+    "why this decision is honest": "The PR demonstrates the stricter transition rule: completion_gate blocks full closeout claims when the agent self-review says active human intent is unsatisfied and no human-accepted partial exists.",
+    "evidence carried forward": "Focused completion_gate tests, closeout_report rendering regression, full workspace validation, schema/reference docs, and dogfooding notes.",
+    "reopen trigger": "Reopen if a closeout/final-response completion claim can still say done/implemented/Closes/full-complete while completion_gate.active_intent_satisfied=false and human_accepted_partial=false."
   },
   "improvement_signal_review": {
     "status": "signals_routed",

--- a/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -237,7 +237,6 @@
         "claim_level_allowed",
         "required_next_action",
         "claim_authorization",
-        "blocked_claims",
         "self_review",
         "continuation",
         "authority_boundary"
@@ -253,7 +252,6 @@
         "claim_level_allowed": { "type": "string" },
         "required_next_action": { "type": "string" },
         "claim_authorization": { "$ref": "#/$defs/claim_authorization" },
-        "blocked_claims": { "$ref": "#/$defs/string_array" },
         "residual_intent": { "type": "string" },
         "self_review": { "type": "object" },
         "continuation": { "type": "object" },

--- a/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -236,6 +236,7 @@
         "claim_level_requested",
         "claim_level_allowed",
         "required_next_action",
+        "claim_authorization",
         "blocked_claims",
         "self_review",
         "continuation",
@@ -251,11 +252,56 @@
         "claim_level_requested": { "type": "string" },
         "claim_level_allowed": { "type": "string" },
         "required_next_action": { "type": "string" },
+        "claim_authorization": { "$ref": "#/$defs/claim_authorization" },
         "blocked_claims": { "$ref": "#/$defs/string_array" },
         "residual_intent": { "type": "string" },
         "self_review": { "type": "object" },
         "continuation": { "type": "object" },
         "authority_boundary": { "type": "object" }
+      }
+    },
+    "claim_authorization": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["kind", "allowed_claim_classes", "blocked_claim_classes", "closure_actions", "renderer_rule", "diagnostics"],
+      "properties": {
+        "kind": { "const": "agentic-workspace/claim-authorization/v1" },
+        "allowed_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": ["partial_progress", "slice_complete", "lane_complete", "parent_complete", "full_intent_complete", "issue_closure"]
+          }
+        },
+        "blocked_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": ["partial_progress", "slice_complete", "lane_complete", "parent_complete", "full_intent_complete", "issue_closure"]
+          }
+        },
+        "closure_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["kind", "target", "authorized", "reason"],
+            "properties": {
+              "kind": { "const": "issue_closure" },
+              "target": { "type": "string" },
+              "authorized": { "type": "boolean" },
+              "reason": { "type": "string" }
+            }
+          }
+        },
+        "renderer_rule": { "type": "string" },
+        "diagnostics": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["unsafe_claim_examples", "diagnostic_only"],
+          "properties": {
+            "unsafe_claim_examples": { "$ref": "#/$defs/string_array" },
+            "diagnostic_only": { "const": true }
+          }
+        }
       }
     },
     "reference": {

--- a/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -140,6 +140,7 @@
     "intent_satisfaction": { "$ref": "#/$defs/string_map" },
     "system_intent_alignment": { "$ref": "#/$defs/string_map" },
     "closure_check": { "$ref": "#/$defs/string_map" },
+    "completion_gate": { "$ref": "#/$defs/completion_gate" },
     "generated_closeout": { "$ref": "#/$defs/string_map" },
     "memory_learning_capture": { "$ref": "#/$defs/string_map" },
     "durable_residue": {
@@ -222,6 +223,39 @@
           { "type": "number" },
           { "type": "null" }
         ]
+      }
+    },
+    "completion_gate": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "status",
+        "active_intent_satisfied",
+        "human_accepted_partial",
+        "claim_level_requested",
+        "claim_level_allowed",
+        "required_next_action",
+        "blocked_claims",
+        "self_review",
+        "continuation",
+        "authority_boundary"
+      ],
+      "properties": {
+        "kind": { "const": "agentic-workspace/completion-gate/v1" },
+        "status": {
+          "enum": ["allowed", "blocked", "continue-required", "clarification-required", "human-accepted-partial"]
+        },
+        "active_intent_satisfied": { "type": "boolean" },
+        "human_accepted_partial": { "type": "boolean" },
+        "claim_level_requested": { "type": "string" },
+        "claim_level_allowed": { "type": "string" },
+        "required_next_action": { "type": "string" },
+        "blocked_claims": { "$ref": "#/$defs/string_array" },
+        "residual_intent": { "type": "string" },
+        "self_review": { "type": "object" },
+        "continuation": { "type": "object" },
+        "authority_boundary": { "type": "object" }
       }
     },
     "reference": {

--- a/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -98,6 +98,9 @@
     "closeout_state": {
       "$ref": "#/$defs/closeout_state"
     },
+    "completion_gate": {
+      "$ref": "#/$defs/completion_gate"
+    },
     "references": {
       "type": "array",
       "items": {
@@ -211,6 +214,67 @@
         },
         "next_owner": {
           "type": "string"
+        }
+      }
+    },
+    "completion_gate": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "status",
+        "active_intent_satisfied",
+        "human_accepted_partial",
+        "claim_level_requested",
+        "claim_level_allowed",
+        "required_next_action",
+        "blocked_claims",
+        "self_review",
+        "continuation",
+        "authority_boundary"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/completion-gate/v1"
+        },
+        "status": {
+          "enum": [
+            "allowed",
+            "blocked",
+            "continue-required",
+            "clarification-required",
+            "human-accepted-partial"
+          ]
+        },
+        "active_intent_satisfied": {
+          "type": "boolean"
+        },
+        "human_accepted_partial": {
+          "type": "boolean"
+        },
+        "claim_level_requested": {
+          "type": "string"
+        },
+        "claim_level_allowed": {
+          "type": "string"
+        },
+        "required_next_action": {
+          "type": "string"
+        },
+        "blocked_claims": {
+          "$ref": "#/$defs/string_array"
+        },
+        "residual_intent": {
+          "type": "string"
+        },
+        "self_review": {
+          "type": "object"
+        },
+        "continuation": {
+          "type": "object"
+        },
+        "authority_boundary": {
+          "type": "object"
         }
       }
     },

--- a/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -228,6 +228,7 @@
         "claim_level_requested",
         "claim_level_allowed",
         "required_next_action",
+        "claim_authorization",
         "blocked_claims",
         "self_review",
         "continuation",
@@ -261,6 +262,9 @@
         "required_next_action": {
           "type": "string"
         },
+        "claim_authorization": {
+          "$ref": "#/$defs/claim_authorization"
+        },
         "blocked_claims": {
           "$ref": "#/$defs/string_array"
         },
@@ -275,6 +279,95 @@
         },
         "authority_boundary": {
           "type": "object"
+        }
+      }
+    },
+    "claim_authorization": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "allowed_claim_classes",
+        "blocked_claim_classes",
+        "closure_actions",
+        "renderer_rule",
+        "diagnostics"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/claim-authorization/v1"
+        },
+        "allowed_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "partial_progress",
+              "slice_complete",
+              "lane_complete",
+              "parent_complete",
+              "full_intent_complete",
+              "issue_closure"
+            ]
+          }
+        },
+        "blocked_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "partial_progress",
+              "slice_complete",
+              "lane_complete",
+              "parent_complete",
+              "full_intent_complete",
+              "issue_closure"
+            ]
+          }
+        },
+        "closure_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "kind",
+              "target",
+              "authorized",
+              "reason"
+            ],
+            "properties": {
+              "kind": {
+                "const": "issue_closure"
+              },
+              "target": {
+                "type": "string"
+              },
+              "authorized": {
+                "type": "boolean"
+              },
+              "reason": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "renderer_rule": {
+          "type": "string"
+        },
+        "diagnostics": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "unsafe_claim_examples",
+            "diagnostic_only"
+          ],
+          "properties": {
+            "unsafe_claim_examples": {
+              "$ref": "#/$defs/string_array"
+            },
+            "diagnostic_only": {
+              "const": true
+            }
+          }
         }
       }
     },

--- a/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -229,7 +229,6 @@
         "claim_level_allowed",
         "required_next_action",
         "claim_authorization",
-        "blocked_claims",
         "self_review",
         "continuation",
         "authority_boundary"
@@ -264,9 +263,6 @@
         },
         "claim_authorization": {
           "$ref": "#/$defs/claim_authorization"
-        },
-        "blocked_claims": {
-          "$ref": "#/$defs/string_array"
         },
         "residual_intent": {
           "type": "string"

--- a/.agentic-workspace/planning/state.toml
+++ b/.agentic-workspace/planning/state.toml
@@ -13,7 +13,7 @@ execplans = []
 
 [todo]
 active_items = [
-  { id = "issue-1380-active-intent-satisfaction-guard", title = "Implement #1380 active intent satisfaction guard", maturity = "active", status = "active", surface = ".agentic-workspace/planning/execplans/issue-1380-active-intent-satisfaction-guard.plan.json", why_now = "Created by new-plan scaffold.", owner_role = "implementation", review_role = "validation", handoff_ready = true, next_action = "Tighten scaffold fields, touched paths, and validation before implementation starts.", done_when = "Implement #1380 active intent satisfaction guard is implemented, validated, and closed out honestly.", proof = "Run the proof selected by implement --changed before claiming completion." },
+  { id = "issue-1380-active-intent-satisfaction-guard", title = "Implement #1383 completion gate", maturity = "active", status = "active", surface = ".agentic-workspace/planning/execplans/issue-1380-active-intent-satisfaction-guard.plan.json", why_now = "PR #1382 pivoted from #1380 packet-first direction to #1383 completion-gate enforcement.", owner_role = "implementation", review_role = "validation", handoff_ready = true, next_action = "Update PR #1382 body, commit, and push.", done_when = "The #1383 completion gate pivot is implemented, validated, and closed out honestly.", proof = "Focused completion_gate tests plus make test-workspace, make lint-workspace, contract checks, maintainer surfaces, and schema-reference docs passed." },
 ]
 queued_items = []
 

--- a/.agentic-workspace/planning/state.toml
+++ b/.agentic-workspace/planning/state.toml
@@ -12,9 +12,7 @@ work_items = []
 execplans = []
 
 [todo]
-active_items = [
-  { id = "issue-1380-active-intent-satisfaction-guard", title = "Implement #1383 completion gate", maturity = "active", status = "active", surface = ".agentic-workspace/planning/execplans/issue-1380-active-intent-satisfaction-guard.plan.json", why_now = "PR #1382 pivoted from #1380 packet-first direction to #1383 completion-gate enforcement.", owner_role = "implementation", review_role = "validation", handoff_ready = true, next_action = "Update PR #1382 body, commit, and push.", done_when = "The #1383 completion gate pivot is implemented, validated, and closed out honestly.", proof = "Focused completion_gate tests plus make test-workspace, make lint-workspace, contract checks, maintainer surfaces, and schema-reference docs passed." },
-]
+active_items = []
 queued_items = []
 
 [roadmap]

--- a/.agentic-workspace/planning/state.toml
+++ b/.agentic-workspace/planning/state.toml
@@ -12,7 +12,9 @@ work_items = []
 execplans = []
 
 [todo]
-active_items = []
+active_items = [
+  { id = "issue-1380-active-intent-satisfaction-guard", title = "Implement #1380 active intent satisfaction guard", maturity = "active", status = "active", surface = ".agentic-workspace/planning/execplans/issue-1380-active-intent-satisfaction-guard.plan.json", why_now = "Created by new-plan scaffold.", owner_role = "implementation", review_role = "validation", handoff_ready = true, next_action = "Tighten scaffold fields, touched paths, and validation before implementation starts.", done_when = "Implement #1380 active intent satisfaction guard is implemented, validated, and closed out honestly.", proof = "Run the proof selected by implement --changed before claiming completion." },
+]
 queued_items = []
 
 [roadmap]

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -87,6 +87,8 @@ Cheap implementer context for a bounded changed-path scope.
 | `acceptance_reconciliation.task_carry_forward_hint` | string | yes |  | Short reminder to preserve task text across start and implement calls. |  |  |
 | `intent_acknowledgement` | object | yes |  | Guidance for stating inferred intent, first slice, non-goals, and correction point before non-direct implementation. |  |  |
 | `intent_evidence` | object | yes |  | Compact provenance and assumption evidence for the task intent being implemented, including source chain, correction point, and clarification/proceed posture. |  |  |
+| `active_intent_contract` | object | no |  | Active controlling-intent contract preserving chat, planning, external, and mixed intent sources before completion claims. |  |  |
+| `intent_satisfaction_matrix` | object | no |  | Compact satisfaction matrix shape that maps active intent items to evidence, gaps, and the honest completion claim level. |  |  |
 | `parent_intent_status` | object | no |  | Parent/original-intent status preserving larger intent across bounded slices. |  |  |
 | `parent_intent_status.kind` | const `"agentic-workspace/parent-intent-status/v1"` | yes |  | Discriminator for the parent/original-intent status packet. |  |  |
 | `parent_intent_status.status` | string | yes |  | Whether the recorded parent/original intent is satisfied, open, or only guidance. |  |  |

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -141,6 +141,8 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `durable_intent_promotion` | object | no |  | Guidance for promoting non-finishable task intent into durable memory, docs, subsystem intent, or system intent. |  |  |
 | `intent_acknowledgement` | object | no |  | Guidance for the middle path between silent inference and clarification halt: state inferred intent, first slice, non-goals, and correction point before non-direct work. |  |  |
 | `intent_evidence` | object | no |  | Compact provenance and assumption evidence for the current task intent, including source chain, correction point, and clarification/proceed posture. |  |  |
+| `active_intent_contract` | object | no |  | Active controlling-intent contract preserving chat, planning, external, and mixed intent sources before completion claims. |  |  |
+| `intent_satisfaction_matrix` | object | no |  | Compact satisfaction matrix shape that maps active intent items to evidence, gaps, and the honest completion claim level. |  |  |
 | `durable_intent` | object | no |  | Compact durable task, subsystem, and system intent pressure to consider before implementation. |  |  |
 | `skill_routing` | ref `#/$defs/skill_routing` | no |  | Skill-discovery route and fallback guidance for task-specific instructions. |  |  |
 | `skill_routing.status` | string | yes |  | Current lifecycle, readiness, or health state. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -153,7 +153,16 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `closeout_report.completion_gate.claim_level_requested` | string | yes |  | Requested claim level being evaluated. |  |  |
 | `closeout_report.completion_gate.claim_level_allowed` | string | yes |  | Highest claim level supported by the gate. |  |  |
 | `closeout_report.completion_gate.required_next_action` | enum `"continue-current-work"`, `"create-follow-on-plan"`, `"activate-next-slice"`, `"ask-human"`, `"close-complete"`, `"close-human-accepted-partial"` | yes |  | Required transition before the workflow can stop or claim completion. |  |  |
-| `closeout_report.completion_gate.blocked_claims` | array of string | yes |  | Completion, done, or close-keyword claims blocked by the gate. |  |  |
+| `closeout_report.completion_gate.blocked_claims` | array of string | yes |  | Compatibility diagnostics listing human-readable unsafe claim examples. Enforcement uses claim_authorization. |  |  |
+| `closeout_report.completion_gate.claim_authorization` | ref `#/$defs/claim_authorization` | yes |  | Structured claim classes and closure actions authorized or blocked by the gate. |  |  |
+| `closeout_report.completion_gate.claim_authorization.kind` | const `"agentic-workspace/claim-authorization/v1"` | yes |  | Discriminator for structured completion claim authorization. |  |  |
+| `closeout_report.completion_gate.claim_authorization.allowed_claim_classes` | array of enum `"partial_progress"`, `"slice_complete"`, `"lane_complete"`, `"parent_complete"`, `"full_intent_complete"`, `"issue_closure"` | yes |  | Claim classes renderers may use. |  |  |
+| `closeout_report.completion_gate.claim_authorization.blocked_claim_classes` | array of enum `"partial_progress"`, `"slice_complete"`, `"lane_complete"`, `"parent_complete"`, `"full_intent_complete"`, `"issue_closure"` | yes |  | Claim classes renderers must not use. |  |  |
+| `closeout_report.completion_gate.claim_authorization.closure_actions` | array of object | yes |  | Structured closure actions such as issue closure for concrete targets. |  |  |
+| `closeout_report.completion_gate.claim_authorization.renderer_rule` | string | yes |  | Renderer rule requiring templates to be selected only from authorized claim classes/actions. |  |  |
+| `closeout_report.completion_gate.claim_authorization.diagnostics` | object | yes |  | Human-readable examples for explanation only; not the enforcement model. |  |  |
+| `closeout_report.completion_gate.claim_authorization.diagnostics.unsafe_claim_examples` | array of string | yes |  | Human-readable examples of unsafe completion prose for explanation only. |  |  |
+| `closeout_report.completion_gate.claim_authorization.diagnostics.diagnostic_only` | const `true` | yes |  | Marker that unsafe_claim_examples are diagnostics, not enforcement rules. |  |  |
 | `closeout_report.completion_gate.residual_intent` | string | no |  | Remaining active human intent when the requested full claim is unsupported. |  |  |
 | `closeout_report.completion_gate.self_review` | object | yes |  | Mandatory agent self-review before final completion claims. |  |  |
 | `closeout_report.completion_gate.self_review.question` | string | yes |  | Self-review question the agent must answer before making a completion claim. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -153,7 +153,6 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `closeout_report.completion_gate.claim_level_requested` | string | yes |  | Requested claim level being evaluated. |  |  |
 | `closeout_report.completion_gate.claim_level_allowed` | string | yes |  | Highest claim level supported by the gate. |  |  |
 | `closeout_report.completion_gate.required_next_action` | enum `"continue-current-work"`, `"create-follow-on-plan"`, `"activate-next-slice"`, `"ask-human"`, `"close-complete"`, `"close-human-accepted-partial"` | yes |  | Required transition before the workflow can stop or claim completion. |  |  |
-| `closeout_report.completion_gate.blocked_claims` | array of string | yes |  | Compatibility diagnostics listing human-readable unsafe claim examples. Enforcement uses claim_authorization. |  |  |
 | `closeout_report.completion_gate.claim_authorization` | ref `#/$defs/claim_authorization` | yes |  | Structured claim classes and closure actions authorized or blocked by the gate. |  |  |
 | `closeout_report.completion_gate.claim_authorization.kind` | const `"agentic-workspace/claim-authorization/v1"` | yes |  | Discriminator for structured completion claim authorization. |  |  |
 | `closeout_report.completion_gate.claim_authorization.allowed_claim_classes` | array of enum `"partial_progress"`, `"slice_complete"`, `"lane_complete"`, `"parent_complete"`, `"full_intent_complete"`, `"issue_closure"` | yes |  | Claim classes renderers may use. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -145,6 +145,26 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `closeout_report.review_compression` | object | no |  | Derived closeout-first human review guide naming the selected work-shape mode, first-inspection facts and contract, rendered fact requirements, behavior-preserving refactor semantic-risk focus, detail routes, and human-owned decisions. |  |  |
 | `closeout_report.validation` | object | no |  | Closeout validation projection, including proof confidence and behavior_preservation facts when preservation claims, proof classes, unsupported claims, or caveats were recorded. |  |  |
 | `closeout_report.closeout_adoption` | object | no |  | Derived closeout quality rubric, representative examples, and current rendering adoption status for human-useful final reports. |  |  |
+| `closeout_report.completion_gate` | ref `#/$defs/completion_gate` | no |  | Closeout transition gate that blocks full completion or closure-language claims when active human intent is unsatisfied and no explicit human-accepted partial scope exists. |  |  |
+| `closeout_report.completion_gate.kind` | const `"agentic-workspace/completion-gate/v1"` | yes |  | Discriminator for the closeout completion gate. |  |  |
+| `closeout_report.completion_gate.status` | enum `"allowed"`, `"blocked"`, `"continue-required"`, `"clarification-required"`, `"human-accepted-partial"` | yes |  | State-machine result for the requested completion claim. |  |  |
+| `closeout_report.completion_gate.active_intent_satisfied` | boolean | yes |  | Agent-recorded answer to whether delivered work satisfies the active human intent. |  |  |
+| `closeout_report.completion_gate.human_accepted_partial` | boolean | yes |  | Whether the human explicitly accepted a partial or narrower completion claim. |  |  |
+| `closeout_report.completion_gate.claim_level_requested` | string | yes |  | Requested claim level being evaluated. |  |  |
+| `closeout_report.completion_gate.claim_level_allowed` | string | yes |  | Highest claim level supported by the gate. |  |  |
+| `closeout_report.completion_gate.required_next_action` | enum `"continue-current-work"`, `"create-follow-on-plan"`, `"activate-next-slice"`, `"ask-human"`, `"close-complete"`, `"close-human-accepted-partial"` | yes |  | Required transition before the workflow can stop or claim completion. |  |  |
+| `closeout_report.completion_gate.blocked_claims` | array of string | yes |  | Completion, done, or close-keyword claims blocked by the gate. |  |  |
+| `closeout_report.completion_gate.residual_intent` | string | no |  | Remaining active human intent when the requested full claim is unsupported. |  |  |
+| `closeout_report.completion_gate.self_review` | object | yes |  | Mandatory agent self-review before final completion claims. |  |  |
+| `closeout_report.completion_gate.self_review.question` | string | yes |  | Self-review question the agent must answer before making a completion claim. |  |  |
+| `closeout_report.completion_gate.self_review.answer` | enum `"yes"`, `"no"` | yes |  | Agent-owned self-review answer for active human intent satisfaction. |  |  |
+| `closeout_report.completion_gate.self_review.reason` | string | yes |  | Reason the self-review answer supports or blocks the requested completion claim. |  |  |
+| `closeout_report.completion_gate.continuation` | object | yes |  | Durable follow-on route or required continuation state. |  |  |
+| `closeout_report.completion_gate.continuation.owner_surface` | string | no |  | Planning, lane, decomposition, or other durable surface that owns the residual intent. |  |  |
+| `closeout_report.completion_gate.continuation.created_or_required` | boolean | no |  | Whether follow-on work has been created or is required before full completion can be claimed. |  |  |
+| `closeout_report.completion_gate.continuation.reason` | string | no |  | Why continuation or follow-on routing is required. |  |  |
+| `closeout_report.completion_gate.authority_boundary` | object | yes |  | Boundary stating AW enforces the transition rule while the agent owns semantic satisfaction judgment and the human owns accepted narrowing. |  |  |
+| `closeout_report.completion_gate.rule` | string | no |  | Invariant enforced by the completion gate. |  |  |
 | `continuation_next_actions` | object | yes |  | Evidence-ranked next actions for safe continuation. |  |  |
 | `migration_pilot_template` | object | yes |  | Optional migration-pilot decomposition template with parity and rollout boundaries. |  |  |
 | `compact_output_criteria` | object | yes |  | Criteria for compact CLI outputs to remain sufficient for cheap continuation. |  |  |

--- a/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -237,7 +237,6 @@
         "claim_level_allowed",
         "required_next_action",
         "claim_authorization",
-        "blocked_claims",
         "self_review",
         "continuation",
         "authority_boundary"
@@ -253,7 +252,6 @@
         "claim_level_allowed": { "type": "string" },
         "required_next_action": { "type": "string" },
         "claim_authorization": { "$ref": "#/$defs/claim_authorization" },
-        "blocked_claims": { "$ref": "#/$defs/string_array" },
         "residual_intent": { "type": "string" },
         "self_review": { "type": "object" },
         "continuation": { "type": "object" },

--- a/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -236,6 +236,7 @@
         "claim_level_requested",
         "claim_level_allowed",
         "required_next_action",
+        "claim_authorization",
         "blocked_claims",
         "self_review",
         "continuation",
@@ -251,11 +252,56 @@
         "claim_level_requested": { "type": "string" },
         "claim_level_allowed": { "type": "string" },
         "required_next_action": { "type": "string" },
+        "claim_authorization": { "$ref": "#/$defs/claim_authorization" },
         "blocked_claims": { "$ref": "#/$defs/string_array" },
         "residual_intent": { "type": "string" },
         "self_review": { "type": "object" },
         "continuation": { "type": "object" },
         "authority_boundary": { "type": "object" }
+      }
+    },
+    "claim_authorization": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["kind", "allowed_claim_classes", "blocked_claim_classes", "closure_actions", "renderer_rule", "diagnostics"],
+      "properties": {
+        "kind": { "const": "agentic-workspace/claim-authorization/v1" },
+        "allowed_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": ["partial_progress", "slice_complete", "lane_complete", "parent_complete", "full_intent_complete", "issue_closure"]
+          }
+        },
+        "blocked_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": ["partial_progress", "slice_complete", "lane_complete", "parent_complete", "full_intent_complete", "issue_closure"]
+          }
+        },
+        "closure_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["kind", "target", "authorized", "reason"],
+            "properties": {
+              "kind": { "const": "issue_closure" },
+              "target": { "type": "string" },
+              "authorized": { "type": "boolean" },
+              "reason": { "type": "string" }
+            }
+          }
+        },
+        "renderer_rule": { "type": "string" },
+        "diagnostics": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["unsafe_claim_examples", "diagnostic_only"],
+          "properties": {
+            "unsafe_claim_examples": { "$ref": "#/$defs/string_array" },
+            "diagnostic_only": { "const": true }
+          }
+        }
       }
     },
     "reference": {

--- a/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -140,6 +140,7 @@
     "intent_satisfaction": { "$ref": "#/$defs/string_map" },
     "system_intent_alignment": { "$ref": "#/$defs/string_map" },
     "closure_check": { "$ref": "#/$defs/string_map" },
+    "completion_gate": { "$ref": "#/$defs/completion_gate" },
     "generated_closeout": { "$ref": "#/$defs/string_map" },
     "memory_learning_capture": { "$ref": "#/$defs/string_map" },
     "durable_residue": {
@@ -222,6 +223,39 @@
           { "type": "number" },
           { "type": "null" }
         ]
+      }
+    },
+    "completion_gate": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "status",
+        "active_intent_satisfied",
+        "human_accepted_partial",
+        "claim_level_requested",
+        "claim_level_allowed",
+        "required_next_action",
+        "blocked_claims",
+        "self_review",
+        "continuation",
+        "authority_boundary"
+      ],
+      "properties": {
+        "kind": { "const": "agentic-workspace/completion-gate/v1" },
+        "status": {
+          "enum": ["allowed", "blocked", "continue-required", "clarification-required", "human-accepted-partial"]
+        },
+        "active_intent_satisfied": { "type": "boolean" },
+        "human_accepted_partial": { "type": "boolean" },
+        "claim_level_requested": { "type": "string" },
+        "claim_level_allowed": { "type": "string" },
+        "required_next_action": { "type": "string" },
+        "blocked_claims": { "$ref": "#/$defs/string_array" },
+        "residual_intent": { "type": "string" },
+        "self_review": { "type": "object" },
+        "continuation": { "type": "object" },
+        "authority_boundary": { "type": "object" }
       }
     },
     "reference": {

--- a/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -98,6 +98,9 @@
     "closeout_state": {
       "$ref": "#/$defs/closeout_state"
     },
+    "completion_gate": {
+      "$ref": "#/$defs/completion_gate"
+    },
     "references": {
       "type": "array",
       "items": {
@@ -211,6 +214,67 @@
         },
         "next_owner": {
           "type": "string"
+        }
+      }
+    },
+    "completion_gate": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "status",
+        "active_intent_satisfied",
+        "human_accepted_partial",
+        "claim_level_requested",
+        "claim_level_allowed",
+        "required_next_action",
+        "blocked_claims",
+        "self_review",
+        "continuation",
+        "authority_boundary"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/completion-gate/v1"
+        },
+        "status": {
+          "enum": [
+            "allowed",
+            "blocked",
+            "continue-required",
+            "clarification-required",
+            "human-accepted-partial"
+          ]
+        },
+        "active_intent_satisfied": {
+          "type": "boolean"
+        },
+        "human_accepted_partial": {
+          "type": "boolean"
+        },
+        "claim_level_requested": {
+          "type": "string"
+        },
+        "claim_level_allowed": {
+          "type": "string"
+        },
+        "required_next_action": {
+          "type": "string"
+        },
+        "blocked_claims": {
+          "$ref": "#/$defs/string_array"
+        },
+        "residual_intent": {
+          "type": "string"
+        },
+        "self_review": {
+          "type": "object"
+        },
+        "continuation": {
+          "type": "object"
+        },
+        "authority_boundary": {
+          "type": "object"
         }
       }
     },

--- a/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -228,6 +228,7 @@
         "claim_level_requested",
         "claim_level_allowed",
         "required_next_action",
+        "claim_authorization",
         "blocked_claims",
         "self_review",
         "continuation",
@@ -261,6 +262,9 @@
         "required_next_action": {
           "type": "string"
         },
+        "claim_authorization": {
+          "$ref": "#/$defs/claim_authorization"
+        },
         "blocked_claims": {
           "$ref": "#/$defs/string_array"
         },
@@ -275,6 +279,95 @@
         },
         "authority_boundary": {
           "type": "object"
+        }
+      }
+    },
+    "claim_authorization": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "allowed_claim_classes",
+        "blocked_claim_classes",
+        "closure_actions",
+        "renderer_rule",
+        "diagnostics"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/claim-authorization/v1"
+        },
+        "allowed_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "partial_progress",
+              "slice_complete",
+              "lane_complete",
+              "parent_complete",
+              "full_intent_complete",
+              "issue_closure"
+            ]
+          }
+        },
+        "blocked_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "partial_progress",
+              "slice_complete",
+              "lane_complete",
+              "parent_complete",
+              "full_intent_complete",
+              "issue_closure"
+            ]
+          }
+        },
+        "closure_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "kind",
+              "target",
+              "authorized",
+              "reason"
+            ],
+            "properties": {
+              "kind": {
+                "const": "issue_closure"
+              },
+              "target": {
+                "type": "string"
+              },
+              "authorized": {
+                "type": "boolean"
+              },
+              "reason": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "renderer_rule": {
+          "type": "string"
+        },
+        "diagnostics": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "unsafe_claim_examples",
+            "diagnostic_only"
+          ],
+          "properties": {
+            "unsafe_claim_examples": {
+              "$ref": "#/$defs/string_array"
+            },
+            "diagnostic_only": {
+              "const": true
+            }
+          }
         }
       }
     },

--- a/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/generated/planning/python/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -229,7 +229,6 @@
         "claim_level_allowed",
         "required_next_action",
         "claim_authorization",
-        "blocked_claims",
         "self_review",
         "continuation",
         "authority_boundary"
@@ -264,9 +263,6 @@
         },
         "claim_authorization": {
           "$ref": "#/$defs/claim_authorization"
-        },
-        "blocked_claims": {
-          "$ref": "#/$defs/string_array"
         },
         "residual_intent": {
           "type": "string"

--- a/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -237,7 +237,6 @@
         "claim_level_allowed",
         "required_next_action",
         "claim_authorization",
-        "blocked_claims",
         "self_review",
         "continuation",
         "authority_boundary"
@@ -253,7 +252,6 @@
         "claim_level_allowed": { "type": "string" },
         "required_next_action": { "type": "string" },
         "claim_authorization": { "$ref": "#/$defs/claim_authorization" },
-        "blocked_claims": { "$ref": "#/$defs/string_array" },
         "residual_intent": { "type": "string" },
         "self_review": { "type": "object" },
         "continuation": { "type": "object" },

--- a/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -236,6 +236,7 @@
         "claim_level_requested",
         "claim_level_allowed",
         "required_next_action",
+        "claim_authorization",
         "blocked_claims",
         "self_review",
         "continuation",
@@ -251,11 +252,56 @@
         "claim_level_requested": { "type": "string" },
         "claim_level_allowed": { "type": "string" },
         "required_next_action": { "type": "string" },
+        "claim_authorization": { "$ref": "#/$defs/claim_authorization" },
         "blocked_claims": { "$ref": "#/$defs/string_array" },
         "residual_intent": { "type": "string" },
         "self_review": { "type": "object" },
         "continuation": { "type": "object" },
         "authority_boundary": { "type": "object" }
+      }
+    },
+    "claim_authorization": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["kind", "allowed_claim_classes", "blocked_claim_classes", "closure_actions", "renderer_rule", "diagnostics"],
+      "properties": {
+        "kind": { "const": "agentic-workspace/claim-authorization/v1" },
+        "allowed_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": ["partial_progress", "slice_complete", "lane_complete", "parent_complete", "full_intent_complete", "issue_closure"]
+          }
+        },
+        "blocked_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": ["partial_progress", "slice_complete", "lane_complete", "parent_complete", "full_intent_complete", "issue_closure"]
+          }
+        },
+        "closure_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["kind", "target", "authorized", "reason"],
+            "properties": {
+              "kind": { "const": "issue_closure" },
+              "target": { "type": "string" },
+              "authorized": { "type": "boolean" },
+              "reason": { "type": "string" }
+            }
+          }
+        },
+        "renderer_rule": { "type": "string" },
+        "diagnostics": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["unsafe_claim_examples", "diagnostic_only"],
+          "properties": {
+            "unsafe_claim_examples": { "$ref": "#/$defs/string_array" },
+            "diagnostic_only": { "const": true }
+          }
+        }
       }
     },
     "reference": {

--- a/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -140,6 +140,7 @@
     "intent_satisfaction": { "$ref": "#/$defs/string_map" },
     "system_intent_alignment": { "$ref": "#/$defs/string_map" },
     "closure_check": { "$ref": "#/$defs/string_map" },
+    "completion_gate": { "$ref": "#/$defs/completion_gate" },
     "generated_closeout": { "$ref": "#/$defs/string_map" },
     "memory_learning_capture": { "$ref": "#/$defs/string_map" },
     "durable_residue": {
@@ -222,6 +223,39 @@
           { "type": "number" },
           { "type": "null" }
         ]
+      }
+    },
+    "completion_gate": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "status",
+        "active_intent_satisfied",
+        "human_accepted_partial",
+        "claim_level_requested",
+        "claim_level_allowed",
+        "required_next_action",
+        "blocked_claims",
+        "self_review",
+        "continuation",
+        "authority_boundary"
+      ],
+      "properties": {
+        "kind": { "const": "agentic-workspace/completion-gate/v1" },
+        "status": {
+          "enum": ["allowed", "blocked", "continue-required", "clarification-required", "human-accepted-partial"]
+        },
+        "active_intent_satisfied": { "type": "boolean" },
+        "human_accepted_partial": { "type": "boolean" },
+        "claim_level_requested": { "type": "string" },
+        "claim_level_allowed": { "type": "string" },
+        "required_next_action": { "type": "string" },
+        "blocked_claims": { "$ref": "#/$defs/string_array" },
+        "residual_intent": { "type": "string" },
+        "self_review": { "type": "object" },
+        "continuation": { "type": "object" },
+        "authority_boundary": { "type": "object" }
       }
     },
     "reference": {

--- a/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -98,6 +98,9 @@
     "closeout_state": {
       "$ref": "#/$defs/closeout_state"
     },
+    "completion_gate": {
+      "$ref": "#/$defs/completion_gate"
+    },
     "references": {
       "type": "array",
       "items": {
@@ -211,6 +214,67 @@
         },
         "next_owner": {
           "type": "string"
+        }
+      }
+    },
+    "completion_gate": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "status",
+        "active_intent_satisfied",
+        "human_accepted_partial",
+        "claim_level_requested",
+        "claim_level_allowed",
+        "required_next_action",
+        "blocked_claims",
+        "self_review",
+        "continuation",
+        "authority_boundary"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/completion-gate/v1"
+        },
+        "status": {
+          "enum": [
+            "allowed",
+            "blocked",
+            "continue-required",
+            "clarification-required",
+            "human-accepted-partial"
+          ]
+        },
+        "active_intent_satisfied": {
+          "type": "boolean"
+        },
+        "human_accepted_partial": {
+          "type": "boolean"
+        },
+        "claim_level_requested": {
+          "type": "string"
+        },
+        "claim_level_allowed": {
+          "type": "string"
+        },
+        "required_next_action": {
+          "type": "string"
+        },
+        "blocked_claims": {
+          "$ref": "#/$defs/string_array"
+        },
+        "residual_intent": {
+          "type": "string"
+        },
+        "self_review": {
+          "type": "object"
+        },
+        "continuation": {
+          "type": "object"
+        },
+        "authority_boundary": {
+          "type": "object"
         }
       }
     },

--- a/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -228,6 +228,7 @@
         "claim_level_requested",
         "claim_level_allowed",
         "required_next_action",
+        "claim_authorization",
         "blocked_claims",
         "self_review",
         "continuation",
@@ -261,6 +262,9 @@
         "required_next_action": {
           "type": "string"
         },
+        "claim_authorization": {
+          "$ref": "#/$defs/claim_authorization"
+        },
         "blocked_claims": {
           "$ref": "#/$defs/string_array"
         },
@@ -275,6 +279,95 @@
         },
         "authority_boundary": {
           "type": "object"
+        }
+      }
+    },
+    "claim_authorization": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "allowed_claim_classes",
+        "blocked_claim_classes",
+        "closure_actions",
+        "renderer_rule",
+        "diagnostics"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/claim-authorization/v1"
+        },
+        "allowed_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "partial_progress",
+              "slice_complete",
+              "lane_complete",
+              "parent_complete",
+              "full_intent_complete",
+              "issue_closure"
+            ]
+          }
+        },
+        "blocked_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "partial_progress",
+              "slice_complete",
+              "lane_complete",
+              "parent_complete",
+              "full_intent_complete",
+              "issue_closure"
+            ]
+          }
+        },
+        "closure_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "kind",
+              "target",
+              "authorized",
+              "reason"
+            ],
+            "properties": {
+              "kind": {
+                "const": "issue_closure"
+              },
+              "target": {
+                "type": "string"
+              },
+              "authorized": {
+                "type": "boolean"
+              },
+              "reason": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "renderer_rule": {
+          "type": "string"
+        },
+        "diagnostics": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "unsafe_claim_examples",
+            "diagnostic_only"
+          ],
+          "properties": {
+            "unsafe_claim_examples": {
+              "$ref": "#/$defs/string_array"
+            },
+            "diagnostic_only": {
+              "const": true
+            }
+          }
         }
       }
     },

--- a/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/generated/planning/typescript/resources/_payload/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -229,7 +229,6 @@
         "claim_level_allowed",
         "required_next_action",
         "claim_authorization",
-        "blocked_claims",
         "self_review",
         "continuation",
         "authority_boundary"
@@ -264,9 +263,6 @@
         },
         "claim_authorization": {
           "$ref": "#/$defs/claim_authorization"
-        },
-        "blocked_claims": {
-          "$ref": "#/$defs/string_array"
         },
         "residual_intent": {
           "type": "string"

--- a/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -237,7 +237,6 @@
         "claim_level_allowed",
         "required_next_action",
         "claim_authorization",
-        "blocked_claims",
         "self_review",
         "continuation",
         "authority_boundary"
@@ -253,7 +252,6 @@
         "claim_level_allowed": { "type": "string" },
         "required_next_action": { "type": "string" },
         "claim_authorization": { "$ref": "#/$defs/claim_authorization" },
-        "blocked_claims": { "$ref": "#/$defs/string_array" },
         "residual_intent": { "type": "string" },
         "self_review": { "type": "object" },
         "continuation": { "type": "object" },

--- a/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -236,6 +236,7 @@
         "claim_level_requested",
         "claim_level_allowed",
         "required_next_action",
+        "claim_authorization",
         "blocked_claims",
         "self_review",
         "continuation",
@@ -251,11 +252,56 @@
         "claim_level_requested": { "type": "string" },
         "claim_level_allowed": { "type": "string" },
         "required_next_action": { "type": "string" },
+        "claim_authorization": { "$ref": "#/$defs/claim_authorization" },
         "blocked_claims": { "$ref": "#/$defs/string_array" },
         "residual_intent": { "type": "string" },
         "self_review": { "type": "object" },
         "continuation": { "type": "object" },
         "authority_boundary": { "type": "object" }
+      }
+    },
+    "claim_authorization": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["kind", "allowed_claim_classes", "blocked_claim_classes", "closure_actions", "renderer_rule", "diagnostics"],
+      "properties": {
+        "kind": { "const": "agentic-workspace/claim-authorization/v1" },
+        "allowed_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": ["partial_progress", "slice_complete", "lane_complete", "parent_complete", "full_intent_complete", "issue_closure"]
+          }
+        },
+        "blocked_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": ["partial_progress", "slice_complete", "lane_complete", "parent_complete", "full_intent_complete", "issue_closure"]
+          }
+        },
+        "closure_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["kind", "target", "authorized", "reason"],
+            "properties": {
+              "kind": { "const": "issue_closure" },
+              "target": { "type": "string" },
+              "authorized": { "type": "boolean" },
+              "reason": { "type": "string" }
+            }
+          }
+        },
+        "renderer_rule": { "type": "string" },
+        "diagnostics": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["unsafe_claim_examples", "diagnostic_only"],
+          "properties": {
+            "unsafe_claim_examples": { "$ref": "#/$defs/string_array" },
+            "diagnostic_only": { "const": true }
+          }
+        }
       }
     },
     "reference": {

--- a/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-execplan.schema.json
+++ b/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-execplan.schema.json
@@ -140,6 +140,7 @@
     "intent_satisfaction": { "$ref": "#/$defs/string_map" },
     "system_intent_alignment": { "$ref": "#/$defs/string_map" },
     "closure_check": { "$ref": "#/$defs/string_map" },
+    "completion_gate": { "$ref": "#/$defs/completion_gate" },
     "generated_closeout": { "$ref": "#/$defs/string_map" },
     "memory_learning_capture": { "$ref": "#/$defs/string_map" },
     "durable_residue": {
@@ -222,6 +223,39 @@
           { "type": "number" },
           { "type": "null" }
         ]
+      }
+    },
+    "completion_gate": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "status",
+        "active_intent_satisfied",
+        "human_accepted_partial",
+        "claim_level_requested",
+        "claim_level_allowed",
+        "required_next_action",
+        "blocked_claims",
+        "self_review",
+        "continuation",
+        "authority_boundary"
+      ],
+      "properties": {
+        "kind": { "const": "agentic-workspace/completion-gate/v1" },
+        "status": {
+          "enum": ["allowed", "blocked", "continue-required", "clarification-required", "human-accepted-partial"]
+        },
+        "active_intent_satisfied": { "type": "boolean" },
+        "human_accepted_partial": { "type": "boolean" },
+        "claim_level_requested": { "type": "string" },
+        "claim_level_allowed": { "type": "string" },
+        "required_next_action": { "type": "string" },
+        "blocked_claims": { "$ref": "#/$defs/string_array" },
+        "residual_intent": { "type": "string" },
+        "self_review": { "type": "object" },
+        "continuation": { "type": "object" },
+        "authority_boundary": { "type": "object" }
       }
     },
     "reference": {

--- a/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -98,6 +98,9 @@
     "closeout_state": {
       "$ref": "#/$defs/closeout_state"
     },
+    "completion_gate": {
+      "$ref": "#/$defs/completion_gate"
+    },
     "references": {
       "type": "array",
       "items": {
@@ -211,6 +214,67 @@
         },
         "next_owner": {
           "type": "string"
+        }
+      }
+    },
+    "completion_gate": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "status",
+        "active_intent_satisfied",
+        "human_accepted_partial",
+        "claim_level_requested",
+        "claim_level_allowed",
+        "required_next_action",
+        "blocked_claims",
+        "self_review",
+        "continuation",
+        "authority_boundary"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/completion-gate/v1"
+        },
+        "status": {
+          "enum": [
+            "allowed",
+            "blocked",
+            "continue-required",
+            "clarification-required",
+            "human-accepted-partial"
+          ]
+        },
+        "active_intent_satisfied": {
+          "type": "boolean"
+        },
+        "human_accepted_partial": {
+          "type": "boolean"
+        },
+        "claim_level_requested": {
+          "type": "string"
+        },
+        "claim_level_allowed": {
+          "type": "string"
+        },
+        "required_next_action": {
+          "type": "string"
+        },
+        "blocked_claims": {
+          "$ref": "#/$defs/string_array"
+        },
+        "residual_intent": {
+          "type": "string"
+        },
+        "self_review": {
+          "type": "object"
+        },
+        "continuation": {
+          "type": "object"
+        },
+        "authority_boundary": {
+          "type": "object"
         }
       }
     },

--- a/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -228,6 +228,7 @@
         "claim_level_requested",
         "claim_level_allowed",
         "required_next_action",
+        "claim_authorization",
         "blocked_claims",
         "self_review",
         "continuation",
@@ -261,6 +262,9 @@
         "required_next_action": {
           "type": "string"
         },
+        "claim_authorization": {
+          "$ref": "#/$defs/claim_authorization"
+        },
         "blocked_claims": {
           "$ref": "#/$defs/string_array"
         },
@@ -275,6 +279,95 @@
         },
         "authority_boundary": {
           "type": "object"
+        }
+      }
+    },
+    "claim_authorization": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "allowed_claim_classes",
+        "blocked_claim_classes",
+        "closure_actions",
+        "renderer_rule",
+        "diagnostics"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/claim-authorization/v1"
+        },
+        "allowed_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "partial_progress",
+              "slice_complete",
+              "lane_complete",
+              "parent_complete",
+              "full_intent_complete",
+              "issue_closure"
+            ]
+          }
+        },
+        "blocked_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "partial_progress",
+              "slice_complete",
+              "lane_complete",
+              "parent_complete",
+              "full_intent_complete",
+              "issue_closure"
+            ]
+          }
+        },
+        "closure_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "kind",
+              "target",
+              "authorized",
+              "reason"
+            ],
+            "properties": {
+              "kind": {
+                "const": "issue_closure"
+              },
+              "target": {
+                "type": "string"
+              },
+              "authorized": {
+                "type": "boolean"
+              },
+              "reason": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "renderer_rule": {
+          "type": "string"
+        },
+        "diagnostics": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "unsafe_claim_examples",
+            "diagnostic_only"
+          ],
+          "properties": {
+            "unsafe_claim_examples": {
+              "$ref": "#/$defs/string_array"
+            },
+            "diagnostic_only": {
+              "const": true
+            }
+          }
         }
       }
     },

--- a/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-lane.schema.json
+++ b/packages/planning/bootstrap/.agentic-workspace/planning/schemas/planning-lane.schema.json
@@ -229,7 +229,6 @@
         "claim_level_allowed",
         "required_next_action",
         "claim_authorization",
-        "blocked_claims",
         "self_review",
         "continuation",
         "authority_boundary"
@@ -264,9 +263,6 @@
         },
         "claim_authorization": {
           "$ref": "#/$defs/claim_authorization"
-        },
-        "blocked_claims": {
-          "$ref": "#/$defs/string_array"
         },
         "residual_intent": {
           "type": "string"

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -11031,11 +11031,6 @@ def _planning_completion_gate_payload(
         proof_status="representative" if proof_supports_full else "",
         issue_refs=issue_refs,
     )
-    diagnostics = claim_authorization.get("diagnostics", {})
-    diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
-    diagnostic_unsafe_claims = diagnostics.get("unsafe_claim_examples", [])
-    diagnostic_unsafe_claims = diagnostic_unsafe_claims if isinstance(diagnostic_unsafe_claims, list) else []
-    blocked_claims = [] if active_intent_satisfied else [str(item) for item in diagnostic_unsafe_claims if str(item).strip()]
     reason = (
         "Planning closeout evidence supports the requested completion claim."
         if active_intent_satisfied
@@ -11053,7 +11048,6 @@ def _planning_completion_gate_payload(
         "claim_level_allowed": claim_level_allowed,
         "required_next_action": required_next_action,
         "claim_authorization": claim_authorization,
-        "blocked_claims": _dedupe(blocked_claims),
         "residual_intent": "" if active_intent_satisfied else residual_intent,
         "self_review": {
             "question": "Does the delivered work satisfy the active human intent?",

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -3422,6 +3422,13 @@ def _planning_lane_projection(*, target_root: Path) -> dict[str, Any]:
                         "residual_work": str(closeout.get("residual_work", "")).strip(),
                         "next_owner": str(closeout.get("next_owner", "")).strip(),
                     },
+                    "completion_gate": {
+                        "status": str(record.get("completion_gate", {}).get("status", "")).strip(),
+                        "claim_level_allowed": str(record.get("completion_gate", {}).get("claim_level_allowed", "")).strip(),
+                        "active_intent_satisfied": bool(record.get("completion_gate", {}).get("active_intent_satisfied", False)),
+                    }
+                    if isinstance(record.get("completion_gate"), dict)
+                    else {},
                 }
             )
     archived_count = 0
@@ -9588,6 +9595,38 @@ def close_lane_record(
         "residual_work": residual_work.strip() or "none",
         "next_owner": next_owner.strip() or ("parent decomposition" if known_gaps else "none"),
     }
+    lane_gate_patch = {
+        "intent_satisfaction": {
+            "original intent": str(record.get("lane_outcome") or record.get("title") or slug).strip(),
+            "was original intent fully satisfied?": "yes" if evidence and not known_gaps else "no",
+            "evidence of intent satisfaction": "; ".join(evidence),
+            "unsolved intent passed to": record["closeout_state"]["next_owner"] if known_gaps else "none",
+        },
+        "closure_check": {
+            "slice status": "completed",
+            "larger-intent status": "closed" if not known_gaps else "open",
+            "closure decision": "archive-and-close" if not known_gaps else "archive-but-keep-lane-open",
+            "why this decision is honest": record["closeout_state"]["summary"],
+            "evidence carried forward": "; ".join(evidence) or "not recorded",
+            "reopen trigger": "None unless new evidence shows the lane closeout was incomplete."
+            if not known_gaps
+            else "Reopen when residual lane work resumes.",
+        },
+        "proof_report": {
+            "validation proof": "; ".join(evidence),
+            "proof achieved now": "lane proof aggregation satisfied"
+            if evidence and not known_gaps
+            else "lane proof aggregation has known gaps",
+            'evidence for "proof achieved" state': "; ".join(evidence),
+        },
+        "required_continuation": {
+            "required follow-on for the larger intended outcome": "no" if not known_gaps else "yes",
+            "owner surface": record["closeout_state"]["next_owner"] if known_gaps else "none",
+        },
+    }
+    record["completion_gate"] = _planning_completion_gate_payload(
+        record=record, patch=lane_gate_patch, claim_level_requested="lane-complete"
+    )
     lane_relative = record_path.relative_to(target_root).as_posix()
     if dry_run:
         result.add("would update", record_path, "record lane proof aggregation, parent contribution, and closeout state")
@@ -10768,6 +10807,7 @@ def _generated_closeout_adapter(
     memory_learning = _record_section_dict(patch, "memory_learning_capture") or {}
     execution_run = _record_section_dict(record, "execution_run") or {}
     execution_summary = _canonical_execution_summary(_record_section_dict(record, "execution_summary") or {})
+    completion_gate = patch.get("completion_gate") if isinstance(patch.get("completion_gate"), dict) else {}
 
     changed_surfaces = execution_run.get("changed surfaces", "").strip() or execution_run.get("scope touched", "").strip() or "not recorded"
     unsolved_intent = intent_satisfaction.get("unsolved intent passed to", "").strip()
@@ -10790,11 +10830,158 @@ def _generated_closeout_adapter(
         f"Memory learning: {memory_learning.get('decision', 'not recorded').strip() or 'not recorded'}",
         f"Follow-up: {follow_up}",
     ]
+    if completion_gate:
+        lines.extend(
+            [
+                f"Completion gate: {completion_gate.get('status', 'not recorded')}",
+                f"Completion claim allowed: {completion_gate.get('claim_level_allowed', 'not recorded')}",
+            ]
+        )
     return {
         "status": "generated",
         "source": "archive-plan --prepare-closeout",
         "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
         "text": "\n".join(lines),
+    }
+
+
+def _planning_completion_gate_payload(
+    *,
+    record: dict[str, Any],
+    patch: dict[str, Any],
+    claim_level_requested: str = "full-intent-complete",
+) -> dict[str, Any]:
+    intent_satisfaction = _record_section_dict(patch, "intent_satisfaction") or {}
+    closure_check = _record_section_dict(patch, "closure_check") or {}
+    proof_report = _record_section_dict(patch, "proof_report") or _record_section_dict(record, "proof_report") or {}
+    required_continuation = (
+        _record_section_dict(patch, "required_continuation") or _record_section_dict(record, "required_continuation") or {}
+    )
+    intent_continuity = _record_section_dict(patch, "intent_continuity") or _record_section_dict(record, "intent_continuity") or {}
+    parent_acceptance = _record_section_dict(patch, "parent_acceptance") or _record_section_dict(record, "parent_acceptance") or {}
+
+    def truthy(value: Any) -> bool:
+        return str(value or "").strip().lower() in {"yes", "true", "accepted", "approved", "explicit", "human-accepted"}
+
+    def present(*values: Any) -> str:
+        for value in values:
+            text = str(value or "").strip()
+            if text and text.lower() not in {"none", "no", "false", "null", "unknown", "pending", "not-recorded", "not recorded"}:
+                return text
+        return ""
+
+    proof_text = present(
+        proof_report.get("validation proof"),
+        proof_report.get("proof achieved now"),
+        proof_report.get('evidence for "proof achieved" state'),
+    )
+    proof_supports_full = bool(proof_text)
+    intent_satisfied = truthy(intent_satisfaction.get("was original intent fully satisfied?"))
+    closure_decision = str(closure_check.get("closure decision") or closure_check.get("closure_decision") or "").strip().lower()
+    larger_status = str(closure_check.get("larger-intent status") or "").strip().lower()
+    required_follow_on = str(required_continuation.get("required follow-on for the larger intended outcome") or "").strip().lower()
+    residual_intent = present(
+        intent_satisfaction.get("unsolved intent passed to"),
+        required_continuation.get("required follow-on for the larger intended outcome"),
+        intent_continuity.get("continuation surface"),
+    )
+    continuation_owner = present(
+        required_continuation.get("owner surface"),
+        intent_continuity.get("continuation surface"),
+        intent_satisfaction.get("unsolved intent passed to"),
+    )
+    human_accepted_partial = any(
+        truthy(value)
+        for value in (
+            closure_check.get("human accepted partial"),
+            closure_check.get("human_accepted_partial"),
+            parent_acceptance.get("human accepted partial"),
+            parent_acceptance.get("human_accepted_partial"),
+        )
+    )
+    active_intent_satisfied = bool(
+        intent_satisfied
+        and closure_decision == "archive-and-close"
+        and larger_status in {"", "closed"}
+        and required_follow_on in {"", "no", "false", "none"}
+        and proof_supports_full
+    )
+    continuation_possible = bool(
+        continuation_owner
+        or residual_intent
+        or closure_decision == "archive-but-keep-lane-open"
+        or required_follow_on in {"yes", "true", "required", "follow-up-required"}
+    )
+    ambiguous_or_blocked = (
+        closure_decision in {"requires-review", "blocked"}
+        or required_follow_on in {"unknown", "ambiguous"}
+        or (intent_satisfied and not proof_supports_full)
+    )
+    if active_intent_satisfied:
+        status = "allowed"
+        claim_level_allowed = claim_level_requested
+        required_next_action = "close-complete"
+    elif human_accepted_partial:
+        status = "human-accepted-partial"
+        claim_level_allowed = "partial-progress"
+        required_next_action = "close-human-accepted-partial"
+    elif ambiguous_or_blocked:
+        status = "clarification-required"
+        claim_level_allowed = "partial-progress"
+        required_next_action = "ask-human"
+    elif continuation_possible:
+        status = "continue-required"
+        claim_level_allowed = "partial-progress"
+        required_next_action = "create-follow-on-plan" if continuation_owner else "continue-current-work"
+    else:
+        status = "blocked"
+        claim_level_allowed = "partial-progress"
+        required_next_action = "ask-human"
+
+    issue_refs: set[str] = set()
+    for reference in record.get("references", []):
+        if isinstance(reference, dict):
+            issue_refs.update(_issue_refs_from_text(str(reference.get("target") or "")))
+            issue_refs.update(_issue_refs_from_text(str(reference.get("url") or "")))
+        else:
+            issue_refs.update(_issue_refs_from_text(str(reference or "")))
+    issue_refs.update(_issue_refs_from_text(str(record.get("title") or "")))
+    blocked_claims = [] if active_intent_satisfied else ["done", "implemented", "complete", "finished", "all", "full intent complete"]
+    if not active_intent_satisfied:
+        blocked_claims.extend(f"Closes {ref}" for ref in sorted(issue_refs))
+    reason = (
+        "Planning closeout evidence supports the requested completion claim."
+        if active_intent_satisfied
+        else present(
+            residual_intent,
+            "Planning closeout evidence does not yet support the requested completion claim.",
+        )
+    )
+    return {
+        "kind": "agentic-workspace/completion-gate/v1",
+        "status": status,
+        "active_intent_satisfied": active_intent_satisfied,
+        "human_accepted_partial": human_accepted_partial,
+        "claim_level_requested": claim_level_requested,
+        "claim_level_allowed": claim_level_allowed,
+        "required_next_action": required_next_action,
+        "blocked_claims": _dedupe(blocked_claims),
+        "residual_intent": "" if active_intent_satisfied else residual_intent,
+        "self_review": {
+            "question": "Does the delivered work satisfy the active human intent?",
+            "answer": "yes" if active_intent_satisfied else "no",
+            "reason": reason,
+        },
+        "continuation": {
+            "owner_surface": continuation_owner,
+            "created_or_required": bool(not active_intent_satisfied and (continuation_possible or status != "allowed")),
+            "reason": "" if active_intent_satisfied else reason,
+        },
+        "authority_boundary": {
+            "aw_owns": ["forcing the transition rule", "blocking unsupported claim language", "routing continuation"],
+            "agent_owns": ["semantic satisfaction judgment", "evidence interpretation", "next implementation decisions"],
+            "human_owns": ["accepting narrower scope", "changing intent", "accepting unresolved residual intent"],
+        },
     }
 
 
@@ -11506,6 +11693,7 @@ def _prepare_execplan_closeout(
             }
         )
     patch["closeout_distillation"] = {"buckets": buckets}
+    patch["completion_gate"] = _planning_completion_gate_payload(record=record, patch=patch)
     patch["generated_closeout"] = _generated_closeout_adapter(record=record, patch=patch)
 
     detail = json.dumps(patch, ensure_ascii=False, sort_keys=True)
@@ -11743,6 +11931,7 @@ def archive_parent_lane_closeout(
             }
         )
     record["closeout_distillation"] = {"buckets": buckets}
+    record["completion_gate"] = _planning_completion_gate_payload(record=record, patch=record, claim_level_requested="lane-complete")
     record["generated_closeout"] = _generated_closeout_adapter(record=record, patch=record)
 
     if dry_run:

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -10845,6 +10845,83 @@ def _generated_closeout_adapter(
     }
 
 
+def _planning_completion_gate_claim_authorization(
+    *,
+    status: str,
+    active_intent_satisfied: bool,
+    human_accepted_partial: bool,
+    claim_level_requested: str,
+    proof_status: str = "",
+    issue_refs: set[str],
+) -> dict[str, Any]:
+    all_claim_classes = [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure",
+    ]
+    rank = {
+        "partial_progress": 0,
+        "slice_complete": 1,
+        "slice": 1,
+        "lane_complete": 2,
+        "lane": 2,
+        "parent_complete": 3,
+        "parent": 3,
+        "full_intent_complete": 4,
+        "work_complete": 4,
+        "full": 4,
+    }
+    requested = str(claim_level_requested or "full-intent-complete").strip().lower().replace("-", "_")
+    requested_rank = rank.get(requested, 4)
+    proof_records_slice = proof_status in {
+        "regression_only",
+        "regression-only",
+        "representative",
+        "sufficient_for_claim",
+        "sufficient-for-claim",
+    }
+    if active_intent_satisfied:
+        allowed_claim_classes = [claim for claim in all_claim_classes if claim != "issue_closure" and rank.get(claim, 5) <= requested_rank]
+        if requested_rank >= rank["full_intent_complete"] and issue_refs:
+            allowed_claim_classes.append("issue_closure")
+    elif proof_records_slice and status in {"blocked", "continue-required"} and not human_accepted_partial:
+        allowed_claim_classes = ["partial_progress", "slice_complete"]
+    elif human_accepted_partial or status == "continue-required":
+        allowed_claim_classes = ["partial_progress"]
+    else:
+        allowed_claim_classes = []
+    blocked_claim_classes = [claim for claim in all_claim_classes if claim not in allowed_claim_classes]
+    closure_actions = [
+        {
+            "kind": "issue_closure",
+            "target": ref,
+            "authorized": "issue_closure" in allowed_claim_classes,
+            "reason": "issue closure requires full-intent completion authorization from the completion gate",
+        }
+        for ref in sorted(issue_refs)
+    ]
+    unsafe_examples = [] if active_intent_satisfied else ["done", "implemented", "complete", "finished", "all", "full intent complete"]
+    if not active_intent_satisfied:
+        unsafe_examples.extend(f"Closes {ref}" for ref in sorted(issue_refs))
+    return {
+        "kind": "agentic-workspace/claim-authorization/v1",
+        "allowed_claim_classes": allowed_claim_classes,
+        "blocked_claim_classes": blocked_claim_classes,
+        "closure_actions": closure_actions,
+        "renderer_rule": (
+            "Renderers must choose only templates whose required claim class and closure action are authorized here; "
+            "unsafe prose examples are diagnostics, not the enforcement model."
+        ),
+        "diagnostics": {
+            "unsafe_claim_examples": _dedupe(unsafe_examples),
+            "diagnostic_only": True,
+        },
+    }
+
+
 def _planning_completion_gate_payload(
     *,
     record: dict[str, Any],
@@ -10946,9 +11023,19 @@ def _planning_completion_gate_payload(
         else:
             issue_refs.update(_issue_refs_from_text(str(reference or "")))
     issue_refs.update(_issue_refs_from_text(str(record.get("title") or "")))
-    blocked_claims = [] if active_intent_satisfied else ["done", "implemented", "complete", "finished", "all", "full intent complete"]
-    if not active_intent_satisfied:
-        blocked_claims.extend(f"Closes {ref}" for ref in sorted(issue_refs))
+    claim_authorization = _planning_completion_gate_claim_authorization(
+        status=status,
+        active_intent_satisfied=active_intent_satisfied,
+        human_accepted_partial=human_accepted_partial,
+        claim_level_requested=claim_level_requested,
+        proof_status="representative" if proof_supports_full else "",
+        issue_refs=issue_refs,
+    )
+    diagnostics = claim_authorization.get("diagnostics", {})
+    diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
+    diagnostic_unsafe_claims = diagnostics.get("unsafe_claim_examples", [])
+    diagnostic_unsafe_claims = diagnostic_unsafe_claims if isinstance(diagnostic_unsafe_claims, list) else []
+    blocked_claims = [] if active_intent_satisfied else [str(item) for item in diagnostic_unsafe_claims if str(item).strip()]
     reason = (
         "Planning closeout evidence supports the requested completion claim."
         if active_intent_satisfied
@@ -10965,6 +11052,7 @@ def _planning_completion_gate_payload(
         "claim_level_requested": claim_level_requested,
         "claim_level_allowed": claim_level_allowed,
         "required_next_action": required_next_action,
+        "claim_authorization": claim_authorization,
         "blocked_claims": _dedupe(blocked_claims),
         "residual_intent": "" if active_intent_satisfied else residual_intent,
         "self_review": {
@@ -10978,7 +11066,11 @@ def _planning_completion_gate_payload(
             "reason": "" if active_intent_satisfied else reason,
         },
         "authority_boundary": {
-            "aw_owns": ["forcing the transition rule", "blocking unsupported claim language", "routing continuation"],
+            "aw_owns": [
+                "forcing the transition rule",
+                "blocking unsupported structured claim classes and closure actions",
+                "routing continuation",
+            ],
             "agent_owns": ["semantic satisfaction judgment", "evidence interpretation", "next implementation decisions"],
             "human_owns": ["accepting narrower scope", "changing intent", "accepting unresolved residual intent"],
         },

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -608,6 +608,7 @@ candidates = []
     assert archived["completion_gate"]["status"] == "allowed"
     assert archived["completion_gate"]["active_intent_satisfied"] is True
     assert archived["completion_gate"]["claim_level_allowed"] == "full-intent-complete"
+    assert "blocked_claims" not in archived["completion_gate"]
     assert "full_intent_complete" in archived["completion_gate"]["claim_authorization"]["allowed_claim_classes"]
     assert archived["iterative_follow_through"]["proof achieved now"] != "pending"
     assert archived["iterative_follow_through"]["validation still needed"] == (
@@ -738,6 +739,7 @@ def test_archive_plan_prepare_closeout_handles_open_parent_lane(tmp_path: Path, 
     assert archived["closure_check"]["closure decision"] == "archive-but-keep-lane-open"
     assert archived["completion_gate"]["status"] == "continue-required"
     assert archived["completion_gate"]["claim_level_allowed"] == "partial-progress"
+    assert "blocked_claims" not in archived["completion_gate"]
     assert archived["completion_gate"]["claim_authorization"]["allowed_claim_classes"] == ["partial_progress", "slice_complete"]
     assert "full_intent_complete" in archived["completion_gate"]["claim_authorization"]["blocked_claim_classes"]
     assert archived["completion_gate"]["claim_authorization"]["diagnostics"]["diagnostic_only"] is True

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -608,6 +608,7 @@ candidates = []
     assert archived["completion_gate"]["status"] == "allowed"
     assert archived["completion_gate"]["active_intent_satisfied"] is True
     assert archived["completion_gate"]["claim_level_allowed"] == "full-intent-complete"
+    assert "full_intent_complete" in archived["completion_gate"]["claim_authorization"]["allowed_claim_classes"]
     assert archived["iterative_follow_through"]["proof achieved now"] != "pending"
     assert archived["iterative_follow_through"]["validation still needed"] == (
         "None for this archived slice; reopen only if new evidence invalidates the proof."
@@ -737,8 +738,9 @@ def test_archive_plan_prepare_closeout_handles_open_parent_lane(tmp_path: Path, 
     assert archived["closure_check"]["closure decision"] == "archive-but-keep-lane-open"
     assert archived["completion_gate"]["status"] == "continue-required"
     assert archived["completion_gate"]["claim_level_allowed"] == "partial-progress"
-    for blocked in ("done", "implemented", "complete", "finished", "all"):
-        assert blocked in archived["completion_gate"]["blocked_claims"]
+    assert archived["completion_gate"]["claim_authorization"]["allowed_claim_classes"] == ["partial_progress", "slice_complete"]
+    assert "full_intent_complete" in archived["completion_gate"]["claim_authorization"]["blocked_claim_classes"]
+    assert archived["completion_gate"]["claim_authorization"]["diagnostics"]["diagnostic_only"] is True
     assert "Archive decision: archive-but-keep-lane-open" in archived["generated_closeout"]["text"]
     assert "Completion gate: continue-required" in archived["generated_closeout"]["text"]
     assert "Follow-up: .agentic-workspace/planning/state.toml" in archived["generated_closeout"]["text"]
@@ -782,6 +784,7 @@ candidates = []
     assert archived["intent_satisfaction"]["was original intent fully satisfied?"] == "yes"
     assert archived["completion_gate"]["status"] == "allowed"
     assert archived["completion_gate"]["active_intent_satisfied"] is True
+    assert "full_intent_complete" in archived["completion_gate"]["claim_authorization"]["allowed_claim_classes"]
     assert archived["durable_residue"]["status"] == "none"
 
 

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -429,6 +429,8 @@ def test_archive_plan_prepare_closeout_dry_run_returns_valid_patch(tmp_path: Pat
     assert "intent_satisfaction" in text
     assert "task_intent_promotion" in text
     assert "do-not-promote" in text
+    assert "completion_gate" in text
+    assert "Completion gate: allowed" in text
     assert "generated_closeout" in text
     assert "Generated closeout adapter; structured execplan fields are authoritative." in text
     assert "closeout_distillation" in text
@@ -602,6 +604,10 @@ candidates = []
     assert archived["machine_readable_contract"]["execution"]["next_step"] == ("No required continuation remains for this archived slice.")
     assert archived["machine_readable_contract"]["execution"]["proof"] == "uv run pytest tests/test_check_planning_surfaces.py"
     assert archived["task_intent_promotion"]["needs review"] is True
+    assert archived["completion_gate"]["kind"] == "agentic-workspace/completion-gate/v1"
+    assert archived["completion_gate"]["status"] == "allowed"
+    assert archived["completion_gate"]["active_intent_satisfied"] is True
+    assert archived["completion_gate"]["claim_level_allowed"] == "full-intent-complete"
     assert archived["iterative_follow_through"]["proof achieved now"] != "pending"
     assert archived["iterative_follow_through"]["validation still needed"] == (
         "None for this archived slice; reopen only if new evidence invalidates the proof."
@@ -729,7 +735,12 @@ def test_archive_plan_prepare_closeout_handles_open_parent_lane(tmp_path: Path, 
     assert archived["intent_satisfaction"]["unsolved intent passed to"] == ".agentic-workspace/planning/state.toml"
     assert archived["closure_check"]["larger-intent status"] == "open"
     assert archived["closure_check"]["closure decision"] == "archive-but-keep-lane-open"
+    assert archived["completion_gate"]["status"] == "continue-required"
+    assert archived["completion_gate"]["claim_level_allowed"] == "partial-progress"
+    for blocked in ("done", "implemented", "complete", "finished", "all"):
+        assert blocked in archived["completion_gate"]["blocked_claims"]
     assert "Archive decision: archive-but-keep-lane-open" in archived["generated_closeout"]["text"]
+    assert "Completion gate: continue-required" in archived["generated_closeout"]["text"]
     assert "Follow-up: .agentic-workspace/planning/state.toml" in archived["generated_closeout"]["text"]
     assert archived["closeout_distillation"]["buckets"]["continuation"][0]["owner"] == ".agentic-workspace/planning/state.toml"
 
@@ -769,6 +780,8 @@ candidates = []
     assert not record_path.exists()
     assert archived["closure_check"]["closure decision"] == "archive-and-close"
     assert archived["intent_satisfaction"]["was original intent fully satisfied?"] == "yes"
+    assert archived["completion_gate"]["status"] == "allowed"
+    assert archived["completion_gate"]["active_intent_satisfied"] is True
     assert archived["durable_residue"]["status"] == "none"
 
 

--- a/packages/planning/tests/test_lanes.py
+++ b/packages/planning/tests/test_lanes.py
@@ -188,6 +188,8 @@ def test_lane_close_and_archive_preserve_parent_contribution(tmp_path: Path) -> 
     assert raw_lane["completion_gate"]["status"] == "allowed"
     assert raw_lane["completion_gate"]["claim_level_requested"] == "lane-complete"
     assert raw_lane["completion_gate"]["claim_level_allowed"] == "lane-complete"
+    assert "lane_complete" in raw_lane["completion_gate"]["claim_authorization"]["allowed_claim_classes"]
+    assert "full_intent_complete" in raw_lane["completion_gate"]["claim_authorization"]["blocked_claim_classes"]
 
     archive_result = archive_lane_record("closeable-lane", target=tmp_path)
     assert [action.kind for action in archive_result.actions] == ["archived", "updated", "proof", "proof"]

--- a/packages/planning/tests/test_lanes.py
+++ b/packages/planning/tests/test_lanes.py
@@ -183,6 +183,11 @@ def test_lane_close_and_archive_preserve_parent_contribution(tmp_path: Path) -> 
     assert lane["proof_aggregation"]["status"] == "satisfied"
     assert lane["lane_to_epic_contribution"] == "lane artifacts now own strategy and proof aggregation"
     assert lane["parent_close_permission"] == "may-advance-parent"
+    raw_lane = json.loads((tmp_path / ".agentic-workspace/planning/lanes/closeable-lane.lane.json").read_text(encoding="utf-8"))
+    assert raw_lane["completion_gate"]["kind"] == "agentic-workspace/completion-gate/v1"
+    assert raw_lane["completion_gate"]["status"] == "allowed"
+    assert raw_lane["completion_gate"]["claim_level_requested"] == "lane-complete"
+    assert raw_lane["completion_gate"]["claim_level_allowed"] == "lane-complete"
 
     archive_result = archive_lane_record("closeable-lane", target=tmp_path)
     assert [action.kind for action in archive_result.actions] == ["archived", "updated", "proof", "proof"]

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -162,6 +162,16 @@
       "description": "Compact provenance and assumption evidence for the task intent being implemented, including source chain, correction point, and clarification/proceed posture.",
       "additionalProperties": true
     },
+    "active_intent_contract": {
+      "type": "object",
+      "description": "Active controlling-intent contract preserving chat, planning, external, and mixed intent sources before completion claims.",
+      "additionalProperties": true
+    },
+    "intent_satisfaction_matrix": {
+      "type": "object",
+      "description": "Compact satisfaction matrix shape that maps active intent items to evidence, gaps, and the honest completion claim level.",
+      "additionalProperties": true
+    },
     "parent_intent_status": {
       "$ref": "#/$defs/parent_intent_status",
       "description": "Compact parent/original-intent status preserving larger intent across bounded implementation slices."

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -366,6 +366,16 @@
       "description": "Compact provenance and assumption evidence for the current task intent, including source chain, correction point, and clarification/proceed posture.",
       "additionalProperties": true
     },
+    "active_intent_contract": {
+      "type": "object",
+      "description": "Active controlling-intent contract preserving chat, planning, external, and mixed intent sources before completion claims.",
+      "additionalProperties": true
+    },
+    "intent_satisfaction_matrix": {
+      "type": "object",
+      "description": "Compact satisfaction matrix shape that maps active intent items to evidence, gaps, and the honest completion claim level.",
+      "additionalProperties": true
+    },
     "durable_intent": {
       "type": "object",
       "description": "Compact durable task, subsystem, and system intent pressure to consider before implementation."

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -331,6 +331,10 @@
         "closeout_adoption": {
           "type": "object",
           "description": "Derived closeout quality rubric, representative examples, and current rendering adoption status for human-useful final reports."
+        },
+        "completion_gate": {
+          "$ref": "#/$defs/completion_gate",
+          "description": "Closeout transition gate that blocks full completion or closure-language claims when active human intent is unsatisfied and no explicit human-accepted partial scope exists."
         }
       },
       "description": "Derived operator-facing closeout report profile, traceability, completeness, decision-review facts, behavior-preservation proof/caveat facts, closeout-first review-compression contract, closeout adoption rubric, validation, gaps, closure boundary, final-response rendering guidance, and profile-bound rendered closeout summary."
@@ -586,6 +590,132 @@
       },
       "additionalProperties": true,
       "description": "Applicable-intent source projection across existing AW surfaces without semantic conflict resolution."
+    },
+    "completion_gate": {
+      "type": "object",
+      "required": [
+        "kind",
+        "status",
+        "active_intent_satisfied",
+        "human_accepted_partial",
+        "claim_level_requested",
+        "claim_level_allowed",
+        "required_next_action",
+        "blocked_claims",
+        "self_review",
+        "continuation",
+        "authority_boundary"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/completion-gate/v1",
+          "description": "Discriminator for the closeout completion gate."
+        },
+        "status": {
+          "enum": [
+            "allowed",
+            "blocked",
+            "continue-required",
+            "clarification-required",
+            "human-accepted-partial"
+          ],
+          "description": "State-machine result for the requested completion claim."
+        },
+        "active_intent_satisfied": {
+          "type": "boolean",
+          "description": "Agent-recorded answer to whether delivered work satisfies the active human intent."
+        },
+        "human_accepted_partial": {
+          "type": "boolean",
+          "description": "Whether the human explicitly accepted a partial or narrower completion claim."
+        },
+        "claim_level_requested": {
+          "type": "string",
+          "description": "Requested claim level being evaluated."
+        },
+        "claim_level_allowed": {
+          "type": "string",
+          "description": "Highest claim level supported by the gate."
+        },
+        "required_next_action": {
+          "enum": [
+            "continue-current-work",
+            "create-follow-on-plan",
+            "activate-next-slice",
+            "ask-human",
+            "close-complete",
+            "close-human-accepted-partial"
+          ],
+          "description": "Required transition before the workflow can stop or claim completion."
+        },
+        "blocked_claims": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Completion, done, or close-keyword claims blocked by the gate."
+        },
+        "residual_intent": {
+          "type": "string",
+          "description": "Remaining active human intent when the requested full claim is unsupported."
+        },
+        "self_review": {
+          "type": "object",
+          "required": [
+            "question",
+            "answer",
+            "reason"
+          ],
+          "properties": {
+            "question": {
+              "type": "string",
+              "description": "Self-review question the agent must answer before making a completion claim."
+            },
+            "answer": {
+              "enum": [
+                "yes",
+                "no"
+              ],
+              "description": "Agent-owned self-review answer for active human intent satisfaction."
+            },
+            "reason": {
+              "type": "string",
+              "description": "Reason the self-review answer supports or blocks the requested completion claim."
+            }
+          },
+          "additionalProperties": true,
+          "description": "Mandatory agent self-review before final completion claims."
+        },
+        "continuation": {
+          "type": "object",
+          "properties": {
+            "owner_surface": {
+              "type": "string",
+              "description": "Planning, lane, decomposition, or other durable surface that owns the residual intent."
+            },
+            "created_or_required": {
+              "type": "boolean",
+              "description": "Whether follow-on work has been created or is required before full completion can be claimed."
+            },
+            "reason": {
+              "type": "string",
+              "description": "Why continuation or follow-on routing is required."
+            }
+          },
+          "additionalProperties": true,
+          "description": "Durable follow-on route or required continuation state."
+        },
+        "authority_boundary": {
+          "type": "object",
+          "description": "Boundary stating AW enforces the transition rule while the agent owns semantic satisfaction judgment and the human owns accepted narrowing."
+        },
+        "rule": {
+          "type": "string",
+          "description": "Invariant enforced by the completion gate."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Closeout transition gate derived from existing intent, proof, Planning, and closeout fields."
     },
     "authority_boundary": {
       "type": "object",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -601,6 +601,7 @@
         "claim_level_requested",
         "claim_level_allowed",
         "required_next_action",
+        "claim_authorization",
         "blocked_claims",
         "self_review",
         "continuation",
@@ -653,7 +654,11 @@
           "items": {
             "type": "string"
           },
-          "description": "Completion, done, or close-keyword claims blocked by the gate."
+          "description": "Compatibility diagnostics listing human-readable unsafe claim examples. Enforcement uses claim_authorization."
+        },
+        "claim_authorization": {
+          "$ref": "#/$defs/claim_authorization",
+          "description": "Structured claim classes and closure actions authorized or blocked by the gate."
         },
         "residual_intent": {
           "type": "string",
@@ -716,6 +721,107 @@
       },
       "additionalProperties": true,
       "description": "Closeout transition gate derived from existing intent, proof, Planning, and closeout fields."
+    },
+    "claim_authorization": {
+      "type": "object",
+      "required": [
+        "kind",
+        "allowed_claim_classes",
+        "blocked_claim_classes",
+        "closure_actions",
+        "renderer_rule",
+        "diagnostics"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/claim-authorization/v1",
+          "description": "Discriminator for structured completion claim authorization."
+        },
+        "allowed_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "partial_progress",
+              "slice_complete",
+              "lane_complete",
+              "parent_complete",
+              "full_intent_complete",
+              "issue_closure"
+            ]
+          },
+          "description": "Claim classes renderers may use."
+        },
+        "blocked_claim_classes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "partial_progress",
+              "slice_complete",
+              "lane_complete",
+              "parent_complete",
+              "full_intent_complete",
+              "issue_closure"
+            ]
+          },
+          "description": "Claim classes renderers must not use."
+        },
+        "closure_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "kind",
+              "target",
+              "authorized",
+              "reason"
+            ],
+            "properties": {
+              "kind": {
+                "const": "issue_closure"
+              },
+              "target": {
+                "type": "string"
+              },
+              "authorized": {
+                "type": "boolean"
+              },
+              "reason": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          "description": "Structured closure actions such as issue closure for concrete targets."
+        },
+        "renderer_rule": {
+          "type": "string",
+          "description": "Renderer rule requiring templates to be selected only from authorized claim classes/actions."
+        },
+        "diagnostics": {
+          "type": "object",
+          "required": [
+            "unsafe_claim_examples",
+            "diagnostic_only"
+          ],
+          "properties": {
+            "unsafe_claim_examples": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Human-readable examples of unsafe completion prose for explanation only."
+            },
+            "diagnostic_only": {
+              "const": true,
+              "description": "Marker that unsafe_claim_examples are diagnostics, not enforcement rules."
+            }
+          },
+          "additionalProperties": true,
+          "description": "Human-readable examples for explanation only; not the enforcement model."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Structured authorization for completion claim classes and closure actions."
     },
     "authority_boundary": {
       "type": "object",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -602,7 +602,6 @@
         "claim_level_allowed",
         "required_next_action",
         "claim_authorization",
-        "blocked_claims",
         "self_review",
         "continuation",
         "authority_boundary"
@@ -648,13 +647,6 @@
             "close-human-accepted-partial"
           ],
           "description": "Required transition before the workflow can stop or claim completion."
-        },
-        "blocked_claims": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Compatibility diagnostics listing human-readable unsafe claim examples. Enforcement uses claim_authorization."
         },
         "claim_authorization": {
           "$ref": "#/$defs/claim_authorization",

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -372,6 +372,7 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
                     "claim_level_requested",
                     "claim_level_allowed",
                     "required_next_action",
+                    "claim_authorization",
                     "blocked_claims",
                     "residual_intent",
                     "self_review",

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -373,7 +373,6 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
                     "claim_level_allowed",
                     "required_next_action",
                     "claim_authorization",
-                    "blocked_claims",
                     "residual_intent",
                     "self_review",
                     "continuation",

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -351,6 +351,8 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
         completion_options = completion_options if isinstance(completion_options, list) else []
         strict_gate = answer.get("strict_closeout_gate", {})
         strict_gate = strict_gate if isinstance(strict_gate, dict) else {}
+        completion_gate = answer.get("completion_gate", {})
+        completion_gate = completion_gate if isinstance(completion_gate, dict) else {}
         detail_command = _command_with_cli_invoke(
             "agentic-workspace report --target ./repo --verbose --format json",
             cli_invoke=cli_invoke,
@@ -360,6 +362,24 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
             "status": answer.get("status", ""),
             "trust": answer.get("trust", ""),
             "strict_closeout_gate": strict_gate,
+            "completion_gate": {
+                key: completion_gate.get(key)
+                for key in (
+                    "kind",
+                    "status",
+                    "active_intent_satisfied",
+                    "human_accepted_partial",
+                    "claim_level_requested",
+                    "claim_level_allowed",
+                    "required_next_action",
+                    "blocked_claims",
+                    "residual_intent",
+                    "self_review",
+                    "continuation",
+                    "authority_boundary",
+                )
+                if key in completion_gate
+            },
             "lower_trust_closeout_count": answer.get("lower_trust_closeout_count", 0),
             "summary": answer.get("summary", ""),
             "terminal_action": terminal_action,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -13278,7 +13278,7 @@ def _completion_gate_payload(
                 text = "; ".join(str(item).strip() for item in value if str(item).strip())
             else:
                 text = str(value or "").strip()
-            if text and text.lower() not in {"none", "null", "unknown", "pending", "not-recorded", "not recorded"}:
+            if text and text.lower() not in {"none", "no", "false", "null", "unknown", "pending", "not-recorded", "not recorded"}:
                 return text
         return ""
 
@@ -13315,7 +13315,6 @@ def _completion_gate_payload(
         )
     )
     proof_supports_full = proof_status in {"representative", "sufficient_for_claim", "sufficient-for-claim"}
-    proof_not_required = proof_status in {"not_recorded", "not-recorded", ""}
     parent_satisfied = parent_status in {"satisfied", "guidance-only", ""}
     intent_satisfied_field = truthy(intent_satisfaction.get("was original intent fully satisfied?")) or truthy(
         intent_continuity.get("this slice completes the larger intended outcome")
@@ -13327,7 +13326,7 @@ def _completion_gate_payload(
         and no_required_follow_on
         and parent_satisfied
         and acceptance_trust in {"", "normal", "not-applicable"}
-        and (proof_supports_full or proof_not_required)
+        and proof_supports_full
         and not applicable_intent_status.get("closeout_blocked")
     )
     continuation_possible = bool(
@@ -13379,7 +13378,7 @@ def _completion_gate_payload(
         present(closure_check.get("closure target"), closure_check.get("closure_target")),
     ):
         issue_refs.update(_issue_refs_from_text(value))
-    blocked_claims = [] if active_intent_satisfied else ["done", "implemented", "full intent complete"]
+    blocked_claims = [] if active_intent_satisfied else ["done", "implemented", "complete", "finished", "all", "full intent complete"]
     if not active_intent_satisfied:
         blocked_claims.extend(f"Closes {ref}" for ref in sorted(issue_refs))
     self_review_answer = "yes" if active_intent_satisfied else "no"
@@ -17039,25 +17038,6 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
             )
             if key in payload["applicable_intent_status"]
         }
-    if isinstance(payload.get("active_intent_contract"), dict) and not (
-        isinstance(task_intent, dict) and task_intent.get("task_argument_mode") == "task-file"
-    ):
-        projected["active_intent_contract"] = {
-            "status": payload["active_intent_contract"].get("status"),
-            "source_count": payload["active_intent_contract"].get("source_count"),
-            "update_relationship_options": payload["active_intent_contract"].get("update_relationship_options", []),
-        }
-    if isinstance(payload.get("intent_satisfaction_matrix"), dict):
-        matrix = payload["intent_satisfaction_matrix"]
-        full_claim = _as_dict(matrix.get("full_completion_claim"))
-        projected["intent_satisfaction_matrix"] = {
-            "status": matrix.get("status"),
-            "full_completion_claim": {
-                "allowed": bool(full_claim.get("allowed")),
-                "blocked_by": full_claim.get("blocked_by", []),
-                "rule": "Self-review first; claim only the proven level.",
-            },
-        }
     assurance_requirements = payload.get("assurance_requirements", {})
     if isinstance(assurance_requirements, dict) and int(assurance_requirements.get("active_count", 0) or 0) > 0:
         projected["assurance_requirements"] = _compact_assurance_requirements(assurance_requirements)
@@ -18546,25 +18526,6 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                 "closeout_blocked",
             )
             if key in payload["applicable_intent_status"]
-        }
-    if isinstance(payload.get("active_intent_contract"), dict) and not (
-        isinstance(payload.get("task_intent"), dict) and payload["task_intent"].get("task_argument_mode") == "task-file"
-    ):
-        context["active_intent_contract"] = {
-            "status": payload["active_intent_contract"].get("status"),
-            "source_count": payload["active_intent_contract"].get("source_count"),
-            "update_relationship_options": payload["active_intent_contract"].get("update_relationship_options", []),
-        }
-    if isinstance(payload.get("intent_satisfaction_matrix"), dict):
-        matrix = payload["intent_satisfaction_matrix"]
-        full_claim = _as_dict(matrix.get("full_completion_claim"))
-        context["intent_satisfaction_matrix"] = {
-            "status": matrix.get("status"),
-            "full_completion_claim": {
-                "allowed": bool(full_claim.get("allowed")),
-                "blocked_by": full_claim.get("blocked_by", []),
-                "rule": "Self-review first; claim only the proven level.",
-            },
         }
     uv_guidance = payload.get("uv_cache_guidance", {})
     if not (isinstance(uv_guidance, dict) and uv_guidance.get("status") == "available"):
@@ -22812,21 +22773,6 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 else [],
             },
             "intent_evidence": _compact_intent_evidence(payload.get("intent_evidence", {})),
-            "active_intent_contract": {
-                "status": payload.get("active_intent_contract", {}).get("status"),
-                "source_count": payload.get("active_intent_contract", {}).get("source_count"),
-                "update_relationship_options": payload.get("active_intent_contract", {}).get("update_relationship_options", []),
-            },
-            "intent_satisfaction_matrix": {
-                "status": payload.get("intent_satisfaction_matrix", {}).get("status"),
-                "full_completion_claim": {
-                    "allowed": bool(_as_dict(payload.get("intent_satisfaction_matrix", {}).get("full_completion_claim")).get("allowed")),
-                    "blocked_by": _as_dict(payload.get("intent_satisfaction_matrix", {}).get("full_completion_claim")).get(
-                        "blocked_by", []
-                    ),
-                    "rule": "Self-review first; claim only the proven level.",
-                },
-            },
             "parent_intent_status": {
                 key: payload.get("parent_intent_status", {}).get(key)
                 for key in (
@@ -22890,8 +22836,8 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "context.workflow_sufficiency",
                 "context.acceptance",
                 "context.intent_evidence",
-                "context.active_intent_contract",
-                "context.intent_satisfaction_matrix",
+                "active_intent_contract",
+                "intent_satisfaction_matrix",
                 "context.parent_intent_status",
                 "context.applicable_intent_status",
                 "context.acceptance_reconciliation",
@@ -28987,6 +28933,10 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
             payload["verification"] = full_payload["verification"]
         if routine_work_context_selected:
             payload["routine_work_context"] = full_payload["routine_work_context"]
+        if _selector_requests(getattr(args, "select", None), "active_intent_contract"):
+            payload["active_intent_contract"] = full_payload["active_intent_contract"]
+        if _selector_requests(getattr(args, "select", None), "intent_satisfaction_matrix"):
+            payload["intent_satisfaction_matrix"] = full_payload["intent_satisfaction_matrix"]
         if reuse_pressure_selected:
             payload["reuse_pressure"] = _reuse_pressure_payload(
                 target_root=target_root,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -8113,9 +8113,10 @@ def _closeout_report_profile_policy_payload(
         high_risk_reasons.append(f"verification status is {verification_status}")
     if external_closeout_safe is False:
         high_risk_reasons.append("external evidence blocks closeout")
-    if request_review:
+    material_closeout_claim = active_planning or completeness_status not in {"guidance-only", "not-applicable", ""}
+    if request_review and material_closeout_claim:
         high_risk_reasons.append("closeout options require review")
-    if route_residue:
+    if route_residue and material_closeout_claim:
         high_risk_reasons.append("durable residue route is available")
     if high_risk_reasons:
         selected = "audit"
@@ -9069,6 +9070,7 @@ def _closeout_report_final_response_rendering_payload(
     parent_intent_status: dict[str, Any] | None = None,
     applicable_intent_status: dict[str, Any] | None = None,
     workflow_obligation_contract: dict[str, Any] | None = None,
+    completion_gate: dict[str, Any] | None = None,
     review_mode: str = "",
 ) -> dict[str, Any]:
     profile = str(profile_policy.get("selected_profile") or "minimal")
@@ -9086,6 +9088,7 @@ def _closeout_report_final_response_rendering_payload(
     parent_intent_status = _as_dict(parent_intent_status)
     applicable_intent_status = _as_dict(applicable_intent_status)
     workflow_obligation_contract = _as_dict(workflow_obligation_contract)
+    completion_gate = _as_dict(completion_gate)
     review_contract = _closeout_report_review_mode_contract(review_mode or "small-direct-edit")
     obligation_items = [item for item in _list_payload(workflow_obligation_contract.get("items")) if isinstance(item, dict)]
     required_obligations = [
@@ -9109,7 +9112,7 @@ def _closeout_report_final_response_rendering_payload(
         plain_done_allowed: bool,
     ) -> dict[str, Any]:
         template_id = f"builtin/{rendering_mode}"
-        rendered_lines = summary_lines[:8]
+        rendered_lines = summary_lines[:10]
         if rendering_mode == "terse" and not rendered_lines:
             rendered_lines = ["Done."]
         required_checks: list[dict[str, str]] = []
@@ -9133,6 +9136,7 @@ def _closeout_report_final_response_rendering_payload(
             "parent intent status": ("parent intent:",),
             "applicable intent status": ("applicable intent:",),
             "workflow obligation status": ("workflow obligations:",),
+            "completion gate": ("completion gate:",),
         }
         for fact in must_include:
             markers = fact_markers.get(fact, (fact,))
@@ -9239,10 +9243,18 @@ def _closeout_report_final_response_rendering_payload(
                         "residue or follow-up status",
                         "missing or partial evidence caveat",
                         "profile reason or caveat",
+                        "completion gate",
                     )
                 ),
                 "lines": caveat_lines,
-                "source_fields": ["completion_boundary", "residual_risk", "completion_options", "blockers", "next_action"],
+                "source_fields": [
+                    "completion_boundary",
+                    "completion_gate",
+                    "residual_risk",
+                    "completion_options",
+                    "blockers",
+                    "next_action",
+                ],
             },
             {
                 "id": "authority",
@@ -9292,6 +9304,9 @@ def _closeout_report_final_response_rendering_payload(
     has_material_guidance_signal = bool(
         guidance_only and (lower_trust or profile_requires_detail or owners or workflow_obligations_block_done)
     )
+    gate_status = present(str(completion_gate.get("status") or ""))
+    gate_blocks_full = gate_status in {"blocked", "continue-required", "clarification-required"}
+    gate_partial = gate_status == "human-accepted-partial"
 
     if guidance_only and not has_material_guidance_signal:
         rendering_mode = "terse"
@@ -9424,6 +9439,21 @@ def _closeout_report_final_response_rendering_payload(
         summary_lines.append("Applicable intent: " + ("; ".join(fragments) if fragments else "unresolved applicable-intent obligation"))
         must_not_claim.extend(str(item) for item in _list_payload(applicable_intent_status.get("must_not_claim")) if str(item).strip())
 
+    if gate_blocks_full or gate_partial:
+        must_include.append("completion gate")
+        blocked_claims = [str(item).strip() for item in _list_payload(completion_gate.get("blocked_claims")) if str(item).strip()]
+        if blocked_claims:
+            must_not_claim.extend(blocked_claims)
+        self_review = _as_dict(completion_gate.get("self_review"))
+        gate_reason = present(str(self_review.get("reason") or completion_gate.get("residual_intent") or ""))
+        summary_lines.append(
+            "Completion gate: "
+            + gate_status
+            + f"; allowed claim: {completion_gate.get('claim_level_allowed') or 'partial-progress'}"
+            + f"; next: {completion_gate.get('required_next_action') or 'continue'}"
+            + (f"; reason: {gate_reason}" if gate_reason else "")
+        )
+
     durable_outcomes = [item for item in _list_payload(applicable_intent_status.get("durable_outcomes")) if isinstance(item, dict)]
     if durable_outcomes:
         must_include.append("applicable intent outcome")
@@ -9505,6 +9535,8 @@ def _closeout_report_final_response_rendering_payload(
             or parent_status_blocks_done
             or applicable_intent_status.get("closeout_blocked")
             or workflow_obligations_block_done
+            or gate_blocks_full
+            or gate_partial
         )
         else "available"
     )
@@ -9515,8 +9547,10 @@ def _closeout_report_final_response_rendering_payload(
         or parent_status_blocks_done
         or applicable_intent_status.get("closeout_blocked")
         or workflow_obligations_block_done
+        or gate_blocks_full
+        or gate_partial
     )
-    summary_lines = summary_lines[:8]
+    summary_lines = summary_lines[:10]
     unique_must_include = list(dict.fromkeys(must_include))
     chat_report_template = chat_report_template_payload(
         rendering_status=status_value,
@@ -9772,6 +9806,17 @@ def _closeout_report_payload(
     proof_confidence = _as_dict(closeout_trust.get("proof_confidence"))
     behavior_preservation = _as_dict(proof_confidence.get("behavior_preservation"))
     residual_risk = str(proof_confidence.get("residual_risk", ""))
+    completion_gate = _as_dict(closeout_trust.get("completion_gate"))
+    if not completion_gate:
+        completion_gate = _completion_gate_payload(
+            active_planning_record=active_planning_record,
+            intent_check=intent_check,
+            acceptance_reconciliation=_as_dict(closeout_trust.get("acceptance_criteria_reconciliation")),
+            intent_proof_check=_as_dict(closeout_trust.get("intent_proof_check")),
+            parent_intent_status=parent_intent_status,
+            applicable_intent_status=applicable_intent_status,
+            durable_residue_action=_as_dict(closeout_trust.get("durable_residue_action")),
+        )
     first_blocking_option = next((item for item in completion_options if item.get("allowed") is False and item.get("blocking_fields")), {})
     blockers = first_blocking_option.get("blocking_fields", [])
     workflow_obligation_contract = _workflow_obligation_closeout_contract_payload(
@@ -9809,6 +9854,7 @@ def _closeout_report_payload(
         parent_intent_status=parent_intent_status,
         applicable_intent_status=applicable_intent_status,
         workflow_obligation_contract=workflow_obligation_contract,
+        completion_gate=completion_gate,
         review_mode=selected_review_mode,
     )
     detail_commands = {
@@ -9914,6 +9960,7 @@ def _closeout_report_payload(
         },
         "gaps_and_residual_risk": {
             "completion_blockers": blockers,
+            "completion_gate": completion_gate,
             "residual_risk": residual_risk,
             "durable_residue_action": closeout_trust.get("durable_residue_action", {}),
             "workflow_trust_impact": workflow_compliance_summary.get("trust_impact", "unknown")
@@ -9921,6 +9968,7 @@ def _closeout_report_payload(
             else "unknown",
         },
         "workflow_obligation_contract": workflow_obligation_contract,
+        "completion_gate": completion_gate,
         "closure_boundary": {
             "completion_decision": completion_contract.get("completion_decision", "unknown"),
             "decision_reasons": completion_contract.get("decision_reasons", []),
@@ -12980,6 +13028,7 @@ def _closeout_completion_options(
     status: str,
     trust: str,
     strict_gate: dict[str, Any],
+    completion_gate: dict[str, Any] | None = None,
     intent_check: dict[str, Any],
     acceptance_reconciliation: dict[str, Any],
     intent_proof_check: dict[str, Any] | None = None,
@@ -13007,6 +13056,14 @@ def _closeout_completion_options(
     intent_trust = str(intent_check.get("trust", "")).strip().lower()
     acceptance_trust = str(acceptance_reconciliation.get("trust", "")).strip().lower()
     intent_proof_check = intent_proof_check if isinstance(intent_proof_check, dict) else {}
+    completion_gate = completion_gate if isinstance(completion_gate, dict) else {}
+    completion_gate_status = str(completion_gate.get("status", "")).strip()
+    completion_gate_blocks_full = completion_gate_status in {
+        "blocked",
+        "continue-required",
+        "clarification-required",
+        "human-accepted-partial",
+    }
     intent_proof_status = str(intent_proof_check.get("status", "not_recorded")).strip().lower() or "not_recorded"
     intent_proof_supports_work = intent_proof_status in {"representative", "sufficient_for_claim"}
     intent_proof_records_execution = intent_proof_status in {"regression_only", "representative", "sufficient_for_claim"}
@@ -13067,6 +13124,8 @@ def _closeout_completion_options(
         completion_blockers.append("intent_proof")
     if unsupported_preservation:
         completion_blockers.append("behavior_preservation")
+    if completion_gate_blocks_full:
+        completion_blockers.append("completion_gate")
     assurance_claim_blockers = _assurance_claim_blockers(assurance_requirements)
 
     slice_blockers = [
@@ -13091,6 +13150,7 @@ def _closeout_completion_options(
         and intent_satisfied
         and (not larger_intent_open)
         and intent_proof_supports_work
+        and not completion_gate_blocks_full
         and not assurance_claim_blockers.get("claim-work-complete")
     )
     close_parent_allowed = claim_work_allowed and close_evidence and not assurance_claim_blockers.get("close-parent-lane")
@@ -13103,6 +13163,7 @@ def _closeout_completion_options(
         or intent_trust == "needs-review"
         or intent_proof_needs_review
         or unsupported_preservation
+        or completion_gate_status in {"blocked", "clarification-required"}
         or str(strict_gate.get("status", "")) == "requires-review"
         or assurance_review_required
     )
@@ -13167,6 +13228,8 @@ def _closeout_completion_options(
             if intent_trust == "needs-review"
             else ["behavior_preservation"]
             if unsupported_preservation
+            else ["completion_gate"]
+            if completion_gate_status in {"blocked", "clarification-required"}
             else ["assurance_requirements"]
             if assurance_review_required
             else None,
@@ -13180,6 +13243,206 @@ def _closeout_completion_options(
             ),
         ),
     ]
+
+
+def _completion_gate_payload(
+    *,
+    active_planning_record: dict[str, Any],
+    intent_check: dict[str, Any],
+    acceptance_reconciliation: dict[str, Any],
+    intent_proof_check: dict[str, Any] | None = None,
+    parent_intent_status: dict[str, Any] | None = None,
+    applicable_intent_status: dict[str, Any] | None = None,
+    durable_residue_action: dict[str, Any] | None = None,
+    claim_level_requested: str = "full-intent-complete",
+) -> dict[str, Any]:
+    active_planning_record = _as_dict(active_planning_record)
+    intent_check = _as_dict(intent_check)
+    acceptance_reconciliation = _as_dict(acceptance_reconciliation)
+    intent_proof_check = _as_dict(intent_proof_check)
+    parent_intent_status = _as_dict(parent_intent_status)
+    applicable_intent_status = _as_dict(applicable_intent_status)
+    durable_residue_action = _as_dict(durable_residue_action)
+    intent_satisfaction = _as_dict(active_planning_record.get("intent_satisfaction"))
+    intent_continuity = _as_dict(active_planning_record.get("intent_continuity"))
+    required_continuation = _as_dict(active_planning_record.get("required_continuation"))
+    closure_check = _as_dict(active_planning_record.get("closure_check"))
+    parent_acceptance = _as_dict(active_planning_record.get("parent_acceptance"))
+
+    def truthy(value: Any) -> bool:
+        return str(value or "").strip().lower() in {"yes", "true", "accepted", "approved", "explicit", "human-accepted"}
+
+    def present(*values: Any) -> str:
+        for value in values:
+            if isinstance(value, (list, tuple)):
+                text = "; ".join(str(item).strip() for item in value if str(item).strip())
+            else:
+                text = str(value or "").strip()
+            if text and text.lower() not in {"none", "null", "unknown", "pending", "not-recorded", "not recorded"}:
+                return text
+        return ""
+
+    parent_status = str(parent_intent_status.get("status") or "").strip()
+    intent_trust = str(intent_check.get("trust") or "").strip()
+    acceptance_trust = str(acceptance_reconciliation.get("trust") or "").strip()
+    proof_status = str(intent_proof_check.get("status") or "").strip()
+    required_follow_on = str(
+        required_continuation.get("required follow-on for the larger intended outcome") or intent_check.get("required_follow_on") or ""
+    ).strip()
+    continuation_owner = present(
+        parent_intent_status.get("continuation_owner"),
+        required_continuation.get("owner surface"),
+        intent_check.get("continuation_surface"),
+        durable_residue_action.get("owner"),
+    )
+    residual_intent = present(
+        parent_intent_status.get("residual_parent_intent"),
+        required_continuation.get("required follow-on for the larger intended outcome"),
+        intent_satisfaction.get("unsolved intent passed to"),
+        intent_check.get("residual_intent"),
+    )
+    human_accepted_partial = any(
+        truthy(value)
+        for value in (
+            closure_check.get("human accepted partial"),
+            closure_check.get("human_accepted_partial"),
+            closure_check.get("human accepted narrower scope"),
+            closure_check.get("human_accepted_narrower_scope"),
+            parent_acceptance.get("human accepted partial"),
+            parent_acceptance.get("human_accepted_partial"),
+            parent_acceptance.get("human accepted narrower scope"),
+            parent_acceptance.get("human_accepted_narrower_scope"),
+        )
+    )
+    proof_supports_full = proof_status in {"representative", "sufficient_for_claim", "sufficient-for-claim"}
+    proof_not_required = proof_status in {"not_recorded", "not-recorded", ""}
+    parent_satisfied = parent_status in {"satisfied", "guidance-only", ""}
+    intent_satisfied_field = truthy(intent_satisfaction.get("was original intent fully satisfied?")) or truthy(
+        intent_continuity.get("this slice completes the larger intended outcome")
+    )
+    no_required_follow_on = required_follow_on.lower() in {"", "no", "false", "none"}
+    active_intent_satisfied = bool(
+        active_planning_record
+        and (intent_satisfied_field or intent_trust in {"satisfied", "normal"})
+        and no_required_follow_on
+        and parent_satisfied
+        and acceptance_trust in {"", "normal", "not-applicable"}
+        and (proof_supports_full or proof_not_required)
+        and not applicable_intent_status.get("closeout_blocked")
+    )
+    continuation_possible = bool(
+        continuation_owner or residual_intent or required_follow_on.lower() in {"yes", "true", "required", "follow-up-required"}
+    )
+    ambiguous_or_blocked = (
+        intent_trust == "needs-review"
+        or applicable_intent_status.get("closeout_blocked")
+        or required_follow_on.lower() in {"unknown", "ambiguous"}
+        or str(closure_check.get("closure decision") or closure_check.get("closure_decision") or "").strip().lower()
+        in {"requires-review", "blocked"}
+    )
+    if active_intent_satisfied:
+        status = "allowed"
+        claim_level_allowed = claim_level_requested
+        required_next_action = "close-complete"
+    elif not active_planning_record and intent_check.get("status") == "unavailable":
+        status = "blocked"
+        claim_level_allowed = "partial-progress"
+        required_next_action = "ask-human"
+    elif human_accepted_partial:
+        status = "human-accepted-partial"
+        claim_level_allowed = "partial-progress"
+        required_next_action = "close-human-accepted-partial"
+    elif ambiguous_or_blocked:
+        status = "clarification-required"
+        claim_level_allowed = "partial-progress"
+        required_next_action = "ask-human"
+    elif continuation_possible:
+        status = "continue-required"
+        claim_level_allowed = "partial-progress"
+        required_next_action = "create-follow-on-plan" if continuation_owner else "continue-current-work"
+    else:
+        status = "blocked"
+        claim_level_allowed = "partial-progress"
+        required_next_action = "ask-human"
+
+    issue_refs: set[str] = set()
+    for reference in _list_payload(active_planning_record.get("references")):
+        if isinstance(reference, dict):
+            issue_refs.update(_issue_refs_from_text(reference.get("target")))
+            issue_refs.update(_issue_refs_from_text(reference.get("url")))
+            issue_refs.update(_issue_refs_from_text(reference.get("role")))
+        else:
+            issue_refs.update(_issue_refs_from_text(reference))
+    for value in (
+        active_planning_record.get("title"),
+        present(intent_satisfaction.get("original intent"), parent_intent_status.get("original_intent")),
+        present(closure_check.get("closure target"), closure_check.get("closure_target")),
+    ):
+        issue_refs.update(_issue_refs_from_text(value))
+    blocked_claims = [] if active_intent_satisfied else ["done", "implemented", "full intent complete"]
+    if not active_intent_satisfied:
+        blocked_claims.extend(f"Closes {ref}" for ref in sorted(issue_refs))
+    self_review_answer = "yes" if active_intent_satisfied else "no"
+    if active_intent_satisfied:
+        reason = "Recorded intent, parent status, proof, acceptance, and continuation fields support the requested completion claim."
+    else:
+        reason = present(
+            residual_intent,
+            parent_intent_status.get("residual_parent_intent"),
+            intent_check.get("summary"),
+            "The delivered work does not yet satisfy the active human intent at the requested claim level.",
+        )
+    return {
+        "kind": "agentic-workspace/completion-gate/v1",
+        "status": status,
+        "active_intent_satisfied": active_intent_satisfied,
+        "human_accepted_partial": human_accepted_partial,
+        "claim_level_requested": claim_level_requested,
+        "claim_level_allowed": claim_level_allowed,
+        "required_next_action": required_next_action,
+        "blocked_claims": _dedupe(blocked_claims),
+        "residual_intent": "" if active_intent_satisfied else residual_intent,
+        "self_review": {
+            "question": "Does the delivered work satisfy the active human intent?",
+            "answer": self_review_answer,
+            "reason": reason,
+        },
+        "continuation": {
+            "owner_surface": continuation_owner,
+            "created_or_required": bool(
+                (not active_intent_satisfied) and (continuation_possible or status in {"blocked", "clarification-required"})
+            ),
+            "reason": ""
+            if active_intent_satisfied
+            else present(
+                residual_intent,
+                "Intent remains unsatisfied and must continue, route durably, or be clarified before full closeout.",
+            ),
+        },
+        "authority_boundary": {
+            "kind": "agentic-workspace/authority-boundary/v1",
+            "surface": "completion_gate",
+            "aw_owns": [
+                "forcing the transition rule",
+                "blocking unsupported claim language",
+                "routing continuation",
+            ],
+            "agent_owns": [
+                "semantic satisfaction judgment",
+                "evidence interpretation",
+                "next implementation decisions",
+            ],
+            "human_owns": [
+                "accepting narrower scope",
+                "changing intent",
+                "accepting unresolved residual intent",
+            ],
+        },
+        "rule": (
+            "If the agent records that active_intent_satisfied=false and human_accepted_partial=false, the workflow must "
+            "not terminate as done/full-complete; it must continue, route durable follow-on planning, or ask."
+        ),
+    }
 
 
 def _assurance_claim_blockers(assurance_requirements: dict[str, Any] | None) -> dict[str, list[str]]:
@@ -13328,10 +13591,20 @@ def _report_closeout_trust_payload(
         )
         assurance_requirements = _assurance_requirements_with_verification(assurance_requirements, verification)
         residue_action = durable_residue_action(trust="unavailable")
+        completion_gate = _completion_gate_payload(
+            active_planning_record={},
+            intent_check=intent_check,
+            acceptance_reconciliation=acceptance_reconciliation,
+            intent_proof_check=intent_proof_check,
+            parent_intent_status={},
+            applicable_intent_status={},
+            durable_residue_action=residue_action,
+        )
         return {
             "status": "unavailable",
             "reason": "planning module is not installed",
             "strict_closeout_gate": gate,
+            "completion_gate": completion_gate,
             "package_workflow_evidence": _package_workflow_evidence_payload(planning_report={}),
             "intent_satisfaction_check": intent_check,
             "acceptance_criteria_reconciliation": acceptance_reconciliation,
@@ -13354,6 +13627,7 @@ def _report_closeout_trust_payload(
                 status="unavailable",
                 trust="unavailable",
                 strict_gate=gate,
+                completion_gate=completion_gate,
                 intent_check=intent_check,
                 acceptance_reconciliation=acceptance_reconciliation,
                 intent_proof_check=intent_proof_check,
@@ -13387,10 +13661,20 @@ def _report_closeout_trust_payload(
         )
         assurance_requirements = _assurance_requirements_with_verification(assurance_requirements, verification)
         residue_action = durable_residue_action(trust="unavailable")
+        completion_gate = _completion_gate_payload(
+            active_planning_record={},
+            intent_check=intent_check,
+            acceptance_reconciliation=acceptance_reconciliation,
+            intent_proof_check=intent_proof_check,
+            parent_intent_status={},
+            applicable_intent_status={},
+            durable_residue_action=residue_action,
+        )
         return {
             "status": "unavailable",
             "reason": "planning intent validation is unavailable",
             "strict_closeout_gate": gate,
+            "completion_gate": completion_gate,
             "package_workflow_evidence": _package_workflow_evidence_payload(planning_report=planning_report),
             "intent_satisfaction_check": intent_check,
             "acceptance_criteria_reconciliation": acceptance_reconciliation,
@@ -13413,6 +13697,7 @@ def _report_closeout_trust_payload(
                 status="unavailable",
                 trust="unavailable",
                 strict_gate=gate,
+                completion_gate=completion_gate,
                 intent_check=intent_check,
                 acceptance_reconciliation=acceptance_reconciliation,
                 intent_proof_check=intent_proof_check,
@@ -13512,10 +13797,25 @@ def _report_closeout_trust_payload(
         active_planning_record=active_planning_record,
     )
     residue_action = durable_residue_action(trust=trust)
+    applicable_intent_status = _applicable_intent_status_payload(
+        active_planning_record=raw_active_planning_record,
+        verification=verification,
+        assurance_requirements=assurance_requirements,
+    )
+    completion_gate = _completion_gate_payload(
+        active_planning_record=raw_active_planning_record,
+        intent_check=intent_satisfaction_check,
+        acceptance_reconciliation=acceptance_reconciliation,
+        intent_proof_check=intent_proof_check,
+        parent_intent_status=parent_intent_status,
+        applicable_intent_status=applicable_intent_status,
+        durable_residue_action=residue_action,
+    )
     return {
         "status": "present",
         "trust": trust,
         "strict_closeout_gate": gate,
+        "completion_gate": completion_gate,
         "lower_trust_closeout_count": effective_lower_trust_count,
         "planning_residue_lower_trust_count": lower_trust_closeout_count,
         "package_evidence_lower_trust_count": len(package_absence_signals),
@@ -13544,6 +13844,7 @@ def _report_closeout_trust_payload(
             status="present",
             trust=trust,
             strict_gate=gate,
+            completion_gate=completion_gate,
             intent_check=intent_satisfaction_check,
             acceptance_reconciliation=acceptance_reconciliation,
             intent_proof_check=intent_proof_check,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -13311,6 +13311,14 @@ def _report_closeout_trust_payload(
         gate = strict_gate(trust="unavailable", reason="planning module is not installed", active_planning_record=False)
         intent_check = _intent_satisfaction_check_payload(planning_report={}, target_root=target_root)
         acceptance_reconciliation = _acceptance_criteria_reconciliation_payload(planning_report={})
+        active_intent_contract = _active_intent_contract_payload(task_text=None, acceptance={}, active_planning_record={})
+        intent_satisfaction_matrix = _intent_satisfaction_matrix_payload(
+            active_intent_contract=active_intent_contract,
+            acceptance={},
+            proof={},
+            intent_check=intent_check,
+            parent_intent_status={},
+        )
         intent_proof_check = _intent_proof_check_payload(planning_report={}, target_root=target_root)
         architecture_decision_closeout = _architecture_decision_closeout_payload(planning_report={}, target_root=target_root, config=config)
         assurance_requirements = _assurance_requirements_report_payload(config=config)
@@ -13327,6 +13335,8 @@ def _report_closeout_trust_payload(
             "package_workflow_evidence": _package_workflow_evidence_payload(planning_report={}),
             "intent_satisfaction_check": intent_check,
             "acceptance_criteria_reconciliation": acceptance_reconciliation,
+            "active_intent_contract": active_intent_contract,
+            "intent_satisfaction_matrix": intent_satisfaction_matrix,
             "intent_proof_check": intent_proof_check,
             "proof_confidence": _proof_confidence_payload(intent_proof=intent_proof_check),
             "assurance_requirements": assurance_requirements,
@@ -13358,6 +13368,14 @@ def _report_closeout_trust_payload(
         gate = strict_gate(trust="unavailable", reason="planning intent validation is unavailable", active_planning_record=False)
         intent_check = _intent_satisfaction_check_payload(planning_report=planning_report, target_root=target_root)
         acceptance_reconciliation = _acceptance_criteria_reconciliation_payload(planning_report=planning_report)
+        active_intent_contract = _active_intent_contract_payload(task_text=None, acceptance={}, active_planning_record={})
+        intent_satisfaction_matrix = _intent_satisfaction_matrix_payload(
+            active_intent_contract=active_intent_contract,
+            acceptance={},
+            proof={},
+            intent_check=intent_check,
+            parent_intent_status={},
+        )
         intent_proof_check = _intent_proof_check_payload(planning_report=planning_report, target_root=target_root)
         architecture_decision_closeout = _architecture_decision_closeout_payload(
             planning_report=planning_report, target_root=target_root, config=config
@@ -13376,6 +13394,8 @@ def _report_closeout_trust_payload(
             "package_workflow_evidence": _package_workflow_evidence_payload(planning_report=planning_report),
             "intent_satisfaction_check": intent_check,
             "acceptance_criteria_reconciliation": acceptance_reconciliation,
+            "active_intent_contract": active_intent_contract,
+            "intent_satisfaction_matrix": intent_satisfaction_matrix,
             "intent_proof_check": intent_proof_check,
             "proof_confidence": _proof_confidence_payload(intent_proof=intent_proof_check),
             "assurance_requirements": assurance_requirements,
@@ -13425,6 +13445,25 @@ def _report_closeout_trust_payload(
         if isinstance(planning_report.get("active"), dict)
         else {},
         target_root=target_root,
+    )
+    active_intent_contract = _active_intent_contract_payload(
+        task_text=None,
+        acceptance={},
+        active_planning_record=raw_active_planning_record
+        or (planning_report.get("active", {}).get("planning_record", {}) if isinstance(planning_report.get("active"), dict) else {}),
+    )
+    parent_intent_status = _parent_intent_status_payload(
+        active_planning_record=raw_active_planning_record
+        or (planning_report.get("active", {}).get("planning_record", {}) if isinstance(planning_report.get("active"), dict) else {}),
+        intent_check=intent_satisfaction_check,
+        completion_boundary=intent_satisfaction_check.get("completion_boundary", {}),
+    )
+    intent_satisfaction_matrix = _intent_satisfaction_matrix_payload(
+        active_intent_contract=active_intent_contract,
+        acceptance={},
+        proof={"intent_proof": intent_proof_check},
+        intent_check=intent_satisfaction_check,
+        parent_intent_status=parent_intent_status,
     )
     assurance_requirements = _assurance_requirements_report_payload(
         config=config,
@@ -13488,6 +13527,8 @@ def _report_closeout_trust_payload(
         "package_workflow_evidence": package_workflow_evidence,
         "intent_satisfaction_check": intent_satisfaction_check,
         "acceptance_criteria_reconciliation": acceptance_reconciliation,
+        "active_intent_contract": active_intent_contract,
+        "intent_satisfaction_matrix": intent_satisfaction_matrix,
         "intent_proof_check": intent_proof_check,
         "proof_confidence": _proof_confidence_payload(intent_proof=intent_proof_check),
         "assurance_requirements": assurance_requirements,
@@ -16697,6 +16738,25 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
             )
             if key in payload["applicable_intent_status"]
         }
+    if isinstance(payload.get("active_intent_contract"), dict) and not (
+        isinstance(task_intent, dict) and task_intent.get("task_argument_mode") == "task-file"
+    ):
+        projected["active_intent_contract"] = {
+            "status": payload["active_intent_contract"].get("status"),
+            "source_count": payload["active_intent_contract"].get("source_count"),
+            "update_relationship_options": payload["active_intent_contract"].get("update_relationship_options", []),
+        }
+    if isinstance(payload.get("intent_satisfaction_matrix"), dict):
+        matrix = payload["intent_satisfaction_matrix"]
+        full_claim = _as_dict(matrix.get("full_completion_claim"))
+        projected["intent_satisfaction_matrix"] = {
+            "status": matrix.get("status"),
+            "full_completion_claim": {
+                "allowed": bool(full_claim.get("allowed")),
+                "blocked_by": full_claim.get("blocked_by", []),
+                "rule": "Self-review first; claim only the proven level.",
+            },
+        }
     assurance_requirements = payload.get("assurance_requirements", {})
     if isinstance(assurance_requirements, dict) and int(assurance_requirements.get("active_count", 0) or 0) > 0:
         projected["assurance_requirements"] = _compact_assurance_requirements(assurance_requirements)
@@ -17528,6 +17588,22 @@ def _start_payload(
         and not _is_prep_only_handoff_task(task_text)
     ):
         payload["intent_evidence"] = intent_evidence
+    active_intent_contract = _active_intent_contract_payload(
+        task_text=task_text,
+        acceptance=task_intent.get("acceptance", {}) if isinstance(task_intent, dict) else {},
+        active_planning_record=active_parent_record,
+        issue_reference_intent=issue_reference_intent,
+    )
+    intent_satisfaction_matrix = _intent_satisfaction_matrix_payload(
+        active_intent_contract=active_intent_contract,
+        acceptance=task_intent.get("acceptance", {}) if isinstance(task_intent, dict) else {},
+        proof=payload.get("proof", {}),
+        intent_check={},
+        parent_intent_status=parent_intent_status,
+    )
+    if active_intent_contract["status"] == "present":
+        payload["active_intent_contract"] = active_intent_contract
+        payload["intent_satisfaction_matrix"] = intent_satisfaction_matrix
     if (
         intent_discovery.get("status") == "ask-human"
         and not active_planning_present
@@ -17849,6 +17925,8 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "intent_discovery_dialogue",
         "intent_acknowledgement",
         "intent_evidence",
+        "active_intent_contract",
+        "intent_satisfaction_matrix",
         "issue_reference_intent",
         "workflow_sufficiency",
         "next_safe_action",
@@ -17881,6 +17959,8 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "context.intent_discovery_dialogue",
         "context.intent_acknowledgement",
         "context.intent_evidence",
+        "context.active_intent_contract",
+        "context.intent_satisfaction_matrix",
         "context.issue_reference_intent",
         "context.workflow_sufficiency",
         "context.guidance",
@@ -18165,6 +18245,25 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                 "closeout_blocked",
             )
             if key in payload["applicable_intent_status"]
+        }
+    if isinstance(payload.get("active_intent_contract"), dict) and not (
+        isinstance(payload.get("task_intent"), dict) and payload["task_intent"].get("task_argument_mode") == "task-file"
+    ):
+        context["active_intent_contract"] = {
+            "status": payload["active_intent_contract"].get("status"),
+            "source_count": payload["active_intent_contract"].get("source_count"),
+            "update_relationship_options": payload["active_intent_contract"].get("update_relationship_options", []),
+        }
+    if isinstance(payload.get("intent_satisfaction_matrix"), dict):
+        matrix = payload["intent_satisfaction_matrix"]
+        full_claim = _as_dict(matrix.get("full_completion_claim"))
+        context["intent_satisfaction_matrix"] = {
+            "status": matrix.get("status"),
+            "full_completion_claim": {
+                "allowed": bool(full_claim.get("allowed")),
+                "blocked_by": full_claim.get("blocked_by", []),
+                "rule": "Self-review first; claim only the proven level.",
+            },
         }
     uv_guidance = payload.get("uv_cache_guidance", {})
     if not (isinstance(uv_guidance, dict) and uv_guidance.get("status") == "available"):
@@ -18540,6 +18639,21 @@ def _start_tiny_payload_fast(
         and not _is_prep_only_handoff_task(task_text)
     ):
         payload["intent_evidence"] = intent_evidence
+    active_intent_contract = _active_intent_contract_payload(
+        task_text=task_text,
+        acceptance=task_intent.get("acceptance", {}) if isinstance(task_intent, dict) else {},
+        active_planning_record=active_parent_record,
+    )
+    intent_satisfaction_matrix = _intent_satisfaction_matrix_payload(
+        active_intent_contract=active_intent_contract,
+        acceptance=task_intent.get("acceptance", {}) if isinstance(task_intent, dict) else {},
+        proof=payload.get("proof", {}),
+        intent_check={},
+        parent_intent_status=parent_intent_status,
+    )
+    if active_intent_contract["status"] == "present":
+        payload["active_intent_contract"] = active_intent_contract
+        payload["intent_satisfaction_matrix"] = intent_satisfaction_matrix
     if (
         intent_discovery.get("status") == "ask-human"
         and not active_planning_present
@@ -19524,6 +19638,211 @@ def _task_acceptance_payload(*, task_text: str | None, requested_outcomes: list[
         else "Provide task intent before closeout if acceptance is not obvious from the changed scope.",
         "proof_rule": "Proof should demonstrate acceptance satisfaction, not only command success.",
         "unresolved_questions": [],
+    }
+
+
+def _active_intent_contract_payload(
+    *,
+    task_text: str | None,
+    acceptance: dict[str, Any] | None = None,
+    active_planning_record: dict[str, Any] | None = None,
+    issue_reference_intent: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    task = " ".join(str(task_text or "").split())
+    acceptance = _as_dict(acceptance)
+    active_planning_record = _as_dict(active_planning_record)
+    issue_reference_intent = _as_dict(issue_reference_intent)
+    sources: list[dict[str, Any]] = []
+    if task:
+        sources.append(
+            {
+                "kind": "chat-task",
+                "authority": "current-user-instruction",
+                "summary": _task_excerpt(task, limit=220),
+            }
+        )
+    planning_intent = _as_dict(active_planning_record.get("intent_satisfaction"))
+    planning_original_intent = str(planning_intent.get("original intent", "")).strip()
+    delegated = _as_dict(active_planning_record.get("delegated_judgment"))
+    delegated_outcome = str(delegated.get("requested outcome") or delegated.get("requested_outcome") or "").strip()
+    if planning_original_intent or delegated_outcome:
+        sources.append(
+            {
+                "kind": "planning-record",
+                "authority": "checked-in-planning",
+                "summary": planning_original_intent or delegated_outcome,
+            }
+        )
+    issue_refs = issue_reference_intent.get("issue_refs", [])
+    if not issue_refs:
+        issue_refs = re.findall(r"#\d+\b", task)
+    if issue_refs:
+        sources.append(
+            {
+                "kind": "external-reference",
+                "authority": "requires-refresh-or-cited-evidence",
+                "refs": [str(item) for item in _list_payload(issue_refs)],
+                "summary": "External references may carry intent; cite refreshed evidence before closing issue-backed scope.",
+            }
+        )
+    requested_outcomes = [str(item).strip() for item in _list_payload(acceptance.get("requested_outcomes")) if str(item).strip()]
+    acceptance_items = [item for item in _list_payload(acceptance.get("items")) if isinstance(item, dict)]
+    if not requested_outcomes and task:
+        requested_outcomes = [_task_excerpt(task, limit=180)]
+    return {
+        "kind": "agentic-workspace/active-intent-contract/v1",
+        "status": "present" if sources else "absent",
+        "controlling_sources": sources,
+        "source_count": len(sources),
+        "requested_outcomes": requested_outcomes[:8],
+        "acceptance_item_count": len(acceptance_items),
+        "update_relationship_options": [
+            "supersede",
+            "refine",
+            "constrain",
+            "narrow",
+            "reopen",
+            "branch",
+        ],
+        "later_instruction_rule": (
+            "When a later chat instruction changes the work, the agent must state whether it supersedes, refines, "
+            "constrains, narrows, reopens, or branches the active intent before claiming completion."
+        ),
+        "artifact_agnostic_rule": "Intent may come from chat, issue, PR/review comment, file, plan, or mixed sources; GitHub is optional evidence, not the owner model.",
+        "authority_boundary": _authority_boundary_payload(
+            surface="active_intent_contract",
+            observed_by_aw=[
+                f"task_text_available={bool(task)}",
+                f"planning_record_available={bool(active_planning_record)}",
+                f"source_count={len(sources)}",
+            ],
+            recommended_by_aw=["carry this contract into implement/proof/closeout before completion claims"],
+            agent_owned_decisions=[
+                "semantic interpretation of the controlling intent",
+                "relationship between later chat instructions and existing intent",
+                "claim level supported by delivered evidence",
+            ],
+            human_owned_decisions=["acceptance of narrowed, deferred, or branched intent"],
+            rule="AW preserves intent sources and required claim-boundary structure; it does not decide semantic satisfaction.",
+        ),
+    }
+
+
+def _intent_satisfaction_matrix_payload(
+    *,
+    active_intent_contract: dict[str, Any],
+    acceptance: dict[str, Any] | None = None,
+    proof: dict[str, Any] | None = None,
+    intent_check: dict[str, Any] | None = None,
+    parent_intent_status: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    contract = _as_dict(active_intent_contract)
+    acceptance = _as_dict(acceptance)
+    proof = _as_dict(proof)
+    intent_check = _as_dict(intent_check)
+    parent_intent_status = _as_dict(parent_intent_status)
+    items: list[dict[str, Any]] = []
+    for source in _list_payload(contract.get("controlling_sources")):
+        if not isinstance(source, dict):
+            continue
+        summary = str(source.get("summary") or "").strip()
+        if summary:
+            items.append(
+                {
+                    "intent_item": summary,
+                    "source": str(source.get("kind") or "intent-source"),
+                    "status": "needs-agent-evidence",
+                    "evidence_required": "Map delivered behavior or explicit deferral to this source before claiming completion.",
+                }
+            )
+    for item in _list_payload(acceptance.get("items")):
+        if not isinstance(item, dict):
+            continue
+        expectation = str(item.get("expectation") or "").strip()
+        if expectation:
+            items.append(
+                {
+                    "intent_item": expectation,
+                    "source": str(item.get("source") or "acceptance"),
+                    "status": str(item.get("status") or "unchecked"),
+                    "evidence_required": str(item.get("proof_hint") or "Name delivered behavior, proof, and any gap."),
+                }
+            )
+    if not items and contract.get("status") == "absent":
+        items.append(
+            {
+                "intent_item": "No active task intent was supplied to this AW surface.",
+                "source": "none",
+                "status": "not-applicable",
+                "evidence_required": "Pass --task or cite planning evidence before making task-satisfaction claims.",
+            }
+        )
+    intent_trust = str(intent_check.get("trust") or "").strip()
+    parent_status = str(parent_intent_status.get("status") or "").strip()
+    proof_claim_boundary = str(_as_dict(proof.get("intent_proof")).get("claim_boundary") or "").strip()
+    blocked_by = []
+    if any(str(item.get("status") or "").strip() in {"unchecked", "needs-agent-evidence"} for item in items):
+        blocked_by.append("satisfaction_matrix.items")
+    if intent_trust in {"follow-up-required", "needs-review"}:
+        blocked_by.append("closeout_trust.intent_satisfaction_check")
+    if parent_status in {"open", "needs-planning", "needs-review"}:
+        blocked_by.append("parent_intent_status")
+    if proof_claim_boundary and proof_claim_boundary not in {"work", "broad-work", "parent", "full-intent"}:
+        blocked_by.append("proof.intent_proof.claim_boundary")
+    full_completion_allowed = not blocked_by and bool(items)
+    return {
+        "kind": "agentic-workspace/intent-satisfaction-matrix/v1",
+        "status": "required-before-completion-claim" if contract.get("status") == "present" else "available-when-intent-known",
+        "claim_levels": [
+            "partial-progress",
+            "slice-complete",
+            "lane-complete",
+            "parent-complete",
+            "full-intent-complete",
+        ],
+        "items": items[:12],
+        "full_completion_claim": {
+            "allowed": full_completion_allowed,
+            "blocked_by": _dedupe(blocked_by),
+            "rule": (
+                "Do not say done, finished, complete, closes, or all unless the stated claim level matches matrix evidence; "
+                "use partial/slice/deferred wording when any item is unproven or explicitly deferred."
+            ),
+        },
+        "matrix_closeout_shape": [
+            "intent item",
+            "delivered behavior or explicit deferral",
+            "proof/evidence",
+            "gap or intentional deviation",
+            "claim level supported",
+        ],
+        "self_review_before_final_claim": {
+            "status": "required",
+            "rule": (
+                "Before final response, review your own result as if a delegated subagent returned it: compare the "
+                "original intent, delivered behavior, evidence, gaps, and claim level before saying done."
+            ),
+            "questions": [
+                "Did the result satisfy the original intent rather than a convenient slice?",
+                "Is every completion claim supported by evidence or explicitly caveated?",
+                "Would a reviewer reject the final wording as overclaiming?",
+            ],
+        },
+        "authority_boundary": _authority_boundary_payload(
+            surface="intent_satisfaction_matrix",
+            observed_by_aw=[
+                f"intent_item_count={len(items)}",
+                f"blocked_by_count={len(_dedupe(blocked_by))}",
+            ],
+            recommended_by_aw=["render a compact satisfaction matrix before broad completion claims"],
+            agent_owned_decisions=[
+                "whether evidence satisfies each semantic intent item",
+                "which completion claim level is honest",
+                "whether a gap is acceptable, deferred, or blocking",
+            ],
+            human_owned_decisions=["acceptance of partial completion, deferral, or parent/full closure"],
+            rule="AW exposes the matrix shape and mechanical blockers; the agent owns semantic satisfaction judgments.",
+        ),
     }
 
 
@@ -21792,6 +22111,18 @@ def _implement_payload(
         generated_surface_trust=generated_surface_trust,
     )
     applicable_intent_status = _applicable_intent_status_payload(active_planning_record=active_planning_record_for_intent)
+    active_intent_contract = _active_intent_contract_payload(
+        task_text=task_text,
+        acceptance=acceptance,
+        active_planning_record=active_planning_record_for_intent,
+    )
+    intent_satisfaction_matrix = _intent_satisfaction_matrix_payload(
+        active_intent_contract=active_intent_contract,
+        acceptance=acceptance,
+        proof=proof,
+        intent_check={},
+        parent_intent_status=parent_intent_status,
+    )
     implement_current_need = "changed-path-implementation" if normalized_paths else "unknown-scope-routing"
     payload = {
         "kind": "implementer-context/v1",
@@ -21878,6 +22209,8 @@ def _implement_payload(
         "acceptance_reconciliation": _acceptance_reconciliation_prompt_payload(task_text=task_text, acceptance=acceptance),
         "intent_acknowledgement": intent_acknowledgement,
         "intent_evidence": intent_evidence,
+        "active_intent_contract": active_intent_contract,
+        "intent_satisfaction_matrix": intent_satisfaction_matrix,
         "parent_intent_status": parent_intent_status,
         "applicable_intent_status": applicable_intent_status,
         "objective_drift": _objective_drift_payload(target_root=target_root, changed_paths=normalized_paths, task_text=task_text),
@@ -22178,6 +22511,21 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 else [],
             },
             "intent_evidence": _compact_intent_evidence(payload.get("intent_evidence", {})),
+            "active_intent_contract": {
+                "status": payload.get("active_intent_contract", {}).get("status"),
+                "source_count": payload.get("active_intent_contract", {}).get("source_count"),
+                "update_relationship_options": payload.get("active_intent_contract", {}).get("update_relationship_options", []),
+            },
+            "intent_satisfaction_matrix": {
+                "status": payload.get("intent_satisfaction_matrix", {}).get("status"),
+                "full_completion_claim": {
+                    "allowed": bool(_as_dict(payload.get("intent_satisfaction_matrix", {}).get("full_completion_claim")).get("allowed")),
+                    "blocked_by": _as_dict(payload.get("intent_satisfaction_matrix", {}).get("full_completion_claim")).get(
+                        "blocked_by", []
+                    ),
+                    "rule": "Self-review first; claim only the proven level.",
+                },
+            },
             "parent_intent_status": {
                 key: payload.get("parent_intent_status", {}).get(key)
                 for key in (
@@ -22241,6 +22589,8 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "context.workflow_sufficiency",
                 "context.acceptance",
                 "context.intent_evidence",
+                "context.active_intent_contract",
+                "context.intent_satisfaction_matrix",
                 "context.parent_intent_status",
                 "context.applicable_intent_status",
                 "context.acceptance_reconciliation",
@@ -22259,6 +22609,16 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             ],
         },
     }
+    if isinstance(payload.get("generated_surface_trust"), dict) and payload["generated_surface_trust"].get("status") == "present":
+        tiny_context = projected.get("context", {})
+        if isinstance(tiny_context, dict):
+            tiny_context.pop("active_intent_contract", None)
+            tiny_context.pop("intent_satisfaction_matrix", None)
+        selectors = projected.get("drill_down", {}).get("available_selectors", [])
+        if isinstance(selectors, list):
+            projected["drill_down"]["available_selectors"] = [
+                item for item in selectors if item not in {"context.active_intent_contract", "context.intent_satisfaction_matrix"}
+            ]
     tiny_context = projected.get("context", {})
     if isinstance(tiny_context, dict):
         parent_packet = tiny_context.get("parent_intent_status", {})

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -9089,6 +9089,7 @@ def _closeout_report_final_response_rendering_payload(
     applicable_intent_status = _as_dict(applicable_intent_status)
     workflow_obligation_contract = _as_dict(workflow_obligation_contract)
     completion_gate = _as_dict(completion_gate)
+    gate_claim_authorization = _as_dict(completion_gate.get("claim_authorization"))
     review_contract = _closeout_report_review_mode_contract(review_mode or "small-direct-edit")
     obligation_items = [item for item in _list_payload(workflow_obligation_contract.get("items")) if isinstance(item, dict)]
     required_obligations = [
@@ -9101,6 +9102,11 @@ def _closeout_report_final_response_rendering_payload(
 
     def present(text: str) -> str:
         return text.strip() if text and text.strip().lower() not in {"none", "null", "unknown"} else ""
+
+    def claim_authorized(claim_class: str) -> bool:
+        return claim_class in {
+            str(item).strip() for item in _list_payload(gate_claim_authorization.get("allowed_claim_classes")) if str(item).strip()
+        }
 
     def rendered_summary_payload(
         *,
@@ -9167,6 +9173,14 @@ def _closeout_report_final_response_rendering_payload(
                 "must_not_claim": must_not_claim,
                 "plain_done_allowed": plain_done_allowed,
                 "raw_json_allowed": False,
+                "claim_authorization": {
+                    "allowed_claim_classes": _list_payload(gate_claim_authorization.get("allowed_claim_classes")),
+                    "blocked_claim_classes": _list_payload(gate_claim_authorization.get("blocked_claim_classes")),
+                    "closure_actions": _list_payload(gate_claim_authorization.get("closure_actions")),
+                    "renderer_rule": gate_claim_authorization.get("renderer_rule", ""),
+                }
+                if gate_claim_authorization
+                else {},
             },
             "warnings": warnings,
             "boundary": "Derived final-response presentation; canonical truth remains in closeout_report and its source fields.",
@@ -9288,6 +9302,13 @@ def _closeout_report_final_response_rendering_payload(
                 "omit empty optional sections",
                 "terse vs evidence-backed wording density",
             ],
+            "claim_authorization": {
+                "allowed_claim_classes": _list_payload(gate_claim_authorization.get("allowed_claim_classes")),
+                "blocked_claim_classes": _list_payload(gate_claim_authorization.get("blocked_claim_classes")),
+                "closure_actions": _list_payload(gate_claim_authorization.get("closure_actions")),
+            }
+            if gate_claim_authorization
+            else {},
             "rule": (
                 "Use this as the final chat-response scaffold when closeout details matter; keep canonical truth in "
                 "closeout_report fields and do not paste raw JSON."
@@ -9307,6 +9328,10 @@ def _closeout_report_final_response_rendering_payload(
     gate_status = present(str(completion_gate.get("status") or ""))
     gate_blocks_full = gate_status in {"blocked", "continue-required", "clarification-required"}
     gate_partial = gate_status == "human-accepted-partial"
+    gate_blocks_full_claim_class = bool(gate_claim_authorization) and not claim_authorized("full_intent_complete")
+    gate_blocks_issue_closure = bool(_list_payload(gate_claim_authorization.get("closure_actions"))) and not claim_authorized(
+        "issue_closure"
+    )
 
     if guidance_only and not has_material_guidance_signal:
         rendering_mode = "terse"
@@ -9441,15 +9466,23 @@ def _closeout_report_final_response_rendering_payload(
 
     if gate_blocks_full or gate_partial:
         must_include.append("completion gate")
-        blocked_claims = [str(item).strip() for item in _list_payload(completion_gate.get("blocked_claims")) if str(item).strip()]
-        if blocked_claims:
-            must_not_claim.extend(blocked_claims)
+        diagnostics = _as_dict(gate_claim_authorization.get("diagnostics"))
+        unsafe_examples = [str(item).strip() for item in _list_payload(diagnostics.get("unsafe_claim_examples")) if str(item).strip()]
+        if unsafe_examples:
+            must_not_claim.extend(f"Diagnostic unsafe claim example only, not enforcement rule: {item}" for item in unsafe_examples)
         self_review = _as_dict(completion_gate.get("self_review"))
         gate_reason = present(str(self_review.get("reason") or completion_gate.get("residual_intent") or ""))
+        allowed_claim_classes = [
+            str(item) for item in _list_payload(gate_claim_authorization.get("allowed_claim_classes")) if str(item).strip()
+        ]
+        blocked_claim_classes = [
+            str(item) for item in _list_payload(gate_claim_authorization.get("blocked_claim_classes")) if str(item).strip()
+        ]
         summary_lines.append(
             "Completion gate: "
             + gate_status
-            + f"; allowed claim: {completion_gate.get('claim_level_allowed') or 'partial-progress'}"
+            + f"; allowed claim classes: {', '.join(allowed_claim_classes) or 'none'}"
+            + f"; blocked claim classes: {', '.join(blocked_claim_classes) or 'none'}"
             + f"; next: {completion_gate.get('required_next_action') or 'continue'}"
             + (f"; reason: {gate_reason}" if gate_reason else "")
         )
@@ -9537,6 +9570,8 @@ def _closeout_report_final_response_rendering_payload(
             or workflow_obligations_block_done
             or gate_blocks_full
             or gate_partial
+            or gate_blocks_full_claim_class
+            or gate_blocks_issue_closure
         )
         else "available"
     )
@@ -9549,6 +9584,8 @@ def _closeout_report_final_response_rendering_payload(
         or workflow_obligations_block_done
         or gate_blocks_full
         or gate_partial
+        or gate_blocks_full_claim_class
+        or gate_blocks_issue_closure
     )
     summary_lines = summary_lines[:10]
     unique_must_include = list(dict.fromkeys(must_include))
@@ -13010,6 +13047,7 @@ def _completion_option(
     command: str | None = None,
     owner: str | None = None,
     blocking_fields: list[str] | None = None,
+    required_claim_class: str | None = None,
 ) -> dict[str, Any]:
     if option_id not in _COMPLETION_OPTION_IDS:
         raise ValueError(f"unknown completion option id: {option_id}")
@@ -13020,6 +13058,8 @@ def _completion_option(
         item["owner"] = owner
     if blocking_fields:
         item["blocking_fields"] = blocking_fields
+    if required_claim_class:
+        item["required_claim_class"] = required_claim_class
     return item
 
 
@@ -13058,6 +13098,14 @@ def _closeout_completion_options(
     intent_proof_check = intent_proof_check if isinstance(intent_proof_check, dict) else {}
     completion_gate = completion_gate if isinstance(completion_gate, dict) else {}
     completion_gate_status = str(completion_gate.get("status", "")).strip()
+    claim_authorization = _as_dict(completion_gate.get("claim_authorization"))
+    allowed_claim_classes = {
+        str(item).strip() for item in _list_payload(claim_authorization.get("allowed_claim_classes")) if str(item).strip()
+    }
+
+    def structured_claim_authorized(claim_class: str) -> bool:
+        return not claim_authorization or claim_class in allowed_claim_classes
+
     completion_gate_blocks_full = completion_gate_status in {
         "blocked",
         "continue-required",
@@ -13144,6 +13192,7 @@ def _closeout_completion_options(
         and not intent_proof_needs_review
         and not unsupported_preservation
         and not assurance_claim_blockers.get("claim-slice-complete")
+        and structured_claim_authorized("slice_complete")
     )
     claim_work_allowed = (
         claim_slice_allowed
@@ -13152,8 +13201,14 @@ def _closeout_completion_options(
         and intent_proof_supports_work
         and not completion_gate_blocks_full
         and not assurance_claim_blockers.get("claim-work-complete")
+        and structured_claim_authorized("full_intent_complete")
     )
-    close_parent_allowed = claim_work_allowed and close_evidence and not assurance_claim_blockers.get("close-parent-lane")
+    close_parent_allowed = (
+        claim_work_allowed
+        and close_evidence
+        and not assurance_claim_blockers.get("close-parent-lane")
+        and structured_claim_authorized("parent_complete")
+    )
     route_residue_command = str(durable_residue_action.get("command", "")) or _command_with_cli_invoke(
         command="agentic-workspace report --target ./repo --section closeout_trust --format json", cli_invoke=cli_invoke
     )
@@ -13182,6 +13237,7 @@ def _closeout_completion_options(
             if claim_slice_allowed
             else "slice completion is blocked until proof, strict closeout, acceptance, and residue evidence are reconciled",
             blocking_fields=slice_blockers or None,
+            required_claim_class="slice_complete",
         ),
         _completion_option(
             "claim-work-complete",
@@ -13191,6 +13247,7 @@ def _closeout_completion_options(
             else "work completion is blocked until proof, intent, residue, continuation, and closeout evidence support it",
             owner=continuation_owner if larger_intent_open else None,
             blocking_fields=work_blockers or None,
+            required_claim_class="full_intent_complete",
         ),
         _completion_option(
             "keep-parent-open",
@@ -13209,6 +13266,7 @@ def _closeout_completion_options(
             else "parent lane closure requires satisfied larger intent and explicit closure evidence",
             owner=continuation_owner if larger_intent_open else None,
             blocking_fields=parent_blockers if parent_blockers else ["intent_satisfaction.closure_scope.larger_intent_closure"],
+            required_claim_class="parent_complete",
         ),
         _completion_option(
             "route-residue",
@@ -13243,6 +13301,83 @@ def _closeout_completion_options(
             ),
         ),
     ]
+
+
+def _completion_gate_claim_authorization(
+    *,
+    status: str,
+    active_intent_satisfied: bool,
+    human_accepted_partial: bool,
+    claim_level_requested: str,
+    proof_status: str = "",
+    issue_refs: set[str],
+) -> dict[str, Any]:
+    all_claim_classes = [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure",
+    ]
+    rank = {
+        "partial_progress": 0,
+        "slice_complete": 1,
+        "slice": 1,
+        "lane_complete": 2,
+        "lane": 2,
+        "parent_complete": 3,
+        "parent": 3,
+        "full_intent_complete": 4,
+        "work_complete": 4,
+        "full": 4,
+    }
+    requested = str(claim_level_requested or "full-intent-complete").strip().lower().replace("-", "_")
+    requested_rank = rank.get(requested, 4)
+    proof_records_slice = proof_status in {
+        "regression_only",
+        "regression-only",
+        "representative",
+        "sufficient_for_claim",
+        "sufficient-for-claim",
+    }
+    if active_intent_satisfied:
+        allowed_claim_classes = [claim for claim in all_claim_classes if claim != "issue_closure" and rank.get(claim, 5) <= requested_rank]
+        if requested_rank >= rank["full_intent_complete"] and issue_refs:
+            allowed_claim_classes.append("issue_closure")
+    elif proof_records_slice and status in {"blocked", "continue-required"} and not human_accepted_partial:
+        allowed_claim_classes = ["partial_progress", "slice_complete"]
+    elif human_accepted_partial or status == "continue-required":
+        allowed_claim_classes = ["partial_progress"]
+    else:
+        allowed_claim_classes = []
+    blocked_claim_classes = [claim for claim in all_claim_classes if claim not in allowed_claim_classes]
+    closure_actions = [
+        {
+            "kind": "issue_closure",
+            "target": ref,
+            "authorized": "issue_closure" in allowed_claim_classes,
+            "reason": "issue closure requires full-intent completion authorization from the completion gate",
+        }
+        for ref in sorted(issue_refs)
+    ]
+    unsafe_examples = [] if active_intent_satisfied else ["done", "implemented", "complete", "finished", "all", "full intent complete"]
+    if not active_intent_satisfied:
+        unsafe_examples.extend(f"Closes {ref}" for ref in sorted(issue_refs))
+    return {
+        "kind": "agentic-workspace/claim-authorization/v1",
+        "allowed_claim_classes": allowed_claim_classes,
+        "blocked_claim_classes": blocked_claim_classes,
+        "closure_actions": closure_actions,
+        "renderer_rule": (
+            "Renderers must choose only templates whose required claim class and closure action are authorized here; "
+            "unsafe prose examples are diagnostics, not the enforcement model."
+        ),
+        "diagnostics": {
+            "unsafe_claim_examples": _dedupe(unsafe_examples),
+            "diagnostic_only": True,
+        },
+    }
 
 
 def _completion_gate_payload(
@@ -13367,20 +13502,27 @@ def _completion_gate_payload(
     issue_refs: set[str] = set()
     for reference in _list_payload(active_planning_record.get("references")):
         if isinstance(reference, dict):
-            issue_refs.update(_issue_refs_from_text(reference.get("target")))
-            issue_refs.update(_issue_refs_from_text(reference.get("url")))
-            issue_refs.update(_issue_refs_from_text(reference.get("role")))
+            issue_refs.update(_issue_refs_from_text(str(reference.get("target") or "")))
+            issue_refs.update(_issue_refs_from_text(str(reference.get("url") or "")))
+            issue_refs.update(_issue_refs_from_text(str(reference.get("role") or "")))
         else:
-            issue_refs.update(_issue_refs_from_text(reference))
+            issue_refs.update(_issue_refs_from_text(str(reference or "")))
     for value in (
         active_planning_record.get("title"),
         present(intent_satisfaction.get("original intent"), parent_intent_status.get("original_intent")),
         present(closure_check.get("closure target"), closure_check.get("closure_target")),
     ):
-        issue_refs.update(_issue_refs_from_text(value))
-    blocked_claims = [] if active_intent_satisfied else ["done", "implemented", "complete", "finished", "all", "full intent complete"]
-    if not active_intent_satisfied:
-        blocked_claims.extend(f"Closes {ref}" for ref in sorted(issue_refs))
+        issue_refs.update(_issue_refs_from_text(str(value or "")))
+    claim_authorization = _completion_gate_claim_authorization(
+        status=status,
+        active_intent_satisfied=active_intent_satisfied,
+        human_accepted_partial=human_accepted_partial,
+        claim_level_requested=claim_level_requested,
+        proof_status=proof_status,
+        issue_refs=issue_refs,
+    )
+    diagnostic_unsafe_claims = _list_payload(claim_authorization.get("diagnostics", {}).get("unsafe_claim_examples"))
+    blocked_claims = [] if active_intent_satisfied else [str(item) for item in diagnostic_unsafe_claims if str(item).strip()]
     self_review_answer = "yes" if active_intent_satisfied else "no"
     if active_intent_satisfied:
         reason = "Recorded intent, parent status, proof, acceptance, and continuation fields support the requested completion claim."
@@ -13399,6 +13541,7 @@ def _completion_gate_payload(
         "claim_level_requested": claim_level_requested,
         "claim_level_allowed": claim_level_allowed,
         "required_next_action": required_next_action,
+        "claim_authorization": claim_authorization,
         "blocked_claims": _dedupe(blocked_claims),
         "residual_intent": "" if active_intent_satisfied else residual_intent,
         "self_review": {
@@ -13423,7 +13566,7 @@ def _completion_gate_payload(
             "surface": "completion_gate",
             "aw_owns": [
                 "forcing the transition rule",
-                "blocking unsupported claim language",
+                "blocking unsupported structured claim classes and closure actions",
                 "routing continuation",
             ],
             "agent_owns": [

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -13521,8 +13521,6 @@ def _completion_gate_payload(
         proof_status=proof_status,
         issue_refs=issue_refs,
     )
-    diagnostic_unsafe_claims = _list_payload(claim_authorization.get("diagnostics", {}).get("unsafe_claim_examples"))
-    blocked_claims = [] if active_intent_satisfied else [str(item) for item in diagnostic_unsafe_claims if str(item).strip()]
     self_review_answer = "yes" if active_intent_satisfied else "no"
     if active_intent_satisfied:
         reason = "Recorded intent, parent status, proof, acceptance, and continuation fields support the requested completion claim."
@@ -13542,7 +13540,6 @@ def _completion_gate_payload(
         "claim_level_allowed": claim_level_allowed,
         "required_next_action": required_next_action,
         "claim_authorization": claim_authorization,
-        "blocked_claims": _dedupe(blocked_claims),
         "residual_intent": "" if active_intent_satisfied else residual_intent,
         "self_review": {
             "question": "Does the delivered work satisfy the active human intent?",

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1158,6 +1158,48 @@ def test_implement_surfaces_runtime_source_edit_review_for_generated_cli_boundar
     assert "proof.runtime_source_edit_review" in payload["drill_down"]["available_selectors"]
 
 
+def test_implement_surfaces_active_intent_contract_for_refined_chat_instruction(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
+
+    task = (
+        "Previously convert some tests, but now replace most existing tests with contract-owned tests; "
+        "do not claim the parent lane complete unless the replacement is representative."
+    )
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_primitives.py",
+                "--task",
+                task,
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    context = _implement_context(payload)
+    contract = context["active_intent_contract"]
+    assert contract["status"] == "present"
+    assert contract["source_count"] == 1
+    assert "supersede" in contract["update_relationship_options"]
+    matrix = context["intent_satisfaction_matrix"]
+    assert matrix["status"] == "required-before-completion-claim"
+    assert matrix["full_completion_claim"]["allowed"] is False
+    assert "satisfaction_matrix.items" in matrix["full_completion_claim"]["blocked_by"]
+    assert "Self-review first" in matrix["full_completion_claim"]["rule"]
+    assert "proven level" in matrix["full_completion_claim"]["rule"]
+    assert "context.active_intent_contract" in payload["drill_down"]["available_selectors"]
+    assert "context.intent_satisfaction_matrix" in payload["drill_down"]["available_selectors"]
+
+
 def test_implement_detail_commands_use_resolved_cli_invoke(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1158,7 +1158,7 @@ def test_implement_surfaces_runtime_source_edit_review_for_generated_cli_boundar
     assert "proof.runtime_source_edit_review" in payload["drill_down"]["available_selectors"]
 
 
-def test_implement_surfaces_active_intent_contract_for_refined_chat_instruction(tmp_path: Path, capsys) -> None:
+def test_implement_keeps_active_intent_packets_selector_only(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
     _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
@@ -1186,18 +1186,39 @@ def test_implement_surfaces_active_intent_contract_for_refined_chat_instruction(
 
     payload = json.loads(capsys.readouterr().out)
     context = _implement_context(payload)
-    contract = context["active_intent_contract"]
+    assert "active_intent_contract" not in context
+    assert "intent_satisfaction_matrix" not in context
+    assert "active_intent_contract" in payload["drill_down"]["available_selectors"]
+    assert "intent_satisfaction_matrix" in payload["drill_down"]["available_selectors"]
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_primitives.py",
+                "--task",
+                task,
+                "--select",
+                "active_intent_contract,intent_satisfaction_matrix",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    selected = json.loads(capsys.readouterr().out)
+    contract = selected["values"]["active_intent_contract"]
+    assert contract["kind"] == "agentic-workspace/active-intent-contract/v1"
     assert contract["status"] == "present"
     assert contract["source_count"] == 1
     assert "supersede" in contract["update_relationship_options"]
-    matrix = context["intent_satisfaction_matrix"]
+    matrix = selected["values"]["intent_satisfaction_matrix"]
+    assert matrix["kind"] == "agentic-workspace/intent-satisfaction-matrix/v1"
     assert matrix["status"] == "required-before-completion-claim"
-    assert matrix["full_completion_claim"]["allowed"] is False
-    assert "satisfaction_matrix.items" in matrix["full_completion_claim"]["blocked_by"]
-    assert "Self-review first" in matrix["full_completion_claim"]["rule"]
-    assert "proven level" in matrix["full_completion_claim"]["rule"]
-    assert "context.active_intent_contract" in payload["drill_down"]["available_selectors"]
-    assert "context.intent_satisfaction_matrix" in payload["drill_down"]["available_selectors"]
+    assert "full-intent-complete" in matrix["claim_levels"]
 
 
 def test_implement_detail_commands_use_resolved_cli_invoke(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -3384,6 +3384,8 @@ def test_report_completion_gate_blocks_1379_style_overclosure(tmp_path: Path, ca
     assert gate["claim_level_requested"] == "full-intent-complete"
     assert gate["claim_level_allowed"] == "partial-progress"
     assert gate["required_next_action"] == "create-follow-on-plan"
+    for blocked in ("done", "implemented", "complete", "finished", "all", "full intent complete"):
+        assert blocked in gate["blocked_claims"]
     assert "Closes #1374" in gate["blocked_claims"]
     assert gate["self_review"]["answer"] == "no"
     assert gate["continuation"]["owner_surface"] == ".agentic-workspace/planning/execplans/issue-1374-follow-up.plan.json"
@@ -3398,6 +3400,8 @@ def test_report_completion_gate_blocks_1379_style_overclosure(tmp_path: Path, ca
     assert rendering["plain_done_allowed"] is False
     assert "completion gate" in rendering["must_include"]
     assert "Closes #1374" in rendering["must_not_claim"]
+    for blocked in ("complete", "finished", "all"):
+        assert blocked in rendering["must_not_claim"]
     assert "Completion gate: continue-required" in rendering["rendered_summary"]["rendered_text"]
 
 
@@ -3527,6 +3531,39 @@ def test_report_completion_gate_allows_satisfied_intent_full_closeout(tmp_path: 
     assert gate["blocked_claims"] == []
     options = {option["id"]: option for option in closeout["completion_options"]}
     assert options["claim-work-complete"]["allowed"] is True
+
+
+def test_report_completion_gate_blocks_full_closeout_when_proof_missing(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write_completion_gate_fixture(
+        target,
+        plan_id="missing-proof-gate",
+        original_intent="Complete the direct contract migration.",
+        delivered_work="Completed the direct contract migration.",
+        slice_completes="yes",
+        required_follow_on="no",
+        continuation_owner="none",
+        closure_status="closed",
+        closure_decision="archive-and-close",
+        proof_status="not_recorded",
+        claim_boundary="work",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+
+    closeout = json.loads(capsys.readouterr().out)["answer"]
+    gate = closeout["completion_gate"]
+    assert gate["active_intent_satisfied"] is False
+    assert gate["status"] == "blocked"
+    assert gate["claim_level_allowed"] == "partial-progress"
+    for blocked in ("done", "implemented", "complete", "finished", "all", "full intent complete"):
+        assert blocked in gate["blocked_claims"]
+    options = {option["id"]: option for option in closeout["completion_options"]}
+    assert options["claim-work-complete"]["allowed"] is False
 
 
 def test_report_closeout_report_uses_audit_profile_for_strict_closeout(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -3384,6 +3384,7 @@ def test_report_completion_gate_blocks_1379_style_overclosure(tmp_path: Path, ca
     assert gate["claim_level_requested"] == "full-intent-complete"
     assert gate["claim_level_allowed"] == "partial-progress"
     assert gate["required_next_action"] == "create-follow-on-plan"
+    assert "blocked_claims" not in gate
     claim_authorization = gate["claim_authorization"]
     assert claim_authorization["kind"] == "agentic-workspace/claim-authorization/v1"
     assert claim_authorization["allowed_claim_classes"] == ["partial_progress", "slice_complete"]
@@ -3548,7 +3549,6 @@ def test_report_completion_gate_allows_satisfied_intent_full_closeout(tmp_path: 
     assert gate["active_intent_satisfied"] is True
     assert gate["claim_level_allowed"] == "full-intent-complete"
     assert gate["required_next_action"] == "close-complete"
-    assert gate["blocked_claims"] == []
     assert "full_intent_complete" in gate["claim_authorization"]["allowed_claim_classes"]
     assert "issue_closure" in gate["claim_authorization"]["allowed_claim_classes"]
     assert gate["claim_authorization"]["blocked_claim_classes"] == []
@@ -3585,6 +3585,7 @@ def test_report_completion_gate_blocks_full_closeout_when_proof_missing(tmp_path
     assert gate["active_intent_satisfied"] is False
     assert gate["status"] == "blocked"
     assert gate["claim_level_allowed"] == "partial-progress"
+    assert "blocked_claims" not in gate
     assert gate["claim_authorization"]["allowed_claim_classes"] == []
     assert "full_intent_complete" in gate["claim_authorization"]["blocked_claim_classes"]
     assert gate["claim_authorization"]["diagnostics"]["diagnostic_only"] is True

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -3384,13 +3384,26 @@ def test_report_completion_gate_blocks_1379_style_overclosure(tmp_path: Path, ca
     assert gate["claim_level_requested"] == "full-intent-complete"
     assert gate["claim_level_allowed"] == "partial-progress"
     assert gate["required_next_action"] == "create-follow-on-plan"
-    for blocked in ("done", "implemented", "complete", "finished", "all", "full intent complete"):
-        assert blocked in gate["blocked_claims"]
-    assert "Closes #1374" in gate["blocked_claims"]
+    claim_authorization = gate["claim_authorization"]
+    assert claim_authorization["kind"] == "agentic-workspace/claim-authorization/v1"
+    assert claim_authorization["allowed_claim_classes"] == ["partial_progress", "slice_complete"]
+    for blocked_class in ("lane_complete", "parent_complete", "full_intent_complete", "issue_closure"):
+        assert blocked_class in claim_authorization["blocked_claim_classes"]
+    assert claim_authorization["closure_actions"] == [
+        {
+            "kind": "issue_closure",
+            "target": "#1374",
+            "authorized": False,
+            "reason": "issue closure requires full-intent completion authorization from the completion gate",
+        }
+    ]
+    assert claim_authorization["diagnostics"]["diagnostic_only"] is True
+    assert "Closes #1374" in claim_authorization["diagnostics"]["unsafe_claim_examples"]
     assert gate["self_review"]["answer"] == "no"
     assert gate["continuation"]["owner_surface"] == ".agentic-workspace/planning/execplans/issue-1374-follow-up.plan.json"
     options = {option["id"]: option for option in closeout["completion_options"]}
     assert options["claim-work-complete"]["allowed"] is False
+    assert options["claim-work-complete"]["required_claim_class"] == "full_intent_complete"
     assert "completion_gate" in options["claim-work-complete"]["blocking_fields"]
 
     assert cli.main(["report", "--target", str(target), "--section", "closeout_report", "--format", "json"]) == 0
@@ -3399,10 +3412,14 @@ def test_report_completion_gate_blocks_1379_style_overclosure(tmp_path: Path, ca
     rendering = report["final_response_rendering"]
     assert rendering["plain_done_allowed"] is False
     assert "completion gate" in rendering["must_include"]
-    assert "Closes #1374" in rendering["must_not_claim"]
-    for blocked in ("complete", "finished", "all"):
-        assert blocked in rendering["must_not_claim"]
-    assert "Completion gate: continue-required" in rendering["rendered_summary"]["rendered_text"]
+    assert any(item == "Diagnostic unsafe claim example only, not enforcement rule: Closes #1374" for item in rendering["must_not_claim"])
+    rendered_authorization = rendering["rendered_summary"]["constraints"]["claim_authorization"]
+    assert "full_intent_complete" in rendered_authorization["blocked_claim_classes"]
+    assert rendered_authorization["closure_actions"][0]["authorized"] is False
+    assert (
+        "blocked claim classes: lane_complete, parent_complete, full_intent_complete, issue_closure"
+        in rendering["rendered_summary"]["rendered_text"]
+    )
 
 
 def test_report_completion_gate_continuation_possible_requires_follow_on_not_caveat(tmp_path: Path, capsys) -> None:
@@ -3461,7 +3478,8 @@ def test_report_completion_gate_ambiguous_intent_requires_clarification(tmp_path
     assert gate["status"] == "clarification-required"
     assert gate["required_next_action"] == "ask-human"
     assert gate["active_intent_satisfied"] is False
-    assert "done" in gate["blocked_claims"]
+    assert gate["claim_authorization"]["allowed_claim_classes"] == []
+    assert "full_intent_complete" in gate["claim_authorization"]["blocked_claim_classes"]
     options = {option["id"]: option for option in closeout["completion_options"]}
     assert options["request-review"]["allowed"] is True
 
@@ -3495,6 +3513,8 @@ def test_report_completion_gate_allows_explicit_human_partial_only_as_partial(tm
     assert gate["human_accepted_partial"] is True
     assert gate["claim_level_allowed"] == "partial-progress"
     assert gate["required_next_action"] == "close-human-accepted-partial"
+    assert gate["claim_authorization"]["allowed_claim_classes"] == ["partial_progress"]
+    assert "full_intent_complete" in gate["claim_authorization"]["blocked_claim_classes"]
     options = {option["id"]: option for option in closeout["completion_options"]}
     assert options["claim-work-complete"]["allowed"] is False
 
@@ -3529,6 +3549,11 @@ def test_report_completion_gate_allows_satisfied_intent_full_closeout(tmp_path: 
     assert gate["claim_level_allowed"] == "full-intent-complete"
     assert gate["required_next_action"] == "close-complete"
     assert gate["blocked_claims"] == []
+    assert "full_intent_complete" in gate["claim_authorization"]["allowed_claim_classes"]
+    assert "issue_closure" in gate["claim_authorization"]["allowed_claim_classes"]
+    assert gate["claim_authorization"]["blocked_claim_classes"] == []
+    assert gate["claim_authorization"]["closure_actions"][0]["target"] == "#1383"
+    assert gate["claim_authorization"]["closure_actions"][0]["authorized"] is True
     options = {option["id"]: option for option in closeout["completion_options"]}
     assert options["claim-work-complete"]["allowed"] is True
 
@@ -3560,8 +3585,9 @@ def test_report_completion_gate_blocks_full_closeout_when_proof_missing(tmp_path
     assert gate["active_intent_satisfied"] is False
     assert gate["status"] == "blocked"
     assert gate["claim_level_allowed"] == "partial-progress"
-    for blocked in ("done", "implemented", "complete", "finished", "all", "full intent complete"):
-        assert blocked in gate["blocked_claims"]
+    assert gate["claim_authorization"]["allowed_claim_classes"] == []
+    assert "full_intent_complete" in gate["claim_authorization"]["blocked_claim_classes"]
+    assert gate["claim_authorization"]["diagnostics"]["diagnostic_only"] is True
     options = {option["id"]: option for option in closeout["completion_options"]}
     assert options["claim-work-complete"]["allowed"] is False
 

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -2932,6 +2932,17 @@ def test_report_closeout_trust_surfaces_package_workflow_evidence(tmp_path: Path
     assert acceptance["trust"] == "normal"
     assert acceptance["evidence_present"] is True
     assert acceptance["completion_criteria_count"] == 1
+    active_intent = payload["closeout_trust"]["active_intent_contract"]
+    assert active_intent["kind"] == "agentic-workspace/active-intent-contract/v1"
+    assert active_intent["status"] == "present"
+    assert active_intent["controlling_sources"][0]["kind"] == "planning-record"
+    matrix = payload["closeout_trust"]["intent_satisfaction_matrix"]
+    assert matrix["kind"] == "agentic-workspace/intent-satisfaction-matrix/v1"
+    assert matrix["status"] == "required-before-completion-claim"
+    assert matrix["full_completion_claim"]["allowed"] is False
+    assert "closeout_trust.intent_satisfaction_check" in matrix["full_completion_claim"]["blocked_by"]
+    assert "parent_intent_status" in matrix["full_completion_claim"]["blocked_by"]
+    assert "delegated subagent" in matrix["self_review_before_final_claim"]["rule"]
     residue_action = payload["closeout_trust"]["durable_residue_action"]
     assert residue_action["action"] == "route-durable-residue"
     assert residue_action["visible_states"] == ["none-found", "capture", "route-to-owner", "dismissed"]

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -3254,6 +3254,281 @@ def test_report_closeout_trust_allows_work_claim_for_sufficient_intent_proof(tmp
     assert options["claim-work-complete"]["allowed"] is True
 
 
+def _write_completion_gate_fixture(
+    target: Path,
+    *,
+    plan_id: str,
+    original_intent: str,
+    delivered_work: str,
+    slice_completes: str,
+    required_follow_on: str,
+    continuation_owner: str,
+    closure_status: str,
+    closure_decision: str,
+    proof_status: str,
+    claim_boundary: str,
+    human_accepted_partial: bool = False,
+    references: list[dict[str, object]] | None = None,
+) -> None:
+    plan = target / ".agentic-workspace" / "planning" / "execplans" / f"{plan_id}.plan.json"
+    _write_json(
+        plan,
+        {
+            "kind": "planning-execplan/v1",
+            "title": original_intent,
+            "references": references or [],
+            "active_milestone": {"id": plan_id, "status": "complete"},
+            "delegated_judgment": {
+                "requested outcome": original_intent,
+                "hard constraints": "Do not claim broader completion than the delivered evidence supports.",
+                "agent may decide locally": "Exact implementation details.",
+                "escalate when": "Intent satisfaction is ambiguous or blocked.",
+            },
+            "completion_criteria": ["Requested intent is reconciled against delivered behavior and proof."],
+            "proof_expectations": ["Intent proof must support the requested claim level."],
+            "intent_satisfaction": {
+                "original intent": original_intent,
+                "was original intent fully satisfied?": "yes" if slice_completes == "yes" else "no",
+                "unsolved intent passed to": "" if slice_completes == "yes" else "remaining intent from the original request",
+            },
+            "intent_continuity": {
+                "larger intended outcome": original_intent,
+                "this slice completes the larger intended outcome": slice_completes,
+                "continuation surface": continuation_owner,
+            },
+            "required_continuation": {
+                "required follow-on for the larger intended outcome": required_follow_on,
+                "owner surface": continuation_owner,
+                "activation trigger": "after this slice",
+            },
+            "execution_run": {
+                "run status": "complete",
+                "executor": "test",
+                "handoff source": "uv run agentic-workspace preflight --format json",
+                "what happened": delivered_work,
+                "scope touched": "tests",
+                "changed surfaces": "tests",
+                "validations run": (
+                    "uv run agentic-workspace summary --format json; "
+                    "uv run agentic-workspace report --format json; "
+                    "uv run agentic-workspace proof --format json; "
+                    "uv run agentic-workspace reconcile --format json"
+                ),
+                "result for continuation": "close" if slice_completes == "yes" else "continue",
+                "next step": "close" if slice_completes == "yes" else "continue or route follow-on",
+            },
+            "proof_report": {
+                "validation proof": "uv run pytest selected tests passed",
+                "acceptance reconciliation": f"requested {original_intent} -> delivered {delivered_work} -> proof recorded",
+                "proof achieved now": "yes",
+                'evidence for "proof achieved" state': "completion gate fixture",
+                "intent_proof": {
+                    "status": proof_status,
+                    "claim_boundary": claim_boundary,
+                    "intended_behavior": [original_intent],
+                    "proof_dimensions": ["selected regression evidence"],
+                    "unproven_after_tests": [] if proof_status == "sufficient_for_claim" else ["broader replacement/pruning intent"],
+                },
+            },
+            "closure_check": {
+                "slice status": "complete",
+                "larger-intent status": closure_status,
+                "closure decision": closure_decision,
+                "why this decision is honest": "The gate fixture records whether the original intent is fully satisfied.",
+                "evidence carried forward": "report closeout_trust",
+                "reopen trigger": "completion gate blocks the requested claim",
+                "human accepted partial": "yes" if human_accepted_partial else "no",
+            },
+        },
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        "[todo]\n"
+        "active_items = [\n"
+        f"  {{ id = '{plan_id}', title = 'Completion gate', surface = '.agentic-workspace/planning/execplans/{plan_id}.plan.json' }},\n"
+        "]\n"
+        "queued_items = []\n\n"
+        "[roadmap]\nlanes = []\ncandidates = []\n",
+    )
+
+
+def test_report_completion_gate_blocks_1379_style_overclosure(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write_completion_gate_fixture(
+        target,
+        plan_id="issue-1374-test-replacement",
+        original_intent="Replace, prune, and simplify most existing tests through contract-owned conformance tests for #1374.",
+        delivered_work="Removed two ordinary pytest functions, added one conformance contract, and merged one removed test.",
+        slice_completes="no",
+        required_follow_on="yes",
+        continuation_owner=".agentic-workspace/planning/execplans/issue-1374-follow-up.plan.json",
+        closure_status="open",
+        closure_decision="archive-but-keep-lane-open",
+        proof_status="regression_only",
+        claim_boundary="slice",
+        references=[{"target": "#1374", "role": "controlling issue"}],
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+
+    closeout = json.loads(capsys.readouterr().out)["answer"]
+    gate = closeout["completion_gate"]
+    assert gate["kind"] == "agentic-workspace/completion-gate/v1"
+    assert gate["active_intent_satisfied"] is False
+    assert gate["human_accepted_partial"] is False
+    assert gate["status"] == "continue-required"
+    assert gate["claim_level_requested"] == "full-intent-complete"
+    assert gate["claim_level_allowed"] == "partial-progress"
+    assert gate["required_next_action"] == "create-follow-on-plan"
+    assert "Closes #1374" in gate["blocked_claims"]
+    assert gate["self_review"]["answer"] == "no"
+    assert gate["continuation"]["owner_surface"] == ".agentic-workspace/planning/execplans/issue-1374-follow-up.plan.json"
+    options = {option["id"]: option for option in closeout["completion_options"]}
+    assert options["claim-work-complete"]["allowed"] is False
+    assert "completion_gate" in options["claim-work-complete"]["blocking_fields"]
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_report", "--format", "json"]) == 0
+    report = json.loads(capsys.readouterr().out)["answer"]
+    assert report["completion_gate"]["status"] == "continue-required"
+    rendering = report["final_response_rendering"]
+    assert rendering["plain_done_allowed"] is False
+    assert "completion gate" in rendering["must_include"]
+    assert "Closes #1374" in rendering["must_not_claim"]
+    assert "Completion gate: continue-required" in rendering["rendered_summary"]["rendered_text"]
+
+
+def test_report_completion_gate_continuation_possible_requires_follow_on_not_caveat(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write_completion_gate_fixture(
+        target,
+        plan_id="continuation-required",
+        original_intent="Finish the multi-slice migration.",
+        delivered_work="Finished the current bounded migration slice.",
+        slice_completes="no",
+        required_follow_on="yes",
+        continuation_owner=".agentic-workspace/planning/execplans/next-slice.plan.json",
+        closure_status="open",
+        closure_decision="archive-but-keep-lane-open",
+        proof_status="representative",
+        claim_boundary="slice",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+
+    gate = json.loads(capsys.readouterr().out)["answer"]["completion_gate"]
+    assert gate["status"] == "continue-required"
+    assert gate["required_next_action"] == "create-follow-on-plan"
+    assert gate["continuation"]["created_or_required"] is True
+    assert gate["claim_level_allowed"] == "partial-progress"
+
+
+def test_report_completion_gate_ambiguous_intent_requires_clarification(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write_completion_gate_fixture(
+        target,
+        plan_id="ambiguous-gate",
+        original_intent="Finish the work if the larger intent is actually satisfied.",
+        delivered_work="Finished a local implementation slice.",
+        slice_completes="unknown",
+        required_follow_on="unknown",
+        continuation_owner="",
+        closure_status="unknown",
+        closure_decision="requires-review",
+        proof_status="needs_review",
+        claim_boundary="unknown",
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+
+    closeout = json.loads(capsys.readouterr().out)["answer"]
+    gate = closeout["completion_gate"]
+    assert gate["status"] == "clarification-required"
+    assert gate["required_next_action"] == "ask-human"
+    assert gate["active_intent_satisfied"] is False
+    assert "done" in gate["blocked_claims"]
+    options = {option["id"]: option for option in closeout["completion_options"]}
+    assert options["request-review"]["allowed"] is True
+
+
+def test_report_completion_gate_allows_explicit_human_partial_only_as_partial(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write_completion_gate_fixture(
+        target,
+        plan_id="human-partial",
+        original_intent="Complete the full migration, unless the human accepts this bounded slice as partial.",
+        delivered_work="Completed the bounded slice the human accepted.",
+        slice_completes="no",
+        required_follow_on="yes",
+        continuation_owner=".agentic-workspace/planning/execplans/remaining-migration.plan.json",
+        closure_status="partial",
+        closure_decision="human-accepted-partial",
+        proof_status="representative",
+        claim_boundary="slice",
+        human_accepted_partial=True,
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+
+    closeout = json.loads(capsys.readouterr().out)["answer"]
+    gate = closeout["completion_gate"]
+    assert gate["status"] == "human-accepted-partial"
+    assert gate["human_accepted_partial"] is True
+    assert gate["claim_level_allowed"] == "partial-progress"
+    assert gate["required_next_action"] == "close-human-accepted-partial"
+    options = {option["id"]: option for option in closeout["completion_options"]}
+    assert options["claim-work-complete"]["allowed"] is False
+
+
+def test_report_completion_gate_allows_satisfied_intent_full_closeout(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write_completion_gate_fixture(
+        target,
+        plan_id="satisfied-gate",
+        original_intent="Complete the direct contract migration.",
+        delivered_work="Completed the direct contract migration.",
+        slice_completes="yes",
+        required_follow_on="no",
+        continuation_owner="none",
+        closure_status="closed",
+        closure_decision="archive-and-close",
+        proof_status="sufficient_for_claim",
+        claim_boundary="work",
+        references=[{"target": "#1383", "role": "satisfied issue"}],
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+
+    closeout = json.loads(capsys.readouterr().out)["answer"]
+    gate = closeout["completion_gate"]
+    assert gate["status"] == "allowed"
+    assert gate["active_intent_satisfied"] is True
+    assert gate["claim_level_allowed"] == "full-intent-complete"
+    assert gate["required_next_action"] == "close-complete"
+    assert gate["blocked_claims"] == []
+    options = {option["id"]: option for option in closeout["completion_options"]}
+    assert options["claim-work-complete"]["allowed"] is True
+
+
 def test_report_closeout_report_uses_audit_profile_for_strict_closeout(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -889,7 +889,7 @@ def test_start_default_returns_selector_first_router(tmp_path: Path, capsys) -> 
     assert "cli_invocation" in payload["drill_down"]["available_selectors"]
 
 
-def test_start_surfaces_chat_task_active_intent_contract_and_satisfaction_matrix(tmp_path: Path, capsys) -> None:
+def test_start_keeps_active_intent_packets_selector_only(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
@@ -901,17 +901,8 @@ def test_start_surfaces_chat_task_active_intent_contract_and_satisfaction_matrix
 
     payload = json.loads(capsys.readouterr().out)
     context = _start_context(payload)
-    contract = context["active_intent_contract"]
-    assert contract["status"] == "present"
-    assert contract["source_count"] >= 1
-    assert "supersede" in contract["update_relationship_options"]
-    matrix = context["intent_satisfaction_matrix"]
-    assert matrix["status"] == "required-before-completion-claim"
-    assert matrix["full_completion_claim"]["allowed"] is False
-    assert "satisfaction_matrix.items" in matrix["full_completion_claim"]["blocked_by"]
-    assert "Self-review first" in matrix["full_completion_claim"]["rule"]
-    assert "active_intent_contract" in payload["drill_down"]["available_selectors"]
-    assert "intent_satisfaction_matrix" in payload["drill_down"]["available_selectors"]
+    assert "active_intent_contract" not in context
+    assert "intent_satisfaction_matrix" not in context
 
     assert (
         cli.main(

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -889,6 +889,55 @@ def test_start_default_returns_selector_first_router(tmp_path: Path, capsys) -> 
     assert "cli_invocation" in payload["drill_down"]["available_selectors"]
 
 
+def test_start_surfaces_chat_task_active_intent_contract_and_satisfaction_matrix(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    task = "Replace brittle behavior with an explicit intent contract and satisfaction matrix."
+    assert cli.main(["start", "--target", str(target), "--task", task, "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    context = _start_context(payload)
+    contract = context["active_intent_contract"]
+    assert contract["status"] == "present"
+    assert contract["source_count"] >= 1
+    assert "supersede" in contract["update_relationship_options"]
+    matrix = context["intent_satisfaction_matrix"]
+    assert matrix["status"] == "required-before-completion-claim"
+    assert matrix["full_completion_claim"]["allowed"] is False
+    assert "satisfaction_matrix.items" in matrix["full_completion_claim"]["blocked_by"]
+    assert "Self-review first" in matrix["full_completion_claim"]["rule"]
+    assert "active_intent_contract" in payload["drill_down"]["available_selectors"]
+    assert "intent_satisfaction_matrix" in payload["drill_down"]["available_selectors"]
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(target),
+                "--task",
+                task,
+                "--select",
+                "active_intent_contract,intent_satisfaction_matrix",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    selected = json.loads(capsys.readouterr().out)
+    assert selected["values"]["active_intent_contract"]["kind"] == "agentic-workspace/active-intent-contract/v1"
+    assert selected["values"]["intent_satisfaction_matrix"]["kind"] == "agentic-workspace/intent-satisfaction-matrix/v1"
+    assert "full-intent-complete" in selected["values"]["intent_satisfaction_matrix"]["claim_levels"]
+    self_review = selected["values"]["intent_satisfaction_matrix"]["self_review_before_final_claim"]
+    assert self_review["status"] == "required"
+    assert "delegated subagent" in self_review["rule"]
+
+
 def test_start_read_only_reporting_task_does_not_suppress_acceptance_from_keywords(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()


### PR DESCRIPTION
## What landed

PR #1382 implements the superseding #1383 closeout/claim transition gate as the center of gravity. The gate is named `completion_gate` and is derived from existing Planning, proof, acceptance, parent/applicable intent, and closeout fields.

The review follow-ups pivot closeout safety away from keyword matching. `completion_gate` now exposes one canonical structured authorization surface: `claim_authorization`. It carries allowed/blocked claim classes such as `partial_progress`, `slice_complete`, `lane_complete`, `parent_complete`, `full_intent_complete`, and `issue_closure`, plus structured closure actions for concrete issue targets. Human-readable unsafe examples live only under `claim_authorization.diagnostics.unsafe_claim_examples` and are explicitly diagnostic-only.

Coverage includes:

- `closeout_trust`, `closeout_report`, compact closeout output, completion options, and final-response rendering consume the gate.
- Planning `archive-plan --prepare-closeout` writes `completion_gate` into execplan closeout records and generated closeout text.
- `planning closeout` consumes the same gate through its archive-preparation path.
- Parent/lane closeout records and lane closeout records carry schema-backed `completion_gate` evidence.
- Planning schemas, package bootstrap payloads, generated Python payloads, and generated TypeScript payloads were refreshed together.
- `completion_gate.blocked_claims` has been removed from canonical runtime output, workspace report schemas/docs, Planning schemas, generated payloads, tests, and current archived completion-gate records.
- `active_intent_contract` and `intent_satisfaction_matrix` remain selector-only compatibility/supporting projections.

AW still does not decide semantic satisfaction. AW enforces the transition rule and blocks unsupported structured claim classes/closure actions; the agent owns semantic satisfaction judgment and proof interpretation; the human owns accepting narrowed scope.

## Closure matrix

Issue | Closure evidence
--- | ---
#1383 closeout gate | `completion_gate` is emitted by `closeout_trust`, carried into `closeout_report`, included in compact closeout answers, and rendered into `final_response_rendering` when it blocks or narrows completion.
#1383 structured claim authorization | `completion_gate.claim_authorization` authorizes claim classes and issue-closure actions. Tests assert unsupported `full_intent_complete` / `issue_closure` are blocked structurally, not by scanning prose.
#1383 no legacy blocked_claims | `completion_gate.blocked_claims` is removed from runtime payloads, schemas, generated payloads, docs, tests, and current closeout archives. Negative tests assert the field is absent.
#1383 Planning closeout paths | `archive-plan --prepare-closeout` writes a schema-backed `completion_gate`; `planning closeout` archives through that path; parent/lane closeout and lane closeout records carry gate evidence. Covered by focused archive/closeout/lane tests.
#1383 #1379-style overclosure | `test_report_completion_gate_blocks_1379_style_overclosure` models broader #1374 test replacement/pruning intent where only limited progress landed. The gate reports `active_intent_satisfied=false`, blocks structured `full_intent_complete` and `issue_closure` for `#1374`, and requires follow-on planning.
#1383 continuation possible | `test_report_completion_gate_continuation_possible_requires_follow_on_not_caveat` shows unsatisfied intent with a continuation owner becomes `continue-required`, not caveated completion.
#1383 blocked/ambiguous | `test_report_completion_gate_ambiguous_intent_requires_clarification` shows ambiguous larger intent requires asking/review before closeout.
#1383 explicit partial | `test_report_completion_gate_allows_explicit_human_partial_only_as_partial` shows human-accepted partial scope allows only partial claim classes while full completion remains blocked.
#1383 proof required for full closeout | `test_report_completion_gate_blocks_full_closeout_when_proof_missing` prevents self-reported satisfaction from becoming full-intent completion when proof is missing/not recorded.
#1383 satisfied full closeout | `test_report_completion_gate_allows_satisfied_intent_full_closeout` shows explicit satisfied intent, no continuation, sufficient proof, and an issue reference authorize full closeout and the structured issue-closure action.
#1383 final response UX | The overclosure regression asserts `final_response_rendering` sets `plain_done_allowed=false`, includes completion-gate context, and exposes claim authorization constraints; unsafe prose examples are prefixed as diagnostic-only.
#1383 quiet supporting packets | Start/implement packet tests assert ordinary context omits `active_intent_contract` and `intent_satisfaction_matrix`, while explicit selectors still return them.
#1383 schemas/generated targets | `workspace_report.schema.json`, Planning execplan/lane schemas, package bootstrap schemas, generated Python payloads, generated TypeScript payloads, and reference docs are updated and validated.
#1380 | Superseded by #1383. This PR should not be read as closing the original packet-first framing except insofar as those packets are now supporting/compatibility projections for the stricter gate.

## Why #1383 closure is honest

The PR demonstrates the required state machine at completion-claim time across report/final-response and Planning closeout surfaces:

- satisfied intent authorizes full closeout and issue closure when a concrete issue target is present;
- unsatisfied intent with continuation possible requires continuing or durable follow-on planning;
- ambiguous/blocked intent requires asking/review;
- human-accepted partial allows only partial claim classes;
- regression-only proof can authorize bounded `slice_complete` while still blocking `full_intent_complete` and `issue_closure`;
- missing proof prevents full-intent completion even when intent fields self-report satisfaction;
- no canonical `completion_gate.blocked_claims` field remains to preserve the older prose-fragment model.

The gate reuses existing AW surfaces instead of adding a universal intent ledger, semantic classifier, or prose keyword ban list.

## Proof

- Focused completion-gate report regressions: passed.
- Focused Planning archive/closeout/lane gate tests: passed.
- `make test-workspace`: passed.
- `make lint-workspace`: passed.
- `make test-planning`: passed.
- `make lint-planning`: passed.
- `make typecheck-planning`: passed.
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`: passed.
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`: passed.
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`: healthy.
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`: passed after regenerating command packages.
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`: passed.
- `make maintainer-surfaces`: passed.
- `make schema-reference-docs`: passed.

## Runtime-source edit boundary

The direct runtime edits are intentional under the stricter boundary: this is a new primitive/gate implementation plus an existing primitive bugfix for unsupported proof/claim behavior. Generated Python and TypeScript payload targets were refreshed with `uv run python scripts/generate/generate_command_packages.py` so generated targets are current.

## Dogfooding

Helpful: `implement --changed` selected the right proof set, caught stale generated payloads, and flagged runtime-source edit authority. The review also exposed the value of keeping only one canonical claim-safety surface; the legacy `blocked_claims` compatibility field would have made future misuse easier.

Friction: `implement --changed` required an active execplan after the review-comment slice touched runtime, planning schemas, tests, and generated payloads. That was appropriate, but the generated active-item summary retained scaffold wording until closeout, which made the state less informative than the tightened execplan itself.

## Remaining limitation

There is still no provider-specific PR-body or issue-closure engine. This PR blocks and exposes unsupported claim levels in AW closeout/report/final-response and Planning closeout surfaces; PR bodies must consume that gate evidence rather than relying on a separate GitHub-only closure mechanism.

Closes #1383.
