### PR TITLE
Use generated Python operation callables

### DIFF
--- a/.agentic-workspace/planning/closeout-evidence/lane-1476-generated-python-operation-callables.closeout.json
+++ b/.agentic-workspace/planning/closeout-evidence/lane-1476-generated-python-operation-callables.closeout.json
@@ -1,0 +1,108 @@
+{
+  "kind": "planning-closeout-evidence/v1",
+  "title": "Promote migrated AW cases to generated Python operation callables",
+  "plan_id": "lane-1476-generated-python-operation-callables",
+  "created_at": "2026-06-13T18:17:08.589974+00:00",
+  "source_plan": ".agentic-workspace/planning/execplans/lane-1476-generated-python-operation-callables.plan.json",
+  "intended_archive": ".agentic-workspace/planning/execplans/archive/lane-1476-generated-python-operation-callables.plan.json",
+  "retention": {
+    "state": "archive-retention-skipped",
+    "reason": "retained archive would exceed the structured-file inventory max_bytes guardrail; closing after distillation instead",
+    "canonical_evidence": "retained closeout evidence",
+    "ordinary_route": "agentic-workspace summary --format json or report --section closeout_report --format json",
+    "trust_rule": "When this record exists, agents should trust it as the closeout handoff surface without inspecting the omitted full execplan archive.",
+    "rule": "Retained closeout evidence preserves reportable closeout facts when the full execplan archive exceeds inventory size guardrails."
+  },
+  "active_milestone": {
+    "id": "lane-1476-generated-python-operation-callables",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "delegated_judgment": {
+    "requested outcome": "Promoted from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json lane lane-1476-generated-python-operation-callables.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning promote-to-plan decomposition lane",
+    "what happened": "Generated Python command modules now expose operation-shaped invoke(values) callables from command-generation, AW pins that generator commit, defaults operation conformance uses python.function registry proof, and wrapper-only migrated cases retain explicit rationale.",
+    "scope touched": "command-generation generator commit pin, generated Python command packages, operation conformance contracts, generated package static/Docker proof, tiny startup/implement dogfood compactness",
+    "changed surfaces": "pyproject.toml; uv.lock; generated/**/python/**; generated/python/Dockerfile*; scripts/check/check_generated_command_packages.py; src/agentic_workspace/contracts/operation_*.json; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_contract_tooling.py; tests/test_generated_command_package_proof_runner.py",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Slice implementation is complete: Python direct operation callable path is proven for the applicable migrated AW case. Parent #1476 remains represented by the decomposition for target-extension, TypeScript adapter, broader case conversion, wrapper demotion, ordinary-test inventory, and guardrail lanes.",
+    "proof status": "passed",
+    "intent served": "slice served; parent #1476 intent remains partial and routed to the decomposition.",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json"
+  },
+  "proof_report": {
+    "validation proof": "run_operation_conformance_tests.py --target python; check_generated_command_packages.py --python-conformance; check_generated_command_packages.py --python-docker-conformance --require-docker; generate_command_packages.py --check; check_contract_tooling_surfaces.py --quiet-success; check_structured_file_inventory.py --quiet-success; ruff check; pytest tests/test_workspace_cli.py -q; make lint-workspace; make test-workspace",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "#1476 requires an enforced end-to-end model where operation/primitive IR, contracts, and input-output cases generate implementation artifacts, wrappers, and conformance executors, while ordinary feature work changes IR/contracts/cases rather than generated executable code or one-off behavior regressions.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status partial.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json activates a fresh bounded slice."
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "execution_summary": {
+    "outcome delivered": "Applicable migrated AW conformance case defaults now has a generated Python callable symbol and python.function proof path; stdout wrapper leakage is guarded.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+          "owner": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  }
+}

--- a/.agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json
@@ -36,9 +36,9 @@
     {
       "id": "lane-1476-generated-python-operation-callables",
       "title": "Promote migrated AW cases to generated Python operation callables",
-      "readiness": "ready",
+      "readiness": "promoted",
       "outcome": "Applicable migrated AW conformance cases expose generated operation-shaped Python callable surfaces with registry symbol entries and python.function artifacts, replacing wrapper-smoke or cli.process as semantic proof where behavior is operation semantics.",
-      "owner_surface": "AW operation conformance registry/cases, generated workspace Python artifacts, and command-generation#14 callable generation machinery",
+      "owner_surface": ".agentic-workspace/planning/lanes/lane-1476-generated-python-operation-callables.lane.json",
       "proof": "Conformance runner uses python.function for applicable migrated AW cases; non-promoted cases have explicit wrapper-only or runtime-boundary rationale.",
       "slice_contribution_to_parent": "Advances primitive, operation IR, generated implementation, wrapper, and conformance layers for the Python specimen target.",
       "residual_parent_intent": "TypeScript direct operation support, target-extension contract, broader case conversion, wrapper demotion, ordinary-test inventory, and guardrails remain.",

--- a/.agentic-workspace/planning/lanes/lane-1476-generated-python-operation-callables.lane.json
+++ b/.agentic-workspace/planning/lanes/lane-1476-generated-python-operation-callables.lane.json
@@ -1,0 +1,42 @@
+{
+  "kind": "planning-lane/v1",
+  "id": "lane-1476-generated-python-operation-callables",
+  "title": "Promote migrated AW cases to generated Python operation callables",
+  "status": "completed",
+  "parent_decomposition_ref": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+  "lane_outcome": "Applicable migrated AW conformance cases expose generated operation-shaped Python callable surfaces with registry symbol entries and python.function artifacts, replacing wrapper-smoke or cli.process as semantic proof where behavior is operation semantics.",
+  "purpose_for_parent": "Advances primitive, operation IR, generated implementation, wrapper, and conformance layers for the Python specimen target.",
+  "subsystems": [],
+  "technical_strategy": "Generated Python operation callables are supplied by command-generation and consumed by AW generated command packages as direct invoke(values) callables.",
+  "technology_choices": [],
+  "slice_sequence": [],
+  "current_slice": "lane-1476-generated-python-operation-callables",
+  "acceptance_boundary": "All lane slices have landed, lane proof aggregation is satisfied, and residual work is routed.",
+  "proof_strategy": "Conformance runner uses python.function for applicable migrated AW cases; non-promoted cases have explicit wrapper-only or runtime-boundary rationale.",
+  "proof_aggregation": {
+    "status": "satisfied",
+    "evidence": [
+      ".agentic-workspace/planning/closeout-evidence/lane-1476-generated-python-operation-callables.closeout.json"
+    ],
+    "known_gaps": []
+  },
+  "residual_lane_work": "TypeScript direct operation support, target-extension contract, broader case conversion, wrapper demotion, ordinary-test inventory, and guardrails remain.",
+  "lane_to_epic_contribution": "Advances primitive, operation IR, generated implementation, wrapper, and conformance layers for the Python specimen target.",
+  "parent_close_permission": "do-not-close-parent",
+  "closeout_state": {
+    "status": "completed",
+    "summary": "Applicable migrated AW defaults conformance now uses generated Python callable proof through python.function registry metadata.",
+    "residual_work": "Continue parent #1476 from the decomposition for target-extension, TypeScript adapter, broader case conversion, wrapper demotion, ordinary-test inventory, and guardrail lanes.",
+    "next_owner": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json"
+  },
+  "references": [
+    {
+      "kind": "decomposition",
+      "target": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+      "label": "lane-1476-generated-python-operation-callables",
+      "role": "parent",
+      "locator": "candidate_lanes[1]"
+    }
+  ],
+  "notes": ""
+}

--- a/generated/memory/python/commands/memory_adopt_lifecycle.py
+++ b/generated/memory/python/commands/memory_adopt_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.adopt.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.adopt.lifecycle'), values)

--- a/generated/memory/python/commands/memory_bootstrap_cleanup_apply.py
+++ b/generated/memory/python/commands/memory_bootstrap_cleanup_apply.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.bootstrap-cleanup.apply'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.bootstrap-cleanup.apply'), values)

--- a/generated/memory/python/commands/memory_capture_note_report.py
+++ b/generated/memory/python/commands/memory_capture_note_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.capture-note.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.capture-note.report'), values)

--- a/generated/memory/python/commands/memory_create_note_apply.py
+++ b/generated/memory/python/commands/memory_create_note_apply.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.create-note.apply'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.create-note.apply'), values)

--- a/generated/memory/python/commands/memory_current_report.py
+++ b/generated/memory/python/commands/memory_current_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.current.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.current.report'), values)

--- a/generated/memory/python/commands/memory_doctor_report.py
+++ b/generated/memory/python/commands/memory_doctor_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.doctor.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.doctor.report'), values)

--- a/generated/memory/python/commands/memory_init_lifecycle.py
+++ b/generated/memory/python/commands/memory_init_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.init.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.init.lifecycle'), values)

--- a/generated/memory/python/commands/memory_install_lifecycle.py
+++ b/generated/memory/python/commands/memory_install_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.install.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.install.lifecycle'), values)

--- a/generated/memory/python/commands/memory_list_files_report.py
+++ b/generated/memory/python/commands/memory_list_files_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.list-files.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.list-files.report'), values)

--- a/generated/memory/python/commands/memory_list_skills_report.py
+++ b/generated/memory/python/commands/memory_list_skills_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.list-skills.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.list-skills.report'), values)

--- a/generated/memory/python/commands/memory_migrate_layout_lifecycle.py
+++ b/generated/memory/python/commands/memory_migrate_layout_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.migrate-layout.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.migrate-layout.lifecycle'), values)

--- a/generated/memory/python/commands/memory_promotion_report_report.py
+++ b/generated/memory/python/commands/memory_promotion_report_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.promotion-report.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.promotion-report.report'), values)

--- a/generated/memory/python/commands/memory_prompt_render.py
+++ b/generated/memory/python/commands/memory_prompt_render.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.prompt.render'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.prompt.render'), values)

--- a/generated/memory/python/commands/memory_report_report.py
+++ b/generated/memory/python/commands/memory_report_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.report.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.report.report'), values)

--- a/generated/memory/python/commands/memory_route_report.py
+++ b/generated/memory/python/commands/memory_route_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.route.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.route.report'), values)

--- a/generated/memory/python/commands/memory_route_report_report.py
+++ b/generated/memory/python/commands/memory_route_report_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.route-report.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.route-report.report'), values)

--- a/generated/memory/python/commands/memory_route_review_report.py
+++ b/generated/memory/python/commands/memory_route_review_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.route-review.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.route-review.report'), values)

--- a/generated/memory/python/commands/memory_search_report.py
+++ b/generated/memory/python/commands/memory_search_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.search.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.search.report'), values)

--- a/generated/memory/python/commands/memory_status_report.py
+++ b/generated/memory/python/commands/memory_status_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.status.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.status.report'), values)

--- a/generated/memory/python/commands/memory_sync_memory_report.py
+++ b/generated/memory/python/commands/memory_sync_memory_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.sync-memory.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.sync-memory.report'), values)

--- a/generated/memory/python/commands/memory_uninstall_lifecycle.py
+++ b/generated/memory/python/commands/memory_uninstall_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.uninstall.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.uninstall.lifecycle'), values)

--- a/generated/memory/python/commands/memory_upgrade_lifecycle.py
+++ b/generated/memory/python/commands/memory_upgrade_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.upgrade.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.upgrade.lifecycle'), values)

--- a/generated/memory/python/commands/memory_verify_payload_report.py
+++ b/generated/memory/python/commands/memory_verify_payload_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('memory.verify-payload.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('memory.verify-payload.report'), values)

--- a/generated/memory/python/primitives/operation_executor.py
+++ b/generated/memory/python/primitives/operation_executor.py
@@ -8,6 +8,9 @@ Regenerate with: uv run python scripts/generate/generate_command_packages.py
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -27,40 +30,10 @@ class OperationIrExecutionError(RuntimeError):
 
 
 def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int:
-    if operation.get("id") not in {
-        'memory.adopt.lifecycle',
-        'memory.bootstrap-cleanup.apply',
-        'memory.capture-note.report',
-        'memory.create-note.apply',
-        'memory.current.report',
-        'memory.doctor.report',
-        'memory.init.lifecycle',
-        'memory.install.lifecycle',
-        'memory.list-files.report',
-        'memory.list-skills.report',
-        'memory.migrate-layout.lifecycle',
-        'memory.promotion-report.report',
-        'memory.prompt.render',
-        'memory.report.report',
-        'memory.route-report.report',
-        'memory.route-review.report',
-        'memory.route.report',
-        'memory.search.report',
-        'memory.status.report',
-        'memory.sync-memory.report',
-        'memory.uninstall.lifecycle',
-        'memory.upgrade.lifecycle',
-        'memory.verify-payload.report'
-    }:
-        raise OperationIrExecutionError(f"unsupported operation IR contract: {operation.get('id')!r}")
-    if operation.get("migration_status") != "runtime-consumed":
-        raise OperationIrExecutionError(f"operation is not marked runtime-consumed: {operation.get('id')!r}")
-
-    try:
-        values = run_operation_steps(
-            operation,
-            initial_values={
-                "operation_id": operation.get("id"),
+    values = run_operation_values(
+        operation,
+        initial_values={
+            "operation_id": operation.get("id"),
                 'target': getattr(args, 'target', None),
                 'format': getattr(args, 'format', 'text'),
                 'verbose': getattr(args, 'verbose', False),
@@ -99,7 +72,97 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'query': getattr(args, 'query', ''),
                 'current_command': getattr(args, 'current_command', 'show'),
                 'prompt_command': getattr(args, 'prompt_command', 'install'),
+        },
+    )
+    emitted = values.get('emitted')
+    if isinstance(emitted, str):
+        print(emitted, end='')
+    return 0
+
+
+def run_operation_callable(operation: dict[str, Any], values: Mapping[str, Any]) -> object:
+    with contextlib.redirect_stdout(io.StringIO()):
+        result = run_operation_values(
+            operation,
+            initial_values={
+                "operation_id": operation.get("id"),
+                'target': values.get('target', None),
+                'format': values.get('format', 'text'),
+                'verbose': values.get('verbose', False),
+                'strict_doc_ownership': values.get('strict_doc_ownership', False),
+                'project_name': values.get('project_name', None),
+                'project_purpose': values.get('project_purpose', None),
+                'key_repo_docs': values.get('key_repo_docs', None),
+                'key_subsystems': values.get('key_subsystems', None),
+                'primary_build_command': values.get('primary_build_command', None),
+                'primary_test_command': values.get('primary_test_command', None),
+                'other_key_commands': values.get('other_key_commands', None),
+                'notes': values.get('notes', None),
+                'files': values.get('files', []),
+                'surface': values.get('surface', []),
+                'mode': values.get('mode', None),
+                'slug': values.get('slug', ''),
+                'title': values.get('title', None),
+                'folder': values.get('folder', 'domains'),
+                'note_type': values.get('note_type', 'domain'),
+                'applies_to': values.get('applies_to', []),
+                'use_when': values.get('use_when', []),
+                'routes_from': values.get('routes_from', []),
+                'stale_when': values.get('stale_when', []),
+                'evidence': values.get('evidence', []),
+                'memory_role': values.get('memory_role', ''),
+                'promotion_target': values.get('promotion_target', ''),
+                'promotion_trigger': values.get('promotion_trigger', ''),
+                'retention_after_promotion': values.get('retention_after_promotion', ''),
+                'dry_run': values.get('dry_run', False),
+                'policy_profile': values.get('policy_profile', 'default'),
+                'apply_local_entrypoint': values.get('apply_local_entrypoint', False),
+                'force': values.get('force', False),
+                'summary': values.get('summary', ''),
+                'existing_note': values.get('existing_note', ''),
+                'force_new_reason': values.get('force_new_reason', ''),
+                'query': values.get('query', ''),
+                'current_command': values.get('current_command', 'show'),
+                'prompt_command': values.get('prompt_command', 'install'),
             },
+        ).get('result')
+    return result
+
+
+def run_operation_values(operation: dict[str, Any], *, initial_values: Mapping[str, Any]) -> dict[str, Any]:
+    if operation.get("id") not in {
+        'memory.adopt.lifecycle',
+        'memory.bootstrap-cleanup.apply',
+        'memory.capture-note.report',
+        'memory.create-note.apply',
+        'memory.current.report',
+        'memory.doctor.report',
+        'memory.init.lifecycle',
+        'memory.install.lifecycle',
+        'memory.list-files.report',
+        'memory.list-skills.report',
+        'memory.migrate-layout.lifecycle',
+        'memory.promotion-report.report',
+        'memory.prompt.render',
+        'memory.report.report',
+        'memory.route-report.report',
+        'memory.route-review.report',
+        'memory.route.report',
+        'memory.search.report',
+        'memory.status.report',
+        'memory.sync-memory.report',
+        'memory.uninstall.lifecycle',
+        'memory.upgrade.lifecycle',
+        'memory.verify-payload.report'
+    }:
+        raise OperationIrExecutionError(f"unsupported operation IR contract: {operation.get('id')!r}")
+    if operation.get("migration_status") != "runtime-consumed":
+        raise OperationIrExecutionError(f"operation is not marked runtime-consumed: {operation.get('id')!r}")
+
+    try:
+        return run_operation_steps(
+            operation,
+            initial_values=dict(initial_values),
             context=PrimitiveContext(cwd=Path.cwd(), roots={
                 'memory.package-payload': _handle_context_root_memory_package_payload(),
                 'memory.package-skills': _handle_context_root_memory_package_skills(),
@@ -129,12 +192,8 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'memory.search.load': _handle_memory_search_load,
             },
         )
-        emitted = values.get('emitted')
-        if isinstance(emitted, str):
-            print(emitted, end='')
     except PrimitiveExecutionError as exc:
         raise OperationIrExecutionError(str(exc)) from exc
-    return 0
 
 
 def _handle_context_root_memory_package_payload() -> Path:

--- a/generated/planning/python/commands/planning_adopt_lifecycle.py
+++ b/generated/planning/python/commands/planning_adopt_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.adopt.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.adopt.lifecycle'), values)

--- a/generated/planning/python/commands/planning_archive_plan_lifecycle.py
+++ b/generated/planning/python/commands/planning_archive_plan_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.archive-plan.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.archive-plan.lifecycle'), values)

--- a/generated/planning/python/commands/planning_close_item_lifecycle.py
+++ b/generated/planning/python/commands/planning_close_item_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.close-item.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.close-item.lifecycle'), values)

--- a/generated/planning/python/commands/planning_closeout_lifecycle.py
+++ b/generated/planning/python/commands/planning_closeout_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.closeout.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.closeout.lifecycle'), values)

--- a/generated/planning/python/commands/planning_create_review_lifecycle.py
+++ b/generated/planning/python/commands/planning_create_review_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.create-review.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.create-review.lifecycle'), values)

--- a/generated/planning/python/commands/planning_delegation_decision_lifecycle.py
+++ b/generated/planning/python/commands/planning_delegation_decision_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.delegation-decision.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.delegation-decision.lifecycle'), values)

--- a/generated/planning/python/commands/planning_doctor_report.py
+++ b/generated/planning/python/commands/planning_doctor_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.doctor.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.doctor.report'), values)

--- a/generated/planning/python/commands/planning_handoff_report.py
+++ b/generated/planning/python/commands/planning_handoff_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.handoff.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.handoff.report'), values)

--- a/generated/planning/python/commands/planning_init_lifecycle.py
+++ b/generated/planning/python/commands/planning_init_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.init.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.init.lifecycle'), values)

--- a/generated/planning/python/commands/planning_install_lifecycle.py
+++ b/generated/planning/python/commands/planning_install_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.install.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.install.lifecycle'), values)

--- a/generated/planning/python/commands/planning_intake_artifact_lifecycle.py
+++ b/generated/planning/python/commands/planning_intake_artifact_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.intake-artifact.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.intake-artifact.lifecycle'), values)

--- a/generated/planning/python/commands/planning_lane_activate_lifecycle.py
+++ b/generated/planning/python/commands/planning_lane_activate_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.lane-activate.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.lane-activate.lifecycle'), values)

--- a/generated/planning/python/commands/planning_lane_archive_lifecycle.py
+++ b/generated/planning/python/commands/planning_lane_archive_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.lane-archive.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.lane-archive.lifecycle'), values)

--- a/generated/planning/python/commands/planning_lane_close_lifecycle.py
+++ b/generated/planning/python/commands/planning_lane_close_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.lane-close.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.lane-close.lifecycle'), values)

--- a/generated/planning/python/commands/planning_lane_create_lifecycle.py
+++ b/generated/planning/python/commands/planning_lane_create_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.lane-create.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.lane-create.lifecycle'), values)

--- a/generated/planning/python/commands/planning_lane_promote_lifecycle.py
+++ b/generated/planning/python/commands/planning_lane_promote_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.lane-promote.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.lane-promote.lifecycle'), values)

--- a/generated/planning/python/commands/planning_list_files_report.py
+++ b/generated/planning/python/commands/planning_list_files_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.list-files.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.list-files.report'), values)

--- a/generated/planning/python/commands/planning_new_plan_lifecycle.py
+++ b/generated/planning/python/commands/planning_new_plan_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.new-plan.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.new-plan.lifecycle'), values)

--- a/generated/planning/python/commands/planning_promote_to_plan_lifecycle.py
+++ b/generated/planning/python/commands/planning_promote_to_plan_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.promote-to-plan.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.promote-to-plan.lifecycle'), values)

--- a/generated/planning/python/commands/planning_prompt_render.py
+++ b/generated/planning/python/commands/planning_prompt_render.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.prompt.render'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.prompt.render'), values)

--- a/generated/planning/python/commands/planning_reconcile_report.py
+++ b/generated/planning/python/commands/planning_reconcile_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.reconcile.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.reconcile.report'), values)

--- a/generated/planning/python/commands/planning_report_report.py
+++ b/generated/planning/python/commands/planning_report_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.report.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.report.report'), values)

--- a/generated/planning/python/commands/planning_status_report.py
+++ b/generated/planning/python/commands/planning_status_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.status.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.status.report'), values)

--- a/generated/planning/python/commands/planning_summary_report.py
+++ b/generated/planning/python/commands/planning_summary_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.summary.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.summary.report'), values)

--- a/generated/planning/python/commands/planning_uninstall_lifecycle.py
+++ b/generated/planning/python/commands/planning_uninstall_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.uninstall.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.uninstall.lifecycle'), values)

--- a/generated/planning/python/commands/planning_upgrade_lifecycle.py
+++ b/generated/planning/python/commands/planning_upgrade_lifecycle.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.upgrade.lifecycle'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.upgrade.lifecycle'), values)

--- a/generated/planning/python/commands/planning_verify_payload_report.py
+++ b/generated/planning/python/commands/planning_verify_payload_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('planning.verify-payload.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('planning.verify-payload.report'), values)

--- a/generated/planning/python/primitives/operation_executor.py
+++ b/generated/planning/python/primitives/operation_executor.py
@@ -8,6 +8,9 @@ Regenerate with: uv run python scripts/generate/generate_command_packages.py
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -27,44 +30,10 @@ class OperationIrExecutionError(RuntimeError):
 
 
 def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int:
-    if operation.get("id") not in {
-        'planning.adopt.lifecycle',
-        'planning.archive-plan.lifecycle',
-        'planning.close-item.lifecycle',
-        'planning.closeout.lifecycle',
-        'planning.create-review.lifecycle',
-        'planning.delegation-decision.lifecycle',
-        'planning.doctor.report',
-        'planning.handoff.report',
-        'planning.init.lifecycle',
-        'planning.install.lifecycle',
-        'planning.intake-artifact.lifecycle',
-        'planning.lane-activate.lifecycle',
-        'planning.lane-archive.lifecycle',
-        'planning.lane-close.lifecycle',
-        'planning.lane-create.lifecycle',
-        'planning.lane-promote.lifecycle',
-        'planning.list-files.report',
-        'planning.new-plan.lifecycle',
-        'planning.promote-to-plan.lifecycle',
-        'planning.prompt.render',
-        'planning.reconcile.report',
-        'planning.report.report',
-        'planning.status.report',
-        'planning.summary.report',
-        'planning.uninstall.lifecycle',
-        'planning.upgrade.lifecycle',
-        'planning.verify-payload.report'
-    }:
-        raise OperationIrExecutionError(f"unsupported operation IR contract: {operation.get('id')!r}")
-    if operation.get("migration_status") != "runtime-consumed":
-        raise OperationIrExecutionError(f"operation is not marked runtime-consumed: {operation.get('id')!r}")
-
-    try:
-        values = run_operation_steps(
-            operation,
-            initial_values={
-                "operation_id": operation.get("id"),
+    values = run_operation_values(
+        operation,
+        initial_values={
+            "operation_id": operation.get("id"),
                 'target': getattr(args, 'target', None),
                 'format': getattr(args, 'format', 'text'),
                 'verbose': getattr(args, 'verbose', False),
@@ -141,7 +110,139 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'decomposition_adjustment': getattr(args, 'decomposition_adjustment', ''),
                 'expect_planning_revision': getattr(args, 'expect_planning_revision', ''),
                 'paths': getattr(args, 'paths', []),
+        },
+    )
+    emitted = values.get('emitted')
+    if isinstance(emitted, str):
+        print(emitted, end='')
+    return 0
+
+
+def run_operation_callable(operation: dict[str, Any], values: Mapping[str, Any]) -> object:
+    with contextlib.redirect_stdout(io.StringIO()):
+        result = run_operation_values(
+            operation,
+            initial_values={
+                "operation_id": operation.get("id"),
+                'target': values.get('target', None),
+                'format': values.get('format', 'text'),
+                'verbose': values.get('verbose', False),
+                'task': values.get('task', None),
+                'changed': values.get('changed', []),
+                'apply_safe_prune': values.get('apply_safe_prune', False),
+                'dry_run': values.get('dry_run', False),
+                'item': values.get('item', ''),
+                'reason': values.get('reason', ''),
+                'issue': values.get('issue', ''),
+                'slug': values.get('slug', ''),
+                'title': values.get('title', ''),
+                'scope': values.get('scope', None),
+                'classification': values.get('classification', 'review'),
+                'render_markdown': values.get('render_markdown', False),
+                'prompt_command': values.get('prompt_command', ''),
+                'force': values.get('force', False),
+                'local': values.get('local', False),
+                'include_optional': values.get('include_optional', False),
+                'id': values.get('id', ''),
+                'source': values.get('source', ''),
+                'artifact': values.get('artifact', ''),
+                'activate': values.get('activate', False),
+                'queue': values.get('queue', False),
+                'switch_active': values.get('switch_active', False),
+                'prep_only': values.get('prep_only', False),
+                'overwrite': values.get('overwrite', False),
+                'remove_source': values.get('remove_source', False),
+                'item_id': values.get('item_id', ''),
+                'plan_slug': values.get('plan_slug', None),
+                'lane': values.get('lane', ''),
+                'parent_decomposition': values.get('parent_decomposition', ''),
+                'outcome': values.get('outcome', ''),
+                'purpose': values.get('purpose', ''),
+                'proof_strategy': values.get('proof_strategy', ''),
+                'current_slice': values.get('current_slice', ''),
+                'proof': values.get('proof', ''),
+                'residual_work': values.get('residual_work', ''),
+                'parent_contribution': values.get('parent_contribution', ''),
+                'parent_close_permission': values.get('parent_close_permission', 'may-advance-parent'),
+                'next_owner': values.get('next_owner', ''),
+                'plan': values.get('plan', None),
+                'apply_cleanup': values.get('apply_cleanup', False),
+                'prepare_closeout': values.get('prepare_closeout', False),
+                'retain_archive': values.get('retain_archive', False),
+                'parent_lane_closeout': values.get('parent_lane_closeout', None),
+                'closure_decision': values.get('closure_decision', None),
+                'intent_satisfied': values.get('intent_satisfied', None),
+                'unsolved_intent': values.get('unsolved_intent', None),
+                'intent_evidence': values.get('intent_evidence', None),
+                'closure_reason': values.get('closure_reason', None),
+                'closure_evidence': values.get('closure_evidence', None),
+                'reopen_trigger': values.get('reopen_trigger', None),
+                'discard_summary': values.get('discard_summary', None),
+                'continuation_summary': values.get('continuation_summary', None),
+                'claim_level': values.get('claim_level', 'slice'),
+                'intent_status': values.get('intent_status', 'satisfied'),
+                'residue': values.get('residue', 'none'),
+                'proof_from': values.get('proof_from', 'last'),
+                'proof_file': values.get('proof_file', None),
+                'residue_owner': values.get('residue_owner', None),
+                'what_happened': values.get('what_happened', None),
+                'scope_touched': values.get('scope_touched', None),
+                'changed_surfaces': values.get('changed_surfaces', None),
+                'review_summary': values.get('review_summary', None),
+                'outcome_summary': values.get('outcome_summary', None),
+                'discard_archive': values.get('discard_archive', False),
+                'route': values.get('route', ''),
+                'skipped_reason': values.get('skipped_reason', ''),
+                'expected_savings': values.get('expected_savings', ''),
+                'actual_friction': values.get('actual_friction', ''),
+                'proof_result': values.get('proof_result', ''),
+                'quality_concern': values.get('quality_concern', ''),
+                'decomposition_adjustment': values.get('decomposition_adjustment', ''),
+                'expect_planning_revision': values.get('expect_planning_revision', ''),
+                'paths': values.get('paths', []),
             },
+        ).get('result')
+    return result
+
+
+def run_operation_values(operation: dict[str, Any], *, initial_values: Mapping[str, Any]) -> dict[str, Any]:
+    if operation.get("id") not in {
+        'planning.adopt.lifecycle',
+        'planning.archive-plan.lifecycle',
+        'planning.close-item.lifecycle',
+        'planning.closeout.lifecycle',
+        'planning.create-review.lifecycle',
+        'planning.delegation-decision.lifecycle',
+        'planning.doctor.report',
+        'planning.handoff.report',
+        'planning.init.lifecycle',
+        'planning.install.lifecycle',
+        'planning.intake-artifact.lifecycle',
+        'planning.lane-activate.lifecycle',
+        'planning.lane-archive.lifecycle',
+        'planning.lane-close.lifecycle',
+        'planning.lane-create.lifecycle',
+        'planning.lane-promote.lifecycle',
+        'planning.list-files.report',
+        'planning.new-plan.lifecycle',
+        'planning.promote-to-plan.lifecycle',
+        'planning.prompt.render',
+        'planning.reconcile.report',
+        'planning.report.report',
+        'planning.status.report',
+        'planning.summary.report',
+        'planning.uninstall.lifecycle',
+        'planning.upgrade.lifecycle',
+        'planning.verify-payload.report'
+    }:
+        raise OperationIrExecutionError(f"unsupported operation IR contract: {operation.get('id')!r}")
+    if operation.get("migration_status") != "runtime-consumed":
+        raise OperationIrExecutionError(f"operation is not marked runtime-consumed: {operation.get('id')!r}")
+
+    try:
+        return run_operation_steps(
+            operation,
+            initial_values=dict(initial_values),
             context=PrimitiveContext(cwd=Path.cwd(), roots={
                 'planning.package-payload': _handle_context_root_planning_package_payload(),
                 'planning.package-skills': _handle_context_root_planning_package_skills(),
@@ -176,12 +277,8 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'planning.verify-payload.load': _handle_planning_verify_payload_load,
             },
         )
-        emitted = values.get('emitted')
-        if isinstance(emitted, str):
-            print(emitted, end='')
     except PrimitiveExecutionError as exc:
         raise OperationIrExecutionError(str(exc)) from exc
-    return 0
 
 
 def _handle_context_root_planning_package_payload() -> Path:

--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -2,14 +2,15 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir jsonschema "command-generation @ git+https://github.com/rickardvh/command-generation.git@codex/extract-command-generation-package"
+RUN python -m pip install --no-cache-dir jsonschema "command-generation @ git+https://github.com/rickardvh/command-generation.git@6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c"
 
 COPY src ./src
 COPY scripts ./scripts
 COPY packages ./packages
 COPY generated ./generated
+COPY pyproject.toml ./pyproject.toml
 
-ENV PYTHONPATH=/work/src:/work/packages/planning/src:/work/packages/memory/src
+ENV PYTHONPATH=/work:/work/src:/work/packages/planning/src:/work/packages/memory/src
 ENV AGENTIC_GENERATED_CONFORMANCE_CONTAINER=python
 
 CMD ["python", "scripts/check/check_generated_command_packages.py", "--python-conformance"]

--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -2,7 +2,7 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir jsonschema "command-generation @ git+https://github.com/rickardvh/command-generation.git@6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c"
+RUN python -m pip install --no-cache-dir jsonschema "command-generation @ git+https://github.com/rickardvh/command-generation.git@ccad393f36ca3c01fc15c8f5d6951505e2df1a8d"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/python/Dockerfile.primitive-conformance
+++ b/generated/python/Dockerfile.primitive-conformance
@@ -2,6 +2,6 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir "command-generation @ git+https://github.com/rickardvh/command-generation.git@codex/extract-command-generation-package"
+RUN python -m pip install --no-cache-dir "command-generation @ git+https://github.com/rickardvh/command-generation.git@6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c"
 
 CMD ["python", "-m", "command_generation.primitive_conformance"]

--- a/generated/python/Dockerfile.primitive-conformance
+++ b/generated/python/Dockerfile.primitive-conformance
@@ -2,6 +2,6 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir "command-generation @ git+https://github.com/rickardvh/command-generation.git@6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c"
+RUN python -m pip install --no-cache-dir "command-generation @ git+https://github.com/rickardvh/command-generation.git@ccad393f36ca3c01fc15c8f5d6951505e2df1a8d"
 
 CMD ["python", "-m", "command_generation.primitive_conformance"]

--- a/generated/verification/python/commands/verification_report_report.py
+++ b/generated/verification/python/commands/verification_report_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('verification.report.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('verification.report.report'), values)

--- a/generated/verification/python/primitives/operation_executor.py
+++ b/generated/verification/python/primitives/operation_executor.py
@@ -8,6 +8,9 @@ Regenerate with: uv run python scripts/generate/generate_command_packages.py
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +30,38 @@ class OperationIrExecutionError(RuntimeError):
 
 
 def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int:
+    values = run_operation_values(
+        operation,
+        initial_values={
+            "operation_id": operation.get("id"),
+                'target': getattr(args, 'target', None),
+                'changed_paths': getattr(args, 'changed_paths', []),
+                'task_text': getattr(args, 'task_text', ''),
+                'format': getattr(args, 'format', 'text'),
+        },
+    )
+    emitted = values.get('emitted')
+    if isinstance(emitted, str):
+        print(emitted, end='')
+    return 0
+
+
+def run_operation_callable(operation: dict[str, Any], values: Mapping[str, Any]) -> object:
+    with contextlib.redirect_stdout(io.StringIO()):
+        result = run_operation_values(
+            operation,
+            initial_values={
+                "operation_id": operation.get("id"),
+                'target': values.get('target', None),
+                'changed_paths': values.get('changed_paths', []),
+                'task_text': values.get('task_text', ''),
+                'format': values.get('format', 'text'),
+            },
+        ).get('result')
+    return result
+
+
+def run_operation_values(operation: dict[str, Any], *, initial_values: Mapping[str, Any]) -> dict[str, Any]:
     if operation.get("id") not in {
         'verification.report.report'
     }:
@@ -35,15 +70,9 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
         raise OperationIrExecutionError(f"operation is not marked runtime-consumed: {operation.get('id')!r}")
 
     try:
-        values = run_operation_steps(
+        return run_operation_steps(
             operation,
-            initial_values={
-                "operation_id": operation.get("id"),
-                'target': getattr(args, 'target', None),
-                'changed_paths': getattr(args, 'changed_paths', []),
-                'task_text': getattr(args, 'task_text', ''),
-                'format': getattr(args, 'format', 'text'),
-            },
+            initial_values=dict(initial_values),
             context=PrimitiveContext(cwd=Path.cwd(), roots={
                 'verification.contracts': _handle_context_root_verification_contracts(),
             }),
@@ -52,12 +81,8 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'verification.report.load': _handle_verification_report_load,
             },
         )
-        emitted = values.get('emitted')
-        if isinstance(emitted, str):
-            print(emitted, end='')
     except PrimitiveExecutionError as exc:
         raise OperationIrExecutionError(str(exc)) from exc
-    return 0
 
 
 def _handle_context_root_verification_contracts() -> Path:

--- a/generated/workspace/python/commands/config_report.py
+++ b/generated/workspace/python/commands/config_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('config.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('config.report'), values)

--- a/generated/workspace/python/commands/defaults_report.py
+++ b/generated/workspace/python/commands/defaults_report.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('defaults.report'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('defaults.report'), values)

--- a/generated/workspace/python/commands/delegation_outcome_append.py
+++ b/generated/workspace/python/commands/delegation_outcome_append.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('delegation-outcome.append'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('delegation-outcome.append'), values)

--- a/generated/workspace/python/commands/doctor_report.py
+++ b/generated/workspace/python/commands/doctor_report.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_lifecycle_report_adapter
 
     return _run_lifecycle_report_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('doctor.report' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/external_intent_refresh_github.py
+++ b/generated/workspace/python/commands/external_intent_refresh_github.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_external_intent_refresh_github_adapter
 
     return _run_external_intent_refresh_github_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('external-intent.refresh-github' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/implement_context.py
+++ b/generated/workspace/python/commands/implement_context.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_implement_context_adapter
 
     return _run_implement_context_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('implement.context' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/init_lifecycle.py
+++ b/generated/workspace/python/commands/init_lifecycle.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_init_lifecycle_adapter
 
     return _run_init_lifecycle_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('init.lifecycle' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/install_lifecycle.py
+++ b/generated/workspace/python/commands/install_lifecycle.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_init_lifecycle_adapter
 
     return _run_init_lifecycle_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('install.lifecycle' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/memory_front_door.py
+++ b/generated/workspace/python/commands/memory_front_door.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_memory_front_door_adapter
 
     return _run_memory_front_door_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('memory.front-door' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/modules_report.py
+++ b/generated/workspace/python/commands/modules_report.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_modules_report_adapter
 
     return _run_modules_report_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('modules.report' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/ownership_report.py
+++ b/generated/workspace/python/commands/ownership_report.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_ownership_report_adapter
 
     return _run_ownership_report_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('ownership.report' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/planning_front_door.py
+++ b/generated/workspace/python/commands/planning_front_door.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_planning_front_door_adapter
 
     return _run_planning_front_door_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('planning.front-door' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/preflight_report.py
+++ b/generated/workspace/python/commands/preflight_report.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_preflight_report_adapter
 
     return _run_preflight_report_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('preflight.report' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/prompt_init.py
+++ b/generated/workspace/python/commands/prompt_init.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('prompt.init'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('prompt.init'), values)

--- a/generated/workspace/python/commands/prompt_uninstall.py
+++ b/generated/workspace/python/commands/prompt_uninstall.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('prompt.uninstall'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('prompt.uninstall'), values)

--- a/generated/workspace/python/commands/prompt_upgrade.py
+++ b/generated/workspace/python/commands/prompt_upgrade.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('prompt.upgrade'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('prompt.upgrade'), values)

--- a/generated/workspace/python/commands/proof_report.py
+++ b/generated/workspace/python/commands/proof_report.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_proof_report_adapter
 
     return _run_proof_report_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('proof.report' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/reconcile_report.py
+++ b/generated/workspace/python/commands/reconcile_report.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_reconcile_report_adapter
 
     return _run_reconcile_report_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('reconcile.report' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/report_combined.py
+++ b/generated/workspace/python/commands/report_combined.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_report_combined_adapter
 
     return _run_report_combined_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('report.combined' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/setup_guidance.py
+++ b/generated/workspace/python/commands/setup_guidance.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_setup_guidance_adapter
 
     return _run_setup_guidance_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('setup.guidance' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/skills_report.py
+++ b/generated/workspace/python/commands/skills_report.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_skills_report_adapter
 
     return _run_skills_report_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('skills.report' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/start_context.py
+++ b/generated/workspace/python/commands/start_context.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_start_context_adapter
 
     return _run_start_context_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('start.context' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/status_report.py
+++ b/generated/workspace/python/commands/status_report.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_lifecycle_report_adapter
 
     return _run_lifecycle_report_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('status.report' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/summary_report.py
+++ b/generated/workspace/python/commands/summary_report.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_summary_report_adapter
 
     return _run_summary_report_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('summary.report' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/system_intent_sync.py
+++ b/generated/workspace/python/commands/system_intent_sync.py
@@ -10,13 +10,20 @@ from __future__ import annotations
 
 import argparse
 
+from collections.abc import Mapping
+from typing import Any
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
 from ..cli import generated_operation_contract
-from ..primitives.operation_executor import run_operation_ir
+from ..primitives.operation_executor import run_operation_callable, run_operation_ir
 
 
 def run(args: argparse.Namespace) -> int:
     return run_operation_ir(generated_operation_contract('system-intent.sync'), args)
+
+
+def invoke(values: Mapping[str, Any]) -> object:
+    return run_operation_callable(generated_operation_contract('system-intent.sync'), values)

--- a/generated/workspace/python/commands/uninstall_lifecycle.py
+++ b/generated/workspace/python/commands/uninstall_lifecycle.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_lifecycle_mutation_adapter
 
     return _run_lifecycle_mutation_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('uninstall.lifecycle' + ' has no generated operation callable')

--- a/generated/workspace/python/commands/upgrade_lifecycle.py
+++ b/generated/workspace/python/commands/upgrade_lifecycle.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 
+from typing import Any
+from collections.abc import Mapping
+
 # DO NOT EDIT DIRECTLY.
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
@@ -20,3 +23,7 @@ def run(args: argparse.Namespace) -> int:
     from ..primitives.workspace_runtime import _run_lifecycle_mutation_adapter
 
     return _run_lifecycle_mutation_adapter(args)
+
+
+def invoke(_values: Mapping[str, Any]) -> object:
+    raise RuntimeError('upgrade.lifecycle' + ' has no generated operation callable')

--- a/generated/workspace/python/primitives/operation_executor.py
+++ b/generated/workspace/python/primitives/operation_executor.py
@@ -8,6 +8,9 @@ Regenerate with: uv run python scripts/generate/generate_command_packages.py
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -27,24 +30,10 @@ class OperationIrExecutionError(RuntimeError):
 
 
 def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int:
-    if operation.get("id") not in {
-        'config.report',
-        'defaults.report',
-        'delegation-outcome.append',
-        'prompt.init',
-        'prompt.uninstall',
-        'prompt.upgrade',
-        'system-intent.sync'
-    }:
-        raise OperationIrExecutionError(f"unsupported operation IR contract: {operation.get('id')!r}")
-    if operation.get("migration_status") != "runtime-consumed":
-        raise OperationIrExecutionError(f"operation is not marked runtime-consumed: {operation.get('id')!r}")
-
-    try:
-        values = run_operation_steps(
-            operation,
-            initial_values={
-                "operation_id": operation.get("id"),
+    values = run_operation_values(
+        operation,
+        initial_values={
+            "operation_id": operation.get("id"),
                 'format': getattr(args, 'format', 'text'),
                 'verbose': getattr(args, 'verbose', False),
                 'adopt': getattr(args, 'adopt', False),
@@ -63,7 +52,61 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'sync': getattr(args, 'sync', False),
                 'target': getattr(args, 'target', None),
                 'task_class': getattr(args, 'task_class', None),
+        },
+    )
+    emitted = values.get('emitted')
+    if isinstance(emitted, str):
+        print(emitted, end='')
+    return 0
+
+
+def run_operation_callable(operation: dict[str, Any], values: Mapping[str, Any]) -> object:
+    with contextlib.redirect_stdout(io.StringIO()):
+        result = run_operation_values(
+            operation,
+            initial_values={
+                "operation_id": operation.get("id"),
+                'format': values.get('format', 'text'),
+                'verbose': values.get('verbose', False),
+                'adopt': values.get('adopt', False),
+                'agent_instructions_file': values.get('agent_instructions_file', None),
+                'delegation_target': values.get('delegation_target', None),
+                'escalation_required': values.get('escalation_required', False),
+                'handoff_sufficiency': values.get('handoff_sufficiency', None),
+                'module': values.get('module', None),
+                'non_interactive': values.get('non_interactive', False),
+                'outcome': values.get('outcome', None),
+                'prompt_command': values.get('prompt_command', None),
+                'preset': values.get('preset', None),
+                'review_burden': values.get('review_burden', None),
+                'section': values.get('section', None),
+                'select': values.get('select', None),
+                'sync': values.get('sync', False),
+                'target': values.get('target', None),
+                'task_class': values.get('task_class', None),
             },
+        ).get('result')
+    return result
+
+
+def run_operation_values(operation: dict[str, Any], *, initial_values: Mapping[str, Any]) -> dict[str, Any]:
+    if operation.get("id") not in {
+        'config.report',
+        'defaults.report',
+        'delegation-outcome.append',
+        'prompt.init',
+        'prompt.uninstall',
+        'prompt.upgrade',
+        'system-intent.sync'
+    }:
+        raise OperationIrExecutionError(f"unsupported operation IR contract: {operation.get('id')!r}")
+    if operation.get("migration_status") != "runtime-consumed":
+        raise OperationIrExecutionError(f"operation is not marked runtime-consumed: {operation.get('id')!r}")
+
+    try:
+        return run_operation_steps(
+            operation,
+            initial_values=dict(initial_values),
             context=PrimitiveContext(cwd=Path.cwd(), roots={}),
             handlers={
                 'workspace.root.resolve': _handle_workspace_root_resolve,
@@ -82,12 +125,8 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'workspace.config.emit': _handle_workspace_config_emit,
             },
         )
-        emitted = values.get('emitted')
-        if isinstance(emitted, str):
-            print(emitted, end='')
     except PrimitiveExecutionError as exc:
         raise OperationIrExecutionError(str(exc)) from exc
-    return 0
 
 
 def _handle_workspace_root_resolve(values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> Any:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ package = true
 agentic-memory = { workspace = true }
 agentic-planning = { workspace = true }
 agentic-verification = { workspace = true }
-command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c" }
+command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "ccad393f36ca3c01fc15c8f5d6951505e2df1a8d" }
 
 [tool.uv.workspace]
 members = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ package = true
 agentic-memory = { workspace = true }
 agentic-planning = { workspace = true }
 agentic-verification = { workspace = true }
-command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "4b4547cecc2193810e40f6918a387369a6c1c26a" }
+command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c" }
 
 [tool.uv.workspace]
 members = [

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -586,11 +586,30 @@ def _runtime_module_file_for_package(package_id: str) -> str:
 
 
 def _generated_package_for_package(package_id: str):
-    return load_generated_command_package_for_entrypoint(_entrypoint_for_package(package_id))
+    try:
+        return load_generated_command_package_for_entrypoint(_entrypoint_for_package(package_id))
+    except ModuleNotFoundError:
+        generated_package = {
+            "root-workspace": "workspace",
+            "planning-bootstrap": "planning",
+            "memory-bootstrap": "memory",
+            "verification-cli": "verification",
+        }[package_id]
+        return importlib.import_module(f"generated.{generated_package}.python")
 
 
 def _generated_runtime_module_for_package(package_id: str):
-    return load_generated_command_module_for_entrypoint(_entrypoint_for_package(package_id), _runtime_module_file_for_package(package_id))
+    try:
+        return load_generated_command_module_for_entrypoint(_entrypoint_for_package(package_id), _runtime_module_file_for_package(package_id))
+    except ModuleNotFoundError:
+        generated_package = {
+            "root-workspace": "workspace",
+            "planning-bootstrap": "planning",
+            "memory-bootstrap": "memory",
+            "verification-cli": "verification",
+        }[package_id]
+        runtime_module = _runtime_module_file_for_package(package_id).removesuffix(".py")
+        return importlib.import_module(f"generated.{generated_package}.python.{runtime_module}")
 
 
 def _python_command_for_package(package_id: str) -> list[str]:
@@ -3180,6 +3199,33 @@ def _validate_generated_python_target_layout() -> list[str]:
     return errors
 
 
+def _command_generation_git_rev_from_pyproject() -> str:
+    payload = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    sources = payload.get("tool", {}).get("uv", {}).get("sources", {})
+    command_generation_source = sources.get("command-generation", {}) if isinstance(sources, dict) else {}
+    if isinstance(command_generation_source, dict):
+        return str(command_generation_source.get("rev", ""))
+    return ""
+
+
+def _validate_python_dockerfiles_pin_command_generation() -> list[str]:
+    expected_rev = _command_generation_git_rev_from_pyproject()
+    if not expected_rev:
+        return ["pyproject.toml command-generation source must declare a git rev"]
+    errors: list[str] = []
+    for relative_path in (
+        "generated/python/Dockerfile.conformance",
+        "generated/python/Dockerfile.primitive-conformance",
+    ):
+        path = REPO_ROOT / relative_path
+        if not path.is_file():
+            continue
+        expected = f"command-generation.git@{expected_rev}"
+        if expected not in path.read_text(encoding="utf-8"):
+            errors.append(f"{relative_path} command-generation install ref must match pyproject.toml rev {expected_rev}")
+    return errors
+
+
 def _validate_generated_python_commands_absent_from_handwritten_parsers() -> list[str]:
     errors: list[str] = []
     for package_id in ("root-workspace", "planning-bootstrap", "memory-bootstrap", "verification-cli"):
@@ -4084,6 +4130,7 @@ def _validate_static_surfaces() -> list[str]:
     primitive_conformance_dockerfile = REPO_ROOT / "generated" / "python" / "Dockerfile.primitive-conformance"
     if not primitive_conformance_dockerfile.is_file():
         errors.append("generated/python/Dockerfile.primitive-conformance is missing")
+    errors.extend(_validate_python_dockerfiles_pin_command_generation())
     try:
         import command_generation.primitive_conformance as primitive_conformance  # noqa: PLC0415
     except ModuleNotFoundError:

--- a/src/agentic_workspace/contracts/operation_artifact_registry.json
+++ b/src/agentic_workspace/contracts/operation_artifact_registry.json
@@ -13,8 +13,9 @@
       "operation_id": "defaults.report",
       "package_id": "root-workspace",
       "target": "python",
-      "adapter_id": "cli.process",
-      "proof_role": "wrapper-smoke",
+      "adapter_id": "python.function",
+      "proof_role": "operation-conformance",
+      "symbol": "generated.workspace.python.commands.defaults_report:invoke",
       "source_ref": "command_package_ir:root-workspace/defaults",
       "wrapper_refs": [
         "defaults.report.cli"
@@ -24,12 +25,13 @@
       ],
       "path_refs": [
         "generated/workspace/python/commands/defaults_report.py",
+        "generated/workspace/python/primitives/operation_executor.py",
         "src/agentic_workspace/contracts/operations/defaults.report.json",
         "src/agentic_workspace/contracts/conformance/defaults.selected-text.process.json"
       ],
       "stale_when": [
         "defaults.report operation contract changes",
-        "root-workspace defaults generated Python artifact changes",
+        "root-workspace defaults generated Python callable artifact changes",
         "defaults.selected-text.process conformance expectations change"
       ]
     },

--- a/src/agentic_workspace/contracts/operation_conformance_test_ir.json
+++ b/src/agentic_workspace/contracts/operation_conformance_test_ir.json
@@ -160,8 +160,8 @@
         {
           "artifact_id": "root-workspace.defaults.python",
           "target": "python",
-          "adapter_id": "cli.process",
-          "proof_role": "wrapper-smoke",
+          "adapter_id": "python.function",
+          "proof_role": "operation-conformance",
           "source_ref": "command_package_ir:root-workspace/defaults",
           "wrapper_refs": [
             "defaults.report.cli"
@@ -211,6 +211,10 @@
         "exit_code": 0,
         "result": {
           "format": "text",
+          "selected_fields": {
+            "kind": "agentic-workspace/selected-output/v1",
+            "source_command": "defaults"
+          },
           "contains": [
             "Kind: agentic-workspace/selected-output/v1",
             "Source command: defaults",
@@ -248,9 +252,10 @@
         "retain_handwritten_tests": [
           "selector parser unit tests",
           "runtime defaults payload assembly tests",
+          "CLI wrapper text-emission smoke where stdout formatting, argv parsing, or process exit behavior is the behavior under test",
           "tests/test_generated_command_package_proof_runner.py::test_generated_python_conformance_uses_contract_artifacts remains as conformance-registry projection coverage, not behavior proof"
         ],
-        "rationale": "This case preserves black-box selected-output behavior without carrying every current test helper or payload assembly assertion into operation conformance IR."
+        "rationale": "This case now uses the generated Python operation callable for semantic proof. The retained stdout expectations document the wrapper-smoke boundary, but operation completion is proven through the JSON-shaped result returned by generated.workspace.python.commands.defaults_report:invoke."
       }
     },
     {
@@ -355,7 +360,7 @@
           "handwritten root CLI fallback parser tests",
           "target adapter parser mechanics tests that do not assert the config command behavior contract"
         ],
-        "rationale": "The case protects the structured operation error directly while avoiding a one-to-one copy of parser regression cases."
+        "rationale": "This case remains wrapper-smoke because the invalid --format rejection is currently owned by generated parser/transport choice validation, not by the JSON-shaped config.report operation callable. It protects wrapper error behavior without presenting cli.process as operation-semantic proof."
       }
     },
     {
@@ -480,7 +485,7 @@
           "primitive executor tests for filesystem and payload assembly",
           "tests/test_generated_command_package_proof_runner.py::test_generated_typescript_conformance_cases_come_from_contract_artifacts remains as conformance-registry projection coverage, not behavior proof"
         ],
-        "rationale": "Composite parity assumes primitive executor behavior is tested by primitive cases and checks only the higher-level generated operation behavior."
+        "rationale": "This case remains wrapper-smoke because its current acceptance is cross-target CLI parity for generated Memory transport and stable JSON fields. Composite parity assumes primitive executor behavior is tested by primitive cases, and a later TypeScript function target should promote this to direct operation conformance when both direct function adapters are available."
       }
     }
   ]

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -17994,7 +17994,7 @@ def _compact_action_signals_payload(
         "changed_signals": signals,
         "advisory_detail": {
             "selectors": selectors,
-            "rule": "Use selectors for advisory detail.",
+            "rule": "Use selectors.",
         },
         "agent_judgment": agent_judgment,
         "order": [
@@ -18612,6 +18612,9 @@ def _compact_start_delegation_decision(value: Any, *, include_manual_handoff_det
     )
     compact = {key: value.get(key) for key in common_keys if key in value}
     compact.setdefault("recommended_route", value.get("recommended_route") or value.get("decision"))
+    decision = str(value.get("recommended_route") or value.get("decision") or "")
+    if not include_manual_handoff_detail and decision == "stay-local":
+        compact.pop("authority_boundary", None)
     if "authority_boundary" in compact:
         compact["authority_boundary"] = _compact_authority_boundary(compact["authority_boundary"])
     if isinstance(compact.get("route_evidence"), dict):
@@ -18628,7 +18631,6 @@ def _compact_start_delegation_decision(value: Any, *, include_manual_handoff_det
         }
     if isinstance(compact.get("effort_guidance"), dict):
         compact["effort_guidance"] = _compact_effort_guidance(compact["effort_guidance"])
-    decision = str(value.get("recommended_route") or value.get("decision") or "")
     suppress_manual_detail = not include_manual_handoff_detail and decision in {"manual-handoff", "ask-human"}
     config_effect = value.get("config_effect")
     manual_external_relay = value.get("manual_external_relay")
@@ -18668,7 +18670,15 @@ def _compact_start_delegation_decision(value: Any, *, include_manual_handoff_det
                         "execution_authority",
                     )
                     if suppress_manual_detail:
-                        config_keys = ("delegation_mode", "safe_to_auto_run_commands", "execution_authority")
+                        config_keys = (
+                            "authority",
+                            "source_path",
+                            "configured_delegation_mode",
+                            "delegation_mode",
+                            "safe_to_auto_run_commands",
+                            "disabled_reason",
+                            "execution_authority",
+                        )
                     compact[routed_key] = {key: routed_value.get(key) for key in config_keys if key in routed_value}
                 else:
                     compact[routed_key] = routed_value
@@ -18677,9 +18687,11 @@ def _compact_start_delegation_decision(value: Any, *, include_manual_handoff_det
         compact["reason"] = value.get("reason")
     decomposition_delegation = value.get("decomposition_delegation")
     delegation_candidates = [item for item in value.get("delegation_candidates", []) if isinstance(item, dict)]
+    delegation_candidate_detail_allowed = decision in {"suggest-delegation", "suggest-downroute", "delegate-bounded-slice"}
     include_decomposition = (
         isinstance(decomposition_delegation, dict)
         and decomposition_delegation.get("status") in {"present", "available-without-active-planning"}
+        and (delegation_candidate_detail_allowed or config_changes_effective_behavior)
         and (
             decision == "suggest-delegation"
             or bool(delegation_candidates)
@@ -18711,8 +18723,7 @@ def _compact_start_delegation_decision(value: Any, *, include_manual_handoff_det
                 for target in skipped_targets[:2]
             ]
     if (
-        not suppress_manual_detail
-        and isinstance(manual_external_relay, dict)
+        isinstance(manual_external_relay, dict)
         and manual_external_relay.get("target_kind") == "manual-external"
         and (manual_external_relay.get("status") == "appropriate" or decision in {"suggest-escalation", "manual-handoff"})
     ):
@@ -18723,7 +18734,7 @@ def _compact_start_delegation_decision(value: Any, *, include_manual_handoff_det
     if decision in {"suggest-delegation", "suggest-escalation", "delegate-bounded-slice", "manual-handoff", "ask-human"}:
         if value.get("handoff_command"):
             compact["handoff_command"] = value.get("handoff_command")
-        if include_manual_handoff_detail and value.get("manual_prompt"):
+        if (include_manual_handoff_detail or decision in {"manual-handoff", "ask-human"}) and value.get("manual_prompt"):
             compact["manual_prompt"] = value.get("manual_prompt")
         if value.get("delegation_next_step"):
             next_step = value.get("delegation_next_step")
@@ -19895,7 +19906,7 @@ def _startup_skills_projection(
     return {
         "kind": "agentic-workspace/startup-skills-projection/v1",
         "status": "recommended" if required else "available",
-        "rule": "Compact skill projection; use catalog.command only when explicit task-specific skill search is useful.",
+        "rule": "Use catalog.command only for task-specific skill search.",
         "required": required,
         "recommended": recommended,
         "catalog": {
@@ -20114,6 +20125,9 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         )
         if isinstance(task_intent, dict) and "acceptance" in task_intent and not prep_only_active and not read_only_compact_default:
             context["acceptance"] = _tiny_acceptance_payload(task_intent["acceptance"])
+            if context["task"].get("task_argument_mode") == "task-file":
+                context["acceptance"].pop("items", None)
+                context["acceptance"].pop("proof_rule", None)
         if read_only_compact_default:
             context["read_only_response"] = read_only_response
         for optional_key in ("task_file", "task_file_instruction", "task_excerpt", "task_digest", "task_text_length"):
@@ -20171,15 +20185,6 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         "drill_down": {
             "ordinary_profile": "primary=next_safe_action;skills=proj;legacy=select/context",
             "rule": "Use --select <field[,field...]> for exact fields; use --verbose only for broad diagnostics.",
-            "examples": [
-                _command_with_cli_invoke(
-                    command="agentic-workspace start --select cli_invocation,durable_intent --format json", cli_invoke=cli_invoke
-                ),
-                _command_with_cli_invoke(
-                    command="agentic-workspace start --select workflow_obligations,closeout_obligations --format json",
-                    cli_invoke=cli_invoke,
-                ),
-            ],
             "available_selectors": available_selectors,
         },
     }
@@ -20200,12 +20205,14 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             context["durable_intent_promotion"] = _tiny_task_intent_promotion_guidance(task_intent["promotion_guidance"])
     delegation = payload.get("delegation_decision", {})
     delegation_route = delegation.get("recommended_route") or delegation.get("decision") if isinstance(delegation, dict) else None
-    if isinstance(delegation, dict) and (
-        delegation_route not in {"", None, "stay-local"}
-        or delegation.get("delegation_candidates")
-        or (isinstance(delegation.get("auto_delegation_audit"), dict) and delegation["auto_delegation_audit"].get("status") == "skipped")
-    ):
-        context["delegation_decision"] = delegation
+    delegation_config_effect = delegation.get("config_effect", {}) if isinstance(delegation, dict) else {}
+    delegation_config_changes_behavior = isinstance(delegation_config_effect, dict) and (
+        delegation_config_effect.get("configured_delegation_mode") != delegation_config_effect.get("delegation_mode")
+        or delegation_config_effect.get("disabled_reason") not in (None, "")
+        or delegation_config_effect.get("safe_to_auto_run_commands") is False
+    )
+    if isinstance(delegation, dict) and (delegation_route not in {"", None, "stay-local"} or delegation_config_changes_behavior):
+        context["delegation_decision"] = _compact_start_delegation_decision(delegation, include_manual_handoff_detail=False)
     cli_invocation = payload.get("cli_invocation", {})
     if isinstance(cli_invocation, dict) and cli_invocation.get("mismatch"):
         selected["cli_invocation"] = cli_invocation
@@ -20230,7 +20237,6 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         "closeout_trust_inspection",
         "closeout_report_route",
         "repo_posture",
-        "continuation_reorientation",
         "intent_elicitation_protocol",
         "intent_discovery_dialogue",
         "vague_outcome_orientation",
@@ -24614,7 +24620,12 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
         if compact_gate.get("status") in {"clear", "satisfied"}:
             compact_gate.pop("candidate_pressure", None)
             compact_gate.pop("issue_scope_evidence", None)
-        projected["context"]["planning_safety_gate"] = compact_gate
+        if not (
+            isinstance(generated_surface_trust, dict)
+            and generated_surface_trust.get("status") == "present"
+            and compact_gate.get("status") in {"clear", "satisfied"}
+        ):
+            projected["context"]["planning_safety_gate"] = compact_gate
     if isinstance(intent_acknowledgement, dict) and intent_acknowledgement.get("decision") == "proceed-with-stated-assumption":
         projected["context"]["intent_acknowledgement"] = {
             "decision": intent_acknowledgement.get("decision"),
@@ -24702,8 +24713,8 @@ def _tiny_acceptance_payload(value: Any) -> dict[str, Any]:
             compact_items.append(
                 {
                     "id": item.get("id"),
-                    "expectation": _task_excerpt(str(item.get("expectation", "")), limit=92),
-                    "proof_hint": _task_excerpt(str(item.get("proof_hint", "")), limit=80),
+                    "expectation": _task_excerpt(str(item.get("expectation", "")), limit=72),
+                    "proof_hint": _task_excerpt(str(item.get("proof_hint", "")), limit=56),
                     "status": item.get("status"),
                 }
             )

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -678,8 +679,12 @@ def test_operation_conformance_test_ir_defines_success_error_and_parity_cases() 
         "cross-target-parity",
     }
     assert cases["defaults.selected-output.success"]["operation_ref"]["conformance_ref"] == "defaults.selected-text.process"
-    assert cases["defaults.selected-output.success"]["artifacts"][0]["adapter_id"] == "cli.process"
-    assert cases["defaults.selected-output.success"]["artifacts"][0]["proof_role"] == "wrapper-smoke"
+    assert cases["defaults.selected-output.success"]["artifacts"][0]["adapter_id"] == "python.function"
+    assert cases["defaults.selected-output.success"]["artifacts"][0]["proof_role"] == "operation-conformance"
+    assert cases["defaults.selected-output.success"]["expected"]["result"]["selected_fields"] == {
+        "kind": "agentic-workspace/selected-output/v1",
+        "source_command": "defaults",
+    }
     assert cases["config.invalid-format.error"]["expected"]["exit_code"] != 0
     assert cases["config.invalid-format.error"]["expected"]["error"] == {
         "kind": "invalid-choice",
@@ -797,7 +802,7 @@ def test_operation_conformance_test_ir_references_known_command_contracts() -> N
     bulk_preserving["migration_policy"]["do_not_preserve"] = ["old helper names"]
     assert any("one-for-one regression-test bulk" in error for error in module._validate_operation_conformance_test_ir(bulk_preserving))
     cli_default = copy.deepcopy(manifest)
-    cli_default["initial_cases"][0]["artifacts"][0].pop("proof_role")
+    cli_default["initial_cases"][1]["artifacts"][0].pop("proof_role")
     assert any(
         "cli.process artifacts must declare wrapper-smoke" in error for error in module._validate_operation_conformance_test_ir(cli_default)
     )
@@ -816,9 +821,9 @@ def test_operation_artifact_registry_routes_cases_and_proof_layers() -> None:
     assert list(Draft202012Validator(schema).iter_errors(registry)) == []
     assert module._validate_operation_artifact_registry(registry) == []
     artifacts = {artifact["artifact_id"]: artifact for artifact in registry["artifacts"]}
-    assert artifacts["root-workspace.defaults.python"]["adapter_id"] == "cli.process"
-    assert artifacts["root-workspace.defaults.python"]["proof_role"] == "wrapper-smoke"
-    assert "symbol" not in artifacts["root-workspace.defaults.python"]
+    assert artifacts["root-workspace.defaults.python"]["adapter_id"] == "python.function"
+    assert artifacts["root-workspace.defaults.python"]["proof_role"] == "operation-conformance"
+    assert artifacts["root-workspace.defaults.python"]["symbol"] == "generated.workspace.python.commands.defaults_report:invoke"
     assert artifacts["root-workspace.config.python"]["proof_role"] == "wrapper-smoke"
     assert "do not use wrapper execution as the default" in registry["proof_routing"]["rule"]
     assert {route["changed_surface"] for route in registry["proof_routing"]["routes"]} >= {
@@ -831,8 +836,13 @@ def test_operation_artifact_registry_routes_cases_and_proof_layers() -> None:
     }
 
     broken = copy.deepcopy(registry)
-    broken["artifacts"][0]["proof_role"] = "operation-conformance"
+    broken["artifacts"][1]["proof_role"] = "operation-conformance"
     assert any("cli.process must be wrapper-smoke" in error for error in module._validate_operation_artifact_registry(broken))
+    missing_symbol = copy.deepcopy(registry)
+    missing_symbol["artifacts"][0].pop("symbol")
+    assert any(
+        "direct function adapters must declare symbol" in error for error in module._validate_operation_artifact_registry(missing_symbol)
+    )
 
 
 def test_command_package_ir_reuses_generated_adapter_truth() -> None:
@@ -1151,15 +1161,22 @@ def test_generated_command_package_docker_skip_message_uses_proof_label(monkeypa
 
 def test_generated_command_package_docker_conformance_surface_exists() -> None:
     repo_root = Path(__file__).resolve().parents[1]
+    pyproject = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    command_generation_rev = pyproject["tool"]["uv"]["sources"]["command-generation"]["rev"]
     python_dockerfile = repo_root / "generated" / "python" / "Dockerfile.conformance"
     python_text = python_dockerfile.read_text(encoding="utf-8")
+    primitive_python_text = (repo_root / "generated" / "python" / "Dockerfile.primitive-conformance").read_text(encoding="utf-8")
     dockerfile = repo_root / "generated" / "typescript.conformance.Dockerfile"
     text = dockerfile.read_text(encoding="utf-8")
 
     assert "scripts/check/check_generated_command_packages.py" in python_text
     assert "--python-conformance" in python_text
+    assert f"command-generation.git@{command_generation_rev}" in python_text
+    assert f"command-generation.git@{command_generation_rev}" in primitive_python_text
+    assert "ENV PYTHONPATH=/work:" in python_text
     assert "COPY src ./src" in python_text
     assert "COPY generated ./generated" in python_text
+    assert "COPY pyproject.toml ./pyproject.toml" in python_text
     assert "scripts/check/check_generated_command_packages.py" in text
     assert "--conformance" in text
     assert "--require-node" in text

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -142,7 +142,7 @@ def test_generated_command_package_proof_all_runs_every_step(monkeypatch, capsys
     assert "[ok] generated command package proof (8 steps," in capsys.readouterr().out
 
 
-def test_operation_conformance_runner_executes_python_cases() -> None:
+def test_operation_conformance_runner_executes_python_cases(capsys) -> None:
     runner = _load_test_ir_runner()
 
     payload = runner.run_ir_cases(target_selection="python", case_filter=set(), require_node=False)
@@ -154,6 +154,8 @@ def test_operation_conformance_runner_executes_python_cases() -> None:
     assert payload["summary"]["pass_count"] == 3
     cases = {(case["case_id"], case["target"]): case for case in payload["cases"]}
     assert cases[("defaults.selected-output.success", "python")]["state"] == "pass"
+    assert cases[("defaults.selected-output.success", "python")]["adapter_id"] == "python.function"
+    assert "Kind: agentic-workspace/selected-output/v1" not in capsys.readouterr().out
     assert cases[("config.invalid-format.error", "python")]["exit_code"] == 2
     assert cases[("memory.list-skills.parity", "python")]["selected_fields"] == {"mode": "skills"}
 

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c" },
+    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=ccad393f36ca3c01fc15c8f5d6951505e2df1a8d" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -145,7 +145,7 @@ wheels = [
 [[package]]
 name = "command-generation"
 version = "0.1.0"
-source = { git = "https://github.com/rickardvh/command-generation.git?rev=6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c#6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c" }
+source = { git = "https://github.com/rickardvh/command-generation.git?rev=ccad393f36ca3c01fc15c8f5d6951505e2df1a8d#ccad393f36ca3c01fc15c8f5d6951505e2df1a8d" }
 dependencies = [
     { name = "jsonschema" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=4b4547cecc2193810e40f6918a387369a6c1c26a" },
+    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -145,7 +145,7 @@ wheels = [
 [[package]]
 name = "command-generation"
 version = "0.1.0"
-source = { git = "https://github.com/rickardvh/command-generation.git?rev=4b4547cecc2193810e40f6918a387369a6c1c26a#4b4547cecc2193810e40f6918a387369a6c1c26a" }
+source = { git = "https://github.com/rickardvh/command-generation.git?rev=6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c#6afd6b091fb9e1faeb29efea1cfdc314a20c4e7c" }
 dependencies = [
     { name = "jsonschema" },
 ]


### PR DESCRIPTION
## Summary
- pin command-generation to the Python callable generator commit and regenerate Python command packages with `invoke(values)` entry points
- promote the defaults migrated conformance case to `python.function` with registry symbol metadata while preserving wrapper-only rationale for non-promoted cases
- harden generated package proof for source-checkout/Docker contexts and guard direct callable stdout leakage
- record lane closeout evidence while routing the remaining #1476 parent work through the decomposition

## Upstream
- Depends on rickardvh/command-generation#15

## Proof
- `uv run python scripts/check/run_operation_conformance_tests.py --target python`
- `uv run python scripts/check/check_generated_command_packages.py --python-conformance`
- `uv run python scripts/check/check_generated_command_packages.py --python-docker-conformance --require-docker`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py tests/test_contract_tooling.py tests/test_generated_command_package_proof_runner.py src/agentic_workspace/workspace_runtime_primitives.py`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make lint-workspace`
- `make test-workspace`

Fixes #1479