### PR TITLE
Fix dogfooding lane workflow findings

### DIFF
--- a/.agentic-workspace/agent-aids/scripts/github-issue-body/examples/direction-request.json
+++ b/.agentic-workspace/agent-aids/scripts/github-issue-body/examples/direction-request.json
@@ -1,0 +1,33 @@
+{
+  "kind": "agentic-workspace/issue-body-request/v1",
+  "template": "direction",
+  "title": "Example structured issue body",
+  "fields": {
+    "problem_intent": {
+      "kind": "markdown",
+      "value": "Render issue bodies from structured request data."
+    },
+    "intended_outcome": {
+      "kind": "markdown",
+      "value": "The issue-body aid validates typed fields before rendering."
+    },
+    "larger_picture": {
+      "kind": "markdown",
+      "value": "Nontrivial issue bodies avoid shell-composed semantic fields."
+    },
+    "scope": {
+      "kind": "markdown",
+      "value": "In scope: structured request rendering."
+    },
+    "acceptance": {
+      "kind": "markdown",
+      "value": "The rendered body preserves the repository issue template headings."
+    }
+  },
+  "source_refs": [
+    {
+      "kind": "example",
+      "id": "structured-request"
+    }
+  ]
+}

--- a/.agentic-workspace/agent-aids/scripts/github-issue-body/manifest.json
+++ b/.agentic-workspace/agent-aids/scripts/github-issue-body/manifest.json
@@ -9,7 +9,9 @@
   "owner": "workspace",
   "created_because": "Agents bypassed the repo GitHub issue templates when creating issues from review findings.",
   "use_when": [
-    "creating GitHub issues from review findings, dogfooding friction, bugs, or planning follow-ups"
+    "creating GitHub issues from review findings, dogfooding friction, bugs, or planning follow-ups",
+    "for nontrivial issue bodies, use --input-json, --from-lane, or --from-decomposition so semantic fields come from structured data",
+    "use --field only as a manual scalar fallback for simple one-off bodies; do not assemble Planning-derived fields in the shell"
   ],
   "entrypoint": ".agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py",
   "safety": {

--- a/.agentic-workspace/agent-aids/scripts/github-issue-body/manifest.json
+++ b/.agentic-workspace/agent-aids/scripts/github-issue-body/manifest.json
@@ -22,7 +22,7 @@
   },
   "validation": {
     "commands": [
-      "uv run python .agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py --kind direction --field problem_intent=Example --field intended_outcome=Example --field larger_picture=Example --field scope=Example --field acceptance=Example --format json"
+      "uv run python .agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py --input-json .agentic-workspace/agent-aids/scripts/github-issue-body/examples/direction-request.json --format json"
     ]
   },
   "promotion": {

--- a/.agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py
+++ b/.agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py
@@ -31,6 +31,12 @@ COMPLETION_BOUNDARY_FIELDS = {
     "evidence_required_for_final_completion",
 }
 
+SHELL_INTERPOLATION_RESIDUE_MARKERS = (
+    "$(@{",
+    "@{",
+    "System.Object[]",
+)
+
 
 def _parse_field(value: str) -> tuple[str, str]:
     if "=" not in value:
@@ -40,6 +46,23 @@ def _parse_field(value: str) -> tuple[str, str]:
     if not key:
         raise argparse.ArgumentTypeError("field id must not be blank")
     return key, field_value
+
+
+def _shell_interpolation_residue(value: str) -> str:
+    for marker in SHELL_INTERPOLATION_RESIDUE_MARKERS:
+        if marker in value:
+            return marker
+    return ""
+
+
+def _validate_field_values(fields: dict[str, str]) -> None:
+    for field_id, value in fields.items():
+        marker = _shell_interpolation_residue(value)
+        if marker:
+            raise ValueError(
+                f"field {field_id!r} contains shell interpolation residue {marker!r}; "
+                "render the value from structured data before publishing the issue body"
+            )
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -153,6 +176,7 @@ def _completion_boundary_default(*, field_id: str, fields: dict[str, str]) -> st
 
 
 def render_issue(*, kind: str, title: str, fields: dict[str, str]) -> dict[str, Any]:
+    _validate_field_values(fields)
     template = _load_template(kind)
     title_prefix = str(template.get("title", "")).strip()
     labels = template.get("labels", [])
@@ -194,7 +218,10 @@ def render_issue(*, kind: str, title: str, fields: dict[str, str]) -> dict[str, 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     fields = dict(args.field)
-    rendered = render_issue(kind=args.kind, title=args.title, fields=fields)
+    try:
+        rendered = render_issue(kind=args.kind, title=args.title, fields=fields)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     if args.format == "json":
         json.dump(rendered, sys.stdout, indent=2)
         sys.stdout.write("\n")

--- a/.agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py
+++ b/.agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from jsonschema import Draft202012Validator
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 ISSUE_TEMPLATE_ROOT = REPO_ROOT / ".github" / "ISSUE_TEMPLATE"
@@ -31,11 +32,50 @@ COMPLETION_BOUNDARY_FIELDS = {
     "evidence_required_for_final_completion",
 }
 
-SHELL_INTERPOLATION_RESIDUE_MARKERS = (
-    "$(@{",
-    "@{",
-    "System.Object[]",
-)
+ISSUE_BODY_REQUEST_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["kind", "template", "fields"],
+    "additionalProperties": False,
+    "properties": {
+        "kind": {"const": "agentic-workspace/issue-body-request/v1"},
+        "template": {"enum": sorted(TEMPLATE_BY_KIND)},
+        "title": {"type": "string"},
+        "fields": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": "object",
+                "required": ["kind", "value"],
+                "additionalProperties": False,
+                "properties": {
+                    "kind": {"enum": ["markdown", "text", "scalar"]},
+                    "value": {"type": "string"},
+                },
+            },
+        },
+        "source_refs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["kind"],
+                "additionalProperties": {"type": ["string", "number", "boolean"]},
+                "properties": {
+                    "kind": {"type": "string", "minLength": 1},
+                    "id": {"type": "string"},
+                    "path": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+                "anyOf": [
+                    {"required": ["id"]},
+                    {"required": ["path"]},
+                    {"required": ["url"]},
+                ],
+            },
+        },
+    },
+}
+ISSUE_BODY_REQUEST_VALIDATOR = Draft202012Validator(ISSUE_BODY_REQUEST_SCHEMA)
 
 
 def _parse_field(value: str) -> tuple[str, str]:
@@ -48,27 +88,16 @@ def _parse_field(value: str) -> tuple[str, str]:
     return key, field_value
 
 
-def _shell_interpolation_residue(value: str) -> str:
-    for marker in SHELL_INTERPOLATION_RESIDUE_MARKERS:
-        if marker in value:
-            return marker
-    return ""
-
-
-def _validate_field_values(fields: dict[str, str]) -> None:
-    for field_id, value in fields.items():
-        marker = _shell_interpolation_residue(value)
-        if marker:
-            raise ValueError(
-                f"field {field_id!r} contains shell interpolation residue {marker!r}; "
-                "render the value from structured data before publishing the issue body"
-            )
-
-
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Render a GitHub issue body from this repo's issue-form templates.")
-    parser.add_argument("--kind", required=True, choices=sorted(TEMPLATE_BY_KIND), help="Issue template kind to render.")
+    parser.add_argument("--kind", choices=sorted(TEMPLATE_BY_KIND), help="Issue template kind to render.")
     parser.add_argument("--title", default="", help="Issue title without the template prefix.")
+    parser.add_argument(
+        "--input-json",
+        default="",
+        metavar="PATH",
+        help="Read an agentic-workspace/issue-body-request/v1 JSON request from PATH, or '-' for stdin.",
+    )
     parser.add_argument(
         "--field",
         action="append",
@@ -175,8 +204,64 @@ def _completion_boundary_default(*, field_id: str, fields: dict[str, str]) -> st
     return ""
 
 
+def _load_request(path: str) -> dict[str, Any]:
+    try:
+        raw = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+        payload = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read issue body request JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("issue body request must be a JSON object")
+    return payload
+
+
+def _request_fields(payload: dict[str, Any]) -> dict[str, str]:
+    raw_fields = payload.get("fields")
+    if not isinstance(raw_fields, dict):
+        raise ValueError("issue body request must contain object field 'fields'")
+    fields: dict[str, str] = {}
+    for field_id, field_payload in raw_fields.items():
+        normalized_id = str(field_id).strip()
+        if not normalized_id:
+            raise ValueError("issue body request field ids must not be blank")
+        if not isinstance(field_payload, dict):
+            raise ValueError(f"field {normalized_id!r} must be an object with kind and value")
+        field_kind = str(field_payload.get("kind", "")).strip()
+        if field_kind not in {"markdown", "text", "scalar"}:
+            raise ValueError(f"field {normalized_id!r} kind must be one of markdown, text, or scalar")
+        value = field_payload.get("value")
+        if not isinstance(value, str):
+            raise ValueError(f"field {normalized_id!r} value must be a string")
+        fields[normalized_id] = value
+    return fields
+
+
+def validate_issue_body_request(payload: dict[str, Any]) -> dict[str, Any]:
+    schema_errors = sorted(ISSUE_BODY_REQUEST_VALIDATOR.iter_errors(payload), key=lambda error: list(error.path))
+    if schema_errors:
+        error = schema_errors[0]
+        location = ".".join(str(part) for part in error.path) or "<root>"
+        raise ValueError(f"issue body request schema error at {location}: {error.message}")
+    template = str(payload["template"]).strip()
+    title = str(payload.get("title", ""))
+    source_refs = payload.get("source_refs", [])
+    return {
+        "template": template,
+        "title": title,
+        "fields": _request_fields(payload),
+        "source_refs": source_refs,
+    }
+
+
+def render_issue_request(payload: dict[str, Any]) -> dict[str, Any]:
+    request = validate_issue_body_request(payload)
+    rendered = render_issue(kind=request["template"], title=request["title"], fields=request["fields"])
+    rendered["request_kind"] = "agentic-workspace/issue-body-request/v1"
+    rendered["source_refs"] = request["source_refs"]
+    return rendered
+
+
 def render_issue(*, kind: str, title: str, fields: dict[str, str]) -> dict[str, Any]:
-    _validate_field_values(fields)
     template = _load_template(kind)
     title_prefix = str(template.get("title", "")).strip()
     labels = template.get("labels", [])
@@ -217,9 +302,16 @@ def render_issue(*, kind: str, title: str, fields: dict[str, str]) -> dict[str, 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
-    fields = dict(args.field)
     try:
-        rendered = render_issue(kind=args.kind, title=args.title, fields=fields)
+        if args.input_json:
+            if args.kind or args.field:
+                raise ValueError("--input-json must not be combined with --kind or --field")
+            rendered = render_issue_request(_load_request(args.input_json))
+        else:
+            if not args.kind:
+                raise ValueError("--kind is required unless --input-json is supplied")
+            fields = dict(args.field)
+            rendered = render_issue(kind=args.kind, title=args.title, fields=fields)
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
     if args.format == "json":

--- a/.agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py
+++ b/.agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -92,11 +93,24 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Render a GitHub issue body from this repo's issue-form templates.")
     parser.add_argument("--kind", choices=sorted(TEMPLATE_BY_KIND), help="Issue template kind to render.")
     parser.add_argument("--title", default="", help="Issue title without the template prefix.")
+    parser.add_argument("--target", default=str(REPO_ROOT), help="Repository root for Planning source loading.")
     parser.add_argument(
         "--input-json",
         default="",
         metavar="PATH",
         help="Read an agentic-workspace/issue-body-request/v1 JSON request from PATH, or '-' for stdin.",
+    )
+    parser.add_argument("--from-lane", default="", metavar="ID", help="Render from a Planning lane record by id.")
+    parser.add_argument(
+        "--from-decomposition",
+        default="",
+        metavar="PATH",
+        help="Render from a Planning decomposition JSON file.",
+    )
+    parser.add_argument(
+        "--lane-id",
+        default="",
+        help="Candidate lane id to select when --from-decomposition contains multiple lanes.",
     )
     parser.add_argument(
         "--field",
@@ -108,6 +122,50 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--format", choices=("body", "json"), default="body", help="Output body only or JSON metadata.")
     return parser.parse_args(argv)
+
+
+def _repo_relative(path: Path, *, target_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(target_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _slugify(value: str) -> str:
+    chars: list[str] = []
+    previous_dash = False
+    for char in value.strip().lower():
+        if char.isalnum():
+            chars.append(char)
+            previous_dash = False
+        elif not previous_dash:
+            chars.append("-")
+            previous_dash = True
+    return "".join(chars).strip("-")
+
+
+def _typed(value: str) -> dict[str, str]:
+    return {"kind": "markdown", "value": value}
+
+
+def _issue_body_request(*, title: str, fields: dict[str, str], source_refs: list[dict[str, str]]) -> dict[str, Any]:
+    return {
+        "kind": "agentic-workspace/issue-body-request/v1",
+        "template": "direction",
+        "title": title,
+        "fields": {field_id: _typed(value) for field_id, value in fields.items() if value.strip()},
+        "source_refs": source_refs,
+    }
+
+
+def _references_text(source_refs: list[dict[str, str]]) -> str:
+    lines: list[str] = []
+    for ref in source_refs:
+        label = ref.get("id") or ref.get("path") or ref.get("url") or ref.get("kind", "reference")
+        details = [ref.get("path", ""), ref.get("url", "")]
+        suffix = " ".join(f"({detail})" for detail in details if detail and detail != label)
+        lines.append(f"- {label} {suffix}".strip())
+    return "\n".join(lines)
 
 
 def _load_template(kind: str) -> dict[str, Any]:
@@ -215,6 +273,161 @@ def _load_request(path: str) -> dict[str, Any]:
     return payload
 
 
+def _load_json_object(path: Path, *, description: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read {description} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{description} {path} must be a JSON object")
+    return payload
+
+
+def _state_lane_surface(*, target_root: Path, lane_id: str) -> str:
+    state_path = target_root / ".agentic-workspace" / "planning" / "state.toml"
+    try:
+        state = tomllib.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return ""
+    roadmap = state.get("roadmap", {})
+    lanes = roadmap.get("lanes", []) if isinstance(roadmap, dict) else []
+    if not isinstance(lanes, list):
+        return ""
+    for lane in lanes:
+        if not isinstance(lane, dict) or str(lane.get("id", "")).strip() != lane_id:
+            continue
+        return str(lane.get("owner_surface") or lane.get("surface") or "").strip()
+    return ""
+
+
+def _lane_record_path(*, target_root: Path, lane_id: str) -> Path:
+    slug = _slugify(lane_id)
+    state_surface = _state_lane_surface(target_root=target_root, lane_id=lane_id)
+    candidates = []
+    if state_surface:
+        candidates.append(target_root / state_surface)
+    candidates.extend(
+        [
+            target_root / ".agentic-workspace" / "planning" / "lanes" / f"{slug}.lane.json",
+            target_root / ".agentic-workspace" / "planning" / "lanes" / "archive" / f"{slug}.lane.json",
+        ]
+    )
+    for path in candidates:
+        if path.is_file():
+            return path
+    raise ValueError(f"Planning lane record {lane_id!r} was not found in state, lanes, or lane archive")
+
+
+def _lane_request_from_record(record: dict[str, Any], *, source_ref: dict[str, str]) -> dict[str, Any]:
+    lane_id = str(record.get("id", "")).strip()
+    title = str(record.get("title", "")).strip() or lane_id
+    outcome = str(record.get("lane_outcome") or "").strip()
+    purpose = str(record.get("purpose_for_parent") or "").strip()
+    proof = str(record.get("proof_strategy") or "").strip()
+    residual = str(record.get("residual_lane_work") or "").strip()
+    parent = str(record.get("parent_decomposition_ref") or "").strip()
+    references = [source_ref]
+    if parent:
+        references.append({"kind": "planning-decomposition", "path": parent})
+    fields = {
+        "issue_kind": "Parent direction / lane",
+        "parent_issue": parent,
+        "problem_intent": purpose or outcome or f"Create a routable issue for Planning lane {lane_id}.",
+        "intended_outcome": outcome or f"Planning lane {lane_id} is represented as a GitHub issue.",
+        "larger_picture": purpose or f"This issue is generated from Planning lane {lane_id}.",
+        "scope": "\n".join(
+            line
+            for line in [
+                "In scope:",
+                f"- Lane: {lane_id}",
+                f"- Owner surface: {source_ref.get('path', '')}" if source_ref.get("path") else "",
+                "",
+                "Out of scope:",
+                "- Shell-composed semantic field extraction.",
+            ]
+            if line or line == ""
+        ).strip(),
+        "acceptance": proof or "The issue body accurately reflects the structured Planning lane record.",
+        "final_satisfaction": outcome or "The generated issue is complete when the lane outcome is delivered and proven.",
+        "bounded_slice_success": "A partial PR may land only when it records remaining lane intent and continuation owner.",
+        "partial_pr_may_close": "no",
+        "required_follow_up_owner": source_ref.get("path", "") or lane_id,
+        "required_residual_intent": residual or "Any lane intent not delivered by a partial slice remains on the Planning lane.",
+        "evidence_required_for_final_completion": proof or "Lane proof aggregation must show the final intended state.",
+        "planning_expectations": "Generated from structured Planning lane data; do not reconstruct this body with shell property interpolation.",
+        "related_references": _references_text(references),
+    }
+    return _issue_body_request(title=title, fields=fields, source_refs=references)
+
+
+def request_from_lane(*, target_root: Path, lane_id: str) -> dict[str, Any]:
+    path = _lane_record_path(target_root=target_root, lane_id=lane_id)
+    record = _load_json_object(path, description="Planning lane record")
+    if record.get("kind") != "planning-lane/v1":
+        raise ValueError(f"{path} is not a planning-lane/v1 record")
+    return _lane_request_from_record(
+        record,
+        source_ref={
+            "kind": "planning-lane",
+            "id": str(record.get("id", lane_id)),
+            "path": _repo_relative(path, target_root=target_root),
+        },
+    )
+
+
+def request_from_decomposition(*, target_root: Path, decomposition: str, lane_id: str = "") -> dict[str, Any]:
+    path = (target_root / decomposition).resolve() if not Path(decomposition).is_absolute() else Path(decomposition)
+    record = _load_json_object(path, description="Planning decomposition")
+    if record.get("kind") != "planning-decomposition/v1":
+        raise ValueError(f"{path} is not a planning-decomposition/v1 record")
+    lanes = record.get("candidate_lanes")
+    if not isinstance(lanes, list) or not lanes:
+        raise ValueError(f"{path} does not contain candidate_lanes")
+    lane: dict[str, Any] | None = None
+    if lane_id:
+        lane = next((item for item in lanes if isinstance(item, dict) and str(item.get("id", "")).strip() == lane_id), None)
+        if lane is None:
+            raise ValueError(f"candidate lane {lane_id!r} was not found in {path}")
+    elif len(lanes) == 1 and isinstance(lanes[0], dict):
+        lane = lanes[0]
+    else:
+        raise ValueError("--lane-id is required when a decomposition contains multiple candidate lanes")
+    source_path = _repo_relative(path, target_root=target_root)
+    source_ref = {
+        "kind": "planning-decomposition",
+        "id": str(lane.get("id", "")),
+        "path": source_path,
+    }
+    fields = {
+        "issue_kind": "Parent direction / lane",
+        "parent_issue": source_path,
+        "problem_intent": str(lane.get("slice_contribution_to_parent") or lane.get("outcome") or "").strip(),
+        "intended_outcome": str(lane.get("outcome") or "").strip(),
+        "larger_picture": str(record.get("larger_intended_outcome") or "").strip(),
+        "scope": "\n".join(
+            [
+                "In scope:",
+                f"- Candidate lane: {lane.get('id', '')}",
+                f"- Owner surface: {lane.get('owner_surface', '')}",
+                "",
+                "Out of scope:",
+                "- Shell/object interpolation of decomposition fields.",
+            ]
+        ),
+        "acceptance": str(lane.get("proof") or "").strip(),
+        "final_satisfaction": str(lane.get("outcome") or "").strip(),
+        "bounded_slice_success": str(lane.get("slice_contribution_to_parent") or "").strip()
+        or "A coherent lane slice may land when residual parent intent remains explicit.",
+        "partial_pr_may_close": "no",
+        "required_follow_up_owner": str(lane.get("owner_surface") or source_path).strip(),
+        "required_residual_intent": str(lane.get("residual_parent_intent") or "").strip(),
+        "evidence_required_for_final_completion": str(lane.get("proof") or record.get("parent_acceptance", {}).get("parent_proof_required") or "").strip(),
+        "planning_expectations": "Generated from structured Planning decomposition data; select lanes with --lane-id.",
+        "related_references": _references_text([source_ref]),
+    }
+    return _issue_body_request(title=str(lane.get("title", "")).strip(), fields=fields, source_refs=[source_ref])
+
+
 def _request_fields(payload: dict[str, Any]) -> dict[str, str]:
     raw_fields = payload.get("fields")
     if not isinstance(raw_fields, dict):
@@ -303,13 +516,30 @@ def render_issue(*, kind: str, title: str, fields: dict[str, str]) -> dict[str, 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     try:
-        if args.input_json:
+        source_modes = [bool(args.input_json), bool(args.from_lane), bool(args.from_decomposition)]
+        if sum(1 for enabled in source_modes if enabled) > 1:
+            raise ValueError("--input-json, --from-lane, and --from-decomposition are mutually exclusive")
+        if any(source_modes):
             if args.kind or args.field:
-                raise ValueError("--input-json must not be combined with --kind or --field")
+                raise ValueError("structured source modes must not be combined with --kind or --field")
+        target_root = Path(args.target).resolve()
+        if args.input_json:
             rendered = render_issue_request(_load_request(args.input_json))
+        elif args.from_lane:
+            rendered = render_issue_request(request_from_lane(target_root=target_root, lane_id=args.from_lane))
+        elif args.from_decomposition:
+            rendered = render_issue_request(
+                request_from_decomposition(
+                    target_root=target_root,
+                    decomposition=args.from_decomposition,
+                    lane_id=args.lane_id,
+                )
+            )
         else:
             if not args.kind:
                 raise ValueError("--kind is required unless --input-json is supplied")
+            if args.lane_id:
+                raise ValueError("--lane-id requires --from-decomposition")
             fields = dict(args.field)
             rendered = render_issue(kind=args.kind, title=args.title, fields=fields)
     except ValueError as exc:

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -9824,7 +9824,7 @@ def _default_lane_record(
     }
 
 
-def _lane_state_projection(record: dict[str, Any], *, lane_relative: str) -> dict[str, Any]:
+def _lane_state_projection(record: dict[str, Any], *, target_root: Path, lane_relative: str) -> dict[str, Any]:
     references = record.get("references", [])
     current_slice = str(record.get("current_slice", "")).strip()
     current_slice_record = next(
@@ -9836,8 +9836,30 @@ def _lane_state_projection(record: dict[str, Any], *, lane_relative: str) -> dic
         {},
     )
     execplan_ref = ""
+    next_action = ""
+    done_when = ""
     if isinstance(current_slice_record, dict):
         execplan_ref = str(current_slice_record.get("execplan_ref") or current_slice_record.get("execplan") or "").strip()
+        next_action = str(current_slice_record.get("next_action") or "").strip()
+        done_when = str(current_slice_record.get("done_when") or "").strip()
+    if current_slice and not execplan_ref:
+        inferred_execplan = (Path(".agentic-workspace") / "planning" / "execplans" / f"{_slugify(current_slice)}.plan.json").as_posix()
+        if (target_root / inferred_execplan).exists():
+            execplan_ref = inferred_execplan
+    if execplan_ref and (not next_action or not done_when):
+        execplan_record = _load_execplan_record(target_root / execplan_ref)
+        if isinstance(execplan_record, dict):
+            canonical_core = execplan_record.get("canonical_core", {})
+            if isinstance(canonical_core, dict):
+                next_action = next_action or str(canonical_core.get("next_action") or "").strip()
+                done_when = done_when or str(canonical_core.get("done_when") or "").strip()
+                completion_criteria = canonical_core.get("completion_criteria")
+                if not done_when and isinstance(completion_criteria, list) and completion_criteria:
+                    done_when = str(completion_criteria[0] or "").strip()
+            if not next_action:
+                immediate_next_action = execplan_record.get("immediate_next_action")
+                if isinstance(immediate_next_action, list) and immediate_next_action:
+                    next_action = str(immediate_next_action[0] or "").strip()
     projection = {
         "id": str(record.get("id", "")).strip(),
         "title": str(record.get("title", "")).strip(),
@@ -9858,6 +9880,10 @@ def _lane_state_projection(record: dict[str, Any], *, lane_relative: str) -> dic
         projection["current_slice"] = current_slice
     if execplan_ref:
         projection["execplan"] = execplan_ref
+    if next_action:
+        projection["next_action"] = next_action
+    if done_when:
+        projection["done_when"] = done_when
     return projection
 
 
@@ -9878,7 +9904,7 @@ def _upsert_roadmap_lane_state(target_root: Path, record: dict[str, Any], *, lan
     if not isinstance(lanes, list):
         lanes = []
     lane_id = str(record.get("id", "")).strip()
-    projection = _lane_state_projection(record, lane_relative=lane_relative)
+    projection = _lane_state_projection(record, target_root=target_root, lane_relative=lane_relative)
     updated = False
     next_lanes: list[Any] = []
     for raw in lanes:

--- a/packages/planning/tests/test_lanes.py
+++ b/packages/planning/tests/test_lanes.py
@@ -150,13 +150,44 @@ def test_lane_activate_projects_current_slice_execplan_ref_and_keeps_summary_cle
     assert [action.kind for action in result.actions] == ["updated", "updated", "proof", "proof"]
     state = tomllib.loads((tmp_path / ".agentic-workspace/planning/state.toml").read_text(encoding="utf-8"))
     active_lane = state["roadmap"]["lanes"][0]
+    assert active_lane["status"] == "active"
+    assert active_lane["maturity"] == "active"
     assert active_lane["current_slice"] == "slice-one"
     assert active_lane["execplan"] == ".agentic-workspace/planning/execplans/slice-one.plan.json"
+    assert active_lane["next_action"] == "execute the slice."
+    assert active_lane["done_when"] == "slice proof passes."
 
     summary = planning_summary(target=tmp_path, profile="compact")
     warnings = summary["planning_surface_health"]["warnings"]
     assert not [warning for warning in warnings if warning["warning_class"] == "execplan_unregistered"]
     assert not [warning for warning in warnings if warning["warning_class"] == "historical_work_in_live_planning_state"]
+    doctor = doctor_bootstrap(target=tmp_path)
+    assert doctor.warnings == []
+
+
+def test_lane_activate_infers_current_slice_execplan_when_slice_sequence_is_minimal(tmp_path: Path) -> None:
+    install_bootstrap(target=tmp_path)
+    create_lane_record(lane_id="activation-lane", title="Activation Lane", target=tmp_path)
+    _write_execplan_fixture(
+        tmp_path / ".agentic-workspace/planning/execplans/slice-one.plan.json",
+        item_id="slice-one",
+        status="planned",
+    )
+
+    result = activate_lane_record("activation-lane", target=tmp_path, current_slice="slice-one")
+
+    assert [action.kind for action in result.actions] == ["updated", "updated", "proof", "proof"]
+    state = tomllib.loads((tmp_path / ".agentic-workspace/planning/state.toml").read_text(encoding="utf-8"))
+    active_lane = state["roadmap"]["lanes"][0]
+    assert active_lane["status"] == "active"
+    assert active_lane["current_slice"] == "slice-one"
+    assert active_lane["execplan"] == ".agentic-workspace/planning/execplans/slice-one.plan.json"
+    assert active_lane["next_action"] == "execute the slice."
+    assert active_lane["done_when"] == "slice proof passes."
+
+    summary = planning_summary(target=tmp_path, profile="compact")
+    warnings = summary["planning_surface_health"]["warnings"]
+    assert not [warning for warning in warnings if warning["warning_class"] == "execplan_unregistered"]
     doctor = doctor_bootstrap(target=tmp_path)
     assert doctor.warnings == []
 

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -203,6 +203,18 @@
       "checked_in_justification": "Shared aid metadata is durable checked-in state used to prove safety, portability, validation, and promotion criteria."
     },
     {
+      "pattern": ".agentic-workspace/agent-aids/scripts/github-issue-body/examples/*.json",
+      "format": "json",
+      "owner": "agent-aids",
+      "status": "typed-validator-backed",
+      "schema_or_validator": ".agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py ISSUE_BODY_REQUEST_SCHEMA",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Checked-in examples for the GitHub issue-body aid use the same issue-body-request/v1 schema validator as runtime --input-json requests.",
+      "storage_class": "diagnostic-fixture",
+      "checked_in_justification": "Small executable fixture proves nontrivial issue bodies are rendered from structured request data instead of shell-composed fields."
+    },
+    {
       "pattern": ".agentic-workspace/proof-route-hints.json",
       "format": "json",
       "owner": "workspace-lifecycle",

--- a/tests/test_github_issue_body_agent_aid.py
+++ b/tests/test_github_issue_body_agent_aid.py
@@ -138,18 +138,55 @@ def test_issue_body_normalizes_duplicate_template_title_prefix() -> None:
     assert rendered["duplicate_prefix_normalized"] is True
 
 
-def test_issue_body_rejects_shell_interpolation_residue() -> None:
-    try:
-        issue_body.render_issue(
-            kind="direction",
-            title="Malformed lane body",
-            fields={
-                "problem_intent": "Lane id: $(@{id=lane-example; readiness=ready}.id)",
-                "intended_outcome": "Avoid publishing shell residue.",
+def test_issue_body_renders_typed_structured_request() -> None:
+    rendered = issue_body.render_issue_request(
+        {
+            "kind": "agentic-workspace/issue-body-request/v1",
+            "template": "direction",
+            "title": "Structured lane body",
+            "fields": {
+                "problem_intent": {
+                    "kind": "markdown",
+                    "value": "Create issue bodies from typed request data instead of shell-composed strings.",
+                },
+                "intended_outcome": {
+                    "kind": "markdown",
+                    "value": "Planning-derived issue bodies render from structured data.",
+                },
+                "acceptance": {
+                    "kind": "markdown",
+                    "value": "The generated body carries template headings and source refs.",
+                },
             },
+            "source_refs": [
+                {
+                    "kind": "planning-lane",
+                    "id": "lane-example",
+                    "path": ".agentic-workspace/planning/lanes/lane-example.lane.json",
+                }
+            ],
+        }
+    )
+
+    assert rendered["request_kind"] == "agentic-workspace/issue-body-request/v1"
+    assert rendered["title"] == "[Workspace]: Structured lane body"
+    assert rendered["source_refs"][0]["id"] == "lane-example"
+    assert "## Problem / intent\nCreate issue bodies from typed request data" in rendered["body"]
+    assert "## Final satisfaction\nFinal completion requires satisfying: Planning-derived issue bodies" in rendered["body"]
+
+
+def test_issue_body_request_rejects_untyped_fields() -> None:
+    try:
+        issue_body.render_issue_request(
+            {
+                "kind": "agentic-workspace/issue-body-request/v1",
+                "template": "direction",
+                "title": "Untyped body",
+                "fields": {"problem_intent": "shell-composed scalar"},
+            }
         )
     except ValueError as exc:
-        assert "shell interpolation residue" in str(exc)
+        assert "schema error" in str(exc)
         assert "problem_intent" in str(exc)
     else:
-        raise AssertionError("render_issue should reject unevaluated shell interpolation residue")
+        raise AssertionError("render_issue_request should require typed field objects")

--- a/tests/test_github_issue_body_agent_aid.py
+++ b/tests/test_github_issue_body_agent_aid.py
@@ -136,3 +136,20 @@ def test_issue_body_normalizes_duplicate_template_title_prefix() -> None:
     assert rendered["title_prefix"] == "[Review]:"
     assert rendered["normalized_title"] == "Template friction"
     assert rendered["duplicate_prefix_normalized"] is True
+
+
+def test_issue_body_rejects_shell_interpolation_residue() -> None:
+    try:
+        issue_body.render_issue(
+            kind="direction",
+            title="Malformed lane body",
+            fields={
+                "problem_intent": "Lane id: $(@{id=lane-example; readiness=ready}.id)",
+                "intended_outcome": "Avoid publishing shell residue.",
+            },
+        )
+    except ValueError as exc:
+        assert "shell interpolation residue" in str(exc)
+        assert "problem_intent" in str(exc)
+    else:
+        raise AssertionError("render_issue should reject unevaluated shell interpolation residue")

--- a/tests/test_github_issue_body_agent_aid.py
+++ b/tests/test_github_issue_body_agent_aid.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -13,6 +14,11 @@ assert _SPEC is not None and _SPEC.loader is not None
 issue_body = importlib.util.module_from_spec(_SPEC)
 sys.modules[_SPEC.name] = issue_body
 _SPEC.loader.exec_module(issue_body)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
 def test_issue_templates_include_completion_boundary_fields() -> None:
@@ -190,3 +196,122 @@ def test_issue_body_request_rejects_untyped_fields() -> None:
         assert "problem_intent" in str(exc)
     else:
         raise AssertionError("render_issue_request should require typed field objects")
+
+
+def test_issue_body_renders_from_archived_lane_record(tmp_path: Path) -> None:
+    lane_path = tmp_path / ".agentic-workspace" / "planning" / "lanes" / "archive" / "lane-example.lane.json"
+    _write_json(
+        lane_path,
+        {
+            "kind": "planning-lane/v1",
+            "id": "lane-example",
+            "title": "Example Lane",
+            "lane_outcome": "The lane issue body is rendered from structured lane data.",
+            "purpose_for_parent": "Avoid shell property extraction from lane objects.",
+            "proof_strategy": "Issue-body tests prove source loading.",
+            "residual_lane_work": "Remaining lane work stays routed to Planning.",
+            "parent_decomposition_ref": ".agentic-workspace/planning/decompositions/example.decomposition.json",
+        },
+    )
+
+    rendered = issue_body.render_issue_request(issue_body.request_from_lane(target_root=tmp_path, lane_id="lane-example"))
+
+    assert rendered["title"] == "[Workspace]: Example Lane"
+    assert rendered["source_refs"] == [
+        {
+            "kind": "planning-lane",
+            "id": "lane-example",
+            "path": ".agentic-workspace/planning/lanes/archive/lane-example.lane.json",
+        },
+        {
+            "kind": "planning-decomposition",
+            "path": ".agentic-workspace/planning/decompositions/example.decomposition.json",
+        },
+    ]
+    assert "## Problem / intent\nAvoid shell property extraction from lane objects." in rendered["body"]
+    assert "## Acceptance / success signal\nIssue-body tests prove source loading." in rendered["body"]
+
+
+def test_issue_body_renders_from_decomposition_candidate_lane(tmp_path: Path) -> None:
+    decomposition_path = tmp_path / ".agentic-workspace" / "planning" / "decompositions" / "example.decomposition.json"
+    _write_json(
+        decomposition_path,
+        {
+            "kind": "planning-decomposition/v1",
+            "larger_intended_outcome": "Create GitHub issues from Planning decomposition data.",
+            "parent_acceptance": {"parent_proof_required": "All candidate lane issue bodies render from structured fields."},
+            "candidate_lanes": [
+                {
+                    "id": "lane-one",
+                    "title": "Lane One",
+                    "outcome": "Wrong lane.",
+                    "owner_surface": "wrong",
+                    "proof": "wrong",
+                },
+                {
+                    "id": "lane-two",
+                    "title": "Lane Two",
+                    "outcome": "The selected decomposition lane renders an issue body.",
+                    "owner_surface": ".agentic-workspace/planning/lanes/lane-two.lane.json",
+                    "proof": "The source-loading test selects lane-two.",
+                    "slice_contribution_to_parent": "Directly addresses Planning-derived issue generation.",
+                    "residual_parent_intent": "Further lanes remain in the decomposition.",
+                },
+            ],
+        },
+    )
+
+    rendered = issue_body.render_issue_request(
+        issue_body.request_from_decomposition(
+            target_root=tmp_path,
+            decomposition=".agentic-workspace/planning/decompositions/example.decomposition.json",
+            lane_id="lane-two",
+        )
+    )
+
+    assert rendered["title"] == "[Workspace]: Lane Two"
+    assert rendered["source_refs"] == [
+        {
+            "kind": "planning-decomposition",
+            "id": "lane-two",
+            "path": ".agentic-workspace/planning/decompositions/example.decomposition.json",
+        }
+    ]
+    assert "## Problem / intent\nDirectly addresses Planning-derived issue generation." in rendered["body"]
+    assert "## Required residual intent\nFurther lanes remain in the decomposition." in rendered["body"]
+
+
+def test_issue_body_cli_rejects_mixed_structured_and_field_modes(tmp_path: Path) -> None:
+    request_path = tmp_path / "request.json"
+    _write_json(
+        request_path,
+        {
+            "kind": "agentic-workspace/issue-body-request/v1",
+            "template": "direction",
+            "fields": {"problem_intent": {"kind": "markdown", "value": "Example"}},
+        },
+    )
+
+    try:
+        issue_body.main(["--input-json", str(request_path), "--kind", "direction"])
+    except SystemExit as exc:
+        assert "--input-json" in str(exc) or "structured source modes" in str(exc)
+    else:
+        raise AssertionError("input-json must be mutually exclusive with --kind")
+
+    try:
+        issue_body.main(["--from-decomposition", "example.json", "--field", "problem_intent=Example"])
+    except SystemExit as exc:
+        assert "structured source modes" in str(exc)
+    else:
+        raise AssertionError("source loading must be mutually exclusive with raw --field")
+
+
+def test_issue_body_aid_validation_uses_structured_input_not_semantic_shell_fields() -> None:
+    payload = json.loads(
+        (_REPO_ROOT / ".agentic-workspace" / "agent-aids" / "scripts" / "github-issue-body" / "manifest.json").read_text(encoding="utf-8")
+    )
+    commands = payload["validation"]["commands"]
+
+    assert any("--input-json" in command or "--from-lane" in command or "--from-decomposition" in command for command in commands)
+    assert not any("--field" in command for command in commands)

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -1580,13 +1580,19 @@ def test_start_tiny_routes_existing_task_paths_to_implement_surface(tmp_path: Pa
     assert action["read_first"] == [action["command"]]
 
 
-def test_start_tiny_does_not_route_config_posture_questions_from_prompt_keywords(capsys) -> None:
+def test_start_tiny_does_not_route_config_posture_questions_from_prompt_keywords(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--preset", "full", "--format", "json"]) == 0
+    capsys.readouterr()
+
     task = (
         "Inspect this repo enough to answer how a small follow-up should be reported. "
         "Keep the answer aligned with the repo's configured operating and reporting posture."
     )
 
-    assert cli.main(["start", "--task", task, "--format", "json"]) == 0
+    assert cli.main(["start", "--target", str(target), "--task", task, "--format", "json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
     action = _start_primary_action(payload)


### PR DESCRIPTION
## Summary

- fixes lane activation roadmap projection so active lanes carry current slice, execplan, next action, and completion condition when the slice execplan exists
- makes the GitHub issue-body aid reject shell interpolation residue before publishing malformed bodies
- isolates the startup tiny-payload budget test from the repo's live Planning state

## Validation

- `uv run pytest packages/planning/tests/test_lanes.py::test_lane_activate_projects_current_slice_execplan_ref_and_keeps_summary_clean packages/planning/tests/test_lanes.py::test_lane_activate_infers_current_slice_execplan_when_slice_sequence_is_minimal -q`
- `uv run pytest tests/test_github_issue_body_agent_aid.py::test_issue_body_rejects_shell_interpolation_residue -q`
- `uv run pytest tests/test_workspace_start_preflight_cli.py::test_start_tiny_does_not_route_config_posture_questions_from_prompt_keywords -q`
- `uv run pytest packages/planning/tests/test_lanes.py tests/test_github_issue_body_agent_aid.py tests/test_workspace_start_preflight_cli.py::test_start_tiny_does_not_route_config_posture_questions_from_prompt_keywords -q`
- `make lint-planning`
- `make typecheck-planning`
- `uv run python scripts/check/check_agent_aids.py --quiet-success`
- `make lint-workspace`
- `make test-planning`
- `make test-workspace`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/check/check_generated_command_packages.py`
- `make maintainer-surfaces`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`

Resolves #1485.
Resolves #1487.
Resolves #1488.