### PR TITLE
Surface Verification proof governance in root views

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1535-proof-governance.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1535-proof-governance.plan.json
@@ -26,9 +26,9 @@
     "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
   },
   "canonical_core": {
-    "requested_outcome": "Finish #1535 by adding a host-neutral Verification proof-governance diagnostic to the existing evidence_strategy report.",
+    "requested_outcome": "Implement a bounded #1535 proof-governance diagnostic slice by adding a host-neutral Verification proof-governance diagnostic to the existing evidence_strategy report.",
     "hard_constraints": "Keep reasoning and disposition decisions agent-owned; Verification may surface facts, candidate enums, and questions but must not infer host strategy from prose or prescribe a testing policy.",
-    "agent_may_decide": "Exact JSON shape, field naming, tests, docs wording, and whether #1535 can honestly close after the diagnostic lands.",
+    "agent_may_decide": "Exact JSON shape, field naming, tests, docs wording, and whether this bounded slice is complete.",
     "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
     "next_action": "Add the proof_governance diagnostic to Verification report output, validate it with package tests, and update docs.",
     "proof_expectations": [
@@ -48,7 +48,7 @@
       "Tests cover host-neutral proof-governance questions for proposed test evidence and absent strategy.",
       "Docs explain that proof_governance is advisory fact/question surfacing, not a policy engine."
     ],
-    "continuation_owner": "none",
+    "continuation_owner": "broader #1535 lane",
     "closeout_decision": "archive-and-close"
   },
   "goal": [
@@ -61,16 +61,16 @@
   ],
   "machine_readable_contract": {
     "intent": {
-      "outcome": "Finish #1535 by adding a host-neutral Verification proof-governance diagnostic to the existing evidence_strategy report.",
+      "outcome": "Implement a bounded #1535 proof-governance diagnostic slice by adding a host-neutral Verification proof-governance diagnostic to the existing evidence_strategy report.",
       "constraints": "Keep reasoning and disposition decisions agent-owned; Verification may surface facts, candidate enums, and questions but must not infer host strategy from prose or prescribe a testing policy.",
-      "latitude": "Exact JSON shape, field naming, tests, docs wording, and whether #1535 can honestly close after the diagnostic lands.",
+      "latitude": "Exact JSON shape, field naming, tests, docs wording, and whether this bounded slice is complete.",
       "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
       "proof": "See proof_report.validation proof."
     },
     "execution": {
       "milestone": "issue-1535-proof-governance",
       "status": "completed",
-      "next_step": "none; #1535 is implemented by this slice.",
+      "next_step": "broader #1535 lane closure remains subject to separate review.",
       "proof": "See proof_report.validation proof."
     },
     "scope": {
@@ -98,7 +98,7 @@
   },
   "iterative_follow_through": {
     "what this slice enabled": "A report-level proof_governance block can let agents answer #1535's pre-test questions without adding a new root command or policy engine.",
-    "intentionally deferred": "none for #1535; future refinements should be new issues.",
+    "intentionally deferred": "broader #1535 lane closure remains subject to separate review.",
     "discovered implications": "none requiring continuation.",
     "proof achieved now": "yes; planning closeout recorded explicit proof input.",
     "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
@@ -197,8 +197,8 @@
     "scope touched": "Verification runtime report projection, Verification runtime tests, Verification docs, active planning record.",
     "changed surfaces": "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py; packages/verification/tests/test_runtime_primitives.py; docs/verification.md; .agentic-workspace/planning/execplans/issue-1535-proof-governance.plan.json; .agentic-workspace/planning/state.toml",
     "validations run": "See proof_report.validation proof.",
-    "result for continuation": "none; #1535 is implemented by this slice.",
-    "next step": "open PR and close #1535 on merge."
+    "result for continuation": "broader #1535 lane closure remains subject to separate review.",
+    "next step": "open PR for this bounded slice; do not close the broader #1535 lane from this record alone."
   },
   "finished_run_review": {
     "review status": "complete",
@@ -260,7 +260,7 @@
     "slice status": "completed",
     "larger-intent status": "closed",
     "closure decision": "archive-and-close",
-    "why this decision is honest": "The remaining open #1535 issue asked for Verification support for sustainable testing strategies. This slice adds the pre-test proof-governance diagnostic, decision vocabulary, agent-owned decision template, tests, docs, and full selected proof.",
+    "why this decision is honest": "The #1535 lane asked for Verification support for sustainable testing strategies. This bounded slice adds the pre-test proof-governance diagnostic, decision vocabulary, agent-owned decision template, tests, docs, and selected proof without claiming broader lane closure.",
     "evidence carried forward": "See proof_report.validation proof.",
     "reopen trigger": "Open a new issue if a future host needs structured strategy configuration, enforcement, budgets, or root command surfaces."
   },
@@ -317,49 +317,37 @@
     "status": "allowed",
     "active_intent_satisfied": true,
     "human_accepted_partial": false,
-    "claim_level_requested": "full_intent_complete",
-    "claim_level_allowed": "full_intent_complete",
+    "claim_level_requested": "slice_complete",
+    "claim_level_allowed": "slice_complete",
     "required_next_action": "none",
     "claim_authorization": {
       "kind": "agentic-workspace/claim-authorization/v1",
       "allowed_claim_classes": [
         "partial_progress",
-        "slice_complete",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
         "parent_complete",
         "full_intent_complete",
         "issue_closure"
       ],
-      "blocked_claim_classes": [],
-      "closure_actions": [
-        {
-          "kind": "issue_closure",
-          "target": "#1535",
-          "authorized": true,
-          "reason": "archive-and-close was authorized after the completion gate marked issue #1535 complete"
-        },
-        {
-          "kind": "issue_closure",
-          "target": "#1535",
-          "authorized": true,
-          "reason": "close-issue-on-pr-merge was authorized by the PR closure path"
-        }
-      ],
-      "renderer_rule": "Renderers may claim #1535 implemented when citing this proof and the PR closure path.",
+      "closure_actions": [],
+      "renderer_rule": "Renderers may claim only this bounded #1535 proof-governance slice complete when citing this proof; broader lane or issue closure requires separate review.",
       "diagnostics": {
         "unsafe_claim_examples": [],
         "diagnostic_only": true
       }
     },
-    "residual_intent": "none",
+    "residual_intent": "Broader #1535 lane closure remains subject to separate review.",
     "self_review": {
       "question": "Does the delivered work satisfy the active human intent?",
       "answer": "yes",
-      "reason": "The remaining #1535 issue is implemented by the proof_governance diagnostic, tests, docs, and proof."
+      "reason": "This bounded #1535 proof-governance slice is implemented by the proof_governance diagnostic, tests, docs, and proof."
     },
     "continuation": {
-      "owner_surface": "none",
-      "created_or_required": false,
-      "reason": "none"
+      "owner_surface": "broader #1535 lane",
+      "created_or_required": true,
+      "reason": "This archived record does not authorize parent-lane or issue closure."
     },
     "authority_boundary": {
       "aw_owns": [
@@ -383,6 +371,6 @@
     "status": "generated",
     "source": "archive-plan --prepare-closeout",
     "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
-    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement the remaining open issue #1535 after #1542 merged.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest packages/verification/tests/test_runtime_primitives.py -q -> 11 passed; uv run agentic-verification report --target . --changed packages/verification/tests/test_runtime_primitives.py --task 'Should I add a new regression test for issue 1535?' --format json -> proof_governance present with agent-owned unset decisions; make test-workspace -> passed in 101.40s; make lint-workspace -> passed; make maintainer-surfaces -> passed; summary passed; planning doctor exited 0 with existing module-residue warnings\nChanged surfaces: packages/verification/src/repo_verification_bootstrap/runtime_primitives.py; packages/verification/tests/test_runtime_primitives.py; docs/verification.md; .agentic-workspace/planning/execplans/issue-1535-proof-governance.plan.json; .agentic-workspace/planning/state.toml\nDurable residue: none\nMemory learning: none\nFollow-up: none\nCompletion gate: complete\nCompletion claim allowed: full-intent-complete"
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement a bounded #1535 proof-governance diagnostic slice after #1542 merged.\nIntent satisfied: yes for this bounded slice\nArchive decision: archive-and-close for this bounded slice only\nProof: uv run pytest packages/verification/tests/test_runtime_primitives.py -q -> 11 passed; uv run agentic-verification report --target . --changed packages/verification/tests/test_runtime_primitives.py --task 'Should I add a new regression test for issue 1535?' --format json -> proof_governance present with agent-owned unset decisions; make test-workspace -> passed in 101.40s; make lint-workspace -> passed; make maintainer-surfaces -> passed; summary passed; planning doctor exited 0 with existing module-residue warnings\nChanged surfaces: packages/verification/src/repo_verification_bootstrap/runtime_primitives.py; packages/verification/tests/test_runtime_primitives.py; docs/verification.md; .agentic-workspace/planning/execplans/issue-1535-proof-governance.plan.json; .agentic-workspace/planning/state.toml\nDurable residue: broader #1535 lane closure remains subject to separate review\nMemory learning: none\nFollow-up: broader #1535 lane closure remains subject to separate review\nCompletion gate: slice_complete\nCompletion claim allowed: slice_complete"
   }
 }

--- a/.agentic-workspace/planning/execplans/archive/issue-1535-proof-governance.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1535-proof-governance.plan.json
@@ -49,7 +49,7 @@
       "Docs explain that proof_governance is advisory fact/question surfacing, not a policy engine."
     ],
     "continuation_owner": "broader #1535 lane",
-    "closeout_decision": "archive-and-close"
+    "closeout_decision": "archive-but-keep-lane-open"
   },
   "goal": [
     "Implement #1535 by adding host-neutral Verification proof-governance diagnostics."
@@ -258,8 +258,8 @@
   "closure_check": {
     "closeout scope": "slice",
     "slice status": "completed",
-    "larger-intent status": "closed",
-    "closure decision": "archive-and-close",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
     "why this decision is honest": "The #1535 lane asked for Verification support for sustainable testing strategies. This bounded slice adds the pre-test proof-governance diagnostic, decision vocabulary, agent-owned decision template, tests, docs, and selected proof without claiming broader lane closure.",
     "evidence carried forward": "See proof_report.validation proof.",
     "reopen trigger": "Open a new issue if a future host needs structured strategy configuration, enforcement, budgets, or root command surfaces."
@@ -371,6 +371,6 @@
     "status": "generated",
     "source": "archive-plan --prepare-closeout",
     "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
-    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement a bounded #1535 proof-governance diagnostic slice after #1542 merged.\nIntent satisfied: yes for this bounded slice\nArchive decision: archive-and-close for this bounded slice only\nProof: uv run pytest packages/verification/tests/test_runtime_primitives.py -q -> 11 passed; uv run agentic-verification report --target . --changed packages/verification/tests/test_runtime_primitives.py --task 'Should I add a new regression test for issue 1535?' --format json -> proof_governance present with agent-owned unset decisions; make test-workspace -> passed in 101.40s; make lint-workspace -> passed; make maintainer-surfaces -> passed; summary passed; planning doctor exited 0 with existing module-residue warnings\nChanged surfaces: packages/verification/src/repo_verification_bootstrap/runtime_primitives.py; packages/verification/tests/test_runtime_primitives.py; docs/verification.md; .agentic-workspace/planning/execplans/issue-1535-proof-governance.plan.json; .agentic-workspace/planning/state.toml\nDurable residue: broader #1535 lane closure remains subject to separate review\nMemory learning: none\nFollow-up: broader #1535 lane closure remains subject to separate review\nCompletion gate: slice_complete\nCompletion claim allowed: slice_complete"
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Implement a bounded #1535 proof-governance diagnostic slice after #1542 merged.\nIntent satisfied: yes for this bounded slice\nArchive decision: archive-but-keep-lane-open\nProof: uv run pytest packages/verification/tests/test_runtime_primitives.py -q -> 11 passed; uv run agentic-verification report --target . --changed packages/verification/tests/test_runtime_primitives.py --task 'Should I add a new regression test for issue 1535?' --format json -> proof_governance present with agent-owned unset decisions; make test-workspace -> passed in 101.40s; make lint-workspace -> passed; make maintainer-surfaces -> passed; summary passed; planning doctor exited 0 with existing module-residue warnings\nChanged surfaces: packages/verification/src/repo_verification_bootstrap/runtime_primitives.py; packages/verification/tests/test_runtime_primitives.py; docs/verification.md; .agentic-workspace/planning/execplans/issue-1535-proof-governance.plan.json; .agentic-workspace/planning/state.toml\nDurable residue: broader #1535 lane closure remains subject to separate review\nMemory learning: none\nFollow-up: broader #1535 lane closure remains subject to separate review\nCompletion gate: slice_complete\nCompletion claim allowed: slice_complete"
   }
 }

--- a/.agentic-workspace/planning/execplans/archive/issue-1535-proof-governance.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1535-proof-governance.plan.json
@@ -314,11 +314,11 @@
   },
   "completion_gate": {
     "kind": "agentic-workspace/completion-gate/v1",
-    "status": "complete",
+    "status": "allowed",
     "active_intent_satisfied": true,
     "human_accepted_partial": false,
-    "claim_level_requested": "full-intent-complete",
-    "claim_level_allowed": "full-intent-complete",
+    "claim_level_requested": "full_intent_complete",
+    "claim_level_allowed": "full_intent_complete",
     "required_next_action": "none",
     "claim_authorization": {
       "kind": "agentic-workspace/claim-authorization/v1",
@@ -331,8 +331,18 @@
       ],
       "blocked_claim_classes": [],
       "closure_actions": [
-        "archive-and-close",
-        "close-issue-on-pr-merge"
+        {
+          "kind": "issue_closure",
+          "target": "#1535",
+          "authorized": true,
+          "reason": "archive-and-close was authorized after the completion gate marked issue #1535 complete"
+        },
+        {
+          "kind": "issue_closure",
+          "target": "#1535",
+          "authorized": true,
+          "reason": "close-issue-on-pr-merge was authorized by the PR closure path"
+        }
       ],
       "renderer_rule": "Renderers may claim #1535 implemented when citing this proof and the PR closure path.",
       "diagnostics": {

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -163,6 +163,12 @@ invalid, or present. These are review facts only. The block never classifies a
 test as redundant and never recommends deletion, merge, or conformance
 conversion.
 
+Root workspace surfaces expose the same Verification report under
+`agentic-workspace report --section verification --format json` and
+`agentic-workspace implement --select verification --format json`. Agents should
+use the proof-governance, proof-decision, lifecycle, and regression-sprawl fields
+as closeout inputs when ordinary tests are added, merged, moved, or removed.
+
 Without host-owned structured strategy enums or configuration, dispositions remain
 `needs-human-strategy-choice`, owners remain `unknown`, and confidence stays low.
 The report does not delete tests, prove semantic equivalence, require a manifest

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -1446,6 +1446,14 @@ def _compact_verification(value: Any) -> dict[str, Any]:
     active = active if isinstance(active, list) else []
     evidence_status = value.get("evidence_status", [])
     evidence_status = evidence_status if isinstance(evidence_status, list) else []
+    evidence_strategy = value.get("evidence_strategy", {})
+    evidence_strategy = evidence_strategy if isinstance(evidence_strategy, dict) else {}
+    proof_governance = evidence_strategy.get("proof_governance", {})
+    proof_governance = proof_governance if isinstance(proof_governance, dict) else {}
+    proof_decision = evidence_strategy.get("proof_decision", {})
+    proof_decision = proof_decision if isinstance(proof_decision, dict) else {}
+    regression_sprawl = evidence_strategy.get("regression_sprawl", {})
+    regression_sprawl = regression_sprawl if isinstance(regression_sprawl, dict) else {}
     return {
         "kind": value.get("kind", "agentic-workspace/verification/v1"),
         "status": value.get("status", "absent"),
@@ -1470,6 +1478,24 @@ def _compact_verification(value: Any) -> dict[str, Any]:
             for item in evidence_status[:3]
             if isinstance(item, dict)
         ],
+        "proof_governance": {
+            "status": proof_governance.get("status", "unavailable"),
+            "decision_authority": proof_governance.get("decision_authority", "agent"),
+            "available_decisions": proof_governance.get("available_decisions", []),
+        },
+        "proof_decision": {
+            "status": proof_decision.get("status", "missing"),
+            "missing_fields": proof_decision.get("missing_fields", []),
+            "invalid_fields": proof_decision.get("invalid_fields", []),
+            "lifecycle": proof_decision.get("lifecycle", {}),
+        },
+        "regression_sprawl": {
+            "status": regression_sprawl.get("status", "unavailable"),
+            "proof_decision_status": regression_sprawl.get("proof_decision_status", "missing"),
+            "missing_or_incomplete_proof_decision": regression_sprawl.get("missing_or_incomplete_proof_decision", False),
+            "ordinary_test_function_count": regression_sprawl.get("ordinary_test_function_count", 0),
+            "likely_fixture_variant_group_count": regression_sprawl.get("likely_fixture_variant_group_count", 0),
+        },
         "detail_command": "agentic-workspace report --target ./repo --section verification --format json",
     }
 

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -379,6 +379,57 @@ authority_refs = ["docs/compliance/privacy.md"]
     assert "does not decide the user's semantic intent" in verification["authority_boundary"]["reporting_rule"]
 
 
+def test_implement_verification_surfaces_proof_governance_and_decision_status(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "verification" / "proof-decision.json",
+        json.dumps(
+            {
+                "selected_decision": "prune",
+                "trust_question": "Is the deleted regression knowledge preserved elsewhere?",
+                "host_strategy_source": "docs/verification.md",
+                "proof_owner": "verification-evidence",
+                "proof_intent": "migration-residue",
+                "evidence_durability": "temporary",
+                "narrowest_evidence": "A retained conformance-owned scenario.",
+                "prune_or_replacement_condition": "Equivalent coverage remains documented.",
+                "confidence": "medium",
+                "residual_risk": "Closeout still needs the agent's judgment.",
+                "stale_when": ["tests/**"],
+            }
+        ),
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "tests/test_removed_regression.py",
+                "--task",
+                "Remove legacy regression test",
+                "--select",
+                "verification",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    verification = json.loads(capsys.readouterr().out)["values"]["verification"]
+    strategy = verification["evidence_strategy"]
+    assert strategy["proof_governance"]["decision_authority"] == "agent"
+    assert strategy["proof_decision"]["status"] == "present"
+    assert strategy["proof_decision"]["lifecycle"]["state"] == "stale"
+    assert strategy["regression_sprawl"]["proof_decision_status"] == "present"
+    assert strategy["regression_sprawl"]["missing_or_incomplete_proof_decision"] is False
+    assert strategy["regression_sprawl"]["deleted_or_missing_test_files"] == ["tests/test_removed_regression.py"]
+
+
 def test_implement_matches_non_code_assurance_requirement(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)


### PR DESCRIPTION
## Summary
- surface compact Verification proof governance, proof-decision, and regression-sprawl status in root verification projections
- add an implement --select verification regression test for proof governance and proof-decision closeout inputs
- document the root report/implement pass-through and normalize an archived #1535 plan record that was failing structured inventory validation

## Proof
- uv run pytest tests/test_workspace_implement_cli.py -q -k "verification"
- uv run pytest packages/verification/tests/test_runtime_primitives.py -q
- uv run pytest tests/test_structured_file_inventory.py::test_current_tracked_structured_files_are_classified -q
- make test-workspace
- make lint-workspace
- make maintainer-surfaces
- uv run python scripts/run_agentic_workspace.py summary --target . --format json
- uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json (exits 0; reports existing disabled-module residue warnings for memory and verification)
- git diff --check

Closes #1545

Stacked on #1554.