### PR TITLE
Pin command-generation merged commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ package = true
 agentic-memory = { workspace = true }
 agentic-planning = { workspace = true }
 agentic-verification = { workspace = true }
-command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "2ece5d410bacaedc5eb0b050b731dd57fc7ddce6" }
+command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "4b4547cecc2193810e40f6918a387369a6c1c26a" }
 
 [tool.uv.workspace]
 members = [

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=2ece5d410bacaedc5eb0b050b731dd57fc7ddce6" },
+    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=4b4547cecc2193810e40f6918a387369a6c1c26a" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -145,7 +145,7 @@ wheels = [
 [[package]]
 name = "command-generation"
 version = "0.1.0"
-source = { git = "https://github.com/rickardvh/command-generation.git?rev=2ece5d410bacaedc5eb0b050b731dd57fc7ddce6#2ece5d410bacaedc5eb0b050b731dd57fc7ddce6" }
+source = { git = "https://github.com/rickardvh/command-generation.git?rev=4b4547cecc2193810e40f6918a387369a6c1c26a#4b4547cecc2193810e40f6918a387369a6c1c26a" }
 dependencies = [
     { name = "jsonschema" },
 ]


### PR DESCRIPTION
## Summary
- updates the command-generation dependency pin from PR head 2ece5d4 to merged master commit 4b4547c
- regenerates uv.lock for the new pinned revision

## Proof
- uv run pytest tests/test_contract_tooling.py::test_command_generation_dependency_exposes_package_owned_conformance_cases -q
- make lint-workspace
- make test-workspace