### PR TITLE
Implement continuation re-grounding view

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1385-continuation-view-model.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1385-continuation-view-model.plan.json
@@ -1,0 +1,368 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1385 continuation re-grounding view model",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1385 as a continuation re-grounding view model that lets low-context agents cheaply answer preserved intent, allowed claim, next safe action, and trustworthy source evidence.",
+    "hard_constraints": "Do not create a durable regrounding state owner, transcript store, universal intent ledger, or semantic classifier. Reuse current Planning, Verification, Memory, closeout, routine-work, and completion-gate owners with explicit source precedence and freshness.",
+    "agent_may_decide": "Exact field names, compact projection shape, tests, and whether start uses the Planning summary projection directly or a workspace-local compact adapter.",
+    "escalate_when": "The implementation requires a new state store, broad runtime architecture change, or changes source ownership beyond existing summary/start/closeout projection surfaces.",
+    "next_action": "Implement and validate the continuation view model across Planning summary and workspace start surfaces.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "packages/planning/src/repo_planning_bootstrap/installer.py",
+      "packages/planning/tests/test_promote.py",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+      "docs/reference/startup-context.md",
+      "tests/test_workspace_start_preflight_cli.py",
+      "tests/test_workspace_summary_cli.py",
+      ".agentic-workspace/planning/execplans/issue-1385-continuation-view-model.plan.json"
+    ],
+    "completion_criteria": [
+      "Low-context agents can cheaply answer preserved intent, allowed claim, next safe action, and trust basis without transcript material or a new durable regrounding owner."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Implement #1385 continuation re-grounding view model."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Implement #1385 continuation re-grounding view model.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1385-continuation-view-model",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Implement #1385 continuation re-grounding view model.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1385 continuation re-grounding view model",
+    "inferred intended outcome": "Create a bounded plan for Implement #1385 continuation re-grounding view model.",
+    "chosen concrete what": "Low-context agents can cheaply answer preserved intent, allowed claim, next safe action, and trust basis without transcript material or a new durable regrounding owner.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Implement #1385 continuation re-grounding view model.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1385-continuation-view-model",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement #1385 continuation re-grounding view model is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented #1385 continuation view model over existing owner surfaces: Planning summary now projects a lossy continuation view, workspace start renders a tiny projection, startup schema/docs expose the selector, and tests cover stale todo precedence plus unsatisfied-intent continuation.",
+    "scope touched": "Planning summary, workspace startup projection, startup schema/reference docs, and focused tests.",
+    "changed surfaces": "packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_promote.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; docs/reference/startup-context.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_summary_cli.py",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed inside existing AW surfaces. The view is a read projection only; Planning/Verification/Memory/closeout remain the write owners. Startup projection was trimmed after payload-budget tests caught excess size.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Passed: focused continuation-view tests; make test-planning; make lint-planning; make typecheck-planning; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; ruff selected surfaces; make schema-reference-docs; make maintainer-surfaces; AW summary; AW doctor planning.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement #1385 continuation re-grounding view model.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Low-context agents can cheaply answer preserved intent, allowed claim, next safe action, and trust basis without transcript material or a new durable regrounding owner.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-07: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "blocked_claim_classes": [],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1385",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement #1385 continuation re-grounding view model.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Passed: focused continuation-view tests; make test-planning; make lint-planning; make typecheck-planning; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; ruff selected surfaces; make schema-reference-docs; make maintainer-surfaces; AW summary; AW doctor planning.\nChanged surfaces: packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_promote.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; docs/reference/startup-context.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_summary_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/issue-1385-continuation-view-model.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1385-continuation-view-model.plan.json
@@ -51,16 +51,16 @@
     "closeout_decision": "archive-and-close"
   },
   "goal": [
-    "Create a bounded plan for Implement #1385 continuation re-grounding view model."
+    "Implement #1385 as a continuation re-grounding view model over existing AW owner surfaces."
   ],
   "non_goals": [
     "Leave adjacent backlog or follow-on work out of this plan."
   ],
   "machine_readable_contract": {
     "intent": {
-      "outcome": "Create a bounded plan for Implement #1385 continuation re-grounding view model.",
-      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
-      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "outcome": "Implement #1385 as a continuation re-grounding view model over existing AW owner surfaces.",
+      "constraints": "Do not add a durable regrounding state owner, transcript store, universal intent ledger, or prose-claim policy surface.",
+      "latitude": "Field naming, compact projection shape, and selector placement were local implementation decisions.",
       "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
       "proof": "See proof_report.validation proof."
     },
@@ -80,7 +80,7 @@
     }
   },
   "intent_continuity": {
-    "larger intended outcome": "Create a bounded plan for Implement #1385 continuation re-grounding view model.",
+    "larger intended outcome": "Implement #1385 as a continuation re-grounding view model over existing AW owner surfaces.",
     "this slice completes the larger intended outcome": "yes",
     "continuation surface": "none"
   },
@@ -99,10 +99,10 @@
   },
   "intent_interpretation": {
     "literal request": "Implement #1385 continuation re-grounding view model",
-    "inferred intended outcome": "Create a bounded plan for Implement #1385 continuation re-grounding view model.",
+    "inferred intended outcome": "Implement #1385 as a continuation re-grounding view model over existing AW owner surfaces.",
     "chosen concrete what": "Low-context agents can cheaply answer preserved intent, allowed claim, next safe action, and trust basis without transcript material or a new durable regrounding owner.",
     "interpretation distance": "low",
-    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+    "review guidance": "Confirm the archived evidence matches the implemented continuation-view behavior before relying on it."
   },
   "execution_bounds": {
     "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
@@ -127,9 +127,9 @@
     "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
   },
   "delegated_judgment": {
-    "requested outcome": "Create a bounded plan for Implement #1385 continuation re-grounding view model.",
-    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
-    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "requested outcome": "Implement #1385 as a continuation re-grounding view model over existing AW owner surfaces.",
+    "hard constraints": "Do not add a durable regrounding state owner, transcript store, universal intent ledger, or prose-claim policy surface.",
+    "agent may decide locally": "Field naming, compact projection shape, and selector placement.",
     "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
   },
   "post_decomposition_delegation": {
@@ -148,7 +148,7 @@
   "active_milestone": {
     "id": "issue-1385-continuation-view-model",
     "status": "completed",
-    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "scope": "Keep this execution thread bounded to the #1385 continuation-view implementation lane.",
     "ready": "ready",
     "blocked": "none",
     "optional_deps": "none"
@@ -209,7 +209,7 @@
     "evidence for \"proof achieved\" state": "See proof_report.validation proof."
   },
   "intent_satisfaction": {
-    "original intent": "Create a bounded plan for Implement #1385 continuation re-grounding view model.",
+    "original intent": "Implement #1385 as a continuation re-grounding view model over existing AW owner surfaces.",
     "was original intent fully satisfied?": "yes",
     "evidence of intent satisfaction": "See proof_report.validation proof.",
     "unsolved intent passed to": "none"
@@ -286,7 +286,8 @@
     }
   },
   "drift_log": [
-    "2026-06-07: Scaffolded by agentic-planning new-plan."
+    "2026-06-07: Created active execplan for #1385.",
+    "2026-06-07: Implemented and archived continuation-view slice after proof."
   ],
   "memory_learning_capture": {
     "status": "reviewed",
@@ -363,6 +364,6 @@
     "status": "generated",
     "source": "archive-plan --prepare-closeout",
     "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
-    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement #1385 continuation re-grounding view model.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Passed: focused continuation-view tests; make test-planning; make lint-planning; make typecheck-planning; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; ruff selected surfaces; make schema-reference-docs; make maintainer-surfaces; AW summary; AW doctor planning.\nChanged surfaces: packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_promote.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; docs/reference/startup-context.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_summary_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement #1385 as a continuation re-grounding view model over existing AW owner surfaces.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Passed: focused continuation-view tests; make test-planning; make lint-planning; make typecheck-planning; make test-workspace; make lint-workspace; check_contract_tooling_surfaces; check_structured_file_inventory; ruff selected surfaces; make schema-reference-docs; make maintainer-surfaces; AW summary; AW doctor planning.\nChanged surfaces: packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_promote.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/startup_context.schema.json; docs/reference/startup-context.md; tests/test_workspace_start_preflight_cli.py; tests/test_workspace_summary_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
   }
 }

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -64,6 +64,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `active_state_summary.todo_active_count` | integer | yes |  | Todo active count numeric value used by this contract. |  |  |
 | `active_state_summary.active_execplan` | string \| null | yes |  | Active execplan contract value used by this contract. |  |  |
 | `active_state_summary.planning_status` | string | yes |  | Planning status text value used by this contract. |  |  |
+| `continuation_view` | object | no |  | Lossy continuation/re-grounding view projected from existing owner surfaces so a low-context agent can identify preserved intent, allowed claim class, next safe action, source freshness, omissions, and drill-down routes without treating startup as a durable state owner. |  |  |
 | `package_boundary` | ref `#/$defs/package_boundary` | no |  | Current package/root boundary information for the command invocation. |  |  |
 | `package_boundary.status` | string | yes |  | Current lifecycle, readiness, or health state. |  |  |
 | `package_boundary.cwd` | string | yes |  | Working directory context used when running the command. |  |  |

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -2019,6 +2019,13 @@ def planning_summary(
         context_budget_contract=context_budget_contract,
         intent_interpretation_contract=intent_interpretation_contract,
     )
+    continuation_view = _planning_continuation_view_payload(
+        target_root=target_root,
+        active_items=active_items,
+        active_execplans=active_execplans,
+        planning_record=planning_record,
+        summary_profile="full",
+    )
     full_summary = {
         "kind": "planning-summary/v1",
         "profile": "full",
@@ -2055,6 +2062,7 @@ def planning_summary(
             roadmap_candidates=roadmap_candidates,
         ),
         "planning_record": planning_record,
+        "continuation_view": continuation_view,
         "active_contract": _contract_projection(active_contract, view_name="active_contract"),
         "resumable_contract": _contract_projection(resumable_contract, view_name="resumable_contract"),
         "follow_through_contract": _contract_projection(follow_through_contract, view_name="follow_through_contract"),
@@ -2730,6 +2738,7 @@ def _planning_summary_schema() -> dict[str, Any]:
             "autopilot_loop",
             "ownership_review",
             "planning_surface_health",
+            "continuation_view",
             "planning_record",
             "active_contract",
             "resumable_contract",
@@ -3676,6 +3685,7 @@ def _planning_summary_compact_schema() -> dict[str, Any]:
             "planning_surface_health",
             "projection_state",
             "planning_revision",
+            "continuation_view",
             "planning_record",
             "active_contract",
             "resumable_contract",
@@ -3717,6 +3727,7 @@ def _planning_summary_tiny_schema() -> dict[str, Any]:
             "execution_readiness",
             "current_execution_pressure",
             "residue_governance",
+            "continuation_view",
             "decomposition",
             "lanes",
             "detail_commands",
@@ -3809,6 +3820,13 @@ def _planning_summary_tiny_fast(*, target_root: Path) -> dict[str, Any]:
             changed_paths=[],
         )
     )
+    continuation_view = _planning_continuation_view_payload(
+        target_root=target_root,
+        active_items=active_items,
+        active_execplans=active_execplans,
+        planning_record=None,
+        summary_profile="tiny",
+    )
     return _drop_empty_compact_fields(
         {
             "kind": "planning-summary/v1",
@@ -3843,6 +3861,7 @@ def _planning_summary_tiny_fast(*, target_root: Path) -> dict[str, Any]:
                 "recommended_next_action": recommendation,
                 "active_plan_required": bool(active_items or active_execplans),
             },
+            "continuation_view": continuation_view,
             "decomposition": {"status": "not-evaluated", "detail": "Use compact or full summary for decomposition detail."},
             "lanes": {
                 "status": lane_projection.get("status", "none"),
@@ -3870,6 +3889,7 @@ def _planning_summary_tiny_fast(*, target_root: Path) -> dict[str, Any]:
                 "execution_readiness",
                 "current_execution_pressure",
                 "residue_governance",
+                "continuation_view",
                 "roadmap",
                 "lanes",
             ],
@@ -4130,6 +4150,7 @@ def _planning_summary_task_scoped_projection(
         },
         "planning_surface_health": compact_summary.get("planning_surface_health", {}),
         "residue_governance": compact_summary.get("residue_governance", {}),
+        "continuation_view": compact_summary.get("continuation_view", {}),
         "planning_record": compact_summary.get("planning_record", {}),
         "handoff_contract": compact_summary.get("handoff_contract", {}),
         "current_execution_pressure": compact_summary.get("current_execution_pressure", {}),
@@ -4168,6 +4189,7 @@ def _planning_summary_tiny_projection(compact_summary: dict[str, Any]) -> dict[s
     residue_governance = (
         compact_summary.get("residue_governance", {}) if isinstance(compact_summary.get("residue_governance"), dict) else {}
     )
+    continuation_view = compact_summary.get("continuation_view", {}) if isinstance(compact_summary.get("continuation_view"), dict) else {}
     tiny: dict[str, Any] = {
         "kind": compact_summary.get("kind", "planning-summary/v1"),
         "profile": "tiny",
@@ -4214,6 +4236,26 @@ def _planning_summary_tiny_projection(compact_summary: dict[str, Any]) -> dict[s
             for key in ("status", "review_count", "archived_execplan_count", "matrix_class_count", "review_routing", "rule")
             if key in residue_governance
         },
+        "continuation_view": {
+            key: continuation_view[key]
+            for key in (
+                "status",
+                "view_role",
+                "answers",
+                "next_action",
+                "proof_state",
+                "claim_boundary",
+                "resume_predicate",
+                "source_freshness",
+                "stale_projections",
+                "uncertainty",
+                "omitted_detail",
+                "drill_down",
+                "write_responsibility",
+                "authority_boundary",
+            )
+            if key in continuation_view
+        },
         "detail_commands": {
             "compact": "agentic-workspace summary --verbose --format json",
             "full": "agentic-workspace summary --verbose --format json",
@@ -4243,6 +4285,7 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
     roadmap = dict(summary.get("roadmap", {}))
     planning_surface_health = dict(summary.get("planning_surface_health", {}))
     residue_governance = dict(summary.get("residue_governance", {}))
+    continuation_view = dict(summary.get("continuation_view", {}))
     ownership_review = dict(summary.get("ownership_review", {}))
     intent_validation_contract = dict(summary.get("intent_validation_contract", {}))
     if "historical_audit_references" in intent_validation_contract:
@@ -4499,6 +4542,27 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
                 "continuation_owner",
                 "execution_bounds",
                 "minimal_refs",
+            ),
+            idle_unavailable_reason=idle_unavailable_reason,
+        ),
+        "continuation_view": _compact_projection(
+            continuation_view,
+            fields=(
+                "view_role",
+                "answers",
+                "active_intent",
+                "next_action",
+                "proof_state",
+                "claim_boundary",
+                "resume_predicate",
+                "source_precedence",
+                "source_freshness",
+                "stale_projections",
+                "uncertainty",
+                "omitted_detail",
+                "drill_down",
+                "write_responsibility",
+                "authority_boundary",
             ),
             idle_unavailable_reason=idle_unavailable_reason,
         ),
@@ -8020,6 +8084,7 @@ def _canonical_planning_record(
     threat_failure_aids: list[Any] = []
     review_residue: list[dict[str, Any]] = []
     prep_only_contract: dict[str, Any] = {}
+    completion_gate: dict[str, Any] = {}
     canonical_core: dict[str, Any] = {}
     execplan_profile: dict[str, Any] = {}
     if plan_path is not None:
@@ -8048,6 +8113,7 @@ def _canonical_planning_record(
         architecture_decision_promotion = _execplan_raw_dict(plan_path, "architecture_decision_promotion")
         threat_failure_aids = _execplan_raw_list(plan_path, "threat_failure_aids")
         prep_only_contract = _execplan_prep_only_contract(plan_path)
+        completion_gate = _execplan_raw_dict(plan_path, "completion_gate")
         review_residue = _review_residue_from_references(
             target_root=target_root,
             references=list(active_contract.get("references", [])),
@@ -8100,6 +8166,7 @@ def _canonical_planning_record(
         "architecture_decision_promotion": architecture_decision_promotion,
         "threat_failure_aids": threat_failure_aids,
         "prep_only_contract": prep_only_contract,
+        "completion_gate": completion_gate,
         "tool_verification": dict(resumable_contract.get("tool_verification", {})),
         "escalate_when": str(resumable_contract.get("escalate_when", "")).strip(),
         "continuation_owner": continuation_owner,
@@ -9068,6 +9135,370 @@ def _active_handoff_contract(
             worker_contract=worker_contract,
         ),
     }
+
+
+def _truthy_status(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    return text in {"yes", "true", "satisfied", "complete", "completed", "closed", "passed", "allowed"}
+
+
+def _negative_status(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    return text in {"no", "false", "unsatisfied", "incomplete", "open", "partial", "blocked", "failed"}
+
+
+def _first_nonempty(*values: Any) -> str:
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            return text
+    return ""
+
+
+def _claim_boundary_for_continuation_view(planning_record: dict[str, Any]) -> dict[str, Any]:
+    completion_gate = dict(planning_record.get("completion_gate", {})) if isinstance(planning_record.get("completion_gate"), dict) else {}
+    intent_satisfaction = (
+        dict(planning_record.get("intent_satisfaction", {})) if isinstance(planning_record.get("intent_satisfaction"), dict) else {}
+    )
+    required_continuation = (
+        dict(planning_record.get("required_continuation", {})) if isinstance(planning_record.get("required_continuation"), dict) else {}
+    )
+    closure_check = dict(planning_record.get("closure_check", {})) if isinstance(planning_record.get("closure_check"), dict) else {}
+    if completion_gate:
+        authorization = completion_gate.get("claim_authorization", {})
+        blocked_classes = []
+        allowed_classes = []
+        if isinstance(authorization, dict):
+            blocked_classes = [str(item) for item in authorization.get("blocked_claim_classes", []) if str(item).strip()]
+            allowed_classes = [str(item) for item in authorization.get("allowed_claim_classes", []) if str(item).strip()]
+        blocked_claims = [str(item) for item in completion_gate.get("blocked_claims", []) if str(item).strip()]
+        return {
+            "status": completion_gate.get("status", "unknown"),
+            "source": "planning_record.completion_gate",
+            "claim_level_allowed": completion_gate.get("claim_level_allowed", ""),
+            "required_next_action": completion_gate.get("required_next_action", ""),
+            "active_intent_satisfied": bool(completion_gate.get("active_intent_satisfied", False)),
+            "human_accepted_partial": bool(completion_gate.get("human_accepted_partial", False)),
+            "allowed_claim_classes": allowed_classes,
+            "blocked_claim_classes": blocked_classes,
+            "blocked_claims": blocked_claims,
+            "rule": "completion_gate owns closeout claim authorization; continuation_view only projects it.",
+        }
+    satisfied = _truthy_status(intent_satisfaction.get("was original intent fully satisfied?"))
+    unsatisfied = _negative_status(intent_satisfaction.get("was original intent fully satisfied?"))
+    continuation_required = _truthy_status(required_continuation.get("required follow-on for the larger intended outcome"))
+    if satisfied and not continuation_required:
+        status = "allowed"
+        claim_level_allowed = "full-intent-complete"
+        required_next_action = "close-complete"
+        active_intent_satisfied = True
+        blocked_claims: list[str] = []
+    elif unsatisfied or continuation_required:
+        status = "continue-required"
+        claim_level_allowed = "partial-progress"
+        required_next_action = "continue-current-work"
+        active_intent_satisfied = False
+        blocked_claims = ["done", "implemented", "complete", "finished", "all", "full intent complete"]
+    else:
+        status = "unknown"
+        claim_level_allowed = "partial-progress"
+        required_next_action = "reconcile-claim-boundary"
+        active_intent_satisfied = False
+        blocked_claims = ["done", "implemented", "complete", "finished", "all", "full intent complete"]
+    return {
+        "status": status,
+        "source": "planning_record.intent_satisfaction + required_continuation + closure_check",
+        "claim_level_allowed": claim_level_allowed,
+        "required_next_action": required_next_action,
+        "active_intent_satisfied": active_intent_satisfied,
+        "human_accepted_partial": False,
+        "allowed_claim_classes": ["partial_progress"] if claim_level_allowed == "partial-progress" else ["full_intent_complete"],
+        "blocked_claim_classes": ["full_intent_complete", "issue_closure"] if claim_level_allowed == "partial-progress" else [],
+        "blocked_claims": blocked_claims,
+        "closure_decision": closure_check.get("closure decision", ""),
+        "rule": "When completion_gate is absent, this is a conservative projection from existing Planning closeout fields.",
+    }
+
+
+def _proof_state_for_continuation_view(planning_record: dict[str, Any]) -> dict[str, Any]:
+    proof_report = dict(planning_record.get("proof_report", {})) if isinstance(planning_record.get("proof_report"), dict) else {}
+    achieved = _first_nonempty(proof_report.get("proof achieved now"), proof_report.get("validation proof"))
+    lower = achieved.lower()
+    if not achieved or lower in {"pending", "not-recorded", "not recorded", "none", "unknown"}:
+        status = "missing-or-pending"
+    elif "pending" in lower or "not recorded" in lower:
+        status = "missing-or-pending"
+    else:
+        status = "present"
+    return {
+        "status": status,
+        "summary": achieved,
+        "source": "planning_record.proof_report",
+        "freshness": "current-owner" if status == "present" else "unknown-or-pending",
+        "known_gap": "" if status == "present" else "Proof is not recorded as current in the active planning record.",
+    }
+
+
+def _compact_source_entry(
+    *, claim: str, owner: str, source: str, source_hash: str = "", freshness: str = "current-owner"
+) -> dict[str, str]:
+    entry = {
+        "claim": claim,
+        "owner": owner,
+        "source": source,
+        "freshness": freshness,
+    }
+    if source_hash:
+        entry["source_hash"] = source_hash
+    return entry
+
+
+def _planning_continuation_view_payload(
+    *,
+    target_root: Path,
+    active_items: list[dict[str, Any]],
+    active_execplans: list[dict[str, str]],
+    planning_record: dict[str, Any] | None,
+    summary_profile: str,
+) -> dict[str, Any]:
+    revision = planning_revision(target_root)
+    if not active_items and not active_execplans:
+        return {
+            "kind": "agentic-planning/continuation-view/v1",
+            "status": "quiet",
+            "view_role": "lossy-continuation-projection",
+            "reason": "no active Planning owner is present",
+            "detail_command": "agentic-workspace summary --verbose --format json",
+        }
+
+    active_item = active_items[0] if active_items else {}
+    if planning_record is None:
+        active_contract = _active_intent_contract(target_root=target_root, active_items=active_items, active_execplans=active_execplans)
+        resumable_contract = _active_resumable_contract(
+            target_root=target_root,
+            active_contract=active_contract,
+            active_execplans=active_execplans,
+        )
+        planning_record = _canonical_planning_record(
+            target_root=target_root,
+            active_contract=active_contract,
+            resumable_contract=resumable_contract,
+        )
+
+    plan_source = str(revision.get("active_execplan") or "").strip()
+    state_source = str(revision.get("state_path") or PLANNING_STATE_PATH.as_posix()).strip()
+    stale_projections: list[dict[str, str]] = []
+    uncertainty: list[dict[str, str]] = []
+    source_precedence = [
+        {
+            "rank": 1,
+            "owner": "Planning active execplan",
+            "uses": ["active intent", "next action", "proof state", "claim boundary"],
+            "source": plan_source,
+            "freshness": "current" if str(revision.get("active_execplan_hash", "")) not in {"", "missing"} else "missing",
+        },
+        {
+            "rank": 2,
+            "owner": "Planning state todo row",
+            "uses": ["active item identity", "surface pointer", "legacy projection"],
+            "source": state_source,
+            "freshness": "current unless a more canonical execplan field disagrees",
+        },
+        {
+            "rank": 3,
+            "owner": "Closeout/completion gate",
+            "uses": ["authorized claim class", "blocked completion language"],
+            "source": "planning_record.completion_gate",
+            "freshness": "current when recorded in active execplan",
+        },
+        {
+            "rank": 4,
+            "owner": "Verification and Memory",
+            "uses": ["proof summaries and durable anti-rediscovery facts only when referenced"],
+            "source": "Verification/Memory owner surfaces",
+            "freshness": "not loaded by this compact Planning view",
+        },
+    ]
+
+    if planning_record.get("status") != "present":
+        uncertainty.append(
+            {
+                "kind": "missing-owner",
+                "summary": str(planning_record.get("reason") or "active Planning owner could not be resolved"),
+                "route": "agentic-workspace summary --verbose --format json",
+            }
+        )
+        return {
+            "kind": "agentic-planning/continuation-view/v1",
+            "status": "needs-reconcile",
+            "view_role": "lossy-continuation-projection",
+            "summary_profile": summary_profile,
+            "source_precedence": source_precedence,
+            "resume_predicate": {
+                "status": "blocked",
+                "must_be_true": [
+                    "active owner exists",
+                    "revision matches",
+                    "next action is current",
+                    "claim boundary is known",
+                    "proof state is not stale when proof is required",
+                ],
+                "failed": ["active owner exists"],
+                "required_next_action": "reconcile-active-planning-owner",
+            },
+            "uncertainty": uncertainty,
+            "drill_down": {
+                "summary_verbose": "agentic-workspace summary --verbose --format json",
+                "planning_record": "agentic-workspace summary --select planning_record --format json",
+            },
+        }
+
+    todo_next_action = str(active_item.get("next_action", "")).strip() if isinstance(active_item, dict) else ""
+    plan_next_action = str(planning_record.get("next_action", "")).strip()
+    if todo_next_action and plan_next_action and todo_next_action != plan_next_action:
+        stale_projections.append(
+            {
+                "field": "todo.active_items[0].next_action",
+                "stale_value": todo_next_action,
+                "chosen_value": plan_next_action,
+                "chosen_source": plan_source,
+                "reason": "active execplan next action has higher source precedence than todo metadata",
+            }
+        )
+    if todo_next_action and not plan_next_action:
+        uncertainty.append(
+            {
+                "kind": "ambiguous-next-action",
+                "summary": "Only todo metadata provides a next action; active execplan next action is unavailable.",
+                "route": "agentic-workspace summary --select planning_record,resumable_contract --format json",
+            }
+        )
+
+    proof_state = _proof_state_for_continuation_view(planning_record)
+    claim_boundary = _claim_boundary_for_continuation_view(planning_record)
+    failed_predicates: list[str] = []
+    if not plan_source:
+        failed_predicates.append("active owner exists")
+    if not revision.get("revision_id"):
+        failed_predicates.append("revision matches")
+    if not plan_next_action:
+        failed_predicates.append("next action is current")
+    if claim_boundary.get("status") == "unknown":
+        failed_predicates.append("claim boundary is known")
+    if proof_state.get("status") == "missing-or-pending" and claim_boundary.get("claim_level_allowed") == "full-intent-complete":
+        failed_predicates.append("proof state is not stale when proof is required")
+
+    required_next_action = str(claim_boundary.get("required_next_action") or "continue-current-work")
+    if failed_predicates:
+        predicate_status = "needs-reconcile"
+        required_next_action = "drill-down-or-reconcile"
+    elif claim_boundary.get("claim_level_allowed") == "partial-progress":
+        predicate_status = "continue-with-boundary"
+    else:
+        predicate_status = "pass"
+
+    source_freshness = [
+        _compact_source_entry(
+            claim="active intent",
+            owner="Planning active execplan",
+            source=plan_source,
+            source_hash=str(revision.get("active_execplan_hash", "")),
+        ),
+        _compact_source_entry(
+            claim="planning state projection",
+            owner="Planning state",
+            source=state_source,
+            source_hash=str(revision.get("state_hash", "")),
+            freshness="stale-projection" if stale_projections else "current",
+        ),
+        _compact_source_entry(
+            claim="proof state",
+            owner="Planning proof_report",
+            source=f"{plan_source}#proof_report" if plan_source else "planning_record.proof_report",
+            source_hash=str(revision.get("active_execplan_hash", "")),
+            freshness=str(proof_state.get("freshness", "unknown")),
+        ),
+        _compact_source_entry(
+            claim="claim boundary",
+            owner="completion_gate" if planning_record.get("completion_gate") else "Planning closeout fields",
+            source=f"{plan_source}#completion_gate"
+            if planning_record.get("completion_gate") and plan_source
+            else claim_boundary.get("source", ""),
+            source_hash=str(revision.get("active_execplan_hash", "")) if planning_record.get("completion_gate") else "",
+            freshness="current-owner" if claim_boundary.get("status") != "unknown" else "unknown",
+        ),
+    ]
+    return _drop_empty_compact_fields(
+        {
+            "kind": "agentic-planning/continuation-view/v1",
+            "status": "present",
+            "view_role": "lossy-continuation-projection",
+            "summary_profile": summary_profile,
+            "answers": {
+                "preserved_intent": str(planning_record.get("requested_outcome", "")).strip(),
+                "claim_allowed": str(claim_boundary.get("claim_level_allowed", "")).strip(),
+                "next_safe_action": plan_next_action or todo_next_action,
+                "trust_basis": "source_freshness + resume_predicate + claim_boundary",
+            },
+            "active_intent": {
+                "summary": str(planning_record.get("requested_outcome", "")).strip(),
+                "owner": "Planning active execplan",
+                "source": plan_source,
+                "freshness": "current-owner",
+            },
+            "next_action": {
+                "summary": plan_next_action or todo_next_action,
+                "owner": "Planning active execplan" if plan_next_action else "Planning state todo row",
+                "source": plan_source if plan_next_action else state_source,
+                "freshness": "current-owner" if plan_next_action else "lower-precedence-fallback",
+            },
+            "proof_state": proof_state,
+            "claim_boundary": claim_boundary,
+            "resume_predicate": {
+                "status": predicate_status,
+                "must_be_true": [
+                    "active owner exists",
+                    "revision matches",
+                    "next action is current",
+                    "claim boundary is known",
+                    "proof state is not stale when proof is required",
+                ],
+                "failed": failed_predicates,
+                "required_next_action": required_next_action,
+                "rule": "A passing predicate allows continuation from this compact packet; failures route to drill-down or reconciliation before broad claims.",
+            },
+            "source_precedence": source_precedence,
+            "source_freshness": source_freshness,
+            "stale_projections": stale_projections,
+            "uncertainty": uncertainty,
+            "omitted_detail": [
+                "raw transcript material",
+                "full execplan prose",
+                "historical review archives",
+                "Memory notes not selected by owner surfaces",
+                "Verification detail not referenced by current proof state",
+            ],
+            "drill_down": {
+                "summary_verbose": "agentic-workspace summary --verbose --format json",
+                "planning_record": "agentic-workspace summary --select planning_record --format json",
+                "proof": "agentic-workspace summary --select continuation_view.proof_state,planning_record.proof_report --format json",
+                "claim_boundary": "agentic-workspace summary --select continuation_view.claim_boundary,planning_record.completion_gate --format json",
+                "owner_sources": "agentic-workspace summary --select continuation_view.source_freshness,planning_revision --format json",
+            },
+            "write_responsibility": {
+                "active_work": "Planning execplan/lane/decomposition commands write active continuation state.",
+                "proof": "Verification or Planning proof_report owns proof summaries.",
+                "claim_residue": "closeout/completion_gate owns closure and residual intent routing.",
+                "memory": "Memory owns reusable anti-rediscovery facts only, not current task state.",
+                "summary_start": "summary/start render this lossy projection and must not become durable owners.",
+            },
+            "authority_boundary": {
+                "aw_owns": ["assembling source precedence", "exposing freshness", "surfacing blocked claim classes"],
+                "agent_owns": ["semantic intent satisfaction judgment", "whether compact evidence is sufficient for the next step"],
+                "human_owns": ["intent changes", "accepted narrowing", "accepting unresolved residual intent"],
+            },
+        }
+    )
 
 
 def _system_intent_contract_payload() -> dict[str, Any]:

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -9301,7 +9301,7 @@ def _planning_continuation_view_payload(
         {
             "rank": 3,
             "owner": "Closeout/completion gate",
-            "uses": ["authorized claim class", "blocked completion language"],
+            "uses": ["authorized claim class", "blocked claim classes"],
             "source": "planning_record.completion_gate",
             "freshness": "current when recorded in active execplan",
         },

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -9171,7 +9171,6 @@ def _claim_boundary_for_continuation_view(planning_record: dict[str, Any]) -> di
         if isinstance(authorization, dict):
             blocked_classes = [str(item) for item in authorization.get("blocked_claim_classes", []) if str(item).strip()]
             allowed_classes = [str(item) for item in authorization.get("allowed_claim_classes", []) if str(item).strip()]
-        blocked_claims = [str(item) for item in completion_gate.get("blocked_claims", []) if str(item).strip()]
         return {
             "status": completion_gate.get("status", "unknown"),
             "source": "planning_record.completion_gate",
@@ -9181,7 +9180,6 @@ def _claim_boundary_for_continuation_view(planning_record: dict[str, Any]) -> di
             "human_accepted_partial": bool(completion_gate.get("human_accepted_partial", False)),
             "allowed_claim_classes": allowed_classes,
             "blocked_claim_classes": blocked_classes,
-            "blocked_claims": blocked_claims,
             "rule": "completion_gate owns closeout claim authorization; continuation_view only projects it.",
         }
     satisfied = _truthy_status(intent_satisfaction.get("was original intent fully satisfied?"))
@@ -9192,19 +9190,16 @@ def _claim_boundary_for_continuation_view(planning_record: dict[str, Any]) -> di
         claim_level_allowed = "full-intent-complete"
         required_next_action = "close-complete"
         active_intent_satisfied = True
-        blocked_claims: list[str] = []
     elif unsatisfied or continuation_required:
         status = "continue-required"
         claim_level_allowed = "partial-progress"
         required_next_action = "continue-current-work"
         active_intent_satisfied = False
-        blocked_claims = ["done", "implemented", "complete", "finished", "all", "full intent complete"]
     else:
         status = "unknown"
         claim_level_allowed = "partial-progress"
         required_next_action = "reconcile-claim-boundary"
         active_intent_satisfied = False
-        blocked_claims = ["done", "implemented", "complete", "finished", "all", "full intent complete"]
     return {
         "status": status,
         "source": "planning_record.intent_satisfaction + required_continuation + closure_check",
@@ -9214,7 +9209,6 @@ def _claim_boundary_for_continuation_view(planning_record: dict[str, Any]) -> di
         "human_accepted_partial": False,
         "allowed_claim_classes": ["partial_progress"] if claim_level_allowed == "partial-progress" else ["full_intent_complete"],
         "blocked_claim_classes": ["full_intent_complete", "issue_closure"] if claim_level_allowed == "partial-progress" else [],
-        "blocked_claims": blocked_claims,
         "closure_decision": closure_check.get("closure decision", ""),
         "rule": "When completion_gate is absent, this is a conservative projection from existing Planning closeout fields.",
     }

--- a/packages/planning/tests/test_promote.py
+++ b/packages/planning/tests/test_promote.py
@@ -1252,6 +1252,152 @@ candidates = [
     )
 
 
+def test_planning_summary_continuation_view_prefers_fresh_execplan_over_stale_todo(tmp_path: Path) -> None:
+    install_bootstrap(target=tmp_path)
+    plan_path = tmp_path / ".agentic-workspace/planning/execplans/resume-lane.plan.json"
+    record = installer_mod._build_execplan_record_from_todo_item(
+        title="Resume Lane",
+        item_id="resume-lane",
+        status="active",
+        why_now="Preserve the active intent.",
+        next_action="Use the fresher execplan action.",
+        done_when="The active intent is fully satisfied.",
+    )
+    record["proof_report"] = {
+        "validation proof": "Passed current characterization proof.",
+        "proof achieved now": "yes",
+        'evidence for "proof achieved" state': "Current proof receipt.",
+    }
+    record["intent_satisfaction"] = {
+        "original intent": "Preserve the active intent.",
+        "was original intent fully satisfied?": "yes",
+        "evidence of intent satisfaction": "Current proof receipt.",
+        "unsolved intent passed to": "none",
+    }
+    record["completion_gate"] = {
+        "kind": "agentic-workspace/completion-gate/v1",
+        "status": "allowed",
+        "active_intent_satisfied": True,
+        "human_accepted_partial": False,
+        "claim_level_requested": "full-intent-complete",
+        "claim_level_allowed": "full-intent-complete",
+        "required_next_action": "close-complete",
+        "blocked_claims": [],
+        "claim_authorization": {
+            "allowed_claim_classes": ["full_intent_complete"],
+            "blocked_claim_classes": [],
+        },
+    }
+    _write(plan_path, json.dumps(record, indent=2))
+    _write(
+        tmp_path / ".agentic-workspace/planning/state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "resume-lane", title = "Resume Lane", maturity = "active", status = "active", surface = ".agentic-workspace/planning/execplans/resume-lane.plan.json", why_now = "Old todo projection.", next_action = "Stale todo action.", done_when = "Old todo done text.", proof = "Old todo proof." },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+
+    summary = planning_summary(target=tmp_path, profile="tiny")
+    view = summary["continuation_view"]
+
+    assert view["answers"]["preserved_intent"] == "Preserve the active intent."
+    assert view["answers"]["next_safe_action"] == "Use the fresher execplan action."
+    assert view["resume_predicate"]["status"] == "pass"
+    assert view["claim_boundary"]["claim_level_allowed"] == "full-intent-complete"
+    assert view["proof_state"]["status"] == "present"
+    assert view["stale_projections"][0]["field"] == "todo.active_items[0].next_action"
+    assert view["stale_projections"][0]["stale_value"] == "Stale todo action."
+    assert view["stale_projections"][0]["chosen_value"] == "Use the fresher execplan action."
+    assert any(
+        item["claim"] == "planning state projection" and item["freshness"] == "stale-projection" for item in view["source_freshness"]
+    )
+    assert "raw transcript material" in view["omitted_detail"]
+    assert view["write_responsibility"]["summary_start"].startswith("summary/start render")
+
+
+def test_planning_summary_continuation_view_routes_unsatisfied_intent_to_continuation(tmp_path: Path) -> None:
+    install_bootstrap(target=tmp_path)
+    plan_path = tmp_path / ".agentic-workspace/planning/execplans/unfinished-lane.plan.json"
+    record = installer_mod._build_execplan_record_from_todo_item(
+        title="Unfinished Lane",
+        item_id="unfinished-lane",
+        status="active",
+        why_now="Replace broad test structure.",
+        next_action="Continue replacing the remaining tests.",
+        done_when="Most existing tests are replaced by contract-owned conformance tests.",
+    )
+    record["proof_report"] = {
+        "validation proof": "Partial proof only.",
+        "proof achieved now": "yes",
+        'evidence for "proof achieved" state': "One contract fixture.",
+    }
+    record["intent_satisfaction"] = {
+        "original intent": "Replace broad test structure.",
+        "was original intent fully satisfied?": "no",
+        "evidence of intent satisfaction": "Only one conversion landed.",
+        "unsolved intent passed to": "#follow-up",
+    }
+    record["required_continuation"] = {
+        "required follow-on for the larger intended outcome": "yes",
+        "owner surface": ".agentic-workspace/planning/execplans/unfinished-lane.plan.json",
+        "activation trigger": "Continue current work.",
+    }
+    record["completion_gate"] = {
+        "kind": "agentic-workspace/completion-gate/v1",
+        "status": "continue-required",
+        "active_intent_satisfied": False,
+        "human_accepted_partial": False,
+        "claim_level_requested": "full-intent-complete",
+        "claim_level_allowed": "partial-progress",
+        "required_next_action": "continue-current-work",
+        "blocked_claims": ["done", "implemented", "complete", "finished", "all", "full intent complete"],
+        "claim_authorization": {
+            "allowed_claim_classes": ["partial_progress"],
+            "blocked_claim_classes": ["full_intent_complete", "issue_closure"],
+        },
+    }
+    _write(plan_path, json.dumps(record, indent=2))
+    _write(
+        tmp_path / ".agentic-workspace/planning/state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "unfinished-lane", title = "Unfinished Lane", maturity = "active", status = "active", surface = ".agentic-workspace/planning/execplans/unfinished-lane.plan.json", next_action = "Continue replacing the remaining tests.", done_when = "Replace tests.", proof = "Partial proof." },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+
+    summary = planning_summary(target=tmp_path, profile="compact")
+    view = summary["continuation_view"]
+
+    assert view["answers"]["claim_allowed"] == "partial-progress"
+    assert view["resume_predicate"]["status"] == "continue-with-boundary"
+    assert view["resume_predicate"]["required_next_action"] == "continue-current-work"
+    assert view["claim_boundary"]["status"] == "continue-required"
+    assert view["claim_boundary"]["active_intent_satisfied"] is False
+    assert "full_intent_complete" in view["claim_boundary"]["blocked_claim_classes"]
+    assert "complete" in view["claim_boundary"]["blocked_claims"]
+    assert view["answers"]["next_safe_action"] == "Continue replacing the remaining tests."
+
+
 def test_finished_work_inspection_treats_state_roadmap_owner_as_routed_continuation(tmp_path: Path) -> None:
     install_bootstrap(target=tmp_path)
     _write(

--- a/packages/planning/tests/test_promote.py
+++ b/packages/planning/tests/test_promote.py
@@ -1282,7 +1282,6 @@ def test_planning_summary_continuation_view_prefers_fresh_execplan_over_stale_to
         "claim_level_requested": "full-intent-complete",
         "claim_level_allowed": "full-intent-complete",
         "required_next_action": "close-complete",
-        "blocked_claims": [],
         "claim_authorization": {
             "allowed_claim_classes": ["full_intent_complete"],
             "blocked_claim_classes": [],
@@ -1360,7 +1359,6 @@ def test_planning_summary_continuation_view_routes_unsatisfied_intent_to_continu
         "claim_level_requested": "full-intent-complete",
         "claim_level_allowed": "partial-progress",
         "required_next_action": "continue-current-work",
-        "blocked_claims": ["done", "implemented", "complete", "finished", "all", "full intent complete"],
         "claim_authorization": {
             "allowed_claim_classes": ["partial_progress"],
             "blocked_claim_classes": ["full_intent_complete", "issue_closure"],
@@ -1394,7 +1392,7 @@ candidates = []
     assert view["claim_boundary"]["status"] == "continue-required"
     assert view["claim_boundary"]["active_intent_satisfied"] is False
     assert "full_intent_complete" in view["claim_boundary"]["blocked_claim_classes"]
-    assert "complete" in view["claim_boundary"]["blocked_claims"]
+    assert "blocked_claims" not in view["claim_boundary"]
     assert view["answers"]["next_safe_action"] == "Continue replacing the remaining tests."
 
 

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -181,6 +181,11 @@
       "additionalProperties": false,
       "description": "Small active-work projection used to decide whether raw planning state needs to be opened."
     },
+    "continuation_view": {
+      "type": "object",
+      "description": "Lossy continuation/re-grounding view projected from existing owner surfaces so a low-context agent can identify preserved intent, allowed claim class, next safe action, source freshness, omissions, and drill-down routes without treating startup as a durable state owner.",
+      "additionalProperties": true
+    },
     "package_boundary": {
       "$ref": "#/$defs/package_boundary",
       "description": "Current package/root boundary information for the command invocation."

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -17040,6 +17040,85 @@ def _startup_closeout_report_route(closeout_inspection: dict[str, Any]) -> dict[
     }
 
 
+def _startup_continuation_view_payload(*, target_root: Path) -> dict[str, Any]:
+    try:
+        from repo_planning_bootstrap.installer import planning_summary
+
+        summary = planning_summary(target=target_root, profile="tiny")
+    except Exception:
+        return {
+            "kind": "agentic-planning/continuation-view/v1",
+            "status": "unavailable",
+            "reason": "Planning summary continuation view could not be loaded.",
+            "detail_command": "agentic-workspace summary --format json",
+        }
+    if not isinstance(summary, dict):
+        return {
+            "kind": "agentic-planning/continuation-view/v1",
+            "status": "unavailable",
+            "reason": "Planning summary did not return a structured payload.",
+            "detail_command": "agentic-workspace summary --format json",
+        }
+    view = summary.get("continuation_view")
+    if isinstance(view, dict):
+        return _compact_start_continuation_view(view)
+    return {
+        "kind": "agentic-planning/continuation-view/v1",
+        "status": "quiet",
+        "reason": "Planning summary did not report active continuation pressure.",
+        "detail_command": "agentic-workspace summary --format json",
+    }
+
+
+def _compact_start_continuation_view(view: dict[str, Any]) -> dict[str, Any]:
+    def _clip(value: Any, *, limit: int = 180) -> Any:
+        if not isinstance(value, str) or len(value) <= limit:
+            return value
+        return value[: limit - 1].rstrip() + "..."
+
+    answers = view.get("answers", {}) if isinstance(view.get("answers"), dict) else {}
+    compact_answers = {
+        key: _clip(answers.get(key))
+        for key in ("preserved_intent", "claim_allowed", "next_safe_action", "trust_basis")
+        if answers.get(key) not in ("", None)
+    }
+    claim_boundary = view.get("claim_boundary", {}) if isinstance(view.get("claim_boundary"), dict) else {}
+    resume_predicate = view.get("resume_predicate", {}) if isinstance(view.get("resume_predicate"), dict) else {}
+    stale_projections = view.get("stale_projections", []) if isinstance(view.get("stale_projections"), list) else []
+    compact_stale = [
+        {
+            key: _clip(item.get(key), limit=120)
+            for key in ("field", "stale_value", "chosen_value", "reason")
+            if isinstance(item, dict) and key in item
+        }
+        for item in stale_projections[:2]
+        if isinstance(item, dict)
+    ]
+    compact = {
+        "kind": view.get("kind", "agentic-planning/continuation-view/v1"),
+        "status": view.get("status", "unknown"),
+        "answers": compact_answers,
+        "claim_boundary": {
+            key: claim_boundary.get(key)
+            for key in (
+                "status",
+                "claim_level_allowed",
+                "required_next_action",
+                "active_intent_satisfied",
+            )
+            if key in claim_boundary
+        },
+        "resume_predicate": {
+            key: resume_predicate.get(key) for key in ("status", "failed", "required_next_action") if key in resume_predicate
+        },
+        "stale_projections": compact_stale,
+        "drill_down": {
+            "full_view": "agentic-workspace summary --select continuation_view --format json",
+        },
+    }
+    return {key: value for key, value in compact.items() if value not in ({}, [], "", None)}
+
+
 def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Project startup context to the smallest schema-compatible first-contact answer."""
     immediate = copy.deepcopy(payload["immediate_next_allowed_action"])
@@ -17135,6 +17214,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "read_first": payload.get("memory_consult", {}).get("read_first", []),
             "do_not_bulk_read": payload.get("memory_consult", {}).get("do_not_bulk_read", True),
         },
+        **({"continuation_view": payload["continuation_view"]} if isinstance(payload.get("continuation_view"), dict) else {}),
         "routine_work_context": payload.get("routine_work_context", {}),
         "operating_posture": {
             "status": payload.get("operating_posture", {}).get("status", "unknown"),
@@ -17889,6 +17969,8 @@ def _start_payload(
         payload["parent_intent_status"] = parent_intent_status
     if applicable_intent_status.get("status") != "guidance-only":
         payload["applicable_intent_status"] = applicable_intent_status
+    if active_planning_present:
+        payload["continuation_view"] = _startup_continuation_view_payload(target_root=target_root)
     if int(assurance_requirements.get("configured_count", 0) or 0) > 0:
         payload["assurance_requirements"] = assurance_requirements
     startup_review = _workspace_absence_startup_review(target_root=target_root, config=config)
@@ -18367,6 +18449,7 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "workflow_obligations",
         "closeout_obligations",
         "routine_work_context",
+        "continuation_view",
         "read_only_response",
         "proof",
         "repair_plan_profile",
@@ -18773,6 +18856,8 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             "available_selectors": available_selectors,
         },
     }
+    if isinstance(payload.get("continuation_view"), dict):
+        selected["continuation_view"] = payload["continuation_view"]
     if "task_intent" in payload:
         task_intent = payload["task_intent"]
         if (
@@ -18969,6 +19054,8 @@ def _start_tiny_payload_fast(
         payload["parent_intent_status"] = parent_intent_status
     if applicable_intent_status.get("status") != "guidance-only":
         payload["applicable_intent_status"] = applicable_intent_status
+    if active_planning_present:
+        payload["continuation_view"] = _startup_continuation_view_payload(target_root=target_root)
     startup_review = _workspace_absence_startup_review(target_root=target_root, config=config)
     if startup_review["status"] == "attention":
         payload["startup_review"] = startup_review

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -706,6 +706,76 @@ def test_start_command_returns_minimum_safe_startup_context(tmp_path: Path, caps
     ]
 
 
+def test_start_surfaces_continuation_view_for_active_planning(tmp_path: Path, capsys) -> None:
+    from repo_planning_bootstrap import installer as planning_installer
+
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    _write(
+        target / ".agentic-workspace" / "config.local.toml",
+        'schema_version = 1\n\n[workspace]\ncli_invoke = "uv run agentic-workspace"\n',
+    )
+    plan_path = target / ".agentic-workspace/planning/execplans/resume.plan.json"
+    record = planning_installer._build_execplan_record_from_todo_item(
+        title="Resume",
+        item_id="resume",
+        status="active",
+        why_now="Preserve the active user intent.",
+        next_action="Continue from the execplan next action.",
+        done_when="The active user intent is satisfied.",
+    )
+    record["proof_report"] = {
+        "validation proof": "Passed focused proof.",
+        "proof achieved now": "yes",
+        'evidence for "proof achieved" state': "Focused proof receipt.",
+    }
+    record["completion_gate"] = {
+        "kind": "agentic-workspace/completion-gate/v1",
+        "status": "continue-required",
+        "active_intent_satisfied": False,
+        "human_accepted_partial": False,
+        "claim_level_requested": "full-intent-complete",
+        "claim_level_allowed": "partial-progress",
+        "required_next_action": "continue-current-work",
+        "blocked_claims": ["done", "implemented", "complete", "finished", "all", "full intent complete"],
+        "claim_authorization": {
+            "allowed_claim_classes": ["partial_progress"],
+            "blocked_claim_classes": ["full_intent_complete", "issue_closure"],
+        },
+    }
+    _write_json(plan_path, record)
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "resume", title = "Resume", maturity = "active", status = "active", surface = ".agentic-workspace/planning/execplans/resume.plan.json", next_action = "Stale todo action.", done_when = "Done.", proof = "Proof." },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+
+    assert cli.main(["start", "--target", str(target), "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    view = payload["continuation_view"]
+    assert view["kind"] == "agentic-planning/continuation-view/v1"
+    assert view["answers"]["preserved_intent"] == "Preserve the active user intent."
+    assert view["answers"]["next_safe_action"] == "Continue from the execplan next action."
+    assert view["answers"]["claim_allowed"] == "partial-progress"
+    assert view["resume_predicate"]["required_next_action"] == "continue-current-work"
+    assert view["stale_projections"][0]["field"] == "todo.active_items[0].next_action"
+    assert "continuation_view" in payload["drill_down"]["available_selectors"]
+
+
 def test_start_surfaces_maintainer_mode_dogfooding_routes_from_local_config(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -738,7 +738,6 @@ def test_start_surfaces_continuation_view_for_active_planning(tmp_path: Path, ca
         "claim_level_requested": "full-intent-complete",
         "claim_level_allowed": "partial-progress",
         "required_next_action": "continue-current-work",
-        "blocked_claims": ["done", "implemented", "complete", "finished", "all", "full intent complete"],
         "claim_authorization": {
             "allowed_claim_classes": ["partial_progress"],
             "blocked_claim_classes": ["full_intent_complete", "issue_closure"],

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -70,6 +70,7 @@ candidates = [
         "planning_surface_health",
         "execution_readiness",
         "current_execution_pressure",
+        "continuation_view",
         "decomposition",
         "lanes",
         "residue_governance",


### PR DESCRIPTION
## What landed

- Adds a `continuation_view` to Planning summary as a lossy read projection over existing owners rather than a new durable re-grounding state store.
- Projects a tiny `continuation_view` from `start` when active Planning state exists, keeping richer freshness, omission, and write-owner detail behind `summary --select continuation_view`.
- Carries source precedence, freshness, stale projection reporting, uncertainty, drill-down routes, read/write responsibility boundaries, and completion-gate claim boundaries in the Planning-owned view.
- Updates startup schema/reference docs and focused tests for stale todo vs fresher execplan/proof, unsatisfied-intent continuation, and startup payload-budget behavior.
- Archives the #1385 execplan through the Planning closeout writer with no durable residue.

## Closure evidence

- The view answers the four refined acceptance questions cheaply: preserved intent, allowed claim, next safe action, and trust basis.
- Planning summary is the fuller continuation view and keeps owner precedence explicit: Planning owns active work, proof/Verification owns proof summaries, Memory owns reusable facts, closeout/completion_gate owns claim and residue routing, and summary/start only render projections.
- Startup renders a compact projection only when active Planning exists; detailed provenance remains selector-backed to preserve low-residue first contact.
- Stale todo metadata is not smoothed over: tests prove the fresher execplan next action wins and the stale todo row is reported.
- Unsatisfied intent routes to continuation through the projected completion-gate boundary rather than full closeout.

## Runtime source edit boundary

This branch directly edits existing Planning and workspace runtime primitives because it implements a new projection/view primitive. It does not directly edit generated CLI output. Generated schema/reference surfaces were refreshed and validated.

## Proof

- `uv run pytest packages/planning/tests/test_promote.py::test_planning_summary_continuation_view_prefers_fresh_execplan_over_stale_todo packages/planning/tests/test_promote.py::test_planning_summary_continuation_view_routes_unsatisfied_intent_to_continuation -q`
- `uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_surfaces_continuation_view_for_active_planning -q`
- focused startup budget regressions for minimum/tiny start and tiny summary
- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make schema-reference-docs`
- `make maintainer-surfaces`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`

Closes #1385