### PR TITLE
Add tiny payload budget diagnostics

### DIFF
--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4,6 +4,26 @@ from __future__ import annotations
 from tests.workspace_cli_support import *
 
 
+def test_json_payload_budget_failure_reports_largest_contributors() -> None:
+    payload = {
+        "small": "ok",
+        "context": {
+            "large": "x" * 80,
+            "nested": {"medium": "y" * 40},
+        },
+        "items": [{"detail": "z" * 30}],
+    }
+
+    with pytest.raises(AssertionError) as excinfo:
+        _assert_json_payload_under(payload, 50, label="example tiny payload")
+
+    message = str(excinfo.value)
+    assert "example tiny payload JSON payload is" in message
+    assert "Largest JSON contributors:" in message
+    assert "context" in message
+    assert "context.large" in message
+
+
 def test_preset_conflicts_with_modules(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
     with pytest.raises(SystemExit) as excinfo:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1103,7 +1103,6 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
 
     payload = json.loads(capsys.readouterr().out)
     context = _implement_context(payload)
-    encoded = json.dumps(payload)
     assert payload["kind"] == "implementer-context-tiny/v1"
     assert set(payload) <= {
         "kind",
@@ -1192,8 +1191,13 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert "durable_intent" not in payload
     assert "inference_limits" not in payload
     assert "generated_surface_trust" in payload["drill_down"]["available_selectors"]
-    assert len(json.dumps(payload["generated_surface_trust"])) < 700
-    assert len(encoded) < 15850
+    _assert_json_payload_under(
+        payload["generated_surface_trust"],
+        700,
+        label="implement generated-surface trust compact projection",
+        sort_keys=False,
+    )
+    _assert_json_payload_under(payload, 15850, label="implement generated-surface tiny payload", sort_keys=False)
 
 
 def test_implement_surfaces_runtime_source_edit_review_for_generated_cli_boundary(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -787,7 +787,7 @@ def test_start_command_returns_minimum_safe_startup_context(tmp_path: Path, caps
         "manual-handoff",
         "ask-human",
     }
-    assert len(json.dumps(payload, sort_keys=True)) < 18450
+    _assert_json_payload_under(payload, 18450, label="start generated CLI changed-path payload")
     assert payload["proof"]["required_commands"] == [
         "uv run agentic-workspace defaults --section root_cli_authority --format json",
         "uv run python scripts/check/check_generated_command_packages.py",
@@ -1007,8 +1007,7 @@ def test_start_tiny_profile_returns_first_contact_projection(capsys) -> None:
     assert cli.main(["start", "--task", task, "--format", "json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
-    encoded = json.dumps(payload, sort_keys=True)
-    assert len(encoded) < 15000
+    _assert_json_payload_under(payload, 15000, label="start first-contact tiny payload")
     assert payload["kind"] == "startup-context/v1"
     assert payload["drill_down"]["rule"].startswith("Use --select")
     assert "cli_invocation" in payload["drill_down"]["available_selectors"]
@@ -1044,8 +1043,7 @@ def test_start_default_returns_selector_first_router(tmp_path: Path, capsys) -> 
     assert cli.main(["start", "--target", str(target), "--task", task, "--format", "json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
-    encoded = json.dumps(payload, sort_keys=True)
-    assert len(encoded) < 9000
+    _assert_json_payload_under(payload, 9000, label="start selector-first router payload")
     assert payload["kind"] == "startup-context/v1"
     assert set(payload) == {"kind", "target", "action_signals", "next_safe_action", "skills", "context", "drill_down"}
     competing_top_level_decision_fields = {
@@ -1597,7 +1595,7 @@ def test_start_tiny_does_not_route_config_posture_questions_from_prompt_keywords
     payload = json.loads(capsys.readouterr().out)
     action = _start_primary_action(payload)
     assert action["action"] != "inspect-effective-config"
-    assert len(json.dumps(payload, sort_keys=True)) < 14500
+    _assert_json_payload_under(payload, 14500, label="start config-posture prompt tiny payload")
 
 
 def test_start_tiny_compacts_long_task_carry_forward_command(tmp_path: Path, capsys) -> None:
@@ -1630,7 +1628,7 @@ def test_start_tiny_compacts_long_task_carry_forward_command(tmp_path: Path, cap
     assert "Write the original request once" in task_context["task_file_instruction"]
     assert len(task_context["task_digest"]) == 16
     assert task_context["task_text_length"] == len(task)
-    assert len(json.dumps(payload, sort_keys=True)) < 8800
+    _assert_json_payload_under(payload, 8800, label="start long-task tiny payload")
 
 
 def test_start_tiny_does_not_route_prep_only_handoff_from_prompt_keywords(tmp_path: Path, capsys) -> None:
@@ -1652,7 +1650,7 @@ def test_start_tiny_does_not_route_prep_only_handoff_from_prompt_keywords(tmp_pa
     assert "prep_only_handoff" not in _start_context(payload)
     packet = payload["next_safe_action"]
     assert packet["next_safe_action"] == "choose-smallest-workflow-shape"
-    assert len(json.dumps(payload, sort_keys=True)) < 9500
+    _assert_json_payload_under(payload, 9500, label="start prep-only tiny payload")
 
 
 def test_start_tiny_keeps_paraphrased_prep_only_prompt_agent_owned(tmp_path: Path, capsys) -> None:

--- a/tests/workspace_cli_support.py
+++ b/tests/workspace_cli_support.py
@@ -342,4 +342,38 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
     _write(path, json.dumps(payload, indent=2) + "\n")
 
 
+def _json_payload_size(value: object, *, sort_keys: bool = True) -> int:
+    return len(json.dumps(value, sort_keys=sort_keys).encode("utf-8"))
+
+
+def _json_payload_contributors(value: object, *, sort_keys: bool = True, limit: int = 8) -> list[tuple[str, int]]:
+    contributors: list[tuple[str, int]] = []
+
+    def walk(current: object, path: str) -> None:
+        if isinstance(current, dict):
+            for key, child in current.items():
+                child_path = f"{path}.{key}" if path else str(key)
+                contributors.append((child_path, _json_payload_size(child, sort_keys=sort_keys)))
+                walk(child, child_path)
+        elif isinstance(current, list):
+            for index, child in enumerate(current):
+                child_path = f"{path}[{index}]"
+                contributors.append((child_path, _json_payload_size(child, sort_keys=sort_keys)))
+                walk(child, child_path)
+
+    walk(value, "")
+    return sorted(contributors, key=lambda item: item[1], reverse=True)[:limit]
+
+
+def _assert_json_payload_under(value: object, max_bytes: int, *, label: str, sort_keys: bool = True) -> None:
+    actual = _json_payload_size(value, sort_keys=sort_keys)
+    if actual < max_bytes:
+        return
+    contributors = _json_payload_contributors(value, sort_keys=sort_keys)
+    contribution_lines = "\n".join(f"  - {path}: {size} bytes" for path, size in contributors)
+    raise AssertionError(
+        f"{label} JSON payload is {actual} bytes; budget is < {max_bytes} bytes.\nLargest JSON contributors:\n{contribution_lines}"
+    )
+
+
 __all__ = [name for name in globals() if not name.startswith("__")]


### PR DESCRIPTION
## Summary
- Add a shared JSON payload budget assertion helper that reports the largest nested contributors when a budget is exceeded.
- Convert startup and implement tiny payload budget checks to use the helper.
- Add regression coverage for the diagnostic failure message.

## Proof
- `uv run pytest tests/test_workspace_cli.py::test_json_payload_budget_failure_reports_largest_contributors tests/test_workspace_start_preflight_cli.py::test_start_tiny_compacts_long_task_carry_forward_command tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q`
- `make test-workspace`
- `make lint-workspace`

Resolves #1492