### PR TITLE
Fix close-item archive projection refresh

### DIFF
--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -11753,7 +11753,18 @@ def _closeout_sequence_needs_normalization(value: Any) -> bool:
         text = json.dumps(value, sort_keys=True).lower()
     else:
         return False
-    return any(token in text for token in ("fill in", "pending", "not-run-yet", "not run yet", "todo", "tbd"))
+    return any(
+        token in text
+        for token in (
+            "fill in",
+            "pending",
+            "not-run-yet",
+            "not run yet",
+            "todo",
+            "tbd",
+            "open upstream issue from refreshed external intent evidence",
+        )
+    )
 
 
 def _prepared_canonical_core_closeout(
@@ -11768,6 +11779,8 @@ def _prepared_canonical_core_closeout(
     canonical_core = copy.deepcopy(raw_canonical_core) if isinstance(raw_canonical_core, dict) else {}
     proof = validation_evidence.strip() or "closeout proof recorded in proof_report."
     outcome = outcome_delivered.strip() or "bounded slice closeout completed."
+    if _closeout_sequence_needs_normalization(canonical_core.get("requested_outcome")):
+        canonical_core["requested_outcome"] = outcome
     if _closeout_sequence_needs_normalization(canonical_core.get("proof_expectations")):
         canonical_core["proof_expectations"] = [proof]
     if _closeout_sequence_needs_normalization(canonical_core.get("touched_scope")):
@@ -11792,6 +11805,11 @@ def _prepared_machine_readable_contract_closeout(
     execution = dict(contract.get("execution", {})) if isinstance(contract.get("execution"), dict) else {}
     scope = dict(contract.get("scope", {})) if isinstance(contract.get("scope"), dict) else {}
     proof = validation_evidence.strip() or "closeout proof recorded in proof_report."
+    outcome = str(
+        _canonical_execution_summary(_record_section_dict(record, "execution_summary") or {}).get("outcome delivered", "")
+    ).strip()
+    if _closeout_sequence_needs_normalization(intent.get("outcome")):
+        intent["outcome"] = outcome or "bounded slice closeout completed."
     if _closeout_sequence_needs_normalization(intent.get("proof")):
         intent["proof"] = proof
     execution["status"] = "completed"
@@ -11840,6 +11858,8 @@ def _prepared_intent_interpretation_closeout(*, record: dict[str, Any], outcome_
     existing = _record_section_dict(record, "intent_interpretation") or {}
     prepared = dict(existing)
     outcome = outcome_delivered.strip() or "The bounded slice completed with recorded closeout evidence."
+    if _closeout_sequence_needs_normalization(prepared.get("inferred intended outcome")):
+        prepared["inferred intended outcome"] = outcome
     if _closeout_sequence_needs_normalization(prepared.get("chosen concrete what")):
         prepared["chosen concrete what"] = outcome
     if _closeout_sequence_needs_normalization(prepared.get("review guidance")):
@@ -12279,6 +12299,21 @@ def _prepare_execplan_closeout(
         validation_evidence=validation_evidence,
         outcome_delivered=str(execution_summary.get("outcome delivered", "")).strip(),
     )
+    outcome_delivered = (
+        str(execution_summary.get("outcome delivered", "")).strip() or "The bounded slice completed with recorded closeout evidence."
+    )
+    if _closeout_sequence_needs_normalization(record.get("goal")):
+        patch["goal"] = [outcome_delivered]
+    prepared_delegated_judgment = dict(delegated_judgment)
+    if _closeout_sequence_needs_normalization(prepared_delegated_judgment.get("requested outcome")):
+        prepared_delegated_judgment["requested outcome"] = outcome_delivered
+    if prepared_delegated_judgment:
+        patch["delegated_judgment"] = prepared_delegated_judgment
+    prepared_intent_continuity = dict(intent_continuity)
+    if _closeout_sequence_needs_normalization(prepared_intent_continuity.get("larger intended outcome")):
+        prepared_intent_continuity["larger intended outcome"] = outcome_delivered
+    if prepared_intent_continuity:
+        patch["intent_continuity"] = prepared_intent_continuity
     patch["machine_readable_contract"] = _prepared_machine_readable_contract_closeout(
         record=record,
         validation_evidence=validation_evidence,
@@ -13225,11 +13260,13 @@ def close_planning_item(
 
     candidate = candidates[0]
     if candidate["kind"] == "execplan":
+        prepare_closeout = _close_item_can_prepare_execplan_archive(target_root=target_root, candidate=candidate)
         archive_result = archive_execplan(
             str(candidate["plan_arg"]),
             target=target_root,
             dry_run=dry_run,
             apply_cleanup=True,
+            prepare_closeout=prepare_closeout,
             retain_archive=True,
         )
         archive_result.message = f"Close planning item {item_id} through execplan archive flow"
@@ -16843,6 +16880,20 @@ def _close_item_id_match(candidate_id: str, item_id: str) -> str | None:
     if candidate_id.startswith(item_id):
         return "prefix"
     return None
+
+
+def _close_item_can_prepare_execplan_archive(*, target_root: Path, candidate: dict[str, Any]) -> bool:
+    path_text = str(candidate.get("path", "")).strip()
+    if not path_text:
+        return False
+    record = _load_execplan_record(target_root / path_text)
+    if record is None:
+        return False
+    closure_check = _record_section_dict(record, "closure_check") or {}
+    closure_decision = str(closure_check.get("closure decision") or "").strip().lower()
+    if closure_decision in {"archive-and-close", "archive-but-keep-lane-open"}:
+        return True
+    return False
 
 
 def _collapse_close_item_plan_state_pairs(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/packages/planning/tests/test_close_item.py
+++ b/packages/planning/tests/test_close_item.py
@@ -95,15 +95,40 @@ active_items = [
 """,
     )
     _write_execplan_record(tmp_path / ".agentic-workspace/planning/execplans/plan-alpha.plan.json", status="completed")
+    plan_path = tmp_path / ".agentic-workspace/planning/execplans/plan-alpha.plan.json"
+    record = json.loads(plan_path.read_text(encoding="utf-8"))
+    scaffold_outcome = "Open upstream issue from refreshed external intent evidence; priority P2 inferred from inferred-planning."
+    record["goal"] = [scaffold_outcome]
+    record["canonical_core"]["requested_outcome"] = scaffold_outcome
+    record["canonical_core"]["proof_expectations"] = ["Fill in the narrowest command that proves the promoted work."]
+    record["machine_readable_contract"]["intent"]["outcome"] = scaffold_outcome
+    record["machine_readable_contract"]["execution"]["status"] = "in-progress"
+    record["machine_readable_contract"]["execution"]["proof"] = "Fill in the narrowest command that proves the promoted work."
+    record["delegated_judgment"]["requested outcome"] = scaffold_outcome
+    record["intent_continuity"]["larger intended outcome"] = scaffold_outcome
+    record["intent_interpretation"]["inferred intended outcome"] = scaffold_outcome
+    record["execution_bounds"]["required validation commands"] = "Fill in the narrowest command that proves the promoted work."
+    record["validation_commands"] = ["Fill in the narrowest command that proves the promoted work."]
+    installer_mod._write_execplan_record(record_path=plan_path, record=record)
 
     result = close_planning_item("plan-alpha", target=tmp_path)
     state = tomllib.loads((tmp_path / ".agentic-workspace/planning/state.toml").read_text(encoding="utf-8"))
+    archived_path = tmp_path / ".agentic-workspace/planning/execplans/archive/plan-alpha.plan.json"
+    archived = json.loads(archived_path.read_text(encoding="utf-8"))
+    archived_text = json.dumps(archived)
 
     assert result.warnings == []
     assert not (tmp_path / ".agentic-workspace/planning/execplans/plan-alpha.plan.json").exists()
-    assert (tmp_path / ".agentic-workspace/planning/execplans/archive/plan-alpha.plan.json").exists()
+    assert archived_path.exists()
     assert state["todo"]["active_items"] == []
     assert any(action.kind == "archived" for action in result.actions)
+    assert any(action.kind == "updated" and "prepared normalized closeout fields" in action.detail for action in result.actions)
+    assert "Open upstream issue from refreshed external intent evidence" not in archived_text
+    assert "Fill in the narrowest command" not in archived_text
+    assert archived["machine_readable_contract"]["execution"]["status"] == "completed"
+    assert archived["goal"] == [archived["execution_summary"]["outcome delivered"]]
+    assert archived["canonical_core"]["requested_outcome"] == archived["execution_summary"]["outcome delivered"]
+    assert archived["machine_readable_contract"]["intent"]["outcome"] == archived["execution_summary"]["outcome delivered"]
 
 
 def test_close_item_blocked_archive_flow_reports_machine_readable_status(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Fixes #1399 by making `close-item` run closeout projection normalization before retaining an archived execplan, but only when the existing closure gate already authorizes archive (`archive-and-close` or `archive-but-keep-lane-open`).
- Expands closeout normalization to replace stale scaffold compatibility projections such as `Open upstream issue from refreshed external intent evidence...` and `Fill in the narrowest command...` across `goal`, `canonical_core`, `machine_readable_contract`, `delegated_judgment`, `intent_continuity`, and `intent_interpretation`.
- Adds a regression proving `close-item` archives do not retain those scaffold projections while preserving the existing missing/keep-active closure blockers.

## Root Cause

`close-item` routed completed execplan ids straight through `archive_execplan(... retain_archive=True)` without `prepare_closeout=True`. That meant the canonical closeout fields could be correct while retained archive compatibility projections still contained scaffold text.

## Validation

- `uv run python scripts/run_agentic_workspace.py implement --changed packages/planning/src/repo_planning_bootstrap/installer.py packages/planning/tests/test_close_item.py --task "Fix #1399 dogfooding finding: close-item should refresh or reject stale scaffold projections before retaining archived execplans" --format json`
- `uv run pytest packages/planning/tests/test_close_item.py::test_close_item_routes_execplan_id_through_archive_flow -q`
- `uv run pytest packages/planning/tests/test_close_item.py::test_close_item_routes_execplan_id_through_archive_flow packages/planning/tests/test_close_item.py::test_close_item_blocked_archive_flow_reports_machine_readable_status packages/planning/tests/test_close_item.py::test_close_item_runtime_cli_reports_blocked_json_status -q`
- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`
- `uv run python scripts/check/check_planning_surfaces.py`
- Spark review: no blocker; confirmed missing/keep-active gates remain blocking.
- commit hook: `sync-all`, workspace/memory/planning/verification lint, prompt semantic markers, absolute-path check

Closes #1399
Refs #1389
