### PR TITLE
[codex] Ignore repo-owned AW local runtime state

### DIFF
--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -4951,6 +4951,7 @@ EXTERNAL_INTENT_PLANNING_RELATIVE_PATH = Path(".agentic-workspace") / "planning"
 EXTERNAL_INTENT_CACHE_CLOSED_RETENTION_DAYS = 7
 LOCAL_ONLY_IGNORE_BLOCK = "# Agentic Workspace local-only storage\n.agentic-workspace/\nAGENTS.local.md\n"
 LEGACY_LOCAL_ONLY_IGNORE_BLOCKS = ("# Agentic Workspace local-only storage\n.agentic-workspace/\n",)
+REPO_OWNED_LOCAL_IGNORE_BLOCK = "# Agentic Workspace local runtime state\n.agentic-workspace/local/\n"
 LOCAL_ONLY_STATE_FILE = Path(".agentic-workspace") / "LOCAL-ONLY.toml"
 
 
@@ -5238,6 +5239,23 @@ def _remove_legacy_local_only_gitignore(*, repo_root: Path, dry_run: bool) -> di
     }
 
 
+def _ensure_repo_owned_local_gitignore(*, target_root: Path, dry_run: bool) -> dict[str, str]:
+    gitignore_path = target_root / ".gitignore"
+    existing_text = gitignore_path.read_text(encoding="utf-8") if gitignore_path.exists() else ""
+    if re.search(r"(?m)^\.agentic-workspace/local/?$", existing_text):
+        return {"kind": "current", "path": ".gitignore", "detail": "repo-owned local runtime state already ignored"}
+    rendered_text = existing_text.rstrip()
+    addition = "\n" + REPO_OWNED_LOCAL_IGNORE_BLOCK
+    rendered_text = rendered_text + addition if rendered_text else addition.lstrip("\n")
+    if not dry_run:
+        gitignore_path.write_text(rendered_text, encoding="utf-8")
+    return {
+        "kind": "would create" if dry_run and (not gitignore_path.exists()) else "would update" if dry_run else "created",
+        "path": ".gitignore",
+        "detail": "record .agentic-workspace/local/ as repo-owned ignored runtime state",
+    }
+
+
 def _managed_workspace_config_header(*, cli_invoke: str) -> str:
     return "\n".join(
         [
@@ -5468,6 +5486,8 @@ def _workspace_init_or_upgrade_report(
                     "detail": "legacy llms.txt exists but is not recognized as the retired generated adapter",
                 }
             )
+    if local_only_repo_root is None:
+        actions.append(_ensure_repo_owned_local_gitignore(target_root=target_root, dry_run=dry_run))
     actions.append(_ensure_local_scratch(target_root=target_root, dry_run=dry_run))
     policy_actions, policy_warnings = _sync_update_policy_actions(
         target_root=target_root, selected_modules=selected_modules, dry_run=dry_run, command_name=command_name, config=config, apply=True

--- a/tests/test_workspace_lifecycle_cli.py
+++ b/tests/test_workspace_lifecycle_cli.py
@@ -124,6 +124,39 @@ def test_init_seeds_schema_valid_workspace_config(monkeypatch, tmp_path: Path, c
     assert ".agentic-workspace/config.toml" in payload["created"]
 
 
+def test_init_ignores_repo_owned_local_runtime_state(monkeypatch, tmp_path: Path, capsys) -> None:
+    calls: list[tuple[str, str, dict[str, object]]] = []
+    subprocess.run(["git", "-C", str(tmp_path), "init"], check=True, capture_output=True, text=True)
+    monkeypatch.setattr(cli, "_module_operations", lambda: _fake_descriptors(tmp_path, calls))
+
+    assert cli.main(["init", "--target", str(tmp_path), "--preset", "planning", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    gitignore_text = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    cache_path = tmp_path / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json"
+    _write(cache_path, "{}\n", encoding="utf-8")
+    check_ignore = subprocess.run(
+        ["git", "-C", str(tmp_path), "check-ignore", "-v", ".agentic-workspace/local/cache/external-intent-evidence.json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    status = subprocess.run(
+        ["git", "-C", str(tmp_path), "status", "--short", "--untracked-files=all", "--", ".agentic-workspace/local"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert ".agentic-workspace/local/" in gitignore_text
+    workspace_report = next(report for report in payload["module_reports"] if report["module"] == "workspace")
+    ignore_action = next(action for action in workspace_report["actions"] if action["path"] == ".gitignore")
+    assert ignore_action["kind"] == "created"
+    assert "repo-owned ignored runtime state" in ignore_action["detail"]
+    assert ".gitignore" in check_ignore.stdout
+    assert status.stdout == ""
+
+
 def test_init_dry_run_reports_workspace_config_seed_without_writing(monkeypatch, tmp_path: Path, capsys) -> None:
     calls: list[tuple[str, str, dict[str, object]]] = []
     _init_git_repo(tmp_path)


### PR DESCRIPTION
## Summary

- add repo-owned lifecycle sync for a .gitignore rule covering .agentic-workspace/local/
- keep local-only installs on their existing .git/info/exclude path
- add a regression that creates a real Git repo, runs init, writes local cache state, and proves Git ignores it

Resolves #1508

## Validation

- uv run pytest tests/test_workspace_lifecycle_cli.py -k "repo_owned_local_runtime_state or local_only_uses_normal_layout"
- uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_lifecycle_cli.py
- make test-workspace
- make lint-workspace
