### PR TITLE
Clarify closeout evidence retention route

### DIFF
--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -14128,9 +14128,9 @@ def _closeout_evidence_record(
         "retention": {
             "state": "archive-retention-skipped",
             "reason": reason,
-            "canonical evidence": "retained closeout evidence",
-            "ordinary route": "agentic-workspace summary --format json or report --section closeout_report --format json",
-            "trust rule": "When this record exists, agents should trust it as the closeout handoff surface without inspecting the omitted full execplan archive.",
+            "canonical_evidence": "retained closeout evidence",
+            "ordinary_route": "agentic-workspace summary --format json or report --section closeout_report --format json",
+            "trust_rule": "When this record exists, agents should trust it as the closeout handoff surface without inspecting the omitted full execplan archive.",
             "rule": "Retained closeout evidence preserves reportable closeout facts when the full execplan archive exceeds inventory size guardrails.",
         },
     }

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -14128,6 +14128,9 @@ def _closeout_evidence_record(
         "retention": {
             "state": "archive-retention-skipped",
             "reason": reason,
+            "canonical evidence": "retained closeout evidence",
+            "ordinary route": "agentic-workspace summary --format json or report --section closeout_report --format json",
+            "trust rule": "When this record exists, agents should trust it as the closeout handoff surface without inspecting the omitted full execplan archive.",
             "rule": "Retained closeout evidence preserves reportable closeout facts when the full execplan archive exceeds inventory size guardrails.",
         },
     }

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -1179,6 +1179,9 @@ candidates = []
     assert retained["kind"] == "planning-closeout-evidence/v1"
     assert retained["plan_id"] == "plan-alpha"
     assert retained["retention"]["state"] == "archive-retention-skipped"
+    assert retained["retention"]["canonical evidence"] == "retained closeout evidence"
+    assert "closeout_report" in retained["retention"]["ordinary route"]
+    assert "omitted full execplan archive" in retained["retention"]["trust rule"]
     assert retained["execution_run"]["what happened"] == "implemented the retention skip closeout option fix."
     assert retained["execution_run"]["next step"] == "compact closeout evidence retained; no active planning work remains"
     assert retained["proof_report"]["validation proof"] == "uv run pytest packages/planning/tests/test_archive.py -q"

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -1179,9 +1179,9 @@ candidates = []
     assert retained["kind"] == "planning-closeout-evidence/v1"
     assert retained["plan_id"] == "plan-alpha"
     assert retained["retention"]["state"] == "archive-retention-skipped"
-    assert retained["retention"]["canonical evidence"] == "retained closeout evidence"
-    assert "closeout_report" in retained["retention"]["ordinary route"]
-    assert "omitted full execplan archive" in retained["retention"]["trust rule"]
+    assert retained["retention"]["canonical_evidence"] == "retained closeout evidence"
+    assert "closeout_report" in retained["retention"]["ordinary_route"]
+    assert "omitted full execplan archive" in retained["retention"]["trust_rule"]
     assert retained["execution_run"]["what happened"] == "implemented the retention skip closeout option fix."
     assert retained["execution_run"]["next step"] == "compact closeout evidence retained; no active planning work remains"
     assert retained["proof_report"]["validation proof"] == "uv run pytest packages/planning/tests/test_archive.py -q"


### PR DESCRIPTION
## Summary

- Makes retained Planning closeout evidence explicitly identify itself as the canonical handoff surface when full execplan archive retention is skipped by size guardrails.
- Adds `canonical_evidence`, `ordinary_route`, and `trust_rule` fields to the existing retention map.
- Extends the retention-skip regression so future agents can trust closeout-evidence-only closeout without inspecting omitted archive detail.

Closes #1409.
Does not close #1389.

Stacked on #1419 / `codex/1389-1416-report-select-closeout-latency-v2`.

## Validation

- `uv run pytest packages/planning/tests/test_archive.py::test_planning_closeout_treats_retention_size_skip_as_non_blocking packages/planning/tests/test_archive.py::test_planning_closeout_skips_oversized_retained_evidence -q`
- `make lint-planning`
- `make typecheck-planning`
- `make test-planning`
