### PR TITLE
[codex] Route improvement pressure into posture

### DIFF
--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -18,6 +18,7 @@ Cheap implementer context for a bounded changed-path scope.
 | `task_posture_packet.kind` | const `"agentic-workspace/task-posture-packet/v1"` | yes |  | Discriminator for dynamic task posture. |  |  |
 | `task_posture_packet.operating_posture` | object | yes |  | Resolved optimization, artifact, initiative, assurance, and delegation posture for this task. |  |  |
 | `task_posture_packet.workflow_obligations` | array of object | yes |  | Matched workflow obligations with stage, force, scope, and provenance. |  |  |
+| `task_posture_packet.improvement_obligations` | array of object | yes |  | Active improvement-pressure obligations that affect proof, closeout, allowed actions, or posture adherence. |  |  |
 | `task_posture_packet.skill_routes` | array of object | yes |  | Task-selected skills, prompts, or routing fragments. |  |  |
 | `task_posture_packet.allowed_actions` | array of string | yes |  | Actions allowed under the resolved posture. |  |  |
 | `task_posture_packet.forbidden_actions` | array of string | yes |  | Actions forbidden under the resolved posture. |  |  |

--- a/docs/reference/improvement-signal-contract.md
+++ b/docs/reference/improvement-signal-contract.md
@@ -30,6 +30,9 @@ Contract for classifying improvement signals and routing them to the right owner
 | `correct_by_design_review.closeout_field` | string | yes |  | Closeout field text value used by this contract. |  |  |
 | `confidence` | array of enum `"low"`, `"medium"`, `"high"` | yes |  | Ordered confidence entries used by this contract. |  |  |
 | `recurrence` | array of enum `"first_seen"`, `"repeated"`, `"human_confirmed"` | yes |  | Ordered recurrence entries used by this contract. |  |  |
+| `lifecycle_states` | array of enum `"active"`, `"mitigated"`, `"accepted-risk"`, `"promoted-to-issue"`, `"obsolete"` | yes |  | Ordered lifecycle states entries used by this contract. |  |  |
+| `lifecycle_rule` | string | yes |  | Policy rule that explains how improvement pressure lifecycle state affects routing. |  |  |
+| `retirement_criteria_fields` | array of string | yes |  | Fields that explain what retires or promotes an improvement pressure record. |  |  |
 | `immediate_actions` | array of enum `"fix_now"`, `"route"`, `"review"`, `"remember"`, `"dismiss"` | yes |  | Ordered immediate actions entries used by this contract. |  |  |
 | `retention` | array of enum `"shrink_after_fix"`, `"delete_after_fix"`, `"keep_with_justification"` | yes |  | Ordered retention entries used by this contract. |  |  |
 | `destinations` | array of string | yes |  | Ordered destinations entries used by this contract. |  |  |

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -18,6 +18,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `task_posture_packet.kind` | const `"agentic-workspace/task-posture-packet/v1"` | yes |  | Discriminator for dynamic task posture. |  |  |
 | `task_posture_packet.operating_posture` | object | yes |  | Resolved optimization, artifact, initiative, assurance, and delegation posture for this task. |  |  |
 | `task_posture_packet.workflow_obligations` | array of object | yes |  | Matched workflow obligations with stage, force, scope, and provenance. |  |  |
+| `task_posture_packet.improvement_obligations` | array of object | yes |  | Active improvement-pressure obligations that affect proof, closeout, allowed actions, or posture adherence. |  |  |
 | `task_posture_packet.skill_routes` | array of object | yes |  | Task-selected skills, prompts, or routing fragments. |  |  |
 | `task_posture_packet.allowed_actions` | array of string | yes |  | Actions allowed under the resolved posture. |  |  |
 | `task_posture_packet.forbidden_actions` | array of string | yes |  | Actions forbidden under the resolved posture. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -61,6 +61,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `task_posture_packet.kind` | const `"agentic-workspace/task-posture-packet/v1"` | yes |  | Discriminator for dynamic task posture. |  |  |
 | `task_posture_packet.operating_posture` | object | yes |  | Resolved optimization, artifact, initiative, assurance, and delegation posture for this task. |  |  |
 | `task_posture_packet.workflow_obligations` | array of object | yes |  | Matched workflow obligations with stage, force, scope, and provenance. |  |  |
+| `task_posture_packet.improvement_obligations` | array of object | yes |  | Active improvement-pressure obligations that affect proof, closeout, allowed actions, or posture adherence. |  |  |
 | `task_posture_packet.skill_routes` | array of object | yes |  | Task-selected skills, prompts, or routing fragments. |  |  |
 | `task_posture_packet.allowed_actions` | array of string | yes |  | Actions allowed under the resolved posture. |  |  |
 | `task_posture_packet.forbidden_actions` | array of string | yes |  | Actions forbidden under the resolved posture. |  |  |
@@ -211,6 +212,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `discovery` | object | yes |  | Discovery hints for relevant repo surfaces and compact commands. |  |  |
 | `standing_intent` | object | yes |  | Standing intent details used by this contract. |  |  |
 | `improvement_intake` | object | yes |  | Improvement intake details used by this contract. |  |  |
+| `improvement_pressure` | object | yes |  | Derived improvement-pressure lifecycle records and active posture obligations compiled from improvement intake. |  |  |
 | `repo_friction` | object | yes |  | Repo friction details used by this contract. |  |  |
 | `registry` | array | yes |  | Ordered registry entries used by this contract. |  |  |
 | `config` | object | yes |  | Config details used by this contract. |  |  |

--- a/src/agentic_workspace/contracts/improvement_signal_contract.json
+++ b/src/agentic_workspace/contracts/improvement_signal_contract.json
@@ -135,6 +135,21 @@
     "repeated",
     "human_confirmed"
   ],
+  "lifecycle_states": [
+    "active",
+    "mitigated",
+    "accepted-risk",
+    "promoted-to-issue",
+    "obsolete"
+  ],
+  "lifecycle_rule": "Only active pressure may compile into posture obligations or next-action pressure; mitigated, accepted-risk, promoted, and obsolete pressure remains quiet except for compact provenance and audit detail.",
+  "retirement_criteria_fields": [
+    "state",
+    "retire_when",
+    "resulting_owner",
+    "posture_obligation_ref",
+    "evidence_ref"
+  ],
   "immediate_actions": [
     "fix_now",
     "route",

--- a/src/agentic_workspace/contracts/report_contract.json
+++ b/src/agentic_workspace/contracts/report_contract.json
@@ -59,6 +59,7 @@
     "discovery",
     "standing_intent",
     "improvement_intake",
+    "improvement_pressure",
     "repo_friction",
     "registry",
     "config",
@@ -79,6 +80,7 @@
     "make each config setting's actual force inspectable instead of relying on setting names alone",
     "let optimization bias change rendering density, not canonical truth or execution method",
     "route improvement signals through one intake model before promoting them to work, memory, docs, checks, or dismissal",
+    "compile only active improvement pressure into posture obligations; keep mitigated, promoted, accepted-risk, and obsolete pressure quiet by default",
     "make recent successful-completion cost evidence inspectable without broad dogfooding or review archaeology",
     "compress routine agent routing into authority, active work, evidence, durable knowledge, and promotion residue without changing canonical owners",
     "expose continuation, completion, external-evidence, automation-readiness, and migration-pilot answers as derived projections rather than new stores or runtime ownership"

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -645,6 +645,7 @@
         "kind",
         "operating_posture",
         "workflow_obligations",
+        "improvement_obligations",
         "skill_routes",
         "allowed_actions",
         "forbidden_actions",
@@ -677,6 +678,14 @@
           "type": "array",
           "items": { "type": "object", "additionalProperties": true },
           "description": "Matched workflow obligations with stage, force, scope, and provenance."
+        },
+        "improvement_obligations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Active improvement-pressure obligations that affect proof, closeout, allowed actions, or posture adherence."
         },
         "skill_routes": {
           "type": "array",

--- a/src/agentic_workspace/contracts/schemas/improvement_signal_contract.schema.json
+++ b/src/agentic_workspace/contracts/schemas/improvement_signal_contract.schema.json
@@ -18,6 +18,9 @@
     "correct_by_design_review",
     "confidence",
     "recurrence",
+    "lifecycle_states",
+    "lifecycle_rule",
+    "retirement_criteria_fields",
     "immediate_actions",
     "retention",
     "destinations",
@@ -218,6 +221,36 @@
         "description": "One entry in the recurrence list."
       },
       "description": "Ordered recurrence entries used by this contract."
+    },
+    "lifecycle_states": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "enum": [
+          "active",
+          "mitigated",
+          "accepted-risk",
+          "promoted-to-issue",
+          "obsolete"
+        ],
+        "description": "One entry in the lifecycle states list."
+      },
+      "description": "Ordered lifecycle states entries used by this contract."
+    },
+    "lifecycle_rule": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Policy rule that explains how improvement pressure lifecycle state affects routing."
+    },
+    "retirement_criteria_fields": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "One entry in the retirement criteria fields list."
+      },
+      "description": "Fields that explain what retires or promotes an improvement pressure record."
     },
     "immediate_actions": {
       "type": "array",

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -438,6 +438,7 @@
         "kind",
         "operating_posture",
         "workflow_obligations",
+        "improvement_obligations",
         "skill_routes",
         "allowed_actions",
         "forbidden_actions",
@@ -470,6 +471,14 @@
           "type": "array",
           "items": { "type": "object", "additionalProperties": true },
           "description": "Matched workflow obligations with stage, force, scope, and provenance."
+        },
+        "improvement_obligations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Active improvement-pressure obligations that affect proof, closeout, allowed actions, or posture adherence."
         },
         "skill_routes": {
           "type": "array",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -63,6 +63,7 @@
     "discovery",
     "standing_intent",
     "improvement_intake",
+    "improvement_pressure",
     "repo_friction",
     "registry",
     "config",
@@ -416,6 +417,11 @@
       "type": "object",
       "description": "Improvement intake details used by this contract."
     },
+    "improvement_pressure": {
+      "type": "object",
+      "description": "Derived improvement-pressure lifecycle records and active posture obligations compiled from improvement intake.",
+      "additionalProperties": true
+    },
     "repo_friction": {
       "type": "object",
       "description": "Repo friction details used by this contract."
@@ -449,6 +455,7 @@
         "kind",
         "operating_posture",
         "workflow_obligations",
+        "improvement_obligations",
         "skill_routes",
         "allowed_actions",
         "forbidden_actions",
@@ -484,6 +491,14 @@
             "additionalProperties": true
           },
           "description": "Matched workflow obligations with stage, force, scope, and provenance."
+        },
+        "improvement_obligations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Active improvement-pressure obligations that affect proof, closeout, allowed actions, or posture adherence."
         },
         "skill_routes": {
           "type": "array",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -2935,6 +2935,13 @@ def _normalized_setup_finding(raw: Any) -> dict[str, Any] | None:
     }
     if isinstance(validation_failure_class, str) and validation_failure_class in validation_failure_classes:
         normalized["validation_failure_class"] = validation_failure_class
+    pressure_state = raw.get("pressure_state", raw.get("state"))
+    if isinstance(pressure_state, str) and pressure_state in _IMPROVEMENT_SIGNAL_CONTRACT["lifecycle_states"]:
+        normalized["pressure_state"] = pressure_state
+    for field in ("retire_when", "resulting_owner", "posture_obligation_ref", "evidence_ref", "issue_ref"):
+        value = raw.get(field)
+        if isinstance(value, str) and value.strip():
+            normalized[field] = value.strip()
     return normalized
 
 
@@ -3020,6 +3027,9 @@ def _improvement_signal_contract_payload() -> dict[str, Any]:
         "validation_failure_classes": list(_IMPROVEMENT_SIGNAL_CONTRACT.get("validation_failure_classes", [])),
         "validation_remedy_order": list(_IMPROVEMENT_SIGNAL_CONTRACT.get("validation_remedy_order", [])),
         "correct_by_design_review": dict(_IMPROVEMENT_SIGNAL_CONTRACT.get("correct_by_design_review", {})),
+        "lifecycle_states": list(_IMPROVEMENT_SIGNAL_CONTRACT["lifecycle_states"]),
+        "lifecycle_rule": str(_IMPROVEMENT_SIGNAL_CONTRACT["lifecycle_rule"]),
+        "retirement_criteria_fields": list(_IMPROVEMENT_SIGNAL_CONTRACT["retirement_criteria_fields"]),
         "closeout_statuses": list(_IMPROVEMENT_SIGNAL_CONTRACT["closeout_statuses"]),
         "destinations": list(_IMPROVEMENT_SIGNAL_CONTRACT["destinations"]),
         "guardrails": list(_IMPROVEMENT_SIGNAL_CONTRACT["guardrails"]),
@@ -3166,8 +3176,123 @@ def _improvement_signal_candidates_from_repo_friction(repo_friction: dict[str, A
             )
             if validation_failure_class:
                 candidate["validation_failure_class"] = validation_failure_class
+            for optional_field in (
+                "pressure_state",
+                "state",
+                "retire_when",
+                "resulting_owner",
+                "posture_obligation_ref",
+                "evidence_ref",
+                "issue_ref",
+            ):
+                if optional_field in item:
+                    candidate[optional_field] = copy.deepcopy(item[optional_field])
             candidates.append(candidate)
     return candidates[:5]
+
+
+def _improvement_pressure_state(candidate: dict[str, Any]) -> str:
+    allowed = set(_IMPROVEMENT_SIGNAL_CONTRACT["lifecycle_states"])
+    state = str(candidate.get("pressure_state") or candidate.get("state") or "").strip()
+    if state in allowed:
+        return state
+    immediate_action = str(candidate.get("immediate_action") or "").strip()
+    if immediate_action == "dismiss":
+        return "accepted-risk"
+    if candidate.get("issue_ref"):
+        return "promoted-to-issue"
+    return "active"
+
+
+def _improvement_pressure_obligation_for_record(record: dict[str, Any]) -> dict[str, Any]:
+    record_id = str(record.get("id") or "improvement-pressure").strip()
+    kind = str(record.get("kind") or "").strip()
+    validation_class = str(record.get("validation_failure_class") or "").strip()
+    if kind == "validation_friction" and validation_class in {"interface_design_error", "unclear_proof_contract"}:
+        return {
+            "id": f"{record_id}-correct-by-design",
+            "source": "improvement-pressure",
+            "effect": "require correct-by-design assessment before broad completion claim",
+            "routes_to": ["proof_boundaries", "closeout_boundaries", "posture_adherence"],
+            "forbidden_actions": ["claim completion before improvement obligation is resolved"],
+            "proof_boundary": "record correct_by_design_assessment or route the active validation-friction pressure to an owner",
+            "closeout_boundary": "improvement-pressure obligation resolved, overridden, or accepted-risk before full completion claim",
+            "next_allowed_action": "record improvement obligation adherence",
+            "adherence": "unresolved",
+            "provenance": record.get("provenance", []),
+        }
+    return {
+        "id": f"{record_id}-owner-route",
+        "source": "improvement-pressure",
+        "effect": "route or dismiss owner before treating the friction signal as closed",
+        "routes_to": ["closeout_boundaries", "posture_adherence"],
+        "forbidden_actions": ["claim improvement pressure resolved without owner, dismissal, or accepted-risk state"],
+        "proof_boundary": "show owner route, mitigation, accepted-risk decision, or obsolete evidence for this pressure",
+        "closeout_boundary": "active improvement pressure has a recorded owner, mitigation, or accepted-risk disposition",
+        "next_allowed_action": "route active improvement pressure or record accepted-risk",
+        "adherence": "unresolved",
+        "provenance": record.get("provenance", []),
+    }
+
+
+def _improvement_pressure_payload(improvement_intake: dict[str, Any]) -> dict[str, Any]:
+    candidates = [item for item in _list_payload(improvement_intake.get("improvement_signal_candidates")) if isinstance(item, dict)]
+    records: list[dict[str, Any]] = []
+    for candidate in candidates:
+        owner = str(candidate.get("suspected_owner") or candidate.get("source") or "unknown").strip()
+        record_id = "pressure-" + _decision_slug(f"{candidate.get('kind', 'signal')}-{owner}")[:72]
+        state = _improvement_pressure_state(candidate)
+        record: dict[str, Any] = {
+            "kind": "workspace-improvement-pressure-record/v1",
+            "id": record_id,
+            "state": state,
+            "signal_kind": str(candidate.get("candidate_kind") or ""),
+            "pressure_kind": str(candidate.get("kind") or ""),
+            "what_keeps_going_wrong": str(candidate.get("symptom") or ""),
+            "evidence": {
+                "source": str(candidate.get("source") or ""),
+                "observed_during": str(candidate.get("observed_during") or ""),
+                "evidence_ref": str(candidate.get("evidence_ref") or ""),
+            },
+            "cost_or_frequency": {
+                "cost": str(candidate.get("cost") or ""),
+                "recurrence": str(candidate.get("recurrence") or "first_seen"),
+                "confidence": str(candidate.get("confidence") or "medium"),
+            },
+            "owner_surface": owner,
+            "resulting_owner": str(candidate.get("resulting_owner") or candidate.get("issue_ref") or owner),
+            "retire_when": str(
+                candidate.get("retire_when") or "the owner route, mitigation, accepted-risk decision, or obsolete evidence is recorded"
+            ),
+            "posture_obligation_ref": str(candidate.get("posture_obligation_ref") or f"{record_id}-owner-route"),
+            "provenance": [
+                {"source": "improvement_intake.improvement_signal_candidates", "candidate_kind": candidate.get("candidate_kind")},
+                {"source": str(candidate.get("source") or "unknown")},
+            ],
+        }
+        validation_failure_class = str(candidate.get("validation_failure_class") or "").strip()
+        if validation_failure_class:
+            record["validation_failure_class"] = validation_failure_class
+            record["posture_obligation_ref"] = str(candidate.get("posture_obligation_ref") or f"{record_id}-correct-by-design")
+        if candidate.get("issue_ref"):
+            record["issue_ref"] = candidate["issue_ref"]
+        if state == "active":
+            record["posture_obligation"] = _improvement_pressure_obligation_for_record({**record, "kind": str(candidate.get("kind") or "")})
+        records.append(record)
+    active_records = [record for record in records if record.get("state") == "active"]
+    obligations = [record["posture_obligation"] for record in active_records if isinstance(record.get("posture_obligation"), dict)]
+    return {
+        "kind": "workspace-improvement-pressure/v1",
+        "status": "active" if active_records else ("quiet" if records else "none"),
+        "lifecycle_states": list(_IMPROVEMENT_SIGNAL_CONTRACT["lifecycle_states"]),
+        "lifecycle_rule": str(_IMPROVEMENT_SIGNAL_CONTRACT["lifecycle_rule"]),
+        "records": records,
+        "active_record_refs": [str(record.get("id")) for record in active_records],
+        "inactive_record_refs": [str(record.get("id")) for record in records if record.get("state") != "active"],
+        "posture_obligations": obligations,
+        "active_obligation_refs": [str(obligation.get("id")) for obligation in obligations],
+        "routing_rule": "Active pressure may compile into posture obligations; inactive pressure stays as compact audit detail.",
+    }
 
 
 def _improvement_intake_payload(
@@ -6940,6 +7065,8 @@ def _run_report_command(
         cli_invoke=config.cli_invoke,
     )
     workflow_obligations = _workflow_obligations_report_payload(config=config, active_planning_record=active_planning_record)
+    improvement_intake = _improvement_intake_payload(target_root=target_root, config=config, repo_friction=repo_friction)
+    improvement_pressure = _improvement_pressure_payload(improvement_intake)
     intent_custody = _intent_custody_payload(
         task_text=None,
         active_planning_record=raw_active_planning_record or active_planning_record,
@@ -6957,6 +7084,7 @@ def _run_report_command(
         proof={},
         completion_gate=_as_dict(closeout_trust.get("completion_gate")),
         closeout_trust=closeout_trust,
+        improvement_pressure=improvement_pressure,
     )
     payload = {
         "kind": "workspace-report/v1",
@@ -6998,6 +7126,7 @@ def _run_report_command(
         ),
         "system_intent_mirror": _system_intent_report_payload(target_root=target_root, config=config),
         "workflow_obligations": workflow_obligations,
+        "improvement_pressure": improvement_pressure,
         "task_posture_packet": task_posture_packet,
         "applicable_intent": applicable_intent,
         "assurance_requirements": assurance_requirements,
@@ -7021,7 +7150,7 @@ def _run_report_command(
         "next_action": next_action,
         "discovery": discovery,
         "standing_intent": standing_intent,
-        "improvement_intake": _improvement_intake_payload(target_root=target_root, config=config, repo_friction=repo_friction),
+        "improvement_intake": improvement_intake,
         "repo_friction": repo_friction,
         "registry": status_payload["registry"],
         "config": status_payload["config"],
@@ -18072,6 +18201,7 @@ def _compact_task_posture_packet_projection(task_posture_packet: dict[str, Any])
         "kind": task_posture_packet.get("kind"),
         "operating_posture": task_posture_packet.get("operating_posture", {}),
         "workflow_obligations": task_posture_packet.get("workflow_obligations", []),
+        "improvement_obligations": task_posture_packet.get("improvement_obligations", []),
         "skill_routes": task_posture_packet.get("skill_routes", []),
         "allowed_actions": task_posture_packet.get("allowed_actions", []),
         "forbidden_actions": task_posture_packet.get("forbidden_actions", []),
@@ -27225,6 +27355,7 @@ def _task_posture_packet_payload(
     proof: dict[str, Any] | None = None,
     completion_gate: dict[str, Any] | None = None,
     closeout_trust: dict[str, Any] | None = None,
+    improvement_pressure: dict[str, Any] | None = None,
     compact: bool = False,
 ) -> dict[str, Any]:
     normalized_paths = _normalize_changed_paths(changed_paths or [])
@@ -27234,6 +27365,10 @@ def _task_posture_packet_payload(
     proof = _as_dict(proof)
     completion_gate = _as_dict(completion_gate)
     closeout_trust = _as_dict(closeout_trust)
+    improvement_pressure = _as_dict(improvement_pressure)
+    improvement_obligations = [
+        dict(item) for item in _list_payload(improvement_pressure.get("posture_obligations")) if isinstance(item, dict)
+    ]
     relevant_obligations = [
         dict(item) for item in _list_payload(workflow_obligations.get("relevant_to_current_work")) if isinstance(item, dict)
     ]
@@ -27306,11 +27441,16 @@ def _task_posture_packet_payload(
             "inline all module instructions into AGENTS.md instead of using routed posture",
         ]
     )
+    for obligation in improvement_obligations:
+        forbidden_actions.extend(str(item) for item in _list_payload(obligation.get("forbidden_actions")) if str(item).strip())
     proof_boundaries = [str(item) for item in _list_payload(proof.get("required_commands")) if str(item).strip()]
     if not proof_boundaries:
         proof_boundaries = [str(item) for item in _list_payload(proof.get("proof_commands")) if str(item).strip()]
     if not proof_boundaries and planning_safety_gate.get("workflow_sufficient") is False:
         proof_boundaries = ["create or promote active Planning before selecting implementation proof"]
+    proof_boundaries.extend(
+        str(item.get("proof_boundary")) for item in improvement_obligations if str(item.get("proof_boundary") or "").strip()
+    )
     repo_posture = _repo_posture_payload(config=config, surface=surface, compact=True)
     closeout_boundaries = [
         str(planning_safety_gate.get("claim_boundary", {}).get("completion_claim") or ""),
@@ -27320,6 +27460,9 @@ def _task_posture_packet_payload(
     closeout_boundaries = [item for item in closeout_boundaries if item]
     if not closeout_boundaries:
         closeout_boundaries = ["record proof, acceptance, posture adherence, and residue before completion claims"]
+    improvement_closeout_boundaries = [
+        str(item.get("closeout_boundary")) for item in improvement_obligations if str(item.get("closeout_boundary") or "").strip()
+    ]
     authority_boundaries = []
     for source_name, source_payload in (
         ("planning_safety_gate", planning_safety_gate),
@@ -27394,6 +27537,8 @@ def _task_posture_packet_payload(
     ]
     if relevant_obligations:
         review_rubrics.append("Were matched workflow obligations satisfied or explicitly routed?")
+    if improvement_obligations:
+        review_rubrics.append("Were active improvement-pressure obligations followed, overridden, accepted-risk, or left unresolved?")
     knowledge_gates = _knowledge_gates_payload(
         surface=surface,
         task_text=task_text,
@@ -27418,6 +27563,9 @@ def _task_posture_packet_payload(
         and str(gate.get("resolution_state") or "") == "open"
         and str(gate.get("force") or "") != "informational"
     ]
+    improvement_next_actions = [
+        str(item.get("next_allowed_action")) for item in improvement_obligations if str(item.get("next_allowed_action") or "").strip()
+    ]
     packet: dict[str, Any] = {
         "kind": "agentic-workspace/task-posture-packet/v1",
         "operating_posture": {
@@ -27436,19 +27584,20 @@ def _task_posture_packet_payload(
             "repo_posture_reminder": repo_posture["reminder"],
         },
         "workflow_obligations": relevant_obligations,
+        "improvement_obligations": improvement_obligations,
         "skill_routes": skill_routes,
         "allowed_actions": _dedupe(allowed_actions),
         "forbidden_actions": _dedupe(forbidden_actions),
         "proof_boundaries": _dedupe(proof_boundaries),
-        "closeout_boundaries": _dedupe([*closeout_boundaries, *gate_closeout_boundaries]),
+        "closeout_boundaries": _dedupe([*closeout_boundaries, *gate_closeout_boundaries, *improvement_closeout_boundaries]),
         "read_budget": read_budget,
         "authority_boundaries": authority_boundaries,
         "knowledge_gates": knowledge_gates,
         "gate_summary": gate_summary,
         "blocked_actions": blocked_actions,
-        "next_allowed_action": gate_next_actions[0]
-        if gate_next_actions
-        else (allowed_actions[0] if allowed_actions else "continue-direct"),
+        "next_allowed_action": improvement_next_actions[0]
+        if improvement_next_actions
+        else (gate_next_actions[0] if gate_next_actions else (allowed_actions[0] if allowed_actions else "continue-direct")),
         "output_shape_requirements": output_shape_requirements,
         "review_rubrics": review_rubrics,
         "module_contributions": module_contributions,
@@ -27457,6 +27606,7 @@ def _task_posture_packet_payload(
             {"source": "workflow_obligations", "matched_count": len(relevant_obligations)},
             {"source": "planning_safety_gate", "status": planning_safety_gate.get("status", "not-present")},
             {"source": "module_registry", "matched_module_count": len(module_contributions)},
+            {"source": "improvement_pressure", "active_obligation_count": len(improvement_obligations)},
         ],
     }
     packet["dynamic_instruction_projection"] = {
@@ -27478,6 +27628,15 @@ def _task_posture_packet_payload(
         "status": "requires-closeout-review",
         "closeout_question": "Did the work follow the task posture packet, and were any divergences recorded?",
         "allowed_states": ["complied", "intentional-divergence", "gap"],
+        "improvement_obligation_adherence": [
+            {
+                "obligation_ref": str(obligation.get("id") or ""),
+                "status": str(obligation.get("adherence") or "unresolved"),
+                "allowed_states": ["followed", "ignored", "overridden", "unresolved", "accepted-risk"],
+                "record_to": "closeout evidence, report closeout, or PR body",
+            }
+            for obligation in improvement_obligations
+        ],
     }
     return packet
 

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -7365,6 +7365,8 @@ def test_report_surfaces_promotable_setup_findings_as_repo_friction_evidence(tmp
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
+    (target / "src").mkdir()
+    (target / "src" / "large_surface.py").write_text("\n".join(f"line_{index}" for index in range(450)) + "\n")
     (target / "tools").mkdir()
     (target / "tools" / "setup-findings.json").write_text(
         json.dumps(
@@ -7384,6 +7386,21 @@ def test_report_surfaces_promotable_setup_findings_as_repo_friction_evidence(tmp
                         "recurrence": "repeated",
                         "validation_failure_class": "interface_design_error",
                         "refs": [".agentic-workspace/docs/reporting-contract.md"],
+                    },
+                    {
+                        "class": "repo_friction_evidence",
+                        "summary": "Old validation pressure was mitigated by a writer helper.",
+                        "confidence": 0.9,
+                        "path": "generated/workspace/python/review_writer.py",
+                        "observed_during": "uv run pytest tests/test_workspace_cli.py",
+                        "signal_kind": "validation_friction",
+                        "cost": "Previously repeated hand-authored shape repair.",
+                        "suspected_owner": "agentic-workspace review writer",
+                        "likely_remediation": "writer_helper",
+                        "recurrence": "repeated",
+                        "validation_failure_class": "interface_design_error",
+                        "pressure_state": "mitigated",
+                        "retire_when": "writer helper constructs the required shape",
                     },
                     {
                         "class": "repo_friction_evidence",
@@ -7414,16 +7431,41 @@ def test_report_surfaces_promotable_setup_findings_as_repo_friction_evidence(tmp
     assert setup_findings["items"][0]["validation_failure_class"] == "interface_design_error"
     assert setup_findings["items"][0]["promotion_reason"] == "grounded friction evidence is worth preserving"
     signal = payload["improvement_intake"]["improvement_signal_candidates"][0]
+    signals_by_owner = {signal["suspected_owner"]: signal for signal in payload["improvement_intake"]["improvement_signal_candidates"]}
+    signal = signals_by_owner["agentic-workspace create-review"]
     assert signal["kind"] == "validation_friction"
     assert signal["observed_during"] == "uv run pytest tests/test_workspace_cli.py"
-    assert signal["suspected_owner"] == "agentic-workspace create-review"
     assert signal["likely_remediation"] == "scaffold"
     assert signal["recurrence"] == "repeated"
     assert signal["validation_failure_class"] == "interface_design_error"
+    assert signals_by_owner["agentic-workspace review writer"]["pressure_state"] == "mitigated"
     assert payload["improvement_intake"]["setup_findings"]["status"] == "loaded"
-    assert payload["improvement_intake"]["setup_findings"]["loaded_count"] == 2
-    assert payload["improvement_intake"]["setup_findings"]["promotable_counts"]["repo_friction_evidence"] == 1
+    assert payload["improvement_intake"]["setup_findings"]["loaded_count"] == 3
+    assert payload["improvement_intake"]["setup_findings"]["promotable_counts"]["repo_friction_evidence"] == 2
     assert payload["improvement_intake"]["setup_findings"]["transient_count"] == 1
+    pressure = payload["improvement_pressure"]
+    assert pressure["lifecycle_states"] == ["active", "mitigated", "accepted-risk", "promoted-to-issue", "obsolete"]
+    assert pressure["status"] == "active"
+    active_obligations = {item["id"]: item for item in pressure["posture_obligations"]}
+    assert len(active_obligations) >= 2
+    assert any(
+        item["effect"] == "require correct-by-design assessment before broad completion claim" for item in active_obligations.values()
+    )
+    assert any(
+        item["effect"] == "route or dismiss owner before treating the friction signal as closed" for item in active_obligations.values()
+    )
+    mitigated = [record for record in pressure["records"] if record["state"] == "mitigated"]
+    assert mitigated
+    assert mitigated[0]["id"] not in pressure["active_record_refs"]
+    packet = payload["task_posture_packet"]
+    assert packet["improvement_obligations"] == pressure["posture_obligations"]
+    assert "claim completion before improvement obligation is resolved" in packet["forbidden_actions"]
+    assert packet["next_allowed_action"] in {
+        "record improvement obligation adherence",
+        "route active improvement pressure or record accepted-risk",
+    }
+    assert any("correct_by_design_assessment" in boundary for boundary in packet["proof_boundaries"])
+    assert packet["posture_adherence"]["improvement_obligation_adherence"][0]["status"] == "unresolved"
 
 
 def test_report_surfaces_reporting_only_repo_friction_posture(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Closes #1472.
Closes #1473.

Implements the pressure-to-posture loop without adding a new workflow subsystem:

- adds lifecycle states for improvement pressure records: `active`, `mitigated`, `accepted-risk`, `promoted-to-issue`, `obsolete`
- preserves compact lifecycle metadata from setup findings into improvement signal candidates
- derives `improvement_pressure` from existing `improvement_intake` candidates
- compiles only active pressure into `task_posture_packet.improvement_obligations`
- routes active obligations into forbidden actions, proof boundaries, closeout boundaries, next allowed action, and posture adherence
- keeps mitigated/inactive pressure quiet except for compact audit provenance

## Validation

- `uv run pytest tests/test_workspace_report_cli.py::test_report_surfaces_promotable_setup_findings_as_repo_friction_evidence -q`
- `make render-schema-reference`
- `uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_report_cli.py src/agentic_workspace/contracts`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `make schema-reference-docs`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make maintainer-surfaces`
