### PR TITLE
Track temporary Verification proof decisions

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -136,6 +136,24 @@ does not create or complete the decision.
 }
 ```
 
+Proof decisions may also include optional lifecycle fields for temporary or
+replaceable evidence:
+
+```json
+{
+  "retention_until": "2026-07-01",
+  "stale_when": ["packages/verification/src/**"],
+  "replacement_owner": "conformance-contract",
+  "review_trigger": "Review before retiring the temporary proof."
+}
+```
+
+Verification reports these fields under `evidence_strategy.proof_decision.lifecycle`.
+`permanent` evidence reports `state: "permanent"`. `temporary` and `replaceable`
+evidence can report `current`, `stale`, `expired`, or `invalid` based only on the
+explicit date and changed-path glob fields. The lifecycle state is a prompt for
+agent review; it does not decide whether evidence is sufficient.
+
 Without host-owned structured strategy enums or configuration, dispositions remain
 `needs-human-strategy-choice`, owners remain `unknown`, and confidence stays low.
 The report does not delete tests, prove semantic equivalence, require a manifest

--- a/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
+++ b/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
@@ -361,7 +361,53 @@ def _proof_governance_payload(
     }
 
 
-def _proof_decision_payload(*, target_root: Path) -> dict[str, Any]:
+def _proof_decision_lifecycle(*, decision: dict[str, Any], changed_paths: list[str]) -> dict[str, Any]:
+    durability = str(decision.get("evidence_durability", "")).strip()
+    retention_until = str(decision.get("retention_until", "")).strip()
+    replacement_owner = str(decision.get("replacement_owner", "")).strip()
+    review_trigger = str(decision.get("review_trigger", "")).strip()
+    stale_when = [str(item).strip() for item in _list_payload(decision.get("stale_when")) if str(item).strip()]
+    stale_matches: list[str] = []
+    for path in _normalize_changed_paths(changed_paths):
+        for pattern in stale_when:
+            if fnmatch.fnmatch(path, pattern):
+                stale_matches.append(f"changed path matched {pattern}")
+    invalid_fields: list[str] = []
+    expired = False
+    if retention_until:
+        try:
+            expired = date.fromisoformat(retention_until) < date.today()
+        except ValueError:
+            invalid_fields.append("retention_until")
+    state = "unknown"
+    if durability == "permanent":
+        state = "permanent"
+    elif durability in {"temporary", "replaceable"}:
+        if invalid_fields:
+            state = "invalid"
+        elif expired:
+            state = "expired"
+        elif stale_matches:
+            state = "stale"
+        else:
+            state = "current"
+    return {
+        "state": state,
+        "retention_until": retention_until,
+        "stale_when": stale_when,
+        "stale_because": _dedupe(stale_matches),
+        "replacement_owner": replacement_owner,
+        "review_trigger": review_trigger,
+        "review_needed": state in {"expired", "stale", "invalid"},
+        "invalid_fields": invalid_fields,
+        "limits": [
+            "Lifecycle state is derived only from explicit proof-decision fields.",
+            "Verification does not decide whether temporary evidence remains sufficient.",
+        ],
+    }
+
+
+def _proof_decision_payload(*, target_root: Path, changed_paths: list[str]) -> dict[str, Any]:
     decision_path = target_root / PROOF_DECISION_PATH
     exists, payload, parse_error = _read_json_if_present(decision_path)
     base = {
@@ -381,6 +427,7 @@ def _proof_decision_payload(*, target_root: Path) -> dict[str, Any]:
             "missing_fields": PROOF_DECISION_REQUIRED_FIELDS,
             "invalid_fields": [],
             "decision": {},
+            "lifecycle": {},
         }
     if parse_error:
         return {
@@ -390,6 +437,7 @@ def _proof_decision_payload(*, target_root: Path) -> dict[str, Any]:
             "missing_fields": [],
             "invalid_fields": ["json"],
             "decision": {},
+            "lifecycle": {},
         }
     if not isinstance(payload, dict):
         return {
@@ -398,6 +446,7 @@ def _proof_decision_payload(*, target_root: Path) -> dict[str, Any]:
             "missing_fields": [],
             "invalid_fields": ["root"],
             "decision": {},
+            "lifecycle": {},
         }
     decision = payload.get("proof_decision", payload)
     if not isinstance(decision, dict):
@@ -407,6 +456,7 @@ def _proof_decision_payload(*, target_root: Path) -> dict[str, Any]:
             "missing_fields": [],
             "invalid_fields": ["proof_decision"],
             "decision": {},
+            "lifecycle": {},
         }
     missing_fields = [field for field in PROOF_DECISION_REQUIRED_FIELDS if not str(decision.get(field, "")).strip()]
     invalid_fields: list[str] = []
@@ -433,6 +483,8 @@ def _proof_decision_payload(*, target_root: Path) -> dict[str, Any]:
     confidence = str(decision.get("confidence", "")).strip()
     if confidence and confidence not in {"high", "medium", "low"}:
         invalid_fields.append("confidence")
+    lifecycle = _proof_decision_lifecycle(decision=decision, changed_paths=changed_paths)
+    invalid_fields.extend(field for field in lifecycle["invalid_fields"] if field not in invalid_fields)
     status = "present"
     if invalid_fields:
         status = "invalid"
@@ -444,6 +496,7 @@ def _proof_decision_payload(*, target_root: Path) -> dict[str, Any]:
         "missing_fields": missing_fields,
         "invalid_fields": invalid_fields,
         "decision": {field: decision.get(field, "") for field in PROOF_DECISION_REQUIRED_FIELDS},
+        "lifecycle": lifecycle,
     }
 
 
@@ -690,7 +743,7 @@ def _evidence_strategy_payload(
         task_text=task_text,
         manifest=manifest,
     )
-    proof_decision = _proof_decision_payload(target_root=target_root)
+    proof_decision = _proof_decision_payload(target_root=target_root, changed_paths=changed_paths)
     return {
         "kind": EVIDENCE_STRATEGY_KIND,
         "status": "attention" if candidate_sources or observed_signals else "unavailable",

--- a/packages/verification/tests/test_runtime_primitives.py
+++ b/packages/verification/tests/test_runtime_primitives.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
@@ -632,6 +633,135 @@ def test_verification_proof_decision_reports_complete_agent_authored_record(tmp_
     assert decision["missing_fields"] == []
     assert decision["invalid_fields"] == []
     assert decision["decision"]["selected_decision"] == "add"
+    assert decision["lifecycle"]["state"] == "permanent"
+    assert decision["lifecycle"]["review_needed"] is False
+
+
+def test_verification_proof_decision_reports_current_temporary_lifecycle(tmp_path: Path) -> None:
+    decision_path = tmp_path / ".agentic-workspace" / "verification" / "proof-decision.json"
+    decision_path.parent.mkdir(parents=True)
+    decision_path.write_text(
+        json.dumps(
+            {
+                "selected_decision": "record-manual-evidence",
+                "trust_question": "Does the temporary evidence cover the migration window?",
+                "host_strategy_source": "docs/verification.md",
+                "proof_owner": "verification-evidence",
+                "proof_intent": "temporary-characterization",
+                "evidence_durability": "temporary",
+                "narrowest_evidence": "Short-lived manual record.",
+                "prune_or_replacement_condition": "Replace when the contract proof lands.",
+                "confidence": "low",
+                "residual_risk": "Temporary evidence may go stale.",
+                "retention_until": (date.today() + timedelta(days=7)).isoformat(),
+                "stale_when": ["src/**"],
+                "replacement_owner": "conformance-contract",
+                "review_trigger": "Before retiring the temporary proof.",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=["docs/verification.md"], task_text="")
+
+    lifecycle = payload["evidence_strategy"]["proof_decision"]["lifecycle"]
+    assert lifecycle["state"] == "current"
+    assert lifecycle["review_needed"] is False
+    assert lifecycle["replacement_owner"] == "conformance-contract"
+    assert lifecycle["review_trigger"] == "Before retiring the temporary proof."
+
+
+def test_verification_proof_decision_reports_stale_replaceable_lifecycle(tmp_path: Path) -> None:
+    decision_path = tmp_path / ".agentic-workspace" / "verification" / "proof-decision.json"
+    decision_path.parent.mkdir(parents=True)
+    decision_path.write_text(
+        json.dumps(
+            {
+                "selected_decision": "add",
+                "trust_question": "Does replaceable evidence cover the current adapter shape?",
+                "host_strategy_source": "docs/verification.md",
+                "proof_owner": "verification-evidence",
+                "proof_intent": "temporary-characterization",
+                "evidence_durability": "replaceable",
+                "narrowest_evidence": "Focused runtime primitive test.",
+                "prune_or_replacement_condition": "Replace with protocol conformance.",
+                "confidence": "medium",
+                "residual_risk": "Adapter changes can stale it.",
+                "stale_when": ["packages/verification/src/**"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(
+        target_root=tmp_path,
+        changed_paths=["packages/verification/src/repo_verification_bootstrap/runtime_primitives.py"],
+        task_text="",
+    )
+
+    lifecycle = payload["evidence_strategy"]["proof_decision"]["lifecycle"]
+    assert lifecycle["state"] == "stale"
+    assert lifecycle["review_needed"] is True
+    assert lifecycle["stale_because"] == ["changed path matched packages/verification/src/**"]
+
+
+def test_verification_proof_decision_reports_expired_temporary_lifecycle(tmp_path: Path) -> None:
+    decision_path = tmp_path / ".agentic-workspace" / "verification" / "proof-decision.json"
+    decision_path.parent.mkdir(parents=True)
+    decision_path.write_text(
+        json.dumps(
+            {
+                "selected_decision": "record-manual-evidence",
+                "trust_question": "Was the temporary proof still inside its retention window?",
+                "host_strategy_source": "docs/verification.md",
+                "proof_owner": "verification-evidence",
+                "proof_intent": "temporary-characterization",
+                "evidence_durability": "temporary",
+                "narrowest_evidence": "Temporary review note.",
+                "prune_or_replacement_condition": "Expires after migration.",
+                "confidence": "low",
+                "residual_risk": "Expired evidence cannot support closeout alone.",
+                "retention_until": (date.today() - timedelta(days=1)).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=[], task_text="")
+
+    lifecycle = payload["evidence_strategy"]["proof_decision"]["lifecycle"]
+    assert lifecycle["state"] == "expired"
+    assert lifecycle["review_needed"] is True
+
+
+def test_verification_proof_decision_reports_invalid_lifecycle_date(tmp_path: Path) -> None:
+    decision_path = tmp_path / ".agentic-workspace" / "verification" / "proof-decision.json"
+    decision_path.parent.mkdir(parents=True)
+    decision_path.write_text(
+        json.dumps(
+            {
+                "selected_decision": "record-manual-evidence",
+                "trust_question": "Was the temporary proof date valid?",
+                "host_strategy_source": "docs/verification.md",
+                "proof_owner": "verification-evidence",
+                "proof_intent": "temporary-characterization",
+                "evidence_durability": "temporary",
+                "narrowest_evidence": "Temporary review note.",
+                "prune_or_replacement_condition": "Expires after migration.",
+                "confidence": "low",
+                "residual_risk": "Bad dates hide lifecycle state.",
+                "retention_until": "soon",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=[], task_text="")
+
+    decision = payload["evidence_strategy"]["proof_decision"]
+    assert decision["status"] == "invalid"
+    assert decision["lifecycle"]["state"] == "invalid"
+    assert decision["lifecycle"]["invalid_fields"] == ["retention_until"]
 
 
 def test_verification_proof_decision_reports_incomplete_record_without_inference(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add lifecycle reporting for temporary and replaceable proof decisions
- derive current, stale, expired, and invalid states only from explicit date/glob fields
- document optional lifecycle fields and add runtime coverage

## Proof
- uv run pytest packages/verification/tests/test_runtime_primitives.py -q
- uv run ruff check packages/verification/src packages/verification/tests
- make maintainer-surfaces
- git diff --check

Closes #1548

Stacked on #1552.