### PR TITLE
[codex] Finish #1521 follow-up test reductions

### DIFF
--- a/.agentic-workspace/planning/closeout-evidence/expand-1534-dramatic-test-reduction.closeout.json
+++ b/.agentic-workspace/planning/closeout-evidence/expand-1534-dramatic-test-reduction.closeout.json
@@ -1,0 +1,108 @@
+{
+  "kind": "planning-closeout-evidence/v1",
+  "title": "Add Verification evidence strategy report before expanding #1534",
+  "plan_id": "expand-1534-dramatic-test-reduction",
+  "created_at": "2026-06-15T15:29:37.172214+00:00",
+  "source_plan": ".agentic-workspace/planning/execplans/expand-1534-dramatic-test-reduction.plan.json",
+  "intended_archive": ".agentic-workspace/planning/execplans/archive/expand-1534-dramatic-test-reduction.plan.json",
+  "retention": {
+    "state": "archive-retention-skipped",
+    "reason": "retained archive would exceed the structured-file inventory max_bytes guardrail; closing after distillation instead",
+    "canonical_evidence": "retained closeout evidence",
+    "ordinary_route": "agentic-workspace summary --format json or report --section closeout_report --format json",
+    "trust_rule": "When this record exists, agents should trust it as the closeout handoff surface without inspecting the omitted full execplan archive.",
+    "rule": "Retained closeout evidence preserves reportable closeout facts when the full execplan archive exceeds inventory size guardrails."
+  },
+  "active_milestone": {
+    "id": "expand-1534-dramatic-test-reduction",
+    "status": "completed",
+    "scope": "Verification evidence strategy report diagnostic plus high-confidence #1534 dogfood reductions.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement the first #1535 Verification evidence strategy report slice and dogfood it on #1534 hotspot tests before expanding test reductions.",
+    "hard constraints": "Keep the first slice diagnostic and read-only: no enforcement, no automatic test mutation, no manifest schema requirement, no new root command, and no universal testing strategy.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented the Verification evidence_strategy diagnostic report, dogfooded it on #1534 hotspot files, merged the clearest high-confidence ordinary regression groups, and updated maintainer strategy inventory.",
+    "scope touched": "Verification report runtime primitive, package tests/docs, model harness/generated proof-runner/implement CLI test matrices, maintainer strategy docs, and planning closeout state.",
+    "changed surfaces": "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py; packages/verification/tests/test_runtime_primitives.py; docs/verification.md; tests/test_model_cli_harness.py; tests/test_generated_command_package_proof_runner.py; tests/test_workspace_implement_cli.py; docs/maintainer/testing-strategy.md; tests/test_maintainer_surfaces.py",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from #1534/#1521 follow-up",
+    "next step": "promote the next bounded slice from #1534/#1521 follow-up"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Slice satisfies #1535 evidence_strategy acceptance and improves #1534 reductions; dogfood now reports 3 remaining high-confidence planning-test merge candidates that need owner review before further reduction.",
+    "proof status": "passed",
+    "intent served": "yes for slice; parent remains open via #1534/#1521 follow-up",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "#1534/#1521 follow-up"
+  },
+  "proof_report": {
+    "validation proof": "Passed: make test-workspace (122.48s); make lint-workspace; make maintainer-surfaces; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json (repair plan clean, known residue warnings); uv run pytest tests/test_model_cli_harness.py -q (123 passed); focused pytest/ruff; agentic-verification dogfood report; collect-only 1,726 tests in 0.44s; git diff --check only CRLF normalization warning.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Expand #1534 test reduction by behavior class.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "#1534/#1521 follow-up"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when #1534/#1521 follow-up activates a fresh bounded slice."
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed issue residue to #1534/#1521 follow-up.",
+    "motivation worth preserving": "Future agents should continue from #1534/#1521 follow-up rather than rediscover this closeout residue.",
+    "canonical owner now": "#1534/#1521 follow-up",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "execution_summary": {
+    "outcome delivered": "agentic-verification report now includes evidence_strategy; hotspot dogfood guided 9 ordinary root test removals and 3 new Verification tests for a net suite count of 1,726.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "#1534/#1521 follow-up",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "#1534/#1521 follow-up",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "#1534/#1521 follow-up",
+          "owner": "#1534/#1521 follow-up",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/expand-1534-material-test-reduction.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/expand-1534-material-test-reduction.plan.json
@@ -1,0 +1,388 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Expand #1534 material test reduction",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for Expand #1534 material test reduction.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Expand #1534 material test reduction is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "#1534/#1521 follow-up",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Expand #1534 material test reduction."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Expand #1534 material test reduction.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "expand-1534-material-test-reduction",
+      "status": "completed",
+      "next_step": "Continue via #1534/#1521 follow-up.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Expand #1534 material test reduction.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "#1534/#1521 follow-up"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "#1534/#1521 follow-up",
+    "activation trigger": "when the continuation owner promotes the next slice"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via #1534/#1521 follow-up."
+  },
+  "intent_interpretation": {
+    "literal request": "Expand #1534 material test reduction",
+    "inferred intended outcome": "Create a bounded plan for Expand #1534 material test reduction.",
+    "chosen concrete what": "Merged additional repeated scenario groups while retaining labels and assertion families; updated maintainer strategy counts to root 1,113, planning 341, memory 246, verification 9, total 1,709.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Expand #1534 material test reduction.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "expand-1534-material-test-reduction",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Expand #1534 material test reduction is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Expanded #1534 reductions beyond the Verification diagnostic slice by merging additional ordinary regression variants into scenario matrices across implement CLI, model CLI harness, generated-package proof runner, planning archive cleanup, and planning summary routing tests.",
+    "scope touched": "Root regression tests, planning package tests, maintainer strategy inventory, and planning closeout state.",
+    "changed surfaces": "tests/test_workspace_implement_cli.py; tests/test_model_cli_harness.py; packages/planning/tests/test_archive.py; packages/planning/tests/test_summary.py; tests/test_generated_command_package_proof_runner.py; docs/maintainer/testing-strategy.md; tests/test_maintainer_surfaces.py",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from #1534/#1521 follow-up",
+    "next step": "promote the next bounded slice from #1534/#1521 follow-up"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Slice satisfies the request to take #1534 materially further than the previous small count change. Suite inventory is now 1,709 collected tests, down from 1,726 in the prior PR revision and 1,732 before the Verification dogfood slice.",
+    "proof status": "passed",
+    "intent served": "yes for slice; parent remains open via #1534/#1521 follow-up",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "#1534/#1521 follow-up"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "Passed: make test-workspace (148.78s); make lint-workspace; make test-planning (16.49s); make lint-planning; make maintainer-surfaces; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json (repair plan clean, known installed-module residue warnings); uv run pytest tests/test_model_cli_harness.py -q (115 passed); focused pytest/ruff; collect-only 1,709 tests in 0.47s; git diff --check only CRLF normalization warning.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Expand #1534 material test reduction.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "#1534/#1521 follow-up"
+  },
+  "execution_summary": {
+    "outcome delivered": "Merged additional repeated scenario groups while retaining labels and assertion families; updated maintainer strategy counts to root 1,113, planning 341, memory 246, verification 9, total 1,709.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "#1534/#1521 follow-up",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "#1534/#1521 follow-up",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed issue residue to #1534/#1521 follow-up.",
+    "motivation worth preserving": "Future agents should continue from #1534/#1521 follow-up rather than rediscover this closeout residue.",
+    "canonical owner now": "#1534/#1521 follow-up",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "#1534/#1521 follow-up",
+    "proposed durable intent": "Future agents should continue from #1534/#1521 follow-up rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "#1534/#1521 follow-up"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when #1534/#1521 follow-up activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      {
+        "summary": "Closeout routed issue residue to #1534/#1521 follow-up.",
+        "owner": "#1534/#1521 follow-up",
+        "source": "durable_residue"
+      }
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      {
+        "summary": "Closeout routed issue residue to #1534/#1521 follow-up.",
+        "owner": "#1534/#1521 follow-up",
+        "source": "durable_residue"
+      }
+    ],
+    "signals dismissed": [],
+    "next owner": "see routed signal owner"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "#1534/#1521 follow-up",
+          "owner": "#1534/#1521 follow-up",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-15: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "#1534/#1521 follow-up",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "continue-required",
+    "active_intent_satisfied": false,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "partial-progress",
+    "required_next_action": "create-follow-on-plan",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1534",
+          "authorized": false,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [
+          "done",
+          "implemented",
+          "complete",
+          "finished",
+          "all",
+          "full intent complete",
+          "Closes #1534"
+        ],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "#1534/#1521 follow-up",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "no",
+      "reason": "#1534/#1521 follow-up"
+    },
+    "continuation": {
+      "owner_surface": "#1534/#1521 follow-up",
+      "created_or_required": true,
+      "reason": "#1534/#1521 follow-up"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Expand #1534 material test reduction.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: Passed: make test-workspace (148.78s); make lint-workspace; make test-planning (16.49s); make lint-planning; make maintainer-surfaces; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json (repair plan clean, known installed-module residue warnings); uv run pytest tests/test_model_cli_harness.py -q (115 passed); focused pytest/ruff; collect-only 1,709 tests in 0.47s; git diff --check only CRLF normalization warning.\nChanged surfaces: tests/test_workspace_implement_cli.py; tests/test_model_cli_harness.py; packages/planning/tests/test_archive.py; packages/planning/tests/test_summary.py; tests/test_generated_command_package_proof_runner.py; docs/maintainer/testing-strategy.md; tests/test_maintainer_surfaces.py\nDurable residue: planning (#1534/#1521 follow-up)\nMemory learning: route_to_planning\nFollow-up: #1534/#1521 follow-up\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/github-1521-inventory-and-reduce-slow-or-redundant-remaining.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1521-inventory-and-reduce-slow-or-redundant-remaining.plan.json
@@ -115,7 +115,7 @@
     "activation trigger": "Continue with focused follow-up issues #1531, #1532, and #1533 after #1530 lands."
   },
   "iterative_follow_through": {
-    "what this slice enabled": "Packaging artifact tests now separate artifact build cost from assertion count, generated-command proof-runner smoke coverage no longer reasserts selected generated output values already owned by conformance, live-checkout preflight modes are grouped as one scenario matrix, maintainer inventory docs now match current counts and conformance surfaces, and root/package ownership guidance is explicit.",
+    "what this slice enabled": "Reduced packaging, generated proof-runner, preflight, inventory, and Memory current-view test duplication while recording root/package ownership guidance.",
     "intentionally deferred": "The #1521 parent lane remains open for known follow-up clusters: report/start-preflight (#1531), model CLI harness (#1532), and generated-package proof runner (#1533).",
     "discovered implications": "The broad root duration run exceeded 10 minutes; future slices should avoid full-suite proof unless required.",
     "proof achieved now": "packaging subset and lint passed before final proof selection",
@@ -410,6 +410,6 @@
     "status": "generated",
     "source": "archive-plan --prepare-closeout",
     "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
-    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Open upstream issue from refreshed external intent evidence; priority P1 inferred from inferred-lane.\nIntent satisfied: no; this slice completed #1526/#1527, while #1521 remains open as the parent lane.\nArchive decision: archive-but-keep-lane-open\nProof: passed: maintainer surfaces, workspace tests/lint, memory tests/lint, summary, planning doctor, targeted maintainer/current-memory proof, and Memory current/install ownership subset\nChanged surfaces: testing strategy; Memory current-memory tests; maintainer guard; planning closeout record\nDurable residue: issue (#1521, #1531, #1532, #1533)\nMemory learning: none\nFollow-up: #1531, #1532, and #1533\nCompletion gate: allowed for the slice only\nCompletion claim allowed: bounded-slice-complete"
+    "text": "Generated closeout adapter; structured fields are authoritative. Slice completed #1526/#1527; #1521 remains open with follow-ups #1531, #1532, and #1533. Archive decision: archive-but-keep-lane-open. Proof passed; completion claim is bounded-slice-complete."
   }
 }

--- a/.agentic-workspace/planning/execplans/archive/github-1521-open-followups-test-reductions.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1521-open-followups-test-reductions.plan.json
@@ -1,0 +1,393 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement #1521 open follow-up test reductions",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement the remaining open #1521 follow-up issues #1531, #1532, and #1533 with small test-count reductions and recorded evidence.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Run selected proof, then close out this bounded follow-up slice.",
+    "proof_expectations": [
+      "Focused merged tests pass.",
+      "Affected files collect fewer tests than the pre-slice baseline.",
+      "Workspace tests, lint, maintainer surfaces, and model harness proof pass."
+    ],
+    "touched_scope": [
+      "tests/test_workspace_report_cli.py",
+      "tests/test_model_cli_harness.py",
+      "tests/test_generated_command_package_proof_runner.py",
+      "tests/test_maintainer_surfaces.py",
+      "docs/maintainer/testing-strategy.md",
+      "docs/maintainer/aw-contract-test-replacement-inventory.md",
+      ".agentic-workspace/planning/execplans/archive/github-1521-inventory-and-reduce-slow-or-redundant-remaining.plan.json"
+    ],
+    "completion_criteria": [
+      "#1531 has a report/start-preflight cluster reduction or explicit retention evidence.",
+      "#1532 has a model CLI harness scenario reduction or explicit retention evidence.",
+      "#1533 has a generated-package proof-runner reduction or explicit retention evidence.",
+      "Testing strategy records before/after count evidence.",
+      "Selected proof passes."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Reduce the remaining open #1521 follow-up clusters with bounded scenario merges across report, model harness, and generated proof-runner tests."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement the remaining open #1521 follow-up issues #1531, #1532, and #1533 with small test-count reductions and recorded evidence.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "github-1521-open-followups-test-reductions",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "tests/test_workspace_report_cli.py",
+        "tests/test_model_cli_harness.py",
+        "tests/test_generated_command_package_proof_runner.py",
+        "tests/test_maintainer_surfaces.py",
+        "docs/maintainer/testing-strategy.md",
+        "docs/maintainer/aw-contract-test-replacement-inventory.md",
+        ".agentic-workspace/planning/execplans/archive/github-1521-inventory-and-reduce-slow-or-redundant-remaining.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Finish the #1521 parent lane by reducing or explicitly retaining the known remaining slow/redundant clusters.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "The final open #1521 follow-up issues each have a narrow reduction and retained-coverage record.",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "focused tests, lint, and collection proof passed before full selected proof",
+    "validation still needed": "make test-workspace; make lint-workspace; make maintainer-surfaces; uv run pytest tests/test_model_cli_harness.py -q",
+    "next likely slice": "close #1531, #1532, #1533, and then #1521 after merge if review accepts the parent completion"
+  },
+  "intent_interpretation": {
+    "literal request": "Implement #1521 open follow-up test reductions",
+    "inferred intended outcome": "Create a bounded plan for Implement #1521 open follow-up test reductions.",
+    "chosen concrete what": "Merge three duplicate scenario groups: report section aliases, model CLI raw-read warning variants, and generated proof completion-gate checks.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "tests/test_workspace_report_cli.py; tests/test_model_cli_harness.py; tests/test_generated_command_package_proof_runner.py; tests/test_maintainer_surfaces.py; docs/maintainer/testing-strategy.md; docs/maintainer/aw-contract-test-replacement-inventory.md; #1521 archived plan shrink; planning state/execplan",
+    "max changed files": "9 tracked files including planning state",
+    "required validation commands": "focused merged tests; ruff on touched tests; full collect; make test-workspace; make lint-workspace; make maintainer-surfaces; uv run pytest tests/test_model_cli_harness.py -q",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Run selected proof and close out the #1531/#1532/#1533 reduction slice.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Implement #1521 open follow-up test reductions.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1521-open-followups-test-reductions",
+    "status": "completed",
+    "scope": "Bounded implementation of #1531/#1532/#1533 under parent #1521.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run selected proof, then close out the #1531/#1532/#1533 reduction slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "tests/test_workspace_report_cli.py",
+    "tests/test_model_cli_harness.py",
+    "tests/test_generated_command_package_proof_runner.py",
+    "tests/test_maintainer_surfaces.py",
+    "docs/maintainer/testing-strategy.md",
+    "docs/maintainer/aw-contract-test-replacement-inventory.md",
+    ".agentic-workspace/planning/execplans/archive/github-1521-inventory-and-reduce-slow-or-redundant-remaining.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_report_cli.py::test_report_section_selector_accepts_current_work_aliases tests/test_model_cli_harness.py::test_model_cli_harness_scores_vague_outcome_raw_reads_without_compact_startup tests/test_generated_command_package_proof_runner.py::test_static_generated_package_proof_requires_completion_gate_evidence tests/test_maintainer_surfaces.py::test_testing_strategy_guides_against_one_off_regression_sprawl -q",
+    "uv run ruff check tests/test_workspace_report_cli.py tests/test_model_cli_harness.py tests/test_generated_command_package_proof_runner.py tests/test_maintainer_surfaces.py",
+    "uv run pytest --collect-only -q tests packages/memory/tests packages/planning/tests packages/verification/tests",
+    "make test-workspace",
+    "make lint-workspace",
+    "make maintainer-surfaces",
+    "uv run pytest tests/test_model_cli_harness.py -q"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "#1531, #1532, and #1533 have concrete merged scenario groups or retained evidence.",
+    "Total collected test count is reduced and recorded.",
+    "Selected proof passes."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Merged three duplicate scenario groups for #1531, #1532, and #1533; recorded before/after count evidence; updated replacement inventory; and shrank an archived plan that tripped the structured file size guard.",
+    "scope touched": "Report/start-preflight aliases, model CLI raw-read warning variants, generated-package proof completion-gate variants, maintainer docs, and planning closeout surfaces.",
+    "changed surfaces": "tests/test_workspace_report_cli.py; tests/test_model_cli_harness.py; tests/test_generated_command_package_proof_runner.py; tests/test_maintainer_surfaces.py; docs/maintainer/testing-strategy.md; docs/maintainer/aw-contract-test-replacement-inventory.md; .agentic-workspace/planning/execplans/archive/github-1521-inventory-and-reduce-slow-or-redundant-remaining.plan.json",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within the promoted #1521 follow-up lane; selected proof covers the merged scenario groups and maintainer documentation.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "focused merged tests: 4 passed in 9.30s; ruff touched tests: passed; full collect: 1732 tests / 60 files; targeted subset: 428 collected tests, down from 433; structured inventory guard: passed; make test-workspace: passed in 124.33s; make lint-workspace: passed; make maintainer-surfaces: passed; tests/test_model_cli_harness.py: 126 passed in 2.83s; generated command package python conformance/static proof: passed; summary: active plan only, no warnings; doctor planning: known memory/verification residue warnings only, no repair actions; git diff --check: passed.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement #1521 open follow-up test reductions.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "The remaining open #1521 follow-up issues have bounded reductions and evidence sufficient for PR closure.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "epic",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a epic claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-15: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "blocked_claim_classes": [],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1521",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement #1521 open follow-up test reductions.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: focused merged tests: 4 passed in 9.30s; ruff touched tests: passed; full collect: 1732 tests / 60 files; targeted subset: 428 collected tests, down from 433; structured inventory guard: passed; make test-workspace: passed in 124.33s; make lint-workspace: passed; make maintainer-surfaces: passed; tests/test_model_cli_harness.py: 126 passed in 2.83s; generated command package python conformance/static proof: passed; summary: active plan only, no warnings; doctor planning: known memory/verification residue warnings only, no repair actions; git diff --check: passed.\nChanged surfaces: tests/test_workspace_report_cli.py; tests/test_model_cli_harness.py; tests/test_generated_command_package_proof_runner.py; tests/test_maintainer_surfaces.py; docs/maintainer/testing-strategy.md; docs/maintainer/aw-contract-test-replacement-inventory.md; .agentic-workspace/planning/execplans/archive/github-1521-inventory-and-reduce-slow-or-redundant-remaining.plan.json\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/docs/maintainer/aw-contract-test-replacement-inventory.md
+++ b/docs/maintainer/aw-contract-test-replacement-inventory.md
@@ -39,6 +39,12 @@ The June 2026 audit found additional stable text-output tests that could not be 
 | `tests/test_generated_command_package_proof_runner.py::test_operation_conformance_runner_executes_python_cases` | `defaults.root-cli-authority.success` selected field `answer.command` ends with the root CLI authority command. | `defaults.root-cli-authority.process` / `minimal-repo` | The test still proves the Python conformance runner loads and executes the case successfully. |
 | `tests/test_generated_command_package_proof_runner.py::test_operation_conformance_runner_executes_python_cases` | `modules.report-router.success` selected field `kind` equals the modules router kind. | `modules.report.process` / `minimal-repo` | The test still proves the Python conformance runner loads and executes the case successfully. |
 
+## Merged Ordinary Proof Checks
+
+| Old ordinary tests | Merge reason | Remaining ordinary coverage |
+| --- | --- | --- |
+| `tests/test_generated_command_package_proof_runner.py::test_static_generated_package_proof_requires_python_completion_gate_evidence`, `tests/test_generated_command_package_proof_runner.py::test_static_generated_package_proof_requires_operation_ir_runtime_consumption_evidence`, `tests/test_generated_command_package_proof_runner.py::test_static_generated_package_proof_requires_exhaustive_operation_inventory_evidence` | All three tests remove one required `python_cli_completion.completion_gate.satisfied_by` item and assert that static proof rejects the missing evidence. | `tests/test_generated_command_package_proof_runner.py::test_static_generated_package_proof_requires_completion_gate_evidence` keeps the checker-internal contract as one scenario matrix. |
+
 ## Kept Ordinary
 
 | Surface | Keep reason | Future conversion condition |

--- a/docs/maintainer/testing-strategy.md
+++ b/docs/maintainer/testing-strategy.md
@@ -6,11 +6,11 @@ Use this guide before adding or pruning tests in this repository. The goal is to
 
 The June 15, 2026 inventory for #1521 was refreshed after the first reduction slices with:
 
-- root workspace: 1,135 collected tests / 39 files
+- root workspace: 1,126 collected tests / 39 files
 - planning package: 345 collected tests
 - memory package: 246 collected tests
-- verification package: 6 collected tests
-- total: 1,732 collected tests / 60 files
+- verification package: 9 collected tests
+- total: 1,726 collected tests / 60 files
 
 Collection is fast, so the immediate problem is not raw collection time. A full root duration pass exceeded 10 minutes during #1521 measurement, so the current pressure is both runtime hotspots and a growing pile of narrow regression tests around broad workflow surfaces.
 
@@ -37,6 +37,8 @@ The #1524 workflow-cluster slice merged the live-checkout active-only and verbos
 The #1526 ownership slice reviewed root lifecycle/module orchestration against Memory and Planning package-local install/current-state tests. The package-local install/current-memory subset moved from 143 tests / 3.33 seconds to 142 tests / 2.98 seconds by merging duplicate generated `current show` JSON/text view tests in `packages/memory/tests/test_current_memory.py`; the remaining current-memory tests are retained as explicit Memory residue, migration, and stale-active-state guard coverage.
 
 The #1531/#1532/#1533 follow-up slice merged narrow duplicate scenario groups in the largest remaining root clusters: report section aliases, model CLI harness raw-read warning variants, and static generated-package completion-gate evidence checks. The affected report/start-preflight, model harness, and generated proof-runner subset moved from 433 collected tests to 428 collected tests while retaining high-risk workflow, scorer-warning, and proof/checker coverage.
+
+The #1535 Verification dogfood slice added the host-neutral `evidence_strategy` diagnostic report and used it to classify #1534 hotspot files before further reduction. The dogfood pass found 7 high-confidence merge candidates across 710 hotspot tests under the conservative exact-prefix heuristic, then merged the clearest model-harness, generated proof-runner, and implement-context groups. The full suite inventory moved from 1,732 collected tests to 1,726 collected tests: 3 new Verification package tests and 9 fewer ordinary root regression tests.
 
 Use this compact inventory when changing these clusters:
 

--- a/docs/maintainer/testing-strategy.md
+++ b/docs/maintainer/testing-strategy.md
@@ -6,11 +6,11 @@ Use this guide before adding or pruning tests in this repository. The goal is to
 
 The June 15, 2026 inventory for #1521 was refreshed after the first reduction slices with:
 
-- root workspace: 1,140 collected tests / 39 files
+- root workspace: 1,135 collected tests / 39 files
 - planning package: 345 collected tests
 - memory package: 246 collected tests
 - verification package: 6 collected tests
-- total: 1,737 collected tests / 60 files
+- total: 1,732 collected tests / 60 files
 
 Collection is fast, so the immediate problem is not raw collection time. A full root duration pass exceeded 10 minutes during #1521 measurement, so the current pressure is both runtime hotspots and a growing pile of narrow regression tests around broad workflow surfaces.
 
@@ -35,6 +35,8 @@ The first #1521 reduction slice consolidated repeated packaging builds in `tests
 The #1524 workflow-cluster slice merged the live-checkout active-only and verbose preflight mode checks in `tests/test_workspace_start_preflight_cli.py` into one scenario-matrix test. The affected `tests/test_workspace_report_cli.py` plus `tests/test_workspace_start_preflight_cli.py` subset moved from 234 collected tests / 139.18 seconds to 233 collected tests / 133.93 seconds while retaining the active-state, full-takeover, startup-guidance, and resolved-config assertions.
 
 The #1526 ownership slice reviewed root lifecycle/module orchestration against Memory and Planning package-local install/current-state tests. The package-local install/current-memory subset moved from 143 tests / 3.33 seconds to 142 tests / 2.98 seconds by merging duplicate generated `current show` JSON/text view tests in `packages/memory/tests/test_current_memory.py`; the remaining current-memory tests are retained as explicit Memory residue, migration, and stale-active-state guard coverage.
+
+The #1531/#1532/#1533 follow-up slice merged narrow duplicate scenario groups in the largest remaining root clusters: report section aliases, model CLI harness raw-read warning variants, and static generated-package completion-gate evidence checks. The affected report/start-preflight, model harness, and generated proof-runner subset moved from 433 collected tests to 428 collected tests while retaining high-risk workflow, scorer-warning, and proof/checker coverage.
 
 Use this compact inventory when changing these clusters:
 

--- a/docs/maintainer/testing-strategy.md
+++ b/docs/maintainer/testing-strategy.md
@@ -6,11 +6,11 @@ Use this guide before adding or pruning tests in this repository. The goal is to
 
 The June 15, 2026 inventory for #1521 was refreshed after the first reduction slices with:
 
-- root workspace: 1,126 collected tests / 39 files
-- planning package: 345 collected tests
+- root workspace: 1,113 collected tests / 39 files
+- planning package: 341 collected tests
 - memory package: 246 collected tests
 - verification package: 9 collected tests
-- total: 1,726 collected tests / 60 files
+- total: 1,709 collected tests / 60 files
 
 Collection is fast, so the immediate problem is not raw collection time. A full root duration pass exceeded 10 minutes during #1521 measurement, so the current pressure is both runtime hotspots and a growing pile of narrow regression tests around broad workflow surfaces.
 
@@ -38,7 +38,7 @@ The #1526 ownership slice reviewed root lifecycle/module orchestration against M
 
 The #1531/#1532/#1533 follow-up slice merged narrow duplicate scenario groups in the largest remaining root clusters: report section aliases, model CLI harness raw-read warning variants, and static generated-package completion-gate evidence checks. The affected report/start-preflight, model harness, and generated proof-runner subset moved from 433 collected tests to 428 collected tests while retaining high-risk workflow, scorer-warning, and proof/checker coverage.
 
-The #1535 Verification dogfood slice added the host-neutral `evidence_strategy` diagnostic report and used it to classify #1534 hotspot files before further reduction. The dogfood pass found 7 high-confidence merge candidates across 710 hotspot tests under the conservative exact-prefix heuristic, then merged the clearest model-harness, generated proof-runner, and implement-context groups. The full suite inventory moved from 1,732 collected tests to 1,726 collected tests: 3 new Verification package tests and 9 fewer ordinary root regression tests.
+The #1535 Verification dogfood slice added the host-neutral `evidence_strategy` diagnostic report and used it to classify #1534 hotspot files before further reduction. The dogfood pass found 7 high-confidence merge candidates across 710 hotspot tests under the conservative exact-prefix heuristic, then merged the clearest model-harness, generated proof-runner, implement-context, and planning cleanup/routing groups. A follow-up reduction pass broadened that same scenario-matrix approach to adapter rendering, quality-signal, execution-warning, and generated-proof acceptance variants. The full suite inventory moved from 1,732 collected tests to 1,709 collected tests: 3 new Verification package tests, 22 fewer ordinary root regression tests, and 4 fewer planning package tests.
 
 Use this compact inventory when changing these clusters:
 

--- a/docs/maintainer/testing-strategy.md
+++ b/docs/maintainer/testing-strategy.md
@@ -9,8 +9,8 @@ The June 15, 2026 inventory for #1521 was refreshed after the first reduction sl
 - root workspace: 1,113 collected tests / 39 files
 - planning package: 341 collected tests
 - memory package: 246 collected tests
-- verification package: 9 collected tests
-- total: 1,709 collected tests / 60 files
+- verification package: 10 collected tests
+- total: 1,710 collected tests / 60 files
 
 Collection is fast, so the immediate problem is not raw collection time. A full root duration pass exceeded 10 minutes during #1521 measurement, so the current pressure is both runtime hotspots and a growing pile of narrow regression tests around broad workflow surfaces.
 
@@ -38,7 +38,7 @@ The #1526 ownership slice reviewed root lifecycle/module orchestration against M
 
 The #1531/#1532/#1533 follow-up slice merged narrow duplicate scenario groups in the largest remaining root clusters: report section aliases, model CLI harness raw-read warning variants, and static generated-package completion-gate evidence checks. The affected report/start-preflight, model harness, and generated proof-runner subset moved from 433 collected tests to 428 collected tests while retaining high-risk workflow, scorer-warning, and proof/checker coverage.
 
-The #1535 Verification dogfood slice added the host-neutral `evidence_strategy` diagnostic report and used it to classify #1534 hotspot files before further reduction. The dogfood pass found 7 high-confidence merge candidates across 710 hotspot tests under the conservative exact-prefix heuristic, then merged the clearest model-harness, generated proof-runner, implement-context, and planning cleanup/routing groups. A follow-up reduction pass broadened that same scenario-matrix approach to adapter rendering, quality-signal, execution-warning, and generated-proof acceptance variants. The full suite inventory moved from 1,732 collected tests to 1,709 collected tests: 3 new Verification package tests, 22 fewer ordinary root regression tests, and 4 fewer planning package tests.
+The #1535 Verification dogfood slice added the host-neutral `evidence_strategy` diagnostic report and used it to classify #1534 hotspot files before further reduction. The dogfood pass found 7 high-confidence merge candidates across 710 hotspot tests under the conservative exact-prefix heuristic, then merged the clearest model-harness, generated proof-runner, implement-context, and planning cleanup/routing groups. A follow-up reduction pass broadened that same scenario-matrix approach to adapter rendering, quality-signal, execution-warning, and generated-proof acceptance variants. The review fix tightened the Verification authority boundary so strategy prose is surfaced for agent judgment rather than interpreted by string matching. The full suite inventory moved from 1,732 collected tests to 1,710 collected tests: 4 new Verification package tests, 22 fewer ordinary root regression tests, and 4 fewer planning package tests.
 
 Use this compact inventory when changing these clusters:
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -31,6 +31,38 @@ under `packages/verification/src/repo_verification_bootstrap/contracts/operation
 module-owned runtime primitives own manifest semantics, while root workspace
 surfaces adapt the resulting projection.
 
+## Evidence Strategy Report
+
+The Verification report also includes a diagnostic `evidence_strategy` section:
+
+```json
+{
+  "kind": "agentic-workspace/verification-evidence-strategy/v1",
+  "status": "ready"
+}
+```
+
+This section helps an agent classify proposed or existing proof evidence against
+the host repository's own declared or observed strategy. It is intentionally
+host-neutral: Verification does not prescribe a testing pyramid, AW-specific
+coverage style, or conformance-first policy. It separates declared strategy
+sources, observed signals, and confidence-qualified agent inferences so naming
+or path heuristics never become policy by themselves.
+
+The first diagnostic slice uses cheap local inputs only:
+
+- changed paths and task text passed to `agentic-verification report`
+- `.agentic-workspace/verification/manifest.toml`, when present
+- repo-owned strategy and proof docs, when present
+- simple AST facts from changed Python test files
+
+The report may classify evidence owner, evidence role, strategy fit, and a
+recommended disposition such as `keep`, `merge`, `convert-to-conformance`,
+`record-verification-evidence`, or `needs-human-strategy-choice`. These are
+review prompts, not enforcement. The report does not delete tests, prove semantic
+equivalence, require a manifest extension, or create a universal testing
+strategy for the host repository.
+
 ## Manifest Shape
 
 ```toml

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -42,26 +42,27 @@ The Verification report also includes a diagnostic `evidence_strategy` section:
 }
 ```
 
-This section helps an agent classify proposed or existing proof evidence against
-the host repository's own declared or observed strategy. It is intentionally
-host-neutral: Verification does not prescribe a testing pyramid, AW-specific
-coverage style, or conformance-first policy. It separates declared strategy
-sources, observed signals, and confidence-qualified agent inferences so naming
-or path heuristics never become policy by themselves.
+This section helps an agent inspect proposed or existing proof evidence next to
+candidate host-owned strategy sources. It is intentionally host-neutral:
+Verification does not prescribe a testing pyramid, AW-specific coverage style,
+or conformance-first policy. It surfaces facts and decision questions; the agent
+does the reasoning.
 
 The first diagnostic slice uses cheap local inputs only:
 
 - changed paths and task text passed to `agentic-verification report`
 - `.agentic-workspace/verification/manifest.toml`, when present
-- repo-owned strategy and proof docs, when present
+- candidate repo-owned strategy and proof docs, when present
 - simple AST facts from changed Python test files
 
-The report may classify evidence owner, evidence role, strategy fit, and a
-recommended disposition such as `keep`, `merge`, `convert-to-conformance`,
-`record-verification-evidence`, or `needs-human-strategy-choice`. These are
-review prompts, not enforcement. The report does not delete tests, prove semantic
-equivalence, require a manifest extension, or create a universal testing
-strategy for the host repository.
+The first slice does not interpret prose in those docs and does not infer a
+host strategy from phrase matching. It can report that candidate source files
+exist, list changed test functions, identify simple same-file/name-prefix
+groups, and ask what the agent should decide. Without host-owned structured
+strategy enums or configuration, dispositions remain
+`needs-human-strategy-choice`, owners remain `unknown`, and confidence stays low.
+The report does not delete tests, prove semantic equivalence, require a manifest
+extension, or create a universal testing strategy for the host repository.
 
 ## Manifest Shape
 

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -2336,23 +2336,13 @@ candidates = [
     assert "Graceful partial compliance and bypass trust" in state_text
 
 
-def test_archive_execplan_apply_cleanup_removes_matching_candidate_queue_entry(tmp_path: Path) -> None:
-    _write(
-        tmp_path / ".agentic-workspace/planning/state.toml",
-        """
-# TODO
-
-## Next
-
-- ID: workspace-result-contract
-  Status: completed
-  Surface: .agentic-workspace/planning/execplans/workspace-result-contract-2026-04-05.md
-  Why now: already finished.
-""",
-    )
-    _write(
-        tmp_path / "ROADMAP.md",
-        """
+def test_archive_execplan_apply_cleanup_removes_matching_candidate_entries(tmp_path: Path) -> None:
+    scenarios = [
+        (
+            "workspace-result-contract",
+            "workspace-result-contract-2026-04-05",
+            _minimal_execplan(status="completed"),
+            """
 # Roadmap
 
 ## Active Handoff
@@ -2365,38 +2355,15 @@ def test_archive_execplan_apply_cleanup_removes_matching_candidate_queue_entry(t
     orchestrated module actions and warnings when more module families land.
 - Shared tooling extraction: evaluate a common checker core when repeated maintenance friction appears.
 """,
-    )
-    plan_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "workspace-result-contract-2026-04-05.md"
-    _write(plan_path, _minimal_execplan(status="completed"))
-
-    result = archive_execplan("workspace-result-contract-2026-04-05", target=tmp_path, apply_cleanup=True)
-
-    roadmap_text = (tmp_path / "ROADMAP.md").read_text(encoding="utf-8")
-    assert "Workspace result contract:" not in roadmap_text
-    assert "Shared tooling extraction:" in roadmap_text
-    assert any(
-        action.kind == "updated" and action.path == tmp_path / "ROADMAP.md" and "Next Candidate Queue" in action.detail
-        for action in result.actions
-    )
-
-
-def test_archive_execplan_apply_cleanup_removes_matching_candidate_lane_entry(tmp_path: Path) -> None:
-    _write(
-        tmp_path / ".agentic-workspace/planning/state.toml",
-        """
-# TODO
-
-## Next
-
-- ID: memory-trust-lane
-  Status: completed
-  Surface: .agentic-workspace/planning/execplans/memory-trust-lane-2026-04-17.md
-  Why now: already finished.
-""",
-    )
-    _write(
-        tmp_path / "ROADMAP.md",
-        """
+            "Workspace result contract:",
+            "Shared tooling extraction:",
+            "Next Candidate Queue",
+        ),
+        (
+            "memory-trust-lane",
+            "memory-trust-lane-2026-04-17",
+            _minimal_execplan(status="completed").replace("plan-alpha", "memory-trust-lane"),
+            """
 # Roadmap
 
 ## Candidate Lanes
@@ -2418,19 +2385,38 @@ def test_archive_execplan_apply_cleanup_removes_matching_candidate_lane_entry(tm
   Promotion signal: promote when later.
   Suggested first slice: later slice.
 """,
-    )
-    plan_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "memory-trust-lane-2026-04-17.md"
-    _write(plan_path, _minimal_execplan(status="completed").replace("plan-alpha", "memory-trust-lane"))
+            "Memory trust, usefulness, and cleanup ergonomics",
+            "Separate lane",
+            "Candidate Lanes",
+        ),
+    ]
+    for label, plan_slug, plan_text, roadmap_text, removed_text, retained_text, action_detail in scenarios:
+        repo = tmp_path / label
+        _write(
+            repo / ".agentic-workspace/planning/state.toml",
+            f"""
+# TODO
 
-    result = archive_execplan("memory-trust-lane-2026-04-17", target=tmp_path, apply_cleanup=True)
+## Next
 
-    roadmap_text = (tmp_path / "ROADMAP.md").read_text(encoding="utf-8")
-    assert "Memory trust, usefulness, and cleanup ergonomics" not in roadmap_text
-    assert "Separate lane" in roadmap_text
-    assert any(
-        action.kind == "updated" and action.path == tmp_path / "ROADMAP.md" and "Candidate Lanes" in action.detail
-        for action in result.actions
-    )
+- ID: {label}
+  Status: completed
+  Surface: .agentic-workspace/planning/execplans/{plan_slug}.md
+  Why now: already finished.
+""",
+        )
+        _write(repo / "ROADMAP.md", roadmap_text)
+        plan_path = repo / ".agentic-workspace" / "planning" / "execplans" / f"{plan_slug}.md"
+        _write(plan_path, plan_text)
+
+        result = archive_execplan(plan_slug, target=repo, apply_cleanup=True)
+
+        updated_roadmap = (repo / "ROADMAP.md").read_text(encoding="utf-8")
+        assert removed_text not in updated_roadmap, label
+        assert retained_text in updated_roadmap, label
+        assert any(
+            action.kind == "updated" and action.path == repo / "ROADMAP.md" and action_detail in action.detail for action in result.actions
+        )
 
 
 def test_archive_execplan_cleanup_does_not_remove_unrelated_candidate_lane_from_generic_plan_stem(tmp_path: Path) -> None:

--- a/packages/planning/tests/test_summary.py
+++ b/packages/planning/tests/test_summary.py
@@ -2632,11 +2632,11 @@ def test_planning_summary_suppresses_child_continuation_consumed_by_later_parent
     assert summary["execution_readiness"]["status"] == "narrow-direct-ready"
 
 
-def test_planning_summary_suppresses_archived_child_when_continuation_is_active(tmp_path: Path) -> None:
-    install_bootstrap(target=tmp_path)
-    _write(
-        tmp_path / ".agentic-workspace/planning/state.toml",
-        """
+def test_planning_summary_suppresses_archived_child_when_continuation_is_routed(tmp_path: Path) -> None:
+    scenarios = [
+        (
+            "active-continuation",
+            """
 [todo]
 active_items = [
   { id = "active-follow-on", status = "in-progress", source = "github:#463", surface = ".agentic-workspace/planning/execplans/active-follow-on.plan.json", why_now = "active continuation for #461" }
@@ -2647,79 +2647,17 @@ queued_items = []
 lanes = []
 candidates = []
 """,
-    )
-    active_path = tmp_path / ".agentic-workspace/planning/execplans/active-follow-on.plan.json"
-    _write_execplan_record(
-        active_path,
-        item_id="active-follow-on",
-        status="in-progress",
-        references=[
-            {
-                "kind": "github-issue",
-                "target": "#463",
-                "label": "active follow-on",
-                "role": "source_intent",
-                "locator": "issue",
-            },
-            {
-                "kind": "github-issue",
-                "target": "#461",
-                "label": "parent lane",
-                "role": "parent_intent",
-                "locator": "issue",
-            },
-        ],
-    )
-
-    archive_dir = tmp_path / ".agentic-workspace/planning/execplans/archive"
-    archive_dir.mkdir(parents=True, exist_ok=True)
-    child_path = archive_dir / "completed-child.plan.json"
-    _write_execplan_record(
-        child_path,
-        item_id="completed-child",
-        status="completed",
-        references=[
-            {
-                "kind": "github-issue",
-                "target": "#462",
-                "label": "completed child",
-                "role": "closed_item",
-                "locator": "issue",
-            },
-            {
-                "kind": "github-issue",
-                "target": "#461",
-                "label": "parent lane",
-                "role": "parent_intent",
-                "locator": "issue",
-            },
-        ],
-    )
-    child_record = json.loads(child_path.read_text(encoding="utf-8"))
-    child_record["intent_satisfaction"]["was original intent fully satisfied?"] = "no"
-    child_record["intent_satisfaction"]["unsolved intent passed to"] = ".agentic-workspace/planning/state.toml active continuation for #461"
-    child_record["closure_check"]["larger-intent status"] = "open"
-    child_record["closure_check"]["closure decision"] = "archive-but-keep-lane-open"
-    installer_mod._write_execplan_record(record_path=child_path, record=child_record)
-
-    summary = planning_summary(target=tmp_path)
-    contract = summary["finished_work_inspection_contract"]
-
-    assert contract["counts"]["partial_count"] == 1
-    assert contract["counts"]["routed_continuation_count"] == 1
-    assert contract["counts"]["derived_follow_up_candidate_count"] == 0
-    inspection = contract["inspections"][0]
-    assert inspection["classification"] == "routed_partial"
-    assert inspection["routed_by"] == [".agentic-workspace/planning/execplans/active-follow-on.plan.json"]
-    assert contract["derived_follow_up_candidates"] == []
-    assert summary["execution_readiness"]["status"] == "planning-backed"
-
-
-def test_planning_summary_suppresses_archived_child_when_continuation_is_in_roadmap(tmp_path: Path) -> None:
-    install_bootstrap(target=tmp_path)
-    _write(
-        tmp_path / ".agentic-workspace/planning/state.toml",
-        """
+            (".agentic-workspace/planning/execplans/active-follow-on.plan.json", "#461", "#463"),
+            ["#462", "#461"],
+            "no",
+            ".agentic-workspace/planning/state.toml active continuation for #461",
+            ".agentic-workspace/planning/execplans/active-follow-on.plan.json",
+            "planning-backed",
+            None,
+        ),
+        (
+            "roadmap-issues",
+            """
 [todo]
 active_items = []
 queued_items = []
@@ -2730,65 +2668,17 @@ lanes = [
 ]
 candidates = []
 """,
-    )
-
-    archive_dir = tmp_path / ".agentic-workspace/planning/execplans/archive"
-    archive_dir.mkdir(parents=True, exist_ok=True)
-    child_path = archive_dir / "completed-child.plan.json"
-    _write_execplan_record(
-        child_path,
-        item_id="completed-child",
-        status="completed",
-        references=[
-            {
-                "kind": "github-issue",
-                "target": "#700",
-                "label": "completed child",
-                "role": "source_intent",
-                "locator": "issue",
-            },
-            {
-                "kind": "github-issue",
-                "target": "#701",
-                "label": "parent lane",
-                "role": "parent_intent",
-                "locator": "issue",
-            },
-            {
-                "kind": "github-issue",
-                "target": "#702",
-                "label": "next child",
-                "role": "next_lane",
-                "locator": "issue",
-            },
-        ],
-    )
-    child_record = json.loads(child_path.read_text(encoding="utf-8"))
-    child_record["intent_satisfaction"]["was original intent fully satisfied?"] = "yes"
-    child_record["intent_satisfaction"]["unsolved intent passed to"] = ".agentic-workspace/planning/state.toml roadmap lane parent-lane"
-    child_record["closure_check"]["larger-intent status"] = "open"
-    child_record["closure_check"]["closure decision"] = "archive-but-keep-lane-open"
-    installer_mod._write_execplan_record(record_path=child_path, record=child_record)
-
-    summary = planning_summary(target=tmp_path)
-    contract = summary["finished_work_inspection_contract"]
-
-    assert contract["counts"]["partial_count"] == 1
-    assert contract["counts"]["routed_continuation_count"] == 1
-    assert contract["counts"]["derived_follow_up_candidate_count"] == 0
-    inspection = contract["inspections"][0]
-    assert inspection["classification"] == "routed_partial"
-    assert inspection["intent_satisfied"] == "yes"
-    assert inspection["routed_by"] == [".agentic-workspace/planning/state.toml roadmap lane parent-lane"]
-    assert contract["derived_follow_up_candidates"] == []
-    assert summary["execution_readiness"]["status"] == "roadmap-needs-promotion"
-
-
-def test_planning_summary_uses_roadmap_refs_for_archived_continuation_routing(tmp_path: Path) -> None:
-    install_bootstrap(target=tmp_path)
-    _write(
-        tmp_path / ".agentic-workspace/planning/state.toml",
-        """
+            None,
+            ["#700", "#701", "#702"],
+            "yes",
+            ".agentic-workspace/planning/state.toml roadmap lane parent-lane",
+            ".agentic-workspace/planning/state.toml roadmap lane parent-lane",
+            "roadmap-needs-promotion",
+            None,
+        ),
+        (
+            "roadmap-refs",
+            """
 [todo]
 active_items = []
 queued_items = []
@@ -2799,65 +2689,17 @@ lanes = [
 ]
 candidates = []
 """,
-    )
-
-    archive_dir = tmp_path / ".agentic-workspace/planning/execplans/archive"
-    archive_dir.mkdir(parents=True, exist_ok=True)
-    child_path = archive_dir / "completed-child.plan.json"
-    _write_execplan_record(
-        child_path,
-        item_id="completed-child",
-        status="completed",
-        references=[
-            {
-                "kind": "github-issue",
-                "target": "#900",
-                "label": "completed child",
-                "role": "source_intent",
-                "locator": "issue",
-            },
-            {
-                "kind": "github-issue",
-                "target": "#901",
-                "label": "parent lane",
-                "role": "parent_intent",
-                "locator": "issue",
-            },
-            {
-                "kind": "github-issue",
-                "target": "#902",
-                "label": "next child",
-                "role": "next_lane",
-                "locator": "issue",
-            },
-        ],
-    )
-    child_record = json.loads(child_path.read_text(encoding="utf-8"))
-    child_record["intent_satisfaction"]["was original intent fully satisfied?"] = "yes"
-    child_record["intent_satisfaction"]["unsolved intent passed to"] = ".agentic-workspace/planning/state.toml roadmap lane parent-lane"
-    child_record["closure_check"]["larger-intent status"] = "open"
-    child_record["closure_check"]["closure decision"] = "archive-but-keep-lane-open"
-    installer_mod._write_execplan_record(record_path=child_path, record=child_record)
-
-    summary = planning_summary(target=tmp_path)
-    contract = summary["finished_work_inspection_contract"]
-
-    assert {reference["target"] for reference in summary["roadmap"]["candidate_lanes"][0]["references"]} == {"#901", "#902"}
-    assert contract["counts"]["partial_count"] == 1
-    assert contract["counts"]["routed_continuation_count"] == 1
-    assert contract["counts"]["derived_follow_up_candidate_count"] == 0
-    inspection = contract["inspections"][0]
-    assert inspection["classification"] == "routed_partial"
-    assert inspection["routed_by"] == [".agentic-workspace/planning/state.toml roadmap lane parent-lane"]
-    assert contract["derived_follow_up_candidates"] == []
-    assert summary["execution_readiness"]["status"] == "roadmap-needs-promotion"
-
-
-def test_planning_summary_suppresses_archived_child_when_continuation_is_in_work_items(tmp_path: Path) -> None:
-    install_bootstrap(target=tmp_path)
-    _write(
-        tmp_path / ".agentic-workspace/planning/state.toml",
-        """
+            None,
+            ["#900", "#901", "#902"],
+            "yes",
+            ".agentic-workspace/planning/state.toml roadmap lane parent-lane",
+            ".agentic-workspace/planning/state.toml roadmap lane parent-lane",
+            "roadmap-needs-promotion",
+            {"#901", "#902"},
+        ),
+        (
+            "work-items",
+            """
 kind = "agentic-planning-state"
 schema_version = "planning-state/v1"
 
@@ -2868,58 +2710,82 @@ work_items = [
 [active]
 execplans = []
 """,
-    )
+            None,
+            ["#800", "#801", "#802"],
+            "yes",
+            ".agentic-workspace/planning/state.toml work_items lane parent-lane",
+            ".agentic-workspace/planning/state.toml work_items lane parent-lane",
+            "roadmap-needs-promotion",
+            None,
+        ),
+    ]
+    for (
+        label,
+        state_text,
+        active_record,
+        child_refs,
+        intent_satisfied,
+        unsolved_intent,
+        routed_by,
+        readiness,
+        expected_roadmap_refs,
+    ) in scenarios:
+        repo = tmp_path / label
+        install_bootstrap(target=repo)
+        _write(repo / ".agentic-workspace/planning/state.toml", state_text)
+        if active_record is not None:
+            active_path_text, parent_ref, active_ref = active_record
+            _write_execplan_record(
+                repo / active_path_text,
+                item_id="active-follow-on",
+                status="in-progress",
+                references=[
+                    {
+                        "kind": "github-issue",
+                        "target": active_ref,
+                        "label": "active follow-on",
+                        "role": "source_intent",
+                        "locator": "issue",
+                    },
+                    {"kind": "github-issue", "target": parent_ref, "label": "parent lane", "role": "parent_intent", "locator": "issue"},
+                ],
+            )
 
-    archive_dir = tmp_path / ".agentic-workspace/planning/execplans/archive"
-    archive_dir.mkdir(parents=True, exist_ok=True)
-    child_path = archive_dir / "completed-child.plan.json"
-    _write_execplan_record(
-        child_path,
-        item_id="completed-child",
-        status="completed",
-        references=[
-            {
-                "kind": "github-issue",
-                "target": "#800",
-                "label": "completed child",
-                "role": "source_intent",
-                "locator": "issue",
-            },
-            {
-                "kind": "github-issue",
-                "target": "#801",
-                "label": "parent lane",
-                "role": "parent_intent",
-                "locator": "issue",
-            },
-            {
-                "kind": "github-issue",
-                "target": "#802",
-                "label": "next child",
-                "role": "next_lane",
-                "locator": "issue",
-            },
-        ],
-    )
-    child_record = json.loads(child_path.read_text(encoding="utf-8"))
-    child_record["intent_satisfaction"]["was original intent fully satisfied?"] = "yes"
-    child_record["intent_satisfaction"]["unsolved intent passed to"] = ".agentic-workspace/planning/state.toml work_items lane parent-lane"
-    child_record["closure_check"]["larger-intent status"] = "open"
-    child_record["closure_check"]["closure decision"] = "archive-but-keep-lane-open"
-    installer_mod._write_execplan_record(record_path=child_path, record=child_record)
+        archive_dir = repo / ".agentic-workspace/planning/execplans/archive"
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        child_path = archive_dir / "completed-child.plan.json"
+        roles = ["source_intent", "parent_intent", "next_lane"] if len(child_refs) == 3 else ["closed_item", "parent_intent"]
+        _write_execplan_record(
+            child_path,
+            item_id="completed-child",
+            status="completed",
+            references=[
+                {"kind": "github-issue", "target": target, "label": role.replace("_", " "), "role": role, "locator": "issue"}
+                for target, role in zip(child_refs, roles)
+            ],
+        )
+        child_record = json.loads(child_path.read_text(encoding="utf-8"))
+        child_record["intent_satisfaction"]["was original intent fully satisfied?"] = intent_satisfied
+        child_record["intent_satisfaction"]["unsolved intent passed to"] = unsolved_intent
+        child_record["closure_check"]["larger-intent status"] = "open"
+        child_record["closure_check"]["closure decision"] = "archive-but-keep-lane-open"
+        installer_mod._write_execplan_record(record_path=child_path, record=child_record)
 
-    summary = planning_summary(target=tmp_path)
-    contract = summary["finished_work_inspection_contract"]
+        summary = planning_summary(target=repo)
+        contract = summary["finished_work_inspection_contract"]
 
-    assert contract["counts"]["partial_count"] == 1
-    assert contract["counts"]["routed_continuation_count"] == 1
-    assert contract["counts"]["derived_follow_up_candidate_count"] == 0
-    inspection = contract["inspections"][0]
-    assert inspection["classification"] == "routed_partial"
-    assert inspection["intent_satisfied"] == "yes"
-    assert inspection["routed_by"] == [".agentic-workspace/planning/state.toml work_items lane parent-lane"]
-    assert contract["derived_follow_up_candidates"] == []
-    assert summary["execution_readiness"]["status"] == "roadmap-needs-promotion"
+        if expected_roadmap_refs is not None:
+            assert {reference["target"] for reference in summary["roadmap"]["candidate_lanes"][0]["references"]} == expected_roadmap_refs
+        assert contract["counts"]["partial_count"] == 1, label
+        assert contract["counts"]["routed_continuation_count"] == 1, label
+        assert contract["counts"]["derived_follow_up_candidate_count"] == 0, label
+        inspection = contract["inspections"][0]
+        assert inspection["classification"] == "routed_partial", label
+        assert inspection["routed_by"] == [routed_by], label
+        if intent_satisfied == "yes":
+            assert inspection["intent_satisfied"] == "yes", label
+        assert contract["derived_follow_up_candidates"] == [], label
+        assert summary["execution_readiness"]["status"] == readiness, label
 
 
 def test_planning_summary_suppresses_archived_child_when_parent_ref_is_externally_closed(tmp_path: Path) -> None:

--- a/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
+++ b/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
@@ -11,21 +11,11 @@ VERIFICATION_MANIFEST_PATH = Path(".agentic-workspace/verification/manifest.toml
 SCHEMA_VERSION = "agentic-workspace/verification-manifest/v1"
 EVIDENCE_STRATEGY_KIND = "agentic-workspace/verification-evidence-strategy/v1"
 
-DECLARED_STRATEGY_SOURCE_PATHS = [
+STRATEGY_SOURCE_HINT_PATHS = [
     Path("docs/maintainer/testing-strategy.md"),
     Path("docs/maintainer/aw-contract-test-replacement-inventory.md"),
     Path(".agentic-workspace/docs/proof-surfaces-contract.md"),
     Path("docs/host-repo-learning.md"),
-]
-
-STRATEGY_SIGNAL_MARKERS = [
-    ("prefer behavior contracts over one-off regressions", ["behavior contracts", "one-off regressions"]),
-    ("merge repeated mode/section/branch-shape checks", ["Merge", "Repeated mode", "section", "branch-shape"]),
-    ("convert stable generated command output only with named conformance owner", ["Contract-Owned Cases", "conformance"]),
-    ("prune only with equivalent coverage recorded", ["Prune only", "equivalent coverage"]),
-    ("root tests prove product orchestration", ["Root workspace tests prove", "product orchestration"]),
-    ("package-local tests prove module-owned behavior", ["Package-local tests prove", "module-owned behavior"]),
-    ("filenames and markers are hints, not authority", ["suggest discovery questions", "not authority"]),
 ]
 
 FIXTURE_VARIANT_TOKENS = {
@@ -101,19 +91,19 @@ def _read_text_if_present(path: Path) -> str:
         return ""
 
 
-def _declared_strategy_sources(*, target_root: Path) -> list[dict[str, Any]]:
+def _candidate_strategy_sources(*, target_root: Path) -> list[dict[str, Any]]:
     sources: list[dict[str, Any]] = []
-    for relative_path in DECLARED_STRATEGY_SOURCE_PATHS:
-        text = _read_text_if_present(target_root / relative_path)
-        if not text:
+    for relative_path in STRATEGY_SOURCE_HINT_PATHS:
+        absolute_path = target_root / relative_path
+        if not absolute_path.is_file():
             continue
-        signals = [
-            signal
-            for signal, required_markers in STRATEGY_SIGNAL_MARKERS
-            if all(marker.lower() in text.lower() for marker in required_markers)
-        ]
-        if signals:
-            sources.append({"path": relative_path.as_posix(), "signals": signals})
+        sources.append(
+            {
+                "path": relative_path.as_posix(),
+                "source_role": "candidate-host-strategy-source",
+                "authority": "uninterpreted-source",
+            }
+        )
     return sources
 
 
@@ -176,49 +166,6 @@ def _test_group_key(name: str) -> str:
     return "_".join(parts[: min(len(parts), 7)])
 
 
-def _proof_owner_for_path(path: str) -> str:
-    if path.startswith("packages/") and "/tests/" in path:
-        return "package-local-behavior"
-    if "generated_command" in path or "conformance" in path:
-        return "conformance-contract"
-    if path.startswith("docs/") or path.startswith(".agentic-workspace/docs/"):
-        return "docs-manual-review"
-    if path.startswith("tests/"):
-        return "root-orchestration"
-    return "unknown"
-
-
-def _evidence_role_for_test(function: dict[str, Any]) -> str:
-    name = str(function.get("name", "")).lower()
-    path = str(function.get("path", "")).lower()
-    if any(token in name for token in ("reject", "error", "invalid", "fail", "usage")):
-        return "error-path"
-    if any(token in name for token in ("edge", "stale", "missing", "gap", "empty")):
-        return "edge-case"
-    if "generated_command" in path or "generated_package" in name or "conformance" in name:
-        return "generated-output-assertion"
-    if any(token in name for token in ("adapter", "cli", "stdout", "stderr", "exit")):
-        return "transport-adapter-compatibility"
-    if "migration" in name or "residue" in name:
-        return "migration-residue"
-    if "characterization" in name:
-        return "temporary-characterization"
-    return "behavior-class-coverage"
-
-
-def _strategy_disposition(*, role: str, proof_owner: str, group_size: int, declared_sources: list[dict[str, Any]]) -> str:
-    declared_text = " ".join(signal for source in declared_sources for signal in source.get("signals", []))
-    if group_size > 1 and "merge repeated" in declared_text:
-        return "merge"
-    if role == "generated-output-assertion" and proof_owner == "conformance-contract" and "conformance" in declared_text:
-        return "convert-to-conformance"
-    if role == "temporary-characterization":
-        return "record-verification-evidence"
-    if not declared_sources:
-        return "needs-human-strategy-choice"
-    return "keep"
-
-
 def _evidence_strategy_payload(
     *,
     target_root: Path,
@@ -226,7 +173,7 @@ def _evidence_strategy_payload(
     task_text: str | None,
     manifest: dict[str, Any],
 ) -> dict[str, Any]:
-    declared_sources = _declared_strategy_sources(target_root=target_root)
+    candidate_sources = _candidate_strategy_sources(target_root=target_root)
     test_functions = [
         function
         for changed_path in changed_paths
@@ -237,27 +184,12 @@ def _evidence_strategy_payload(
         grouped.setdefault((str(function["path"]), _test_group_key(str(function["name"]))), []).append(function)
 
     observed_signals: list[dict[str, Any]] = []
-    hotspot_paths = [
-        path
-        for path in changed_paths
-        if path
-        in {
-            "tests/test_model_cli_harness.py",
-            "tests/test_workspace_report_cli.py",
-            "tests/test_workspace_start_preflight_cli.py",
-            "tests/test_generated_command_package_proof_runner.py",
-            "tests/test_workspace_proof_cli.py",
-            "tests/test_workspace_implement_cli.py",
-            "packages/planning/tests/test_summary.py",
-            "packages/planning/tests/test_archive.py",
-        }
-    ]
-    if hotspot_paths:
+    if changed_paths:
         observed_signals.append(
             {
                 "source": "changed_paths",
-                "signal": "hotspot test file touched",
-                "paths": hotspot_paths,
+                "signal": "changed paths supplied",
+                "paths": changed_paths,
                 "confidence": "medium",
             }
         )
@@ -285,7 +217,6 @@ def _evidence_strategy_payload(
     for (path, key), members in sorted(grouped.items()):
         if len(members) < 2:
             continue
-        confidence = "high" if declared_sources else "medium"
         member_names = [str(member["name"]) for member in members]
         for member in members:
             group_size_by_function[f"{path}::{member['name']}"] = len(members)
@@ -295,13 +226,11 @@ def _evidence_strategy_payload(
                 "paths": [path],
                 "members": member_names,
                 "group_role": "fixture-variant",
-                "recommended_disposition": "merge",
-                "confidence": confidence,
+                "recommended_disposition": "needs-human-strategy-choice",
+                "confidence": "low",
                 "explanation": (
-                    "Tests share a path and name prefix, and the declared strategy supports merging repeated checks; "
-                    "inspect setup/assertion shape before merging."
-                    if declared_sources
-                    else "Tests share a path and name prefix; inspect setup/assertion shape before merging."
+                    "Tests share a path and name prefix. Verification surfaces this as a review question; "
+                    "the agent must decide whether the host strategy supports merging."
                 ),
             }
         )
@@ -310,16 +239,8 @@ def _evidence_strategy_payload(
     for function in test_functions:
         path = str(function["path"])
         item_id = f"{path}::{function['name']}"
-        proof_owner = _proof_owner_for_path(path)
-        role = _evidence_role_for_test(function)
         group_size = group_size_by_function.get(item_id, 1)
-        disposition = _strategy_disposition(
-            role="fixture-variant" if group_size > 1 else role,
-            proof_owner=proof_owner,
-            group_size=group_size,
-            declared_sources=declared_sources,
-        )
-        signals = ["changed Python test function", f"proof owner inferred from path: {proof_owner}"]
+        signals = ["changed Python test function"]
         if group_size > 1:
             signals.append("shares name prefix with sibling tests")
         if function.get("helper_calls"):
@@ -329,24 +250,23 @@ def _evidence_strategy_payload(
                 "id": item_id,
                 "path": path,
                 "item_type": "test-function",
-                "proof_owner": proof_owner,
-                "evidence_role": "fixture-variant" if group_size > 1 else role,
-                "strategy_fit": "fits-declared-strategy" if declared_sources else "strategy-unclear",
-                "recommended_disposition": disposition,
-                "confidence": "medium" if declared_sources else "low",
+                "proof_owner": "unknown",
+                "evidence_role": "fixture-variant" if group_size > 1 else "unknown",
+                "strategy_fit": "strategy-unclear",
+                "recommended_disposition": "needs-human-strategy-choice",
+                "confidence": "low",
                 "explanation": (
-                    "Classification is based on repo-declared strategy signals, changed path ownership, and cheap AST facts; "
-                    "it is diagnostic and not proof-equivalence."
+                    "Verification reports structural evidence facts only. The agent must interpret host strategy and decide disposition."
                 ),
                 "observed_signals": signals,
-                "required_replacement_evidence": ["retain behavior-class coverage"] if disposition in {"merge", "prune"} else [],
-                "unsafe_to_prune_because": [] if disposition != "prune" else ["first-slice report does not prove semantic equivalence"],
+                "required_replacement_evidence": [],
+                "unsafe_to_prune_because": [],
             }
         )
 
-    if declared_sources:
-        declared_state = "declared"
-        strategy_confidence = "high"
+    if candidate_sources:
+        declared_state = "partially-declared"
+        strategy_confidence = "low"
     elif observed_signals:
         declared_state = "not-declared"
         strategy_confidence = "low"
@@ -361,28 +281,35 @@ def _evidence_strategy_payload(
                 "based_on": [
                     "shared test path",
                     "shared test name prefix",
-                    "declared merge policy" if declared_sources else "observed AST grouping",
+                    "observed AST grouping",
                 ],
-                "confidence": "medium" if declared_sources else "low",
+                "confidence": "low",
             }
         )
     return {
         "kind": EVIDENCE_STRATEGY_KIND,
-        "status": "ready" if declared_sources else "unclear" if observed_signals else "unavailable",
+        "status": "attention" if candidate_sources or observed_signals else "unavailable",
         "strategy_basis": {
             "declared_strategy_state": declared_state,
-            "declared_strategy_sources": declared_sources,
+            "declared_strategy_sources": [],
+            "candidate_strategy_sources": candidate_sources,
+            "matched_strategy_signals": [],
             "observed_signal_state": "observed" if observed_signals else "absent",
             "observed_signals": observed_signals,
             "agent_inference_state": "inferred" if agent_inferences else "not-inferred",
             "agent_inferences": agent_inferences,
             "strategy_confidence": strategy_confidence,
             "strategy_summary": (
-                "This repo declares behavior-contract coverage, scenario-matrix consolidation for repeated checks, "
-                "contract-owned conformance for suitable generated behavior, and explicit replacement evidence before pruning."
-                if declared_sources
-                else "No declared host testing strategy was found; treat classifications as discovery prompts, not policy."
+                "Verification found candidate host-owned strategy sources but did not interpret their prose. "
+                "The agent must read them and decide how the evidence fits."
+                if candidate_sources
+                else "No candidate host strategy source was found; the agent must decide how to interpret the evidence."
             ),
+            "decision_questions": [
+                "Which host-owned strategy source, if any, should govern this evidence?",
+                "Do grouped tests represent one behavior class or separate regression records?",
+                "What replacement evidence would be required before merging, moving, converting, or pruning evidence?",
+            ],
         },
         "evidence_items": evidence_items,
         "groups": group_entries,
@@ -394,11 +321,11 @@ def _evidence_strategy_payload(
                 1 for item in evidence_items if item["recommended_disposition"] == "needs-human-strategy-choice"
             ),
             "ordinary_tests_touched": len(test_functions),
-            "hotspot_files_touched": hotspot_paths,
+            "hotspot_files_touched": [],
             "candidate_threshold_note": (
-                "Fewer than 10 high-confidence merge candidates were found with the first-slice exact-prefix heuristic; "
-                "broader reductions need human review or stronger equivalence signals."
-                if declared_sources and sum(1 for group in group_entries if group["confidence"] == "high") < 10
+                "Verification does not assign high-confidence merge or prune candidates from prose or name matching; "
+                "the agent must make the strategy decision."
+                if group_entries
                 else ""
             ),
         },

--- a/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
+++ b/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import fnmatch
 import tomllib
 from datetime import date
@@ -8,6 +9,47 @@ from typing import Any
 
 VERIFICATION_MANIFEST_PATH = Path(".agentic-workspace/verification/manifest.toml")
 SCHEMA_VERSION = "agentic-workspace/verification-manifest/v1"
+EVIDENCE_STRATEGY_KIND = "agentic-workspace/verification-evidence-strategy/v1"
+
+DECLARED_STRATEGY_SOURCE_PATHS = [
+    Path("docs/maintainer/testing-strategy.md"),
+    Path("docs/maintainer/aw-contract-test-replacement-inventory.md"),
+    Path(".agentic-workspace/docs/proof-surfaces-contract.md"),
+    Path("docs/host-repo-learning.md"),
+]
+
+STRATEGY_SIGNAL_MARKERS = [
+    ("prefer behavior contracts over one-off regressions", ["behavior contracts", "one-off regressions"]),
+    ("merge repeated mode/section/branch-shape checks", ["Merge", "Repeated mode", "section", "branch-shape"]),
+    ("convert stable generated command output only with named conformance owner", ["Contract-Owned Cases", "conformance"]),
+    ("prune only with equivalent coverage recorded", ["Prune only", "equivalent coverage"]),
+    ("root tests prove product orchestration", ["Root workspace tests prove", "product orchestration"]),
+    ("package-local tests prove module-owned behavior", ["Package-local tests prove", "module-owned behavior"]),
+    ("filenames and markers are hints, not authority", ["suggest discovery questions", "not authority"]),
+]
+
+FIXTURE_VARIANT_TOKENS = {
+    "active",
+    "alias",
+    "aliases",
+    "before",
+    "current",
+    "external",
+    "json",
+    "later",
+    "missing",
+    "mode",
+    "modes",
+    "path",
+    "posix",
+    "raw",
+    "section",
+    "selector",
+    "text",
+    "verbose",
+    "windows",
+    "without",
+}
 
 
 class VerificationUsageError(ValueError):
@@ -50,6 +92,322 @@ def _normalize_changed_paths(paths: list[str] | None) -> list[str]:
         if stripped and stripped not in normalized:
             normalized.append(stripped)
     return normalized
+
+
+def _read_text_if_present(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _declared_strategy_sources(*, target_root: Path) -> list[dict[str, Any]]:
+    sources: list[dict[str, Any]] = []
+    for relative_path in DECLARED_STRATEGY_SOURCE_PATHS:
+        text = _read_text_if_present(target_root / relative_path)
+        if not text:
+            continue
+        signals = [
+            signal
+            for signal, required_markers in STRATEGY_SIGNAL_MARKERS
+            if all(marker.lower() in text.lower() for marker in required_markers)
+        ]
+        if signals:
+            sources.append({"path": relative_path.as_posix(), "signals": signals})
+    return sources
+
+
+def _test_functions_from_path(*, target_root: Path, changed_path: str) -> list[dict[str, Any]]:
+    relative_path = Path(changed_path)
+    if relative_path.suffix != ".py" or not relative_path.name.startswith("test_"):
+        return []
+    absolute_path = relative_path if relative_path.is_absolute() else target_root / relative_path
+    text = _read_text_if_present(absolute_path)
+    if not text:
+        return []
+    try:
+        module = ast.parse(text)
+    except SyntaxError:
+        return []
+    functions: list[dict[str, Any]] = []
+    for node in module.body:
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test_"):
+            continue
+        assertions: list[str] = []
+        helper_calls: list[str] = []
+        decorator_names: list[str] = []
+        for decorator in node.decorator_list:
+            if isinstance(decorator, ast.Call):
+                decorator = decorator.func
+            if isinstance(decorator, ast.Attribute):
+                decorator_names.append(decorator.attr)
+            elif isinstance(decorator, ast.Name):
+                decorator_names.append(decorator.id)
+        for child in ast.walk(node):
+            if isinstance(child, ast.Assert):
+                assertions.append(ast.unparse(child.test) if hasattr(ast, "unparse") else "assert")
+            elif isinstance(child, ast.Call):
+                call = child.func
+                if isinstance(call, ast.Name) and call.id.startswith("_"):
+                    helper_calls.append(call.id)
+                elif isinstance(call, ast.Attribute) and call.attr.startswith("_"):
+                    helper_calls.append(call.attr)
+        functions.append(
+            {
+                "name": node.name,
+                "path": Path(changed_path).as_posix(),
+                "line": node.lineno,
+                "decorators": _dedupe(decorator_names),
+                "helper_calls": _dedupe(helper_calls)[:8],
+                "assertion_fragments": _dedupe(assertions)[:5],
+                "assertion_count": len(assertions),
+            }
+        )
+    return functions
+
+
+def _test_group_key(name: str) -> str:
+    stem = name.removeprefix("test_")
+    parts = stem.split("_")
+    while parts and parts[-1] in FIXTURE_VARIANT_TOKENS:
+        parts.pop()
+    if len(parts) < 3:
+        return stem
+    return "_".join(parts[: min(len(parts), 7)])
+
+
+def _proof_owner_for_path(path: str) -> str:
+    if path.startswith("packages/") and "/tests/" in path:
+        return "package-local-behavior"
+    if "generated_command" in path or "conformance" in path:
+        return "conformance-contract"
+    if path.startswith("docs/") or path.startswith(".agentic-workspace/docs/"):
+        return "docs-manual-review"
+    if path.startswith("tests/"):
+        return "root-orchestration"
+    return "unknown"
+
+
+def _evidence_role_for_test(function: dict[str, Any]) -> str:
+    name = str(function.get("name", "")).lower()
+    path = str(function.get("path", "")).lower()
+    if any(token in name for token in ("reject", "error", "invalid", "fail", "usage")):
+        return "error-path"
+    if any(token in name for token in ("edge", "stale", "missing", "gap", "empty")):
+        return "edge-case"
+    if "generated_command" in path or "generated_package" in name or "conformance" in name:
+        return "generated-output-assertion"
+    if any(token in name for token in ("adapter", "cli", "stdout", "stderr", "exit")):
+        return "transport-adapter-compatibility"
+    if "migration" in name or "residue" in name:
+        return "migration-residue"
+    if "characterization" in name:
+        return "temporary-characterization"
+    return "behavior-class-coverage"
+
+
+def _strategy_disposition(*, role: str, proof_owner: str, group_size: int, declared_sources: list[dict[str, Any]]) -> str:
+    declared_text = " ".join(signal for source in declared_sources for signal in source.get("signals", []))
+    if group_size > 1 and "merge repeated" in declared_text:
+        return "merge"
+    if role == "generated-output-assertion" and proof_owner == "conformance-contract" and "conformance" in declared_text:
+        return "convert-to-conformance"
+    if role == "temporary-characterization":
+        return "record-verification-evidence"
+    if not declared_sources:
+        return "needs-human-strategy-choice"
+    return "keep"
+
+
+def _evidence_strategy_payload(
+    *,
+    target_root: Path,
+    changed_paths: list[str],
+    task_text: str | None,
+    manifest: dict[str, Any],
+) -> dict[str, Any]:
+    declared_sources = _declared_strategy_sources(target_root=target_root)
+    test_functions = [
+        function
+        for changed_path in changed_paths
+        for function in _test_functions_from_path(target_root=target_root, changed_path=changed_path)
+    ]
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for function in test_functions:
+        grouped.setdefault((str(function["path"]), _test_group_key(str(function["name"]))), []).append(function)
+
+    observed_signals: list[dict[str, Any]] = []
+    hotspot_paths = [
+        path
+        for path in changed_paths
+        if path
+        in {
+            "tests/test_model_cli_harness.py",
+            "tests/test_workspace_report_cli.py",
+            "tests/test_workspace_start_preflight_cli.py",
+            "tests/test_generated_command_package_proof_runner.py",
+            "tests/test_workspace_proof_cli.py",
+            "tests/test_workspace_implement_cli.py",
+            "packages/planning/tests/test_summary.py",
+            "packages/planning/tests/test_archive.py",
+        }
+    ]
+    if hotspot_paths:
+        observed_signals.append(
+            {
+                "source": "changed_paths",
+                "signal": "hotspot test file touched",
+                "paths": hotspot_paths,
+                "confidence": "medium",
+            }
+        )
+    if test_functions:
+        observed_signals.append(
+            {
+                "source": "test_ast",
+                "signal": "changed Python test functions collected by AST",
+                "paths": _dedupe([str(function["path"]) for function in test_functions]),
+                "confidence": "medium",
+            }
+        )
+    if manifest.get("configured"):
+        observed_signals.append(
+            {
+                "source": "verification_manifest",
+                "signal": "verification manifest is configured",
+                "paths": [str(manifest.get("path", VERIFICATION_MANIFEST_PATH.as_posix()))],
+                "confidence": "medium",
+            }
+        )
+
+    group_entries: list[dict[str, Any]] = []
+    group_size_by_function: dict[str, int] = {}
+    for (path, key), members in sorted(grouped.items()):
+        if len(members) < 2:
+            continue
+        confidence = "high" if declared_sources else "medium"
+        member_names = [str(member["name"]) for member in members]
+        for member in members:
+            group_size_by_function[f"{path}::{member['name']}"] = len(members)
+        group_entries.append(
+            {
+                "id": key.replace("_", "-"),
+                "paths": [path],
+                "members": member_names,
+                "group_role": "fixture-variant",
+                "recommended_disposition": "merge",
+                "confidence": confidence,
+                "explanation": (
+                    "Tests share a path and name prefix, and the declared strategy supports merging repeated checks; "
+                    "inspect setup/assertion shape before merging."
+                    if declared_sources
+                    else "Tests share a path and name prefix; inspect setup/assertion shape before merging."
+                ),
+            }
+        )
+
+    evidence_items: list[dict[str, Any]] = []
+    for function in test_functions:
+        path = str(function["path"])
+        item_id = f"{path}::{function['name']}"
+        proof_owner = _proof_owner_for_path(path)
+        role = _evidence_role_for_test(function)
+        group_size = group_size_by_function.get(item_id, 1)
+        disposition = _strategy_disposition(
+            role="fixture-variant" if group_size > 1 else role,
+            proof_owner=proof_owner,
+            group_size=group_size,
+            declared_sources=declared_sources,
+        )
+        signals = ["changed Python test function", f"proof owner inferred from path: {proof_owner}"]
+        if group_size > 1:
+            signals.append("shares name prefix with sibling tests")
+        if function.get("helper_calls"):
+            signals.append("uses helper calls")
+        evidence_items.append(
+            {
+                "id": item_id,
+                "path": path,
+                "item_type": "test-function",
+                "proof_owner": proof_owner,
+                "evidence_role": "fixture-variant" if group_size > 1 else role,
+                "strategy_fit": "fits-declared-strategy" if declared_sources else "strategy-unclear",
+                "recommended_disposition": disposition,
+                "confidence": "medium" if declared_sources else "low",
+                "explanation": (
+                    "Classification is based on repo-declared strategy signals, changed path ownership, and cheap AST facts; "
+                    "it is diagnostic and not proof-equivalence."
+                ),
+                "observed_signals": signals,
+                "required_replacement_evidence": ["retain behavior-class coverage"] if disposition in {"merge", "prune"} else [],
+                "unsafe_to_prune_because": [] if disposition != "prune" else ["first-slice report does not prove semantic equivalence"],
+            }
+        )
+
+    if declared_sources:
+        declared_state = "declared"
+        strategy_confidence = "high"
+    elif observed_signals:
+        declared_state = "not-declared"
+        strategy_confidence = "low"
+    else:
+        declared_state = "not-declared"
+        strategy_confidence = "unclear"
+    agent_inferences = []
+    if group_entries:
+        agent_inferences.append(
+            {
+                "inference": "changed tests include likely fixture variants under shared behavior classes",
+                "based_on": [
+                    "shared test path",
+                    "shared test name prefix",
+                    "declared merge policy" if declared_sources else "observed AST grouping",
+                ],
+                "confidence": "medium" if declared_sources else "low",
+            }
+        )
+    return {
+        "kind": EVIDENCE_STRATEGY_KIND,
+        "status": "ready" if declared_sources else "unclear" if observed_signals else "unavailable",
+        "strategy_basis": {
+            "declared_strategy_state": declared_state,
+            "declared_strategy_sources": declared_sources,
+            "observed_signal_state": "observed" if observed_signals else "absent",
+            "observed_signals": observed_signals,
+            "agent_inference_state": "inferred" if agent_inferences else "not-inferred",
+            "agent_inferences": agent_inferences,
+            "strategy_confidence": strategy_confidence,
+            "strategy_summary": (
+                "This repo declares behavior-contract coverage, scenario-matrix consolidation for repeated checks, "
+                "contract-owned conformance for suitable generated behavior, and explicit replacement evidence before pruning."
+                if declared_sources
+                else "No declared host testing strategy was found; treat classifications as discovery prompts, not policy."
+            ),
+        },
+        "evidence_items": evidence_items,
+        "groups": group_entries,
+        "summary": {
+            "candidate_count": len(evidence_items),
+            "high_confidence_merge_count": sum(1 for group in group_entries if group["confidence"] == "high"),
+            "high_confidence_prune_count": 0,
+            "needs_human_strategy_choice_count": sum(
+                1 for item in evidence_items if item["recommended_disposition"] == "needs-human-strategy-choice"
+            ),
+            "ordinary_tests_touched": len(test_functions),
+            "hotspot_files_touched": hotspot_paths,
+            "candidate_threshold_note": (
+                "Fewer than 10 high-confidence merge candidates were found with the first-slice exact-prefix heuristic; "
+                "broader reductions need human review or stronger equivalence signals."
+                if declared_sources and sum(1 for group in group_entries if group["confidence"] == "high") < 10
+                else ""
+            ),
+        },
+        "limits": [
+            "No automatic deletion.",
+            "No proof-equivalence guarantee.",
+            "No universal testing strategy inferred.",
+        ],
+    }
 
 
 def _required_string(*, payload: dict[str, Any], key: str, surface: str) -> str:
@@ -677,6 +1035,12 @@ def verification_report_payload(
     active_known_gaps = [
         gap for gap in known_gaps if str(gap.get("protocol_id", "")).strip() in active_protocol_ids and gap.get("status") != "closed"
     ]
+    evidence_strategy = _evidence_strategy_payload(
+        target_root=target_root,
+        changed_paths=normalized_paths,
+        task_text=task_text,
+        manifest=manifest,
+    )
     return {
         "kind": "agentic-workspace/verification/v1",
         "status": "attention"
@@ -718,6 +1082,7 @@ def verification_report_payload(
         "active_count": len(active_protocols),
         "evidence_status": evidence_status,
         "evidence_bundle_status": [_bundle_state(bundle, changed_paths=normalized_paths) for bundle in evidence_bundles],
+        "evidence_strategy": evidence_strategy,
         "match_evidence": {
             "observed_scope_source": ", ".join(
                 source

--- a/packages/verification/tests/test_runtime_primitives.py
+++ b/packages/verification/tests/test_runtime_primitives.py
@@ -14,6 +14,9 @@ def test_verification_report_absent_manifest(tmp_path: Path) -> None:
     assert payload["configured"] is False
     assert payload["protocol_count"] == 0
     assert payload["active_count"] == 0
+    assert payload["evidence_strategy"]["kind"] == "agentic-workspace/verification-evidence-strategy/v1"
+    assert payload["evidence_strategy"]["status"] == "unavailable"
+    assert payload["evidence_strategy"]["strategy_basis"]["declared_strategy_state"] == "not-declared"
 
 
 def test_verification_report_matches_path_protocol_and_evidence(tmp_path: Path) -> None:
@@ -155,3 +158,130 @@ stale_when = ["web/**"]
     assert payload["evidence_status"][0]["state"] == "stale-evidence"
     assert payload["evidence_status"][0]["stale_expected_evidence"] == ["ui_review_passed"]
     assert payload["evidence_status"][0]["missing_evidence"] == ["ui_review_passed"]
+
+
+def test_verification_evidence_strategy_reports_declared_host_strategy(tmp_path: Path) -> None:
+    strategy_doc = tmp_path / "docs" / "maintainer" / "testing-strategy.md"
+    strategy_doc.parent.mkdir(parents=True)
+    strategy_doc.write_text(
+        """
+# Testing Strategy
+
+Prefer behavior contracts over one-off regressions. Merge repeated mode, section,
+or branch-shape checks when the same behavior is covered. Contract-Owned Cases
+use conformance when suitable. Prune only when equivalent coverage remains.
+Root workspace tests prove product orchestration. Package-local tests prove
+module-owned behavior.
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=[], task_text="")
+
+    strategy = payload["evidence_strategy"]
+    assert strategy["status"] == "ready"
+    basis = strategy["strategy_basis"]
+    assert basis["declared_strategy_state"] == "declared"
+    assert basis["strategy_confidence"] == "high"
+    assert basis["declared_strategy_sources"] == [
+        {
+            "path": "docs/maintainer/testing-strategy.md",
+            "signals": [
+                "prefer behavior contracts over one-off regressions",
+                "merge repeated mode/section/branch-shape checks",
+                "convert stable generated command output only with named conformance owner",
+                "prune only with equivalent coverage recorded",
+                "root tests prove product orchestration",
+                "package-local tests prove module-owned behavior",
+            ],
+        }
+    ]
+    assert "No universal testing strategy inferred." in strategy["limits"]
+
+
+def test_verification_evidence_strategy_classifies_changed_test_fixture_variants(tmp_path: Path) -> None:
+    strategy_doc = tmp_path / "docs" / "maintainer" / "testing-strategy.md"
+    strategy_doc.parent.mkdir(parents=True)
+    strategy_doc.write_text(
+        """
+# Testing Strategy
+
+Prefer behavior contracts over one-off regressions. Merge repeated mode, section,
+or branch-shape checks when the same behavior is covered.
+""".strip(),
+        encoding="utf-8",
+    )
+    test_file = tmp_path / "tests" / "test_model_cli_harness.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        """
+def _warning_case(value):
+    return value
+
+
+def test_model_cli_harness_scores_raw_read_posix():
+    warnings = _warning_case("posix")
+    assert "raw workspace files" in warnings
+
+
+def test_model_cli_harness_scores_raw_read_windows():
+    warnings = _warning_case("windows")
+    assert "raw workspace files" in warnings
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(
+        target_root=tmp_path,
+        changed_paths=["tests/test_model_cli_harness.py"],
+        task_text="reduce regression sprawl",
+    )
+
+    strategy = payload["evidence_strategy"]
+    assert strategy["status"] == "ready"
+    assert strategy["summary"]["ordinary_tests_touched"] == 2
+    assert strategy["summary"]["hotspot_files_touched"] == ["tests/test_model_cli_harness.py"]
+    assert strategy["groups"] == [
+        {
+            "id": "model-cli-harness-scores-raw-read",
+            "paths": ["tests/test_model_cli_harness.py"],
+            "members": [
+                "test_model_cli_harness_scores_raw_read_posix",
+                "test_model_cli_harness_scores_raw_read_windows",
+            ],
+            "group_role": "fixture-variant",
+            "recommended_disposition": "merge",
+            "confidence": "high",
+            "explanation": (
+                "Tests share a path and name prefix, and the declared strategy supports merging repeated checks; "
+                "inspect setup/assertion shape before merging."
+            ),
+        }
+    ]
+    assert strategy["summary"]["high_confidence_merge_count"] == 1
+    assert "Fewer than 10 high-confidence merge candidates" in strategy["summary"]["candidate_threshold_note"]
+    assert {item["recommended_disposition"] for item in strategy["evidence_items"]} == {"merge"}
+    assert {item["evidence_role"] for item in strategy["evidence_items"]} == {"fixture-variant"}
+    assert {item["proof_owner"] for item in strategy["evidence_items"]} == {"root-orchestration"}
+
+
+def test_verification_evidence_strategy_keeps_unclear_strategy_host_neutral(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests" / "test_widget.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        """
+def test_widget_handles_error():
+    assert True
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=["tests/test_widget.py"], task_text="")
+
+    strategy = payload["evidence_strategy"]
+    assert strategy["status"] == "unclear"
+    assert strategy["strategy_basis"]["declared_strategy_state"] == "not-declared"
+    assert strategy["strategy_basis"]["strategy_confidence"] == "low"
+    assert strategy["evidence_items"][0]["recommended_disposition"] == "needs-human-strategy-choice"
+    assert strategy["evidence_items"][0]["confidence"] == "low"
+    assert "No universal testing strategy inferred." in strategy["limits"]

--- a/packages/verification/tests/test_runtime_primitives.py
+++ b/packages/verification/tests/test_runtime_primitives.py
@@ -160,7 +160,7 @@ stale_when = ["web/**"]
     assert payload["evidence_status"][0]["missing_evidence"] == ["ui_review_passed"]
 
 
-def test_verification_evidence_strategy_reports_declared_host_strategy(tmp_path: Path) -> None:
+def test_verification_evidence_strategy_reports_candidate_strategy_sources_without_interpreting_prose(tmp_path: Path) -> None:
     strategy_doc = tmp_path / "docs" / "maintainer" / "testing-strategy.md"
     strategy_doc.parent.mkdir(parents=True)
     strategy_doc.write_text(
@@ -179,22 +179,24 @@ module-owned behavior.
     payload = verification_report_payload(target_root=tmp_path, changed_paths=[], task_text="")
 
     strategy = payload["evidence_strategy"]
-    assert strategy["status"] == "ready"
+    assert strategy["status"] == "attention"
     basis = strategy["strategy_basis"]
-    assert basis["declared_strategy_state"] == "declared"
-    assert basis["strategy_confidence"] == "high"
-    assert basis["declared_strategy_sources"] == [
+    assert basis["declared_strategy_state"] == "partially-declared"
+    assert basis["strategy_confidence"] == "low"
+    assert basis["declared_strategy_sources"] == []
+    assert basis["matched_strategy_signals"] == []
+    assert basis["candidate_strategy_sources"] == [
         {
             "path": "docs/maintainer/testing-strategy.md",
-            "signals": [
-                "prefer behavior contracts over one-off regressions",
-                "merge repeated mode/section/branch-shape checks",
-                "convert stable generated command output only with named conformance owner",
-                "prune only with equivalent coverage recorded",
-                "root tests prove product orchestration",
-                "package-local tests prove module-owned behavior",
-            ],
+            "source_role": "candidate-host-strategy-source",
+            "authority": "uninterpreted-source",
         }
+    ]
+    assert "did not interpret their prose" in basis["strategy_summary"]
+    assert basis["decision_questions"] == [
+        "Which host-owned strategy source, if any, should govern this evidence?",
+        "Do grouped tests represent one behavior class or separate regression records?",
+        "What replacement evidence would be required before merging, moving, converting, or pruning evidence?",
     ]
     assert "No universal testing strategy inferred." in strategy["limits"]
 
@@ -238,9 +240,9 @@ def test_model_cli_harness_scores_raw_read_windows():
     )
 
     strategy = payload["evidence_strategy"]
-    assert strategy["status"] == "ready"
+    assert strategy["status"] == "attention"
     assert strategy["summary"]["ordinary_tests_touched"] == 2
-    assert strategy["summary"]["hotspot_files_touched"] == ["tests/test_model_cli_harness.py"]
+    assert strategy["summary"]["hotspot_files_touched"] == []
     assert strategy["groups"] == [
         {
             "id": "model-cli-harness-scores-raw-read",
@@ -250,19 +252,19 @@ def test_model_cli_harness_scores_raw_read_windows():
                 "test_model_cli_harness_scores_raw_read_windows",
             ],
             "group_role": "fixture-variant",
-            "recommended_disposition": "merge",
-            "confidence": "high",
+            "recommended_disposition": "needs-human-strategy-choice",
+            "confidence": "low",
             "explanation": (
-                "Tests share a path and name prefix, and the declared strategy supports merging repeated checks; "
-                "inspect setup/assertion shape before merging."
+                "Tests share a path and name prefix. Verification surfaces this as a review question; "
+                "the agent must decide whether the host strategy supports merging."
             ),
         }
     ]
-    assert strategy["summary"]["high_confidence_merge_count"] == 1
-    assert "Fewer than 10 high-confidence merge candidates" in strategy["summary"]["candidate_threshold_note"]
-    assert {item["recommended_disposition"] for item in strategy["evidence_items"]} == {"merge"}
+    assert strategy["summary"]["high_confidence_merge_count"] == 0
+    assert "does not assign high-confidence merge" in strategy["summary"]["candidate_threshold_note"]
+    assert {item["recommended_disposition"] for item in strategy["evidence_items"]} == {"needs-human-strategy-choice"}
     assert {item["evidence_role"] for item in strategy["evidence_items"]} == {"fixture-variant"}
-    assert {item["proof_owner"] for item in strategy["evidence_items"]} == {"root-orchestration"}
+    assert {item["proof_owner"] for item in strategy["evidence_items"]} == {"unknown"}
 
 
 def test_verification_evidence_strategy_keeps_unclear_strategy_host_neutral(tmp_path: Path) -> None:
@@ -279,9 +281,53 @@ def test_widget_handles_error():
     payload = verification_report_payload(target_root=tmp_path, changed_paths=["tests/test_widget.py"], task_text="")
 
     strategy = payload["evidence_strategy"]
-    assert strategy["status"] == "unclear"
+    assert strategy["status"] == "attention"
     assert strategy["strategy_basis"]["declared_strategy_state"] == "not-declared"
     assert strategy["strategy_basis"]["strategy_confidence"] == "low"
     assert strategy["evidence_items"][0]["recommended_disposition"] == "needs-human-strategy-choice"
     assert strategy["evidence_items"][0]["confidence"] == "low"
     assert "No universal testing strategy inferred." in strategy["limits"]
+
+
+def test_verification_evidence_strategy_does_not_force_merge_for_different_host_strategy_prose(tmp_path: Path) -> None:
+    strategy_doc = tmp_path / "docs" / "maintainer" / "testing-strategy.md"
+    strategy_doc.parent.mkdir(parents=True)
+    strategy_doc.write_text(
+        """
+# Testing Strategy
+
+This repository keeps one test per regression record so incident history stays
+auditable. Do not merge unrelated regression records just because they share
+fixtures or assertion shape.
+""".strip(),
+        encoding="utf-8",
+    )
+    test_file = tmp_path / "tests" / "test_widget.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        """
+def test_widget_case_regression_posix():
+    assert True
+
+
+def test_widget_case_regression_windows():
+    assert True
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=["tests/test_widget.py"], task_text="")
+
+    strategy = payload["evidence_strategy"]
+    assert strategy["strategy_basis"]["declared_strategy_sources"] == []
+    assert strategy["strategy_basis"]["matched_strategy_signals"] == []
+    assert strategy["strategy_basis"]["candidate_strategy_sources"] == [
+        {
+            "path": "docs/maintainer/testing-strategy.md",
+            "source_role": "candidate-host-strategy-source",
+            "authority": "uninterpreted-source",
+        }
+    ]
+    assert {group["recommended_disposition"] for group in strategy["groups"]} == {"needs-human-strategy-choice"}
+    assert {item["recommended_disposition"] for item in strategy["evidence_items"]} == {"needs-human-strategy-choice"}
+    assert strategy["summary"]["high_confidence_merge_count"] == 0

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -1318,14 +1318,34 @@ def test_static_generated_package_proof_rejects_legacy_generated_python_package_
     assert any("legacy generated Python package directories" in error for error in errors)
 
 
-def test_static_generated_package_proof_accepts_current_runtime_projection_inventory_for_partial_completion() -> None:
-    errors = _checker_case_errors(
-        """
-        _emit({"errors": checker._validate_python_runtime_projection_inventory(full_completion=False)})
-        """
-    )
+def test_static_generated_package_proof_accepts_current_static_surfaces() -> None:
+    scenarios = [
+        (
+            "runtime-projection-inventory",
+            """
+            _emit({"errors": checker._validate_python_runtime_projection_inventory(full_completion=False)})
+            """,
+            lambda errors: errors == [],
+        ),
+        (
+            "shipped-source-retirement",
+            """
+            _emit({"errors": checker._validate_python_shipped_source_executable_retirement()})
+            """,
+            lambda errors: errors == [],
+        ),
+        (
+            "python-completion-gate",
+            """
+            _emit({"errors": checker._validate_static_surfaces()})
+            """,
+            lambda errors: not [error for error in errors if "Python CLI completion" in error or "Python completion" in error],
+        ),
+    ]
+    for label, script, assertion in scenarios:
+        errors = _checker_case_errors(script)
 
-    assert errors == []
+        assert assertion(errors), label
 
 
 def test_static_generated_package_proof_rejects_shipped_source_cli_backslide() -> None:
@@ -1383,16 +1403,6 @@ def test_static_generated_package_proof_uses_behavior_detection_not_plain_keywor
     assert errors == []
 
 
-def test_static_generated_package_proof_accepts_current_shipped_source_retirement() -> None:
-    errors = _checker_case_errors(
-        """
-        _emit({"errors": checker._validate_python_shipped_source_executable_retirement()})
-        """
-    )
-
-    assert errors == []
-
-
 def test_tracked_python_source_files_falls_back_without_git(monkeypatch) -> None:
     checker = _load_checker()
 
@@ -1416,16 +1426,6 @@ def test_static_generated_package_proof_rejects_satisfied_gate_for_non_full_stat
     )
 
     assert any("cannot mark the Python CLI completion gate satisfied" in error for error in errors)
-
-
-def test_static_generated_package_proof_accepts_current_python_completion_gate() -> None:
-    errors = _checker_case_errors(
-        """
-        _emit({"errors": checker._validate_static_surfaces()})
-        """
-    )
-
-    assert not [error for error in errors if "Python CLI completion" in error or "Python completion" in error]
 
 
 def test_static_generated_package_proof_rejects_missing_primitive_conformance_case() -> None:

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -1063,58 +1063,28 @@ def test_static_generated_package_proof_rejects_read_only_routing_for_mutating_t
     assert any("weak-agent-safe-adapter while generated commands include mutation-capable effects" in error for error in errors)
 
 
-def test_static_generated_package_proof_requires_python_completion_gate_evidence() -> None:
-    errors = _checker_case_errors(
-        """
-        ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
-        ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
-        ir["generation_policy"]["python_cli_completion"]["completion_gate"]["satisfied_by"] = [
-            item
-            for item in ir["generation_policy"]["python_cli_completion"]["completion_gate"]["satisfied_by"]
-            if item["id"] != "python-docker-conformance"
-        ]
-        checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-        _emit({"errors": checker._validate_static_surfaces()})
-        """
-    )
+def test_static_generated_package_proof_requires_completion_gate_evidence() -> None:
+    required_gate_items = [
+        "python-docker-conformance",
+        "representative-operation-ir-runtime-consumed",
+        "operation-execution-inventory-exhaustive",
+    ]
+    for item_id in required_gate_items:
+        errors = _checker_case_errors(
+            f"""
+            ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
+            ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
+            ir["generation_policy"]["python_cli_completion"]["completion_gate"]["satisfied_by"] = [
+                item
+                for item in ir["generation_policy"]["python_cli_completion"]["completion_gate"]["satisfied_by"]
+                if item["id"] != {item_id!r}
+            ]
+            checker.load_workspace_command_package_ir = lambda *, repo_root: ir
+            _emit({{"errors": checker._validate_static_surfaces()}})
+            """
+        )
 
-    assert any("python-docker-conformance" in error for error in errors)
-
-
-def test_static_generated_package_proof_requires_operation_ir_runtime_consumption_evidence() -> None:
-    errors = _checker_case_errors(
-        """
-        ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
-        ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
-        ir["generation_policy"]["python_cli_completion"]["completion_gate"]["satisfied_by"] = [
-            item
-            for item in ir["generation_policy"]["python_cli_completion"]["completion_gate"]["satisfied_by"]
-            if item["id"] != "representative-operation-ir-runtime-consumed"
-        ]
-        checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-        _emit({"errors": checker._validate_static_surfaces()})
-        """
-    )
-
-    assert any("representative-operation-ir-runtime-consumed" in error for error in errors)
-
-
-def test_static_generated_package_proof_requires_exhaustive_operation_inventory_evidence() -> None:
-    errors = _checker_case_errors(
-        """
-        ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
-        ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
-        ir["generation_policy"]["python_cli_completion"]["completion_gate"]["satisfied_by"] = [
-            item
-            for item in ir["generation_policy"]["python_cli_completion"]["completion_gate"]["satisfied_by"]
-            if item["id"] != "operation-execution-inventory-exhaustive"
-        ]
-        checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-        _emit({"errors": checker._validate_static_surfaces()})
-        """
-    )
-
-    assert any("operation-execution-inventory-exhaustive" in error for error in errors)
+        assert any(item_id in error for error in errors), item_id
 
 
 def test_static_generated_package_proof_rejects_python_completion_proof_surface_drift() -> None:

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -1104,125 +1104,169 @@ def test_static_generated_package_proof_rejects_python_completion_proof_surface_
     assert any("--python-docker-conformance --require-docker" in error for error in errors)
 
 
-def test_static_generated_package_proof_rejects_full_completion_with_compatibility_handlers() -> None:
-    errors = _checker_case_errors(
-        """
-        ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
-        ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
-        ir["generation_policy"]["python_cli_completion"]["completion_gate"]["state"] = "satisfied"
-        original_load_json = checker._load_json
+def test_static_generated_package_proof_rejects_full_completion_with_runtime_debt() -> None:
+    scenarios = [
+        (
+            "compatibility-handlers",
+            """
+            ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
+            ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
+            ir["generation_policy"]["python_cli_completion"]["completion_gate"]["state"] = "satisfied"
+            original_load_json = checker._load_json
 
-        def fake_load_json(path: str) -> dict[str, object]:
-            payload = original_load_json(path)
-            if path == "python_operation_execution_inventory.json":
+            def fake_load_json(path: str) -> dict[str, object]:
+                payload = original_load_json(path)
+                if path == "python_operation_execution_inventory.json":
+                    payload = dict(payload)
+                    entries = [dict(entry) for entry in payload["entries"]]
+                    entries[0]["status"] = "compatibility-runtime-handler"
+                    payload["entries"] = entries
+                return payload
+
+            checker.load_workspace_command_package_ir = lambda *, repo_root: ir
+            checker._load_json = fake_load_json
+            _emit({"errors": checker._validate_static_surfaces()})
+            """,
+            "compatibility-runtime-handler",
+        ),
+        (
+            "generic-runtime-debt",
+            """
+            ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
+            ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
+            ir["generation_policy"]["python_cli_completion"]["completion_gate"]["state"] = "satisfied"
+            original_load_json = checker._load_json
+
+            def fake_load_json(path: str) -> dict[str, object]:
+                payload = original_load_json(path)
+                if path == "python_operation_execution_inventory.json":
+                    payload = dict(payload)
+                    entries = [dict(entry) for entry in payload["entries"]]
+                    entries[0]["status"] = "accepted-hand-owned-runtime-primitive"
+                    entries[0]["runtime_boundary_class"] = "generic-deterministic-runtime-debt"
+                    entries[0]["runtime_boundary_reason"] = "still generic runtime debt"
+                    payload["entries"] = entries
+                return payload
+
+            checker.load_workspace_command_package_ir = lambda *, repo_root: ir
+            checker._load_json = fake_load_json
+            _emit({"errors": checker._validate_static_surfaces()})
+            """,
+            "generic deterministic behavior as runtime debt",
+        ),
+        (
+            "generated-main-delegates-first",
+            r"""
+            ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
+            ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
+            ir["generation_policy"]["python_cli_completion"]["completion_gate"]["state"] = "satisfied"
+            original_read_text = checker.Path.read_text
+
+            def fake_read_text(self, *args, **kwargs):
+                text = original_read_text(self, *args, **kwargs)
+                if self.as_posix().endswith("generated/workspace/python/cli.py"):
+                    return text.replace(
+                        "    if supports_generated_command(argv_list):\n"
+                        "        try:\n"
+                        "            return run_generated_command(argv_list, _run_command_module)\n"
+                        "        except Exception as exc:\n"
+                        "            if exc.__class__.__name__.endswith('UsageError') or exc.__class__.__name__ == 'RepoDetectionError':\n"
+                        "                build_generated_parser().error(str(exc))\n"
+                        "            raise\n\n"
+                        "    build_generated_parser().parse_args(argv_list)\n"
+                        "    return 0\n",
+                        "    return 2\n",
+                    )
+                return text
+
+            checker.load_workspace_command_package_ir = lambda *, repo_root: ir
+            checker.Path.read_text = fake_read_text
+            _emit({"errors": checker._validate_static_surfaces()})
+            """,
+            "missing generated-main boundary fragment",
+        ),
+        (
+            "product-runtime-source",
+            r"""
+            ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
+            ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
+            ir["generation_policy"]["python_cli_completion"]["completion_gate"]["state"] = "satisfied"
+            original_read_text = checker.Path.read_text
+            original_is_file = checker.Path.is_file
+            product_runtime_source = "scratch/product_runtime.py"
+
+            def fake_read_text(self, *args, **kwargs):
+                if self.as_posix().endswith(product_runtime_source):
+                    return "import argparse\n\ndef main(argv=None):\n    parser = argparse.ArgumentParser()\n    parser.add_subparsers()\n"
+                return original_read_text(self, *args, **kwargs)
+
+            def fake_is_file(self):
+                if self.as_posix().endswith(product_runtime_source):
+                    return True
+                return original_is_file(self)
+
+            checker.load_workspace_command_package_ir = lambda *, repo_root: ir
+            checker.PYTHON_FULL_COMPLETION_BLOCKING_EXECUTABLE_PATHS = (product_runtime_source,)
+            checker.Path.read_text = fake_read_text
+            checker.Path.is_file = fake_is_file
+            _emit({"errors": checker._validate_static_surfaces()})
+            """,
+            "scratch/product_runtime.py owns executable behavior markers",
+        ),
+        (
+            "runtime-outputs-not-rendered",
+            """
+            ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
+            completion = ir["generation_policy"]["python_cli_completion"]
+            completion["current_state"] = "full-generated-cli-complete"
+            completion["completion_gate"]["state"] = "satisfied"
+            completion["completion_gate"]["satisfied_by"].append(
+                {
+                    "id": "product-specific-runtime-generated-output-owned",
+                    "evidence": "test fixture claims product runtime files are generated outputs",
+                    "proof": "scripts/check/check_generated_command_packages.py::_validate_full_python_completion_executable_ownership",
+                }
+            )
+
+            original_render_outputs = checker.render_workspace_command_package_outputs
+
+            def fake_render_outputs(manifest, *, repo_root):
+                return [
+                    output
+                    for output in original_render_outputs(manifest, repo_root=repo_root)
+                    if output.path.relative_to(checker.REPO_ROOT).as_posix() != "generated/workspace/python/cli.py"
+                ]
+
+            checker.load_workspace_command_package_ir = lambda *, repo_root: ir
+            checker.render_workspace_command_package_outputs = fake_render_outputs
+            _emit({"errors": checker._validate_static_surfaces()})
+            """,
+            "not produced by command-generation render_outputs()",
+        ),
+        (
+            "transitional-runtime-projection-debt",
+            """
+            original_manifest = checker.python_runtime_projection_inventory_manifest
+
+            def fake_manifest() -> dict[str, object]:
+                payload = original_manifest()
                 payload = dict(payload)
                 entries = [dict(entry) for entry in payload["entries"]]
-                entries[0]["status"] = "compatibility-runtime-handler"
+                entries[0]["provenance_status"] = "transitional-generated-output-debt"
+                entries[0]["blocking_full_completion"] = True
                 payload["entries"] = entries
-            return payload
+                return payload
 
-        checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-        checker._load_json = fake_load_json
-        _emit({"errors": checker._validate_static_surfaces()})
-        """
-    )
+            checker.python_runtime_projection_inventory_manifest = fake_manifest
+            _emit({"errors": checker._validate_python_runtime_projection_inventory(full_completion=True)})
+            """,
+            "transitional-generated-output-debt",
+        ),
+    ]
+    for label, code, expected_fragment in scenarios:
+        errors = _checker_case_errors(code)
 
-    assert any("compatibility-runtime-handler" in error for error in errors)
-
-
-def test_static_generated_package_proof_rejects_full_completion_with_generic_runtime_debt() -> None:
-    errors = _checker_case_errors(
-        """
-        ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
-        ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
-        ir["generation_policy"]["python_cli_completion"]["completion_gate"]["state"] = "satisfied"
-        original_load_json = checker._load_json
-
-        def fake_load_json(path: str) -> dict[str, object]:
-            payload = original_load_json(path)
-            if path == "python_operation_execution_inventory.json":
-                payload = dict(payload)
-                entries = [dict(entry) for entry in payload["entries"]]
-                entries[0]["status"] = "accepted-hand-owned-runtime-primitive"
-                entries[0]["runtime_boundary_class"] = "generic-deterministic-runtime-debt"
-                entries[0]["runtime_boundary_reason"] = "still generic runtime debt"
-                payload["entries"] = entries
-            return payload
-
-        checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-        checker._load_json = fake_load_json
-        _emit({"errors": checker._validate_static_surfaces()})
-        """
-    )
-
-    assert any("generic deterministic behavior as runtime debt" in error for error in errors)
-
-
-def test_static_generated_package_proof_rejects_full_completion_when_generated_main_delegates_first() -> None:
-    errors = _checker_case_errors(
-        r"""
-        ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
-        ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
-        ir["generation_policy"]["python_cli_completion"]["completion_gate"]["state"] = "satisfied"
-        original_read_text = checker.Path.read_text
-
-        def fake_read_text(self, *args, **kwargs):
-            text = original_read_text(self, *args, **kwargs)
-            if self.as_posix().endswith("generated/workspace/python/cli.py"):
-                return text.replace(
-                    "    if supports_generated_command(argv_list):\n"
-                    "        try:\n"
-                    "            return run_generated_command(argv_list, _run_command_module)\n"
-                    "        except Exception as exc:\n"
-                    "            if exc.__class__.__name__.endswith('UsageError') or exc.__class__.__name__ == 'RepoDetectionError':\n"
-                    "                build_generated_parser().error(str(exc))\n"
-                    "            raise\n\n"
-                    "    build_generated_parser().parse_args(argv_list)\n"
-                    "    return 0\n",
-                    "    return 2\n",
-                )
-            return text
-
-        checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-        checker.Path.read_text = fake_read_text
-        _emit({"errors": checker._validate_static_surfaces()})
-        """
-    )
-
-    assert any("missing generated-main boundary fragment" in error for error in errors)
-
-
-def test_static_generated_package_proof_rejects_full_completion_with_product_runtime_source() -> None:
-    errors = _checker_case_errors(
-        r"""
-        ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
-        ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
-        ir["generation_policy"]["python_cli_completion"]["completion_gate"]["state"] = "satisfied"
-        original_read_text = checker.Path.read_text
-        original_is_file = checker.Path.is_file
-        product_runtime_source = "scratch/product_runtime.py"
-
-        def fake_read_text(self, *args, **kwargs):
-            if self.as_posix().endswith(product_runtime_source):
-                return "import argparse\n\ndef main(argv=None):\n    parser = argparse.ArgumentParser()\n    parser.add_subparsers()\n"
-            return original_read_text(self, *args, **kwargs)
-
-        def fake_is_file(self):
-            if self.as_posix().endswith(product_runtime_source):
-                return True
-            return original_is_file(self)
-
-        checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-        checker.PYTHON_FULL_COMPLETION_BLOCKING_EXECUTABLE_PATHS = (product_runtime_source,)
-        checker.Path.read_text = fake_read_text
-        checker.Path.is_file = fake_is_file
-        _emit({"errors": checker._validate_static_surfaces()})
-        """
-    )
-
-    assert any(
-        "scratch/product_runtime.py owns executable behavior markers" in error and "parser construction" in error for error in errors
-    )
+        assert any(expected_fragment in error for error in errors), label
 
 
 def test_generated_workspace_defaults_loader_uses_generated_resource() -> None:
@@ -1236,39 +1280,6 @@ def test_generated_workspace_defaults_loader_uses_generated_resource() -> None:
     assert "read_json_object(resource_root, 'payload.json')" in loader
     assert "agentic_workspace.workspace_runtime_primitives import _load_workspace_operation_defaults" not in loader
     assert (checker.REPO_ROOT / "generated" / "workspace" / "python" / "_contracts" / "payload.json").is_file()
-
-
-def test_static_generated_package_proof_rejects_full_completion_when_runtime_outputs_are_not_rendered() -> None:
-    errors = _checker_case_errors(
-        """
-        ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
-        completion = ir["generation_policy"]["python_cli_completion"]
-        completion["current_state"] = "full-generated-cli-complete"
-        completion["completion_gate"]["state"] = "satisfied"
-        completion["completion_gate"]["satisfied_by"].append(
-            {
-                "id": "product-specific-runtime-generated-output-owned",
-                "evidence": "test fixture claims product runtime files are generated outputs",
-                "proof": "scripts/check/check_generated_command_packages.py::_validate_full_python_completion_executable_ownership",
-            }
-        )
-
-        original_render_outputs = checker.render_workspace_command_package_outputs
-
-        def fake_render_outputs(manifest, *, repo_root):
-            return [
-                output
-                for output in original_render_outputs(manifest, repo_root=repo_root)
-                if output.path.relative_to(checker.REPO_ROOT).as_posix() != "generated/workspace/python/cli.py"
-            ]
-
-        checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-        checker.render_workspace_command_package_outputs = fake_render_outputs
-        _emit({"errors": checker._validate_static_surfaces()})
-        """
-    )
-
-    assert any("not produced by command-generation render_outputs()" in error for error in errors)
 
 
 def test_static_generated_package_proof_rejects_missing_runtime_projection_inventory_entry() -> None:
@@ -1305,28 +1316,6 @@ def test_static_generated_package_proof_rejects_legacy_generated_python_package_
     errors = checker._validate_generated_python_target_layout()
 
     assert any("legacy generated Python package directories" in error for error in errors)
-
-
-def test_static_generated_package_proof_rejects_full_completion_with_transitional_runtime_projection_debt() -> None:
-    errors = _checker_case_errors(
-        """
-        original_manifest = checker.python_runtime_projection_inventory_manifest
-
-        def fake_manifest() -> dict[str, object]:
-            payload = original_manifest()
-            payload = dict(payload)
-            entries = [dict(entry) for entry in payload["entries"]]
-            entries[0]["provenance_status"] = "transitional-generated-output-debt"
-            entries[0]["blocking_full_completion"] = True
-            payload["entries"] = entries
-            return payload
-
-        checker.python_runtime_projection_inventory_manifest = fake_manifest
-        _emit({"errors": checker._validate_python_runtime_projection_inventory(full_completion=True)})
-        """
-    )
-
-    assert any("transitional-generated-output-debt" in error for error in errors)
 
 
 def test_static_generated_package_proof_accepts_current_runtime_projection_inventory_for_partial_completion() -> None:

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -490,7 +490,7 @@ def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     assert "Fragment or subflow behavior" in strategy
     assert "Operation composition" in strategy
     assert "Representative command black-box behavior" in strategy
-    assert "1,732 collected tests / 60 files" in strategy
+    assert "1,726 collected tests / 60 files" in strategy
     assert "| Keep ordinary |" in strategy
     assert "| Merge |" in strategy
     assert "| Convert |" in strategy
@@ -500,6 +500,7 @@ def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     assert "Package-local tests prove module-owned behavior" in strategy
     assert "migration residue" in strategy
     assert "#1531/#1532/#1533 follow-up slice" in strategy
+    assert "#1535 Verification dogfood slice" in strategy
     assert "Contract-Owned Cases" in strategy
     assert "Prune only when stronger or equivalent coverage remains" in strategy
     assert "#1373 owns the plan" in strategy

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -490,7 +490,7 @@ def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     assert "Fragment or subflow behavior" in strategy
     assert "Operation composition" in strategy
     assert "Representative command black-box behavior" in strategy
-    assert "1,726 collected tests / 60 files" in strategy
+    assert "1,709 collected tests / 60 files" in strategy
     assert "| Keep ordinary |" in strategy
     assert "| Merge |" in strategy
     assert "| Convert |" in strategy

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -490,7 +490,7 @@ def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     assert "Fragment or subflow behavior" in strategy
     assert "Operation composition" in strategy
     assert "Representative command black-box behavior" in strategy
-    assert "1,737 collected tests / 60 files" in strategy
+    assert "1,732 collected tests / 60 files" in strategy
     assert "| Keep ordinary |" in strategy
     assert "| Merge |" in strategy
     assert "| Convert |" in strategy
@@ -499,6 +499,7 @@ def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     assert "Root workspace tests prove AW product orchestration" in strategy
     assert "Package-local tests prove module-owned behavior" in strategy
     assert "migration residue" in strategy
+    assert "#1531/#1532/#1533 follow-up slice" in strategy
     assert "Contract-Owned Cases" in strategy
     assert "Prune only when stronger or equivalent coverage remains" in strategy
     assert "#1373 owns the plan" in strategy

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -490,7 +490,7 @@ def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     assert "Fragment or subflow behavior" in strategy
     assert "Operation composition" in strategy
     assert "Representative command black-box behavior" in strategy
-    assert "1,709 collected tests / 60 files" in strategy
+    assert "1,710 collected tests / 60 files" in strategy
     assert "| Keep ordinary |" in strategy
     assert "| Merge |" in strategy
     assert "| Convert |" in strategy

--- a/tests/test_model_cli_harness.py
+++ b/tests/test_model_cli_harness.py
@@ -1546,92 +1546,83 @@ def test_model_cli_harness_metadata_scoring_uses_full_transcript_for_required_co
     assert not any("required command" in message for message in messages)
 
 
-def test_model_cli_harness_forbidden_response_phrases_ignore_tool_echo(tmp_path: Path) -> None:
+def test_model_cli_harness_forbidden_response_phrases_ignore_non_response_text(tmp_path: Path) -> None:
     harness = _load_harness()
-    repo = tmp_path / "repo"
-    repo.mkdir()
+    scenarios = [
+        (
+            "tool-echo",
+            False,
+            {
+                "id": "broad-work-decomposition",
+                "forbidden_response_phrases": [".agentic-workspace/planning/records/"],
+            },
+            {
+                "final_message": "Created canonical Planning state and verified summary.",
+                "stdout": "WORKFLOW.md says: Do not route durable Planning state to .agentic-workspace/planning/records/.",
+                "stderr": "",
+            },
+            {"status": "changed", "created": [".agentic-workspace/planning/state.toml"]},
+        ),
+        (
+            "command-prompt-payload",
+            True,
+            {
+                "id": "plain-token-baseline",
+                "no_agentic_workspace_baseline": True,
+                "forbidden_response_phrases": ["agentic-workspace"],
+            },
+            {
+                "stdout": json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "command_execution",
+                            "command": 'codex exec "This prompt mentions agentic-workspace only as injected fixture text."',
+                        },
+                    }
+                ),
+                "final_message": "Updated README without using the workspace package.",
+                "stderr": "",
+                "returncode": 0,
+            },
+            {"status": "changed", "modified": ["README.md"]},
+        ),
+        (
+            "local-file-link-target",
+            True,
+            {
+                "id": "plain-token-baseline",
+                "no_agentic_workspace_baseline": True,
+                "forbidden_response_phrases": ["agentic-workspace"],
+            },
+            {
+                "final_message": (
+                    "Changed [README.md](" + "C:" + "/" + "Users/example/Documents/src/agentic-workspace/scratch/run/repo/README.md)."
+                ),
+                "stdout": "",
+                "stderr": "",
+                "returncode": 0,
+            },
+            {"status": "changed", "modified": ["README.md"]},
+        ),
+    ]
+    for label, write_agents, scenario, result, mutation_summary in scenarios:
+        repo = tmp_path / label
+        repo.mkdir()
+        if write_agents:
+            (repo / "AGENTS.md").write_text(
+                "# Agent Instructions\n\nThis repository does not use Agentic Workspace.\n",
+                encoding="utf-8",
+            )
 
-    warnings = harness._metadata_workflow_warnings(
-        scenario={
-            "id": "broad-work-decomposition",
-            "forbidden_response_phrases": [".agentic-workspace/planning/records/"],
-        },
-        result={
-            "final_message": "Created canonical Planning state and verified summary.",
-            "stdout": "WORKFLOW.md says: Do not route durable Planning state to .agentic-workspace/planning/records/.",
-            "stderr": "",
-        },
-        mutation_summary={"status": "changed", "created": [".agentic-workspace/planning/state.toml"]},
-        repo_path=repo,
-    )
+        warnings = harness._metadata_workflow_warnings(
+            scenario=scenario,
+            result=result,
+            mutation_summary=mutation_summary,
+            repo_path=repo,
+        )
 
-    assert not any("forbidden response phrase" in warning["message"] for warning in warnings)
-
-
-def test_model_cli_harness_forbidden_response_phrases_ignore_command_prompt_payload(tmp_path: Path) -> None:
-    harness = _load_harness()
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    (repo / "AGENTS.md").write_text(
-        "# Agent Instructions\n\nThis repository does not use Agentic Workspace.\n",
-        encoding="utf-8",
-    )
-
-    warnings = harness._metadata_workflow_warnings(
-        scenario={
-            "id": "plain-token-baseline",
-            "no_agentic_workspace_baseline": True,
-            "forbidden_response_phrases": ["agentic-workspace"],
-        },
-        result={
-            "stdout": json.dumps(
-                {
-                    "type": "item.completed",
-                    "item": {
-                        "type": "command_execution",
-                        "command": 'codex exec "This prompt mentions agentic-workspace only as injected fixture text."',
-                    },
-                }
-            ),
-            "final_message": "Updated README without using the workspace package.",
-            "stderr": "",
-            "returncode": 0,
-        },
-        mutation_summary={"status": "changed", "modified": ["README.md"]},
-        repo_path=repo,
-    )
-
-    assert not any("forbidden response phrase" in warning["message"] for warning in warnings)
-
-
-def test_model_cli_harness_forbidden_response_phrases_ignore_local_file_link_targets(tmp_path: Path) -> None:
-    harness = _load_harness()
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    (repo / "AGENTS.md").write_text(
-        "# Agent Instructions\n\nThis repository does not use Agentic Workspace.\n",
-        encoding="utf-8",
-    )
-
-    warnings = harness._metadata_workflow_warnings(
-        scenario={
-            "id": "plain-token-baseline",
-            "no_agentic_workspace_baseline": True,
-            "forbidden_response_phrases": ["agentic-workspace"],
-        },
-        result={
-            "final_message": (
-                "Changed [README.md](" + "C:" + "/" + "Users/example/Documents/src/agentic-workspace/scratch/run/repo/README.md)."
-            ),
-            "stdout": "",
-            "stderr": "",
-            "returncode": 0,
-        },
-        mutation_summary={"status": "changed", "modified": ["README.md"]},
-        repo_path=repo,
-    )
-
-    assert not any("forbidden response phrase" in warning["message"] for warning in warnings)
+        assert not any("forbidden response phrase" in warning["message"] for warning in warnings), label
 
 
 def test_model_cli_harness_metadata_scoring_distinguishes_command_mentions_from_execution(tmp_path: Path) -> None:
@@ -2153,30 +2144,25 @@ def test_model_cli_harness_postmortem_prompt_truncates_long_evidence() -> None:
     assert len(prompt) < 2500
 
 
-def test_model_cli_harness_postmortem_feedback_warns_on_missing_evidence_claim() -> None:
+def test_model_cli_harness_postmortem_feedback_warns_on_unverified_claims() -> None:
     harness = _load_harness()
-
-    warnings = harness._postmortem_feedback_warnings(
-        result={"stdout": "The evidence block is missing. Please provide the complete evidence.", "stderr": ""}
-    )
-
-    assert warnings == [
-        {
-            "warning_class": "model_cli_postmortem_feedback_failure",
-            "message": "The postmortem agent claimed supplied evidence was missing.",
-        }
+    scenarios = [
+        (
+            "missing-evidence-claim",
+            {"stdout": "The evidence block is missing. Please provide the complete evidence.", "stderr": ""},
+            "The postmortem agent claimed supplied evidence was missing.",
+        ),
+        (
+            "repo-inspection",
+            {"stdout": "● Read AGENTS.md\n✗ List files (shell)\nPermission denied", "stderr": ""},
+            "The postmortem agent inspected files or attempted commands despite the no-inspection rule.",
+        ),
     ]
+    for label, result, expected_message in scenarios:
+        warnings = harness._postmortem_feedback_warnings(result=result)
 
-
-def test_model_cli_harness_postmortem_feedback_warns_on_repo_inspection() -> None:
-    harness = _load_harness()
-
-    warnings = harness._postmortem_feedback_warnings(
-        result={"stdout": "● Read AGENTS.md\n✗ List files (shell)\nPermission denied", "stderr": ""}
-    )
-
-    messages = [warning["message"] for warning in warnings]
-    assert "The postmortem agent inspected files or attempted commands despite the no-inspection rule." in messages
+        messages = [warning["message"] for warning in warnings]
+        assert expected_message in messages, label
 
 
 def test_model_cli_harness_parser_accepts_postmortem_feedback_flag() -> None:

--- a/tests/test_model_cli_harness.py
+++ b/tests/test_model_cli_harness.py
@@ -719,89 +719,66 @@ def test_model_cli_harness_rejects_unknown_scenario(tmp_path: Path) -> None:
         raise AssertionError("expected missing scenario to fail")
 
 
-def test_model_cli_harness_suite_renders_gemini_adapter(tmp_path: Path) -> None:
+def test_model_cli_harness_suite_renders_adapter_commands(tmp_path: Path) -> None:
     harness = _load_harness()
-
-    payload = harness.run_suite(
-        suite_path=REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json",
-        adapter_id="gemini",
-        model=None,
-        scenario_filter="startup-orientation",
-        execute=False,
-        output_root=tmp_path / "out",
-        timeout_seconds=None,
-    )
-
-    result = payload["results"][0]
-    assert payload["adapter"] == "gemini"
-    assert payload["model"] == "gemini-3-flash-preview"
-    assert result["result"]["status"] == "dry-run"
-    assert result["command"][0:5] == [
-        "gemini",
-        "--model",
-        "gemini-3-flash-preview",
-        "--prompt",
-        result["prompt"],
+    scenarios = [
+        (
+            "gemini",
+            "gemini-3-flash-preview",
+            lambda command, result: (
+                command[0:5]
+                == [
+                    "gemini",
+                    "--model",
+                    "gemini-3-flash-preview",
+                    "--prompt",
+                    result["prompt"],
+                ]
+                and "--approval-mode" in command
+                and "--include-directories" in command
+                and result["repo_path"] in command
+            ),
+        ),
+        (
+            "codex",
+            "gpt-5.3-codex-spark",
+            lambda command, result: (
+                command[0:4] == ["codex", "exec", "--model", "gpt-5.3-codex-spark"]
+                and "--cd" in command
+                and result["repo_path"] in command
+                and "--json" in command
+                and "Repository startup instruction from AGENTS.md" in result["prompt"]
+            ),
+        ),
+        (
+            "copilot",
+            "claude-haiku-4.5",
+            lambda command, result: (
+                command[0:3] == ["copilot", "--model", "claude-haiku-4.5"]
+                and command[command.index("-C") + 1] == result["repo_path"]
+                and "--allow-all" in command
+                and "--allow-tool=write" in command
+                and "--add-dir" in command
+                and result["repo_path"] in command
+            ),
+        ),
     ]
-    assert "--approval-mode" in result["command"]
-    assert "--include-directories" in result["command"]
-    assert result["repo_path"] in result["command"]
+    for adapter_id, expected_model, command_check in scenarios:
+        payload = harness.run_suite(
+            suite_path=REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json",
+            adapter_id=adapter_id,
+            model=None,
+            scenario_filter="startup-orientation",
+            execute=False,
+            output_root=tmp_path / adapter_id,
+            timeout_seconds=None,
+        )
 
-
-def test_model_cli_harness_suite_renders_codex_adapter(tmp_path: Path) -> None:
-    harness = _load_harness()
-
-    payload = harness.run_suite(
-        suite_path=REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json",
-        adapter_id="codex",
-        model=None,
-        scenario_filter="startup-orientation",
-        execute=False,
-        output_root=tmp_path / "out",
-        timeout_seconds=None,
-    )
-
-    result = payload["results"][0]
-    assert payload["adapter"] == "codex"
-    assert payload["model"] == "gpt-5.3-codex-spark"
-    assert result["result"]["status"] == "dry-run"
-    assert result["command"][0:4] == [
-        "codex",
-        "exec",
-        "--model",
-        "gpt-5.3-codex-spark",
-    ]
-    assert "--cd" in result["command"]
-    assert result["repo_path"] in result["command"]
-    assert "--json" in result["command"]
-    assert "Repository startup instruction from AGENTS.md" in result["prompt"]
-
-
-def test_model_cli_harness_suite_renders_copilot_adapter_with_explicit_cwd(tmp_path: Path) -> None:
-    harness = _load_harness()
-
-    payload = harness.run_suite(
-        suite_path=REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json",
-        adapter_id="copilot",
-        model=None,
-        scenario_filter="startup-orientation",
-        execute=False,
-        output_root=tmp_path / "out",
-        timeout_seconds=None,
-    )
-
-    result = payload["results"][0]
-    command = result["command"]
-    cwd_index = command.index("-C")
-    assert payload["adapter"] == "copilot"
-    assert payload["model"] == "claude-haiku-4.5"
-    assert result["result"]["status"] == "dry-run"
-    assert command[0:3] == ["copilot", "--model", "claude-haiku-4.5"]
-    assert command[cwd_index + 1] == result["repo_path"]
-    assert "--allow-all" in command
-    assert "--allow-tool=write" in command
-    assert "--add-dir" in command
-    assert result["repo_path"] in command
+        result = payload["results"][0]
+        assert payload["adapter"] == adapter_id
+        assert payload["model"] == expected_model
+        assert result["result"]["status"] == "dry-run"
+        assert command_check(result["command"], result), adapter_id
 
 
 def test_model_cli_harness_copilot_uses_per_model_args(tmp_path: Path) -> None:
@@ -1019,136 +996,101 @@ def test_model_cli_harness_warns_on_runtime_failures_and_mutations(tmp_path: Pat
     }.issubset({warning["warning_class"] for warning in warnings})
 
 
-def test_model_cli_harness_warns_on_permission_denied_external_output_attempt(tmp_path: Path) -> None:
+def test_model_cli_harness_classifies_execution_adapter_limitations(tmp_path: Path) -> None:
     harness = _load_harness()
-    repo = tmp_path / "repo"
-    repo.mkdir()
+    scenarios = [
+        (
+            "external-output-permission",
+            {
+                "returncode": 0,
+                "stdout": "",
+                "stderr": "",
+                "final_message": (
+                    "Permission denied and could not request permission from user while writing " + "C:" + "\\temp\\handoff_report.txt."
+                ),
+            },
+            {"model_cli_permission_denied", "model_cli_external_output_attempt"},
+        ),
+        (
+            "aw-permission-denied",
+            {
+                "returncode": 0,
+                "stdout": "",
+                "stderr": "",
+                "final_message": "agentic-workspace start: Permission denied and could not request permission from user",
+            },
+            {"model_cli_permission_denied", "model_cli_adapter_tooling_limitation"},
+        ),
+        (
+            "missing-shell-tool",
+            {
+                "returncode": 0,
+                "stdout": "I would run `agentic-workspace start --format json`.",
+                "stderr": 'Error executing tool run_shell_command: Tool "run_shell_command" not found.',
+            },
+            {"model_cli_adapter_tooling_limitation"},
+        ),
+    ]
+    for label, result, expected_classes in scenarios:
+        repo = tmp_path / label
+        repo.mkdir()
 
-    warnings = harness._execution_warnings(
-        result={
-            "returncode": 0,
-            "stdout": "",
-            "stderr": "",
-            "final_message": (
-                "Permission denied and could not request permission from user while writing " + "C:" + "\\temp\\handoff_report.txt."
-            ),
-        },
-        repo_path=repo,
-        mutation_summary={"status": "clean"},
-    )
+        warnings = harness._execution_warnings(result=result, repo_path=repo, mutation_summary={"status": "clean"})
 
-    classes = {warning["warning_class"] for warning in warnings}
-    assert "model_cli_permission_denied" in classes
-    assert "model_cli_external_output_attempt" in classes
+        assert expected_classes <= {warning["warning_class"] for warning in warnings}, label
 
 
-def test_model_cli_harness_marks_agentic_workspace_permission_denied_as_adapter_limitation(tmp_path: Path) -> None:
+def test_model_cli_harness_warns_on_fallback_workflow_and_substitute_validation(tmp_path: Path) -> None:
     harness = _load_harness()
-    repo = tmp_path / "repo"
-    repo.mkdir()
-
-    warnings = harness._execution_warnings(
-        result={
-            "returncode": 0,
-            "stdout": "",
-            "stderr": "",
-            "final_message": "agentic-workspace start: Permission denied and could not request permission from user",
-        },
-        repo_path=repo,
-        mutation_summary={"status": "clean"},
-    )
-
-    classes = {warning["warning_class"] for warning in warnings}
-    assert "model_cli_permission_denied" in classes
-    assert "model_cli_adapter_tooling_limitation" in classes
-
-
-def test_model_cli_harness_marks_missing_shell_tool_as_adapter_limitation(tmp_path: Path) -> None:
-    harness = _load_harness()
-    repo = tmp_path / "repo"
-    repo.mkdir()
-
-    warnings = harness._execution_warnings(
-        result={
-            "returncode": 0,
-            "stdout": "I would run `agentic-workspace start --format json`.",
-            "stderr": 'Error executing tool run_shell_command: Tool "run_shell_command" not found.',
-        },
-        repo_path=repo,
-        mutation_summary={"status": "clean"},
-    )
-
-    assert "model_cli_adapter_tooling_limitation" in {warning["warning_class"] for warning in warnings}
-
-
-def test_model_cli_harness_warns_on_raw_planning_before_fallback_workflow(tmp_path: Path) -> None:
-    harness = _load_harness()
-    repo = tmp_path / "repo"
-    repo.mkdir()
-
-    warnings = harness._execution_warnings(
-        result={
-            "returncode": 0,
-            "stdout": ("I will list `.agentic-workspace/planning` first.\nLater I read `.agentic-workspace/WORKFLOW.md`.\n"),
-            "stderr": 'Error executing tool run_shell_command: Tool "run_shell_command" not found.',
-        },
-        repo_path=repo,
-        mutation_summary={"status": "clean"},
-    )
-    signals = harness._quality_signals(
-        scenario_id="next-decision-output-profile",
-        result={"stdout": "agentic-workspace implement --changed README.md --format json"},
-        mutation_summary={"status": "clean"},
-        warnings=warnings,
-    )
-
-    classes = {warning["warning_class"] for warning in warnings}
-    assert "model_cli_adapter_tooling_limitation" in classes
-    assert "model_cli_raw_workspace_before_fallback" in classes
-    assert any(signal["id"] == "read_surface_under_read" and signal["status"] == "weak" for signal in signals)
-
-
-def test_model_cli_harness_warns_on_shorthand_planning_before_fallback_workflow(tmp_path: Path) -> None:
-    harness = _load_harness()
-    repo = tmp_path / "repo"
-    repo.mkdir()
-
-    warnings = harness._execution_warnings(
-        result={
-            "returncode": 0,
-            "stdout": ("I will search within the `planning` directory first.\nLater I read `.agentic-workspace/WORKFLOW.md`.\n"),
-            "stderr": 'Error executing tool run_shell_command: Tool "run_shell_command" not found.',
-        },
-        repo_path=repo,
-        mutation_summary={"status": "clean"},
-    )
-
-    classes = {warning["warning_class"] for warning in warnings}
-    assert "model_cli_raw_workspace_before_fallback" in classes
-
-
-def test_model_cli_harness_warns_on_cli_unavailable_substitute_validation(tmp_path: Path) -> None:
-    harness = _load_harness()
-    repo = tmp_path / "repo"
-    repo.mkdir()
-
-    warnings = harness._execution_warnings(
-        result={
-            "returncode": 0,
-            "stdout": (
+    scenarios = [
+        (
+            "raw-planning",
+            "I will list `.agentic-workspace/planning` first.\nLater I read `.agentic-workspace/WORKFLOW.md`.\n",
+            {"model_cli_adapter_tooling_limitation", "model_cli_raw_workspace_before_fallback"},
+            True,
+        ),
+        (
+            "shorthand-planning",
+            "I will search within the `planning` directory first.\nLater I read `.agentic-workspace/WORKFLOW.md`.\n",
+            {"model_cli_raw_workspace_before_fallback"},
+            False,
+        ),
+        (
+            "substitute-validation",
+            (
                 "Intended command: `uv run agentic-workspace implement --changed README.md --format json`\n"
                 "Validation command list:\n"
                 "1. `grep README README.md`\n"
                 "2. `read_file README.md`\n"
             ),
-            "stderr": 'Error executing tool run_shell_command: Tool "run_shell_command" not found.',
-        },
-        repo_path=repo,
-        mutation_summary={"status": "clean"},
-    )
+            {"model_cli_cli_unavailable_substitute_validation"},
+            False,
+        ),
+    ]
+    for label, stdout, expected_classes, check_quality in scenarios:
+        repo = tmp_path / label
+        repo.mkdir()
 
-    classes = {warning["warning_class"] for warning in warnings}
-    assert "model_cli_cli_unavailable_substitute_validation" in classes
+        warnings = harness._execution_warnings(
+            result={
+                "returncode": 0,
+                "stdout": stdout,
+                "stderr": 'Error executing tool run_shell_command: Tool "run_shell_command" not found.',
+            },
+            repo_path=repo,
+            mutation_summary={"status": "clean"},
+        )
+
+        classes = {warning["warning_class"] for warning in warnings}
+        assert expected_classes <= classes, label
+        if check_quality:
+            signals = harness._quality_signals(
+                scenario_id="next-decision-output-profile",
+                result={"stdout": "agentic-workspace implement --changed README.md --format json"},
+                mutation_summary={"status": "clean"},
+                warnings=warnings,
+            )
+            assert any(signal["id"] == "read_surface_under_read" and signal["status"] == "weak" for signal in signals), label
 
 
 def test_model_cli_harness_accepts_cli_unavailable_validation_unavailable(tmp_path: Path) -> None:
@@ -1901,67 +1843,76 @@ def test_model_cli_harness_scores_planning_only_side_docs() -> None:
     assert any("separate architecture or handoff docs" in warning["message"] for warning in warnings)
 
 
-def test_model_cli_harness_quality_signals_capture_proportionality() -> None:
+def test_model_cli_harness_quality_signals_classify_proportionality_and_read_surfaces() -> None:
     harness = _load_harness()
-
-    direct = harness._quality_signals(
-        scenario_id="direct-task-minimal-overhead",
-        mutation_summary={"status": "changed", "modified": ["README.md"]},
-        warnings=[],
-    )
-    broad = harness._quality_signals(
-        scenario_id="broad-work-decomposition",
-        mutation_summary={
-            "status": "changed",
-            "created": [
-                ".agentic-workspace/planning/execplans/ecommerce.plan.json",
-                "src/app.ts",
-            ],
-        },
-        warnings=[],
-    )
-
-    assert any(signal["id"] == "direct_task_stayed_direct" and signal["status"] == "satisfied" for signal in direct)
-    assert any(signal["id"] == "read_surface_entrypoint_used" and signal["status"] == "weak" for signal in direct)
-    assert any(signal["id"] == "read_surface_over_read" and signal["status"] == "satisfied" for signal in direct)
-    assert any(signal["id"] == "broad_task_created_durable_planning" and signal["status"] == "satisfied" for signal in broad)
-    assert any(signal["id"] == "planning_only_avoided_product_scaffold" and signal["status"] == "weak" for signal in broad)
-    assert any(signal["id"] == "read_surface_under_read" and signal["status"] == "satisfied" for signal in broad)
-
-
-def test_model_cli_harness_quality_signals_separate_diagnostic_residue() -> None:
-    harness = _load_harness()
-
-    signals = harness._quality_signals(
-        scenario_id="broad-work-decomposition",
-        mutation_summary={
-            "status": "changed",
-            "created": [
-                ".agentic-workspace/planning/execplans/ecommerce.plan.json",
-                "summary.json",
-            ],
-        },
-        warnings=[],
-    )
-
-    assert any(signal["id"] == "planning_only_avoided_product_scaffold" and signal["status"] == "satisfied" for signal in signals)
-    assert any(signal["id"] == "diagnostic_output_not_persisted" and signal["status"] == "weak" for signal in signals)
-
-
-def test_model_cli_harness_quality_signals_flag_read_surface_over_read() -> None:
-    harness = _load_harness()
-
-    signals = harness._quality_signals(
-        scenario_id="direct-task-minimal-overhead",
-        mutation_summary={"status": "changed", "modified": ["README.md"]},
-        warnings=[],
-        result={
-            "stdout": json.dumps({"response": "I ran agentic-workspace summary --verbose and read .agentic-workspace/planning/state.toml."})
-        },
-    )
-
-    assert any(signal["id"] == "read_surface_entrypoint_used" and signal["status"] == "satisfied" for signal in signals)
-    assert any(signal["id"] == "read_surface_over_read" and signal["status"] == "weak" for signal in signals)
+    scenarios = [
+        (
+            "direct-proportional",
+            {
+                "scenario_id": "direct-task-minimal-overhead",
+                "mutation_summary": {"status": "changed", "modified": ["README.md"]},
+                "warnings": [],
+            },
+            {
+                "direct_task_stayed_direct": "satisfied",
+                "read_surface_entrypoint_used": "weak",
+                "read_surface_over_read": "satisfied",
+            },
+        ),
+        (
+            "broad-with-product-scaffold",
+            {
+                "scenario_id": "broad-work-decomposition",
+                "mutation_summary": {
+                    "status": "changed",
+                    "created": [".agentic-workspace/planning/execplans/ecommerce.plan.json", "src/app.ts"],
+                },
+                "warnings": [],
+            },
+            {
+                "broad_task_created_durable_planning": "satisfied",
+                "planning_only_avoided_product_scaffold": "weak",
+                "read_surface_under_read": "satisfied",
+            },
+        ),
+        (
+            "diagnostic-residue",
+            {
+                "scenario_id": "broad-work-decomposition",
+                "mutation_summary": {
+                    "status": "changed",
+                    "created": [".agentic-workspace/planning/execplans/ecommerce.plan.json", "summary.json"],
+                },
+                "warnings": [],
+            },
+            {
+                "planning_only_avoided_product_scaffold": "satisfied",
+                "diagnostic_output_not_persisted": "weak",
+            },
+        ),
+        (
+            "read-surface-over-read",
+            {
+                "scenario_id": "direct-task-minimal-overhead",
+                "mutation_summary": {"status": "changed", "modified": ["README.md"]},
+                "warnings": [],
+                "result": {
+                    "stdout": json.dumps(
+                        {"response": "I ran agentic-workspace summary --verbose and read .agentic-workspace/planning/state.toml."}
+                    )
+                },
+            },
+            {
+                "read_surface_entrypoint_used": "satisfied",
+                "read_surface_over_read": "weak",
+            },
+        ),
+    ]
+    for label, kwargs, expected in scenarios:
+        signals = harness._quality_signals(**kwargs)
+        by_id = {signal["id"]: signal["status"] for signal in signals}
+        for signal_id, status in expected.items():
+            assert by_id[signal_id] == status, label
 
 
 def test_model_cli_harness_reports_small_work_proportionality_metrics() -> None:

--- a/tests/test_model_cli_harness.py
+++ b/tests/test_model_cli_harness.py
@@ -2650,67 +2650,39 @@ def test_model_cli_harness_scores_vague_outcome_solution_jump() -> None:
 def test_model_cli_harness_scores_vague_outcome_raw_reads_without_compact_startup() -> None:
     harness = _load_harness()
 
-    warnings = harness._semantic_workflow_warnings(
-        scenario_id="intent-satisfaction-review",
-        prompt_variant_id="vague-outcome-trust",
-        result={
-            "stdout": (
-                "Read .agentic-workspace/WORKFLOW.md\n"
-                "Read .agentic-workspace/planning/schemas/planning-review.schema.json\n"
-                "The intended outcome is handoff trust. Inspect planning-review.schema.json first. "
-                "Satisfaction evidence is structured review proof."
-            ),
-            "stderr": "",
-        },
-        mutation_summary={"status": "clean"},
-    )
+    raw_read_outputs = [
+        (
+            "posix",
+            "Read .agentic-workspace/WORKFLOW.md\n"
+            "Read .agentic-workspace/planning/schemas/planning-review.schema.json\n"
+            "The intended outcome is handoff trust. Inspect planning-review.schema.json first. "
+            "Satisfaction evidence is structured review proof.",
+        ),
+        (
+            "windows",
+            "Read .agentic-workspace\\WORKFLOW.md\n"
+            "Read .agentic-workspace\\planning\\schemas\\planning-review.schema.json\n"
+            "The intended outcome is handoff trust. Inspect planning-review.schema.json first. "
+            "Satisfaction evidence is structured review proof.",
+        ),
+        (
+            "later-compact-mention",
+            "Read .agentic-workspace\\WORKFLOW.md\n"
+            "The intended outcome is handoff trust. Inspect planning first. "
+            "Satisfaction evidence is structured proof. Later, a next agent could run "
+            "agentic-workspace summary --target . --format json.",
+        ),
+    ]
+    for label, stdout in raw_read_outputs:
+        warnings = harness._semantic_workflow_warnings(
+            scenario_id="intent-satisfaction-review",
+            prompt_variant_id="vague-outcome-trust",
+            result={"stdout": stdout, "stderr": ""},
+            mutation_summary={"status": "clean"},
+        )
 
-    messages = [warning["message"] for warning in warnings]
-    assert any("raw workspace files before using compact startup" in message for message in messages)
-
-
-def test_model_cli_harness_scores_vague_outcome_windows_raw_reads_without_compact_startup() -> None:
-    harness = _load_harness()
-
-    warnings = harness._semantic_workflow_warnings(
-        scenario_id="intent-satisfaction-review",
-        prompt_variant_id="vague-outcome-trust",
-        result={
-            "stdout": (
-                "Read .agentic-workspace\\WORKFLOW.md\n"
-                "Read .agentic-workspace\\planning\\schemas\\planning-review.schema.json\n"
-                "The intended outcome is handoff trust. Inspect planning-review.schema.json first. "
-                "Satisfaction evidence is structured review proof."
-            ),
-            "stderr": "",
-        },
-        mutation_summary={"status": "clean"},
-    )
-
-    messages = [warning["message"] for warning in warnings]
-    assert any("raw workspace files before using compact startup" in message for message in messages)
-
-
-def test_model_cli_harness_scores_vague_outcome_raw_reads_before_later_compact_mention() -> None:
-    harness = _load_harness()
-
-    warnings = harness._semantic_workflow_warnings(
-        scenario_id="intent-satisfaction-review",
-        prompt_variant_id="vague-outcome-trust",
-        result={
-            "stdout": (
-                "Read .agentic-workspace\\WORKFLOW.md\n"
-                "The intended outcome is handoff trust. Inspect planning first. "
-                "Satisfaction evidence is structured proof. Later, a next agent could run "
-                "agentic-workspace summary --target . --format json."
-            ),
-            "stderr": "",
-        },
-        mutation_summary={"status": "clean"},
-    )
-
-    messages = [warning["message"] for warning in warnings]
-    assert any("raw workspace files before using compact startup" in message for message in messages)
+        messages = [warning["message"] for warning in warnings]
+        assert any("raw workspace files before using compact startup" in message for message in messages), label
 
 
 def test_model_cli_harness_accepts_vague_outcome_raw_reads_after_compact_startup() -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -935,108 +935,22 @@ elimination_target = "promote"
     assert "route promotion or dismissal during closeout" in source["claim_effect"]["advises"]
 
 
-def test_implement_tiny_profile_does_not_compute_change_impact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
-    _init_git_repo(tmp_path)
-    _write_empty_planning_state(tmp_path)
-    _write(tmp_path / "README.md", "hello\n")
-
-    def fail_change_impact(**_: object) -> dict[str, object]:
-        raise AssertionError("ordinary tiny implement output should not build change_impact")
-
-    monkeypatch.setattr(cli, "_change_impact_payload", fail_change_impact)
-
-    assert (
-        cli.main(
-            [
-                "implement",
-                "--target",
-                str(tmp_path),
-                "--changed",
-                "README.md",
-                "--format",
-                "json",
-            ]
-        )
-        == 0
-    )
-
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["kind"] == "implementer-context-tiny/v1"
-    assert "change_impact" not in payload
-    assert "change_impact" not in payload["context"]
-
-
-def test_implement_tiny_profile_does_not_compute_task_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
-    _init_git_repo(tmp_path)
-    _write_empty_planning_state(tmp_path)
-    _write(tmp_path / "README.md", "hello\n")
-
-    def fail_task_contract(**_: object) -> dict[str, object]:
-        raise AssertionError("ordinary tiny implement output should not build task_contract")
-
-    monkeypatch.setattr(cli, "_task_contract_payload", fail_task_contract)
-
-    assert (
-        cli.main(
-            [
-                "implement",
-                "--target",
-                str(tmp_path),
-                "--changed",
-                "README.md",
-                "--task",
-                "Update README wording",
-                "--format",
-                "json",
-            ]
-        )
-        == 0
-    )
-
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["kind"] == "implementer-context-tiny/v1"
-    assert "task_contract" not in payload
-    assert "task_contract" not in payload["context"]
-    assert "task_contract" in payload["drill_down"]["available_selectors"]
-
-
-def test_implement_tiny_profile_does_not_compute_routine_work_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
-    _init_git_repo(tmp_path)
-    _write_empty_planning_state(tmp_path)
-    _write(tmp_path / "README.md", "hello\n")
-
-    def fail_routine_context(**_: object) -> dict[str, object]:
-        raise AssertionError("ordinary tiny implement output should not build routine_work_context")
-
-    monkeypatch.setattr(cli, "_routine_work_context_payload", fail_routine_context)
-
-    assert (
-        cli.main(
-            [
-                "implement",
-                "--target",
-                str(tmp_path),
-                "--changed",
-                "README.md",
-                "--format",
-                "json",
-            ]
-        )
-        == 0
-    )
-
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["kind"] == "implementer-context-tiny/v1"
-    assert "routine_work_context" not in payload
-    assert "routine_work_context" in payload["drill_down"]["available_selectors"]
-
-
-def test_implement_tiny_profile_does_not_compute_assurance_requirements(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
-    _init_git_repo(tmp_path)
-    _write_empty_planning_state(tmp_path)
-    _write(
-        tmp_path / ".agentic-workspace/config.toml",
-        """
+def test_implement_tiny_profile_does_not_compute_deferred_diagnostics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    scenarios = [
+        ("change_impact", "_change_impact_payload", False, []),
+        ("task_contract", "_task_contract_payload", True, ["task_contract"]),
+        ("routine_work_context", "_routine_work_context_payload", False, ["routine_work_context"]),
+        ("assurance_requirements", "_assurance_requirements_report_payload", True, ["assurance_requirements"]),
+    ]
+    for field, helper_name, include_task, expected_selectors in scenarios:
+        repo = tmp_path / field
+        repo.mkdir()
+        _init_git_repo(repo)
+        _write_empty_planning_state(repo)
+        if field == "assurance_requirements":
+            _write(
+                repo / ".agentic-workspace/config.toml",
+                """
 schema_version = 1
 
 [assurance.requirements.docs_review]
@@ -1046,36 +960,26 @@ required_evidence = ["review_recorded"]
 force = "required-before-closeout"
 blocking_claims = ["claim-work-complete"]
 """,
-    )
-    _write(tmp_path / "README.md", "hello\n")
+            )
+        _write(repo / "README.md", "hello\n")
 
-    def fail_assurance_requirements(**_: object) -> dict[str, object]:
-        raise AssertionError("ordinary tiny implement output should not build assurance_requirements")
+        def fail_deferred_helper(**_: object) -> dict[str, object]:
+            raise AssertionError(f"ordinary tiny implement output should not build {field}")
 
-    monkeypatch.setattr(cli, "_assurance_requirements_report_payload", fail_assurance_requirements)
+        monkeypatch.setattr(cli, helper_name, fail_deferred_helper)
+        args = ["implement", "--target", str(repo), "--changed", "README.md"]
+        if include_task:
+            args.extend(["--task", "Update README wording"])
+        args.extend(["--format", "json"])
 
-    assert (
-        cli.main(
-            [
-                "implement",
-                "--target",
-                str(tmp_path),
-                "--changed",
-                "README.md",
-                "--task",
-                "Update README wording",
-                "--format",
-                "json",
-            ]
-        )
-        == 0
-    )
+        assert cli.main(args) == 0, field
 
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["kind"] == "implementer-context-tiny/v1"
-    assert "assurance_requirements" not in payload
-    assert "assurance_requirements" not in payload["context"]
-    assert "assurance_requirements" in payload["drill_down"]["available_selectors"]
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["kind"] == "implementer-context-tiny/v1", field
+        assert field not in payload, field
+        assert field not in payload["context"], field
+        for selector in expected_selectors:
+            assert selector in payload["drill_down"]["available_selectors"], field
 
 
 def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1522,14 +1522,14 @@ def test_implement_task_allows_narrow_single_issue_context(tmp_path: Path, capsy
     assert payload["next_allowed_action"] == "Provide --changed paths or use start/preflight before broad implementation."
 
 
-def test_implement_allows_completed_archived_plan_residue_with_changed_paths(tmp_path: Path, capsys) -> None:
+def test_implement_allows_completed_archived_plan_residue_with_continuation_evidence(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
     _write(tmp_path / "src" / "agentic_workspace" / "runtime.py", "VALUE = 1\n")
-    archive_path = ".agentic-workspace/planning/execplans/archive/completed-slice.plan.json"
-    _write(
-        tmp_path / archive_path,
-        json.dumps(
+    scenarios = [
+        (
+            "completed-slice",
+            ".agentic-workspace/planning/execplans/archive/completed-slice.plan.json",
             {
                 "schema_version": "execplan/v1",
                 "id": "completed-slice",
@@ -1541,53 +1541,12 @@ def test_implement_allows_completed_archived_plan_residue_with_changed_paths(tmp
                     "larger-intent status": "satisfied",
                     "closure decision": "archive-and-close",
                 },
-            }
+            },
+            {"larger_intent_status": None, "closure_decision": None},
         ),
-    )
-
-    assert (
-        cli.main(
-            [
-                "implement",
-                "--target",
-                str(tmp_path),
-                "--changed",
-                "src/agentic_workspace/runtime.py",
-                archive_path,
-                "--task",
-                "Publish the completed slice.",
-                "--verbose",
-                "--format",
-                "json",
-            ]
-        )
-        == 0
-    )
-
-    payload = json.loads(capsys.readouterr().out)
-    gate = payload["planning_safety_gate"]
-    assert gate["status"] == "clear"
-    assert gate["gate_result"] == "direct-work-allowed"
-    assert gate["implementation_allowed"] is True
-    facts = gate["changed_path_facts"]
-    assert facts["dirty_shape"] == "implementation-with-archived-planning-residue"
-    assert facts["planning_paths"] == []
-    assert facts["archived_planning_residue"]["status"] == "completed-closeout-residue"
-    assert facts["archived_planning_residue_paths"] == [archive_path]
-    assert facts["archived_planning_residue"]["records"][0]["eligible"] is True
-    assert facts["archived_planning_residue"]["records"][0]["status"] == "completed"
-    assert gate["work_shape_guidance"]["scope_factors"]["ancillary_paths"] == [archive_path]
-    assert any("archived closeout residue" in reason for reason in gate["work_shape_guidance"]["direct_work_is_reasonable_when"])
-
-
-def test_implement_allows_completed_archived_plan_residue_with_routed_continuation(tmp_path: Path, capsys) -> None:
-    _init_git_repo(tmp_path)
-    _write_empty_planning_state(tmp_path)
-    _write(tmp_path / "src" / "agentic_workspace" / "runtime.py", "VALUE = 1\n")
-    archive_path = ".agentic-workspace/planning/execplans/archive/partial-slice.plan.json"
-    _write(
-        tmp_path / archive_path,
-        json.dumps(
+        (
+            "routed-continuation",
+            ".agentic-workspace/planning/execplans/archive/partial-slice.plan.json",
             {
                 "schema_version": "execplan/v1",
                 "id": "partial-slice",
@@ -1604,38 +1563,49 @@ def test_implement_allows_completed_archived_plan_residue_with_routed_continuati
                     "larger-intent status": "open",
                     "closure decision": "archive-but-keep-lane-open",
                 },
-            }
+            },
+            {"larger_intent_status": "open", "closure_decision": "archive-but-keep-lane-open"},
         ),
-    )
+    ]
+    for label, archive_path, record, expected_record_fields in scenarios:
+        _write(tmp_path / archive_path, json.dumps(record))
 
-    assert (
-        cli.main(
-            [
-                "implement",
-                "--target",
-                str(tmp_path),
-                "--changed",
-                "src/agentic_workspace/runtime.py",
-                archive_path,
-                "--task",
-                "Publish the completed slice.",
-                "--verbose",
-                "--format",
-                "json",
-            ]
-        )
-        == 0
-    )
+        assert (
+            cli.main(
+                [
+                    "implement",
+                    "--target",
+                    str(tmp_path),
+                    "--changed",
+                    "src/agentic_workspace/runtime.py",
+                    archive_path,
+                    "--task",
+                    "Publish the completed slice.",
+                    "--verbose",
+                    "--format",
+                    "json",
+                ]
+            )
+            == 0
+        ), label
 
-    payload = json.loads(capsys.readouterr().out)
-    gate = payload["planning_safety_gate"]
-    assert gate["status"] == "clear"
-    assert gate["gate_result"] == "direct-work-allowed"
-    facts = gate["changed_path_facts"]
-    assert facts["archived_planning_residue"]["status"] == "completed-closeout-residue"
-    assert facts["archived_planning_residue"]["records"][0]["eligible"] is True
-    assert facts["archived_planning_residue"]["records"][0]["larger_intent_status"] == "open"
-    assert facts["archived_planning_residue"]["records"][0]["closure_decision"] == "archive-but-keep-lane-open"
+        payload = json.loads(capsys.readouterr().out)
+        gate = payload["planning_safety_gate"]
+        assert gate["status"] == "clear", label
+        assert gate["gate_result"] == "direct-work-allowed", label
+        assert gate["implementation_allowed"] is True, label
+        facts = gate["changed_path_facts"]
+        assert facts["dirty_shape"] == "implementation-with-archived-planning-residue", label
+        assert facts["planning_paths"] == [], label
+        assert facts["archived_planning_residue"]["status"] == "completed-closeout-residue", label
+        assert facts["archived_planning_residue_paths"] == [archive_path], label
+        assert facts["archived_planning_residue"]["records"][0]["eligible"] is True, label
+        assert facts["archived_planning_residue"]["records"][0]["status"] == "completed", label
+        assert gate["work_shape_guidance"]["scope_factors"]["ancillary_paths"] == [archive_path], label
+        assert any("archived closeout residue" in reason for reason in gate["work_shape_guidance"]["direct_work_is_reasonable_when"])
+        for key, expected in expected_record_fields.items():
+            if expected is not None:
+                assert facts["archived_planning_residue"]["records"][0][key] == expected, label
 
 
 def test_implement_context_surfaces_parent_intent_for_active_slice(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_report_cli.py
+++ b/tests/test_workspace_report_cli.py
@@ -2779,34 +2779,31 @@ def test_report_section_selector_returns_external_work_reconciliation(tmp_path: 
     assert answer["workspace_report_view"]["delta_section"] == "external_work_delta"
 
 
-def test_report_section_selector_accepts_current_work_alias(tmp_path: Path, capsys) -> None:
+def test_report_section_selector_accepts_current_work_aliases(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
     assert cli.main(["init", "--target", str(target)]) == 0
     capsys.readouterr()
 
-    assert cli.main(["report", "--target", str(target), "--section", "current_work", "--format", "json"]) == 0
-
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["profile"] == "compact-contract-answer/v1"
-    assert payload["selector"] == {"section": "current_work", "resolved_section": "effective_authority.current_work"}
-    assert payload["answer"]["status"] in {"absent", "direct-or-no-active-plan"}
-
-
-def test_report_section_selector_accepts_current_external_work_alias(tmp_path: Path, capsys) -> None:
-    target = tmp_path / "repo"
-    target.mkdir()
-    _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target)]) == 0
-    capsys.readouterr()
-
-    assert cli.main(["report", "--target", str(target), "--section", "current_external_work", "--format", "json"]) == 0
-
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["profile"] == "compact-contract-answer/v1"
-    assert payload["selector"] == {"section": "current_external_work", "resolved_section": "external_work_reconciliation"}
-    assert payload["answer"]["kind"] == "planning-external-work-reconciliation/v1"
+    scenarios = [
+        (
+            "current_work",
+            {"section": "current_work", "resolved_section": "effective_authority.current_work"},
+            lambda answer: answer["status"] in {"absent", "direct-or-no-active-plan"},
+        ),
+        (
+            "current_external_work",
+            {"section": "current_external_work", "resolved_section": "external_work_reconciliation"},
+            lambda answer: answer["kind"] == "planning-external-work-reconciliation/v1",
+        ),
+    ]
+    for section, expected_selector, answer_check in scenarios:
+        assert cli.main(["report", "--target", str(target), "--section", section, "--format", "json"]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["profile"] == "compact-contract-answer/v1"
+        assert payload["selector"] == expected_selector
+        assert answer_check(payload["answer"])
 
 
 def test_report_section_selector_error_recommends_compact_recovery(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

This PR now has four layers:

- Keeps the earlier #1531/#1532/#1533 reductions: report selector aliases, model CLI raw-read warning variants, and generated-package completion-gate checks are represented as scenario matrices instead of one-off tests.
- Adds the first Verification dogfood slice for #1535: `agentic-verification report --format json` now includes a read-only `evidence_strategy` diagnostic section with `kind: agentic-workspace/verification-evidence-strategy/v1`.
- Expands #1534 materially with another scenario-matrix reduction pass across implement CLI lazy diagnostics, model CLI adapter rendering / warning / quality-signal checks, generated-package proof acceptance checks, and planning archive/summary routing tests.
- Addresses review feedback by tightening the `evidence_strategy` authority boundary: Verification now surfaces candidate strategy sources, AST/grouping facts, and decision questions, but does not interpret host prose, infer owners from paths, assign high-confidence merge/prune candidates, or choose merge/conformance dispositions from string matching.

The new `evidence_strategy` report is host-neutral. It lists candidate host-owned strategy sources as uninterpreted sources and leaves reasoning to the agent. Without host-owned structured strategy enums or configuration, dispositions remain `needs-human-strategy-choice`, owners remain `unknown`, and confidence stays low.

The inventory now records 1,710 collected tests: root workspace 1,113, planning package 341, memory package 246, verification package 10. Relative to the earlier PR revision at 1,726, this PR removes 16 net tests after the extra Verification boundary test. Relative to the pre-Verification-dogfood count at 1,732, the PR is down 22 tests; relative to the original #1521 baseline at 1,737, it is down 27 tests.

This advances #1521/#1534 but still does not close #1521. The closeout evidence keeps #1521/#1534 follow-up explicit because the parent lane still needs owner-mapped retention/reduction decisions beyond these diagnostic and consolidation slices.

Closes #1531.
Closes #1532.
Closes #1533.

## Validation

- `make test-workspace` (86.52s on latest pass)
- `make lint-workspace`
- `make test-planning` (16.49s on the reduction pass)
- `make lint-planning`
- `make maintainer-surfaces`
- `uv run pytest packages/verification/tests/test_runtime_primitives.py tests/test_maintainer_surfaces.py::test_testing_strategy_guides_against_one_off_regression_sprawl -q` (11 passed)
- `uv run ruff check packages/verification/src/repo_verification_bootstrap/runtime_primitives.py packages/verification/tests/test_runtime_primitives.py tests/test_maintainer_surfaces.py`
- `uv run pytest tests/test_model_cli_harness.py -q` (115 passed on the reduction pass)
- `uv run agentic-verification report --target . --changed tests/test_model_cli_harness.py tests/test_workspace_report_cli.py tests/test_workspace_start_preflight_cli.py tests/test_generated_command_package_proof_runner.py tests/test_workspace_proof_cli.py tests/test_workspace_implement_cli.py packages/planning/tests/test_summary.py packages/planning/tests/test_archive.py --task "Finish #1521 follow-up test reductions" --format json`
- `uv run pytest --collect-only -q tests packages/memory/tests packages/planning/tests packages/verification/tests` (1,710 tests collected in 0.45s)
- `git diff --check`
