### PR TITLE
Install generated behavior closure guardrails

### DIFF
--- a/.agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json
+++ b/.agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json
@@ -121,9 +121,9 @@
     {
       "id": "lane-1476-closure-inventory-and-guardrails",
       "title": "Install closure inventory and bypass guardrails",
-      "readiness": "ready",
+      "readiness": "promoted",
       "outcome": "Generated-behavior and contract-test inventories account for every migrated, retained, rejected, or blocked behavior group, with checkers preventing future stable behavior changes from bypassing IR/contracts/cases or target-specific code from owning product semantics outside explicit runtime primitive or wrapper boundaries.",
-      "owner_surface": "generated-behavior inventories, contract-test inventories, guardrail checks, command-generation#14 integration evidence, and #1476 closeout comment",
+      "owner_surface": ".agentic-workspace/planning/execplans/lane-1476-closure-inventory-and-guardrails.plan.json",
       "proof": "Checks fail for direct generated executable behavior edits, one-off ordinary stable behavior regressions without IR/case owner, and target-specific per-operation semantics outside explicit runtime primitive or wrapper boundaries.",
       "slice_contribution_to_parent": "Provides parent-closure evidence and prevents representative slices from being mistaken for full #1476 completion.",
       "residual_parent_intent": "None only if all #1476 acceptance bullets are satisfied or explicitly rejected with evidence and durable owner-approved rationale.",

--- a/.agentic-workspace/planning/execplans/archive/lane-1476-closure-inventory-and-guardrails.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/lane-1476-closure-inventory-and-guardrails.plan.json
@@ -1,0 +1,381 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Install closure inventory and bypass guardrails",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "lane",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "required_continuation",
+      "iterative_follow_through",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Promoted from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json lane lane-1476-closure-inventory-and-guardrails.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Generated-behavior and contract-test inventories account for every migrated, retained, rejected, or blocked behavior group, with checkers preventing future stable behavior changes from bypassing IR/contracts/cases or target-specific code from owning product semantics outside explicit runtime primitive or wrapper boundaries.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Checks fail for direct generated executable behavior edits, one-off ordinary stable behavior regressions without IR/case owner, and target-specific per-operation semantics outside explicit runtime primitive or wrapper boundaries."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Promoted from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json lane lane-1476-closure-inventory-and-guardrails."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Promoted from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json lane lane-1476-closure-inventory-and-guardrails.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "lane-1476-closure-inventory-and-guardrails",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "#1476 requires an enforced end-to-end model where operation/primitive IR, contracts, and input-output cases generate implementation artifacts, wrappers, and conformance executors, while ordinary feature work changes IR/contracts/cases rather than generated executable code or one-off behavior regressions.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Install closure inventory and bypass guardrails",
+    "inferred intended outcome": "Promoted from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json lane lane-1476-closure-inventory-and-guardrails.",
+    "chosen concrete what": "Generated-behavior and contract-test inventories account for every migrated, retained, rejected, or blocked behavior group, with checkers preventing future stable behavior changes from bypassing IR/contracts/cases or target-specific code from owning product semantics outside explicit runtime primitive or wrapper boundaries.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Generated-behavior and contract-test inventories account for every migrated, retained, rejected, or blocked behavior group, with checkers preventing future stable behavior changes from bypassing IR/contracts/cases or target-specific code from owning product semantics outside explicit runtime primitive or wrapper boundaries.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Promoted from .agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json lane lane-1476-closure-inventory-and-guardrails.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": ".agentic-workspace/planning/decompositions/operation-test-ir-single-source.decomposition.json",
+      "label": "decomposition lane lane-1476-closure-inventory-and-guardrails",
+      "role": "intake",
+      "locator": "candidate_lanes[6]"
+    }
+  ],
+  "active_milestone": {
+    "id": "lane-1476-closure-inventory-and-guardrails",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Generated-behavior and contract-test inventories account for every migrated, retained, rejected, or blocked behavior group, with checkers preventing future stable behavior changes from bypassing IR/contracts/cases or target-specific code from owning product semantics outside explicit runtime primitive or wrapper boundaries."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Checks fail for direct generated executable behavior edits, one-off ordinary stable behavior regressions without IR/case owner, and target-specific per-operation semantics outside explicit runtime primitive or wrapper boundaries.",
+    "Parent acceptance: prove this slice's contribution and explicitly route residual parent intent before closeout."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning promote-to-plan decomposition lane",
+    "what happened": "Installed a checked parent closure inventory for #1476 in generated_behavior_stratification.json, added bypass guardrails for direct generated edits, ordinary regression bypass, target-owned product semantics, and representative-slice parent closure, and documented the final accounting in package docs.",
+    "scope touched": "#1484 final parent-evidence lane for #1476",
+    "changed surfaces": "generated_behavior_stratification contract and schema; contract tooling checker; contract tests; generated reference docs; package overview/index docs; generated behavior closure inventory doc; planning decomposition/state",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "#1476 final-state requirements are all marked satisfied with evidence refs and proof routes; parent_closure_inventory.unresolved is empty; negative tests cover partial requirements, unresolved gaps, and missing representative-slice guardrail.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_contract_tooling.py -q; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; uv run python scripts/generate/generate_schema_reference.py --check --check-annotations; make schema-reference-docs; make lint-workspace; make maintainer-surfaces; make test-workspace",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "#1476 requires an enforced end-to-end model where operation/primitive IR, contracts, and input-output cases generate implementation artifacts, wrappers, and conformance executors, while ordinary feature work changes IR/contracts/cases rather than generated executable code or one-off behavior regressions.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1476 closure inventory and bypass guardrails installed; parent closure is honest.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "epic",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a epic claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-14: Scaffolded by agentic-planning promote-to-plan from decomposition lane lane-1476-closure-inventory-and-guardrails."
+  ],
+  "parent_acceptance": {
+    "original_intent": "#1476 requires an enforced end-to-end model where operation/primitive IR, contracts, and input-output cases generate implementation artifacts, wrappers, and conformance executors, while ordinary feature work changes IR/contracts/cases rather than generated executable code or one-off behavior regressions.",
+    "parent_intent": "#1476 requires an enforced end-to-end model where operation/primitive IR, contracts, and input-output cases generate implementation artifacts, wrappers, and conformance executors, while ordinary feature work changes IR/contracts/cases rather than generated executable code or one-off behavior regressions.",
+    "parent_acceptance": "AW has a checked stratification contract, generated direct operation callable artifacts for applicable migrated cases, target-extension and conformance behavior delegated to command-generation#14, wrapper tests demoted to wrapper semantics, ordinary tests inventoried with explicit keep/conversion rationale, and guardrails preventing behavior changes from bypassing IR/contracts/cases.",
+    "acceptance_target": "AW has a checked stratification contract, generated direct operation callable artifacts for applicable migrated cases, target-extension and conformance behavior delegated to command-generation#14, wrapper tests demoted to wrapper semantics, ordinary tests inventoried with explicit keep/conversion rationale, and guardrails preventing behavior changes from bypassing IR/contracts/cases.",
+    "current_slice": "Generated-behavior and contract-test inventories account for every migrated, retained, rejected, or blocked behavior group, with checkers preventing future stable behavior changes from bypassing IR/contracts/cases or target-specific code from owning product semantics outside explicit runtime primitive or wrapper boundaries.",
+    "slice_contribution": "Provides parent-closure evidence and prevents representative slices from being mistaken for full #1476 completion.",
+    "residual_parent_intent": "None only if all #1476 acceptance bullets are satisfied or explicitly rejected with evidence and durable owner-approved rationale.",
+    "proof_boundary": "parent-closure",
+    "parent_proof_required": "Parent closure requires proof across all final-state bullets in #1476: checked stratification model, direct operation adapters for applicable AW cases, target support declaration, IR-backed conformance cases, wrapper demotion, ordinary-test boundary inventory, generated-code/edit guardrails, target-maintenance guardrails, command-generation#14 consumption evidence, and explicit closeout of remaining gaps.",
+    "human_confirmation_needed": [
+      "Confirm #1476 can close if any final-state bullet is satisfied by documented rejection rather than implementation."
+    ],
+    "clarification_needed_when": "Ask for owner confirmation before closing #1476 if TypeScript direct-operation support, target-extension machinery, or any retained ordinary test/generator boundary is rejected rather than implemented."
+  },
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: #1476 requires an enforced end-to-end model where operation/primitive IR, contracts, and input-output cases generate implementation artifacts, wrappers, and conformance executors, while ordinary feature work changes IR/contracts/cases rather than generated executable code or one-off behavior regressions.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_contract_tooling.py -q; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; uv run python scripts/generate/generate_schema_reference.py --check --check-annotations; make schema-reference-docs; make lint-workspace; make maintainer-surfaces; make test-workspace\nChanged surfaces: generated_behavior_stratification contract and schema; contract tooling checker; contract tests; generated reference docs; package overview/index docs; generated behavior closure inventory doc; planning decomposition/state\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ Use this map when updating docs so each page stays complete at its level without
 | How should agents route governing knowledge and source authority? | [Knowledge routing and source authority](package/knowledge-routing.md) | a page only needs to name a source kind, authority class, route trigger, freshness rule, or capture obligation |
 | When should governing knowledge block or constrain work? | [Pre-work knowledge gates](package/knowledge-gates.md) | a page only needs to name gate force, blocked actions, closeout evidence, or fallback behavior |
 | Which generated-command tests belong at the CLI wrapper boundary? | [CLI boundary tests](package/cli-boundary-tests.md) | a page only needs to distinguish operation conformance from argv/help/error/exit/stdout wrapper proof |
+| What final accounting proves generated behavior migration is complete? | [Generated behavior closure inventory](package/generated-behavior-closure-inventory.md) | a page only needs the #1476 parent closure evidence, unresolved-state rule, or bypass guardrails |
 | What do Planning and Memory own? | [Modules](package/modules.md), then the module READMEs | a page only needs to distinguish active execution state from durable repo knowledge |
 | What are the exact fields and generated references? | [Contracts and references](package/contracts.md) and [Reference material](reference/index.md) | hand-written docs would otherwise copy generated schema detail |
 | What is source-checkout maintainer workflow? | [Maintainer index](maintainer/index.md) | ordinary host-repo docs mention internal validation, dogfooding, or generation only as a boundary |
@@ -35,6 +36,7 @@ Use this map when updating docs so each page stays complete at its level without
 - [Knowledge routing and source authority](package/knowledge-routing.md): how startup, posture, closeout, Memory, Planning, issues, docs, and external sources route governing knowledge without broad mirroring.
 - [Pre-work knowledge gates](package/knowledge-gates.md): when routed knowledge should block design, edits, claims, or closeout until resolved.
 - [CLI boundary tests](package/cli-boundary-tests.md): how shell-facing wrapper tests stay separate from operation conformance cases.
+- [Generated behavior closure inventory](package/generated-behavior-closure-inventory.md): final #1476 accounting and bypass guardrails for generated behavior migration.
 - [Contracts and references](package/contracts.md): how JSON contracts, schemata, generated reference docs, and runtime outputs relate.
 - [Jumpstart contract](jumpstart-contract.md): how a newly installed or adopted workspace in a lived-in repo should discover candidate durable surfaces without bulk importing repo prose.
 - [Collaboration safety](collaboration-safety.md): git-native collaboration model, merge recovery, and shared-state pressure rules.

--- a/docs/package/generated-behavior-closure-inventory.md
+++ b/docs/package/generated-behavior-closure-inventory.md
@@ -1,0 +1,28 @@
+# Generated Behavior Closure Inventory
+
+This is the final #1476 parent accounting. The checked source is `src/agentic_workspace/contracts/generated_behavior_stratification.json`, under `parent_closure_inventory`.
+
+## Final State
+
+| Requirement | Status | Evidence |
+| --- | --- | --- |
+| Checked stratification contract | satisfied | `generated_behavior_stratification.json`, its schema, and contract-tooling tests |
+| Generated direct operation callables | satisfied | operation artifact registry, operation conformance IR, Python callable closeout evidence, TypeScript callable closeout evidence |
+| Target-extension consumption | satisfied | `target_support.json` and target-support checker tests |
+| IR-backed conformance cases | satisfied | `operation_conformance_test_ir.json`, conformance runner, and #1482 closeout evidence |
+| Wrapper demotion | satisfied | operation artifact registry, CLI boundary docs, and #1483 closeout evidence |
+| Ordinary-test boundary inventory | satisfied | `retained_ordinary_test_groups`, generated behavior test inventory, and retained-test negative checks |
+| Generated-code and test bypass guardrails | satisfied | contract-tooling guardrails and parent-closure negative checks |
+
+## Bypass Guardrails
+
+| Guardrail | Prevents | Checked by |
+| --- | --- | --- |
+| `direct-generated-edit-bypass` | Direct generated executable behavior edits replacing source contracts, IR, cases, or command-generation renderers | `check_contract_tooling_surfaces.py` |
+| `ordinary-regression-bypass` | One-off ordinary stable behavior regressions replacing minimal IR-backed conformance cases | operation conformance migration policy and retained-test inventory checks |
+| `target-product-semantics-bypass` | Target-specific per-operation product semantics or feature maintenance in AW target support | target-extension validation and target-support tests |
+| `representative-slice-parent-closure-bypass` | Parent completion from representative slices while a final-state requirement remains partial, blocked, or unrouted | `parent_closure_inventory` validation |
+
+## Closure Statement
+
+#1476 is ready for parent closure because every final-state requirement is implemented with checked evidence and no parent-level gap remains unresolved.

--- a/docs/package/overview.md
+++ b/docs/package/overview.md
@@ -23,7 +23,7 @@ The root package currently depends on the first-party Planning and Memory packag
 
 Exact profile and footprint metadata is defined in the generated [Module registry](../reference/module-registry.md). Exact command metadata is defined in [CLI commands](../reference/cli-commands.md). The reviewed ordinary operating model and surface classification live in [Ordinary continuity loop and surface classification](ordinary-continuity-loop.md). Knowledge routing, source authority, and pre-work gates are defined in [Knowledge routing and source authority](knowledge-routing.md) and [Pre-work knowledge gates](knowledge-gates.md).
 
-Generated command behavior test ownership is accounted for in [Generated behavior test inventory](generated-behavior-test-inventory.md). That inventory distinguishes operation conformance cases, shared command-generation ownership, AW wrapper/proof/lifecycle tests, and intentionally rejected regression-test bulk. Shell-facing wrapper coverage is defined separately in [CLI boundary tests](cli-boundary-tests.md).
+Generated command behavior test ownership is accounted for in [Generated behavior test inventory](generated-behavior-test-inventory.md). That inventory distinguishes operation conformance cases, shared command-generation ownership, AW wrapper/proof/lifecycle tests, and intentionally rejected regression-test bulk. Shell-facing wrapper coverage is defined separately in [CLI boundary tests](cli-boundary-tests.md). Final parent-level generated-behavior accounting and bypass guardrails are summarized in [Generated behavior closure inventory](generated-behavior-closure-inventory.md).
 
 ## Runtime Model
 
@@ -74,4 +74,5 @@ The threshold is not team size. A solo maintainer and one agent can still benefi
 - [Knowledge routing and source authority](knowledge-routing.md)
 - [Pre-work knowledge gates](knowledge-gates.md)
 - [CLI boundary tests](cli-boundary-tests.md)
+- [Generated behavior closure inventory](generated-behavior-closure-inventory.md)
 - [Contracts and references](contracts.md)

--- a/docs/reference/generated-behavior-stratification.md
+++ b/docs/reference/generated-behavior-stratification.md
@@ -18,5 +18,11 @@ Authoritative layer model for generated behavior, operation IR, adapters, confor
 | `layers` | array of ref `#/$defs/layer` | yes |  | Ordered generated-behavior strata from primitive contracts through retained ordinary-test boundaries. |  |  |
 | `retained_hand_owned_boundaries` | array of ref `#/$defs/retained_boundary` | yes |  | Hand-owned runtime or test boundaries that remain allowed only with owner, proof, keep reason, and conversion criteria. |  |  |
 | `retained_ordinary_test_groups` | array of ref `#/$defs/retained_ordinary_test_group` | yes |  | Concrete ordinary handwritten test groups retained in AW with owner, proof route, keep reason, future conversion condition, and durable-boundary rationale. |  |  |
+| `parent_closure_inventory` | ref `#/$defs/parent_closure_inventory` | yes |  | Final #1476 accounting across acceptance requirements, evidence, residual state, and bypass guardrails. |  |  |
+| `parent_closure_inventory.status` | enum `"ready-to-close-parent"`, `"partial"`, `"blocked"` | yes |  | Parent closure posture for #1476 after evaluating all final-state requirements. |  |  |
+| `parent_closure_inventory.final_state_requirements` | array of ref `#/$defs/final_state_requirement` | yes |  | Acceptance requirements that must be satisfied or explicitly owner-rejected before #1476 parent closure. |  |  |
+| `parent_closure_inventory.bypass_guardrails` | array of ref `#/$defs/bypass_guardrail` | yes |  | Checked guardrails that prevent future generated-behavior work from bypassing contracts, IR, cases, or explicit boundaries. |  |  |
+| `parent_closure_inventory.unresolved` | array of string | yes |  | Open parent-level gaps. Empty only when status is ready-to-close-parent. |  |  |
+| `parent_closure_inventory.closure_statement` | string | yes |  | Human-readable statement explaining why the parent closure claim is honest. |  |  |
 | `lane_sequence` | array of string | yes |  | Issue sequence for the decomposed #1476 lanes. |  |  |
 | `closure_rule` | string | yes |  | Rule for when the parent epic can be resolved. |  |  |

--- a/scripts/check/check_contract_tooling_surfaces.py
+++ b/scripts/check/check_contract_tooling_surfaces.py
@@ -1330,6 +1330,67 @@ def _validate_generated_behavior_stratification(payload: dict[str, object]) -> l
     missing_groups = sorted(required_group_ids - group_ids)
     if missing_groups:
         errors.append("generated_behavior_stratification.json missing retained ordinary test group(s): " + ", ".join(missing_groups))
+    closure_inventory = payload.get("parent_closure_inventory", {})
+    if not isinstance(closure_inventory, dict):
+        errors.append("generated_behavior_stratification.json parent_closure_inventory must be an object")
+        return errors
+    required_requirement_ids = {
+        "checked-stratification-contract",
+        "generated-direct-operation-callables",
+        "target-extension-consumed",
+        "ir-backed-conformance-cases",
+        "wrapper-demotion",
+        "ordinary-test-boundary-inventory",
+        "generated-code-and-test-bypass-guardrails",
+    }
+    requirements = closure_inventory.get("final_state_requirements", [])
+    requirement_ids: set[str] = set()
+    for requirement in requirements:
+        if not isinstance(requirement, dict):
+            errors.append("generated_behavior_stratification.json final_state_requirements must contain objects")
+            continue
+        requirement_id = str(requirement.get("id", ""))
+        requirement_ids.add(requirement_id)
+        if requirement.get("status") not in {"satisfied", "owner-approved-rejected"}:
+            errors.append(f"generated_behavior_stratification.json final requirement {requirement_id} is not closure-ready")
+        for field in ("intent_served", "proof_route"):
+            if not requirement.get(field):
+                errors.append(f"generated_behavior_stratification.json final requirement {requirement_id} missing {field}")
+        if not requirement.get("evidence_refs"):
+            errors.append(f"generated_behavior_stratification.json final requirement {requirement_id} missing evidence_refs")
+    missing_requirements = sorted(required_requirement_ids - requirement_ids)
+    if missing_requirements:
+        errors.append("generated_behavior_stratification.json missing final requirement(s): " + ", ".join(missing_requirements))
+    required_guardrail_ids = {
+        "direct-generated-edit-bypass",
+        "ordinary-regression-bypass",
+        "target-product-semantics-bypass",
+        "representative-slice-parent-closure-bypass",
+    }
+    guardrails = closure_inventory.get("bypass_guardrails", [])
+    guardrail_ids: set[str] = set()
+    for guardrail in guardrails:
+        if not isinstance(guardrail, dict):
+            errors.append("generated_behavior_stratification.json bypass_guardrails must contain objects")
+            continue
+        guardrail_id = str(guardrail.get("id", ""))
+        guardrail_ids.add(guardrail_id)
+        for field in ("prevents", "check_surface", "proof_route"):
+            if not guardrail.get(field):
+                errors.append(f"generated_behavior_stratification.json bypass guardrail {guardrail_id} missing {field}")
+        if not guardrail.get("fails_when"):
+            errors.append(f"generated_behavior_stratification.json bypass guardrail {guardrail_id} missing fails_when")
+    missing_guardrails = sorted(required_guardrail_ids - guardrail_ids)
+    if missing_guardrails:
+        errors.append("generated_behavior_stratification.json missing bypass guardrail(s): " + ", ".join(missing_guardrails))
+    status = closure_inventory.get("status")
+    unresolved = closure_inventory.get("unresolved", [])
+    if status == "ready-to-close-parent" and unresolved:
+        errors.append("generated_behavior_stratification.json cannot be ready-to-close-parent with unresolved parent gaps")
+    if status != "ready-to-close-parent":
+        errors.append("generated_behavior_stratification.json parent closure inventory is not ready-to-close-parent")
+    if not closure_inventory.get("closure_statement"):
+        errors.append("generated_behavior_stratification.json parent closure inventory must include closure_statement")
     return errors
 
 

--- a/src/agentic_workspace/contracts/generated_behavior_stratification.json
+++ b/src/agentic_workspace/contracts/generated_behavior_stratification.json
@@ -234,6 +234,134 @@
       "durable_boundary_rationale": "Installed-product behavior is an AW domain boundary: users experience generated resources through AW startup, proof, lifecycle, and package surfaces."
     }
   ],
+  "parent_closure_inventory": {
+    "status": "ready-to-close-parent",
+    "final_state_requirements": [
+      {
+        "id": "checked-stratification-contract",
+        "status": "satisfied",
+        "intent_served": "The generated-behavior model is a checked contract with layers for primitives, operation IR, generated implementation, target extension, wrapper adapters, conformance cases, and retained ordinary tests.",
+        "evidence_refs": [
+          "src/agentic_workspace/contracts/generated_behavior_stratification.json",
+          "src/agentic_workspace/contracts/schemas/generated_behavior_stratification.schema.json",
+          "tests/test_contract_tooling.py::test_generated_behavior_stratification_declares_layers_and_retained_boundaries"
+        ],
+        "proof_route": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success"
+      },
+      {
+        "id": "generated-direct-operation-callables",
+        "status": "satisfied",
+        "intent_served": "Applicable migrated defaults behavior has generated Python and TypeScript direct operation callable artifacts, and wrapper execution is no longer the default semantic substitute for those cases.",
+        "evidence_refs": [
+          "src/agentic_workspace/contracts/operation_artifact_registry.json",
+          "src/agentic_workspace/contracts/operation_conformance_test_ir.json",
+          ".agentic-workspace/planning/closeout-evidence/lane-1476-generated-python-operation-callables.closeout.json",
+          ".agentic-workspace/planning/closeout-evidence/lane-1476-typescript-direct-operation-adapter.closeout.json"
+        ],
+        "proof_route": "uv run python scripts/check/run_operation_conformance_tests.py --target python; uv run python scripts/check/run_operation_conformance_tests.py --target typescript --require-node"
+      },
+      {
+        "id": "target-extension-consumed",
+        "status": "satisfied",
+        "intent_served": "AW consumes command-generation target-extension contracts and target support matrix projection without making targets own product operation semantics or per-operation feature maintenance.",
+        "evidence_refs": [
+          "src/agentic_workspace/contracts/target_support.json",
+          "tests/test_contract_tooling.py::test_target_support_consumes_command_generation_extension_contract",
+          "tests/test_contract_tooling.py::test_target_support_checker_rejects_semantic_target_ownership"
+        ],
+        "proof_route": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success"
+      },
+      {
+        "id": "ir-backed-conformance-cases",
+        "status": "satisfied",
+        "intent_served": "Stable generated behavior groups are represented as compact operation conformance cases, preserving black-box behavior without preserving one-off regression-test bulk.",
+        "evidence_refs": [
+          "src/agentic_workspace/contracts/operation_conformance_test_ir.json",
+          "scripts/check/run_operation_conformance_tests.py",
+          ".agentic-workspace/planning/closeout-evidence/lane-1476-ir-backed-conformance-cases.closeout.json"
+        ],
+        "proof_route": "uv run python scripts/check/run_operation_conformance_tests.py --target python; uv run python scripts/check/run_operation_conformance_tests.py --target typescript --require-node"
+      },
+      {
+        "id": "wrapper-demotion",
+        "status": "satisfied",
+        "intent_served": "CLI/process artifacts are classified as wrapper-smoke unless a direct function adapter owns semantic operation proof; wrapper docs name the retained argv/help/error/stdout/stderr/exit-code boundary.",
+        "evidence_refs": [
+          "src/agentic_workspace/contracts/operation_artifact_registry.json",
+          "docs/package/cli-boundary-tests.md",
+          ".agentic-workspace/planning/closeout-evidence/lane-1476-wrapper-demotion-and-test-boundary.closeout.json"
+        ],
+        "proof_route": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success"
+      },
+      {
+        "id": "ordinary-test-boundary-inventory",
+        "status": "satisfied",
+        "intent_served": "Retained AW ordinary tests are inventoried with owner, proof route, keep reason, future conversion condition, and durable-boundary rationale.",
+        "evidence_refs": [
+          "src/agentic_workspace/contracts/generated_behavior_stratification.json#retained_ordinary_test_groups",
+          "docs/package/generated-behavior-test-inventory.md",
+          "tests/test_contract_tooling.py::test_generated_behavior_stratification_rejects_unowned_retained_ordinary_tests"
+        ],
+        "proof_route": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success"
+      },
+      {
+        "id": "generated-code-and-test-bypass-guardrails",
+        "status": "satisfied",
+        "intent_served": "Checkers fail when stable generated behavior is claimed from direct generated edits, one-off ordinary regressions, target-specific product semantics, or parent completion from representative slices.",
+        "evidence_refs": [
+          "scripts/check/check_contract_tooling_surfaces.py::_validate_generated_behavior_stratification",
+          "tests/test_contract_tooling.py::test_generated_behavior_stratification_parent_closure_inventory_and_guardrails",
+          "tests/test_contract_tooling.py::test_generated_behavior_stratification_rejects_incomplete_parent_closure_inventory"
+        ],
+        "proof_route": "uv run pytest tests/test_contract_tooling.py -q"
+      }
+    ],
+    "bypass_guardrails": [
+      {
+        "id": "direct-generated-edit-bypass",
+        "prevents": "direct generated executable behavior edits being treated as product behavior changes without updating source contracts, IR, cases, or command-generation renderers",
+        "check_surface": "scripts/check/check_contract_tooling_surfaces.py::_validate_generated_behavior_stratification",
+        "proof_route": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+        "fails_when": [
+          "generated-implementation.direct_edit_policy no longer rejects hand-editing generated artifacts",
+          "parent_closure_inventory lacks this guardrail"
+        ]
+      },
+      {
+        "id": "ordinary-regression-bypass",
+        "prevents": "one-off ordinary stable behavior regressions replacing minimal IR-backed conformance cases",
+        "check_surface": "operation_conformance_test_ir.migration_policy plus generated_behavior_stratification.parent_closure_inventory",
+        "proof_route": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+        "fails_when": [
+          "operation conformance migration policy stops rejecting one-for-one regression-test bulk",
+          "retained ordinary test groups lack conversion ownership"
+        ]
+      },
+      {
+        "id": "target-product-semantics-bypass",
+        "prevents": "target-specific per-operation product semantics or feature maintenance living in AW target support instead of reusable target machinery and product contracts",
+        "check_surface": "src/agentic_workspace/contracts/target_support.json and command-generation target-extension validation",
+        "proof_route": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+        "fails_when": [
+          "target_support declares target_owns_product_semantics",
+          "target_support declares per_operation_feature_maintenance"
+        ]
+      },
+      {
+        "id": "representative-slice-parent-closure-bypass",
+        "prevents": "closing #1476 from representative slices while a final-state requirement remains partial, blocked, or unrouted",
+        "check_surface": "generated_behavior_stratification.parent_closure_inventory",
+        "proof_route": "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+        "fails_when": [
+          "parent_closure_inventory.status is ready-to-close-parent while unresolved is non-empty",
+          "any final_state_requirements entry is not satisfied or owner-approved-rejected",
+          "a required final-state requirement id is missing"
+        ]
+      }
+    ],
+    "unresolved": [],
+    "closure_statement": "#1476 is ready for parent closure because every final-state requirement is implemented with checked evidence and no parent-level gap remains unresolved."
+  },
   "lane_sequence": [
     "#1478",
     "#1479",

--- a/src/agentic_workspace/contracts/schemas/generated_behavior_stratification.schema.json
+++ b/src/agentic_workspace/contracts/schemas/generated_behavior_stratification.schema.json
@@ -13,6 +13,7 @@
     "layers",
     "retained_hand_owned_boundaries",
     "retained_ordinary_test_groups",
+    "parent_closure_inventory",
     "lane_sequence",
     "closure_rule"
   ],
@@ -57,6 +58,10 @@
         "$ref": "#/$defs/retained_ordinary_test_group"
       },
       "description": "Concrete ordinary handwritten test groups retained in AW with owner, proof route, keep reason, future conversion condition, and durable-boundary rationale."
+    },
+    "parent_closure_inventory": {
+      "$ref": "#/$defs/parent_closure_inventory",
+      "description": "Final #1476 accounting across acceptance requirements, evidence, residual state, and bypass guardrails."
     },
     "lane_sequence": {
       "type": "array",
@@ -261,6 +266,131 @@
           "type": "string",
           "minLength": 1
         }
+      }
+    },
+    "parent_closure_inventory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "final_state_requirements",
+        "bypass_guardrails",
+        "unresolved",
+        "closure_statement"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "ready-to-close-parent",
+            "partial",
+            "blocked"
+          ],
+          "description": "Parent closure posture for #1476 after evaluating all final-state requirements."
+        },
+        "final_state_requirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/final_state_requirement"
+          },
+          "description": "Acceptance requirements that must be satisfied or explicitly owner-rejected before #1476 parent closure."
+        },
+        "bypass_guardrails": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/bypass_guardrail"
+          },
+          "description": "Checked guardrails that prevent future generated-behavior work from bypassing contracts, IR, cases, or explicit boundaries."
+        },
+        "unresolved": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Open parent-level gaps. Empty only when status is ready-to-close-parent."
+        },
+        "closure_statement": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable statement explaining why the parent closure claim is honest."
+        }
+      }
+    },
+    "final_state_requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "status",
+        "intent_served",
+        "evidence_refs",
+        "proof_route"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": [
+            "satisfied",
+            "owner-approved-rejected",
+            "blocked",
+            "partial"
+          ]
+        },
+        "intent_served": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_refs": {
+          "$ref": "#/$defs/non_empty_strings"
+        },
+        "proof_route": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "bypass_guardrail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "prevents",
+        "check_surface",
+        "proof_route",
+        "fails_when"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "prevents": {
+          "type": "string",
+          "minLength": 1
+        },
+        "check_surface": {
+          "type": "string",
+          "minLength": 1
+        },
+        "proof_route": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fails_when": {
+          "$ref": "#/$defs/non_empty_strings"
+        }
+      }
+    },
+    "non_empty_strings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
       }
     }
   },

--- a/tests/test_contract_tooling.py
+++ b/tests/test_contract_tooling.py
@@ -197,6 +197,29 @@ def test_generated_behavior_stratification_declares_layers_and_retained_boundari
         assert entry["durable_boundary_rationale"]
         assert entry["retained_boundary_ref"] in retained
 
+    closure_inventory = manifest["parent_closure_inventory"]
+    assert closure_inventory["status"] == "ready-to-close-parent"
+    assert closure_inventory["unresolved"] == []
+    requirements = {entry["id"]: entry for entry in closure_inventory["final_state_requirements"]}
+    assert {
+        "checked-stratification-contract",
+        "generated-direct-operation-callables",
+        "target-extension-consumed",
+        "ir-backed-conformance-cases",
+        "wrapper-demotion",
+        "ordinary-test-boundary-inventory",
+        "generated-code-and-test-bypass-guardrails",
+    } == requirements.keys()
+    assert {entry["status"] for entry in requirements.values()} == {"satisfied"}
+    guardrails = {entry["id"]: entry for entry in closure_inventory["bypass_guardrails"]}
+    assert {
+        "direct-generated-edit-bypass",
+        "ordinary-regression-bypass",
+        "target-product-semantics-bypass",
+        "representative-slice-parent-closure-bypass",
+    } == guardrails.keys()
+    assert "representative slices" in guardrails["representative-slice-parent-closure-bypass"]["prevents"]
+
 
 def test_target_support_consumes_command_generation_extension_contract() -> None:
     manifest = contract_tooling.target_support_manifest()
@@ -936,6 +959,39 @@ def test_generated_behavior_stratification_rejects_unowned_retained_ordinary_tes
     manifest["retained_ordinary_test_groups"][0]["retained_boundary_ref"] = "missing-boundary"
     assert any(
         "references unknown retained boundary missing-boundary" in error
+        for error in module._validate_generated_behavior_stratification(manifest)
+    )
+
+
+def test_generated_behavior_stratification_rejects_incomplete_parent_closure_inventory() -> None:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "check" / "check_contract_tooling_surfaces.py"
+    spec = importlib.util.spec_from_file_location("check_contract_tooling_surfaces", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    manifest = copy.deepcopy(contract_tooling.generated_behavior_stratification_manifest())
+    manifest["parent_closure_inventory"]["final_state_requirements"][0]["status"] = "partial"
+    assert any(
+        "final requirement checked-stratification-contract is not closure-ready" in error
+        for error in module._validate_generated_behavior_stratification(manifest)
+    )
+
+    manifest = copy.deepcopy(contract_tooling.generated_behavior_stratification_manifest())
+    manifest["parent_closure_inventory"]["unresolved"] = ["missing final guardrail"]
+    assert any(
+        "cannot be ready-to-close-parent with unresolved parent gaps" in error
+        for error in module._validate_generated_behavior_stratification(manifest)
+    )
+
+    manifest = copy.deepcopy(contract_tooling.generated_behavior_stratification_manifest())
+    manifest["parent_closure_inventory"]["bypass_guardrails"] = [
+        guardrail
+        for guardrail in manifest["parent_closure_inventory"]["bypass_guardrails"]
+        if guardrail["id"] != "representative-slice-parent-closure-bypass"
+    ]
+    assert any(
+        "missing bypass guardrail(s): representative-slice-parent-closure-bypass" in error
         for error in module._validate_generated_behavior_stratification(manifest)
     )
 


### PR DESCRIPTION
## Summary

- add a checked #1476 parent closure inventory to the generated-behavior stratification contract
- add bypass guardrails for direct generated edits, one-off ordinary regression bypass, target-owned product semantics, and representative-slice parent closure
- add negative tests so partial requirements, unresolved parent gaps, or missing parent guardrails fail contract validation
- document the final generated-behavior closure inventory in package docs
- archive the final #1484 planning lane with parent-level completion evidence

## Final accounting

What landed:

- checked stratification model
- generated direct operation callable artifacts for applicable migrated cases
- target-extension consumption and target support matrix proof
- IR-backed conformance cases
- wrapper demotion to wrapper-smoke boundaries
- retained ordinary-test inventory with owner/proof/keep/future-conversion/durable-boundary rationale
- parent-level bypass guardrails and closure inventory

What remains unresolved:

- no #1476 parent-level gap is recorded; parent_closure_inventory.unresolved is empty.

Why closure is honest:

- every final-state requirement in parent_closure_inventory.final_state_requirements is satisfied
- the checker fails if a requirement becomes partial/blocked, if unresolved gaps are present, or if the representative-slice parent-closure guardrail is missing

## Proof

- uv run pytest tests/test_contract_tooling.py -q
- uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success
- uv run python scripts/run_agentic_workspace.py summary --target . --format json
- uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json
- git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md
- uv run python scripts/check/check_structured_file_inventory.py --quiet-success
- uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py
- uv run python scripts/generate/generate_schema_reference.py --check --check-annotations
- make schema-reference-docs
- make lint-workspace
- make maintainer-surfaces
- make test-workspace

Resolves #1484.
Resolves #1476.