### PR TITLE
Trust archived slice closeout evidence

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/github-1431-closeout-trust-archive.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1431-closeout-trust-archive.plan.json
@@ -1,0 +1,375 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Trust archived slice closeout evidence",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "GitHub #1431",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Trust archived slice closeout evidence is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "GitHub #1431"
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "GitHub #1431",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace."
+    },
+    "execution": {
+      "milestone": "github-1431-closeout-trust-archive",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "GitHub #1431",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Trust archived slice closeout evidence",
+    "inferred intended outcome": "GitHub #1431",
+    "chosen concrete what": "Implemented #1431 as a bounded closeout_trust bugfix; no residual #1431 follow-up remains.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "GitHub #1431",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "recorded",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract",
+    "route chosen": "keep-local",
+    "route skipped reason": "Small runtime bugfix with focused regression already implemented locally; delegation would add handoff overhead without reducing proof burden.",
+    "decision command": "agentic-planning delegation-decision",
+    "planning revision observed": "6fd718cb3b692bb6",
+    "recorded at": "2026-06-11T15:14:21+00:00"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": "GitHub #1431",
+      "label": "GitHub #1431",
+      "role": "intake",
+      "locator": ""
+    }
+  ],
+  "active_milestone": {
+    "id": "github-1431-closeout-trust-archive",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Trust archived slice closeout evidence is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "closeout_trust now reports archived command-owned slice closeout evidence as slice-trusted while keeping parent/epic continuation and closure blockers visible.",
+    "scope touched": "closeout_trust runtime payload, compact report section projection, and workspace report regression tests for no-active-record archived closeout evidence.",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; tests/test_workspace_report_cli.py.",
+    "validations run": "Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "#1431 acceptance is satisfied: archived satisfied slice evidence is named as canonical slice evidence, claim-slice-complete can be allowed from that evidence, and parent/work closure remains blocked when package-owned continuation is open.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "keep-local",
+    "route skipped reason": "Small runtime bugfix with focused regression already implemented locally; delegation would add handoff overhead without reducing proof burden.",
+    "expected savings": "unknown",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace."
+  },
+  "intent_satisfaction": {
+    "original intent": "GitHub #1431",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Implemented #1431 as a bounded closeout_trust bugfix; no residual #1431 follow-up remains.",
+    "validation confirmed": "Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-11: Scaffolded by agentic-planning new-plan.",
+    "2026-06-11: Recorded delegation decision route=keep-local."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "blocked_claim_classes": [],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1431",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: GitHub #1431\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Passed: focused closeout_trust regression pair; ruff edited runtime/report/test files; make lint-workspace; planning summary; planning doctor; make test-workspace.\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/reporting_support.py; tests/test_workspace_report_cli.py.\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/github-1436-review-tighten-archived-slice.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1436-review-tighten-archived-slice.plan.json
@@ -1,0 +1,369 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Tighten archived slice review fix",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "PR #1436 review",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Tighten archived slice review fix is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "PR #1436 review"
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "PR #1436 review",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace."
+    },
+    "execution": {
+      "milestone": "github-1436-review-tighten-archived-slice",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "PR #1436 review",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Tighten archived slice review fix",
+    "inferred intended outcome": "PR #1436 review",
+    "chosen concrete what": "Review tightening complete for PR #1436.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "PR #1436 review",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": "PR #1436 review",
+      "label": "PR #1436 review",
+      "role": "intake",
+      "locator": ""
+    }
+  ],
+  "active_milestone": {
+    "id": "github-1436-review-tighten-archived-slice",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Tighten archived slice review fix is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Tightened archived slice closeout handling so trusted archived proof only adjusts run-proof and claim-slice-complete, leaving parent/work completion blockers intact; corrected the regression fixture so the archived evidence says the parent intent remains open.",
+    "scope touched": "src/agentic_workspace/workspace_runtime_primitives.py and tests/test_workspace_report_cli.py.",
+    "changed surfaces": "closeout_trust completion option adjustment and archived-slice parent-open regression fixture.",
+    "validations run": "Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "PR #1436 review concern addressed without broad redesign: archived slice evidence no longer removes validation-proof blockers from claim-work-complete or close-parent-lane, and the fixture now matches the parent-open scenario it asserts.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace."
+  },
+  "intent_satisfaction": {
+    "original intent": "PR #1436 review",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Review tightening complete for PR #1436.",
+    "validation confirmed": "Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-11: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "blocked_claim_classes": [],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1436",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: PR #1436 review\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Passed: focused archived-slice closeout_trust regression; edited-file ruff; make lint-workspace; make test-workspace.\nChanged surfaces: closeout_trust completion option adjustment and archived-slice parent-open regression fixture.\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -345,6 +345,8 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
         architecture_candidate = architecture_candidate if isinstance(architecture_candidate, dict) else {}
         terminal_action = answer.get("terminal_action", {})
         terminal_action = terminal_action if isinstance(terminal_action, dict) else {}
+        archived_slice = answer.get("archived_slice_closeout_evidence", {})
+        archived_slice = archived_slice if isinstance(archived_slice, dict) else {}
         durable_action = answer.get("durable_residue_action", {})
         durable_action = durable_action if isinstance(durable_action, dict) else {}
         completion_options = answer.get("completion_options", [])
@@ -363,6 +365,24 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
         compact_answer = {
             "status": answer.get("status", ""),
             "trust": answer.get("trust", ""),
+            "archived_slice_closeout_evidence": {
+                key: archived_slice.get(key)
+                for key in (
+                    "status",
+                    "trust",
+                    "scope",
+                    "canonical_evidence",
+                    "owner_surface",
+                    "proof_recorded",
+                    "slice_completed",
+                    "slice_status",
+                    "closure_decision",
+                    "parent_intent_status",
+                    "parent_closure_blocked",
+                    "rule",
+                )
+                if key in archived_slice
+            },
             "strict_closeout_gate": strict_gate,
             "completion_gate": {
                 key: completion_gate.get(key)

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -14146,19 +14146,21 @@ def _report_closeout_trust_payload(
                 adjusted.append(option)
                 continue
             updated = dict(option)
-            blockers = [blocker for blocker in _list_payload(updated.get("blocking_fields")) if str(blocker) != validation_proof_blocker]
-            if blockers:
-                updated["blocking_fields"] = blockers
-            else:
-                updated.pop("blocking_fields", None)
             if updated.get("id") == "run-proof":
                 updated["allowed"] = False
                 updated["why"] = "archived command-owned slice closeout proof is already visible"
+                updated.pop("blocking_fields", None)
                 updated["evidence_owner"] = slice_evidence.get("owner_surface", "")
             elif updated.get("id") == "claim-slice-complete":
+                blockers = [
+                    blocker for blocker in _list_payload(updated.get("blocking_fields")) if str(blocker) != validation_proof_blocker
+                ]
                 updated["allowed"] = True
                 updated["why"] = "archived command-owned slice closeout evidence supports a bounded slice completion claim"
-                updated.pop("blocking_fields", None)
+                if blockers:
+                    updated["blocking_fields"] = blockers
+                else:
+                    updated.pop("blocking_fields", None)
                 updated["evidence_owner"] = slice_evidence.get("owner_surface", "")
             adjusted.append(updated)
         return adjusted

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -14093,6 +14093,76 @@ def _report_closeout_trust_payload(
         action["run"] = action["command"]
         return action
 
+    def archived_slice_closeout_evidence() -> dict[str, Any]:
+        archived_record = _closeout_planning_record_for_report(active_planning_record={}, target_root=target_root)
+        if not archived_record:
+            return {"status": "absent", "trust": "not-applicable"}
+        evidence_source = _as_dict(archived_record.get("_closeout_evidence_source"))
+        proof_report = _as_dict(archived_record.get("proof_report"))
+        closure_check = _as_dict(archived_record.get("closure_check"))
+        proof_text = " ".join(
+            str(value)
+            for value in (
+                proof_report.get("validation proof"),
+                proof_report.get("proof achieved now"),
+                proof_report.get('evidence for "proof achieved" state'),
+            )
+            if value
+        ).lower()
+        proof_recorded = any(marker in proof_text for marker in ("passed", "yes", "satisfied", "achieved", "complete"))
+        slice_status = str(closure_check.get("slice status") or "").strip().lower()
+        closure_decision = str(closure_check.get("closure decision") or "").strip().lower()
+        slice_completed = slice_status in {"complete", "completed", "done", "closed", "satisfied"}
+        command_owned = evidence_source.get("authority") in {"archived-planning-evidence", "retained-closeout-evidence"}
+        slice_trusted = bool(command_owned and proof_recorded and slice_completed and closure_decision)
+        parent_status = str(closure_check.get("larger-intent status") or "").strip().lower()
+        parent_closure_blocked = parent_status not in {"closed", "complete", "completed", "done"}
+        return {
+            "status": "present",
+            "trust": "normal" if slice_trusted else "lower-trust",
+            "scope": "slice",
+            "canonical_evidence": evidence_source.get("authority", "archived-planning-evidence"),
+            "owner_surface": evidence_source.get("path", ""),
+            "source": evidence_source,
+            "proof_recorded": proof_recorded,
+            "slice_completed": slice_completed,
+            "slice_status": closure_check.get("slice status", ""),
+            "closure_decision": closure_check.get("closure decision", ""),
+            "parent_intent_status": closure_check.get("larger-intent status", ""),
+            "parent_closure_blocked": parent_closure_blocked,
+            "rule": (
+                "Archived closeout evidence may be trusted for the completed slice, but it does not restore active "
+                "planning state or authorize parent/epic closure."
+            ),
+        }
+
+    def allow_archived_slice_claim(options: list[dict[str, Any]], slice_evidence: dict[str, Any]) -> list[dict[str, Any]]:
+        if slice_evidence.get("trust") != "normal":
+            return options
+        validation_proof_blocker = "intent_satisfaction.closure_scope.validation_proof"
+        adjusted: list[dict[str, Any]] = []
+        for option in options:
+            if not isinstance(option, dict):
+                adjusted.append(option)
+                continue
+            updated = dict(option)
+            blockers = [blocker for blocker in _list_payload(updated.get("blocking_fields")) if str(blocker) != validation_proof_blocker]
+            if blockers:
+                updated["blocking_fields"] = blockers
+            else:
+                updated.pop("blocking_fields", None)
+            if updated.get("id") == "run-proof":
+                updated["allowed"] = False
+                updated["why"] = "archived command-owned slice closeout proof is already visible"
+                updated["evidence_owner"] = slice_evidence.get("owner_surface", "")
+            elif updated.get("id") == "claim-slice-complete":
+                updated["allowed"] = True
+                updated["why"] = "archived command-owned slice closeout evidence supports a bounded slice completion claim"
+                updated.pop("blocking_fields", None)
+                updated["evidence_owner"] = slice_evidence.get("owner_surface", "")
+            adjusted.append(updated)
+        return adjusted
+
     planning_report = next((report for report in module_reports if isinstance(report, dict) and report.get("module") == "planning"), None)
     if not isinstance(planning_report, dict):
         gate = strict_gate(trust="unavailable", reason="planning module is not installed", active_planning_record=False)
@@ -14274,6 +14344,27 @@ def _report_closeout_trust_payload(
     sample_signals = [message for message in sample_signals if message][:3]
     package_workflow_evidence = _package_workflow_evidence_payload(planning_report=planning_report)
     intent_satisfaction_check = _intent_satisfaction_check_payload(planning_report=planning_report, target_root=target_root)
+    slice_closeout_evidence = {}
+    raw_active = planning_report.get("active", {}).get("planning_record", {}) if isinstance(planning_report.get("active"), dict) else {}
+    if not isinstance(raw_active, dict) or raw_active.get("status") != "present":
+        slice_closeout_evidence = archived_slice_closeout_evidence()
+        if slice_closeout_evidence.get("trust") == "normal":
+            intent_satisfaction_check = copy.deepcopy(intent_satisfaction_check)
+            intent_satisfaction_check["archived_slice_closeout_evidence"] = slice_closeout_evidence
+            closure_scope = _as_dict(intent_satisfaction_check.get("closure_scope"))
+            validation_proof = _as_dict(closure_scope.get("validation_proof"))
+            validation_proof.update(
+                {
+                    "status": "recorded",
+                    "proof_report": "archived command-owned closeout proof is available",
+                    "proof_achieved_now": "yes",
+                    "source": slice_closeout_evidence.get("owner_surface", ""),
+                    "claim_boundary": "slice only",
+                    "not_sufficient_for_closure": True,
+                }
+            )
+            closure_scope["validation_proof"] = validation_proof
+            intent_satisfaction_check["closure_scope"] = closure_scope
     acceptance_reconciliation = _acceptance_criteria_reconciliation_payload(planning_report=planning_report)
     intent_proof_check = _intent_proof_check_payload(planning_report=planning_report, target_root=target_root)
     architecture_decision_closeout = _architecture_decision_closeout_payload(
@@ -14380,9 +14471,11 @@ def _report_closeout_trust_payload(
         lower_trust_closeout_count=effective_lower_trust_count,
         cli_invoke=cli_invoke,
     )
+    completion_options = allow_archived_slice_claim(completion_options, slice_closeout_evidence)
     return {
         "status": "present",
         "trust": trust,
+        "archived_slice_closeout_evidence": slice_closeout_evidence or {"status": "absent", "trust": "not-applicable"},
         "strict_closeout_gate": gate,
         "completion_gate": completion_gate,
         "task_posture_followthrough": task_posture_followthrough,

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -5762,7 +5762,7 @@ candidates = [
             },
             "closure_check": {
                 "slice status": "completed",
-                "larger-intent status": "closed",
+                "larger-intent status": "open",
                 "closure decision": "archive-and-close",
                 "why this decision is honest": "The slice is complete; parent epic closure remains separate.",
             },
@@ -5781,6 +5781,8 @@ candidates = [
     assert archived_slice["owner_surface"] == ".agentic-workspace/planning/execplans/archive/archived-slice.plan.json"
     assert archived_slice["proof_recorded"] is True
     assert archived_slice["slice_completed"] is True
+    assert archived_slice["parent_intent_status"] == "open"
+    assert archived_slice["parent_closure_blocked"] is True
 
     assert answer["trust"] == "lower-trust"
     assert answer["checks"]["intent_satisfaction"]["trust"] == "follow-up-required"
@@ -5790,9 +5792,9 @@ candidates = [
     assert options["claim-slice-complete"]["allowed"] is True
     assert options["claim-slice-complete"]["evidence_owner"] == archived_slice["owner_surface"]
     assert options["claim-work-complete"]["allowed"] is False
-    assert "intent_satisfaction.closure_scope.validation_proof" not in options["claim-work-complete"]["blocking_fields"]
+    assert "intent_satisfaction.closure_scope.validation_proof" in options["claim-work-complete"]["blocking_fields"]
     assert options["close-parent-lane"]["allowed"] is False
-    assert "intent_satisfaction.closure_scope.validation_proof" not in options["close-parent-lane"]["blocking_fields"]
+    assert "intent_satisfaction.closure_scope.validation_proof" in options["close-parent-lane"]["blocking_fields"]
     assert options["keep-parent-open"]["allowed"] is True
     assert options["keep-parent-open"]["owner"] == ".agentic-workspace/planning/state.toml"
     assert answer["closeout_protocol"]["closure_permission"]["keep_parent_open_allowed"] is True

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -5716,6 +5716,89 @@ candidates = [
     assert ".agentic-workspace/planning/state.toml" in compact_continuation["owner_surfaces"]
 
 
+def test_report_closeout_trust_trusts_archived_slice_while_parent_remains_open(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+    _write(
+        target / ".agentic-workspace" / "config.toml",
+        "schema_version = 1\n\n[assurance]\nstrict_closeout = true\n",
+    )
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "github-1389-parent", maturity = "candidate", status = "next", priority = "P1", refs = "#1389", title = "Continue parent epic", outcome = "Finish the parent epic.", reason = "Parent epic remains open after the slice.", promotion_signal = "Promote before parent closeout.", suggested_first_slice = "Run installed-product proof." },
+]
+""",
+    )
+    archive = target / ".agentic-workspace" / "planning" / "execplans" / "archive" / "archived-slice.plan.json"
+    _write_json(
+        archive,
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Archived Slice",
+            "execution_run": {
+                "run status": "completed",
+                "what happened": "Implemented the bounded slice.",
+                "scope touched": "#1431 slice fixture",
+                "changed surfaces": "workspace_runtime_primitives.py; tests/test_workspace_report_cli.py",
+                "validations run": "uv run pytest tests/test_workspace_report_cli.py -q",
+            },
+            "proof_report": {
+                "validation proof": "uv run pytest tests/test_workspace_report_cli.py -q passed",
+                "proof achieved now": "yes",
+            },
+            "closure_check": {
+                "slice status": "completed",
+                "larger-intent status": "closed",
+                "closure decision": "archive-and-close",
+                "why this decision is honest": "The slice is complete; parent epic closure remains separate.",
+            },
+            "delegated_judgment": {"requested outcome": "Complete the bounded slice without closing the parent epic."},
+        },
+    )
+
+    assert cli.main(["report", "--target", str(target), "--section", "closeout_trust", "--format", "json"]) == 0
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    archived_slice = answer["archived_slice_closeout_evidence"]
+    assert archived_slice["status"] == "present"
+    assert archived_slice["trust"] == "normal"
+    assert archived_slice["scope"] == "slice"
+    assert archived_slice["canonical_evidence"] == "archived-planning-evidence"
+    assert archived_slice["owner_surface"] == ".agentic-workspace/planning/execplans/archive/archived-slice.plan.json"
+    assert archived_slice["proof_recorded"] is True
+    assert archived_slice["slice_completed"] is True
+
+    assert answer["trust"] == "lower-trust"
+    assert answer["checks"]["intent_satisfaction"]["trust"] == "follow-up-required"
+    options = {option["id"]: option for option in answer["completion_options"]}
+    assert options["run-proof"]["allowed"] is False
+    assert options["run-proof"]["evidence_owner"] == archived_slice["owner_surface"]
+    assert options["claim-slice-complete"]["allowed"] is True
+    assert options["claim-slice-complete"]["evidence_owner"] == archived_slice["owner_surface"]
+    assert options["claim-work-complete"]["allowed"] is False
+    assert "intent_satisfaction.closure_scope.validation_proof" not in options["claim-work-complete"]["blocking_fields"]
+    assert options["close-parent-lane"]["allowed"] is False
+    assert "intent_satisfaction.closure_scope.validation_proof" not in options["close-parent-lane"]["blocking_fields"]
+    assert options["keep-parent-open"]["allowed"] is True
+    assert options["keep-parent-open"]["owner"] == ".agentic-workspace/planning/state.toml"
+    assert answer["closeout_protocol"]["closure_permission"]["keep_parent_open_allowed"] is True
+    assert answer["closeout_protocol"]["closure_permission"]["close_parent_lane_allowed"] is False
+
+
 def test_report_closeout_trust_lowers_trust_when_active_plan_has_no_package_evidence(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()


### PR DESCRIPTION
## Summary
- Teach `closeout_trust` to surface trusted archived command-owned slice closeout evidence separately from broad/parent completion state.
- Keep parent/work closure blocked when package-owned continuation remains open, while allowing `claim-slice-complete` from the archived slice evidence.
- Include the archived slice evidence in the compact `report --section closeout_trust` answer and cover the no-active-record archived-closeout path with a regression test.

Closes #1431.
Does not close #1389.

## Proof
- `uv run pytest tests/test_workspace_report_cli.py::test_report_closeout_trust_trusts_archived_slice_while_parent_remains_open tests/test_workspace_report_cli.py::test_report_closeout_trust_lowers_trust_for_open_package_owned_continuation_without_active_plan -q`
- `uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py src/agentic_workspace/reporting_support.py tests/test_workspace_report_cli.py`
- `make lint-workspace`
- `uv run python scripts/run_agentic_workspace.py summary --target . --select todo.active_count,planning_surface_health.status,warning_count --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `make test-workspace`
- `uv run python scripts/run_agentic_workspace.py report --section closeout_trust --select answer.archived_slice_closeout_evidence,answer.completion_options,answer.trust,answer.checks.intent_satisfaction --format json`
- `git diff --check`

## Runtime-source review
This is a bounded `closeout_trust` runtime bugfix in `workspace_runtime_primitives._report_closeout_trust_payload` plus the compact report projection. The change does not authorize broad work or parent closure from archived evidence; it only permits a slice-level claim when archived command-owned proof and slice-completed evidence are present. Parent/epic continuation remains visible through Planning state.
