### PR TITLE
Define CLI boundary test ownership

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Use this map when updating docs so each page stays complete at its level without
 | What files are installed and who owns them? | [Installed surfaces](package/installed-surfaces.md) | explaining startup adapters, managed fences, local-only state, or source-checkout boundaries |
 | How should agents route governing knowledge and source authority? | [Knowledge routing and source authority](package/knowledge-routing.md) | a page only needs to name a source kind, authority class, route trigger, freshness rule, or capture obligation |
 | When should governing knowledge block or constrain work? | [Pre-work knowledge gates](package/knowledge-gates.md) | a page only needs to name gate force, blocked actions, closeout evidence, or fallback behavior |
+| Which generated-command tests belong at the CLI wrapper boundary? | [CLI boundary tests](package/cli-boundary-tests.md) | a page only needs to distinguish operation conformance from argv/help/error/exit/stdout wrapper proof |
 | What do Planning and Memory own? | [Modules](package/modules.md), then the module READMEs | a page only needs to distinguish active execution state from durable repo knowledge |
 | What are the exact fields and generated references? | [Contracts and references](package/contracts.md) and [Reference material](reference/index.md) | hand-written docs would otherwise copy generated schema detail |
 | What is source-checkout maintainer workflow? | [Maintainer index](maintainer/index.md) | ordinary host-repo docs mention internal validation, dogfooding, or generation only as a boundary |
@@ -33,6 +34,7 @@ Use this map when updating docs so each page stays complete at its level without
 - [Modules](package/modules.md): how the root package composes Planning and Memory.
 - [Knowledge routing and source authority](package/knowledge-routing.md): how startup, posture, closeout, Memory, Planning, issues, docs, and external sources route governing knowledge without broad mirroring.
 - [Pre-work knowledge gates](package/knowledge-gates.md): when routed knowledge should block design, edits, claims, or closeout until resolved.
+- [CLI boundary tests](package/cli-boundary-tests.md): how shell-facing wrapper tests stay separate from operation conformance cases.
 - [Contracts and references](package/contracts.md): how JSON contracts, schemata, generated reference docs, and runtime outputs relate.
 - [Jumpstart contract](jumpstart-contract.md): how a newly installed or adopted workspace in a lived-in repo should discover candidate durable surfaces without bulk importing repo prose.
 - [Collaboration safety](collaboration-safety.md): git-native collaboration model, merge recovery, and shared-state pressure rules.

--- a/docs/package/cli-boundary-tests.md
+++ b/docs/package/cli-boundary-tests.md
@@ -1,0 +1,46 @@
+# CLI Boundary Tests
+
+CLI boundary tests are wrapper tests. They prove that a shell-facing command faithfully presents and delegates to an already-tested operation layer; they are not the default place to prove operation semantics.
+
+## Boundary
+
+Operation conformance owns:
+
+- JSON input, output, and structured error behavior;
+- operation contracts and schema-coupled expectations;
+- generated or compiled implementation artifacts;
+- direct function/module adapters when an implementation artifact is importable;
+- cross-artifact or cross-target parity after declared normalization.
+
+CLI boundary tests own:
+
+- argv parsing and option wiring;
+- help text and user-facing error text;
+- exit codes;
+- stdout and stderr presentation;
+- JSON/text mode wrapping at the shell boundary;
+- command-name dispatch to the operation adapter;
+- a small number of wrapper-to-operation smoke paths.
+
+## Migration Rule
+
+When a direct implementation adapter exists, operation behavior should run through operation conformance cases, not through a CLI subprocess. The CLI wrapper may keep one narrow smoke test proving that the command delegates to the operation artifact, but it should not duplicate the operation case matrix through argv.
+
+Wrapper tests can assert that a command maps argv into the expected operation input and renders the returned result or structured error correctly. They should not repeat lower-level primitive assertions or every success/error/parity case already owned by operation conformance.
+
+## Current State
+
+The current operation conformance manifest still uses `cli.process` artifacts for migrated AW cases because the generated packages do not yet expose real importable operation functions for those cases. Those artifacts are explicitly marked `wrapper-smoke`; they are transitional proof surfaces, not the preferred semantic route.
+
+When generated packages expose `python.function` or `typescript.function` artifacts, promote the affected cases to direct operation adapters and demote CLI coverage to boundary-only tests.
+
+## Closeout Rule
+
+Before removing or retaining an existing CLI-heavy regression, classify it as one of:
+
+- operation semantic behavior to migrate to operation conformance;
+- CLI wrapper behavior to retain as a small boundary test;
+- adapter mechanics that belongs in command-generation or the adapter owner;
+- duplicated regression bulk to delete with replacement evidence.
+
+Closeout should name the retained owner. A broad statement that a CLI test "covers behavior" is not enough if the behavior belongs to operation conformance.

--- a/docs/package/generated-behavior-test-inventory.md
+++ b/docs/package/generated-behavior-test-inventory.md
@@ -4,6 +4,8 @@ This inventory closes the generated-behavior migration question for #1445. It ac
 
 The rule is behavioral, not filename based. Tests stay in AW when they prove AW-specific operation contracts, proof routing, packaging, lifecycle behavior, wrapper boundaries, or runtime primitives. Generic generated-artifact conformance machinery belongs to `command-generation`.
 
+The CLI wrapper boundary is defined in [CLI boundary tests](cli-boundary-tests.md). Use that page when deciding whether a CLI-heavy regression should remain as argv/help/error/exit/stdout proof or move to operation conformance.
+
 ## Migrated To Operation Conformance
 
 These behaviors are represented as JSON operation conformance cases in `src/agentic_workspace/contracts/operation_conformance_test_ir.json` and executed by `scripts/check/run_operation_conformance_tests.py`.

--- a/docs/package/overview.md
+++ b/docs/package/overview.md
@@ -23,7 +23,7 @@ The root package currently depends on the first-party Planning and Memory packag
 
 Exact profile and footprint metadata is defined in the generated [Module registry](../reference/module-registry.md). Exact command metadata is defined in [CLI commands](../reference/cli-commands.md). The reviewed ordinary operating model and surface classification live in [Ordinary continuity loop and surface classification](ordinary-continuity-loop.md). Knowledge routing, source authority, and pre-work gates are defined in [Knowledge routing and source authority](knowledge-routing.md) and [Pre-work knowledge gates](knowledge-gates.md).
 
-Generated command behavior test ownership is accounted for in [Generated behavior test inventory](generated-behavior-test-inventory.md). That inventory distinguishes operation conformance cases, shared command-generation ownership, AW wrapper/proof/lifecycle tests, and intentionally rejected regression-test bulk.
+Generated command behavior test ownership is accounted for in [Generated behavior test inventory](generated-behavior-test-inventory.md). That inventory distinguishes operation conformance cases, shared command-generation ownership, AW wrapper/proof/lifecycle tests, and intentionally rejected regression-test bulk. Shell-facing wrapper coverage is defined separately in [CLI boundary tests](cli-boundary-tests.md).
 
 ## Runtime Model
 
@@ -73,4 +73,5 @@ The threshold is not team size. A solo maintainer and one agent can still benefi
 - [Modules](modules.md)
 - [Knowledge routing and source authority](knowledge-routing.md)
 - [Pre-work knowledge gates](knowledge-gates.md)
+- [CLI boundary tests](cli-boundary-tests.md)
 - [Contracts and references](contracts.md)

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -695,8 +695,34 @@ def test_generated_behavior_test_inventory_accounts_for_migration_owners() -> No
         "tests/test_generated_command_package_proof_runner.py",
         "tests/test_command_generation_integration.py",
         "Former duplicate AW primitive tests were removed",
+        "CLI boundary tests",
     ]:
         assert required in inventory
+
+
+def test_cli_boundary_tests_doc_separates_wrappers_from_operation_conformance() -> None:
+    boundary = (Path(__file__).resolve().parents[1] / "docs" / "package" / "cli-boundary-tests.md").read_text(encoding="utf-8")
+    overview = (Path(__file__).resolve().parents[1] / "docs" / "package" / "overview.md").read_text(encoding="utf-8")
+    docs_index = (Path(__file__).resolve().parents[1] / "docs" / "index.md").read_text(encoding="utf-8")
+
+    for required in [
+        "CLI boundary tests are wrapper tests",
+        "Operation conformance owns",
+        "CLI boundary tests own",
+        "argv parsing and option wiring",
+        "help text and user-facing error text",
+        "exit codes",
+        "stdout and stderr presentation",
+        "command-name dispatch to the operation adapter",
+        "should not duplicate the operation case matrix through argv",
+        "cli.process",
+        "wrapper-smoke",
+        "python.function",
+        "typescript.function",
+    ]:
+        assert required in boundary
+    assert "CLI boundary tests](cli-boundary-tests.md)" in overview
+    assert "CLI boundary tests](package/cli-boundary-tests.md)" in docs_index
 
 
 def test_operation_conformance_test_ir_references_known_command_contracts() -> None:


### PR DESCRIPTION
Closes #1459.

Stacked on #1463.

## Summary
- Add `docs/package/cli-boundary-tests.md` as the canonical wrapper-boundary artifact.
- Link the boundary from package overview, docs index, and generated-behavior inventory.
- Add contract-tooling tests that lock the wrapper/operation split and ensure the doc stays discoverable.

## Boundary captured
- Operation conformance owns JSON input/output/error behavior, schemata, implementation artifacts, direct adapters, and parity.
- CLI boundary tests own argv, help/error text, exit codes, stdout/stderr presentation, mode wrapping, and command dispatch.
- `cli.process` remains `wrapper-smoke` until generated packages expose direct `python.function` / `typescript.function` operation artifacts.

## Proof
- `uv run pytest tests/test_contract_tooling.py::test_generated_behavior_test_inventory_accounts_for_migration_owners tests/test_contract_tooling.py::test_cli_boundary_tests_doc_separates_wrappers_from_operation_conformance tests/test_contract_tooling.py::test_operation_conformance_test_ir_records_migration_and_composition_boundary tests/test_contract_tooling.py::test_operation_artifact_registry_routes_cases_and_proof_layers -q`
- `git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md`
- `make test-workspace`
- `make lint-workspace`