### PR TITLE
Classify routed workspace skill projections

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/github-1427-skill-payload-visibility.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1427-skill-payload-visibility.plan.json
@@ -1,0 +1,361 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "#1427 skill payload visibility",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for #1427 skill payload visibility.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "#1427 skill payload visibility is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for #1427 skill payload visibility."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for #1427 skill payload visibility.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "github-1427-skill-payload-visibility",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for #1427 skill payload visibility.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "#1427 skill payload visibility",
+    "inferred intended outcome": "Create a bounded plan for #1427 skill payload visibility.",
+    "chosen concrete what": "Skill catalogue now distinguishes ordinary-default reasoning skills from routed-on-demand projection/support skills.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for #1427 skill payload visibility.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1427-skill-payload-visibility",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "#1427 skill payload visibility is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added machine-readable skill visibility, demoted CLI-mirroring workspace skills to routed projection/support, kept intent/work-shape as ordinary-default reasoning skills, and updated installed payload tests.",
+    "scope touched": "#1427 workspace skill registry, installed payload copy, skills runtime payload, and skills CLI tests.",
+    "changed surfaces": ".agentic-workspace/skills/REGISTRY.json; src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_skills_cli.py.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Intent satisfied for #1427. Default installed workspace skill exposure is reduced/justified while routed recommendations still work. #1389 remains open.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Focused skills tests: 22 passed; lifecycle/package payload checks: 9 passed; ruff edited source/tests: ok; make test-workspace: ok; make lint-workspace: ok; planning summary: active state current before closeout; planning doctor: healthy.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for #1427 skill payload visibility.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Skill catalogue now distinguishes ordinary-default reasoning skills from routed-on-demand projection/support skills.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-11: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "blocked_claim_classes": [],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1427",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for #1427 skill payload visibility.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Focused skills tests: 22 passed; lifecycle/package payload checks: 9 passed; ruff edited source/tests: ok; make test-workspace: ok; make lint-workspace: ok; planning summary: active state current before closeout; planning doctor: healthy.\nChanged surfaces: .agentic-workspace/skills/REGISTRY.json; src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_skills_cli.py.\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/.agentic-workspace/skills/REGISTRY.json
+++ b/.agentic-workspace/skills/REGISTRY.json
@@ -6,8 +6,9 @@
     {
       "id": "workspace-startup",
       "path": "workspace-startup/SKILL.md",
-      "scope": "bundled",
-      "stability": "package-managed",
+      "scope": "routed-projection",
+      "stability": "contract-backed-projection",
+      "visibility": "routed-on-demand",
       "summary": "orient through compact workspace commands before opening raw planning, memory, or docs surfaces",
       "activation_hints": {
         "verbs": ["start", "orient", "route", "preflight", "bootstrap", "closeout", "prove"],
@@ -31,6 +32,7 @@
       "path": "workspace-intent-discovery/SKILL.md",
       "scope": "bundled",
       "stability": "package-managed",
+      "visibility": "ordinary-default",
       "summary": "run bounded human intent discovery before vague or high-stakes prompts become Planning or implementation",
       "activation_hints": {
         "verbs": ["ask", "clarify", "discover", "resolve", "brainstorm", "extract", "capture"],
@@ -68,6 +70,7 @@
       "path": "workspace-work-shape/SKILL.md",
       "scope": "bundled",
       "stability": "package-managed",
+      "visibility": "ordinary-default",
       "summary": "decide work shape from AW facts, hard blockers, proof needs, and user intent before implementation",
       "activation_hints": {
         "verbs": ["classify", "triage", "shape", "route", "decide", "infer", "resolve"],
@@ -118,8 +121,9 @@
     {
       "id": "workspace-proof-selection",
       "path": "workspace-proof-selection/SKILL.md",
-      "scope": "bundled",
-      "stability": "package-managed",
+      "scope": "routed-projection",
+      "stability": "contract-backed-projection",
+      "visibility": "routed-on-demand",
       "summary": "select and interpret proof for task, slice, lane, or epic completion claims",
       "activation_hints": {
         "verbs": ["prove", "validate", "verify", "classify", "select"],
@@ -151,8 +155,9 @@
     {
       "id": "workspace-transition-gates",
       "path": "workspace-transition-gates/SKILL.md",
-      "scope": "bundled",
-      "stability": "package-managed",
+      "scope": "routed-support",
+      "stability": "contract-backed-projection",
+      "visibility": "routed-on-demand",
       "summary": "apply SkillSpec-backed gates to startup, planning, proof, memory, and closeout transitions",
       "activation_hints": {
         "verbs": ["gate", "transition", "route", "preserve", "fallback"],
@@ -183,8 +188,9 @@
     {
       "id": "workspace-operating-loop",
       "path": "workspace-operating-loop/SKILL.md",
-      "scope": "bundled",
-      "stability": "package-managed",
+      "scope": "routed-projection",
+      "stability": "contract-backed-projection",
+      "visibility": "routed-on-demand",
       "summary": "apply the core operating loop and module slot contract across workspace, planning, proof, closeout, and memory",
       "activation_hints": {
         "verbs": ["orchestrate", "slot", "route", "own", "preserve"],
@@ -215,8 +221,9 @@
     {
       "id": "workspace-setup-jumpstart",
       "path": "workspace-setup-jumpstart/SKILL.md",
-      "scope": "bundled",
-      "stability": "package-managed",
+      "scope": "routed-support",
+      "stability": "contract-backed-projection",
+      "visibility": "routed-on-demand",
       "summary": "route newly installed or adopted Agentic Workspace in a lived-in repo through bounded setup and jumpstart discovery before seeding durable surfaces",
       "activation_hints": {
         "verbs": ["setup", "jumpstart", "populate", "seed", "adopt", "install", "orient"],

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json
@@ -6,8 +6,9 @@
     {
       "id": "workspace-startup",
       "path": "workspace-startup/SKILL.md",
-      "scope": "bundled",
-      "stability": "package-managed",
+      "scope": "routed-projection",
+      "stability": "contract-backed-projection",
+      "visibility": "routed-on-demand",
       "summary": "orient through compact workspace commands before opening raw planning, memory, or docs surfaces",
       "activation_hints": {
         "verbs": ["start", "orient", "route", "preflight", "bootstrap", "closeout", "prove"],
@@ -31,6 +32,7 @@
       "path": "workspace-intent-discovery/SKILL.md",
       "scope": "bundled",
       "stability": "package-managed",
+      "visibility": "ordinary-default",
       "summary": "run bounded human intent discovery before vague or high-stakes prompts become Planning or implementation",
       "activation_hints": {
         "verbs": ["ask", "clarify", "discover", "resolve", "brainstorm", "extract", "capture"],
@@ -68,6 +70,7 @@
       "path": "workspace-work-shape/SKILL.md",
       "scope": "bundled",
       "stability": "package-managed",
+      "visibility": "ordinary-default",
       "summary": "classify work shape and route direct, bounded, lane, or epic work before implementation",
       "activation_hints": {
         "verbs": ["classify", "triage", "shape", "route", "decide", "infer", "resolve"],
@@ -118,8 +121,9 @@
     {
       "id": "workspace-proof-selection",
       "path": "workspace-proof-selection/SKILL.md",
-      "scope": "bundled",
-      "stability": "package-managed",
+      "scope": "routed-projection",
+      "stability": "contract-backed-projection",
+      "visibility": "routed-on-demand",
       "summary": "select and interpret proof for task, slice, lane, or epic completion claims",
       "activation_hints": {
         "verbs": ["prove", "validate", "verify", "classify", "select"],
@@ -151,8 +155,9 @@
     {
       "id": "workspace-transition-gates",
       "path": "workspace-transition-gates/SKILL.md",
-      "scope": "bundled",
-      "stability": "package-managed",
+      "scope": "routed-support",
+      "stability": "contract-backed-projection",
+      "visibility": "routed-on-demand",
       "summary": "apply SkillSpec-backed gates to startup, planning, proof, memory, and closeout transitions",
       "activation_hints": {
         "verbs": ["gate", "transition", "route", "preserve", "fallback"],
@@ -183,8 +188,9 @@
     {
       "id": "workspace-operating-loop",
       "path": "workspace-operating-loop/SKILL.md",
-      "scope": "bundled",
-      "stability": "package-managed",
+      "scope": "routed-projection",
+      "stability": "contract-backed-projection",
+      "visibility": "routed-on-demand",
       "summary": "apply the core operating loop and module slot contract across workspace, planning, proof, closeout, and memory",
       "activation_hints": {
         "verbs": ["orchestrate", "slot", "route", "own", "preserve"],
@@ -215,8 +221,9 @@
     {
       "id": "workspace-setup-jumpstart",
       "path": "workspace-setup-jumpstart/SKILL.md",
-      "scope": "bundled",
-      "stability": "package-managed",
+      "scope": "routed-support",
+      "stability": "contract-backed-projection",
+      "visibility": "routed-on-demand",
       "summary": "route newly installed or adopted Agentic Workspace in a lived-in repo through bounded setup and jumpstart discovery before seeding durable surfaces",
       "activation_hints": {
         "verbs": ["setup", "jumpstart", "populate", "seed", "adopt", "install", "orient"],

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -1920,6 +1920,7 @@ class RegisteredSkill:
     source_kind: str
     scope: str
     stability: str
+    visibility: str
     summary: str
     activation_hints: SkillActivationHints
     registration: str
@@ -37165,6 +37166,7 @@ def _discover_registered_skills(*, target_root: Path) -> tuple[list[RegisteredSk
                     source_kind=source.source_kind,
                     scope=source.default_scope,
                     stability=source.default_stability,
+                    visibility=_skill_visibility(scope=source.default_scope),
                     summary="unregistered skill discovered by directory scan",
                     activation_hints=SkillActivationHints(verbs=(), nouns=(), phrases=(), when=()),
                     registration="implicit-scan",
@@ -37213,6 +37215,7 @@ def _load_registered_skills(*, source: SkillCatalogSource, registry_file: Path) 
                 source_kind=str(payload.get("source_kind", source.source_kind)),
                 scope=str(raw.get("scope", source.default_scope)),
                 stability=str(raw.get("stability", source.default_stability)),
+                visibility=str(raw.get("visibility", _skill_visibility(scope=str(raw.get("scope", source.default_scope))))),
                 summary=str(raw.get("summary", "")).strip(),
                 activation_hints=SkillActivationHints(
                     verbs=tuple((str(value).strip() for value in activation_hints.get("verbs", []) if str(value).strip())),
@@ -37234,6 +37237,7 @@ def _skill_payload(*, skill: RegisteredSkill) -> dict[str, Any]:
         "source_kind": skill.source_kind,
         "scope": skill.scope,
         "stability": skill.stability,
+        "visibility": skill.visibility,
         "summary": skill.summary,
         "activation_hints": {
             "verbs": list(skill.activation_hints.verbs),
@@ -37243,6 +37247,17 @@ def _skill_payload(*, skill: RegisteredSkill) -> dict[str, Any]:
         },
         "registration": skill.registration,
     }
+
+
+def _skill_visibility(*, scope: str) -> str:
+    normalized = scope.strip().lower()
+    if normalized in {"bundled", "repo-owned"}:
+        return "ordinary-default"
+    if normalized.startswith("routed"):
+        return "routed-on-demand"
+    if normalized.startswith("temporary"):
+        return "temporary"
+    return "catalogued"
 
 
 def _recommend_skills(*, task_text: str, skills: list[RegisteredSkill]) -> list[SkillRecommendation]:

--- a/tests/test_workspace_skills_cli.py
+++ b/tests/test_workspace_skills_cli.py
@@ -101,6 +101,16 @@ def test_skills_command_lists_registered_workspace_skills(tmp_path: Path, capsys
     assert "memory-router" in skill_ids
     assert "planning-reporting" in skill_ids
     assert all(entry["registration"] == "explicit" for entry in payload["skills"])
+    workspace_entries = {entry["id"]: entry for entry in payload["skills"] if entry["source_kind"] == "installed-workspace-skills"}
+    assert {skill_id for skill_id, entry in workspace_entries.items() if entry["visibility"] == "ordinary-default"} == {
+        "workspace-intent-discovery",
+        "workspace-work-shape",
+    }
+    assert workspace_entries["workspace-startup"]["scope"] == "routed-projection"
+    assert workspace_entries["workspace-proof-selection"]["visibility"] == "routed-on-demand"
+    assert workspace_entries["workspace-transition-gates"]["visibility"] == "routed-on-demand"
+    assert workspace_entries["workspace-operating-loop"]["scope"] == "routed-projection"
+    assert workspace_entries["workspace-setup-jumpstart"]["scope"] == "routed-support"
     workspace_startup = next(entry for entry in payload["skills"] if entry["id"] == "workspace-startup")
     assert workspace_startup["source_kind"] == "installed-workspace-skills"
     assert "workspace startup" in workspace_startup["activation_hints"]["phrases"]
@@ -302,6 +312,7 @@ def test_skills_command_recommends_planning_reporting_for_setup_task(tmp_path: P
     payload = json.loads(capsys.readouterr().out)
     assert payload["recommendations"][0]["id"] == "workspace-setup-jumpstart"
     assert payload["recommendations"][0]["score"] > 10
+    assert payload["recommendations"][0]["visibility"] == "routed-on-demand"
     assert "workspace setup jumpstart route" in payload["recommendations"][0]["reasons"][0]
 
 
@@ -331,6 +342,7 @@ def test_skills_command_recommends_setup_jumpstart_for_mature_repo_seeding(tmp_p
     payload = json.loads(capsys.readouterr().out)
     assert payload["recommendations"][0]["id"] == "workspace-setup-jumpstart"
     assert payload["recommendations"][0]["source_kind"] == "installed-workspace-skills"
+    assert payload["recommendations"][0]["scope"] == "routed-support"
     assert "pre-write and pre-seed discovery" in Path("docs/jumpstart-contract.md").read_text(encoding="utf-8")
 
 


### PR DESCRIPTION
## Summary

- Adds machine-readable `visibility` to skills output.
- Classifies workspace intent/work-shape skills as ordinary-default reasoning skills.
- Demotes CLI-mirroring workspace startup/proof/transition/operating-loop/setup skills to routed projection/support while keeping task recommendations working.
- Updates installed payload copy and skills tests.

Closes #1427.
Does not close #1389.

Stacked on #1432.

## Dogfooding

- Used Spark read-only exploration to identify the skill payload hotspots.
- Fixed safely actionable local cleanup: corrected an ugly but valid indentation block before commit.
- Reused #1431 for the larger closeout-trust friction seen during #1426/#1427 closeout.

## Proof

- uv run pytest tests/test_workspace_skills_cli.py -q: 22 passed
- uv run pytest selected lifecycle/package payload checks -q: 9 passed
- uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_skills_cli.py: passed
- make test-workspace: passed
- make lint-workspace: passed
- uv run python scripts/run_agentic_workspace.py summary --target . --format json: clean after closeout
- uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json: healthy
