### PR TITLE
Surface Verification regression sprawl diagnostics

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -154,6 +154,15 @@ evidence can report `current`, `stale`, `expired`, or `invalid` based only on th
 explicit date and changed-path glob fields. The lifecycle state is a prompt for
 agent review; it does not decide whether evidence is sufficient.
 
+The `evidence_strategy.regression_sprawl` block reports ordinary-test growth and
+deletion signals for regression-prone work. It lists changed Python test files,
+deleted or missing changed test paths, AST test-function counts, likely
+same-prefix fixture-variant group counts, shallow generated-output assertion
+signals, and whether the optional proof-decision record is missing, incomplete,
+invalid, or present. These are review facts only. The block never classifies a
+test as redundant and never recommends deletion, merge, or conformance
+conversion.
+
 Without host-owned structured strategy enums or configuration, dispositions remain
 `needs-human-strategy-choice`, owners remain `unknown`, and confidence stays low.
 The report does not delete tests, prove semantic equivalence, require a manifest

--- a/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
+++ b/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
@@ -500,6 +500,65 @@ def _proof_decision_payload(*, target_root: Path, changed_paths: list[str]) -> d
     }
 
 
+def _is_python_test_path(path: str) -> bool:
+    candidate = Path(path)
+    return candidate.suffix == ".py" and candidate.name.startswith("test_")
+
+
+def _regression_sprawl_payload(
+    *,
+    target_root: Path,
+    changed_paths: list[str],
+    test_functions: list[dict[str, Any]],
+    group_entries: list[dict[str, Any]],
+    proof_decision: dict[str, Any],
+) -> dict[str, Any]:
+    normalized_changed = _normalize_changed_paths(changed_paths)
+    changed_test_paths = [path for path in normalized_changed if _is_python_test_path(path)]
+    deleted_or_missing_test_paths = [
+        path for path in changed_test_paths if not ((Path(path) if Path(path).is_absolute() else target_root / Path(path)).exists())
+    ]
+    generated_output_assertions = [
+        {
+            "id": f"{function['path']}::{function['name']}",
+            "path": function["path"],
+            "matched_fragments": [
+                fragment
+                for fragment in function.get("assertion_fragments", [])
+                if any(token in str(fragment).lower() for token in ("stdout", "stderr", "output", "contains"))
+            ],
+        }
+        for function in test_functions
+    ]
+    generated_output_assertions = [item for item in generated_output_assertions if item["matched_fragments"]]
+    proof_status = str(proof_decision.get("status", "missing"))
+    decision_gap = proof_status in {"missing", "incomplete", "invalid"}
+    return {
+        "kind": "agentic-workspace/verification-regression-sprawl/v1",
+        "status": "attention" if changed_test_paths or decision_gap else "unavailable",
+        "authority": "diagnostic-facts",
+        "test_files_touched": changed_test_paths,
+        "deleted_or_missing_test_files": deleted_or_missing_test_paths,
+        "ordinary_test_function_count": len(test_functions),
+        "likely_fixture_variant_group_count": len(group_entries),
+        "generated_output_assertion_count": len(generated_output_assertions),
+        "generated_output_assertions": generated_output_assertions,
+        "proof_decision_status": proof_status,
+        "missing_or_incomplete_proof_decision": decision_gap,
+        "review_questions": [
+            "Is this evidence preserving a durable behavior class or an incident-specific regression record?",
+            "Can repeated fixtures become a scenario matrix without losing labels or historical facts?",
+            "Should generated output assertions move to a named contract or remain local executable proof?",
+            "What proof-decision record explains any ordinary test growth or deletion?",
+        ],
+        "limits": [
+            "No test is classified as redundant.",
+            "No deletion, merge, or conformance conversion is recommended by this diagnostic.",
+            "Generated-output assertion detection is a shallow AST substring signal.",
+        ],
+    }
+
+
 def _structured_strategy_hints_payload(*, target_root: Path) -> dict[str, Any]:
     strategy_path = target_root / PROOF_STRATEGY_PATH
     base = {
@@ -744,6 +803,13 @@ def _evidence_strategy_payload(
         manifest=manifest,
     )
     proof_decision = _proof_decision_payload(target_root=target_root, changed_paths=changed_paths)
+    regression_sprawl = _regression_sprawl_payload(
+        target_root=target_root,
+        changed_paths=changed_paths,
+        test_functions=test_functions,
+        group_entries=group_entries,
+        proof_decision=proof_decision,
+    )
     return {
         "kind": EVIDENCE_STRATEGY_KIND,
         "status": "attention" if candidate_sources or observed_signals else "unavailable",
@@ -784,6 +850,7 @@ def _evidence_strategy_payload(
         },
         "proof_governance": proof_governance,
         "proof_decision": proof_decision,
+        "regression_sprawl": regression_sprawl,
         "summary": {
             "candidate_count": len(evidence_items),
             "high_confidence_merge_count": sum(1 for group in group_entries if group["confidence"] == "high"),

--- a/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
+++ b/packages/verification/src/repo_verification_bootstrap/runtime_primitives.py
@@ -533,9 +533,12 @@ def _regression_sprawl_payload(
     generated_output_assertions = [item for item in generated_output_assertions if item["matched_fragments"]]
     proof_status = str(proof_decision.get("status", "missing"))
     decision_gap = proof_status in {"missing", "incomplete", "invalid"}
+    has_sprawl_context = bool(
+        changed_test_paths or deleted_or_missing_test_paths or test_functions or group_entries or generated_output_assertions
+    )
     return {
         "kind": "agentic-workspace/verification-regression-sprawl/v1",
-        "status": "attention" if changed_test_paths or decision_gap else "unavailable",
+        "status": "attention" if has_sprawl_context else "unavailable",
         "authority": "diagnostic-facts",
         "test_files_touched": changed_test_paths,
         "deleted_or_missing_test_files": deleted_or_missing_test_paths,
@@ -544,7 +547,7 @@ def _regression_sprawl_payload(
         "generated_output_assertion_count": len(generated_output_assertions),
         "generated_output_assertions": generated_output_assertions,
         "proof_decision_status": proof_status,
-        "missing_or_incomplete_proof_decision": decision_gap,
+        "missing_or_incomplete_proof_decision": decision_gap if has_sprawl_context else False,
         "review_questions": [
             "Is this evidence preserving a durable behavior class or an incident-specific regression record?",
             "Can repeated fixtures become a scenario matrix without losing labels or historical facts?",

--- a/packages/verification/tests/test_runtime_primitives.py
+++ b/packages/verification/tests/test_runtime_primitives.py
@@ -639,6 +639,16 @@ def test_command_output_payload_case_windows():
     assert "No deletion, merge, or conformance conversion is recommended by this diagnostic." in sprawl["limits"]
 
 
+def test_verification_regression_sprawl_ignores_missing_decision_without_sprawl_context(tmp_path: Path) -> None:
+    payload = verification_report_payload(target_root=tmp_path, changed_paths=["src/widget.py"], task_text="")
+
+    sprawl = payload["evidence_strategy"]["regression_sprawl"]
+    assert sprawl["status"] == "unavailable"
+    assert sprawl["test_files_touched"] == []
+    assert sprawl["proof_decision_status"] == "missing"
+    assert sprawl["missing_or_incomplete_proof_decision"] is False
+
+
 def test_verification_regression_sprawl_reports_deleted_or_missing_test_paths(tmp_path: Path) -> None:
     payload = verification_report_payload(
         target_root=tmp_path,

--- a/packages/verification/tests/test_runtime_primitives.py
+++ b/packages/verification/tests/test_runtime_primitives.py
@@ -602,6 +602,88 @@ def test_widget_case_regression_windows():
     assert {item["proof_owner"] for item in strategy["evidence_items"]} == {"unknown"}
 
 
+def test_verification_regression_sprawl_reports_changed_test_facts(tmp_path: Path) -> None:
+    test_file = tmp_path / "tests" / "test_command_output.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        """
+def test_command_output_payload_case_posix():
+    result = {"stdout": "ok"}
+    assert result["stdout"] == "ok"
+
+
+def test_command_output_payload_case_windows():
+    result = {"stdout": "warn"}
+    assert "warn" in result["stdout"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(
+        target_root=tmp_path,
+        changed_paths=["tests/test_command_output.py"],
+        task_text="reduce regression sprawl",
+    )
+
+    sprawl = payload["evidence_strategy"]["regression_sprawl"]
+    assert sprawl["kind"] == "agentic-workspace/verification-regression-sprawl/v1"
+    assert sprawl["status"] == "attention"
+    assert sprawl["authority"] == "diagnostic-facts"
+    assert sprawl["test_files_touched"] == ["tests/test_command_output.py"]
+    assert sprawl["deleted_or_missing_test_files"] == []
+    assert sprawl["ordinary_test_function_count"] == 2
+    assert sprawl["likely_fixture_variant_group_count"] == 1
+    assert sprawl["generated_output_assertion_count"] == 2
+    assert sprawl["proof_decision_status"] == "missing"
+    assert sprawl["missing_or_incomplete_proof_decision"] is True
+    assert "No deletion, merge, or conformance conversion is recommended by this diagnostic." in sprawl["limits"]
+
+
+def test_verification_regression_sprawl_reports_deleted_or_missing_test_paths(tmp_path: Path) -> None:
+    payload = verification_report_payload(
+        target_root=tmp_path,
+        changed_paths=["tests/test_removed_regression.py"],
+        task_text="remove legacy regression",
+    )
+
+    sprawl = payload["evidence_strategy"]["regression_sprawl"]
+    assert sprawl["test_files_touched"] == ["tests/test_removed_regression.py"]
+    assert sprawl["deleted_or_missing_test_files"] == ["tests/test_removed_regression.py"]
+    assert sprawl["ordinary_test_function_count"] == 0
+
+
+def test_verification_regression_sprawl_reports_present_proof_decision(tmp_path: Path) -> None:
+    decision_path = tmp_path / ".agentic-workspace" / "verification" / "proof-decision.json"
+    decision_path.parent.mkdir(parents=True)
+    decision_path.write_text(
+        json.dumps(
+            {
+                "selected_decision": "prune",
+                "trust_question": "Is the removed legacy regression covered elsewhere?",
+                "host_strategy_source": "docs/verification.md",
+                "proof_owner": "verification-evidence",
+                "proof_intent": "migration-residue",
+                "evidence_durability": "permanent",
+                "narrowest_evidence": "A retained conformance-owned scenario.",
+                "prune_or_replacement_condition": "Equivalent coverage is recorded.",
+                "confidence": "medium",
+                "residual_risk": "Replacement evidence may still need human review.",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = verification_report_payload(
+        target_root=tmp_path,
+        changed_paths=["tests/test_removed_regression.py"],
+        task_text="remove legacy regression",
+    )
+
+    sprawl = payload["evidence_strategy"]["regression_sprawl"]
+    assert sprawl["proof_decision_status"] == "present"
+    assert sprawl["missing_or_incomplete_proof_decision"] is False
+
+
 def test_verification_proof_decision_reports_complete_agent_authored_record(tmp_path: Path) -> None:
     decision_path = tmp_path / ".agentic-workspace" / "verification" / "proof-decision.json"
     decision_path.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- add evidence_strategy.regression_sprawl as a diagnostic facts block
- report changed/deleted test paths, AST test counts, fixture-variant groups, generated-output assertion signals, and proof-decision gap status
- document that the diagnostic never recommends merge, delete, or conformance conversion

## Proof
- uv run pytest packages/verification/tests/test_runtime_primitives.py -q
- uv run ruff check packages/verification/src packages/verification/tests
- make maintainer-surfaces
- git diff --check

Closes #1547

Stacked on #1553.