### PR TITLE
Consume command-generation conformance case resources

### DIFF
--- a/docs/maintainer/aw-contract-test-replacement-inventory.md
+++ b/docs/maintainer/aw-contract-test-replacement-inventory.md
@@ -6,7 +6,7 @@ This inventory is the #1374 AW-side implementation record for replacing generate
 
 #1374 is complete for the AW repository when this inventory is current: stable generated-command success behavior has a contract-owned conformance owner, duplicate ordinary success-path regressions have been merged or deleted, and the remaining ordinary tests are explicitly retained because they cover runner internals, adapter error classification, proof/checker orchestration, schema/generator mechanics, high-risk workflow semantics, or command-generation-owned primitive behavior.
 
-This inventory does not close `rickardvh/command-generation#9`; portable primitive and command-generation package test replacement remains owned by that repository.
+This inventory now consumes the `rickardvh/command-generation#9` replacement surface from `rickardvh/command-generation#13`: package-owned reusable conformance case resources exposed by `contract_conformance_cases_manifest()` and `load_contract_conformance_case(...)`.
 
 The June 2026 audit found additional stable text-output tests that could not be migrated without weakening coverage because the shared `command-generation` conformance runner only compared JSON fields. `rickardvh/command-generation#10` adds required stdout substring checks, and this AW branch pins that dependency revision so the migrated text cases run through the same generated Python and TypeScript conformance proof as JSON cases.
 
@@ -39,7 +39,7 @@ The June 2026 audit found additional stable text-output tests that could not be 
 | `tests/test_generated_tool_conformance.py` | Conformance harness, registry, and forbidden-write mechanics. These tests validate the runner itself rather than generated command behavior. | Keep ordinary unless a runner contract format is introduced. |
 | `tests/test_generated_command_package_proof_runner.py` | Proof-step selection, crash classification, retry recovery, Docker routing, static drift checks, and checker internals. | Convert only stable command-output examples; keep proof/checker orchestration ordinary. |
 | `tests/test_workspace_proof_generated_packages_cli.py` | AW proof routing and verification-lane semantics for generated package proof. | Keep ordinary because it tests AW proof selection, not generated command behavior. |
-| `tests/test_command_generation_primitive_executor.py` | AW dependency wiring and temporary mirror coverage for command-generation primitive behavior. | Move portable primitive behavior upstream under `rickardvh/command-generation#9`; keep only AW integration wiring here. |
+| `tests/test_command_generation_primitive_executor.py` | AW dependency wiring and former temporary mirror coverage for command-generation primitive behavior. | Portable generic cases now live upstream under `rickardvh/command-generation#9` / `rickardvh/command-generation#13`; keep only AW integration wiring here. |
 | `tests/test_command_generation_artifacts.py` | Artifact ownership, freshness, and operation fragment support checks. | Keep ordinary as contract/generator integrity checks. |
 | `tests/test_workspace_cli_blackbox.py` | Remaining cases cover invalid target usage errors, near-miss command guidance, selector conflicts, and memory-route misuse. | Keep ordinary because these are adapter error classification and recovery-message surfaces. |
 | `tests/test_workspace_cli.py` | Mixed CLI compatibility, selectors, and orchestration behavior. | Convert stable command-output examples only after operation owners are explicit and the case can name a contract owner. |
@@ -53,6 +53,12 @@ The June 2026 audit found additional stable text-output tests that could not be 
 ## Boundary
 
 This inventory does not claim every ordinary test should disappear. Ordinary tests remain legitimate when they prove runner internals, adapter error classification, proof/checker orchestration, schema/generator mechanics, high-risk workflow semantics, or a narrow bug repro that cannot yet be expressed as a stable operational contract.
+
+## #1446 Simplification Closeout
+
+The AW-side simplification pass removes the remaining ambiguous handoff around command-generation-owned behavior by pinning the command-generation revision that exposes package-owned reusable conformance resources. AW keeps product-specific operation contracts, proof routing, generated package freshness, lifecycle behavior, wrapper boundary tests, and installed-product checks.
+
+Parent #1441 should remain open until the stacked PRs for #1452, #1459, #1457, this #1446 slice, and the command-generation #13 dependency are all merged. Once they are merged, the remaining parent decision is review/proof: confirm that no generated-behavior test group remains uncategorized as migrated, moved, retained, or rejected.
 
 ## Drift Guard
 

--- a/docs/maintainer/contract-test-replacement-plan.md
+++ b/docs/maintainer/contract-test-replacement-plan.md
@@ -91,6 +91,6 @@ If that mapping cannot be written, do not delete the test.
 
 #1374 owns AW-side implementation using this plan.
 
-`rickardvh/command-generation#9` owns command-generation implementation using this plan.
+`rickardvh/command-generation#9` owns command-generation implementation using this plan. `rickardvh/command-generation#13` implements the current package-owned reusable conformance case resource surface consumed by AW's #1446 simplification slice.
 
 When either issue closes, its PR body should include an inventory table with `keep`, `convert`, `merge`, and `delete` rows plus proof that generated Python and TypeScript conformance remain green.

--- a/docs/package/generated-behavior-test-inventory.md
+++ b/docs/package/generated-behavior-test-inventory.md
@@ -25,6 +25,7 @@ The shared package now owns the generic machinery that AW should not duplicate:
 | CLI/process contract execution | `process_case_from_contract`, `CliConformanceTarget`, `run_cli_conformance_case` | Used for wrapper-smoke execution of AW-specific cases. |
 | Direct JSON-shaped function execution | `operation_case_from_contract`, `FunctionConformanceTarget`, `run_function_conformance_case` | Used by AW runner for `python.function` artifacts when the registry declares an importable symbol. |
 | Shared ownership/accounting | `conformance_ownership_inventory` | Records which conformance surfaces are generic and which remain consumer-owned. |
+| Package-owned reusable conformance cases | `contract_conformance_cases_manifest`, `load_contract_conformance_case` from `rickardvh/command-generation#13` | Replaces repeated inline generic conformance payloads in command-generation tests; AW consumes the pinned revision instead of carrying generic cases. |
 | Generated output staleness by target family | `generated_output_freshness_report` | AW consumes it for generated package freshness instead of owning generic hashing semantics. |
 | Portable operation IR execution and composition | `run_operation_steps`, `PrimitiveRegistry`, `CommandGenerationHostManifest` | AW pins and tests the dependency; product primitives stay in AW. |
 | Canonical generated command artifact projection | `canonical_command_artifacts` plus command-generation fixture tests | Former AW artifact tests were moved out of `tests/test_command_generation_artifacts.py`. |
@@ -51,7 +52,7 @@ No current test group was copied into operation conformance solely because it me
 - runtime primitive and product integration tests;
 - generated freshness and structured inventory checks whose subject is source-of-truth integrity rather than command behavior.
 
-The previous AW-local generic command-generation primitive and artifact tests were not preserved as duplicate regression mass. Their generic behavior is now covered in command-generation, and AW retains only the dependency-integration checks named above.
+The previous AW-local generic command-generation primitive and artifact tests were not preserved as duplicate regression mass. Their generic behavior is now covered in command-generation, including package-owned reusable conformance case resources from `rickardvh/command-generation#13`, and AW retains only the dependency-integration checks named above.
 
 ## Remaining Trigger
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ package = true
 agentic-memory = { workspace = true }
 agentic-planning = { workspace = true }
 agentic-verification = { workspace = true }
-command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "28e4b587f7b1698beefbeca384e6aa024854be38" }
+command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "2ece5d410bacaedc5eb0b050b731dd57fc7ddce6" }
 
 [tool.uv.workspace]
 members = [

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -695,9 +695,23 @@ def test_generated_behavior_test_inventory_accounts_for_migration_owners() -> No
         "tests/test_generated_command_package_proof_runner.py",
         "tests/test_command_generation_integration.py",
         "Former duplicate AW primitive tests were removed",
+        "contract_conformance_cases_manifest",
+        "rickardvh/command-generation#13",
         "CLI boundary tests",
     ]:
         assert required in inventory
+
+
+def test_command_generation_dependency_exposes_package_owned_conformance_cases() -> None:
+    from command_generation import contract_conformance_cases_manifest, load_contract_conformance_case
+
+    manifest = contract_conformance_cases_manifest()
+    cases = {entry["id"]: entry for entry in manifest["contracts"]}
+
+    assert manifest["schema_version"] == "command-generation/conformance-cases/v1"
+    assert cases["todo.list.process"]["owner"] == "command-generation"
+    assert cases["todo.list.operation"]["category"] == "convert"
+    assert load_contract_conformance_case("todo.list-error.operation")["operation_id"] == "todo.list.report"
 
 
 def test_cli_boundary_tests_doc_separates_wrappers_from_operation_conformance() -> None:

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -502,7 +502,9 @@ def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     assert "replacement contract id and case id" in replacement_plan
     assert "rickardvh/command-generation#9" in replacement_plan
     assert "#1374 is complete for the AW repository" in aw_inventory
-    assert "This inventory does not close `rickardvh/command-generation#9`" in aw_inventory
+    assert "consumes the `rickardvh/command-generation#9` replacement surface" in aw_inventory
+    assert "rickardvh/command-generation#13" in aw_inventory
+    assert "contract_conformance_cases_manifest()" in aw_inventory
     assert "test_blackbox_root_generated_command_executes_through_console_script" in aw_inventory
     assert "test_blackbox_root_generated_command_executes_primitive_ir_through_console_script" in aw_inventory
     assert "test_defaults_tiny_text_uses_generated_output" in aw_inventory
@@ -517,6 +519,7 @@ def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     assert "delegation-outcome.append-text.process" in aw_inventory
     assert "stdout.contains" in aw_inventory
     assert "rickardvh/command-generation#10" in aw_inventory
+    assert "rickardvh/command-generation#13" in replacement_plan
     assert "Deleted Ordinary Regressions" in aw_inventory
     assert "tests/test_generated_command_package_proof_runner.py" in aw_inventory
     assert "tests/test_workspace_proof_generated_packages_cli.py" in aw_inventory

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=28e4b587f7b1698beefbeca384e6aa024854be38" },
+    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=2ece5d410bacaedc5eb0b050b731dd57fc7ddce6" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -145,7 +145,7 @@ wheels = [
 [[package]]
 name = "command-generation"
 version = "0.1.0"
-source = { git = "https://github.com/rickardvh/command-generation.git?rev=28e4b587f7b1698beefbeca384e6aa024854be38#28e4b587f7b1698beefbeca384e6aa024854be38" }
+source = { git = "https://github.com/rickardvh/command-generation.git?rev=2ece5d410bacaedc5eb0b050b731dd57fc7ddce6#2ece5d410bacaedc5eb0b050b731dd57fc7ddce6" }
 dependencies = [
     { name = "jsonschema" },
 ]


### PR DESCRIPTION
## Summary
- pins command-generation to rickardvh/command-generation#13's package-owned conformance case resource commit
- updates generated-behavior and contract-test inventories to record the #1446 simplification closeout
- adds AW proof that the pinned dependency exposes package-owned reusable conformance cases

Depends on rickardvh/command-generation#13.
Closes #1446.
Does not close #1441.

## Proof
- uv run pytest tests/test_contract_tooling.py::test_generated_behavior_test_inventory_accounts_for_migration_owners tests/test_contract_tooling.py::test_command_generation_dependency_exposes_package_owned_conformance_cases tests/test_maintainer_surfaces.py::test_testing_strategy_guides_against_one_off_regression_sprawl -q
- make maintainer-surfaces
- git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md
- make lint-workspace
- make test-workspace