### PR TITLE
Add Verification proof decision records

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -90,6 +90,30 @@ the agent to state the trust question, proof intent, narrowest evidence,
 evidence owner, durability, and safe-to-prune condition. Verification does not
 fill those fields from filenames, prose, markers, or AW conventions.
 
+When an agent has made that decision, it can record the answer in
+`.agentic-workspace/verification/proof-decision.json`. Verification reads that
+optional artifact and reports it as `evidence_strategy.proof_decision` with
+status `missing`, `incomplete`, `invalid`, or `present`. The record is
+agent-authored; Verification validates enum values and missing fields, but it
+does not create or complete the decision.
+
+```json
+{
+  "proof_decision": {
+    "selected_decision": "add",
+    "trust_question": "What trust question is this evidence answering?",
+    "host_strategy_source": "docs/maintainer/testing-strategy.md",
+    "proof_owner": "verification-evidence",
+    "proof_intent": "workflow-routing",
+    "evidence_durability": "permanent",
+    "narrowest_evidence": "Focused Verification runtime primitive tests.",
+    "prune_or_replacement_condition": "A stronger contract-owned case replaces this proof.",
+    "confidence": "medium",
+    "residual_risk": "Closeout still needs to cite the decision."
+  }
+}
+```
+
 Without host-owned structured strategy enums or configuration, dispositions remain
 `needs-human-strategy-choice`, owners remain `unknown`, and confidence stays low.
 The report does not delete tests, prove semantic equivalence, require a manifest

--- a/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
+++ b/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from typing import Any
 
 VERIFICATION_MANIFEST_PATH = Path(".agentic-workspace/verification/manifest.toml")
+PROOF_DECISION_PATH = Path(".agentic-workspace/verification/proof-decision.json")
 SCHEMA_VERSION = "agentic-workspace/verification-manifest/v1"
 EVIDENCE_STRATEGY_KIND = "agentic-workspace/verification-evidence-strategy/v1"
 PROOF_GOVERNANCE_KIND = "agentic-workspace/verification-proof-governance/v1"
+PROOF_DECISION_KIND = "agentic-workspace/verification-proof-decision/v1"
 
 SOURCE_HINTS = [
     (Path("docs/maintainer/testing-strategy.md"), "candidate-host-strategy-source"),
@@ -93,6 +95,18 @@ def _read_text_if_present(path: Path) -> str:
         return ""
 
 
+def _read_json_if_present(path: Path) -> tuple[bool, Any, str]:
+    text = _read_text_if_present(path)
+    if not text:
+        return False, None, ""
+    import json
+
+    try:
+        return True, json.loads(text), ""
+    except json.JSONDecodeError as exc:
+        return True, None, str(exc)
+
+
 GROUP_DECISION_QUESTIONS = [
     "Does this group represent one behavior class or separate regression records?",
     "Which member labels or historical facts must remain visible if this evidence is rewritten?",
@@ -148,6 +162,19 @@ PROOF_GOVERNANCE_QUESTIONS = [
     "Which owner should hold the evidence?",
     "Is this proof permanent, temporary, or replaceable by a host-preferred proof surface?",
     "What would make it safe to prune later?",
+]
+
+PROOF_DECISION_REQUIRED_FIELDS = [
+    "selected_decision",
+    "trust_question",
+    "host_strategy_source",
+    "proof_owner",
+    "proof_intent",
+    "evidence_durability",
+    "narrowest_evidence",
+    "prune_or_replacement_condition",
+    "confidence",
+    "residual_risk",
 ]
 
 
@@ -326,6 +353,92 @@ def _proof_governance_payload(
     }
 
 
+def _proof_decision_payload(*, target_root: Path) -> dict[str, Any]:
+    decision_path = target_root / PROOF_DECISION_PATH
+    exists, payload, parse_error = _read_json_if_present(decision_path)
+    base = {
+        "kind": PROOF_DECISION_KIND,
+        "path": PROOF_DECISION_PATH.as_posix(),
+        "authority": "agent-authored",
+        "decision_authority": "agent",
+        "limits": [
+            "Verification validates the record shape but does not create the decision.",
+            "No missing field is inferred from prose, paths, names, or AW conventions.",
+        ],
+    }
+    if not exists:
+        return {
+            **base,
+            "status": "missing",
+            "missing_fields": PROOF_DECISION_REQUIRED_FIELDS,
+            "invalid_fields": [],
+            "decision": {},
+        }
+    if parse_error:
+        return {
+            **base,
+            "status": "invalid",
+            "parse_error": parse_error,
+            "missing_fields": [],
+            "invalid_fields": ["json"],
+            "decision": {},
+        }
+    if not isinstance(payload, dict):
+        return {
+            **base,
+            "status": "invalid",
+            "missing_fields": [],
+            "invalid_fields": ["root"],
+            "decision": {},
+        }
+    decision = payload.get("proof_decision", payload)
+    if not isinstance(decision, dict):
+        return {
+            **base,
+            "status": "invalid",
+            "missing_fields": [],
+            "invalid_fields": ["proof_decision"],
+            "decision": {},
+        }
+    missing_fields = [field for field in PROOF_DECISION_REQUIRED_FIELDS if not str(decision.get(field, "")).strip()]
+    invalid_fields: list[str] = []
+    selected_decision = str(decision.get("selected_decision", "")).strip()
+    if selected_decision and selected_decision not in PROOF_GOVERNANCE_DECISIONS:
+        invalid_fields.append("selected_decision")
+    proof_owner = str(decision.get("proof_owner", "")).strip()
+    if proof_owner and proof_owner not in {
+        "root-orchestration",
+        "package-local-behavior",
+        "conformance-contract",
+        "verification-evidence",
+        "memory-lesson",
+        "docs-manual-review",
+        "unknown",
+    }:
+        invalid_fields.append("proof_owner")
+    proof_intent = str(decision.get("proof_intent", "")).strip()
+    if proof_intent and proof_intent not in PROOF_INTENT_OPTIONS:
+        invalid_fields.append("proof_intent")
+    durability = str(decision.get("evidence_durability", "")).strip()
+    if durability and durability not in EVIDENCE_DURABILITY_OPTIONS:
+        invalid_fields.append("evidence_durability")
+    confidence = str(decision.get("confidence", "")).strip()
+    if confidence and confidence not in {"high", "medium", "low"}:
+        invalid_fields.append("confidence")
+    status = "present"
+    if invalid_fields:
+        status = "invalid"
+    elif missing_fields:
+        status = "incomplete"
+    return {
+        **base,
+        "status": status,
+        "missing_fields": missing_fields,
+        "invalid_fields": invalid_fields,
+        "decision": {field: decision.get(field, "") for field in PROOF_DECISION_REQUIRED_FIELDS},
+    }
+
+
 def _evidence_strategy_payload(
     *,
     target_root: Path,
@@ -473,6 +586,7 @@ def _evidence_strategy_payload(
         task_text=task_text,
         manifest=manifest,
     )
+    proof_decision = _proof_decision_payload(target_root=target_root)
     return {
         "kind": EVIDENCE_STRATEGY_KIND,
         "status": "attention" if candidate_sources or observed_signals else "unavailable",
@@ -511,6 +625,7 @@ def _evidence_strategy_payload(
             ],
         },
         "proof_governance": proof_governance,
+        "proof_decision": proof_decision,
         "summary": {
             "candidate_count": len(evidence_items),
             "high_confidence_merge_count": sum(1 for group in group_entries if group["confidence"] == "high"),

--- a/packages/verification/tests/test_runtime_primitives.py
+++ b/packages/verification/tests/test_runtime_primitives.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,9 @@ def test_verification_report_absent_manifest(tmp_path: Path) -> None:
     assert payload["evidence_strategy"]["proof_governance"]["kind"] == "agentic-workspace/verification-proof-governance/v1"
     assert payload["evidence_strategy"]["proof_governance"]["status"] == "unavailable"
     assert payload["evidence_strategy"]["proof_governance"]["decision_authority"] == "agent"
+    assert payload["evidence_strategy"]["proof_decision"]["kind"] == "agentic-workspace/verification-proof-decision/v1"
+    assert payload["evidence_strategy"]["proof_decision"]["status"] == "missing"
+    assert payload["evidence_strategy"]["proof_decision"]["decision_authority"] == "agent"
 
 
 def test_verification_report_matches_path_protocol_and_evidence(tmp_path: Path) -> None:
@@ -457,3 +461,91 @@ def test_widget_case_regression_windows():
     ]
     assert {group["recommended_disposition"] for group in strategy["groups"]} == {"needs-human-strategy-choice"}
     assert {item["proof_owner"] for item in strategy["evidence_items"]} == {"unknown"}
+
+
+def test_verification_proof_decision_reports_complete_agent_authored_record(tmp_path: Path) -> None:
+    decision_path = tmp_path / ".agentic-workspace" / "verification" / "proof-decision.json"
+    decision_path.parent.mkdir(parents=True)
+    decision_path.write_text(
+        json.dumps(
+            {
+                "proof_decision": {
+                    "selected_decision": "add",
+                    "trust_question": "Does the new report field preserve host-neutral proof governance?",
+                    "host_strategy_source": "docs/verification.md",
+                    "proof_owner": "verification-evidence",
+                    "proof_intent": "workflow-routing",
+                    "evidence_durability": "permanent",
+                    "narrowest_evidence": "Verification runtime primitive tests.",
+                    "prune_or_replacement_condition": "A schema-owned conformance case replaces the runtime test.",
+                    "confidence": "medium",
+                    "residual_risk": "Closeout surfaces do not consume the decision yet.",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=[], task_text="")
+
+    decision = payload["evidence_strategy"]["proof_decision"]
+    assert decision["status"] == "present"
+    assert decision["authority"] == "agent-authored"
+    assert decision["missing_fields"] == []
+    assert decision["invalid_fields"] == []
+    assert decision["decision"]["selected_decision"] == "add"
+
+
+def test_verification_proof_decision_reports_incomplete_record_without_inference(tmp_path: Path) -> None:
+    decision_path = tmp_path / ".agentic-workspace" / "verification" / "proof-decision.json"
+    decision_path.parent.mkdir(parents=True)
+    decision_path.write_text(
+        json.dumps(
+            {
+                "selected_decision": "merge",
+                "trust_question": "Can two regression rows become one scenario matrix?",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=[], task_text="")
+
+    decision = payload["evidence_strategy"]["proof_decision"]
+    assert decision["status"] == "incomplete"
+    assert "proof_owner" in decision["missing_fields"]
+    assert decision["invalid_fields"] == []
+    assert "No missing field is inferred" in decision["limits"][1]
+
+
+def test_verification_proof_decision_reports_invalid_enums(tmp_path: Path) -> None:
+    decision_path = tmp_path / ".agentic-workspace" / "verification" / "proof-decision.json"
+    decision_path.parent.mkdir(parents=True)
+    decision_path.write_text(
+        json.dumps(
+            {
+                "selected_decision": "auto-delete",
+                "trust_question": "Question",
+                "host_strategy_source": "docs/strategy.md",
+                "proof_owner": "magic-owner",
+                "proof_intent": "unknown",
+                "evidence_durability": "forever",
+                "narrowest_evidence": "Evidence",
+                "prune_or_replacement_condition": "Condition",
+                "confidence": "certain",
+                "residual_risk": "Risk",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=[], task_text="")
+
+    decision = payload["evidence_strategy"]["proof_decision"]
+    assert decision["status"] == "invalid"
+    assert set(decision["invalid_fields"]) == {
+        "selected_decision",
+        "proof_owner",
+        "evidence_durability",
+        "confidence",
+    }


### PR DESCRIPTION
## Summary

Closes #1544.

Adds optional agent-authored Verification proof decision records via `.agentic-workspace/verification/proof-decision.json`.

The report now includes `evidence_strategy.proof_decision` with:

- `missing`, `incomplete`, `invalid`, or `present` status
- required field reporting
- enum validation for decision, owner, intent, durability, and confidence
- explicit agent authority and no-inference limits

This keeps Verification as validator/reporter of the decision artifact, not the decision-maker.

## Stack

Base PR: #1550.

## Proof

- `uv run pytest packages/verification/tests/test_runtime_primitives.py -q`
- `uv run ruff check packages/verification/src packages/verification/tests`
- `make maintainer-surfaces`
- `git diff --check`
