### PR TITLE
Route module diagnostics as drilldown surfaces

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/github-1429-module-cli-diagnostics.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1429-module-cli-diagnostics.plan.json
@@ -1,0 +1,418 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Route module CLI and diagnostics exposure",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Route root module CLI, lifecycle status, and doctor diagnostics as explicit drill-down/recovery surfaces instead of ordinary first-contact workflow.",
+    "hard_constraints": "Keep module CLIs and diagnostics available; do not remove recovery routes, lifecycle controls, or module front doors.",
+    "agent_may_decide": "Adjust root command classification/help, operational affordance roles, generated root command packages, and focused tests.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Run selected proof, reconcile #1429 acceptance, then close out this active plan.",
+    "proof_expectations": [
+      "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+      "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+      "uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py",
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json",
+      "make test-workspace",
+      "make lint-workspace",
+      "uv run pytest tests/test_workspace_cli.py -q",
+      "make schema-reference-docs"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/contracts/cli_commands.json",
+      "src/agentic_workspace/contracts/command_package_ir.json",
+      "src/agentic_workspace/contracts/operational_affordance_roles.json",
+      "src/agentic_workspace/contracts/schemas/operational_affordance_roles.schema.json",
+      "generated/workspace/python/adapter_commands.json",
+      "generated/workspace/python/command_package.json",
+      "generated/workspace/typescript/resources/command_package.json",
+      "generated/workspace/typescript/src/cli.mjs",
+      "tests/test_contract_tooling.py",
+      "tests/test_workspace_modules_cli.py"
+    ],
+    "completion_criteria": [
+      "Operational affordance roles classify modules/status/doctor/ownership/setup as non-first-line drill-down or recovery surfaces.",
+      "Root CLI command metadata no longer presents modules/status/doctor as ordinary startup routes.",
+      "Generated Python and TypeScript root package outputs are refreshed from the source command IR.",
+      "Tests/checks protect the boundary where feasible."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "GitHub #1429"
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Route root module CLI, lifecycle status, and doctor diagnostics as explicit drill-down/recovery surfaces instead of ordinary first-contact workflow.",
+      "constraints": "Keep module CLIs and diagnostics available; do not remove recovery routes, lifecycle controls, or module front doors.",
+      "latitude": "Adjust root command classification/help, operational affordance roles, generated root command packages, and focused tests.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "github-1429-module-cli-diagnostics",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/contracts/cli_commands.json",
+        "src/agentic_workspace/contracts/command_package_ir.json",
+        "src/agentic_workspace/contracts/operational_affordance_roles.json",
+        "src/agentic_workspace/contracts/schemas/operational_affordance_roles.schema.json",
+        "generated/workspace/python/adapter_commands.json",
+        "generated/workspace/python/command_package.json",
+        "generated/workspace/typescript/resources/command_package.json",
+        "generated/workspace/typescript/src/cli.mjs",
+        "tests/test_contract_tooling.py",
+        "tests/test_workspace_modules_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "GitHub #1429",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Route module CLI and diagnostics exposure",
+    "inferred intended outcome": "GitHub #1429",
+    "chosen concrete what": "Classify and expose root module/diagnostic commands as routed drill-down or recovery surfaces while preserving explicit module control.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "Root command contracts, operational affordance roles, generated root workspace package outputs, and focused contract/module CLI tests.",
+    "max changed files": "About 10 files, plus generated root package outputs if refreshed from source.",
+    "required validation commands": "Use the AW-selected proof commands in validation_commands.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Root module/status/doctor exposure classification is implemented; run proof and close out the plan.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Route root module CLI, lifecycle status, and doctor diagnostics as explicit drill-down/recovery surfaces instead of ordinary first-contact workflow.",
+    "hard constraints": "Keep module CLIs and diagnostics available; do not remove recovery routes, lifecycle controls, or module front doors.",
+    "agent may decide locally": "Adjust root command classification/help, operational affordance roles, generated root command packages, and focused tests.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": "GitHub #1429",
+      "label": "GitHub #1429",
+      "role": "intake",
+      "locator": ""
+    }
+  ],
+  "active_milestone": {
+    "id": "github-1429-module-cli-diagnostics",
+    "status": "completed",
+    "scope": "Root module/diagnostic exposure classification and generated root package refresh for #1429.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run selected proof, reconcile #1429 acceptance, then close out this active plan."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/contracts/cli_commands.json",
+    "src/agentic_workspace/contracts/command_package_ir.json",
+    "src/agentic_workspace/contracts/operational_affordance_roles.json",
+    "src/agentic_workspace/contracts/schemas/operational_affordance_roles.schema.json",
+    "generated/workspace/python/adapter_commands.json",
+    "generated/workspace/python/command_package.json",
+    "generated/workspace/typescript/resources/command_package.json",
+    "generated/workspace/typescript/src/cli.mjs",
+    "tests/test_contract_tooling.py",
+    "tests/test_workspace_modules_cli.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
+    "uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json",
+    "make test-workspace",
+    "make lint-workspace",
+    "uv run pytest tests/test_workspace_cli.py -q",
+    "make schema-reference-docs"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Operational affordance roles classify modules/status/doctor/ownership/setup as non-first-line drill-down or recovery surfaces.",
+    "Root CLI command metadata no longer presents modules/status/doctor as ordinary startup routes.",
+    "Generated Python and TypeScript root package outputs are refreshed from the source command IR.",
+    "Tests/checks protect the boundary where feasible."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Classified root module/status/doctor/ownership/setup exposure as routed drill-down or recovery surfaces, updated root CLI command metadata, refreshed generated workspace package outputs, and added focused contract tests.",
+    "scope touched": "Root command contracts, operational affordance roles, generated root workspace command packages, and focused tests for #1429.",
+    "changed surfaces": "cli_commands.json; command_package_ir.json; operational_affordance_roles.json and schema; generated/workspace root package outputs; test_contract_tooling.py; test_workspace_modules_cli.py.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1429. Module CLIs and diagnostics remain available for explicit control, recovery, lifecycle checks, and maintainer proof, but ordinary first-contact routing no longer treats modules/status/doctor as first-line workflow.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Passed: summary; planning doctor; check_contract_tooling_surfaces; check_structured_file_inventory; ruff contracts/scripts/test_structured_file_inventory; check_generated_command_packages; defaults root_cli_authority; make test-workspace; make lint-workspace; tests/test_workspace_cli.py; make schema-reference-docs.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "GitHub #1429",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1429 satisfied as a bounded Milestone C slice. No residual #1429 follow-up remains; parent #1389 remains open for later milestone proof.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-11: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "blocked_claim_classes": [],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1429",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: GitHub #1429\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Passed: summary; planning doctor; check_contract_tooling_surfaces; check_structured_file_inventory; ruff contracts/scripts/test_structured_file_inventory; check_generated_command_packages; defaults root_cli_authority; make test-workspace; make lint-workspace; tests/test_workspace_cli.py; make schema-reference-docs.\nChanged surfaces: cli_commands.json; command_package_ir.json; operational_affordance_roles.json and schema; generated/workspace root package outputs; test_contract_tooling.py; test_workspace_modules_cli.py.\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -2,7 +2,7 @@
   {
     "adapter_id": "modules.report.cli",
     "interface": {
-      "help": "List workspace modules available to the orchestrator.",
+      "help": "Show module inventory as explicit drill-down; ordinary agents should start from start/report routing.",
       "name": "modules",
       "options": [
         {
@@ -3078,7 +3078,7 @@
   {
     "adapter_id": "status.report.cli",
     "interface": {
-      "help": "Report installed modules and workspace health summary.",
+      "help": "Show installed-module health for lifecycle checks; ordinary agents should use start/report routing first.",
       "name": "status",
       "options": [
         {
@@ -3138,7 +3138,7 @@
   {
     "adapter_id": "doctor.report.cli",
     "interface": {
-      "help": "Report drift, missing surfaces, and recommended remediation.",
+      "help": "Show drift diagnostics for recovery or remediation; ordinary agents should use start/report routing first.",
       "name": "doctor",
       "options": [
         {

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -17,7 +17,7 @@
         "writes_repo_state": false
       },
       "interface": {
-        "help": "List workspace modules available to the orchestrator.",
+        "help": "Show module inventory as explicit drill-down; ordinary agents should start from start/report routing.",
         "name": "modules",
         "options": [
           {
@@ -4223,7 +4223,7 @@
         "writes_repo_state": false
       },
       "interface": {
-        "help": "Report installed modules and workspace health summary.",
+        "help": "Show installed-module health for lifecycle checks; ordinary agents should use start/report routing first.",
         "name": "status",
         "options": [
           {
@@ -4336,7 +4336,7 @@
         "writes_repo_state": false
       },
       "interface": {
-        "help": "Report drift, missing surfaces, and recommended remediation.",
+        "help": "Show drift diagnostics for recovery or remediation; ordinary agents should use start/report routing first.",
         "name": "doctor",
         "options": [
           {

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -17,7 +17,7 @@
         "writes_repo_state": false
       },
       "interface": {
-        "help": "List workspace modules available to the orchestrator.",
+        "help": "Show module inventory as explicit drill-down; ordinary agents should start from start/report routing.",
         "name": "modules",
         "options": [
           {
@@ -4223,7 +4223,7 @@
         "writes_repo_state": false
       },
       "interface": {
-        "help": "Report installed modules and workspace health summary.",
+        "help": "Show installed-module health for lifecycle checks; ordinary agents should use start/report routing first.",
         "name": "status",
         "options": [
           {
@@ -4336,7 +4336,7 @@
         "writes_repo_state": false
       },
       "interface": {
-        "help": "Report drift, missing surfaces, and recommended remediation.",
+        "help": "Show drift diagnostics for recovery or remediation; ordinary agents should use start/report routing first.",
         "name": "doctor",
         "options": [
           {

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -13,7 +13,7 @@ const nativeOperationIds = new Set(["config.report", "defaults.report", "delegat
 const commandDefinitions = [
   {
     "interface": {
-      "help": "List workspace modules available to the orchestrator.",
+      "help": "Show module inventory as explicit drill-down; ordinary agents should start from start/report routing.",
       "name": "modules",
       "options": [
         {
@@ -3131,7 +3131,7 @@ const commandDefinitions = [
   },
   {
     "interface": {
-      "help": "Report installed modules and workspace health summary.",
+      "help": "Show installed-module health for lifecycle checks; ordinary agents should use start/report routing first.",
       "name": "status",
       "options": [
         {
@@ -3193,7 +3193,7 @@ const commandDefinitions = [
   },
   {
     "interface": {
-      "help": "Report drift, missing surfaces, and recommended remediation.",
+      "help": "Show drift diagnostics for recovery or remediation; ordinary agents should use start/report routing first.",
       "name": "doctor",
       "options": [
         {

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -5,7 +5,7 @@
   "commands": [
     {
       "name": "modules",
-      "help": "List workspace modules available to the orchestrator.",
+      "help": "Show module inventory as explicit drill-down; ordinary agents should start from start/report routing.",
       "uses_option_groups": [
         "format"
       ],
@@ -27,8 +27,8 @@
         }
       ],
       "role": "module_delegation_front_door",
-      "audience": "ordinary_host_repo",
-      "classification_note": "front door for declared module availability and install state",
+      "audience": "advanced_host_repo",
+      "classification_note": "module inventory drill-down for explicit module inspection; not required for ordinary startup",
       "mutates_state": false
     },
     {
@@ -2157,7 +2157,7 @@
     },
     {
       "name": "status",
-      "help": "Report installed modules and workspace health summary.",
+      "help": "Show installed-module health for lifecycle checks; ordinary agents should use start/report routing first.",
       "uses_option_groups": [
         "selection"
       ],
@@ -2172,13 +2172,13 @@
         }
       ],
       "role": "core_lifecycle",
-      "audience": "ordinary_host_repo",
-      "classification_note": "read-only lifecycle health status",
+      "audience": "advanced_host_repo",
+      "classification_note": "read-only lifecycle health drill-down for explicit lifecycle or remediation checks",
       "mutates_state": false
     },
     {
       "name": "doctor",
-      "help": "Report drift, missing surfaces, and recommended remediation.",
+      "help": "Show drift diagnostics for recovery or remediation; ordinary agents should use start/report routing first.",
       "uses_option_groups": [
         "selection"
       ],
@@ -2200,8 +2200,8 @@
         }
       ],
       "role": "core_lifecycle",
-      "audience": "ordinary_host_repo",
-      "classification_note": "read-only lifecycle drift diagnostics",
+      "audience": "advanced_host_repo",
+      "classification_note": "read-only recovery diagnostic drill-down; not an ordinary first-contact route",
       "mutates_state": false
     },
     {

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -700,7 +700,7 @@
           },
           "interface": {
             "name": "modules",
-            "help": "List workspace modules available to the orchestrator.",
+            "help": "Show module inventory as explicit drill-down; ordinary agents should start from start/report routing.",
             "options": [
               {
                 "name": "target",
@@ -4641,7 +4641,7 @@
           },
           "interface": {
             "name": "status",
-            "help": "Report installed modules and workspace health summary.",
+            "help": "Show installed-module health for lifecycle checks; ordinary agents should use start/report routing first.",
             "options": [
               {
                 "name": "format",
@@ -4754,7 +4754,7 @@
           },
           "interface": {
             "name": "doctor",
-            "help": "Report drift, missing surfaces, and recommended remediation.",
+            "help": "Show drift diagnostics for recovery or remediation; ordinary agents should use start/report routing first.",
             "options": [
               {
                 "name": "format",

--- a/src/agentic_workspace/contracts/operational_affordance_roles.json
+++ b/src/agentic_workspace/contracts/operational_affordance_roles.json
@@ -51,6 +51,48 @@
       "primary_next_action": "select task-specific behavioral guidance"
     },
     {
+      "command": "modules",
+      "role": "module_drilldown",
+      "first_line": false,
+      "primary_next_action": "inspect module inventory only after startup/report/defaults points to module detail"
+    },
+    {
+      "command": "planning",
+      "role": "module_front_door",
+      "first_line": false,
+      "primary_next_action": "run Planning mutations or reports only when compact routing names the Planning command"
+    },
+    {
+      "command": "memory",
+      "role": "module_front_door",
+      "first_line": false,
+      "primary_next_action": "run Memory routing or residue commands only when compact routing names the Memory command"
+    },
+    {
+      "command": "status",
+      "role": "lifecycle_health_drilldown",
+      "first_line": false,
+      "primary_next_action": "inspect installed-module health only for lifecycle or remediation checks"
+    },
+    {
+      "command": "doctor",
+      "role": "recovery_diagnostic",
+      "first_line": false,
+      "primary_next_action": "inspect drift diagnostics only for recovery, remediation, or maintainer proof"
+    },
+    {
+      "command": "ownership",
+      "role": "authority_drilldown",
+      "first_line": false,
+      "primary_next_action": "inspect ownership detail only when authority or edit safety is uncertain"
+    },
+    {
+      "command": "setup",
+      "role": "post_bootstrap_diagnostic",
+      "first_line": false,
+      "primary_next_action": "inspect post-bootstrap guidance only during setup or lifecycle remediation"
+    },
+    {
       "command": "WORKFLOW.md",
       "role": "no_cli_fallback_projection",
       "first_line": false,

--- a/src/agentic_workspace/contracts/schemas/operational_affordance_roles.schema.json
+++ b/src/agentic_workspace/contracts/schemas/operational_affordance_roles.schema.json
@@ -208,6 +208,12 @@
             "diagnostic_router",
             "reference_detail",
             "task_behavior_routing",
+            "module_drilldown",
+            "module_front_door",
+            "lifecycle_health_drilldown",
+            "recovery_diagnostic",
+            "authority_drilldown",
+            "post_bootstrap_diagnostic",
             "no_cli_fallback_projection"
           ]
         },

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -330,6 +330,14 @@ def test_operational_affordance_roles_classify_first_contact_and_diagnostics() -
     assert command_roles["preflight"]["role"] == "recovery_takeover"
     assert command_roles["preflight"]["first_line"] is False
     assert command_roles["summary"]["role"] == "active_planning_state"
+    assert command_roles["modules"]["role"] == "module_drilldown"
+    assert command_roles["modules"]["first_line"] is False
+    assert command_roles["planning"]["role"] == "module_front_door"
+    assert command_roles["memory"]["role"] == "module_front_door"
+    assert command_roles["status"]["role"] == "lifecycle_health_drilldown"
+    assert command_roles["doctor"]["role"] == "recovery_diagnostic"
+    assert command_roles["ownership"]["role"] == "authority_drilldown"
+    assert command_roles["setup"]["role"] == "post_bootstrap_diagnostic"
     assert command_roles["WORKFLOW.md"]["role"] == "no_cli_fallback_projection"
 
     warning_roles = {entry["warning_class"]: entry for entry in manifest["warning_roles"]}

--- a/tests/test_workspace_modules_cli.py
+++ b/tests/test_workspace_modules_cli.py
@@ -232,7 +232,11 @@ def test_root_command_manifest_classifies_host_repo_command_surface() -> None:
     assert command_roles["report"] == "core_context_router"
     assert command_roles["modules"] == "module_delegation_front_door"
     assert command_roles["setup"] == "reusable_host_repo_diagnostics"
+    assert command_roles["doctor"] == "core_lifecycle"
     assert command_roles["external-intent"] == "reusable_host_repo_diagnostics"
+    assert command_audiences["modules"] == "advanced_host_repo"
+    assert command_audiences["status"] == "advanced_host_repo"
+    assert command_audiences["doctor"] == "advanced_host_repo"
     assert command_audiences["note-delegation-outcome"] == "local_only"
     assert command_audiences["setup"] == "advanced_host_repo"
     assert all(command["classification_note"] for command in commands)


### PR DESCRIPTION
## Summary

Routes root module/diagnostic command exposure as explicit drill-down or recovery surfaces instead of ordinary first-contact workflow.

- Adds operational affordance roles for module inventory, module front doors, lifecycle health, recovery diagnostics, ownership drill-down, and post-bootstrap diagnostics.
- Updates root CLI command metadata so `modules`, `status`, and `doctor` point agents back to `start`/`report` for ordinary routing.
- Refreshes generated Python and TypeScript root workspace package outputs from the command-package IR.
- Records command-owned Planning closeout evidence for the #1429 slice.

Closes #1429.
Does not close #1389.

Stacked after #1434.

## Proof

- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `make schema-reference-docs`
- `uv run python scripts/check/check_planning_surfaces.py`

## Dogfooding

- Kept #1431 as the larger routed dogfooding finding: closeout trust should distinguish archived slice closeout from parent-epic incompleteness.
