### PR TITLE
Support structured Verification proof strategy hints

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -86,10 +86,12 @@ proof_intent_vocab = ["workflow-routing", "behavior-unchanged"]
 Supported `ordinary_test_growth` values are `allowed`,
 `requires-proof-decision`, `discouraged`, and `unknown`. `preferred_owner_vocab`
 must use the report's proof-owner enum, and `proof_intent_vocab` must use the
-proof-decision intent enum. Valid structured hints mark the strategy state as
-`declared` with medium confidence because the host provided machine-readable
-configuration. They still do not assign evidence ownership, choose dispositions,
-or authorize pruning.
+proof-decision intent enum. A valid hints file marks the strategy state as
+`declared` with medium confidence only when it names a non-empty
+`strategy_source` and includes at least one meaningful structured strategy field.
+Enum-only or source-only hints are reported as `partially-declared` with low
+confidence. They still do not assign evidence ownership, choose dispositions, or
+authorize pruning.
 
 The `evidence_strategy.proof_governance` block is the pre-test decision aid for
 regression-prone work. It reports local facts such as changed paths, changed

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -71,6 +71,26 @@ It lists candidate test-knowledge inventory sources and per-file AST counts so
 an agent can choose where to inspect first. These counts are routing facts only:
 they do not prove coverage and do not authorize deletion, merging, or conversion.
 
+Hosts may optionally publish structured strategy hints at
+`.agentic-workspace/verification/proof-strategy.toml`. Verification only reads
+enum fields from this file; it does not parse or summarize strategy prose.
+
+```toml
+[proof_strategy]
+strategy_source = "docs/maintainer/testing-strategy.md"
+ordinary_test_growth = "requires-proof-decision"
+preferred_owner_vocab = ["root-orchestration", "verification-evidence"]
+proof_intent_vocab = ["workflow-routing", "behavior-unchanged"]
+```
+
+Supported `ordinary_test_growth` values are `allowed`,
+`requires-proof-decision`, `discouraged`, and `unknown`. `preferred_owner_vocab`
+must use the report's proof-owner enum, and `proof_intent_vocab` must use the
+proof-decision intent enum. Valid structured hints mark the strategy state as
+`declared` with medium confidence because the host provided machine-readable
+configuration. They still do not assign evidence ownership, choose dispositions,
+or authorize pruning.
+
 The `evidence_strategy.proof_governance` block is the pre-test decision aid for
 regression-prone work. It reports local facts such as changed paths, changed
 test functions, same-file/name-prefix groups, candidate strategy sources, and

--- a/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
+++ b/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
@@ -519,6 +519,22 @@ def _structured_strategy_hints_payload(*, target_root: Path) -> dict[str, Any]:
     }
 
 
+def _structured_strategy_state(structured_hints: dict[str, Any]) -> tuple[str, str]:
+    if structured_hints.get("status") != "present":
+        return "not-declared", "unclear"
+    hints = structured_hints.get("hints")
+    hints = hints if isinstance(hints, dict) else {}
+    strategy_source = str(hints.get("strategy_source", "")).strip()
+    has_meaningful_strategy_field = bool(
+        str(hints.get("ordinary_test_growth", "")).strip() not in {"", "unknown"}
+        or _list_payload(hints.get("preferred_owner_vocab"))
+        or _list_payload(hints.get("proof_intent_vocab"))
+    )
+    if strategy_source and has_meaningful_strategy_field:
+        return "declared", "medium"
+    return "partially-declared", "low"
+
+
 def _evidence_strategy_payload(
     *,
     target_root: Path,
@@ -637,9 +653,13 @@ def _evidence_strategy_payload(
             }
         )
 
-    if structured_hints["status"] == "present":
-        declared_state = "declared"
-        strategy_confidence = "medium"
+    structured_declared_state, structured_strategy_confidence = _structured_strategy_state(structured_hints)
+    if structured_declared_state == "declared":
+        declared_state = structured_declared_state
+        strategy_confidence = structured_strategy_confidence
+    elif structured_declared_state == "partially-declared":
+        declared_state = structured_declared_state
+        strategy_confidence = structured_strategy_confidence
     elif candidate_sources:
         declared_state = "partially-declared"
         strategy_confidence = "low"

--- a/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
+++ b/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
@@ -9,6 +9,7 @@ from typing import Any
 
 VERIFICATION_MANIFEST_PATH = Path(".agentic-workspace/verification/manifest.toml")
 PROOF_DECISION_PATH = Path(".agentic-workspace/verification/proof-decision.json")
+PROOF_STRATEGY_PATH = Path(".agentic-workspace/verification/proof-strategy.toml")
 SCHEMA_VERSION = "agentic-workspace/verification-manifest/v1"
 EVIDENCE_STRATEGY_KIND = "agentic-workspace/verification-evidence-strategy/v1"
 PROOF_GOVERNANCE_KIND = "agentic-workspace/verification-proof-governance/v1"
@@ -176,6 +177,13 @@ PROOF_DECISION_REQUIRED_FIELDS = [
     "confidence",
     "residual_risk",
 ]
+
+ORDINARY_TEST_GROWTH_OPTIONS = {
+    "allowed",
+    "requires-proof-decision",
+    "discouraged",
+    "unknown",
+}
 
 
 def _candidate_strategy_sources(*, target_root: Path) -> list[dict[str, Any]]:
@@ -439,6 +447,78 @@ def _proof_decision_payload(*, target_root: Path) -> dict[str, Any]:
     }
 
 
+def _structured_strategy_hints_payload(*, target_root: Path) -> dict[str, Any]:
+    strategy_path = target_root / PROOF_STRATEGY_PATH
+    base = {
+        "path": PROOF_STRATEGY_PATH.as_posix(),
+        "authority": "host-structured-config",
+        "limits": [
+            "Only structured enum fields are interpreted.",
+            "Free-text host strategy prose remains uninterpreted.",
+        ],
+    }
+    if not strategy_path.is_file():
+        return {
+            **base,
+            "status": "absent",
+            "hints": {},
+            "invalid_fields": [],
+        }
+    try:
+        with strategy_path.open("rb") as handle:
+            payload = tomllib.load(handle)
+    except tomllib.TOMLDecodeError as exc:
+        return {
+            **base,
+            "status": "invalid",
+            "parse_error": str(exc),
+            "hints": {},
+            "invalid_fields": ["toml"],
+        }
+    raw_hints = payload.get("proof_strategy", payload)
+    if not isinstance(raw_hints, dict):
+        return {
+            **base,
+            "status": "invalid",
+            "hints": {},
+            "invalid_fields": ["proof_strategy"],
+        }
+    hints = {
+        "strategy_source": str(raw_hints.get("strategy_source", "")).strip(),
+        "ordinary_test_growth": str(raw_hints.get("ordinary_test_growth", "")).strip() or "unknown",
+        "preferred_owner_vocab": [str(item).strip() for item in _list_payload(raw_hints.get("preferred_owner_vocab")) if str(item).strip()],
+        "proof_intent_vocab": [str(item).strip() for item in _list_payload(raw_hints.get("proof_intent_vocab")) if str(item).strip()],
+    }
+    invalid_fields: list[str] = []
+    if hints["ordinary_test_growth"] not in ORDINARY_TEST_GROWTH_OPTIONS:
+        invalid_fields.append("ordinary_test_growth")
+    invalid_owner_values = [
+        item
+        for item in hints["preferred_owner_vocab"]
+        if item
+        not in {
+            "root-orchestration",
+            "package-local-behavior",
+            "conformance-contract",
+            "verification-evidence",
+            "memory-lesson",
+            "docs-manual-review",
+            "unknown",
+        }
+    ]
+    if invalid_owner_values:
+        invalid_fields.append("preferred_owner_vocab")
+    invalid_intents = [item for item in hints["proof_intent_vocab"] if item not in PROOF_INTENT_OPTIONS]
+    if invalid_intents:
+        invalid_fields.append("proof_intent_vocab")
+    return {
+        **base,
+        "status": "invalid" if invalid_fields else "present",
+        "hints": hints,
+        "invalid_fields": invalid_fields,
+    }
+
+
 def _evidence_strategy_payload(
     *,
     target_root: Path,
@@ -447,6 +527,7 @@ def _evidence_strategy_payload(
     manifest: dict[str, Any],
 ) -> dict[str, Any]:
     candidate_sources = _candidate_strategy_sources(target_root=target_root)
+    structured_hints = _structured_strategy_hints_payload(target_root=target_root)
     test_functions = [
         function
         for changed_path in changed_paths
@@ -556,7 +637,10 @@ def _evidence_strategy_payload(
             }
         )
 
-    if candidate_sources:
+    if structured_hints["status"] == "present":
+        declared_state = "declared"
+        strategy_confidence = "medium"
+    elif candidate_sources:
         declared_state = "partially-declared"
         strategy_confidence = "low"
     elif observed_signals:
@@ -593,6 +677,7 @@ def _evidence_strategy_payload(
         "strategy_basis": {
             "declared_strategy_state": declared_state,
             "declared_strategy_sources": [],
+            "structured_strategy_hints": structured_hints,
             "candidate_strategy_sources": candidate_sources,
             "matched_strategy_signals": [],
             "observed_signal_state": "observed" if observed_signals else "absent",

--- a/packages/verification/tests/test_runtime_primitives.py
+++ b/packages/verification/tests/test_runtime_primitives.py
@@ -208,6 +208,104 @@ module-owned behavior.
     assert "No universal testing strategy inferred." in strategy["limits"]
 
 
+def test_verification_evidence_strategy_reports_structured_strategy_hints(tmp_path: Path) -> None:
+    strategy_path = tmp_path / ".agentic-workspace" / "verification" / "proof-strategy.toml"
+    strategy_path.parent.mkdir(parents=True)
+    strategy_path.write_text(
+        """
+[proof_strategy]
+strategy_source = "docs/maintainer/testing-strategy.md"
+ordinary_test_growth = "requires-proof-decision"
+preferred_owner_vocab = ["root-orchestration", "verification-evidence"]
+proof_intent_vocab = ["workflow-routing", "behavior-unchanged"]
+""".strip(),
+        encoding="utf-8",
+    )
+    test_file = tmp_path / "tests" / "test_widget.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        """
+def test_widget_case_regression_posix():
+    assert True
+
+
+def test_widget_case_regression_windows():
+    assert True
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=["tests/test_widget.py"], task_text="")
+
+    strategy = payload["evidence_strategy"]
+    basis = strategy["strategy_basis"]
+    assert basis["declared_strategy_state"] == "declared"
+    assert basis["strategy_confidence"] == "medium"
+    assert basis["declared_strategy_sources"] == []
+    assert basis["matched_strategy_signals"] == []
+    assert basis["structured_strategy_hints"] == {
+        "path": ".agentic-workspace/verification/proof-strategy.toml",
+        "authority": "host-structured-config",
+        "limits": [
+            "Only structured enum fields are interpreted.",
+            "Free-text host strategy prose remains uninterpreted.",
+        ],
+        "status": "present",
+        "hints": {
+            "strategy_source": "docs/maintainer/testing-strategy.md",
+            "ordinary_test_growth": "requires-proof-decision",
+            "preferred_owner_vocab": ["root-orchestration", "verification-evidence"],
+            "proof_intent_vocab": ["workflow-routing", "behavior-unchanged"],
+        },
+        "invalid_fields": [],
+    }
+    assert {group["recommended_disposition"] for group in strategy["groups"]} == {"needs-human-strategy-choice"}
+    assert {item["proof_owner"] for item in strategy["evidence_items"]} == {"unknown"}
+
+
+def test_verification_evidence_strategy_reports_absent_structured_strategy_hints(tmp_path: Path) -> None:
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=[], task_text="")
+
+    hints = payload["evidence_strategy"]["strategy_basis"]["structured_strategy_hints"]
+    assert hints == {
+        "path": ".agentic-workspace/verification/proof-strategy.toml",
+        "authority": "host-structured-config",
+        "limits": [
+            "Only structured enum fields are interpreted.",
+            "Free-text host strategy prose remains uninterpreted.",
+        ],
+        "status": "absent",
+        "hints": {},
+        "invalid_fields": [],
+    }
+
+
+def test_verification_evidence_strategy_reports_invalid_structured_strategy_hints(tmp_path: Path) -> None:
+    strategy_path = tmp_path / ".agentic-workspace" / "verification" / "proof-strategy.toml"
+    strategy_path.parent.mkdir(parents=True)
+    strategy_path.write_text(
+        """
+[proof_strategy]
+ordinary_test_growth = "always-add"
+preferred_owner_vocab = ["invented-owner"]
+proof_intent_vocab = ["coverage-quota"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=[], task_text="")
+
+    basis = payload["evidence_strategy"]["strategy_basis"]
+    assert basis["declared_strategy_state"] == "not-declared"
+    assert basis["strategy_confidence"] == "unclear"
+    assert basis["structured_strategy_hints"]["status"] == "invalid"
+    assert set(basis["structured_strategy_hints"]["invalid_fields"]) == {
+        "ordinary_test_growth",
+        "preferred_owner_vocab",
+        "proof_intent_vocab",
+    }
+
+
 def test_verification_evidence_strategy_classifies_changed_test_fixture_variants(tmp_path: Path) -> None:
     strategy_doc = tmp_path / "docs" / "maintainer" / "testing-strategy.md"
     strategy_doc.parent.mkdir(parents=True)

--- a/packages/verification/tests/test_runtime_primitives.py
+++ b/packages/verification/tests/test_runtime_primitives.py
@@ -280,6 +280,46 @@ def test_verification_evidence_strategy_reports_absent_structured_strategy_hints
     }
 
 
+def test_verification_evidence_strategy_reports_partial_structured_strategy_hints(tmp_path: Path) -> None:
+    strategy_path = tmp_path / ".agentic-workspace" / "verification" / "proof-strategy.toml"
+    strategy_path.parent.mkdir(parents=True)
+    strategy_path.write_text(
+        """
+[proof_strategy]
+ordinary_test_growth = "discouraged"
+preferred_owner_vocab = ["verification-evidence"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=[], task_text="")
+
+    basis = payload["evidence_strategy"]["strategy_basis"]
+    assert basis["declared_strategy_state"] == "partially-declared"
+    assert basis["strategy_confidence"] == "low"
+    assert basis["structured_strategy_hints"]["status"] == "present"
+    assert basis["structured_strategy_hints"]["hints"]["strategy_source"] == ""
+
+
+def test_verification_evidence_strategy_reports_source_only_strategy_hints_as_partial(tmp_path: Path) -> None:
+    strategy_path = tmp_path / ".agentic-workspace" / "verification" / "proof-strategy.toml"
+    strategy_path.parent.mkdir(parents=True)
+    strategy_path.write_text(
+        """
+[proof_strategy]
+strategy_source = "docs/maintainer/testing-strategy.md"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=[], task_text="")
+
+    basis = payload["evidence_strategy"]["strategy_basis"]
+    assert basis["declared_strategy_state"] == "partially-declared"
+    assert basis["strategy_confidence"] == "low"
+    assert basis["structured_strategy_hints"]["hints"]["ordinary_test_growth"] == "unknown"
+
+
 def test_verification_evidence_strategy_reports_invalid_structured_strategy_hints(tmp_path: Path) -> None:
     strategy_path = tmp_path / ".agentic-workspace" / "verification" / "proof-strategy.toml"
     strategy_path.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- add optional .agentic-workspace/verification/proof-strategy.toml structured enum hints
- surface hints under evidence_strategy.strategy_basis without interpreting prose
- document the host-neutral boundary and add runtime tests for present, absent, and invalid hints

## Proof
- uv run pytest packages/verification/tests/test_runtime_primitives.py -q
- uv run ruff check packages/verification/src packages/verification/tests
- make maintainer-surfaces
- git diff --check

Closes #1546

Stacked on #1551.