### PR TITLE
[codex] Add TypeScript direct operation conformance

### DIFF
--- a/.agentic-workspace/planning/closeout-evidence/lane-1476-typescript-direct-operation-adapter.closeout.json
+++ b/.agentic-workspace/planning/closeout-evidence/lane-1476-typescript-direct-operation-adapter.closeout.json
@@ -1,0 +1,108 @@
+{
+  "kind": "planning-closeout-evidence/v1",
+  "title": "Add or route TypeScript direct operation conformance",
+  "plan_id": "lane-1476-typescript-direct-operation-adapter",
+  "created_at": "2026-06-13T21:02:07.429303+00:00",
+  "source_plan": ".agentic-workspace/planning/execplans/lane-1476-typescript-direct-operation-adapter.plan.json",
+  "intended_archive": ".agentic-workspace/planning/execplans/archive/lane-1476-typescript-direct-operation-adapter.plan.json",
+  "retention": {
+    "state": "archive-retention-skipped",
+    "reason": "retained archive would exceed the structured-file inventory max_bytes guardrail; closing after distillation instead",
+    "canonical_evidence": "retained closeout evidence",
+    "ordinary_route": "agentic-workspace summary --format json or report --section closeout_report --format json",
+    "trust_rule": "When this record exists, agents should trust it as the closeout handoff surface without inspecting the omitted full execplan archive.",
+    "rule": "Retained closeout evidence preserves reportable closeout facts when the full execplan archive exceeds inventory size guardrails."
+  },
+  "active_milestone": {
+    "id": "lane-1476-typescript-direct-operation-adapter",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "delegated_judgment": {
+    "requested outcome": "Promoted from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json lane lane-1476-typescript-direct-operation-adapter.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning promote-to-plan decomposition lane",
+    "what happened": "Added a TypeScript direct operation-conformance path for the migrated defaults case, promoted TypeScript target support to implemented, and kept existing CLI parity/error cases as wrapper-smoke proof.",
+    "scope touched": "#1476 TypeScript direct operation adapter lane only.",
+    "changed surfaces": "target_support.json, operation artifact/conformance registries, conformance runner, contract/proof tests, active lane planning record.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within the promoted lane; TypeScript direct proof now uses generated runtime.mjs runGeneratedOperation and does not relabel wrapper cases as semantic proof. Parent decomposition remains the owner for remaining #1476 lanes.",
+    "proof status": "passed",
+    "intent served": "no; intent-status=partial keeps continuation explicit.",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json"
+  },
+  "proof_report": {
+    "validation proof": "Passed: uv run pytest tests/test_contract_tooling.py tests/test_generated_command_package_proof_runner.py -q; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/run_operation_conformance_tests.py --target typescript --require-node --format json; uv run python scripts/check/check_generated_command_packages.py --conformance --require-node; uv run python scripts/check/run_operation_conformance_tests.py --target python --format json; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make test-workspace; make lint-workspace.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "#1476 requires an enforced end-to-end model where operation/primitive IR, contracts, and input-output cases generate implementation artifacts, wrappers, and conformance executors, while ordinary feature work changes IR/contracts/cases rather than generated executable code or one-off behavior regressions.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status partial.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json activates a fresh bounded slice."
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "execution_summary": {
+    "outcome delivered": "Applicable migrated defaults case now runs through typescript.function; target support matrix projects python.function and typescript.function; parent #1476 continuation remains in the decomposition.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+          "owner": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  }
+}

--- a/.agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json
@@ -70,9 +70,9 @@
     {
       "id": "lane-1476-typescript-direct-operation-adapter",
       "title": "Add or route TypeScript direct operation conformance",
-      "readiness": "needs-shaping",
+      "readiness": "promoted",
       "outcome": "TypeScript direct operation conformance is implemented through command-generation machinery, or a precise follow-up owns the adapter boundary with proof that wrapper execution is not treated as final semantic substitute.",
-      "owner_surface": "command-generation#14 TypeScript function adapter machinery and AW target support declaration",
+      "owner_surface": ".agentic-workspace/planning/closeout-evidence/lane-1476-typescript-direct-operation-adapter.closeout.json",
       "proof": "Applicable cases can run through typescript.function or a durable owner-approved adapter-boundary follow-up exists with closure impact recorded on #1476.",
       "slice_contribution_to_parent": "Advances generated implementation, target-extension, and conformance layers beyond Python.",
       "residual_parent_intent": "Wrapper demotion, ordinary-test inventory, and final closure guardrails remain unless already satisfied.",

--- a/docs/package/generated-behavior-test-inventory.md
+++ b/docs/package/generated-behavior-test-inventory.md
@@ -24,6 +24,7 @@ The shared package now owns the generic machinery that AW should not duplicate:
 | --- | --- | --- |
 | CLI/process contract execution | `process_case_from_contract`, `CliConformanceTarget`, `run_cli_conformance_case` | Used for wrapper-smoke execution of AW-specific cases. |
 | Direct JSON-shaped function execution | `operation_case_from_contract`, `FunctionConformanceTarget`, `run_function_conformance_case` | Used by AW runner for `python.function` artifacts when the registry declares an importable symbol. |
+| TypeScript direct operation execution | `TypescriptFunctionConformanceTarget`, `run_typescript_function_conformance_case` | Used by AW runner for `typescript.function` artifacts through generated `invokeGeneratedOperation(...)` runtime exports. |
 | Shared ownership/accounting | `conformance_ownership_inventory` | Records which conformance surfaces are generic and which remain consumer-owned. |
 | Package-owned reusable conformance cases | `contract_conformance_cases_manifest`, `load_contract_conformance_case` from `rickardvh/command-generation#13` | Replaces repeated inline generic conformance payloads in command-generation tests; AW consumes the pinned revision instead of carrying generic cases. |
 | Generated output staleness by target family | `generated_output_freshness_report` | AW consumes it for generated package freshness instead of owning generic hashing semantics. |
@@ -56,4 +57,4 @@ The previous AW-local generic command-generation primitive and artifact tests we
 
 ## Remaining Trigger
 
-The current registry has no real `python.function` or `typescript.function` implementation artifacts for the migrated AW cases, so direct operation conformance is installed as a runner path and tested with a synthetic artifact. When generated command packages expose importable operation functions, add registry `symbol` entries, promote the affected cases from `cli.process` wrapper-smoke to `*.function` operation-conformance, and demote the corresponding wrapper tests to boundary-only smoke.
+The `defaults.selected-output.success` case now has real `python.function` and `typescript.function` artifacts in the registry, with TypeScript routed through the generated `invokeGeneratedOperation(...)` callable rather than the CLI writer path. Remaining migration work should promote additional behavior only when a direct operation artifact exists for that behavior; otherwise keep CLI coverage as wrapper-smoke proof and leave semantic completion claims on direct operation adapters.

--- a/generated/memory/typescript/src/runtime.mjs
+++ b/generated/memory/typescript/src/runtime.mjs
@@ -813,21 +813,32 @@ function executeTypescriptDomainOperation(operationId, values) {
   return { command: values._command_path?.join(' ') ?? operationId, target_root: target, dry_run: Boolean(values.dry_run), message: operationId };
 }
 
-export function runGeneratedOperation({ operationId, operationPath, values }) {
+function executeGeneratedOperationValues({ operationId, operationPath, values }) {
   if (!operationId) throw new RuntimeError('generated command has no operation id');
   if (values.strict_preflight === true && !values.preflight_token) {
-    writeSync(2, 'Strict preflight gate is enabled. Provide --preflight-token to continue.\n');
-    return 2;
+    throw new RuntimeError('Strict preflight gate is enabled. Provide --preflight-token to continue.');
   }
-  let output;
   if (!operationPath) throw new RuntimeError(`operation ${operationId} has no operation resource path`);
   const resourcePath = resolveInside(resourcesRoot, operationPath);
   if (!existsSync(resourcePath)) throw new RuntimeError(`operation resource is missing: ${operationPath}`);
   const operation = loadJsonResource(operationPath);
   const steps = operation?.ir_plan?.steps;
   if (!Array.isArray(steps) || steps.length === 0) throw new RuntimeError(`operation ${operationId} has no executable ir_plan.steps`);
-  const finalValues = runSteps(operation, { ...values });
-  output = finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
+  return runSteps(operation, { ...values });
+}
+
+export function invokeGeneratedOperation({ operationId, operationPath, values }) {
+  const finalValues = executeGeneratedOperationValues({ operationId, operationPath, values });
+  return finalValues.result ?? finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
+}
+
+export function runGeneratedOperation({ operationId, operationPath, values }) {
+  if (values.strict_preflight === true && !values.preflight_token) {
+    writeSync(2, 'Strict preflight gate is enabled. Provide --preflight-token to continue.\n');
+    return 2;
+  }
+  const finalValues = executeGeneratedOperationValues({ operationId, operationPath, values });
+  let output = finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
   if (typeof output !== 'string') output = `${JSON.stringify(output, null, 2)}\n`;
   writeSync(1, output);
   return 0;

--- a/generated/planning/typescript/src/runtime.mjs
+++ b/generated/planning/typescript/src/runtime.mjs
@@ -813,21 +813,32 @@ function executeTypescriptDomainOperation(operationId, values) {
   return { command: values._command_path?.join(' ') ?? operationId, target_root: target, dry_run: Boolean(values.dry_run), message: operationId };
 }
 
-export function runGeneratedOperation({ operationId, operationPath, values }) {
+function executeGeneratedOperationValues({ operationId, operationPath, values }) {
   if (!operationId) throw new RuntimeError('generated command has no operation id');
   if (values.strict_preflight === true && !values.preflight_token) {
-    writeSync(2, 'Strict preflight gate is enabled. Provide --preflight-token to continue.\n');
-    return 2;
+    throw new RuntimeError('Strict preflight gate is enabled. Provide --preflight-token to continue.');
   }
-  let output;
   if (!operationPath) throw new RuntimeError(`operation ${operationId} has no operation resource path`);
   const resourcePath = resolveInside(resourcesRoot, operationPath);
   if (!existsSync(resourcePath)) throw new RuntimeError(`operation resource is missing: ${operationPath}`);
   const operation = loadJsonResource(operationPath);
   const steps = operation?.ir_plan?.steps;
   if (!Array.isArray(steps) || steps.length === 0) throw new RuntimeError(`operation ${operationId} has no executable ir_plan.steps`);
-  const finalValues = runSteps(operation, { ...values });
-  output = finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
+  return runSteps(operation, { ...values });
+}
+
+export function invokeGeneratedOperation({ operationId, operationPath, values }) {
+  const finalValues = executeGeneratedOperationValues({ operationId, operationPath, values });
+  return finalValues.result ?? finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
+}
+
+export function runGeneratedOperation({ operationId, operationPath, values }) {
+  if (values.strict_preflight === true && !values.preflight_token) {
+    writeSync(2, 'Strict preflight gate is enabled. Provide --preflight-token to continue.\n');
+    return 2;
+  }
+  const finalValues = executeGeneratedOperationValues({ operationId, operationPath, values });
+  let output = finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
   if (typeof output !== 'string') output = `${JSON.stringify(output, null, 2)}\n`;
   writeSync(1, output);
   return 0;

--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -2,7 +2,7 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir jsonschema "command-generation @ git+https://github.com/rickardvh/command-generation.git@e9fafcd8d289748f84069419ff7644ec5bede82e"
+RUN python -m pip install --no-cache-dir jsonschema "command-generation @ git+https://github.com/rickardvh/command-generation.git@0bc4f76687d9587808b9e7d4f42362e10566be35"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -2,7 +2,7 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir jsonschema "command-generation @ git+https://github.com/rickardvh/command-generation.git@7a965c98dc978010ba810e006b9654f51434f3b7"
+RUN python -m pip install --no-cache-dir jsonschema "command-generation @ git+https://github.com/rickardvh/command-generation.git@e9fafcd8d289748f84069419ff7644ec5bede82e"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/python/Dockerfile.primitive-conformance
+++ b/generated/python/Dockerfile.primitive-conformance
@@ -2,6 +2,6 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir "command-generation @ git+https://github.com/rickardvh/command-generation.git@7a965c98dc978010ba810e006b9654f51434f3b7"
+RUN python -m pip install --no-cache-dir "command-generation @ git+https://github.com/rickardvh/command-generation.git@e9fafcd8d289748f84069419ff7644ec5bede82e"
 
 CMD ["python", "-m", "command_generation.primitive_conformance"]

--- a/generated/python/Dockerfile.primitive-conformance
+++ b/generated/python/Dockerfile.primitive-conformance
@@ -2,6 +2,6 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir "command-generation @ git+https://github.com/rickardvh/command-generation.git@e9fafcd8d289748f84069419ff7644ec5bede82e"
+RUN python -m pip install --no-cache-dir "command-generation @ git+https://github.com/rickardvh/command-generation.git@0bc4f76687d9587808b9e7d4f42362e10566be35"
 
 CMD ["python", "-m", "command_generation.primitive_conformance"]

--- a/generated/verification/typescript/src/runtime.mjs
+++ b/generated/verification/typescript/src/runtime.mjs
@@ -813,21 +813,32 @@ function executeTypescriptDomainOperation(operationId, values) {
   return { command: values._command_path?.join(' ') ?? operationId, target_root: target, dry_run: Boolean(values.dry_run), message: operationId };
 }
 
-export function runGeneratedOperation({ operationId, operationPath, values }) {
+function executeGeneratedOperationValues({ operationId, operationPath, values }) {
   if (!operationId) throw new RuntimeError('generated command has no operation id');
   if (values.strict_preflight === true && !values.preflight_token) {
-    writeSync(2, 'Strict preflight gate is enabled. Provide --preflight-token to continue.\n');
-    return 2;
+    throw new RuntimeError('Strict preflight gate is enabled. Provide --preflight-token to continue.');
   }
-  let output;
   if (!operationPath) throw new RuntimeError(`operation ${operationId} has no operation resource path`);
   const resourcePath = resolveInside(resourcesRoot, operationPath);
   if (!existsSync(resourcePath)) throw new RuntimeError(`operation resource is missing: ${operationPath}`);
   const operation = loadJsonResource(operationPath);
   const steps = operation?.ir_plan?.steps;
   if (!Array.isArray(steps) || steps.length === 0) throw new RuntimeError(`operation ${operationId} has no executable ir_plan.steps`);
-  const finalValues = runSteps(operation, { ...values });
-  output = finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
+  return runSteps(operation, { ...values });
+}
+
+export function invokeGeneratedOperation({ operationId, operationPath, values }) {
+  const finalValues = executeGeneratedOperationValues({ operationId, operationPath, values });
+  return finalValues.result ?? finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
+}
+
+export function runGeneratedOperation({ operationId, operationPath, values }) {
+  if (values.strict_preflight === true && !values.preflight_token) {
+    writeSync(2, 'Strict preflight gate is enabled. Provide --preflight-token to continue.\n');
+    return 2;
+  }
+  const finalValues = executeGeneratedOperationValues({ operationId, operationPath, values });
+  let output = finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
   if (typeof output !== 'string') output = `${JSON.stringify(output, null, 2)}\n`;
   writeSync(1, output);
   return 0;

--- a/generated/workspace/typescript/src/runtime.mjs
+++ b/generated/workspace/typescript/src/runtime.mjs
@@ -813,21 +813,32 @@ function executeTypescriptDomainOperation(operationId, values) {
   return { command: values._command_path?.join(' ') ?? operationId, target_root: target, dry_run: Boolean(values.dry_run), message: operationId };
 }
 
-export function runGeneratedOperation({ operationId, operationPath, values }) {
+function executeGeneratedOperationValues({ operationId, operationPath, values }) {
   if (!operationId) throw new RuntimeError('generated command has no operation id');
   if (values.strict_preflight === true && !values.preflight_token) {
-    writeSync(2, 'Strict preflight gate is enabled. Provide --preflight-token to continue.\n');
-    return 2;
+    throw new RuntimeError('Strict preflight gate is enabled. Provide --preflight-token to continue.');
   }
-  let output;
   if (!operationPath) throw new RuntimeError(`operation ${operationId} has no operation resource path`);
   const resourcePath = resolveInside(resourcesRoot, operationPath);
   if (!existsSync(resourcePath)) throw new RuntimeError(`operation resource is missing: ${operationPath}`);
   const operation = loadJsonResource(operationPath);
   const steps = operation?.ir_plan?.steps;
   if (!Array.isArray(steps) || steps.length === 0) throw new RuntimeError(`operation ${operationId} has no executable ir_plan.steps`);
-  const finalValues = runSteps(operation, { ...values });
-  output = finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
+  return runSteps(operation, { ...values });
+}
+
+export function invokeGeneratedOperation({ operationId, operationPath, values }) {
+  const finalValues = executeGeneratedOperationValues({ operationId, operationPath, values });
+  return finalValues.result ?? finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
+}
+
+export function runGeneratedOperation({ operationId, operationPath, values }) {
+  if (values.strict_preflight === true && !values.preflight_token) {
+    writeSync(2, 'Strict preflight gate is enabled. Provide --preflight-token to continue.\n');
+    return 2;
+  }
+  const finalValues = executeGeneratedOperationValues({ operationId, operationPath, values });
+  let output = finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
   if (typeof output !== 'string') output = `${JSON.stringify(output, null, 2)}\n`;
   writeSync(1, output);
   return 0;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ package = true
 agentic-memory = { workspace = true }
 agentic-planning = { workspace = true }
 agentic-verification = { workspace = true }
-command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "7a965c98dc978010ba810e006b9654f51434f3b7" }
+command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "e9fafcd8d289748f84069419ff7644ec5bede82e" }
 
 [tool.uv.workspace]
 members = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ package = true
 agentic-memory = { workspace = true }
 agentic-planning = { workspace = true }
 agentic-verification = { workspace = true }
-command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "e9fafcd8d289748f84069419ff7644ec5bede82e" }
+command-generation = { git = "https://github.com/rickardvh/command-generation.git", rev = "0bc4f76687d9587808b9e7d4f42362e10566be35" }
 
 [tool.uv.workspace]
 members = [

--- a/scripts/check/check_contract_tooling_surfaces.py
+++ b/scripts/check/check_contract_tooling_surfaces.py
@@ -1312,8 +1312,8 @@ def _validate_target_support(payload: dict[str, object]) -> list[str]:
     matrix_by_target = {entry["target_id"]: entry for entry in matrix_entries}
     if matrix_by_target.get("python", {}).get("adapter_id") != "python.function":
         errors.append("target_support.json implemented python target must project python.function into the semantic matrix")
-    if "typescript" in matrix_by_target:
-        errors.append("target_support.json planned typescript target must not project into implemented semantic matrix yet")
+    if matrix_by_target.get("typescript", {}).get("adapter_id") != "typescript.function":
+        errors.append("target_support.json implemented typescript target must project typescript.function into the semantic matrix")
     rule = str(payload.get("rule", "")).lower()
     if "must not own product operation semantics" not in rule or "per-operation feature maintenance" not in rule:
         errors.append("target_support.json rule must reject product semantics and per-operation feature maintenance in targets")

--- a/scripts/check/run_operation_conformance_tests.py
+++ b/scripts/check/run_operation_conformance_tests.py
@@ -156,6 +156,8 @@ def _run_case_target(
     adapter_id = str(artifact.get("adapter_id", "cli.process"))
     if target_kind == "python" and adapter_id == "python.function":
         return _run_python_function_case(case=case, artifact=artifact)
+    if target_kind == "typescript" and adapter_id == "typescript.function":
+        return _run_typescript_function_case(case=case, artifact=artifact, temp_root=temp_root, require_node=require_node)
     process_case = _case_process_fixture(case)
     fixture_root = materialize_case_fixture(
         case=process_case,
@@ -235,6 +237,92 @@ def _python_function_target_for_artifact(artifact: Mapping[str, object]) -> Func
     return FunctionConformanceTarget(label=str(artifact.get("artifact_id", "python.function")), invoke=invoke)
 
 
+def _typescript_runtime_symbol(artifact: Mapping[str, object]) -> tuple[Path, str] | None:
+    symbol = str(artifact.get("symbol", ""))
+    if ":" not in symbol:
+        return None
+    runtime_path, function_name = symbol.rsplit(":", 1)
+    if not runtime_path or not function_name:
+        return None
+    return REPO_ROOT / runtime_path, function_name
+
+
+def _run_typescript_function_case(
+    *,
+    case: Mapping[str, object],
+    artifact: Mapping[str, object],
+    temp_root: Path,
+    require_node: bool,
+) -> dict[str, object]:
+    node = shutil.which("node")
+    if node is None:
+        state = "fail" if require_node else "unavailable"
+        return _function_result(case=case, artifact=artifact, state=state, message="node-unavailable")
+    runtime_symbol = _typescript_runtime_symbol(artifact)
+    if runtime_symbol is None:
+        return _function_result(case=case, artifact=artifact, state="unavailable", message="typescript.function artifact has no runtime symbol")
+    runtime_path, function_name = runtime_symbol
+    if not runtime_path.is_file():
+        return _function_result(
+            case=case,
+            artifact=artifact,
+            state="unavailable",
+            message=f"typescript.function runtime is missing: {runtime_path.relative_to(REPO_ROOT).as_posix()}",
+        )
+
+    operation_ref = case.get("operation_ref", {})
+    if not isinstance(operation_ref, Mapping):
+        return _function_result(case=case, artifact=artifact, state="fail", message="malformed operation_ref")
+    case_input = case.get("input", {})
+    if not isinstance(case_input, Mapping):
+        return _function_result(case=case, artifact=artifact, state="fail", message="malformed input block")
+    process_case = _case_process_fixture(case)
+    fixture_root = materialize_case_fixture(
+        case=process_case,
+        root=temp_root / str(case.get("id", "case")).replace(".", "-") / "typescript-function",
+    )
+    runner = temp_root / "typescript_function_runner.mjs"
+    runner.write_text(
+        "import { pathToFileURL } from 'node:url';\n"
+        "const runtime = await import(pathToFileURL(process.argv[2]).href);\n"
+        "const functionName = process.argv[3];\n"
+        "const payload = JSON.parse(process.argv[4]);\n"
+        "if (typeof runtime[functionName] !== 'function') {\n"
+        "  throw new Error(`missing TypeScript operation function: ${functionName}`);\n"
+        "}\n"
+        "const exitCode = runtime[functionName](payload);\n"
+        "process.exitCode = Number.isInteger(exitCode) ? exitCode : 0;\n",
+        encoding="utf-8",
+    )
+    payload = {
+        "operationId": str(operation_ref.get("operation_id", "")),
+        "operationPath": str(operation_ref.get("operation_path", "")),
+        "values": dict(case_input.get("json", {})) if isinstance(case_input.get("json", {}), Mapping) else {},
+    }
+    completed = subprocess.run(
+        [node, str(runner), str(runtime_path), function_name, json.dumps(payload, sort_keys=True)],
+        cwd=fixture_root,
+        env=generated_package_check._conformance_env(runtime=""),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    failures = _evaluate_process_result(case=case, process_case=process_case, completed=completed)
+    return {
+        "case_id": str(case.get("id", "")),
+        "behavioral_class": str(case.get("behavioral_class", "")),
+        "operation_id": str(operation_ref.get("operation_id", "")),
+        "artifact_id": str(artifact.get("artifact_id", "")),
+        "adapter_id": str(artifact.get("adapter_id", "typescript.function")),
+        "conformance_ref": str(operation_ref.get("conformance_ref", "")),
+        "target": "typescript",
+        "state": "fail" if failures else "pass",
+        "exit_code": completed.returncode,
+        "selected_fields": _selected_fields_or_empty(process_case, completed.stdout) if not failures else {},
+        "message": "; ".join(failures) if failures else "",
+    }
+
+
 def _function_result(
     *,
     case: Mapping[str, object],
@@ -245,14 +333,16 @@ def _function_result(
     operation_ref = case.get("operation_ref", {})
     operation_id = operation_ref.get("operation_id", "") if isinstance(operation_ref, Mapping) else ""
     conformance_ref = operation_ref.get("conformance_ref", "") if isinstance(operation_ref, Mapping) else ""
+    adapter_id = str(artifact.get("adapter_id", "python.function"))
+    target = adapter_id.split(".", 1)[0] if "." in adapter_id else "python"
     return {
         "case_id": str(case.get("id", "")),
         "behavioral_class": str(case.get("behavioral_class", "")),
         "operation_id": str(operation_id),
         "artifact_id": str(artifact.get("artifact_id", "")),
-        "adapter_id": str(artifact.get("adapter_id", "python.function")),
+        "adapter_id": adapter_id,
         "conformance_ref": str(conformance_ref),
-        "target": "python",
+        "target": target,
         "state": state,
         "message": message,
     }

--- a/scripts/check/run_operation_conformance_tests.py
+++ b/scripts/check/run_operation_conformance_tests.py
@@ -26,8 +26,10 @@ import check_generated_command_packages as generated_package_check  # noqa: E402
 from command_generation import (  # noqa: E402
     FunctionConformanceTarget,
     OperationConformanceCase,
+    TypescriptFunctionConformanceTarget,
     materialize_case_fixture,
     run_function_conformance_case,
+    run_typescript_function_conformance_case,
 )
 from command_generation.conformance import ProcessConformanceCase  # noqa: E402
 
@@ -281,33 +283,20 @@ def _run_typescript_function_case(
         case=process_case,
         root=temp_root / str(case.get("id", "case")).replace(".", "-") / "typescript-function",
     )
-    runner = temp_root / "typescript_function_runner.mjs"
-    runner.write_text(
-        "import { pathToFileURL } from 'node:url';\n"
-        "const runtime = await import(pathToFileURL(process.argv[2]).href);\n"
-        "const functionName = process.argv[3];\n"
-        "const payload = JSON.parse(process.argv[4]);\n"
-        "if (typeof runtime[functionName] !== 'function') {\n"
-        "  throw new Error(`missing TypeScript operation function: ${functionName}`);\n"
-        "}\n"
-        "const exitCode = runtime[functionName](payload);\n"
-        "process.exitCode = Number.isInteger(exitCode) ? exitCode : 0;\n",
-        encoding="utf-8",
+    function_case = _case_function_fixture(case)
+    result, failures = run_typescript_function_conformance_case(
+        case=function_case,
+        target=TypescriptFunctionConformanceTarget(
+            label=str(artifact.get("artifact_id", "typescript.function")),
+            runtime_path=runtime_path,
+            operation_id=str(operation_ref.get("operation_id", "")),
+            operation_path=str(operation_ref.get("operation_path", "")),
+            cwd=fixture_root,
+            node_command=node,
+            function_name=function_name,
+            env=generated_package_check._conformance_env(runtime=""),
+        ),
     )
-    payload = {
-        "operationId": str(operation_ref.get("operation_id", "")),
-        "operationPath": str(operation_ref.get("operation_path", "")),
-        "values": dict(case_input.get("json", {})) if isinstance(case_input.get("json", {}), Mapping) else {},
-    }
-    completed = subprocess.run(
-        [node, str(runner), str(runtime_path), function_name, json.dumps(payload, sort_keys=True)],
-        cwd=fixture_root,
-        env=generated_package_check._conformance_env(runtime=""),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    failures = _evaluate_process_result(case=case, process_case=process_case, completed=completed)
     return {
         "case_id": str(case.get("id", "")),
         "behavioral_class": str(case.get("behavioral_class", "")),
@@ -317,9 +306,8 @@ def _run_typescript_function_case(
         "conformance_ref": str(operation_ref.get("conformance_ref", "")),
         "target": "typescript",
         "state": "fail" if failures else "pass",
-        "exit_code": completed.returncode,
-        "selected_fields": _selected_fields_or_empty(process_case, completed.stdout) if not failures else {},
-        "message": "; ".join(failures) if failures else "",
+        "selected_fields": result.selected_fields if result is not None and result.selected_fields is not None else {},
+        "message": "; ".join(failure.message for failure in failures),
     }
 
 

--- a/src/agentic_workspace/contracts/contract_inventory.json
+++ b/src/agentic_workspace/contracts/contract_inventory.json
@@ -436,7 +436,7 @@
       "consumers": [
         "scripts/check/check_contract_tooling_surfaces.py",
         "command-generation target-extension contract",
-        "future #1481 TypeScript direct-operation support"
+        "#1481 TypeScript direct-operation support"
       ],
       "notes": "AW target-support declarations consume command-generation target-extension contracts so implemented targets can enter the semantic conformance matrix without target-specific product semantics or per-operation feature maintenance."
     },

--- a/src/agentic_workspace/contracts/operation_artifact_registry.json
+++ b/src/agentic_workspace/contracts/operation_artifact_registry.json
@@ -65,7 +65,7 @@
       "target": "typescript",
       "adapter_id": "typescript.function",
       "proof_role": "operation-conformance",
-      "symbol": "generated/workspace/typescript/src/runtime.mjs:runGeneratedOperation",
+      "symbol": "generated/workspace/typescript/src/runtime.mjs:invokeGeneratedOperation",
       "source_ref": "command_package_ir:root-workspace/defaults",
       "wrapper_refs": [
         "defaults.report.cli"

--- a/src/agentic_workspace/contracts/operation_artifact_registry.json
+++ b/src/agentic_workspace/contracts/operation_artifact_registry.json
@@ -59,6 +59,33 @@
       ]
     },
     {
+      "artifact_id": "root-workspace.defaults.typescript",
+      "operation_id": "defaults.report",
+      "package_id": "root-workspace",
+      "target": "typescript",
+      "adapter_id": "typescript.function",
+      "proof_role": "operation-conformance",
+      "symbol": "generated/workspace/typescript/src/runtime.mjs:runGeneratedOperation",
+      "source_ref": "command_package_ir:root-workspace/defaults",
+      "wrapper_refs": [
+        "defaults.report.cli"
+      ],
+      "case_ids": [
+        "defaults.selected-output.success"
+      ],
+      "path_refs": [
+        "generated/workspace/typescript/src/runtime.mjs",
+        "generated/workspace/typescript/resources/operations/defaults.report.json",
+        "src/agentic_workspace/contracts/operations/defaults.report.json",
+        "src/agentic_workspace/contracts/conformance/defaults.selected-text.process.json"
+      ],
+      "stale_when": [
+        "defaults.report operation contract changes",
+        "root-workspace defaults generated TypeScript runtime artifact changes",
+        "defaults.selected-text.process conformance expectations change"
+      ]
+    },
+    {
       "artifact_id": "root-workspace.config.typescript",
       "operation_id": "config.report",
       "package_id": "root-workspace",

--- a/src/agentic_workspace/contracts/operation_conformance_test_ir.json
+++ b/src/agentic_workspace/contracts/operation_conformance_test_ir.json
@@ -269,7 +269,7 @@
           "CLI wrapper text-emission smoke where stdout formatting, argv parsing, or process exit behavior is the behavior under test",
           "tests/test_generated_command_package_proof_runner.py::test_generated_python_conformance_uses_contract_artifacts remains as conformance-registry projection coverage, not behavior proof"
         ],
-        "rationale": "This case now uses generated Python and TypeScript operation callables for semantic proof. The retained stdout expectations document the wrapper-smoke boundary, but operation completion is proven without argv parsing through generated.workspace.python.commands.defaults_report:invoke and generated/workspace/typescript/src/runtime.mjs:runGeneratedOperation."
+        "rationale": "This case now uses generated Python and TypeScript operation callables for semantic proof. The retained stdout expectations document the wrapper-smoke boundary, but operation completion is proven without argv parsing through generated.workspace.python.commands.defaults_report:invoke and generated/workspace/typescript/src/runtime.mjs:invokeGeneratedOperation."
       }
     },
     {

--- a/src/agentic_workspace/contracts/operation_conformance_test_ir.json
+++ b/src/agentic_workspace/contracts/operation_conformance_test_ir.json
@@ -166,6 +166,16 @@
           "wrapper_refs": [
             "defaults.report.cli"
           ]
+        },
+        {
+          "artifact_id": "root-workspace.defaults.typescript",
+          "target": "typescript",
+          "adapter_id": "typescript.function",
+          "proof_role": "operation-conformance",
+          "source_ref": "command_package_ir:root-workspace/defaults",
+          "wrapper_refs": [
+            "defaults.report.cli"
+          ]
         }
       ],
       "schema_refs": {
@@ -183,6 +193,10 @@
       "targets": [
         {
           "kind": "python",
+          "mode": "run"
+        },
+        {
+          "kind": "typescript",
           "mode": "run"
         }
       ],
@@ -255,7 +269,7 @@
           "CLI wrapper text-emission smoke where stdout formatting, argv parsing, or process exit behavior is the behavior under test",
           "tests/test_generated_command_package_proof_runner.py::test_generated_python_conformance_uses_contract_artifacts remains as conformance-registry projection coverage, not behavior proof"
         ],
-        "rationale": "This case now uses the generated Python operation callable for semantic proof. The retained stdout expectations document the wrapper-smoke boundary, but operation completion is proven through the JSON-shaped result returned by generated.workspace.python.commands.defaults_report:invoke."
+        "rationale": "This case now uses generated Python and TypeScript operation callables for semantic proof. The retained stdout expectations document the wrapper-smoke boundary, but operation completion is proven without argv parsing through generated.workspace.python.commands.defaults_report:invoke and generated/workspace/typescript/src/runtime.mjs:runGeneratedOperation."
       }
     },
     {

--- a/src/agentic_workspace/contracts/target_support.json
+++ b/src/agentic_workspace/contracts/target_support.json
@@ -68,7 +68,7 @@
     {
       "schema_version": "command-generation/target-extension/v1",
       "target_id": "typescript",
-      "implementation_status": "planned",
+      "implementation_status": "implemented",
       "projection_rules": {
         "source": "operation-ir",
         "target_owns": [
@@ -103,7 +103,7 @@
         ]
       },
       "conformance_execution": {
-        "runner": "typescript function conformance",
+        "runner": "run_operation_conformance_tests.py typescript.function",
         "case_model": "input-output-error"
       },
       "support_declaration": {

--- a/src/agentic_workspace/contracts/typescript_runtime_support.mjs
+++ b/src/agentic_workspace/contracts/typescript_runtime_support.mjs
@@ -807,21 +807,32 @@ function executeTypescriptDomainOperation(operationId, values) {
   return { command: values._command_path?.join(' ') ?? operationId, target_root: target, dry_run: Boolean(values.dry_run), message: operationId };
 }
 
-export function runGeneratedOperation({ operationId, operationPath, values }) {
+function executeGeneratedOperationValues({ operationId, operationPath, values }) {
   if (!operationId) throw new RuntimeError('generated command has no operation id');
   if (values.strict_preflight === true && !values.preflight_token) {
-    writeSync(2, 'Strict preflight gate is enabled. Provide --preflight-token to continue.\n');
-    return 2;
+    throw new RuntimeError('Strict preflight gate is enabled. Provide --preflight-token to continue.');
   }
-  let output;
   if (!operationPath) throw new RuntimeError(`operation ${operationId} has no operation resource path`);
   const resourcePath = resolveInside(resourcesRoot, operationPath);
   if (!existsSync(resourcePath)) throw new RuntimeError(`operation resource is missing: ${operationPath}`);
   const operation = loadJsonResource(operationPath);
   const steps = operation?.ir_plan?.steps;
   if (!Array.isArray(steps) || steps.length === 0) throw new RuntimeError(`operation ${operationId} has no executable ir_plan.steps`);
-  const finalValues = runSteps(operation, { ...values });
-  output = finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
+  return runSteps(operation, { ...values });
+}
+
+export function invokeGeneratedOperation({ operationId, operationPath, values }) {
+  const finalValues = executeGeneratedOperationValues({ operationId, operationPath, values });
+  return finalValues.result ?? finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
+}
+
+export function runGeneratedOperation({ operationId, operationPath, values }) {
+  if (values.strict_preflight === true && !values.preflight_token) {
+    writeSync(2, 'Strict preflight gate is enabled. Provide --preflight-token to continue.\n');
+    return 2;
+  }
+  const finalValues = executeGeneratedOperationValues({ operationId, operationPath, values });
+  let output = finalValues.emitted ?? emitOutput({ ...finalValues, result: finalValues.result });
   if (typeof output !== 'string') output = `${JSON.stringify(output, null, 2)}\n`;
   writeSync(1, output);
   return 0;

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -197,9 +197,12 @@ def test_target_support_consumes_command_generation_extension_contract() -> None
         operation_id="defaults.report",
         case_id="defaults.selected-output.success",
     )
-    assert [entry["target_id"] for entry in matrix_entries] == ["python"]
-    assert matrix_entries[0]["adapter_id"] == "python.function"
-    assert contracts["typescript"]["implementation_status"] == "planned"
+    assert [entry["target_id"] for entry in matrix_entries] == ["python", "typescript"]
+    assert {entry["target_id"]: entry["adapter_id"] for entry in matrix_entries} == {
+        "python": "python.function",
+        "typescript": "typescript.function",
+    }
+    assert contracts["typescript"]["implementation_status"] == "implemented"
 
 
 def test_target_support_checker_rejects_semantic_target_ownership() -> None:
@@ -715,6 +718,7 @@ def test_operation_conformance_test_ir_defines_success_error_and_parity_cases() 
     }
     assert cases["defaults.selected-output.success"]["operation_ref"]["conformance_ref"] == "defaults.selected-text.process"
     assert cases["defaults.selected-output.success"]["artifacts"][0]["adapter_id"] == "python.function"
+    assert cases["defaults.selected-output.success"]["artifacts"][1]["adapter_id"] == "typescript.function"
     assert cases["defaults.selected-output.success"]["artifacts"][0]["proof_role"] == "operation-conformance"
     assert cases["defaults.selected-output.success"]["expected"]["result"]["selected_fields"] == {
         "kind": "agentic-workspace/selected-output/v1",
@@ -857,6 +861,8 @@ def test_operation_artifact_registry_routes_cases_and_proof_layers() -> None:
     assert module._validate_operation_artifact_registry(registry) == []
     artifacts = {artifact["artifact_id"]: artifact for artifact in registry["artifacts"]}
     assert artifacts["root-workspace.defaults.python"]["adapter_id"] == "python.function"
+    assert artifacts["root-workspace.defaults.typescript"]["adapter_id"] == "typescript.function"
+    assert artifacts["root-workspace.defaults.typescript"]["proof_role"] == "operation-conformance"
     assert artifacts["root-workspace.defaults.python"]["proof_role"] == "operation-conformance"
     assert artifacts["root-workspace.defaults.python"]["symbol"] == "generated.workspace.python.commands.defaults_report:invoke"
     assert artifacts["root-workspace.config.python"]["proof_role"] == "wrapper-smoke"

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -9,6 +9,8 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check" / "run_generated_command_package_proof.py"
 CHECK_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check" / "check_generated_command_packages.py"
@@ -168,9 +170,27 @@ def test_operation_conformance_runner_reports_typescript_unavailable(monkeypatch
     strict = runner.run_ir_cases(target_selection="typescript", case_filter=set(), require_node=True)
 
     assert soft["summary"]["state"] == "pass"
-    assert soft["summary"]["unavailable_count"] == 2
+    assert soft["summary"]["unavailable_count"] == 3
     assert strict["summary"]["state"] == "fail"
-    assert strict["summary"]["fail_count"] == 2
+    assert strict["summary"]["fail_count"] == 3
+
+
+def test_operation_conformance_runner_executes_typescript_function_case() -> None:
+    runner = _load_test_ir_runner()
+    if runner.shutil.which("node") is None:
+        pytest.skip("node is required for typescript.function proof")
+
+    payload = runner.run_ir_cases(
+        target_selection="typescript",
+        case_filter={"defaults.selected-output.success"},
+        require_node=True,
+    )
+
+    assert payload["summary"]["state"] == "pass"
+    result = payload["cases"][0]
+    assert result["artifact_id"] == "root-workspace.defaults.typescript"
+    assert result["adapter_id"] == "typescript.function"
+    assert result["state"] == "pass"
 
 
 def test_operation_conformance_runner_compares_parity(monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=e9fafcd8d289748f84069419ff7644ec5bede82e" },
+    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=0bc4f76687d9587808b9e7d4f42362e10566be35" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -145,7 +145,7 @@ wheels = [
 [[package]]
 name = "command-generation"
 version = "0.1.0"
-source = { git = "https://github.com/rickardvh/command-generation.git?rev=e9fafcd8d289748f84069419ff7644ec5bede82e#e9fafcd8d289748f84069419ff7644ec5bede82e" }
+source = { git = "https://github.com/rickardvh/command-generation.git?rev=0bc4f76687d9587808b9e7d4f42362e10566be35#0bc4f76687d9587808b9e7d4f42362e10566be35" }
 dependencies = [
     { name = "jsonschema" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=7a965c98dc978010ba810e006b9654f51434f3b7" },
+    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=e9fafcd8d289748f84069419ff7644ec5bede82e" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -145,7 +145,7 @@ wheels = [
 [[package]]
 name = "command-generation"
 version = "0.1.0"
-source = { git = "https://github.com/rickardvh/command-generation.git?rev=7a965c98dc978010ba810e006b9654f51434f3b7#7a965c98dc978010ba810e006b9654f51434f3b7" }
+source = { git = "https://github.com/rickardvh/command-generation.git?rev=e9fafcd8d289748f84069419ff7644ec5bede82e#e9fafcd8d289748f84069419ff7644ec5bede82e" }
 dependencies = [
     { name = "jsonschema" },
 ]


### PR DESCRIPTION
## Summary
- add a `typescript.function` operation-conformance path for the migrated defaults operation by invoking generated `runtime.mjs::runGeneratedOperation` directly
- promote TypeScript target support to implemented and require `typescript.function` in the target-support semantic matrix
- keep existing TypeScript config/error and memory parity cases as `cli.process` wrapper-smoke proof
- retain Planning evidence for the completed lane and route remaining parent #1476 work through the decomposition

## Validation
- `uv run pytest tests/test_contract_tooling.py tests/test_generated_command_package_proof_runner.py -q`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/run_operation_conformance_tests.py --target typescript --require-node --format json`
- `uv run python scripts/check/check_generated_command_packages.py --conformance --require-node`
- `uv run python scripts/check/run_operation_conformance_tests.py --target python --format json`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make test-workspace`
- `make lint-workspace`

## Notes
- Existing issue #1491 already covers the dogfooding affordance where bounded-slice evidence can be easier to express without briefly implying parent intent completion.
- Parent #1476 continues through the remaining decomposition lanes.
