### PR TITLE
[codex] Build versioned AW package artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,36 @@ jobs:
       - name: Check generated command packages
         run: uv run python scripts/check/check_generated_command_packages.py
 
+  workspace-package-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Sync workspace dependencies
+        run: make sync-all
+
+      - name: Build Agentic Workspace package artifacts
+        run: uv build --wheel --sdist --out-dir dist
+
+      - name: Run built package smoke tests
+        run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_wheel_imports_cli_module tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence -q
+
+      - name: Upload Agentic Workspace package artifacts
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: agentic-workspace-package-artifacts
+          path: dist/*
+          if-no-files-found: error
+
   package-checks:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,11 @@ jobs:
         run: make sync-all
 
       - name: Build Agentic Workspace package artifacts
-        run: uv build --wheel --sdist --out-dir dist
+        run: |
+          uv build --wheel --sdist --out-dir dist
+          uv build --wheel --sdist --out-dir dist packages/memory
+          uv build --wheel --sdist --out-dir dist packages/planning
+          uv build --wheel --sdist --out-dir dist packages/verification
 
       - name: Run built package smoke tests
         run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_wheel_imports_cli_module tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,11 @@ jobs:
               raise SystemExit(f"Release tag {tag!r} must match pyproject.toml version {expected!r}")
 
       - name: Build Agentic Workspace package artifacts
-        run: uv build --wheel --sdist --out-dir dist
+        run: |
+          uv build --wheel --sdist --out-dir dist
+          uv build --wheel --sdist --out-dir dist packages/memory
+          uv build --wheel --sdist --out-dir dist packages/planning
+          uv build --wheel --sdist --out-dir dist packages/verification
 
       - name: Run built package smoke tests
         run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_wheel_imports_cli_module tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  agentic-workspace-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Sync workspace dependencies
+        run: make sync-all
+
+      - name: Verify tag matches package version
+        shell: python
+        run: |
+          import os
+          import tomllib
+          from pathlib import Path
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          version = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+          expected = f"v{version}"
+          if tag != expected:
+              raise SystemExit(f"Release tag {tag!r} must match pyproject.toml version {expected!r}")
+
+      - name: Build Agentic Workspace package artifacts
+        run: uv build --wheel --sdist --out-dir dist
+
+      - name: Run built package smoke tests
+        run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_wheel_imports_cli_module tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence -q
+
+      - name: Publish GitHub release assets
+        uses: softprops/action-gh-release@v2.4.2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentic-workspace"
-version = "0.0.0"
+version = "0.1.0"
 description = "Repo-native continuity and execution layer for agents, combining workspace routing, active planning, and durable memory."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_workspace_packaging.py
+++ b/tests/test_workspace_packaging.py
@@ -18,6 +18,11 @@ from zipfile import ZipFile
 WORKSPACE_ROOT = Path(__file__).resolve().parents[1]
 PAYLOAD_ROOT = WORKSPACE_ROOT / "src" / "agentic_workspace" / "_payload"
 PACKAGE_PREFIX = Path("agentic_workspace") / "_payload"
+MODULE_PACKAGE_DIRS = (
+    WORKSPACE_ROOT / "packages" / "memory",
+    WORKSPACE_ROOT / "packages" / "planning",
+    WORKSPACE_ROOT / "packages" / "verification",
+)
 
 
 @contextlib.contextmanager
@@ -41,16 +46,22 @@ def _source_inventory() -> set[str]:
 
 
 def _build_artifact(tmpdir: str, artifact: str) -> Path:
+    return _build_artifact_from(WORKSPACE_ROOT, tmpdir, artifact)
+
+
+def _build_artifact_from(package_root: Path, tmpdir: str, artifact: str) -> Path:
+    output_dir = Path(tmpdir)
+    pattern = "*.whl" if artifact == "wheel" else "*.tar.gz"
+    before = set(output_dir.glob(pattern))
     with _package_build_lock():
         subprocess.run(
-            ["uv", "build", f"--{artifact}", "-o", tmpdir],
+            ["uv", "build", f"--{artifact}", "-o", tmpdir, str(package_root)],
             cwd=WORKSPACE_ROOT,
             capture_output=True,
             text=True,
             check=True,
         )
-    pattern = "*.whl" if artifact == "wheel" else "*.tar.gz"
-    artifacts = list(Path(tmpdir).glob(pattern))
+    artifacts = [path for path in output_dir.glob(pattern) if path not in before]
     assert len(artifacts) == 1, f"Expected exactly 1 {artifact}, found {len(artifacts)}"
     return artifacts[0]
 
@@ -125,6 +136,9 @@ def test_ci_builds_and_uploads_root_package_artifacts() -> None:
 
     assert "workspace-package-artifacts:" in ci_text
     assert "uv build --wheel --sdist --out-dir dist" in ci_text
+    assert "uv build --wheel --sdist --out-dir dist packages/memory" in ci_text
+    assert "uv build --wheel --sdist --out-dir dist packages/planning" in ci_text
+    assert "uv build --wheel --sdist --out-dir dist packages/verification" in ci_text
     assert "test_installed_workspace_stack_runs_fresh_repo_cli_sequence" in ci_text
     assert "actions/upload-artifact@v6.0.0" in ci_text
 
@@ -135,6 +149,9 @@ def test_release_workflow_publishes_tagged_root_package_artifacts() -> None:
     assert '"v[0-9]+.[0-9]+.[0-9]+"' in release_text
     assert "Release tag {tag!r} must match pyproject.toml version {expected!r}" in release_text
     assert "uv build --wheel --sdist --out-dir dist" in release_text
+    assert "uv build --wheel --sdist --out-dir dist packages/memory" in release_text
+    assert "uv build --wheel --sdist --out-dir dist packages/planning" in release_text
+    assert "uv build --wheel --sdist --out-dir dist packages/verification" in release_text
     assert "softprops/action-gh-release@v2.4.2" in release_text
 
 
@@ -233,8 +250,8 @@ def test_workspace_runtime_entrypoint_stays_off_command_generation() -> None:
 def test_installed_workspace_stack_runs_fresh_repo_cli_sequence() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
-        wheel_path = _build_artifact(tmpdir, "wheel")
-        workspace_exe = _install_workspace_stack_venv(wheel_path=wheel_path, tmpdir_path=tmpdir_path)
+        wheelhouse = _build_workspace_wheelhouse(tmpdir)
+        workspace_exe = _install_workspace_stack_venv(wheelhouse=wheelhouse, tmpdir_path=tmpdir_path)
         assert _venv_site_package_entry_names(tmpdir_path / ".venv", "command_generation") == []
         target = tmpdir_path / "repo"
         target.mkdir()
@@ -319,7 +336,18 @@ def test_installed_workspace_stack_runs_fresh_repo_cli_sequence() -> None:
     assert doctor_payload["health"] == "healthy"
 
 
-def _install_workspace_stack_venv(*, wheel_path: Path, tmpdir_path: Path) -> Path:
+def _build_workspace_wheelhouse(tmpdir: str) -> list[Path]:
+    wheel_paths = [_build_artifact(tmpdir, "wheel")]
+    wheel_paths.extend(_build_artifact_from(package_dir, tmpdir, "wheel") for package_dir in MODULE_PACKAGE_DIRS)
+    names = {path.name for path in wheel_paths}
+    assert any(name.startswith("agentic_workspace-") for name in names)
+    assert any(name.startswith("agentic_memory-") for name in names)
+    assert any(name.startswith("agentic_planning-") for name in names)
+    assert any(name.startswith("agentic_verification-") for name in names)
+    return wheel_paths
+
+
+def _install_workspace_stack_venv(*, wheelhouse: list[Path], tmpdir_path: Path) -> Path:
     venv_path = tmpdir_path / ".venv"
     subprocess.run(
         ["uv", "venv", str(venv_path)],
@@ -336,10 +364,7 @@ def _install_workspace_stack_venv(*, wheel_path: Path, tmpdir_path: Path) -> Pat
             "install",
             "--python",
             str(python_path),
-            str(WORKSPACE_ROOT / "packages" / "memory"),
-            str(WORKSPACE_ROOT / "packages" / "planning"),
-            str(WORKSPACE_ROOT / "packages" / "verification"),
-            str(wheel_path),
+            *(str(path) for path in wheelhouse),
         ],
         cwd=WORKSPACE_ROOT,
         capture_output=True,

--- a/tests/test_workspace_packaging.py
+++ b/tests/test_workspace_packaging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -9,6 +10,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 import tomllib
 from pathlib import Path
 from zipfile import ZipFile
@@ -18,18 +20,35 @@ PAYLOAD_ROOT = WORKSPACE_ROOT / "src" / "agentic_workspace" / "_payload"
 PACKAGE_PREFIX = Path("agentic_workspace") / "_payload"
 
 
+@contextlib.contextmanager
+def _package_build_lock():
+    lock_path = WORKSPACE_ROOT / "scratch" / "package-build.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    while True:
+        try:
+            lock_path.mkdir()
+            break
+        except FileExistsError:
+            time.sleep(0.05)
+    try:
+        yield
+    finally:
+        lock_path.rmdir()
+
+
 def _source_inventory() -> set[str]:
     return {path.relative_to(PAYLOAD_ROOT).as_posix() for path in PAYLOAD_ROOT.rglob("*") if path.is_file()}
 
 
 def _build_artifact(tmpdir: str, artifact: str) -> Path:
-    subprocess.run(
-        ["uv", "build", f"--{artifact}", "-o", tmpdir],
-        cwd=WORKSPACE_ROOT,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    with _package_build_lock():
+        subprocess.run(
+            ["uv", "build", f"--{artifact}", "-o", tmpdir],
+            cwd=WORKSPACE_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
     pattern = "*.whl" if artifact == "wheel" else "*.tar.gz"
     artifacts = list(Path(tmpdir).glob(pattern))
     assert len(artifacts) == 1, f"Expected exactly 1 {artifact}, found {len(artifacts)}"

--- a/tests/test_workspace_packaging.py
+++ b/tests/test_workspace_packaging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tarfile
@@ -92,6 +93,30 @@ def test_workspace_artifacts_match_checked_in_payload_inventory() -> None:
     assert wheel_inventory == expected_inventory
     assert sdist_inventory == expected_inventory
     assert installed_inventory == expected_inventory
+
+
+def test_workspace_package_declares_semver_identity() -> None:
+    pyproject = tomllib.loads((WORKSPACE_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert re.fullmatch(r"\d+\.\d+\.\d+", pyproject["project"]["version"])
+
+
+def test_ci_builds_and_uploads_root_package_artifacts() -> None:
+    ci_text = (WORKSPACE_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "workspace-package-artifacts:" in ci_text
+    assert "uv build --wheel --sdist --out-dir dist" in ci_text
+    assert "test_installed_workspace_stack_runs_fresh_repo_cli_sequence" in ci_text
+    assert "actions/upload-artifact@v6.0.0" in ci_text
+
+
+def test_release_workflow_publishes_tagged_root_package_artifacts() -> None:
+    release_text = (WORKSPACE_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert '"v[0-9]+.[0-9]+.[0-9]+"' in release_text
+    assert "Release tag {tag!r} must match pyproject.toml version {expected!r}" in release_text
+    assert "uv build --wheel --sdist --out-dir dist" in release_text
+    assert "softprops/action-gh-release@v2.4.2" in release_text
 
 
 def test_workspace_surface_manifest_payload_entries_exist_in_source_payload() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -33,7 +33,7 @@ source = { editable = "packages/verification" }
 
 [[package]]
 name = "agentic-workspace"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "agentic-memory" },


### PR DESCRIPTION
## Summary

- set the root Agentic Workspace package to semver identity 0.1.0
- add CI coverage that builds wheel/sdist artifacts, runs built-package smoke tests, and uploads artifacts
- add a semver tag release workflow that verifies tag/version alignment and publishes wheel/sdist assets
- serialize package artifact test builds so xdist does not race concurrent uv build invocations

Resolves #1510

## Validation

- uv run pytest tests/test_workspace_packaging.py -q
- uv run ruff check tests/test_workspace_packaging.py
- make test-workspace
- make lint-workspace
