### PR TITLE
[codex] Record AW payload provenance

### DIFF
--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -40,7 +40,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `invoked_cli_identity.kind` | const `"agentic-workspace/invoked-cli-identity/v1"` | yes |  | Discriminator identifying the payload or record shape. |  |  |
 | `invoked_cli_identity.package` | const `"agentic-workspace"` | yes |  | Fixed package value required by this contract. |  |  |
 | `invoked_cli_identity.version` | string | yes |  | Version text value used by this contract. |  |  |
-| `invoked_cli_identity.source_class` | enum `"source-checkout"`, `"installed-package"`, `"unknown"` | yes |  | Allowed source class value for routing or validation. |  |  |
+| `invoked_cli_identity.source_class` | enum `"source-checkout"`, `"installed-package"`, `"editable-dev"`, `"unknown"` | yes |  | Allowed source class value for routing or validation. |  |  |
 | `invoked_cli_identity.confidence` | enum `"high"`, `"medium"`, `"low"` | no |  | Allowed confidence value for routing or validation. |  |  |
 | `invoked_cli_identity.module_path` | string | yes |  | Module path text value used by this contract. |  |  |
 | `invoked_cli_identity.package_root` | string \| null | no |  | Package root contract value used by this contract. |  |  |

--- a/docs/reference/workspace-config.md
+++ b/docs/reference/workspace-config.md
@@ -95,6 +95,6 @@ Repo-owned Agentic Workspace configuration stored in .agentic-workspace/config.t
 | `cli_compatibility.enforcement` | enum `"off"`, `"advisory"`, `"blocking"` | no | `"off"` | How strictly CLI compatibility expectations should be enforced. |  |  |
 | `cli_compatibility.minimum_version` | string | no |  | Minimum accepted Agentic Workspace CLI version. | `"0.4.0"` |  |
 | `cli_compatibility.exact_version` | string | no |  | Exact accepted Agentic Workspace CLI version when a repo must pin execution. | `"0.4.0"` |  |
-| `cli_compatibility.source_classes` | array of enum `"source-checkout"`, `"installed-package"`, `"unknown"` | no | `[]` | Allowed source classes for the invoked CLI executable. |  |  |
+| `cli_compatibility.source_classes` | array of enum `"source-checkout"`, `"installed-package"`, `"editable-dev"`, `"unknown"` | no | `[]` | Allowed source classes for the invoked CLI executable. |  |  |
 | `cli_compatibility.target_relations` | array of enum `"inside-target"`, `"outside-target"`, `"no-target"` | no | `[]` | Allowed relation between the invoked CLI executable and the target repo. |  |  |
 | `cli_compatibility.command` | string | no |  | Expected CLI command string when the repo wants compatibility checks to match a specific invocation. | `"agentic-workspace"` |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -24,7 +24,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `invoked_cli_identity.kind` | const `"agentic-workspace/invoked-cli-identity/v1"` | yes |  | Discriminator identifying the payload or record shape. |  |  |
 | `invoked_cli_identity.package` | const `"agentic-workspace"` | yes |  | Fixed package value required by this contract. |  |  |
 | `invoked_cli_identity.version` | string | yes |  | Version text value used by this contract. |  |  |
-| `invoked_cli_identity.source_class` | enum `"source-checkout"`, `"installed-package"`, `"unknown"` | yes |  | Allowed source class value for routing or validation. |  |  |
+| `invoked_cli_identity.source_class` | enum `"source-checkout"`, `"installed-package"`, `"editable-dev"`, `"unknown"` | yes |  | Allowed source class value for routing or validation. |  |  |
 | `invoked_cli_identity.confidence` | enum `"high"`, `"medium"`, `"low"` | no |  | Allowed confidence value for routing or validation. |  |  |
 | `invoked_cli_identity.module_path` | string | yes |  | Module path text value used by this contract. |  |  |
 | `invoked_cli_identity.package_root` | string \| null | no |  | Package root contract value used by this contract. |  |  |

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -220,6 +220,7 @@ SUPPORTED_CLI_COMPATIBILITY_ENFORCEMENT = (
 SUPPORTED_CLI_SOURCE_CLASSES = (
     "source-checkout",
     "installed-package",
+    "editable-dev",
     "unknown",
 )
 SUPPORTED_CLI_TARGET_RELATIONS = (

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -604,6 +604,7 @@
           "enum": [
             "source-checkout",
             "installed-package",
+            "editable-dev",
             "unknown"
           ],
           "description": "Allowed source class value for routing or validation."

--- a/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
@@ -540,6 +540,7 @@
             "enum": [
               "source-checkout",
               "installed-package",
+              "editable-dev",
               "unknown"
             ],
             "description": "One entry in the source classes list."

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -1142,6 +1142,7 @@
           "enum": [
             "source-checkout",
             "installed-package",
+            "editable-dev",
             "unknown"
           ],
           "description": "Allowed source class value for routing or validation."

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -283,7 +283,7 @@ def _invoked_cli_identity_payload(*, target_root: Path | None = None, compact: b
         source_class = "source-checkout"
         confidence = "high"
     elif module_path.exists():
-        source_class = "installed-package"
+        source_class = _installed_package_source_class(package="agentic-workspace")
         confidence = "medium"
     else:
         source_class = "unknown"
@@ -309,6 +309,24 @@ def _invoked_cli_identity_payload(*, target_root: Path | None = None, compact: b
             key: payload[key] for key in ("kind", "package", "version", "source_class", "module_path", "target_relation", "compatibility")
         }
     return payload
+
+
+def _installed_package_source_class(*, package: str) -> str:
+    try:
+        distribution = importlib.metadata.distribution(package)
+    except importlib.metadata.PackageNotFoundError:
+        return "installed-package"
+    direct_url_text = distribution.read_text("direct_url.json")
+    if not direct_url_text:
+        return "installed-package"
+    try:
+        direct_url = json.loads(direct_url_text)
+    except json.JSONDecodeError:
+        return "installed-package"
+    dir_info = direct_url.get("dir_info") if isinstance(direct_url, dict) else None
+    if isinstance(dir_info, dict) and dir_info.get("editable") is True:
+        return "editable-dev"
+    return "installed-package"
 
 
 def _package_version(package: str) -> str:
@@ -344,6 +362,9 @@ def _payload_installer_identity(*, target_root: Path | None = None) -> dict[str,
     if source_class == "source-checkout":
         source = "local-source"
         source_identity = _git_source_identity(_agentic_workspace_package_root())
+    elif source_class == "editable-dev":
+        source = "repo-local-dev"
+        source_identity = str(identity.get("module_path", ""))
     elif source_class == "installed-package":
         source = "released-wheel"
         source_identity = str(identity.get("module_path", ""))
@@ -398,11 +419,27 @@ def _payload_provenance_payload(*, target_root: Path) -> dict[str, Any]:
     }
 
 
+def _stable_payload_provenance(payload: dict[str, Any]) -> dict[str, Any]:
+    return {key: copy.deepcopy(value) for key, value in payload.items() if key != "installed_at"}
+
+
 def _write_payload_provenance_action(*, target_root: Path, dry_run: bool) -> dict[str, str]:
     relative = WORKSPACE_PAYLOAD_PROVENANCE_PATH
     path = target_root / relative
     existing_text = path.read_text(encoding="utf-8") if path.exists() else None
+    existing_payload: dict[str, Any] | None = None
+    if existing_text is not None:
+        try:
+            parsed_existing = json.loads(existing_text)
+        except json.JSONDecodeError:
+            parsed_existing = None
+        if isinstance(parsed_existing, dict):
+            existing_payload = parsed_existing
     payload = _payload_provenance_payload(target_root=target_root)
+    if existing_payload is not None and _stable_payload_provenance(existing_payload) == _stable_payload_provenance(payload):
+        return {"kind": "current", "path": relative.as_posix(), "detail": "payload provenance already current"}
+    if existing_payload is not None and existing_payload.get("installed_at"):
+        payload["installed_at"] = existing_payload["installed_at"]
     rendered_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     if existing_text == rendered_text:
         return {"kind": "current", "path": relative.as_posix(), "detail": "payload provenance already current"}
@@ -414,6 +451,46 @@ def _write_payload_provenance_action(*, target_root: Path, dry_run: bool) -> dic
         "path": relative.as_posix(),
         "detail": "record AW payload provenance for installed-state compatibility checks",
     }
+
+
+def _validate_payload_provenance(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("payload_schema") != WORKSPACE_PAYLOAD_SCHEMA:
+        errors.append("payload_schema must be agentic-workspace/payload/v1")
+    installed_by = payload.get("installed_by")
+    if not isinstance(installed_by, dict):
+        errors.append("installed_by must be an object")
+    else:
+        required_installed_by = {
+            "package": "agentic-workspace",
+            "version": None,
+            "source": {"released-wheel", "repo-local-dev", "local-source", "unknown"},
+            "source_class": {"installed-package", "editable-dev", "source-checkout", "unknown"},
+            "source_identity": None,
+        }
+        for field, expected in required_installed_by.items():
+            value = installed_by.get(field)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"installed_by.{field} must be a non-empty string")
+            elif isinstance(expected, str) and value != expected:
+                errors.append(f"installed_by.{field} must be {expected}")
+            elif isinstance(expected, set) and value not in expected:
+                errors.append(f"installed_by.{field} has unsupported value {value!r}")
+    command_generation = payload.get("command_generation")
+    if not isinstance(command_generation, dict):
+        errors.append("command_generation must be an object")
+    else:
+        if command_generation.get("package") != "command-generation":
+            errors.append("command_generation.package must be command-generation")
+        source = command_generation.get("source")
+        if not isinstance(source, str) or source not in {"released-wheel", "repo-local-dev", "local-source", "not-installed", "unknown"}:
+            errors.append("command_generation.source has unsupported value")
+    if not isinstance(payload.get("installed_at"), str) or not str(payload.get("installed_at")).strip():
+        errors.append("installed_at must be a non-empty string")
+    payload_files = payload.get("payload_files")
+    if not isinstance(payload_files, list) or not all(isinstance(item, str) and item for item in payload_files):
+        errors.append("payload_files must be a list of non-empty strings")
+    return errors
 
 
 def _read_payload_provenance(*, target_root: Path) -> dict[str, Any]:
@@ -439,6 +516,14 @@ def _read_payload_provenance(*, target_root: Path) -> dict[str, Any]:
             "status": "invalid",
             "path": WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
             "error": "payload provenance kind is missing or unsupported",
+        }
+    validation_errors = _validate_payload_provenance(payload)
+    if validation_errors:
+        return {
+            "kind": "agentic-workspace/payload-provenance-status/v1",
+            "status": "invalid",
+            "path": WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
+            "errors": validation_errors,
         }
     return {
         "kind": "agentic-workspace/payload-provenance-status/v1",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -14,6 +14,7 @@ import difflib
 import fnmatch
 import hashlib
 import importlib
+import importlib.metadata
 import io
 import json
 import os
@@ -205,6 +206,8 @@ WORKSPACE_PAYLOAD_FILES = tuple((Path(relative) for relative in _WORKSPACE_SURFA
 WORKSPACE_CONFIG_CONTRACT_DOC = ".agentic-workspace/docs/workspace-config-contract.md"
 WORKSPACE_CONFIG_SOURCE_SCHEMA = "src/agentic_workspace/contracts/schemas/workspace_config.schema.json"
 WORKSPACE_CONFIG_REFERENCE_DOC = "docs/reference/workspace-config.md"
+WORKSPACE_PAYLOAD_PROVENANCE_PATH = Path(".agentic-workspace") / "payload-provenance.json"
+WORKSPACE_PAYLOAD_SCHEMA = "agentic-workspace/payload/v1"
 WORKSPACE_POINTER_BLOCK = workspace_pointer_block()
 SYSTEM_INTENT_MIRROR_KIND = str(_WORKSPACE_SURFACES_MANIFEST["system_intent_mirror_kind"])
 SUBSYSTEM_INTENT_KIND = str(_WORKSPACE_SURFACES_MANIFEST["subsystem_intent_kind"])
@@ -306,6 +309,143 @@ def _invoked_cli_identity_payload(*, target_root: Path | None = None, compact: b
             key: payload[key] for key in ("kind", "package", "version", "source_class", "module_path", "target_relation", "compatibility")
         }
     return payload
+
+
+def _package_version(package: str) -> str:
+    try:
+        return importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        return ""
+
+
+def _git_source_identity(root: Path | None) -> str:
+    if root is None:
+        return ""
+    git_dir = root / ".git"
+    head_path = git_dir / "HEAD"
+    try:
+        head_text = head_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return root.as_posix()
+    if head_text.startswith("ref:"):
+        ref = head_text.split(":", 1)[1].strip()
+        try:
+            revision = (git_dir / ref).read_text(encoding="utf-8").strip()
+        except OSError:
+            revision = ""
+    else:
+        revision = head_text
+    return f"git:{revision[:12]}" if revision else root.as_posix()
+
+
+def _payload_installer_identity(*, target_root: Path | None = None) -> dict[str, Any]:
+    identity = _invoked_cli_identity_payload(target_root=target_root)
+    source_class = str(identity.get("source_class", "unknown"))
+    if source_class == "source-checkout":
+        source = "local-source"
+        source_identity = _git_source_identity(_agentic_workspace_package_root())
+    elif source_class == "installed-package":
+        source = "released-wheel"
+        source_identity = str(identity.get("module_path", ""))
+    else:
+        source = "unknown"
+        source_identity = str(identity.get("module_path", ""))
+    return {
+        "package": "agentic-workspace",
+        "version": __version__,
+        "source": source,
+        "source_class": source_class,
+        "source_identity": source_identity,
+        "module_path": identity.get("module_path", ""),
+        "python_executable": identity.get("python_executable", ""),
+    }
+
+
+def _command_generation_package_identity() -> dict[str, Any]:
+    version = _package_version("command-generation")
+    if not version:
+        return {
+            "package": "command-generation",
+            "version": "",
+            "source": "not-installed",
+            "source_identity": "",
+            "runtime_required": False,
+        }
+    try:
+        import command_generation  # noqa: PLC0415
+    except ImportError:
+        module_path = ""
+    else:
+        module_path = Path(command_generation.__file__).resolve().as_posix()
+    return {
+        "package": "command-generation",
+        "version": version,
+        "source": "released-wheel",
+        "source_identity": module_path,
+        "runtime_required": False,
+    }
+
+
+def _payload_provenance_payload(*, target_root: Path) -> dict[str, Any]:
+    return {
+        "kind": "agentic-workspace/payload-provenance/v1",
+        "payload_schema": WORKSPACE_PAYLOAD_SCHEMA,
+        "installed_by": _payload_installer_identity(target_root=target_root),
+        "command_generation": _command_generation_package_identity(),
+        "installed_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "payload_files": [relative.as_posix() for relative in WORKSPACE_PAYLOAD_FILES],
+        "rule": "Repo payload provenance records the executable/source identity that installed or last synced the AW payload.",
+    }
+
+
+def _write_payload_provenance_action(*, target_root: Path, dry_run: bool) -> dict[str, str]:
+    relative = WORKSPACE_PAYLOAD_PROVENANCE_PATH
+    path = target_root / relative
+    existing_text = path.read_text(encoding="utf-8") if path.exists() else None
+    payload = _payload_provenance_payload(target_root=target_root)
+    rendered_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if existing_text == rendered_text:
+        return {"kind": "current", "path": relative.as_posix(), "detail": "payload provenance already current"}
+    if not dry_run:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(rendered_text, encoding="utf-8")
+    return {
+        "kind": "would create" if dry_run and existing_text is None else "would update" if dry_run else "created",
+        "path": relative.as_posix(),
+        "detail": "record AW payload provenance for installed-state compatibility checks",
+    }
+
+
+def _read_payload_provenance(*, target_root: Path) -> dict[str, Any]:
+    path = target_root / WORKSPACE_PAYLOAD_PROVENANCE_PATH
+    if not path.is_file():
+        return {
+            "kind": "agentic-workspace/payload-provenance-status/v1",
+            "status": "missing",
+            "path": WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
+        }
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "kind": "agentic-workspace/payload-provenance-status/v1",
+            "status": "invalid",
+            "path": WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
+            "error": str(exc),
+        }
+    if not isinstance(payload, dict) or payload.get("kind") != "agentic-workspace/payload-provenance/v1":
+        return {
+            "kind": "agentic-workspace/payload-provenance-status/v1",
+            "status": "invalid",
+            "path": WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
+            "error": "payload provenance kind is missing or unsupported",
+        }
+    return {
+        "kind": "agentic-workspace/payload-provenance-status/v1",
+        "status": "present",
+        "path": WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
+        "payload": payload,
+    }
 
 
 def _version_key(version: str) -> tuple[int, ...]:
@@ -487,10 +627,29 @@ def _installed_state_compatibility_payload(
     failed_cli_checks = {str(check) for check in cli_payload.get("failed_checks", [])}
     stale_generated_surfaces = list((summary or {}).get("stale_generated_surfaces", []))
     payload_warnings = list((summary or {}).get("warnings", []))
+    provenance_status = _read_payload_provenance(target_root=config.target_root)
+    provenance_payload = provenance_status.get("payload") if isinstance(provenance_status.get("payload"), dict) else {}
+    installed_by = provenance_payload.get("installed_by", {}) if isinstance(provenance_payload, dict) else {}
+    installed_version = str(installed_by.get("version", "")) if isinstance(installed_by, dict) else ""
+    current_identity = _payload_installer_identity(target_root=config.target_root)
+    initialized_payload_present = (config.target_root / WORKSPACE_CONFIG_PATH).is_file() or bool(installed_modules)
+    payload_provenance_drift = "none"
+    if provenance_status.get("status") in {"invalid"}:
+        payload_provenance_drift = "invalid-provenance"
+    elif provenance_status.get("status") == "missing" and initialized_payload_present:
+        payload_provenance_drift = "missing-provenance"
+    elif installed_version and _version_key(installed_version) > _version_key(__version__):
+        payload_provenance_drift = "executable-too-old"
+    elif installed_version and _version_key(installed_version) < _version_key(__version__):
+        payload_provenance_drift = "payload-installed-by-older-aw"
     if cli_payload.get("status") == "blocking-drift":
         status = "blocking-drift"
         next_action = cli_payload.get("remediation", {}).get("command") or config.cli_invoke
         reason = "executable compatibility is blocking"
+    elif payload_provenance_drift == "executable-too-old":
+        status = "blocking-drift"
+        next_action = config.cli_invoke
+        reason = "repo payload provenance was installed by a newer AW version than the current executable"
     elif stale_generated_surfaces:
         status = "payload-upgrade-required"
         next_action = _command_with_cli_invoke(
@@ -498,6 +657,13 @@ def _installed_state_compatibility_payload(
             cli_invoke=config.cli_invoke,
         )
         reason = "module-managed or generated payload surfaces are stale"
+    elif payload_provenance_drift in {"missing-provenance", "invalid-provenance", "payload-installed-by-older-aw"}:
+        status = "payload-upgrade-required"
+        next_action = _command_with_cli_invoke(
+            command=f"agentic-workspace upgrade --target {config.target_root.as_posix()} --dry-run --format json",
+            cli_invoke=config.cli_invoke,
+        )
+        reason = "repo payload provenance must be synced before strong installed-state compatibility claims"
     elif cli_payload.get("status") == "advisory-drift":
         status = "upgrade-recommended"
         next_action = cli_payload.get("remediation", {}).get("command") or config.cli_invoke
@@ -509,12 +675,14 @@ def _installed_state_compatibility_payload(
     executable_class = "compatible"
     if failed_cli_checks & {"exact_version", "minimum_version"}:
         executable_class = "executable-too-old-or-wrong-version"
+    elif payload_provenance_drift == "executable-too-old":
+        executable_class = "executable-too-old-or-wrong-version"
     elif failed_cli_checks & {"source_class", "target_relation"}:
         executable_class = "use-repo-runner-required"
     elif cli_payload.get("status") == "advisory-drift":
         executable_class = "upgrade-recommended"
     generated_status = "stale" if stale_generated_surfaces else "compatible"
-    payload_status = "sync-required" if stale_generated_surfaces else "observed-compatible"
+    payload_status = "sync-required" if stale_generated_surfaces or payload_provenance_drift != "none" else "observed-compatible"
     payload: dict[str, Any] = {
         "kind": "agentic-workspace/installed-state-compatibility/v1",
         "status": status,
@@ -523,7 +691,9 @@ def _installed_state_compatibility_payload(
         "executable": {
             "package": "agentic-workspace",
             "version": __version__,
-            "source_class": _invoked_cli_identity_payload(target_root=config.target_root, compact=True).get("source_class"),
+            "source": current_identity.get("source"),
+            "source_class": current_identity.get("source_class"),
+            "source_identity": current_identity.get("source_identity"),
             "compatibility_status": cli_payload.get("status"),
             "classification": executable_class,
             "failed_checks": list(cli_payload.get("failed_checks", [])),
@@ -535,6 +705,8 @@ def _installed_state_compatibility_payload(
             "installed_modules": list(installed_modules),
             "warning_count": len(payload_warnings),
             "stale_generated_surfaces": stale_generated_surfaces,
+            "provenance": provenance_status,
+            "provenance_drift": payload_provenance_drift,
             "sync_command": _command_with_cli_invoke(
                 command=f"agentic-workspace upgrade --target {config.target_root.as_posix()} --dry-run --format json",
                 cli_invoke=config.cli_invoke,
@@ -578,7 +750,7 @@ def _installed_state_compatibility_payload(
             },
             "payload": {
                 key: payload["payload"][key]
-                for key in ("status", "installed_modules", "stale_generated_surfaces")
+                for key in ("status", "installed_modules", "stale_generated_surfaces", "provenance", "provenance_drift")
                 if payload["payload"].get(key) not in (None, [], "")
             },
             "generated_artifacts": payload["generated_artifacts"],
@@ -5372,6 +5544,7 @@ def _workspace_init_or_upgrade_report(
                 "detail": "refresh workspace shared-layer file from package payload",
             }
         )
+    actions.append(_write_payload_provenance_action(target_root=target_root, dry_run=dry_run))
     local_agent_actions, local_agent_warnings = _sync_workspace_managed_agent_instructions(
         target_root=target_root,
         config=config,

--- a/tests/test_workspace_lifecycle_cli.py
+++ b/tests/test_workspace_lifecycle_cli.py
@@ -157,6 +157,31 @@ def test_init_ignores_repo_owned_local_runtime_state(monkeypatch, tmp_path: Path
     assert status.stdout == ""
 
 
+def test_init_records_payload_provenance_manifest(monkeypatch, tmp_path: Path, capsys) -> None:
+    calls: list[tuple[str, str, dict[str, object]]] = []
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(cli, "_module_operations", lambda: _fake_descriptors(tmp_path, calls))
+
+    assert cli.main(["init", "--target", str(tmp_path), "--preset", "planning", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    provenance_path = tmp_path / ".agentic-workspace" / "payload-provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    workspace_report = next(report for report in payload["module_reports"] if report["module"] == "workspace")
+    provenance_action = next(
+        action for action in workspace_report["actions"] if action["path"] == ".agentic-workspace/payload-provenance.json"
+    )
+
+    assert provenance_action["kind"] == "created"
+    assert provenance["kind"] == "agentic-workspace/payload-provenance/v1"
+    assert provenance["payload_schema"] == "agentic-workspace/payload/v1"
+    assert provenance["installed_by"]["package"] == "agentic-workspace"
+    assert provenance["installed_by"]["version"] == cli.__version__
+    assert provenance["installed_by"]["source"] in {"local-source", "released-wheel", "unknown"}
+    assert provenance["command_generation"]["package"] == "command-generation"
+    assert provenance["installed_at"]
+
+
 def test_init_dry_run_reports_workspace_config_seed_without_writing(monkeypatch, tmp_path: Path, capsys) -> None:
     calls: list[tuple[str, str, dict[str, object]]] = []
     _init_git_repo(tmp_path)

--- a/tests/test_workspace_lifecycle_cli.py
+++ b/tests/test_workspace_lifecycle_cli.py
@@ -177,9 +177,30 @@ def test_init_records_payload_provenance_manifest(monkeypatch, tmp_path: Path, c
     assert provenance["payload_schema"] == "agentic-workspace/payload/v1"
     assert provenance["installed_by"]["package"] == "agentic-workspace"
     assert provenance["installed_by"]["version"] == cli.__version__
-    assert provenance["installed_by"]["source"] in {"local-source", "released-wheel", "unknown"}
+    assert provenance["installed_by"]["source"] in {"local-source", "repo-local-dev", "released-wheel", "unknown"}
     assert provenance["command_generation"]["package"] == "command-generation"
     assert provenance["installed_at"]
+
+
+def test_upgrade_keeps_payload_provenance_current_when_stable(monkeypatch, tmp_path: Path, capsys) -> None:
+    calls: list[tuple[str, str, dict[str, object]]] = []
+    _init_git_repo(tmp_path)
+    monkeypatch.setattr(cli, "_module_operations", lambda: _fake_descriptors(tmp_path, calls))
+    assert cli.main(["init", "--target", str(tmp_path), "--preset", "planning", "--format", "json"]) == 0
+    capsys.readouterr()
+    provenance_path = tmp_path / ".agentic-workspace" / "payload-provenance.json"
+    installed_at = json.loads(provenance_path.read_text(encoding="utf-8"))["installed_at"]
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--preset", "planning", "--dry-run", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    reports = payload.get("module_reports", payload.get("reports", []))
+    workspace_report = next(report for report in reports if report["module"] == "workspace")
+    provenance_action = next(
+        action for action in workspace_report["actions"] if action["path"] == ".agentic-workspace/payload-provenance.json"
+    )
+    assert provenance_action["kind"] == "current"
+    assert json.loads(provenance_path.read_text(encoding="utf-8"))["installed_at"] == installed_at
 
 
 def test_init_dry_run_reports_workspace_config_seed_without_writing(monkeypatch, tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -85,6 +85,8 @@ def test_report_surfaces_installed_state_compatibility_section(tmp_path: Path, c
     assert answer["status"] == "compatible"
     assert answer["authority"] == "repo-state-authoritative"
     assert answer["payload"]["status"] == "observed-compatible"
+    assert answer["payload"]["provenance"]["status"] == "missing"
+    assert answer["payload"]["provenance_drift"] == "none"
     assert answer["generated_artifacts"]["status"] == "compatible"
     assert any(contract["adapter"] == "cli" for contract in answer["adapter_contracts"])
     assert any(contract["adapter"] == "mcp" for contract in answer["adapter_contracts"])

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -3695,7 +3695,8 @@ def test_start_reports_blocking_cli_compatibility_drift_without_health_remediati
     installed_state = _assert_installed_state_compatibility(payload, status="blocking-drift")
     _assert_installed_state_compatibility_schema(payload, schema_name="startup_context.schema.json")
     assert installed_state["executable"]["classification"] == "executable-too-old-or-wrong-version"
-    assert installed_state["payload"]["status"] == "observed-compatible"
+    assert installed_state["payload"]["status"] == "sync-required"
+    assert installed_state["payload"]["provenance_drift"] == "missing-provenance"
     assert any(contract["adapter"] == "mcp" for contract in installed_state["adapter_contracts"])
     assert compatibility["enforcement"] == "blocking"
     assert compatibility["failed_checks"] == ["exact_version"]
@@ -3736,6 +3737,78 @@ def test_start_can_select_compatible_installed_state_without_expanding_tiny_defa
     assert installed_state["generated_artifacts"]["status"] == "compatible"
 
 
+def test_start_compares_present_payload_provenance(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--preset", "planning", "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["start", "--target", str(target), "--select", "installed_state_compatibility", "--format", "json"]) == 0
+
+    selected = json.loads(capsys.readouterr().out)
+    installed_state = _assert_installed_state_compatibility(selected, status="compatible")
+    provenance = installed_state["payload"]["provenance"]
+    assert provenance["status"] == "present"
+    assert provenance["payload"]["installed_by"]["version"] == cli.__version__
+    assert installed_state["payload"]["provenance_drift"] == "none"
+
+
+def test_start_requires_payload_sync_when_initialized_repo_lacks_provenance(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    _write(target / ".agentic-workspace" / "config.toml", "schema_version = 1\n")
+
+    assert cli.main(["start", "--target", str(target), "--select", "installed_state_compatibility", "--format", "json"]) == 0
+
+    selected = json.loads(capsys.readouterr().out)
+    installed_state = _assert_installed_state_compatibility(selected, status="payload-upgrade-required")
+    assert installed_state["payload"]["provenance"]["status"] == "missing"
+    assert installed_state["payload"]["provenance_drift"] == "missing-provenance"
+    assert "upgrade" in installed_state["next_action"]
+
+
+def test_start_blocks_when_payload_provenance_requires_newer_executable(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    _write(target / ".agentic-workspace" / "config.toml", "schema_version = 1\n")
+    _write(
+        target / ".agentic-workspace" / "payload-provenance.json",
+        json.dumps(
+            {
+                "kind": "agentic-workspace/payload-provenance/v1",
+                "payload_schema": "agentic-workspace/payload/v1",
+                "installed_by": {
+                    "package": "agentic-workspace",
+                    "version": "999.0.0",
+                    "source": "released-wheel",
+                    "source_class": "installed-package",
+                    "source_identity": "fixture",
+                },
+                "command_generation": {
+                    "package": "command-generation",
+                    "version": "0.1.0",
+                    "source": "released-wheel",
+                    "source_identity": "fixture",
+                    "runtime_required": False,
+                },
+                "installed_at": "2026-06-14T00:00:00+00:00",
+                "payload_files": [],
+            }
+        )
+        + "\n",
+    )
+
+    assert cli.main(["start", "--target", str(target), "--select", "installed_state_compatibility", "--format", "json"]) == 0
+
+    selected = json.loads(capsys.readouterr().out)
+    installed_state = _assert_installed_state_compatibility(selected, status="blocking-drift")
+    assert installed_state["executable"]["classification"] == "executable-too-old-or-wrong-version"
+    assert installed_state["payload"]["provenance_drift"] == "executable-too-old"
+
+
 def test_start_surfaces_stale_sibling_aw_freshness_without_trial_and_error(tmp_path: Path, capsys) -> None:
     target = tmp_path / "agentic-workspace"
     sibling = tmp_path / "command-generation"
@@ -3770,7 +3843,8 @@ def test_start_surfaces_compatible_sibling_aw_as_advisory(tmp_path: Path, capsys
     sibling.mkdir()
     _init_git_repo(target)
     _init_git_repo(sibling)
-    _write(sibling / ".agentic-workspace" / "config.toml", "schema_version = 1\n")
+    assert cli.main(["init", "--target", str(sibling), "--preset", "planning", "--format", "json"]) == 0
+    capsys.readouterr()
 
     assert cli.main(["start", "--target", str(target), "--task", "Work in command-generation after AW changes", "--format", "json"]) == 0
 

--- a/tests/test_workspace_start_preflight_cli.py
+++ b/tests/test_workspace_start_preflight_cli.py
@@ -3809,6 +3809,36 @@ def test_start_blocks_when_payload_provenance_requires_newer_executable(tmp_path
     assert installed_state["payload"]["provenance_drift"] == "executable-too-old"
 
 
+def test_start_rejects_incomplete_payload_provenance(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    _write(target / ".agentic-workspace" / "config.toml", "schema_version = 1\n")
+    _write(
+        target / ".agentic-workspace" / "payload-provenance.json",
+        json.dumps(
+            {
+                "kind": "agentic-workspace/payload-provenance/v1",
+                "installed_by": {
+                    "package": "agentic-workspace",
+                    "source": "released-wheel",
+                },
+            }
+        )
+        + "\n",
+    )
+
+    assert cli.main(["start", "--target", str(target), "--select", "installed_state_compatibility", "--format", "json"]) == 0
+
+    selected = json.loads(capsys.readouterr().out)
+    installed_state = _assert_installed_state_compatibility(selected, status="payload-upgrade-required")
+    provenance = installed_state["payload"]["provenance"]
+    assert provenance["status"] == "invalid"
+    assert installed_state["payload"]["provenance_drift"] == "invalid-provenance"
+    assert any("payload_schema" in error for error in provenance["errors"])
+    assert any("installed_by.version" in error for error in provenance["errors"])
+
+
 def test_start_surfaces_stale_sibling_aw_freshness_without_trial_and_error(tmp_path: Path, capsys) -> None:
     target = tmp_path / "agentic-workspace"
     sibling = tmp_path / "command-generation"

--- a/tests/workspace_cli_support.py
+++ b/tests/workspace_cli_support.py
@@ -92,7 +92,7 @@ def _assert_invoked_cli_identity(payload: dict[str, object], *, target_relation:
     assert identity["kind"] == "agentic-workspace/invoked-cli-identity/v1"
     assert identity["package"] == "agentic-workspace"
     assert identity["version"] == cli.__version__
-    assert identity["source_class"] in {"source-checkout", "installed-package", "unknown"}
+    assert identity["source_class"] in {"source-checkout", "installed-package", "editable-dev", "unknown"}
     if "confidence" in identity:
         assert identity["confidence"] in {"high", "medium", "low"}
     assert str(identity["module_path"]).replace("\\", "/").endswith("generated/workspace/python/cli.py")


### PR DESCRIPTION
## Summary

- write .agentic-workspace/payload-provenance.json during AW lifecycle sync
- record AW installer identity, payload schema, command-generation identity, install time, and payload file list
- route payload provenance into installed_state_compatibility for report/startup/doctor consumers
- classify missing, invalid, older-payload, and newer-payload provenance with explicit next actions

Stacked on #1512.

Resolves #1511

## Validation

- uv run pytest tests/test_workspace_lifecycle_cli.py -k "payload_provenance" tests/test_workspace_start_preflight_cli.py -k "payload_provenance or lacks_provenance or newer_executable" tests/test_workspace_report_cli.py::test_report_surfaces_installed_state_compatibility_section -q
- uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_lifecycle_cli.py tests/test_workspace_start_preflight_cli.py tests/test_workspace_report_cli.py
- make test-workspace
- make lint-workspace
