### PR TITLE
[codex] Add lane shaping startup gate

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1557-lane-shaping-gate.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1557-lane-shaping-gate.plan.json
@@ -1,0 +1,386 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Lane shaping prompt gate",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1557 so AW start surfaces a first-class lane-shaping prompt gate for broad unshaped work before implementation or slice promotion.",
+    "hard_constraints": "Use AW-owned structural/config enums and planning evidence only; do not encode GitHub-specific semantics or free-form keyword policy as authority.",
+    "agent_may_decide": "Runtime helper shape, compact projection details, focused regression coverage, and dogfood evidence.",
+    "escalate_when": "The fix would make AW decide lane semantics, require a new tracker-specific model, or broaden into general Planning decomposition redesign.",
+    "next_action": "Validate the implemented lane-shaping gate and close out the bounded slice honestly.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_implement_cli.py -q -k \"lane_shaping or epic_work_with_multiple_roadmap_candidates\"",
+      "uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py",
+      "uv run python scripts/run_agentic_workspace.py start --task \"Implement #1557: require a lane-shaping prompt for broad unshaped work\" --select next_safe_action,immediate_next_allowed_action --format json"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_workspace_implement_cli.py",
+      ".agentic-workspace/planning/execplans/issue-1557-lane-shaping-gate.plan.json",
+      ".agentic-workspace/planning/state.toml"
+    ],
+    "completion_criteria": [
+      "Broad unshaped startup work routes to present-lane-shaping-prompt.",
+      "The gate blocks implementation and slice promotion until shaping is recorded.",
+      "The ready-to-forward prompt includes evidence and questions while leaving decisions to the agent/human.",
+      "Regression coverage proves the prompt is generic and not GitHub-specific."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Implement #1557 so AW start surfaces a first-class lane-shaping prompt gate for broad unshaped work before implementation or slice promotion."
+  ],
+  "non_goals": [
+    "Do not redesign Planning decomposition broadly.",
+    "Do not add tracker-specific lane semantics.",
+    "Do not make AW decide the lane answer; only surface evidence and questions."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1557 so AW start surfaces a first-class lane-shaping prompt gate for broad unshaped work before implementation or slice promotion.",
+      "constraints": "Use AW-owned structural/config enums and planning evidence only; do not encode GitHub-specific semantics or free-form keyword policy as authority.",
+      "latitude": "Runtime helper shape, compact projection details, focused regression coverage, and dogfood evidence.",
+      "escalation": "Escalate if the fix would make AW decide lane semantics, require a tracker-specific model, or broaden into general Planning decomposition redesign.",
+      "proof": "make test-workspace passed in 108.79s; make lint-workspace passed; dogfood start selector now returns present-lane-shaping-prompt with preserved prompt inputs"
+    },
+    "execution": {
+      "milestone": "issue-1557-lane-shaping-gate",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "make test-workspace passed in 108.79s; make lint-workspace passed; dogfood start selector now returns present-lane-shaping-prompt with preserved prompt inputs"
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_workspace_implement_cli.py",
+        ".agentic-workspace/planning/execplans/issue-1557-lane-shaping-gate.plan.json",
+        ".agentic-workspace/planning/state.toml"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "AW should halt broad unshaped work with the right shaping prompt before agents create slices or implement.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "Startup can surface a first-class lane-shaping prompt gate from broad/lane structural evidence.",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes",
+    "validation still needed": "Required proof commands and final dogfood output remain pending.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Create a new issue for the missing shaping gate and try it out while implementing.",
+    "inferred intended outcome": "Implement #1557 so broad unshaped AW work halts with a shaping prompt before implementation or slice promotion.",
+    "chosen concrete what": "Add lane-shaping gate payload and route startup next_safe_action to present-lane-shaping-prompt.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_implement_cli.py; .agentic-workspace/planning/execplans/issue-1557-lane-shaping-gate.plan.json; .agentic-workspace/planning/state.toml",
+    "max changed files": "4 planned files plus generated/cache updates only if a proof command requires them.",
+    "required validation commands": "Focused pytest, ruff, and dogfood start selector output.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue validating #1557 lane-shaping gate and close out the active plan honestly.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1557 so AW start surfaces a first-class lane-shaping prompt gate for broad unshaped work before implementation or slice promotion.",
+    "hard constraints": "Use AW-owned structural/config enums and planning evidence only; do not encode GitHub-specific semantics or free-form keyword policy as authority.",
+    "agent may decide locally": "Runtime helper shape, compact projection details, focused regression coverage, and dogfood evidence.",
+    "escalate when": "The fix would make AW decide lane semantics, require a new tracker-specific model, or broaden into general Planning decomposition redesign."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1557-lane-shaping-gate",
+    "status": "completed",
+    "scope": "Implement the startup lane-shaping gate and focused regression coverage for #1557.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run required validation and update closeout fields."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "tests/test_workspace_implement_cli.py",
+    ".agentic-workspace/planning/execplans/issue-1557-lane-shaping-gate.plan.json",
+    ".agentic-workspace/planning/state.toml"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_implement_cli.py -q -k \"lane_shaping or epic_work_with_multiple_roadmap_candidates\"",
+    "uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py",
+    "uv run python scripts/run_agentic_workspace.py start --task \"Implement #1557: require a lane-shaping prompt for broad unshaped work\" --select next_safe_action,immediate_next_allowed_action --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Broad unshaped startup work routes to present-lane-shaping-prompt.",
+    "The gate blocks implementation and slice promotion until shaping is recorded.",
+    "The ready-to-forward prompt includes evidence and questions while leaving decisions to the agent/human.",
+    "Regression coverage proves the prompt is generic and not GitHub-specific."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented a lane-shaping gate for startup routing, added focused regression coverage, and dogfooded #1557 before/after behavior.",
+    "scope touched": "workspace runtime startup routing, focused workspace CLI test, active planning owner fields",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_implement_cli.py; active planning state",
+    "validations run": "make test-workspace; make lint-workspace; focused pytest/ruff; dogfood start selector output",
+    "result for continuation": "ready for PR review",
+    "next step": "Open PR for #1557."
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "yes; implementation stayed within startup routing, tests, and active planning owner fields",
+    "proof status": "passed",
+    "intent served": "yes; broad unshaped startup work now routes to a shaping prompt before implementation or slice promotion",
+    "config compliance": "uses configured delegation target enums and planning/capability signals, not tracker-specific semantics",
+    "misinterpretation risk": "low; prompt explicitly leaves decisions to agent/human",
+    "follow-on decision": "none for this slice"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "make test-workspace passed in 108.79s; make lint-workspace passed; dogfood start selector now returns present-lane-shaping-prompt with preserved prompt inputs",
+    "proof achieved now": "yes",
+    "evidence for \"proof achieved\" state": "Focused regression covered broad unshaped start routing and generic prompt content; workspace test/lint proof passed."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create issue #1557 and implement a practical lane-shaping gate while dogfooding AW.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "Issue #1557 was created; startup now routes broad unshaped work to present-lane-shaping-prompt; make test-workspace and make lint-workspace passed.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Lane-shaping prompt gate implemented for startup routing.",
+    "validation confirmed": "make test-workspace and make lint-workspace passed",
+    "follow-on routed to": "none; bounded issue closed",
+    "post-work posterity capture": "active plan records proof and closeout",
+    "resume from": "no active continuation; review PR for #1557",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "none",
+    "proposed durable intent": "none yet",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "none"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "complete",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "The bounded #1557 intent is satisfied without claiming unrelated AW intent-satisfaction redesign work.",
+    "evidence carried forward": "make test-workspace; make lint-workspace; dogfood start selector output",
+    "reopen trigger": "A broad unshaped startup task with configured shaping support does not surface a ready shaping prompt before implementation or slice promotion."
+  },
+  "improvement_signal_review": {
+    "status": "signals_fixed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      "AW detected broad work but previously surfaced only candidate promotion instead of the intended shaping prompt."
+    ],
+    "signals fixed": [
+      "Added lane_shaping_gate and present-lane-shaping-prompt startup routing."
+    ],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "see routed signal owner"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "Added lane_shaping_gate and present-lane-shaping-prompt startup routing.",
+          "owner": "",
+          "source": "improvement_signal_review.signals fixed"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "none; bounded issue closed",
+          "owner": "none",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-16: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create issue #1557 and implement a practical lane-shaping gate while dogfooding AW.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: make test-workspace passed in 108.79s; make lint-workspace passed; dogfood start selector now returns present-lane-shaping-prompt with preserved prompt inputs\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_implement_cli.py; active planning state\nDurable residue: none (none)\nMemory learning: none\nFollow-up: none; bounded issue closed\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -18919,6 +18919,12 @@ def _lane_shaping_gate_payload(
         return {"kind": "agentic-workspace/lane-shaping-gate/v1", "status": "not-applicable", "reason": "scope signal is not lane or epic"}
 
     target = _configured_lane_shaping_target(config)
+    if target is None:
+        return {
+            "kind": "agentic-workspace/lane-shaping-gate/v1",
+            "status": "not-applicable",
+            "reason": "no configured manual external boundary-shaping target",
+        }
     candidate_ids = [str(item) for item in candidate_pressure.get("candidate_ids", []) if str(item).strip()]
     issue_refs = [str(item) for item in planning_safety_gate.get("issue_refs", []) if str(item).strip()]
     evidence = [
@@ -18927,8 +18933,7 @@ def _lane_shaping_gate_payload(
         f"candidate_count={candidate_pressure.get('candidate_count', 0)}",
         "active_planning_present=False",
     ]
-    if target:
-        evidence.append("manual_external_boundary_shaping_target=configured")
+    evidence.append("manual_external_boundary_shaping_target=configured")
     questions = [
         "What is the larger intended outcome, in host-repo terms?",
         "What evidence would show the larger intent is fully satisfied, not merely advanced?",
@@ -18967,19 +18972,14 @@ def _lane_shaping_gate_payload(
         "required_next_action": "present-lane-shaping-prompt",
         "implementation_allowed": False,
         "reason": "Broad unshaped lane work needs a shaping answer before implementation or slice promotion.",
-        "target": target
-        or {
-            "name": "human-or-strong-planner",
-            "target_kind": "human-or-configured-planner",
-            "execution_methods": ["manual"],
-        },
+        "target": target,
         "observed_evidence": evidence,
         "questions": questions,
         "candidate_ids": candidate_ids[:8],
         "external_refs": issue_refs[:8],
         "ready_to_forward_prompt": {
             "kind": "agentic-workspace/lane-shaping-prompt/v1",
-            "target": (target or {}).get("name", "human-or-strong-planner"),
+            "target": target["name"],
             "copy_paste": "\n".join(prompt_lines),
             "constraints": [
                 "Do not write implementation steps.",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -18483,6 +18483,8 @@ def _next_safe_action_packet(
     skill = ""
     if action == "ask-intent-discovery-question":
         skill = "workspace-intent-discovery"
+    elif action == "present-lane-shaping-prompt":
+        skill = "planning-decompose"
     elif action != "choose-smallest-workflow-shape" and isinstance(preferred_routes, list):
         for route in preferred_routes:
             if isinstance(route, dict) and route.get("skill"):
@@ -18507,11 +18509,19 @@ def _next_safe_action_packet(
         forbidden_actions.extend(["open raw planning files before compact summary", "claim completion"])
     if action == "ask-intent-discovery-question":
         forbidden_actions.extend(["begin implementation", "create planning artifact before clarified intent is captured"])
+    if action == "present-lane-shaping-prompt":
+        forbidden_actions.extend(
+            [
+                "begin implementation",
+                "promote or create a slice before lane shaping is recorded",
+            ]
+        )
     if "closeout" in action:
         forbidden_actions.append("claim completion before closeout trust is reconciled")
     if decision in {
         "active-execplan-required",
         "candidate-lane-promotion-required",
+        "lane-shaping-required",
         "lane-owner-artifact-required",
         "parent-decomposition-decision-required",
         "planning-escalation-required",
@@ -18569,6 +18579,8 @@ def _next_safe_action_packet(
         ],
         human_owned_decisions=["missing intent or acceptance boundary when next_safe_action asks for clarification"]
         if action == "ask-intent-discovery-question"
+        else ["lane intent, decomposition shape, and acceptable first slice"]
+        if action == "present-lane-shaping-prompt"
         else [],
         rule=(
             "next_safe_action may enforce forbidden actions and completion gates; otherwise it is structured guidance "
@@ -18863,10 +18875,192 @@ def _compact_task_posture_packet_projection(task_posture_packet: dict[str, Any])
     return compact
 
 
+def _configured_lane_shaping_target(config: WorkspaceConfig) -> dict[str, Any] | None:
+    for target in config.local_override.delegation_targets:
+        method_set = set(target.execution_methods)
+        capability_set = set(target.capability_classes) | set(target.safe_task_classes)
+        if "manual" in method_set and target.location in {"external", "either"} and "boundary-shaping" in capability_set:
+            return {
+                "name": target.name,
+                "target_kind": "manual-external",
+                "strength": target.strength,
+                "location": target.location,
+                "execution_methods": list(target.execution_methods),
+                "capability_classes": list(target.capability_classes),
+            }
+    return None
+
+
+def _lane_shaping_gate_payload(
+    *,
+    config: WorkspaceConfig,
+    planning_safety_gate: dict[str, Any],
+    delegation_decision: dict[str, Any],
+    task_text: str | None,
+    changed_paths: list[str],
+    cli_invoke: str,
+) -> dict[str, Any]:
+    if changed_paths:
+        return {
+            "kind": "agentic-workspace/lane-shaping-gate/v1",
+            "status": "not-applicable",
+            "reason": "changed paths already define a local proof surface",
+        }
+    if planning_safety_gate.get("gate_result") != "candidate-lane-promotion-required":
+        return {
+            "kind": "agentic-workspace/lane-shaping-gate/v1",
+            "status": "not-applicable",
+            "reason": "planning safety did not require candidate lane promotion",
+        }
+    route_evidence = delegation_decision.get("route_evidence", {}) if isinstance(delegation_decision, dict) else {}
+    candidate_pressure = planning_safety_gate.get("candidate_pressure", {}) if isinstance(planning_safety_gate, dict) else {}
+    scope_signal = str(route_evidence.get("scope_signal") or candidate_pressure.get("work_shape") or "unknown")
+    if scope_signal not in {"lane", "epic"}:
+        return {"kind": "agentic-workspace/lane-shaping-gate/v1", "status": "not-applicable", "reason": "scope signal is not lane or epic"}
+
+    target = _configured_lane_shaping_target(config)
+    candidate_ids = [str(item) for item in candidate_pressure.get("candidate_ids", []) if str(item).strip()]
+    issue_refs = [str(item) for item in planning_safety_gate.get("issue_refs", []) if str(item).strip()]
+    evidence = [
+        f"planning_gate={planning_safety_gate.get('gate_result')}",
+        f"scope_signal={scope_signal}",
+        f"candidate_count={candidate_pressure.get('candidate_count', 0)}",
+        "active_planning_present=False",
+    ]
+    if target:
+        evidence.append("manual_external_boundary_shaping_target=configured")
+    questions = [
+        "What is the larger intended outcome, in host-repo terms?",
+        "What evidence would show the larger intent is fully satisfied, not merely advanced?",
+        "Which bounded first slice is acceptable, and what must remain explicitly open?",
+        "Which proof owner should validate each retained or changed behavior?",
+        "What stop conditions should prevent implementation from continuing?",
+    ]
+    prompt_lines = [
+        "You are being consulted before implementation or slice promotion.",
+        "",
+        f"Task: {task_text.strip() if task_text else '(no task text supplied)'}",
+        "",
+        "AW observed a broad unshaped lane and no active planning owner.",
+        "Use the evidence below to shape the lane, but do not treat it as a decision.",
+        "",
+        "Observed evidence:",
+        *[f"- {item}" for item in evidence],
+    ]
+    if candidate_ids:
+        prompt_lines.extend(["", "Candidate planning refs:", *[f"- {item}" for item in candidate_ids[:8]]])
+    if issue_refs:
+        prompt_lines.extend(["", "External refs mentioned in task:", *[f"- {item}" for item in issue_refs[:8]]])
+    prompt_lines.extend(
+        [
+            "",
+            "Questions to answer:",
+            *[f"- {item}" for item in questions],
+            "",
+            "Return a compact shaping answer only. Leave final reasoning, implementation choices, and proof judgment to the coding agent and human operator.",
+        ]
+    )
+    return {
+        "kind": "agentic-workspace/lane-shaping-gate/v1",
+        "status": "required",
+        "gate_result": "lane-shaping-required",
+        "required_next_action": "present-lane-shaping-prompt",
+        "implementation_allowed": False,
+        "reason": "Broad unshaped lane work needs a shaping answer before implementation or slice promotion.",
+        "target": target
+        or {
+            "name": "human-or-strong-planner",
+            "target_kind": "human-or-configured-planner",
+            "execution_methods": ["manual"],
+        },
+        "observed_evidence": evidence,
+        "questions": questions,
+        "candidate_ids": candidate_ids[:8],
+        "external_refs": issue_refs[:8],
+        "ready_to_forward_prompt": {
+            "kind": "agentic-workspace/lane-shaping-prompt/v1",
+            "target": (target or {}).get("name", "human-or-strong-planner"),
+            "copy_paste": "\n".join(prompt_lines),
+            "constraints": [
+                "Do not write implementation steps.",
+                "Do not assume an external tracker defines AW lane semantics.",
+                "State uncertainty and choices explicitly.",
+                "Keep decisions available to the coding agent and human operator.",
+            ],
+            "return_to": "Paste the shaping answer back into the current agent session before promotion or implementation.",
+        },
+        "recording_options": [
+            _command_with_cli_invoke(
+                command="agentic-workspace planning new-plan --id <id> --title <title> --target . --activate --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "record an explicit bounded-slice exception that does not claim parent or lane closure",
+        ],
+        "authority_boundary": _authority_boundary_payload(
+            surface="lane_shaping_gate",
+            enforced_by_aw=["lane-shaping-required"],
+            observed_by_aw=evidence,
+            recommended_by_aw=["present-lane-shaping-prompt"],
+            agent_owned_decisions=[
+                "whether the shaping answer is sufficient",
+                "which lane or slice shape to record",
+                "which proof owner validates the chosen scope",
+            ],
+            human_owned_decisions=["larger intent, acceptable first slice, and stop conditions"],
+            rule="AW surfaces the shaping question and evidence; it does not decide the lane semantics.",
+        ),
+    }
+
+
+def _apply_lane_shaping_gate_to_start_payload(
+    *,
+    payload: dict[str, Any],
+    config: WorkspaceConfig,
+    planning_safety_gate: dict[str, Any],
+    task_text: str | None,
+    changed_paths: list[str],
+    startup_template: dict[str, Any],
+) -> None:
+    lane_gate = _lane_shaping_gate_payload(
+        config=config,
+        planning_safety_gate=planning_safety_gate,
+        delegation_decision=payload.get("delegation_decision", {}),
+        task_text=task_text,
+        changed_paths=changed_paths,
+        cli_invoke=config.cli_invoke,
+    )
+    if lane_gate.get("status") != "required":
+        return
+    payload["lane_shaping_gate"] = lane_gate
+    payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
+        surface="start",
+        decision="lane-shaping-required",
+        reason=str(lane_gate.get("reason", "")),
+        required_next_action="present-lane-shaping-prompt",
+        evidence_required=["captured lane shaping answer before implementation or slice promotion"],
+    )
+    payload["immediate_next_allowed_action"] = {
+        "action": "present-lane-shaping-prompt",
+        "summary": str(lane_gate.get("reason", "")),
+        "command": None,
+        "run": None,
+        "risk": "lane-shaping-required-before-implementation",
+        "required_inputs": ["larger intent", "acceptable first slice", "proof owner", "stop conditions"],
+        "next_proof": "record the shaping answer in Planning or an explicit bounded-slice exception before implementation",
+        "read_first": [],
+        "open_execplan_only_when": startup_template["open_execplan_only_when"],
+        "lane_shaping_prompt": lane_gate.get("ready_to_forward_prompt", {}),
+    }
+
+
 def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
     """Project startup context to the smallest schema-compatible first-contact answer."""
     immediate = copy.deepcopy(payload["immediate_next_allowed_action"])
-    if not immediate.get("command") and (not immediate.get("read_first")):
+    if (
+        immediate.get("action") not in {"ask-intent-discovery-question", "present-lane-shaping-prompt"}
+        and not immediate.get("command")
+        and (not immediate.get("read_first"))
+    ):
         immediate["required_inputs"] = []
         immediate["next_proof"] = "select proof after changed paths are known"
     skill_routing = payload.get("skill_routing", {})
@@ -18935,6 +19129,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "active_plan_reliance": payload.get("active_plan_reliance", {}),
         "workflow_sufficiency": payload.get("workflow_sufficiency"),
         **({"planning_safety_gate": payload["planning_safety_gate"]} if "planning_safety_gate" in payload else {}),
+        **({"lane_shaping_gate": payload["lane_shaping_gate"]} if "lane_shaping_gate" in payload else {}),
         "package_boundary": payload["package_boundary"],
         "authority_markers": payload["authority_markers"][:1],
         "immediate_next_allowed_action": immediate,
@@ -20083,6 +20278,14 @@ def _start_payload(
             "read_first": [planning_safety_gate["promotion_command"]],
             "open_execplan_only_when": startup_template["open_execplan_only_when"],
         }
+    _apply_lane_shaping_gate_to_start_payload(
+        payload=payload,
+        config=config,
+        planning_safety_gate=planning_safety_gate,
+        task_text=task_text,
+        changed_paths=_normalize_changed_paths(changed_paths),
+        startup_template=startup_template,
+    )
     cli_compatibility = startup_cli_compatibility
     if cli_compatibility["configured"]:
         payload["cli_compatibility"] = cli_compatibility
@@ -20926,6 +21129,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         "intent_discovery_dialogue",
         "vague_outcome_orientation",
         "intent_acknowledgement",
+        "lane_shaping_gate",
     ):
         if optional_key in payload:
             context[optional_key] = payload[optional_key]
@@ -21332,6 +21536,14 @@ def _start_tiny_payload_fast(
                 "read_first": [command],
                 "open_execplan_only_when": startup_template["open_execplan_only_when"],
             }
+    _apply_lane_shaping_gate_to_start_payload(
+        payload=payload,
+        config=config,
+        planning_safety_gate=planning_safety_gate,
+        task_text=task_text,
+        changed_paths=_normalize_changed_paths(changed_paths),
+        startup_template=startup_template,
+    )
     normalized_paths = _normalize_changed_paths(changed_paths)
     if normalized_paths and not active_planning_present:
         proof_command = str(

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1993,6 +1993,80 @@ candidates = [
     assert payload["context"]["workflow_sufficiency"]["sufficiency_result"] == "candidate-lane-promotion-required"
 
 
+def test_start_surfaces_lane_shaping_prompt_for_broad_unshaped_work(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "config.local.toml",
+        "\n".join(
+            [
+                "schema_version = 1",
+                "",
+                "[delegation]",
+                'mode = "auto"',
+                "",
+                "[safety]",
+                "safe_to_auto_run_commands = true",
+                "",
+                "[delegation_targets.chatgpt]",
+                'strength = "strong"',
+                'location = "external"',
+                'capability_classes = ["boundary-shaping", "reasoning-heavy", "mixed"]',
+                'safe_task_classes = ["boundary-shaping", "reasoning-heavy"]',
+                'execution_methods = ["manual"]',
+            ]
+        ),
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "lane-one", maturity = "candidate", status = "next", priority = "P1", title = "First broad lane", outcome = "Shape the first lane.", reason = "Open lane.", promotion_signal = "Promote before implementation.", suggested_first_slice = "Ask shaping questions." },
+  { id = "lane-two", maturity = "candidate", status = "next", priority = "P1", title = "Second broad lane", outcome = "Shape the second lane.", reason = "Open lane.", promotion_signal = "Promote before implementation.", suggested_first_slice = "Ask shaping questions." },
+]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Shape the workflow lane before implementation",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["next_safe_action"]["next_safe_action"] == "present-lane-shaping-prompt"
+    assert payload["next_safe_action"]["implementation_allowed"] is False
+    assert "begin implementation" in payload["next_safe_action"]["forbidden_actions"]
+    assert payload["action_signals"]["allowed_next_action"] == "present-lane-shaping-prompt"
+    assert payload["context"]["planning"]["workflow_sufficiency"]["sufficiency_result"] == "lane-shaping-required"
+    gate = payload["context"]["lane_shaping_gate"]
+    assert gate["status"] == "required"
+    assert gate["target"]["target_kind"] == "manual-external"
+    assert gate["target"]["name"] == "chatgpt"
+    assert gate["candidate_ids"] == ["lane-one", "lane-two"]
+    prompt = gate["ready_to_forward_prompt"]["copy_paste"]
+    assert "What is the larger intended outcome" in prompt
+    assert "External refs mentioned in task" not in prompt
+    assert "GitHub" not in prompt
+
+
 def test_implement_blocks_parent_lane_slice_without_lane_owner_artifact(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(tmp_path / "src" / "agentic_workspace" / "runtime.py", "VALUE = 1\n")

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2067,6 +2067,49 @@ candidates = [
     assert "GitHub" not in prompt
 
 
+def test_start_keeps_candidate_promotion_without_manual_external_shaping_target(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "lane-one", maturity = "candidate", status = "next", priority = "P1", title = "First broad lane", outcome = "Shape the first lane.", reason = "Open lane.", promotion_signal = "Promote before implementation.", suggested_first_slice = "Ask shaping questions." },
+  { id = "lane-two", maturity = "candidate", status = "next", priority = "P1", title = "Second broad lane", outcome = "Shape the second lane.", reason = "Open lane.", promotion_signal = "Promote before implementation.", suggested_first_slice = "Ask shaping questions." },
+]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Shape the workflow lane before implementation",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["next_safe_action"]["next_safe_action"] == "select-or-promote-candidate-lane"
+    assert payload["action_signals"]["allowed_next_action"] == "select-or-promote-candidate-lane"
+    assert payload["context"]["planning"]["workflow_sufficiency"]["sufficiency_result"] == "candidate-lane-promotion-required"
+    assert "lane_shaping_gate" not in payload["context"]
+
+
 def test_implement_blocks_parent_lane_slice_without_lane_owner_artifact(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(tmp_path / "src" / "agentic_workspace" / "runtime.py", "VALUE = 1\n")


### PR DESCRIPTION
## Summary

Closes #1557.

Adds a first-class startup lane-shaping gate for broad unshaped work. When AW has no active planning owner, sees lane/epic scope pressure, and finds configured boundary-shaping support, `start` now routes to `present-lane-shaping-prompt` instead of only `select-or-promote-candidate-lane`.

The prompt carries observed evidence and questions, but leaves lane semantics, slice choice, and proof judgment to the agent and human operator. It uses AW-owned structural/config signals rather than tracker-specific language or free-form keyword authority.

## Dogfood

Before the change, `start --task "Implement #1557..."` returned `select-or-promote-candidate-lane` as the primary next action.

After the change, the same startup route returns `present-lane-shaping-prompt`, blocks implementation/slice promotion, and includes a ready-to-forward prompt targeting the configured manual external boundary-shaping target.

## Validation

- `uv run pytest tests/test_workspace_implement_cli.py -q -k "lane_shaping or epic_work_with_multiple_roadmap_candidates"`
- `uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py`
- `uv run python scripts/run_agentic_workspace.py start --task "Implement #1557: require a lane-shaping prompt for broad unshaped work" --select next_safe_action,immediate_next_allowed_action --format json`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
