### PR TITLE
Keep parent open for slice closeout

### DIFF
--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -13146,6 +13146,7 @@ def closeout_execplan(
         warning for warning in result.warnings if str(warning.get("warning_class", "")) not in retention_skip_warning_classes
     ]
     blocked = bool(blocking_warnings) or any(action.kind == "manual review" for action in result.actions)
+    larger_intent_close_allowed = normalized_claim in {"lane", "epic"} and closure_decision == "archive-and-close" and not blocked
     non_blocking_retention_note = (
         "archive retention was skipped by size guardrail after closeout distillation; no rerun is needed for the removed plan"
     )
@@ -13173,17 +13174,21 @@ def closeout_execplan(
             },
             {
                 "id": "keep-larger-intent-open",
-                "allowed": closure_decision == "archive-but-keep-lane-open" and not blocked,
-                "owner": continuation_owner if closure_decision == "archive-but-keep-lane-open" else "",
+                "allowed": (closure_decision == "archive-but-keep-lane-open" or not larger_intent_close_allowed) and not blocked,
+                "owner": continuation_owner if closure_decision == "archive-but-keep-lane-open" else PLANNING_STATE_PATH.as_posix(),
                 "why": "intent-status keeps continuation explicit"
                 if closure_decision == "archive-but-keep-lane-open"
+                else "slice closeout does not authorize larger-intent closure"
+                if normalized_claim == "slice"
                 else "larger intent was marked satisfied",
             },
             {
                 "id": "close-larger-intent",
-                "allowed": closure_decision == "archive-and-close" and not blocked,
-                "why": "intent-status satisfied was recorded"
-                if closure_decision == "archive-and-close"
+                "allowed": larger_intent_close_allowed,
+                "why": f"{normalized_claim} claim with intent-status satisfied was recorded"
+                if larger_intent_close_allowed
+                else "slice closeout does not authorize larger-intent closure"
+                if normalized_claim == "slice"
                 else "parent or larger intent remains open",
             },
         ]

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -955,8 +955,10 @@ candidates = []
     assert archived["task_intent_promotion"]["needs review"] is True
     options = {option["id"]: option for option in payload["completion_options"]}
     assert options["claim-slice-complete"]["allowed"] is True
-    assert options["close-larger-intent"]["allowed"] is True
-    assert options["keep-larger-intent-open"]["allowed"] is False
+    assert options["close-larger-intent"]["allowed"] is False
+    assert options["close-larger-intent"]["why"] == "slice closeout does not authorize larger-intent closure"
+    assert options["keep-larger-intent-open"]["allowed"] is True
+    assert options["keep-larger-intent-open"]["owner"] == ".agentic-workspace/planning/state.toml"
     assert any(
         action["kind"] == "dogfooding reflection" and "issues, Memory, planning" in action["detail"] for action in payload["actions"]
     )


### PR DESCRIPTION
Closes #1452.

## Summary
- Treat `planning closeout --claim-level slice --intent-status satisfied` as permission to claim the slice only.
- Keep the larger intent routed through Planning state for slice closeout output.
- Block `close-larger-intent` unless the closeout claim level is `lane` or `epic` and closeout is otherwise unblocked.

## Proof
- `uv run pytest packages/planning/tests/test_archive.py::test_planning_closeout_completes_active_run_before_archive_validation packages/planning/tests/test_archive.py::test_planning_closeout_routes_partial_lane_residue_to_continuation packages/planning/tests/test_archive.py::test_planning_closeout_routes_deferred_owner_without_full_intent_satisfaction -q`
- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`

## Manual reproduction
`planning closeout --claim-level slice --intent-status satisfied` now reports:
- `claim-slice-complete`: allowed
- `keep-larger-intent-open`: allowed, owner `.agentic-workspace/planning/state.toml`
- `close-larger-intent`: not allowed