### PR TITLE
Add Verification proof governance diagnostics

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1535-proof-governance.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1535-proof-governance.plan.json
@@ -1,0 +1,378 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Finish Verification proof governance diagnostics for issue 1535",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Finish #1535 by adding a host-neutral Verification proof-governance diagnostic to the existing evidence_strategy report.",
+    "hard_constraints": "Keep reasoning and disposition decisions agent-owned; Verification may surface facts, candidate enums, and questions but must not infer host strategy from prose or prescribe a testing policy.",
+    "agent_may_decide": "Exact JSON shape, field naming, tests, docs wording, and whether #1535 can honestly close after the diagnostic lands.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Add the proof_governance diagnostic to Verification report output, validate it with package tests, and update docs.",
+    "proof_expectations": [
+      "uv run pytest packages/verification/tests/test_runtime_primitives.py -q",
+      "uv run agentic-verification report --target . --changed packages/verification/tests/test_runtime_primitives.py --task \"Should I add a new regression test for issue 1535?\" --format json"
+    ],
+    "touched_scope": [
+      "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py",
+      "packages/verification/tests/test_runtime_primitives.py",
+      "docs/verification.md",
+      ".agentic-workspace/planning/execplans/issue-1535-proof-governance.plan.json",
+      ".agentic-workspace/planning/state.toml"
+    ],
+    "completion_criteria": [
+      "Verification report output includes proof_governance under evidence_strategy.",
+      "The diagnostic asks the #1535 pre-test decision questions without assigning decisions.",
+      "Tests cover host-neutral proof-governance questions for proposed test evidence and absent strategy.",
+      "Docs explain that proof_governance is advisory fact/question surfacing, not a policy engine."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Implement #1535 by adding host-neutral Verification proof-governance diagnostics."
+  ],
+  "non_goals": [
+    "Do not add a new root command.",
+    "Do not add manifest schema fields or enforcement.",
+    "Do not infer host strategy from prose, filenames, or AW conventions."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Finish #1535 by adding a host-neutral Verification proof-governance diagnostic to the existing evidence_strategy report.",
+      "constraints": "Keep reasoning and disposition decisions agent-owned; Verification may surface facts, candidate enums, and questions but must not infer host strategy from prose or prescribe a testing policy.",
+      "latitude": "Exact JSON shape, field naming, tests, docs wording, and whether #1535 can honestly close after the diagnostic lands.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1535-proof-governance",
+      "status": "completed",
+      "next_step": "none; #1535 is implemented by this slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py",
+        "packages/verification/tests/test_runtime_primitives.py",
+        "docs/verification.md",
+        ".agentic-workspace/planning/execplans/issue-1535-proof-governance.plan.json",
+        ".agentic-workspace/planning/state.toml"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Support sustainable testing strategies for agent-maintained repos by making Verification ask useful proof-governance questions before tests accrete.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "A report-level proof_governance block can let agents answer #1535's pre-test questions without adding a new root command or policy engine.",
+    "intentionally deferred": "none for #1535; future refinements should be new issues.",
+    "discovered implications": "none requiring continuation.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "none"
+  },
+  "intent_interpretation": {
+    "literal request": "Merged. There is still one open issue left to implement",
+    "inferred intended outcome": "Implement the remaining open issue #1535 after #1542 merged.",
+    "chosen concrete what": "Add proof_governance diagnostics to evidence_strategy so Verification asks the pre-test proof strategy questions from #1535.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py; packages/verification/tests/test_runtime_primitives.py; docs/verification.md; this execplan and planning state.",
+    "max changed files": "About 5 tracked files plus generated planning closeout/archive if the plan is completed.",
+    "required validation commands": "uv run pytest packages/verification/tests/test_runtime_primitives.py -q; uv run agentic-verification report --target . --changed packages/verification/tests/test_runtime_primitives.py --task \"Should I add a new regression test for issue 1535?\" --format json",
+    "ask-before-refactor threshold": "Ask before adding manifest schema fields, a root command, enforcement, automatic dispositions, or cross-module policy changes.",
+    "stop before touching": "Assurance, Closeout, Memory, root workspace command routing, manifest schema extensions, unrelated test-suite reductions, or issue closure without proof."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Finish #1535 by adding a host-neutral Verification proof-governance diagnostic to the existing evidence_strategy report.",
+    "hard constraints": "Keep reasoning and disposition decisions agent-owned; Verification may surface facts, candidate enums, and questions but must not infer host strategy from prose or prescribe a testing policy.",
+    "agent may decide locally": "Exact JSON shape, field naming, tests, docs wording, and whether #1535 can honestly close after the diagnostic lands.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1535-proof-governance",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Add the proof_governance diagnostic to Verification report output, validate it with package tests, and update docs."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py",
+    "packages/verification/tests/test_runtime_primitives.py",
+    "docs/verification.md",
+    ".agentic-workspace/planning/execplans/issue-1535-proof-governance.plan.json",
+    ".agentic-workspace/planning/state.toml"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest packages/verification/tests/test_runtime_primitives.py -q",
+    "uv run agentic-verification report --target . --changed packages/verification/tests/test_runtime_primitives.py --task \"Should I add a new regression test for issue 1535?\" --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Verification report output includes proof_governance under evidence_strategy.",
+    "The diagnostic asks the #1535 pre-test decision questions without assigning decisions.",
+    "Tests cover host-neutral proof-governance questions for proposed test evidence and absent strategy.",
+    "Docs explain that proof_governance is advisory fact/question surfacing, not a policy engine."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added evidence_strategy.proof_governance to the Verification report as a host-neutral pre-test decision aid for #1535.",
+    "scope touched": "Verification runtime report projection, Verification runtime tests, Verification docs, active planning record.",
+    "changed surfaces": "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py; packages/verification/tests/test_runtime_primitives.py; docs/verification.md; .agentic-workspace/planning/execplans/issue-1535-proof-governance.plan.json; .agentic-workspace/planning/state.toml",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "none; #1535 is implemented by this slice.",
+    "next step": "open PR and close #1535 on merge."
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed inside the planned Verification diagnostic slice. Runtime source edit is inventory-backed as verification_report_payload for verification.report.report; no generated adapter or host policy enforcement was added.",
+    "proof status": "passed",
+    "intent served": "yes; the remaining #1535 issue is implemented by this slice.",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest packages/verification/tests/test_runtime_primitives.py -q -> 11 passed; uv run agentic-verification report --target . --changed packages/verification/tests/test_runtime_primitives.py --task 'Should I add a new regression test for issue 1535?' --format json -> proof_governance present with agent-owned unset decisions; make test-workspace -> passed in 101.40s; make lint-workspace -> passed; make maintainer-surfaces -> passed; summary passed; planning doctor exited 0 with existing module-residue warnings",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Implement the remaining open issue #1535 after #1542 merged.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Verification now surfaces proof_governance questions, decision vocabulary, observed facts, and an unset agent-owned decision template so agents can decide whether to add, merge, convert, record, prune, or skip new proof under host strategy.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "none",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none",
+    "motivation worth preserving": "none",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "planning closeout proof",
+    "target scope": "",
+    "proposed durable intent": "",
+    "confidence": "high",
+    "needs review": false,
+    "owner surface": ""
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "The remaining open #1535 issue asked for Verification support for sustainable testing strategies. This slice adds the pre-test proof-governance diagnostic, decision vocabulary, agent-owned decision template, tests, docs, and full selected proof.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Open a new issue if a future host needs structured strategy configuration, enforcement, budgets, or root command surfaces."
+  },
+  "improvement_signal_review": {
+    "status": "no_signal_found",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": ""
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-15: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "do-not-capture",
+    "target": "",
+    "reason": "No durable anti-rediscovery lesson beyond the implemented docs and tests."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "complete",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "none",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "blocked_claim_classes": [],
+      "closure_actions": [
+        "archive-and-close",
+        "close-issue-on-pr-merge"
+      ],
+      "renderer_rule": "Renderers may claim #1535 implemented when citing this proof and the PR closure path.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "none",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "The remaining #1535 issue is implemented by the proof_governance diagnostic, tests, docs, and proof."
+    },
+    "continuation": {
+      "owner_surface": "none",
+      "created_or_required": false,
+      "reason": "none"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement the remaining open issue #1535 after #1542 merged.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest packages/verification/tests/test_runtime_primitives.py -q -> 11 passed; uv run agentic-verification report --target . --changed packages/verification/tests/test_runtime_primitives.py --task 'Should I add a new regression test for issue 1535?' --format json -> proof_governance present with agent-owned unset decisions; make test-workspace -> passed in 101.40s; make lint-workspace -> passed; make maintainer-surfaces -> passed; summary passed; planning doctor exited 0 with existing module-residue warnings\nChanged surfaces: packages/verification/src/repo_verification_bootstrap/runtime_primitives.py; packages/verification/tests/test_runtime_primitives.py; docs/verification.md; .agentic-workspace/planning/execplans/issue-1535-proof-governance.plan.json; .agentic-workspace/planning/state.toml\nDurable residue: none\nMemory learning: none\nFollow-up: none\nCompletion gate: complete\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -71,6 +71,25 @@ It lists candidate test-knowledge inventory sources and per-file AST counts so
 an agent can choose where to inspect first. These counts are routing facts only:
 they do not prove coverage and do not authorize deletion, merging, or conversion.
 
+The `evidence_strategy.proof_governance` block is the pre-test decision aid for
+regression-prone work. It reports local facts such as changed paths, changed
+test functions, same-file/name-prefix groups, candidate strategy sources, and
+whether a Verification manifest is configured. It also exposes the decision
+vocabulary an agent may consider:
+
+- `add`
+- `merge`
+- `convert-to-conformance`
+- `record-manual-evidence`
+- `prune`
+- `no-new-proof-needed`
+- `needs-human-strategy-choice`
+
+The block leaves every decision unset and agent-owned. Its decision template asks
+the agent to state the trust question, proof intent, narrowest evidence,
+evidence owner, durability, and safe-to-prune condition. Verification does not
+fill those fields from filenames, prose, markers, or AW conventions.
+
 Without host-owned structured strategy enums or configuration, dispositions remain
 `needs-human-strategy-choice`, owners remain `unknown`, and confidence stays low.
 The report does not delete tests, prove semantic equivalence, require a manifest

--- a/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
+++ b/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
@@ -10,6 +10,7 @@ from typing import Any
 VERIFICATION_MANIFEST_PATH = Path(".agentic-workspace/verification/manifest.toml")
 SCHEMA_VERSION = "agentic-workspace/verification-manifest/v1"
 EVIDENCE_STRATEGY_KIND = "agentic-workspace/verification-evidence-strategy/v1"
+PROOF_GOVERNANCE_KIND = "agentic-workspace/verification-proof-governance/v1"
 
 SOURCE_HINTS = [
     (Path("docs/maintainer/testing-strategy.md"), "candidate-host-strategy-source"),
@@ -113,6 +114,42 @@ FILE_REVIEW_QUESTIONS = [
     "What smaller proof surface should own stable behavior after migration?",
 ]
 
+PROOF_GOVERNANCE_DECISIONS = [
+    "add",
+    "merge",
+    "convert-to-conformance",
+    "record-manual-evidence",
+    "prune",
+    "no-new-proof-needed",
+    "needs-human-strategy-choice",
+]
+
+PROOF_INTENT_OPTIONS = [
+    "behavior-unchanged",
+    "target-parity",
+    "workflow-routing",
+    "migration-residue",
+    "cli-compatibility",
+    "temporary-characterization",
+    "unknown",
+]
+
+EVIDENCE_DURABILITY_OPTIONS = [
+    "permanent",
+    "temporary",
+    "replaceable",
+    "unknown",
+]
+
+PROOF_GOVERNANCE_QUESTIONS = [
+    "What host-repo testing or proof strategy applies to this surface?",
+    "What trust question is being answered?",
+    "What is the narrowest evidence that answers it under that strategy?",
+    "Which owner should hold the evidence?",
+    "Is this proof permanent, temporary, or replaceable by a host-preferred proof surface?",
+    "What would make it safe to prune later?",
+]
+
 
 def _candidate_strategy_sources(*, target_root: Path) -> list[dict[str, Any]]:
     sources: list[dict[str, Any]] = []
@@ -187,6 +224,106 @@ def _test_group_key(name: str) -> str:
     if len(parts) < 3:
         return stem
     return "_".join(parts[: min(len(parts), 7)])
+
+
+def _proof_governance_payload(
+    *,
+    candidate_sources: list[dict[str, Any]],
+    changed_paths: list[str],
+    test_functions: list[dict[str, Any]],
+    group_entries: list[dict[str, Any]],
+    task_text: str | None,
+    manifest: dict[str, Any],
+) -> dict[str, Any]:
+    observed_facts: list[dict[str, Any]] = []
+    if task_text:
+        observed_facts.append(
+            {
+                "source": "task_text",
+                "fact": "task text supplied",
+                "confidence": "medium",
+            }
+        )
+    if changed_paths:
+        observed_facts.append(
+            {
+                "source": "changed_paths",
+                "fact": "changed paths supplied",
+                "paths": changed_paths,
+                "confidence": "medium",
+            }
+        )
+    if test_functions:
+        observed_facts.append(
+            {
+                "source": "test_ast",
+                "fact": "changed Python test functions collected by AST",
+                "paths": _dedupe([str(function["path"]) for function in test_functions]),
+                "count": len(test_functions),
+                "confidence": "medium",
+            }
+        )
+    if group_entries:
+        observed_facts.append(
+            {
+                "source": "test_ast",
+                "fact": "same-file test name-prefix groups detected",
+                "count": len(group_entries),
+                "confidence": "low",
+            }
+        )
+    if manifest.get("configured"):
+        observed_facts.append(
+            {
+                "source": "verification_manifest",
+                "fact": "verification manifest is configured",
+                "paths": [str(manifest.get("path", VERIFICATION_MANIFEST_PATH.as_posix()))],
+                "confidence": "medium",
+            }
+        )
+    status = "attention" if observed_facts or candidate_sources else "unavailable"
+    return {
+        "kind": PROOF_GOVERNANCE_KIND,
+        "status": status,
+        "decision_authority": "agent",
+        "available_decisions": PROOF_GOVERNANCE_DECISIONS,
+        "proof_intent_options": PROOF_INTENT_OPTIONS,
+        "proof_owner_options": [
+            "root-orchestration",
+            "package-local-behavior",
+            "conformance-contract",
+            "verification-evidence",
+            "memory-lesson",
+            "docs-manual-review",
+            "unknown",
+        ],
+        "evidence_durability_options": EVIDENCE_DURABILITY_OPTIONS,
+        "candidate_context": {
+            "changed_path_count": len(changed_paths),
+            "ordinary_test_function_count": len(test_functions),
+            "group_count": len(group_entries),
+            "candidate_strategy_source_count": len(candidate_sources),
+            "verification_manifest_configured": bool(manifest.get("configured")),
+            "task_text_present": bool(task_text),
+        },
+        "observed_facts": observed_facts,
+        "pre_test_decision_questions": PROOF_GOVERNANCE_QUESTIONS,
+        "agent_decision_template": {
+            "selected_decision": "unset-agent-owned",
+            "trust_question": "unset-agent-owned",
+            "proof_intent": "unset-agent-owned",
+            "narrowest_evidence": "unset-agent-owned",
+            "evidence_owner": "unset-agent-owned",
+            "durability": "unset-agent-owned",
+            "safe_to_prune_when": "unset-agent-owned",
+        },
+        "limits": [
+            "No decision is assigned by Verification.",
+            "No host strategy is inferred from prose.",
+            "No new proof requirement is created.",
+            "No pruning, merging, or conversion is authorized.",
+        ],
+    }
 
 
 def _evidence_strategy_payload(
@@ -328,6 +465,14 @@ def _evidence_strategy_payload(
                 "confidence": "low",
             }
         )
+    proof_governance = _proof_governance_payload(
+        candidate_sources=candidate_sources,
+        changed_paths=changed_paths,
+        test_functions=test_functions,
+        group_entries=group_entries,
+        task_text=task_text,
+        manifest=manifest,
+    )
     return {
         "kind": EVIDENCE_STRATEGY_KIND,
         "status": "attention" if candidate_sources or observed_signals else "unavailable",
@@ -365,6 +510,7 @@ def _evidence_strategy_payload(
                 "File summaries do not authorize deletion or merge decisions.",
             ],
         },
+        "proof_governance": proof_governance,
         "summary": {
             "candidate_count": len(evidence_items),
             "high_confidence_merge_count": sum(1 for group in group_entries if group["confidence"] == "high"),

--- a/packages/verification/tests/test_runtime_primitives.py
+++ b/packages/verification/tests/test_runtime_primitives.py
@@ -17,6 +17,9 @@ def test_verification_report_absent_manifest(tmp_path: Path) -> None:
     assert payload["evidence_strategy"]["kind"] == "agentic-workspace/verification-evidence-strategy/v1"
     assert payload["evidence_strategy"]["status"] == "unavailable"
     assert payload["evidence_strategy"]["strategy_basis"]["declared_strategy_state"] == "not-declared"
+    assert payload["evidence_strategy"]["proof_governance"]["kind"] == "agentic-workspace/verification-proof-governance/v1"
+    assert payload["evidence_strategy"]["proof_governance"]["status"] == "unavailable"
+    assert payload["evidence_strategy"]["proof_governance"]["decision_authority"] == "agent"
 
 
 def test_verification_report_matches_path_protocol_and_evidence(tmp_path: Path) -> None:
@@ -294,6 +297,44 @@ def test_model_cli_harness_scores_raw_read_windows():
             ],
         }
     ]
+    governance = strategy["proof_governance"]
+    assert governance["status"] == "attention"
+    assert governance["decision_authority"] == "agent"
+    assert governance["available_decisions"] == [
+        "add",
+        "merge",
+        "convert-to-conformance",
+        "record-manual-evidence",
+        "prune",
+        "no-new-proof-needed",
+        "needs-human-strategy-choice",
+    ]
+    assert governance["candidate_context"] == {
+        "changed_path_count": 1,
+        "ordinary_test_function_count": 2,
+        "group_count": 1,
+        "candidate_strategy_source_count": 1,
+        "verification_manifest_configured": False,
+        "task_text_present": True,
+    }
+    assert governance["pre_test_decision_questions"] == [
+        "What host-repo testing or proof strategy applies to this surface?",
+        "What trust question is being answered?",
+        "What is the narrowest evidence that answers it under that strategy?",
+        "Which owner should hold the evidence?",
+        "Is this proof permanent, temporary, or replaceable by a host-preferred proof surface?",
+        "What would make it safe to prune later?",
+    ]
+    assert governance["agent_decision_template"] == {
+        "selected_decision": "unset-agent-owned",
+        "trust_question": "unset-agent-owned",
+        "proof_intent": "unset-agent-owned",
+        "narrowest_evidence": "unset-agent-owned",
+        "evidence_owner": "unset-agent-owned",
+        "durability": "unset-agent-owned",
+        "safe_to_prune_when": "unset-agent-owned",
+    }
+    assert "No decision is assigned by Verification." in governance["limits"]
 
 
 def test_verification_evidence_strategy_keeps_unclear_strategy_host_neutral(tmp_path: Path) -> None:
@@ -316,6 +357,11 @@ def test_widget_handles_error():
     assert strategy["evidence_items"][0]["recommended_disposition"] == "needs-human-strategy-choice"
     assert strategy["evidence_items"][0]["confidence"] == "low"
     assert "No universal testing strategy inferred." in strategy["limits"]
+    governance = strategy["proof_governance"]
+    assert governance["status"] == "attention"
+    assert governance["candidate_context"]["candidate_strategy_source_count"] == 0
+    assert governance["agent_decision_template"]["selected_decision"] == "unset-agent-owned"
+    assert "No host strategy is inferred from prose." in governance["limits"]
 
 
 def test_verification_evidence_strategy_does_not_force_merge_for_different_host_strategy_prose(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #1535.

This PR finishes the remaining Verification testing-strategy lane by adding a diagnostic `evidence_strategy.proof_governance` block to the existing Verification report.

The new block is intentionally host-neutral and decision-free:

- surfaces observed facts from task text, changed paths, changed Python tests, simple AST grouping, and the Verification manifest
- exposes the pre-test decision vocabulary: `add`, `merge`, `convert-to-conformance`, `record-manual-evidence`, `prune`, `no-new-proof-needed`, and `needs-human-strategy-choice`
- asks the #1535 governance questions for trust question, narrowest evidence, owner, durability, and prune conditions
- leaves every decision in an unset agent-owned template rather than inferring strategy or disposition

## Boundary

Verification still does not infer host strategy from prose, filenames, markers, or AW conventions. It does not create a new root command, require manifest schema changes, enforce budgets, or authorize pruning/merging/conversion.

Runtime source edit reason: this updates the inventory-backed `verification_report_payload` primitive for the `verification.report.report` operation.

## Proof

- `uv run pytest packages/verification/tests/test_runtime_primitives.py -q` -> 11 passed
- `uv run agentic-verification report --target . --changed packages/verification/tests/test_runtime_primitives.py --task "Should I add a new regression test for issue 1535?" --format json` -> `proof_governance` present with agent-owned unset decisions
- `make test-workspace` -> passed in 101.40s
- `make lint-workspace` -> passed
- `make maintainer-surfaces` -> passed
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json` -> passed, no active plan
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` -> exited 0; reported existing module-residue warnings
