### PR TITLE
Fix upgrade and jumpstart guidance routing

### DIFF
--- a/.agentic-workspace/planning/lanes/lane-1476-generated-python-operation-callables.lane.json
+++ b/.agentic-workspace/planning/lanes/lane-1476-generated-python-operation-callables.lane.json
@@ -2,7 +2,7 @@
   "kind": "planning-lane/v1",
   "id": "lane-1476-generated-python-operation-callables",
   "title": "Promote migrated AW cases to generated Python operation callables",
-  "status": "completed",
+  "status": "closed",
   "parent_decomposition_ref": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
   "lane_outcome": "Applicable migrated AW conformance cases expose generated operation-shaped Python callable surfaces with registry symbol entries and python.function artifacts, replacing wrapper-smoke or cli.process as semantic proof where behavior is operation semantics.",
   "purpose_for_parent": "Advances primitive, operation IR, generated implementation, wrapper, and conformance layers for the Python specimen target.",
@@ -24,7 +24,7 @@
   "lane_to_epic_contribution": "Advances primitive, operation IR, generated implementation, wrapper, and conformance layers for the Python specimen target.",
   "parent_close_permission": "do-not-close-parent",
   "closeout_state": {
-    "status": "completed",
+    "status": "closed",
     "summary": "Applicable migrated AW defaults conformance now uses generated Python callable proof through python.function registry metadata.",
     "residual_work": "Continue parent #1476 from the decomposition for target-extension, TypeScript adapter, broader case conversion, wrapper demotion, ordinary-test inventory, and guardrail lanes.",
     "next_owner": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json"

--- a/packages/planning/README.md
+++ b/packages/planning/README.md
@@ -314,11 +314,14 @@ The package ships these payload files:
 - `.agentic-workspace/planning/execplans/README.md`
 - `.agentic-workspace/planning/execplans/TEMPLATE.plan.json`
 - `.agentic-workspace/planning/execplans/archive/README.md`
+- `.agentic-workspace/planning/lanes/README.md`
+- `.agentic-workspace/planning/lanes/TEMPLATE.lane.json`
 - `.agentic-workspace/planning/schemas/planning-decomposition.schema.json`
 - `.agentic-workspace/planning/schemas/planning-execplan.schema.json`
 - `.agentic-workspace/planning/schemas/planning-external-intent-evidence.schema.json`
 - `.agentic-workspace/planning/schemas/planning-finished-work-evidence.schema.json`
 - `.agentic-workspace/planning/schemas/planning-closeout-evidence.schema.json`
+- `.agentic-workspace/planning/schemas/planning-lane.schema.json`
 - `.agentic-workspace/planning/schemas/planning-review.schema.json`
 
 The package also ships optional payload files that are not copied by default. Use `--include-optional` with `install`, `adopt`, or `upgrade` to copy them on purpose:

--- a/src/agentic_workspace/_payload/.agentic-workspace/docs/jumpstart-contract.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/docs/jumpstart-contract.md
@@ -1,0 +1,41 @@
+# Jumpstart Contract
+
+Jumpstart is the bounded post-bootstrap phase for a newly installed or adopted Agentic Workspace in a lived-in repo. It orients the agent toward useful durable workspace surfaces without turning init into broad repo analysis.
+
+## Entry
+
+Start with compact routing:
+
+```bash
+agentic-workspace start --target . --task "<task>" --format json
+agentic-workspace setup --target . --format json
+```
+
+Use `setup` as a pre-write and pre-seed discovery report. It may point at candidate surfaces, promotion rules, and follow-up routes, but it does not authorize bulk imports or automatic planning/memory writes by itself.
+
+## Promote
+
+Promote only information that has a durable owner and would reduce future rediscovery:
+
+- stable operating boundaries, invariants, traps, restart rules, or proof expectations to Memory;
+- bounded active follow-up to Planning;
+- evidence-backed friction or workflow improvement to improvement intake;
+- package or host-repo documentation gaps to docs only when the missing guidance is reusable.
+
+Keep low-confidence, generic, one-off, or broad narrative findings transient.
+
+## Mature Repo Seed Bias
+
+For mature repos, prefer compact contract-like surfaces over broad prose mirrors. Good first Memory candidates are surfaces that encode repeatable decisions, restart boundaries, task-shape guidance, proof expectations, or other durable operating knowledge.
+
+Do not bulk-import README files, issue backlogs, generated references, or design prose simply because they exist. Link to canonical docs instead of copying them when the document is already discoverable and not expensive to reconstruct.
+
+## Proof
+
+Before claiming setup follow-through, show:
+
+- the setup command used;
+- the candidate surfaces inspected;
+- each promoted, dismissed, or deferred finding;
+- where durable residue was written, if any;
+- the validation command selected for changed paths.

--- a/src/agentic_workspace/_payload/.agentic-workspace/docs/setup-findings-contract.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/docs/setup-findings-contract.md
@@ -1,0 +1,30 @@
+# Setup Findings Contract
+
+Setup findings are optional agent-produced input from post-bootstrap discovery. They let setup, review, validation friction, and memory-improvement signals enter one improvement-intake path without making setup a repo analyzer.
+
+## Artifact
+
+The optional artifact is `tools/setup-findings.json` with kind `workspace-setup-findings/v1`. It is validated against `src/agentic_workspace/contracts/schemas/setup_findings.schema.json`.
+
+Use:
+
+```bash
+agentic-workspace setup --target . --format json
+agentic-workspace defaults --section improvement_intake --format json
+```
+
+## Accepted Classes
+
+`repo_friction_evidence` is for concrete repeated friction that can become a durable improvement issue, check, doc, memory note, contract, or workflow change.
+
+`planning_candidate` is for bounded future work that has a clear owner, next action, and reason it should not be handled inside current setup.
+
+## Promotion Rule
+
+Preserve a setup finding only when it has enough evidence to reduce future rediscovery or route bounded follow-up. Prefer findings with concrete paths, commands, symptoms, reproduction notes, confidence, and a durable owner.
+
+Dismiss or keep transient any finding that is speculative, generic, broad, missing a next action, or only useful to the current chat.
+
+## Boundaries
+
+Do not build a workspace-owned analyzer. Do not auto-write Planning or Memory state from setup input. Do not preserve findings that have no durable owner or bounded next action.

--- a/src/agentic_workspace/contracts/workspace_surfaces.json
+++ b/src/agentic_workspace/contracts/workspace_surfaces.json
@@ -3,7 +3,9 @@
   "payload_files": [
     ".agentic-workspace/WORKFLOW.md",
     ".agentic-workspace/OWNERSHIP.toml",
+    ".agentic-workspace/docs/jumpstart-contract.md",
     ".agentic-workspace/docs/module-map.md",
+    ".agentic-workspace/docs/setup-findings-contract.md",
     ".agentic-workspace/skills/REGISTRY.json",
     ".agentic-workspace/skills/workspace-startup/SKILL.md",
     ".agentic-workspace/skills/workspace-intent-discovery/SKILL.md",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -6326,6 +6326,47 @@ def _lifecycle_cli_invoke(*, config: WorkspaceConfig, invocation_root: Path | No
     return config.cli_invoke
 
 
+def _lifecycle_review_remediations(
+    *, review_items: list[str], warnings: list[str], target_root: Path, selected_modules: list[str], cli_invoke: str
+) -> list[dict[str, Any]]:
+    messages = [*review_items, *warnings]
+    remediations: list[dict[str, Any]] = []
+    target = target_root.as_posix()
+    for module_name, relative_path in MODULE_UPGRADE_SOURCE_PATHS.items():
+        if module_name not in selected_modules:
+            continue
+        relative = relative_path.as_posix()
+        if not any(relative in message for message in messages):
+            continue
+        dry_run = _command_with_cli_invoke(
+            command=f"agentic-workspace upgrade --target {target} --module {module_name} --dry-run --format json",
+            cli_invoke=cli_invoke,
+        )
+        refresh = _command_with_cli_invoke(
+            command=f"agentic-workspace upgrade --target {target} --module {module_name} --format json",
+            cli_invoke=cli_invoke,
+        )
+        remediations.append(
+            {
+                "id": f"refresh-{module_name}-upgrade-source",
+                "module": module_name,
+                "surface": relative,
+                "reason": "recorded module upgrade source metadata is stale or requires review",
+                "review_first": dry_run,
+                "refresh_command": refresh,
+                "proof_after": _command_with_cli_invoke(
+                    command=f"agentic-workspace doctor --target {target} --module {module_name} --format json",
+                    cli_invoke=cli_invoke,
+                ),
+                "rule": (
+                    "Review the recorded source before refreshing it; use the module-specific refresh route "
+                    "instead of rerunning the same broad blocked lifecycle apply."
+                ),
+            }
+        )
+    return remediations
+
+
 def _lifecycle_plan_payload(
     *,
     payload: dict[str, Any],
@@ -6348,6 +6389,13 @@ def _lifecycle_plan_payload(
     warnings = list(payload.get("warnings", []))
     review_items = list(payload.get("needs_review", [])) + list(payload.get("placeholders", []))
     review_required = bool(review_items or warnings or payload.get("prompt_requirement") in {"required", "recommended"})
+    review_remediations = _lifecycle_review_remediations(
+        review_items=review_items,
+        warnings=warnings,
+        target_root=target_root,
+        selected_modules=selected_modules,
+        cli_invoke=cli_invoke,
+    )
     config_payload = payload.get("config", {})
     update_payload = config_payload.get("update", {}) if isinstance(config_payload, dict) else {}
     module_policy_payloads = update_payload.get("modules", []) if isinstance(update_payload, dict) else []
@@ -6407,6 +6455,7 @@ def _lifecycle_plan_payload(
         "warnings": warnings,
         "review_required": review_required,
         "review_items": review_items,
+        "review_remediations": review_remediations,
         "local_only_state_interaction": "install-root" if local_only else "not-requested",
         "module_update_freshness": module_update_freshness,
         "action_owner_groups": action_owner_groups,
@@ -29132,8 +29181,23 @@ def _configured_local_agent_indirection_is_current(*, target_root: Path, config:
     )
 
 
+def _configured_workspace_pointer_is_current(*, target_root: Path, config: WorkspaceConfig) -> bool:
+    agents_relative = Path(config.agent_instructions_file)
+    agents_path = target_root / agents_relative
+    workflow_path = target_root / ".agentic-workspace" / "WORKFLOW.md"
+    if not agents_path.is_file() or not workflow_path.is_file():
+        return False
+    agents_text = agents_path.read_text(encoding="utf-8")
+    return workspace_pointer_block(cli_invoke=config.cli_invoke) in agents_text or (
+        WORKSPACE_WORKFLOW_MARKER_START in agents_text
+        and WORKSPACE_WORKFLOW_MARKER_END in agents_text
+        and ".agentic-workspace/WORKFLOW.md" in agents_text
+    )
+
+
 def _normalize_module_report_startup_paths(report: dict[str, Any], *, target_root: Path, config: WorkspaceConfig) -> dict[str, Any]:
     local_indirection_current = _configured_local_agent_indirection_is_current(target_root=target_root, config=config)
+    workspace_pointer_current = _configured_workspace_pointer_is_current(target_root=target_root, config=config)
 
     def _rewrite_path(value: Any) -> Any:
         if not isinstance(value, str):
@@ -29146,15 +29210,21 @@ def _normalize_module_report_startup_paths(report: dict[str, Any], *, target_roo
     def _normalize_action(action: dict[str, Any]) -> dict[str, Any]:
         normalized = {**action, "path": _rewrite_path(action.get("path"))}
         if (
-            local_indirection_current
+            (local_indirection_current or workspace_pointer_current)
             and action.get("path") == DEFAULT_AGENT_INSTRUCTIONS_FILE
             and action.get("kind") == "manual review"
             and "--apply-local-entrypoint" in str(action.get("detail", ""))
+            and "redundant top-level memory workflow pointer block" not in str(action.get("detail", ""))
         ):
+            detail = (
+                "local startup indirection points to AGENTS.local.md workspace workflow block"
+                if local_indirection_current
+                else "workspace workflow pointer already routes startup through the shared workspace contract"
+            )
             normalized = {
                 **normalized,
                 "kind": "current",
-                "detail": "local startup indirection points to AGENTS.local.md workspace workflow block",
+                "detail": detail,
                 "safety": "safe",
                 "category": "safe-update",
             }
@@ -29162,9 +29232,10 @@ def _normalize_module_report_startup_paths(report: dict[str, Any], *, target_roo
 
     def _normalize_warning(warning: dict[str, Any]) -> dict[str, Any] | None:
         if (
-            local_indirection_current
+            (local_indirection_current or workspace_pointer_current)
             and warning.get("path") == DEFAULT_AGENT_INSTRUCTIONS_FILE
             and "--apply-local-entrypoint" in str(warning.get("message", ""))
+            and "redundant top-level memory workflow pointer block" not in str(warning.get("message", ""))
         ):
             return None
         return {**warning, "path": _rewrite_path(warning.get("path"))}
@@ -29174,7 +29245,8 @@ def _normalize_module_report_startup_paths(report: dict[str, Any], *, target_roo
         or DEFAULT_AGENT_INSTRUCTIONS_FILE in config.detected_agent_instructions_files
     ):
         if not local_indirection_current:
-            return report
+            if not workspace_pointer_current:
+                return report
         warnings = [_normalize_warning(warning) for warning in report["warnings"]]
         return {
             **report,

--- a/tests/test_workspace_doctor_status_cli.py
+++ b/tests/test_workspace_doctor_status_cli.py
@@ -288,7 +288,9 @@ def test_doctor_json_exposes_standardised_summary_fields(monkeypatch, tmp_path: 
     (tmp_path / ".agentic-workspace").mkdir(parents=True)
     _write((tmp_path / ".agentic-workspace" / "WORKFLOW.md"), "# Workflow\n")
     _write((tmp_path / ".agentic-workspace" / "OWNERSHIP.toml"), "schema_version = 1\n")
+    _write((tmp_path / ".agentic-workspace" / "docs" / "jumpstart-contract.md"), "# Jumpstart Contract\n")
     _write((tmp_path / ".agentic-workspace" / "docs" / "module-map.md"), "# Installed Module Map\n")
+    _write((tmp_path / ".agentic-workspace" / "docs" / "setup-findings-contract.md"), "# Setup Findings Contract\n")
     _write(
         (tmp_path / ".agentic-workspace" / "skills" / "REGISTRY.json"),
         '{"schema_version":"skill-registry.v1","owner":"agentic-workspace","source_kind":"installed-workspace-skills","skills":[]}\n',
@@ -394,6 +396,7 @@ def test_doctor_real_init_preserves_package_contract_shortlists_in_reports(tmp_p
         and ".agentic-workspace/memory/UPGRADE-SOURCE.toml" in action["detail"]
         for action in memory_report["actions"]
     )
+    assert not any(action["path"] == "AGENTS.md" and "--apply-local-entrypoint" in action["detail"] for action in memory_report["actions"])
 
 
 def test_doctor_text_output_shows_package_contract_shortlists(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_lifecycle_cli.py
+++ b/tests/test_workspace_lifecycle_cli.py
@@ -1106,6 +1106,40 @@ def test_lifecycle_plan_uses_resolved_cli_invoke_for_next_actions(monkeypatch, t
     assert payload["next_steps"][0].startswith("Run uv run agentic-workspace doctor ")
 
 
+def test_lifecycle_plan_exposes_module_source_refresh_for_stale_upgrade_source(tmp_path: Path) -> None:
+    payload = {
+        "warnings": [".agentic-workspace/memory/UPGRADE-SOURCE.toml: recorded bootstrap source metadata is stale"],
+        "needs_review": [],
+        "placeholders": [],
+        "created": [],
+        "updated_managed": [],
+        "preserved_existing": [],
+        "module_reports": [],
+        "reports": [],
+    }
+
+    lifecycle_plan = cli._lifecycle_plan_payload(  # type: ignore[attr-defined]
+        payload=payload,
+        command_name="upgrade",
+        target_root=tmp_path,
+        selected_modules=["memory"],
+        dry_run=True,
+        local_only=False,
+        cli_invoke="uv run agentic-workspace",
+    )
+
+    assert lifecycle_plan["review_required"] is True
+    assert lifecycle_plan["next_safe_command"]["status"] == "review-required"
+    remediation = lifecycle_plan["review_remediations"][0]
+    assert remediation["id"] == "refresh-memory-upgrade-source"
+    assert remediation["surface"] == ".agentic-workspace/memory/UPGRADE-SOURCE.toml"
+    assert remediation["review_first"].startswith("uv run agentic-workspace upgrade ")
+    assert "--module memory" in remediation["review_first"]
+    assert remediation["refresh_command"].startswith("uv run agentic-workspace upgrade ")
+    assert "--dry-run" not in remediation["refresh_command"]
+    assert remediation["proof_after"].startswith("uv run agentic-workspace doctor ")
+
+
 def test_install_review_next_actions_use_invoking_workspace_cli_invoke(monkeypatch, tmp_path: Path, capsys) -> None:
     source = tmp_path / "source"
     target = tmp_path / "target"


### PR DESCRIPTION
## Summary
- Treat the shared workspace AGENTS.md pointer as satisfying composed workspace startup so root doctor/status no longer surface conflicting memory-only `--apply-local-entrypoint` guidance.
- Add lifecycle `review_remediations` for stale module `UPGRADE-SOURCE.toml` review, with module-specific review, refresh, and proof commands.
- Ship the jumpstart and setup-findings contract docs in the installed workspace payload.
- Repair a checked-in lane closeout status from `completed` to the schema-supported `closed`, which unblocked structured inventory proof.

## Validation
- `uv run pytest tests/test_workspace_doctor_status_cli.py tests/test_workspace_lifecycle_cli.py -q`
- `uv run pytest tests/test_workspace_packaging.py -q`
- `uv run python scripts/check/check_contract_tooling_surfaces.py`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_source_payload_operational_install.py` (warning-only existing Planning README payload-claim drift)
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `make lint-workspace`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_doctor_status_cli.py tests/test_workspace_lifecycle_cli.py`
- `make test-workspace`

Fixes #1496