### PR TITLE
Align Verification evidence strategy docs

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -38,7 +38,7 @@ The Verification report also includes a diagnostic `evidence_strategy` section:
 ```json
 {
   "kind": "agentic-workspace/verification-evidence-strategy/v1",
-  "status": "ready"
+  "status": "attention"
 }
 ```
 


### PR DESCRIPTION
## Summary

Closes #1549.

Updates the `docs/verification.md` evidence strategy snippet so it no longer shows stale `status: ready` output. The example now matches the current runtime shape where evidence-strategy diagnostics surface as `attention` when local evidence or candidate sources are present.

## Proof

- `make maintainer-surfaces`
- `uv run pytest packages/verification/tests/test_runtime_primitives.py -q`
- `git diff --check`
