### PR TITLE
Fix bounded slice closeout routing

### DIFF
--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -12795,9 +12795,17 @@ def closeout_execplan(
         result.add("manual review", record_path, "planning closeout requires a canonical .plan.json record")
         return result
 
-    closure_decision = "archive-and-close" if normalized_intent == "satisfied" else "archive-but-keep-lane-open"
-    intent_satisfied = "yes" if normalized_intent == "satisfied" else "no"
     continuation_owner = residue_owner or ""
+    inferred_open_parent_slice = (
+        normalized_claim == "slice"
+        and normalized_intent == "satisfied"
+        and normalized_residue not in {"none", "dismissed"}
+        and bool(continuation_owner)
+    )
+    closure_decision = (
+        "archive-but-keep-lane-open" if normalized_intent != "satisfied" or inferred_open_parent_slice else "archive-and-close"
+    )
+    intent_satisfied = "no" if closure_decision == "archive-but-keep-lane-open" else "yes"
     if closure_decision == "archive-but-keep-lane-open" and not continuation_owner:
         continuation_owner = PLANNING_STATE_PATH.as_posix()
 
@@ -12955,7 +12963,11 @@ def closeout_execplan(
                 "scope respected": provided(review_summary) or "yes; closeout accepted the bounded claim.",
                 "proof status": "passed",
                 "intent served": (
-                    "yes" if normalized_intent == "satisfied" else f"no; intent-status={normalized_intent} keeps continuation explicit."
+                    f"yes for slice; parent remains open via {continuation_owner}"
+                    if inferred_open_parent_slice
+                    else "yes"
+                    if normalized_intent == "satisfied"
+                    else f"no; intent-status={normalized_intent} keeps continuation explicit."
                 ),
                 "follow-on decision": follow_on,
             },
@@ -13042,7 +13054,11 @@ def closeout_execplan(
             finished_run_review["scope respected"] = "yes; closeout accepted the bounded claim."
         finished_run_review["proof status"] = "passed"
         finished_run_review["intent served"] = (
-            "yes" if normalized_intent == "satisfied" else f"no; intent-status={normalized_intent} keeps continuation explicit."
+            f"yes for slice; parent remains open via {continuation_owner}"
+            if inferred_open_parent_slice
+            else "yes"
+            if normalized_intent == "satisfied"
+            else f"no; intent-status={normalized_intent} keeps continuation explicit."
         )
         if is_placeholder(finished_run_review.get("config compliance")):
             finished_run_review["config compliance"] = "used planning closeout command-owned writer"

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -1508,6 +1508,75 @@ def test_planning_closeout_routes_deferred_owner_without_full_intent_satisfactio
     assert archived["closeout_distillation"]["buckets"]["continuation"][0]["owner"] == "GitHub #1021"
 
 
+def test_planning_closeout_routes_satisfied_slice_residue_to_open_parent(tmp_path: Path, capsys) -> None:
+    owner = ".agentic-workspace/planning/state.toml roadmap lane generated-cli-runtime"
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="completed")
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record["intent_continuity"]["this slice completes the larger intended outcome"] = "no"
+    record["required_continuation"] = {
+        "required follow-on for the larger intended outcome": "yes",
+        "owner surface": owner,
+        "activation trigger": "next generated CLI slice",
+    }
+    installer_mod._write_execplan_record(record_path=record_path, record=record)
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--claim-level",
+                "slice",
+                "--intent-status",
+                "satisfied",
+                "--residue",
+                "planning",
+                "--residue-owner",
+                owner,
+                "--proof-from",
+                "uv run pytest packages/planning/tests/test_archive.py -q",
+                "--what-happened",
+                "completed bounded generated CLI slice.",
+                "--scope-touched",
+                "generated CLI closeout route",
+                "--changed-surfaces",
+                "planning closeout writer",
+                "--review-summary",
+                "slice behavior is served; parent remains routed.",
+                "--outcome-summary",
+                "bounded slice served with parent continuation.",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    archived = json.loads(
+        (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json").read_text(encoding="utf-8")
+    )
+
+    assert not any(warning["warning_class"] == "archive_larger_intent_proxy_closeout_blocked" for warning in payload["warnings"])
+    assert not any(action["kind"] == "manual review" for action in payload["actions"])
+    assert archived["closure_check"]["closeout scope"] == "slice"
+    assert archived["closure_check"]["closure decision"] == "archive-but-keep-lane-open"
+    assert archived["closure_check"]["larger-intent status"] == "open"
+    assert archived["intent_satisfaction"]["was original intent fully satisfied?"] == "no"
+    assert archived["intent_satisfaction"]["unsolved intent passed to"] == owner
+    assert archived["finished_run_review"]["intent served"] == f"yes for slice; parent remains open via {owner}"
+    assert archived["durable_residue"]["status"] == "planning"
+    assert archived["durable_residue"]["canonical owner now"] == owner
+    options = {option["id"]: option for option in payload["completion_options"]}
+    assert options["claim-slice-complete"]["allowed"] is True
+    assert options["keep-larger-intent-open"]["allowed"] is True
+    assert options["keep-larger-intent-open"]["owner"] == owner
+    assert options["close-larger-intent"]["allowed"] is False
+
+
 def test_planning_closeout_blocks_proxy_lane_archive_and_close(tmp_path: Path, capsys) -> None:
     _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
     record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"


### PR DESCRIPTION
## Summary
- Route satisfied slice closeout with explicit planning residue to `archive-but-keep-lane-open`.
- Keep the parent/larger-intent completion claim unavailable while allowing the slice completion and continuation route.
- Add regression coverage for the first-pass bounded-slice closeout path.

## Proof
- `uv run pytest packages/planning/tests/test_archive.py -q`
- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`

## Runtime source edit review
- Edit reason: existing planning primitive bugfix.
- Owner/symbol: planning package runtime boundary, `closeout_execplan` in `packages/planning/src/repo_planning_bootstrap/installer.py`.
- Command-generation ownership: no generator change is needed; this is planning closeout behavior in AW runtime source.

Resolves #1491