### PR TITLE
Project requirement grounding and delegation decisions

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1556-requirement-grounding-open-issues.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1556-requirement-grounding-open-issues.plan.json
@@ -83,21 +83,21 @@
   },
   "intent_continuity": {
     "larger intended outcome": "Make AW carry stated requirements, delegation contracts, and sustainable testing choices through cheap agent-facing projections.",
-    "this slice completes the larger intended outcome": "yes",
-    "continuation surface": "none"
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "#1556 remains open until the full requirement-grounded operating loop is implemented and accepted"
   },
   "required_continuation": {
-    "required follow-on for the larger intended outcome": "no",
-    "owner surface": "none",
-    "activation trigger": "none"
+    "required follow-on for the larger intended outcome": "Complete #1556 beyond projection fields: requirement source inventory, applicability recording, implementation decisions, verification evidence, known gaps, and closeout claims must operate as one coherent loop.",
+    "owner surface": "GitHub #1556",
+    "activation trigger": "Resume #1556 parent lane or owner requests full requirement-grounded operating-loop closure."
   },
   "iterative_follow_through": {
-    "what this slice enabled": "none yet",
-    "intentionally deferred": "none",
-    "discovered implications": "none yet",
+    "what this slice enabled": "report/proof/implement projections for requirement grounding, delegation packets, and test-sustainability checks",
+    "intentionally deferred": "full #1556 closure; this slice does not complete the coherent requirement-grounded operating loop",
+    "discovered implications": "projection fields alone are insufficient parent-lane closure evidence",
     "proof achieved now": "yes; planning closeout recorded explicit proof input.",
     "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
-    "next likely slice": "No required continuation remains for this archived slice."
+    "next likely slice": "Continue #1556 only when ready to complete the remaining operating-loop requirements."
   },
   "intent_interpretation": {
     "literal request": "Implement the open issues in order of priority.",
@@ -238,9 +238,9 @@
   },
   "intent_satisfaction": {
     "original intent": "Create a bounded plan for Requirement grounding, delegation packets, and test strategy checks.",
-    "was original intent fully satisfied?": "yes",
+    "was original intent fully satisfied?": "no",
     "evidence of intent satisfaction": "See proof_report.validation proof.",
-    "unsolved intent passed to": "none"
+    "unsolved intent passed to": "GitHub #1556"
   },
   "execution_summary": {
     "outcome delivered": "#1559 and #1560 are implemented; #1556 is materially advanced with an end-to-end implement projection but broader closeout/report/proof-loop integration may still need issue-owner judgment before closing the parent lane.",
@@ -271,7 +271,7 @@
   "closure_check": {
     "closeout scope": "slice",
     "slice status": "completed",
-    "larger-intent status": "closed",
+    "larger-intent status": "open-routed-to-#1556",
     "closure decision": "archive-and-close",
     "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
     "evidence carried forward": "See proof_report.validation proof.",
@@ -344,28 +344,29 @@
   "completion_gate": {
     "kind": "agentic-workspace/completion-gate/v1",
     "status": "allowed",
-    "active_intent_satisfied": true,
+    "active_intent_satisfied": false,
     "human_accepted_partial": false,
-    "claim_level_requested": "full-intent-complete",
-    "claim_level_allowed": "full-intent-complete",
+    "claim_level_requested": "slice-complete",
+    "claim_level_allowed": "slice-complete",
     "required_next_action": "close-complete",
     "claim_authorization": {
       "kind": "agentic-workspace/claim-authorization/v1",
       "allowed_claim_classes": [
         "partial_progress",
-        "slice_complete",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
         "lane_complete",
         "parent_complete",
         "full_intent_complete",
         "issue_closure"
       ],
-      "blocked_claim_classes": [],
       "closure_actions": [
         {
           "kind": "issue_closure",
           "target": "#1556",
-          "authorized": true,
-          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+          "authorized": false,
+          "reason": "#1556 requires full requirement-grounded operating-loop closure; this archived slice only delivered projections."
         },
         {
           "kind": "issue_closure",
@@ -386,16 +387,16 @@
         "diagnostic_only": true
       }
     },
-    "residual_intent": "",
+    "residual_intent": "#1556 remains open for coherent requirement-grounded operating-loop closure.",
     "self_review": {
       "question": "Does the delivered work satisfy the active human intent?",
-      "answer": "yes",
-      "reason": "Planning closeout evidence supports the requested completion claim."
+      "answer": "no for #1556 parent lane; yes only for this bounded slice",
+      "reason": "Planning closeout evidence supports only the bounded projection slice; #1556 parent closure remains blocked."
     },
     "continuation": {
-      "owner_surface": "",
-      "created_or_required": false,
-      "reason": ""
+      "owner_surface": "GitHub #1556",
+      "created_or_required": true,
+      "reason": "Projection fields are not sufficient parent-lane closure evidence."
     },
     "authority_boundary": {
       "aw_owns": [
@@ -419,6 +420,6 @@
     "status": "generated",
     "source": "archive-plan --prepare-closeout",
     "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
-    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Requirement grounding, delegation packets, and test strategy checks.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_implement_cli.py -q -k 'requirement_grounding or plan_delegation_packet or test_strategy_check' passed; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py passed; make test-workspace passed; make lint-workspace passed\nChanged surfaces: none yet; execution has not changed files\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded projection slice for requirement grounding, delegation packets, and test strategy checks.\nIntent satisfied: no for #1556 parent lane; yes only for this bounded slice.\nArchive decision: archive-and-close slice only\nProof: uv run pytest tests/test_workspace_implement_cli.py -q -k 'requirement_grounding or plan_delegation_packet or test_strategy_check' passed; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py passed; make test-workspace passed; make lint-workspace passed\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_implement_cli.py\nDurable residue: #1556 remains open for full operating-loop closure\nMemory learning: none\nFollow-up: continue #1556 when implementing the coherent requirement-grounded operating loop\nCompletion gate: slice-only\nCompletion claim allowed: slice-complete"
   }
 }

--- a/.agentic-workspace/planning/execplans/archive/issue-1556-requirement-grounding-open-issues.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1556-requirement-grounding-open-issues.plan.json
@@ -1,0 +1,424 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Requirement grounding, delegation packets, and test strategy checks",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement the open requirement-grounding lane issues by projecting requirement grounding, executable delegation packets, and test-sustainability checks from existing AW state.",
+    "hard_constraints": "Keep the first implementation host-neutral, diagnostic, and agent-decision-owned; do not encode tracker-specific semantics or let AW decide requirement applicability, delegation fit, or test strategy.",
+    "agent_may_decide": "Exact packet field names, compact-vs-full projection shape, and focused tests that prove the diagnostics are visible and selector-backed.",
+    "escalate_when": "The implementation requires new persistence schemas, external API coupling, or enforcement beyond advisory/diagnostic projection.",
+    "next_action": "Implement and validate the three projection packets in the workspace runtime.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_implement_cli.py -q -k \"requirement_grounding or plan_delegation_packet or test_strategy_check\"",
+      "uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py",
+      "make test-workspace",
+      "make lint-workspace"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_workspace_implement_cli.py",
+      ".agentic-workspace/planning/execplans/issue-1556-requirement-grounding-open-issues.plan.json",
+      ".agentic-workspace/planning/state.toml"
+    ],
+    "completion_criteria": [
+      "implement --changed exposes requirement_grounding with requirement refs, applicability, interpretation, design effects, verification refs, known gaps, and closeout claim boundaries",
+      "implement --changed exposes plan_delegation_packet with ready/missing-field states, handoff prompt, route, proof, acceptance, stop conditions, and return contract",
+      "implement --changed exposes test_strategy_check for changed test files with observed hotspot and scenario-matrix facts plus agent-owned disposition options"
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Requirement grounding, delegation packets, and test strategy checks."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Project requirement grounding, delegation packets, and test-sustainability checks from existing AW state.",
+      "constraints": "Diagnostics only; reasoning and final decisions remain agent-owned.",
+      "latitude": "Choose compact/full projection shape and focused tests.",
+      "escalation": "Escalate before adding enforcement, new root commands, or tracker-specific semantics.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1556-requirement-grounding-open-issues",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_workspace_implement_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Make AW carry stated requirements, delegation contracts, and sustainable testing choices through cheap agent-facing projections.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement the open issues in order of priority.",
+    "inferred intended outcome": "Advance #1556 first while implementing concrete support issues #1559 and #1560 that make requirement-grounded execution easier to follow.",
+    "chosen concrete what": "Add implement-projected requirement_grounding, plan_delegation_packet, and test_strategy_check packets with focused tests.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_implement_cli.py; this active execplan and planning state residue",
+    "max changed files": "4 expected, plus generated/cache residue only if AW commands require it.",
+    "required validation commands": "uv run pytest tests/test_workspace_implement_cli.py -q -k \"requirement_grounding or plan_delegation_packet or test_strategy_check\"; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py; make test-workspace; make lint-workspace",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement the three projection packets and prove they are usable from implement --changed.",
+    "hard constraints": "No enforcement, no new root command, no tracker-specific requirement semantics, no AW-owned final reasoning.",
+    "agent may decide locally": "Projection field names, compact summaries, and the tests needed to prove the behavior.",
+    "escalate when": "A correct implementation requires new persistence schema or policy enforcement."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "issue",
+      "target": "#1556",
+      "label": "requirement-grounded execution lane",
+      "role": "parent intent",
+      "locator": "external-intent"
+    },
+    {
+      "kind": "issue",
+      "target": "#1559",
+      "label": "plan-derived delegation packets",
+      "role": "concrete support issue",
+      "locator": "external-intent"
+    },
+    {
+      "kind": "issue",
+      "target": "#1560",
+      "label": "test-sustainability choice packet",
+      "role": "concrete support issue",
+      "locator": "external-intent"
+    }
+  ],
+  "active_milestone": {
+    "id": "issue-1556-requirement-grounding-open-issues",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "tests/test_workspace_implement_cli.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_implement_cli.py -q -k \"requirement_grounding or plan_delegation_packet or test_strategy_check\"",
+    "uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py",
+    "make test-workspace",
+    "make lint-workspace"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Requirement grounding, delegation packets, and test strategy checks is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added implement-projected requirement_grounding, plan_delegation_packet, and test_strategy_check packets; added focused tests; dogfooded the packets against this active plan.",
+    "scope touched": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_implement_cli.py; .agentic-workspace/planning state and active execplan residue",
+    "changed surfaces": "none yet; execution has not changed files",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Packets are diagnostic/advisory, host-neutral, selector-backed, and leave applicability, delegation route choice, testing disposition, and closeout wording to the agent.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_implement_cli.py -q -k 'requirement_grounding or plan_delegation_packet or test_strategy_check' passed; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py passed; make test-workspace passed; make lint-workspace passed",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Requirement grounding, delegation packets, and test strategy checks.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1559 and #1560 are implemented; #1556 is materially advanced with an end-to-end implement projection but broader closeout/report/proof-loop integration may still need issue-owner judgment before closing the parent lane.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": [
+        {
+          "summary": "requirement-grounded execution lane",
+          "owner": "issue",
+          "source": "#1556"
+        },
+        {
+          "summary": "plan-derived delegation packets",
+          "owner": "issue",
+          "source": "#1559"
+        },
+        {
+          "summary": "test-sustainability choice packet",
+          "owner": "issue",
+          "source": "#1560"
+        }
+      ]
+    }
+  },
+  "drift_log": [
+    "2026-06-16: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "blocked_claim_classes": [],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1556",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        },
+        {
+          "kind": "issue_closure",
+          "target": "#1559",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        },
+        {
+          "kind": "issue_closure",
+          "target": "#1560",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Requirement grounding, delegation packets, and test strategy checks.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_implement_cli.py -q -k 'requirement_grounding or plan_delegation_packet or test_strategy_check' passed; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py passed; make test-workspace passed; make lint-workspace passed\nChanged surfaces: none yet; execution has not changed files\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/issue-1556-requirement-grounding-open-issues.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1556-requirement-grounding-open-issues.plan.json
@@ -68,7 +68,7 @@
     "execution": {
       "milestone": "issue-1556-requirement-grounding-open-issues",
       "status": "completed",
-      "next_step": "No required continuation remains for this archived slice.",
+      "next_step": "Parent/lane continuation remains routed to GitHub #1556.",
       "proof": "See proof_report.validation proof."
     },
     "scope": {
@@ -178,7 +178,7 @@
     "optional_deps": "none"
   },
   "immediate_next_action": [
-    "No required continuation remains for this archived slice."
+    "Parent/lane continuation remains routed to GitHub #1556."
   ],
   "blockers": [
     "None."

--- a/.agentic-workspace/planning/execplans/archive/issue-comments-requirement-delegation-test-sustainability.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-comments-requirement-delegation-test-sustainability.plan.json
@@ -60,7 +60,7 @@
     "execution": {
       "milestone": "issue-comments-requirement-delegation-test-sustainability",
       "status": "completed",
-      "next_step": "No required continuation remains for this archived slice.",
+      "next_step": "Parent/lane continuation remains routed to GitHub #1556.",
       "proof": "See proof_report.validation proof."
     },
     "scope": {
@@ -84,11 +84,11 @@
   },
   "iterative_follow_through": {
     "what this slice enabled": "none yet",
-    "intentionally deferred": "none",
+    "intentionally deferred": "#1556 parent-lane closure remains routed to GitHub #1556.",
     "discovered implications": "none yet",
     "proof achieved now": "yes; planning closeout recorded explicit proof input.",
     "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
-    "next likely slice": "No required continuation remains for this archived slice."
+    "next likely slice": "Parent/lane continuation remains routed to GitHub #1556."
   },
   "intent_interpretation": {
     "literal request": "Incorporate issue comments for requirement grounding delegation and test sustainability",
@@ -147,7 +147,7 @@
     "optional_deps": "none"
   },
   "immediate_next_action": [
-    "No required continuation remains for this archived slice."
+    "Parent/lane continuation remains routed to GitHub #1556."
   ],
   "blockers": [
     "None."

--- a/.agentic-workspace/planning/execplans/archive/issue-comments-requirement-delegation-test-sustainability.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-comments-requirement-delegation-test-sustainability.plan.json
@@ -1,0 +1,355 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Incorporate issue comments for requirement grounding delegation and test sustainability",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for Incorporate issue comments for requirement grounding delegation and test sustainability.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Incorporate issue comments for requirement grounding delegation and test sustainability is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Incorporate issue comments for requirement grounding delegation and test sustainability."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Incorporate issue comments for requirement grounding delegation and test sustainability.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-comments-requirement-delegation-test-sustainability",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Incorporate issue comments for requirement grounding delegation and test sustainability.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Incorporate issue comments for requirement grounding delegation and test sustainability",
+    "inferred intended outcome": "Create a bounded plan for Incorporate issue comments for requirement grounding delegation and test sustainability.",
+    "chosen concrete what": "#1559 and #1560 appear fully implemented; #1556 is substantially implemented across report/proof/implement projections but should remain open unless the issue owner accepts that this satisfies the whole operating loop.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Incorporate issue comments for requirement grounding delegation and test sustainability.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-comments-requirement-delegation-test-sustainability",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Incorporate issue comments for requirement grounding delegation and test sustainability is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Incorporated issue comments on #1556, #1559, and #1560: added freshness/source metadata and missing-grounding state; separated delegation readiness from recommendation with planning revision and structured return contract; integrated test sustainability with Verification evidence surfaces and closeout visibility.",
+    "scope touched": "src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_implement_cli.py; .agentic-workspace planning active/archive residue",
+    "changed surfaces": "none yet; execution has not changed files",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "The implementation remains diagnostic and host-neutral: requirement applicability, delegation route choice, testing disposition, and final closeout claims remain agent/human-owned; AW surfaces current evidence and missing decisions.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_implement_cli.py -q -k 'requirement_grounding or plan_delegation_packet or test_strategy_check' passed; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py passed; make test-workspace passed; make lint-workspace passed",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Incorporate issue comments for requirement grounding delegation and test sustainability.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1559 and #1560 appear fully implemented; #1556 is substantially implemented across report/proof/implement projections but should remain open unless the issue owner accepts that this satisfies the whole operating loop.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-16: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Incorporate issue comments for requirement grounding delegation and test sustainability.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_implement_cli.py -q -k 'requirement_grounding or plan_delegation_packet or test_strategy_check' passed; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py passed; make test-workspace passed; make lint-workspace passed\nChanged surfaces: none yet; execution has not changed files\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/issue-comments-requirement-delegation-test-sustainability.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-comments-requirement-delegation-test-sustainability.plan.json
@@ -74,13 +74,13 @@
   },
   "intent_continuity": {
     "larger intended outcome": "Create a bounded plan for Incorporate issue comments for requirement grounding delegation and test sustainability.",
-    "this slice completes the larger intended outcome": "yes",
-    "continuation surface": "none"
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "#1556 remains open; this archive covers only PR comment reconciliation for #1559/#1560 and #1556 projection gaps"
   },
   "required_continuation": {
-    "required follow-on for the larger intended outcome": "no",
-    "owner surface": "none",
-    "activation trigger": "none"
+    "required follow-on for the larger intended outcome": "Complete #1556 as a coherent operating loop before claiming parent lane closure.",
+    "owner surface": "GitHub #1556",
+    "activation trigger": "Resume #1556 parent lane for full operating-loop closure."
   },
   "iterative_follow_through": {
     "what this slice enabled": "none yet",
@@ -203,9 +203,9 @@
   },
   "intent_satisfaction": {
     "original intent": "Create a bounded plan for Incorporate issue comments for requirement grounding delegation and test sustainability.",
-    "was original intent fully satisfied?": "yes",
+    "was original intent fully satisfied?": "no for #1556 parent lane; yes for PR comment reconciliation slice",
     "evidence of intent satisfaction": "See proof_report.validation proof.",
-    "unsolved intent passed to": "none"
+    "unsolved intent passed to": "GitHub #1556"
   },
   "execution_summary": {
     "outcome delivered": "#1559 and #1560 appear fully implemented; #1556 is substantially implemented across report/proof/implement projections but should remain open unless the issue owner accepts that this satisfies the whole operating loop.",
@@ -236,7 +236,7 @@
   "closure_check": {
     "closeout scope": "slice",
     "slice status": "completed",
-    "larger-intent status": "closed",
+    "larger-intent status": "open-routed-to-#1556",
     "closure decision": "archive-and-close",
     "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
     "evidence carried forward": "See proof_report.validation proof.",
@@ -293,21 +293,21 @@
   "completion_gate": {
     "kind": "agentic-workspace/completion-gate/v1",
     "status": "allowed",
-    "active_intent_satisfied": true,
+    "active_intent_satisfied": false,
     "human_accepted_partial": false,
-    "claim_level_requested": "full-intent-complete",
-    "claim_level_allowed": "full-intent-complete",
+    "claim_level_requested": "slice-complete",
+    "claim_level_allowed": "slice-complete",
     "required_next_action": "close-complete",
     "claim_authorization": {
       "kind": "agentic-workspace/claim-authorization/v1",
       "allowed_claim_classes": [
         "partial_progress",
-        "slice_complete",
-        "lane_complete",
-        "parent_complete",
-        "full_intent_complete"
+        "slice_complete"
       ],
       "blocked_claim_classes": [
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
         "issue_closure"
       ],
       "closure_actions": [],
@@ -317,16 +317,16 @@
         "diagnostic_only": true
       }
     },
-    "residual_intent": "",
+    "residual_intent": "#1556 remains open for full requirement-grounded operating-loop closure.",
     "self_review": {
       "question": "Does the delivered work satisfy the active human intent?",
-      "answer": "yes",
-      "reason": "Planning closeout evidence supports the requested completion claim."
+      "answer": "yes for this PR comment reconciliation slice; no for #1556 parent lane",
+      "reason": "Planning closeout evidence supports only the PR comment reconciliation slice; #1556 parent closure remains blocked."
     },
     "continuation": {
-      "owner_surface": "",
-      "created_or_required": false,
-      "reason": ""
+      "owner_surface": "GitHub #1556",
+      "created_or_required": true,
+      "reason": "PR comment reconciliation does not complete the parent requirement-grounded operating loop."
     },
     "authority_boundary": {
       "aw_owns": [
@@ -350,6 +350,6 @@
     "status": "generated",
     "source": "archive-plan --prepare-closeout",
     "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
-    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Incorporate issue comments for requirement grounding delegation and test sustainability.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_implement_cli.py -q -k 'requirement_grounding or plan_delegation_packet or test_strategy_check' passed; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py passed; make test-workspace passed; make lint-workspace passed\nChanged surfaces: none yet; execution has not changed files\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Incorporate issue comments for requirement grounding delegation and test sustainability.\nIntent satisfied: yes for this PR comment reconciliation slice; no for #1556 parent lane.\nArchive decision: archive-and-close slice only\nProof: uv run pytest tests/test_workspace_implement_cli.py -q -k 'requirement_grounding or plan_delegation_packet or test_strategy_check' passed; uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py passed; make test-workspace passed; make lint-workspace passed\nChanged surfaces: src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_implement_cli.py\nDurable residue: #1556 remains open for full operating-loop closure\nMemory learning: none\nFollow-up: continue #1556 when implementing the coherent requirement-grounded operating loop\nCompletion gate: slice-only\nCompletion claim allowed: slice-complete"
   }
 }

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -11814,7 +11814,7 @@ def _prepared_canonical_core_closeout(
     if _closeout_sequence_needs_normalization(canonical_core.get("completion_criteria")):
         canonical_core["completion_criteria"] = [outcome]
     canonical_core["closeout_decision"] = normalized_closure
-    canonical_core["continuation_owner"] = routed_unsolved_intent if normalized_closure == "archive-but-keep-lane-open" else "none"
+    canonical_core["continuation_owner"] = _explicit_closeout_continuation(routed_unsolved_intent) or "none"
     return canonical_core
 
 
@@ -11839,10 +11839,9 @@ def _prepared_machine_readable_contract_closeout(
     if _closeout_sequence_needs_normalization(intent.get("proof")):
         intent["proof"] = proof
     execution["status"] = "completed"
-    execution["next_step"] = (
-        f"Continue via {routed_unsolved_intent}."
-        if normalized_closure == "archive-but-keep-lane-open"
-        else "No required continuation remains for this archived slice."
+    execution["next_step"] = _prepared_closeout_next_step(
+        normalized_closure=normalized_closure,
+        routed_unsolved_intent=routed_unsolved_intent,
     )
     execution["proof"] = proof
     if _closeout_sequence_needs_normalization(scope.get("touched")):
@@ -11919,15 +11918,14 @@ def _prepared_iterative_follow_through(
     if _closeout_value_needs_normalization(prepared.get("validation still needed")):
         prepared["validation still needed"] = "None for this archived slice; reopen only if new evidence invalidates the proof."
     if _closeout_value_needs_normalization(prepared.get("next likely slice")):
-        prepared["next likely slice"] = (
-            f"Continue via {routed_unsolved_intent}."
-            if normalized_closure == "archive-but-keep-lane-open"
-            else "No required continuation remains for this archived slice."
+        prepared["next likely slice"] = _prepared_closeout_next_step(
+            normalized_closure=normalized_closure,
+            routed_unsolved_intent=routed_unsolved_intent,
         )
     if _closeout_value_needs_normalization(prepared.get("intentionally deferred")):
         prepared["intentionally deferred"] = (
             f"Remaining larger intent is routed to {routed_unsolved_intent}."
-            if normalized_closure == "archive-but-keep-lane-open"
+            if _explicit_closeout_continuation(routed_unsolved_intent)
             else "None."
         )
     if _closeout_value_needs_normalization(prepared.get("discovered implications")):
@@ -12031,6 +12029,23 @@ def _closeout_larger_intent_is_unresolved(
         or normalized_follow_on == "yes"
         or (normalized_owner != "" and normalized_owner not in {"none", "n/a", "none yet", "no further action"})
     )
+
+
+def _explicit_closeout_continuation(*values: Any) -> str:
+    ignored = {"", "none", "n/a", "na", "none yet", "no further action", "no", "false", "unknown", "pending"}
+    for value in values:
+        text = str(value or "").strip()
+        if text and text.lower() not in ignored:
+            return text
+    return ""
+
+
+def _prepared_closeout_next_step(*, normalized_closure: str, routed_unsolved_intent: str) -> str:
+    routed = _explicit_closeout_continuation(routed_unsolved_intent)
+    if routed:
+        prefix = "Continue via" if normalized_closure == "archive-but-keep-lane-open" else "Parent/lane continuation remains routed to"
+        return f"{prefix} {routed}."
+    return "No required continuation remains for this archived slice."
 
 
 def _inferred_closeout_scope(
@@ -12187,6 +12202,12 @@ def _prepare_execplan_closeout(
     existing_closure_check = _record_section_dict(record, "closure_check") or {}
     completes_larger_outcome = intent_continuity.get("this slice completes the larger intended outcome", "").strip().lower()
     required_follow_on = required_continuation.get("required follow-on for the larger intended outcome", "").strip().lower()
+    explicit_continuation_owner = _explicit_closeout_continuation(
+        unsolved_intent,
+        intent_continuity.get("continuation surface"),
+        required_continuation.get("owner surface"),
+        intent_continuity.get("parent lane"),
+    )
     continuation_owner = (
         unsolved_intent
         or intent_continuity.get("continuation surface")
@@ -12247,7 +12268,9 @@ def _prepare_execplan_closeout(
         return False
     slice_status = existing_slice_status or "completed"
     larger_status = "open" if normalized_closure == "archive-but-keep-lane-open" else (existing_larger_status or "closed")
-    routed_unsolved_intent = continuation_owner if normalized_closure == "archive-but-keep-lane-open" else "none"
+    routed_unsolved_intent = (
+        continuation_owner if normalized_closure == "archive-but-keep-lane-open" else (explicit_continuation_owner or "none")
+    )
     original_intent = (
         existing_intent_satisfaction.get("original intent")
         or intent_interpretation.get("literal request")

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -749,6 +749,61 @@ def test_archive_plan_prepare_closeout_handles_open_parent_lane(tmp_path: Path, 
     assert archived["closeout_distillation"]["buckets"]["continuation"][0]["owner"] == ".agentic-workspace/planning/state.toml"
 
 
+def test_archive_plan_prepare_closeout_keeps_parent_continuation_visible_for_closed_slice(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="completed")
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record["intent_continuity"]["this slice completes the larger intended outcome"] = "yes"
+    record["intent_continuity"]["continuation surface"] = "GitHub #1556"
+    record["required_continuation"] = {
+        "required follow-on for the larger intended outcome": "Complete the parent operating-loop lane when resumed.",
+        "owner surface": "GitHub #1556",
+        "activation trigger": "when the parent lane resumes",
+    }
+    record["intent_satisfaction"] = {
+        "original intent": "Close this bounded slice without closing the parent lane.",
+        "was original intent fully satisfied?": "yes",
+        "evidence of intent satisfaction": "Slice validation passed.",
+        "unsolved intent passed to": "GitHub #1556",
+    }
+    record["iterative_follow_through"]["next likely slice"] = "continue the current milestone until the completion criteria are met"
+    record.pop("closure_check")
+    record.pop("closeout_distillation", None)
+    installer_mod._write_execplan_record(record_path=record_path, record=record)
+
+    assert (
+        planning_cli.main(
+            [
+                "archive-plan",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--prepare-closeout",
+                "--closure-decision",
+                "archive-and-close",
+                "--dry-run",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    detail = next(action["detail"] for action in payload["actions"] if "prepared closeout patch: " in action["detail"])
+    patch = json.loads(detail.split("prepared closeout patch: ", 1)[1])
+
+    assert payload["warnings"] == []
+    assert patch["closure_check"]["closure decision"] == "archive-and-close"
+    assert patch["canonical_core"]["continuation_owner"] == "GitHub #1556"
+    next_step = patch["machine_readable_contract"]["execution"]["next_step"]
+    next_likely_slice = patch["iterative_follow_through"]["next likely slice"]
+    assert next_step == "Parent/lane continuation remains routed to GitHub #1556."
+    assert next_likely_slice == "Parent/lane continuation remains routed to GitHub #1556."
+    assert "No required continuation remains" not in next_step
+    assert "No required continuation remains" not in next_likely_slice
+
+
 def test_planning_closeout_archives_direct_slice_without_manual_closeout_edits(tmp_path: Path, capsys) -> None:
     _write(
         tmp_path / ".agentic-workspace/planning/state.toml",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -7681,6 +7681,15 @@ def _run_report_command(
         assurance_requirements=assurance_requirements,
     )
     assurance_requirements = _assurance_requirements_with_verification(assurance_requirements, verification)
+    requirement_grounding = _requirement_grounding_payload(
+        target_root=target_root,
+        task_text=None,
+        changed_paths=[],
+        active_planning_record=raw_active_planning_record or active_planning_record or {},
+        issue_scope_evidence={"kind": "agentic-workspace/issue-scope-evidence/v1", "status": "not-applicable", "issue_refs": []},
+        assurance_requirements=assurance_requirements,
+        verification=verification,
+    )
     memory_consult = _memory_consult_payload(target_root=target_root, cli_invoke=config.cli_invoke)
     applicable_intent = _applicable_intent_source_projection_payload(
         target_root=target_root,
@@ -7768,6 +7777,7 @@ def _run_report_command(
         "applicable_intent": applicable_intent,
         "assurance_requirements": assurance_requirements,
         "verification": verification,
+        "requirement_grounding": requirement_grounding,
         "product_managed_enclave": _product_managed_enclave_payload(target_root=target_root, ownership_payload=ownership_payload),
         "ownership_diagnostics": ownership_payload["diagnostics"],
         "surface_value_guardrail": surface_value_guardrail,
@@ -8704,6 +8714,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "kind": "agentic-workspace/verification-report/v1",
         "purpose": "Verification module protocols, routes, evidence bundles, and known gaps",
         "when_to_use": "when evidence production or review provenance matters more than ordinary proof selection",
+    },
+    {
+        "section": "requirement_grounding",
+        "kind": "agentic-workspace/requirement-grounding/v1",
+        "purpose": "requirement refs, applicability, interpretation, design effects, verification evidence, gaps, and claim boundaries",
+        "when_to_use": "when deciding whether work and closeout claims are grounded in the right stated requirements",
     },
     {
         "section": "applicable_intent",
@@ -11274,7 +11290,7 @@ def _run_lazy_report_section_command(
         )
         return _select_report_payload(payload, profile="router", section=normalized)
 
-    if normalized in {"assurance_requirements", "verification", "applicable_intent"}:
+    if normalized in {"assurance_requirements", "verification", "requirement_grounding", "applicable_intent"}:
         assurance_requirements = _assurance_requirements_report_payload(
             config=config,
             active_planning_record=active_planning_record,
@@ -11286,6 +11302,20 @@ def _run_lazy_report_section_command(
         )
         payload["verification"] = verification
         payload["assurance_requirements"] = _assurance_requirements_with_verification(assurance_requirements, verification)
+        if normalized == "requirement_grounding":
+            payload["requirement_grounding"] = _requirement_grounding_payload(
+                target_root=target_root,
+                task_text=None,
+                changed_paths=[],
+                active_planning_record=active_planning_record,
+                issue_scope_evidence={
+                    "kind": "agentic-workspace/issue-scope-evidence/v1",
+                    "status": "not-applicable",
+                    "issue_refs": [],
+                },
+                assurance_requirements=payload["assurance_requirements"],
+                verification=verification,
+            )
         if normalized == "applicable_intent":
             payload["memory_consult"] = _memory_consult_payload(target_root=target_root, cli_invoke=config.cli_invoke)
             payload["standing_intent"] = standing_intent_payload(
@@ -24878,6 +24908,590 @@ def _task_contract_payload(
     }
 
 
+def _active_execplan_record_payload(*, target_root: Path) -> tuple[str, dict[str, Any]]:
+    active_summary = _fast_planning_active_summary(target_root=target_root)
+    active_surface = str(active_summary.get("active_execplan") or "").strip()
+    if not active_surface:
+        return "", {}
+    plan_path = target_root / active_surface
+    if not plan_path.exists() or plan_path.suffix != ".json":
+        return active_surface, {}
+    try:
+        loaded = json.loads(plan_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return active_surface, {}
+    return active_surface, loaded if isinstance(loaded, dict) else {}
+
+
+def _plan_string_list(record: dict[str, Any], *keys: str) -> list[str]:
+    values: list[str] = []
+    for key in keys:
+        raw: Any = record
+        for part in key.split("."):
+            raw = raw.get(part) if isinstance(raw, dict) else None
+        if isinstance(raw, str):
+            values.extend([line.strip() for line in raw.splitlines() if line.strip()])
+        else:
+            values.extend(str(item).strip() for item in _list_payload(raw) if str(item).strip())
+    return _dedupe(values)
+
+
+def _requirement_grounding_payload(
+    *,
+    target_root: Path,
+    task_text: str | None,
+    changed_paths: list[str],
+    active_planning_record: dict[str, Any],
+    issue_scope_evidence: dict[str, Any],
+    assurance_requirements: dict[str, Any],
+    verification: dict[str, Any],
+) -> dict[str, Any]:
+    def source_metadata(*, ref: str, source_type: str, provenance: str) -> dict[str, Any]:
+        source_path = target_root / provenance if provenance and not provenance.startswith(("http://", "https://")) else None
+        return {
+            "source_revision": _git_source_identity(target_root) if source_type in {"repo-doc", "active-plan-ref"} else "",
+            "fetched_at": "",
+            "excerpt_hash": "",
+            "freshness": "repo-current" if source_path is not None and source_path.exists() else "external-or-unverified",
+            "trust_note": "routing/index metadata only; AW does not copy or store the requirement corpus",
+        }
+
+    requirement_refs: list[dict[str, Any]] = []
+    for issue in _list_payload(issue_scope_evidence.get("evidence")):
+        if not isinstance(issue, dict):
+            continue
+        ref = str(issue.get("id") or "").strip()
+        if ref:
+            provenance = str(issue_scope_evidence.get("source_path") or "").strip()
+            requirement_refs.append(
+                {
+                    "ref": ref,
+                    "source_type": "external-intent",
+                    "authority": "task-referenced-requirement-source",
+                    "title": str(issue.get("title") or "").strip(),
+                    "provenance": provenance,
+                    "source_metadata": {
+                        "source_revision": "",
+                        "fetched_at": str(issue.get("fetched_at") or "").strip(),
+                        "excerpt_hash": str(issue.get("excerpt_hash") or "").strip(),
+                        "freshness": "cached-external-intent" if provenance else "external-or-unverified",
+                        "trust_note": "routing/index metadata only; AW does not copy or store the requirement corpus",
+                    },
+                }
+            )
+    traceability = _as_dict(active_planning_record.get("traceability_refs"))
+    for key, authority in (
+        ("requirement_refs", "active-plan-requirement-ref"),
+        ("acceptance_refs", "active-plan-acceptance-ref"),
+        ("decision_refs", "active-plan-decision-ref"),
+    ):
+        for ref in _list_payload(traceability.get(key)):
+            text = str(ref).strip()
+            if text:
+                requirement_refs.append(
+                    {
+                        "ref": text,
+                        "source_type": "active-plan-ref",
+                        "authority": authority,
+                        "provenance": "active_execplan.traceability_refs",
+                        "source_metadata": source_metadata(
+                            ref=text,
+                            source_type="active-plan-ref",
+                            provenance=str(_active_execplan_record_payload(target_root=target_root)[0] or ""),
+                        ),
+                    }
+                )
+    for requirement in _list_payload(assurance_requirements.get("active")):
+        if not isinstance(requirement, dict):
+            continue
+        requirement_id = str(requirement.get("id") or "").strip()
+        if requirement_id:
+            requirement_refs.append(
+                {
+                    "ref": requirement_id,
+                    "source_type": "assurance-requirement",
+                    "authority": "repo-configured-assurance-requirement",
+                    "title": str(requirement.get("title") or "").strip(),
+                    "provenance": "assurance_requirements.active",
+                    "source_metadata": {
+                        "source_revision": _git_source_identity(target_root),
+                        "fetched_at": "",
+                        "excerpt_hash": "",
+                        "freshness": "repo-current",
+                        "trust_note": "routing/index metadata only; AW does not copy or store the requirement corpus",
+                    },
+                }
+            )
+    seen_refs: set[tuple[str, str]] = set()
+    deduped_refs: list[dict[str, Any]] = []
+    for item in requirement_refs:
+        key = (str(item.get("ref") or ""), str(item.get("provenance") or ""))
+        if key in seen_refs:
+            continue
+        seen_refs.add(key)
+        deduped_refs.append(item)
+
+    applicability: list[dict[str, Any]] = []
+    for requirement in _list_payload(assurance_requirements.get("active")):
+        if not isinstance(requirement, dict):
+            continue
+        ref = str(requirement.get("id") or "").strip()
+        if not ref:
+            continue
+        because = [str(item).strip() for item in _list_payload(requirement.get("applies_because")) if str(item).strip()]
+        applicability.append(
+            {
+                "ref": ref,
+                "state": "applicable" if because else "unknown",
+                "why": "; ".join(because) if because else "No applicability rationale was recorded.",
+                "confidence": "medium" if because else "low",
+                "authority": "configured-route" if because else "agent-review-required",
+            }
+        )
+    applicable_intent = _as_dict(active_planning_record.get("applicable_intents") or active_planning_record.get("applicable_intent"))
+    for source in _list_payload(applicable_intent.get("sources")):
+        if not isinstance(source, dict):
+            continue
+        ref = str(source.get("ref") or source.get("id") or source.get("source") or "").strip()
+        if not ref:
+            continue
+        applicability.append(
+            {
+                "ref": ref,
+                "state": str(source.get("state") or "applicable").strip(),
+                "why": str(source.get("why") or source.get("reason") or "").strip(),
+                "confidence": str(source.get("confidence") or "medium").strip(),
+                "authority": "active-plan-applicability",
+            }
+        )
+
+    interpretation = _as_dict(active_planning_record.get("intent_interpretation"))
+    interpretation_summary = str(
+        interpretation.get("chosen concrete what")
+        or interpretation.get("inferred intended outcome")
+        or interpretation.get("literal request")
+        or ""
+    ).strip()
+    design_effects = _plan_string_list(
+        active_planning_record,
+        "canonical_core.hard_constraints",
+        "canonical_core.agent_may_decide",
+        "execution_bounds.allowed paths",
+        "execution_bounds.stop before touching",
+        "delegated_judgment.hard constraints",
+    )
+    decisions = [
+        {"selected": item, "rejected_alternatives": []}
+        for item in _plan_string_list(active_planning_record, "contract_decisions_to_freeze")
+        if item.lower() not in {"none", "none."}
+    ]
+    verification_refs: list[dict[str, Any]] = []
+    for protocol in _list_payload(verification.get("active_protocols")):
+        if not isinstance(protocol, dict):
+            continue
+        protocol_id = str(protocol.get("id") or "").strip()
+        requirement_refs_for_protocol = [
+            str(item).strip() for item in _list_payload(protocol.get("assurance_requirement_refs")) if str(item).strip()
+        ]
+        if protocol_id:
+            verification_refs.append(
+                {
+                    "protocol_id": protocol_id,
+                    "scenario_refs": [str(item).strip() for item in _list_payload(protocol.get("scenario_refs")) if str(item).strip()],
+                    "requirement_refs": requirement_refs_for_protocol,
+                    "evidence_labels": [
+                        str(item).strip() for item in _list_payload(protocol.get("expected_evidence")) if str(item).strip()
+                    ],
+                }
+            )
+    known_gaps: list[dict[str, Any]] = []
+    for gap in _list_payload(verification.get("known_gaps")) + _list_payload(verification.get("active_known_gaps")):
+        if not isinstance(gap, dict):
+            continue
+        known_gaps.append(
+            {
+                "gap": str(gap.get("id") or gap.get("reason") or "verification gap").strip(),
+                "blocked_claims": [str(item).strip() for item in _list_payload(gap.get("blocked_claims")) if str(item).strip()],
+                "source": "verification",
+            }
+        )
+    missing_refs = [str(item).strip() for item in _list_payload(issue_scope_evidence.get("missing_issue_refs")) if str(item).strip()]
+    for ref in missing_refs:
+        known_gaps.append(
+            {
+                "gap": f"external requirement source {ref} is not cached",
+                "blocked_claims": ["requirement-grounded-completion"],
+                "source": "external-intent",
+            }
+        )
+    if deduped_refs and not (applicability or interpretation_summary or design_effects):
+        known_gaps.append(
+            {
+                "gap": "requirement refs exist but no active planning interpretation or design effect was recorded",
+                "blocked_claims": ["requirement-grounded-completion"],
+                "source": "planning",
+            }
+        )
+    sensitivity_signals = []
+    task_lower = str(task_text or "").lower()
+    if any(term in task_lower for term in ("security", "privacy", "compliance", "domain", "requirement", "policy", "regulated")):
+        sensitivity_signals.append("task-text-requirement-sensitive")
+    if assurance_requirements.get("active_count"):
+        sensitivity_signals.append("active-assurance-requirements")
+    if verification.get("active_count"):
+        sensitivity_signals.append("active-verification-routes")
+    if sensitivity_signals and not deduped_refs:
+        known_gaps.append(
+            {
+                "gap": "task appears requirement-sensitive but no applicable requirement refs were selected",
+                "blocked_claims": ["requirement-grounded-completion"],
+                "source": "requirement-sensitivity",
+            }
+        )
+    allowed_claims = []
+    if verification_refs:
+        allowed_claims.append("changed scope has requirement-referenced verification evidence")
+    if applicability and design_effects:
+        allowed_claims.append("active plan recorded applicable requirements and design constraints")
+    blocked_claims = _dedupe(
+        [
+            claim
+            for gap in known_gaps
+            for claim in [str(item).strip() for item in _list_payload(gap.get("blocked_claims")) if str(item).strip()]
+        ]
+    )
+    if not deduped_refs and (task_text or changed_paths):
+        blocked_claims.append("requirement-grounded-completion")
+    status = "ready" if deduped_refs and not blocked_claims else "attention" if deduped_refs or task_text else "not-applicable"
+    return {
+        "kind": "agentic-workspace/requirement-grounding/v1",
+        "status": status,
+        "requirement_refs": deduped_refs,
+        "applicability": applicability,
+        "agent_interpretation": {
+            "status": "present" if interpretation_summary else "not-recorded",
+            "summary": interpretation_summary,
+            "assumptions": _plan_string_list(active_planning_record, "intent_interpretation.assumptions"),
+            "needs_human_confirmation": str(interpretation.get("review guidance") or "").strip().lower() not in {"", "none", "none."},
+            "confidence": "medium" if interpretation_summary else "low",
+        },
+        "design_effects": design_effects,
+        "decisions": decisions,
+        "verification_refs": verification_refs,
+        "known_gaps": known_gaps,
+        "closeout_claims": {"allowed": allowed_claims, "blocked": _dedupe(blocked_claims)},
+        "source_facts": {
+            "changed_paths": changed_paths,
+            "task_issue_refs": sorted(set(re.findall("#\\d+", task_text or ""))),
+            "active_plan_present": bool(active_planning_record),
+            "assurance_active_count": assurance_requirements.get("active_count", 0),
+            "verification_active_count": verification.get("active_count", 0),
+            "sensitivity_signals": sensitivity_signals,
+        },
+        "source_inventory_policy": {
+            "role": "compact-routing-index",
+            "not_a_requirement_corpus": True,
+            "rule": "Requirement refs point to authority and carry provenance/freshness metadata; AW does not copy source text into long-lived state.",
+        },
+        "authority_boundary": _authority_boundary_payload(
+            surface="requirement_grounding",
+            observed_by_aw=[
+                f"requirement_ref_count={len(deduped_refs)}",
+                f"applicability_count={len(applicability)}",
+                f"verification_ref_count={len(verification_refs)}",
+                f"known_gap_count={len(known_gaps)}",
+            ],
+            recommended_by_aw=["inspect missing grounding before claiming requirement-grounded completion"] if blocked_claims else [],
+            proof_hints=["verification protocols, assurance evidence status, active plan decisions, known gaps"],
+            agent_owned_decisions=[
+                "requirement applicability",
+                "requirement interpretation",
+                "implementation choices shaped by requirements",
+                "completion claim wording",
+            ],
+            human_owned_decisions=["acceptance of requirement interpretation and final compliance/fitness claims"],
+            rule="AW links observed requirement refs, planning residue, verification evidence, and closeout claim boundaries; the agent owns reasoning and decisions.",
+        ),
+    }
+
+
+def _plan_delegation_packet_payload(
+    *, target_root: Path, config: WorkspaceConfig, proof: dict[str, Any], task_text: str | None
+) -> dict[str, Any]:
+    active_surface, record = _active_execplan_record_payload(target_root=target_root)
+    planning_revision = _planning_revision_payload(target_root=target_root)
+    if not record:
+        return {
+            "kind": "agentic-workspace/plan-delegation-packet/v1",
+            "status": "unavailable",
+            "delegation_ready": False,
+            "delegation_recommended": False,
+            "active_execplan": active_surface,
+            "planning_revision": planning_revision,
+            "missing_fields": ["active_execplan"],
+        }
+    core = _as_dict(record.get("canonical_core"))
+    delegated = _as_dict(record.get("delegated_judgment"))
+    read_first_refs = [
+        str(item.get("target") or item.get("label") or "").strip()
+        for item in _list_payload(record.get("references"))
+        if isinstance(item, dict) and str(item.get("target") or item.get("label") or "").strip()
+    ]
+    read_first_refs = _dedupe(read_first_refs + _plan_string_list(record, "context_budget.live working set"))
+    allowed_scope = _dedupe(
+        _plan_string_list(record, "canonical_core.touched_scope", "touched_paths")
+        + _plan_string_list(record, "execution_bounds.allowed paths")
+    )
+    forbidden_scope = _dedupe(_plan_string_list(record, "non_goals", "execution_bounds.stop before touching"))
+    stop_conditions = _dedupe(_plan_string_list(record, "stop_conditions.stop when", "stop_conditions.escalate on scope drift"))
+    proof_commands = _dedupe(
+        _plan_string_list(record, "validation_commands", "canonical_core.proof_expectations")
+        + [str(item).strip() for item in _list_payload(proof.get("required_commands")) if str(item).strip()]
+    )
+    acceptance_criteria = _dedupe(_plan_string_list(record, "completion_criteria", "canonical_core.completion_criteria"))
+    requested_outcome = str(
+        delegated.get("requested outcome") or core.get("requested_outcome") or record.get("title") or task_text or ""
+    ).strip()
+    required_fields = {
+        "owned_slice": requested_outcome,
+        "allowed_write_scope": allowed_scope,
+        "stop_conditions": stop_conditions,
+        "proof_commands": proof_commands,
+        "acceptance_criteria": acceptance_criteria,
+    }
+    missing = [field for field, value in required_fields.items() if not value]
+    ambiguous_fields = []
+    for field, values in {
+        "allowed_write_scope": allowed_scope,
+        "proof_commands": proof_commands,
+        "acceptance_criteria": acceptance_criteria,
+    }.items():
+        joined = " ".join(values).lower()
+        if any(marker in joined for marker in ("fill in", "<", ">", "tbd", "broad", "as needed")):
+            ambiguous_fields.append(field)
+        if field == "allowed_write_scope" and any(";" in value or "," in value for value in values):
+            ambiguous_fields.append(field)
+    ambiguous_fields = _dedupe(ambiguous_fields)
+    route = "implementation-delegate"
+    if not allowed_scope:
+        route = "exploration-delegate"
+    elif proof_commands and requested_outcome.lower().startswith(("validate", "verify", "review")):
+        route = "validation-delegate"
+    elif "review" in " ".join(acceptance_criteria).lower():
+        route = "review-delegate"
+    cheap_bounded = not missing and not ambiguous_fields and len(allowed_scope) <= 6 and len(proof_commands) <= 4
+    delegation_ready = not missing and not ambiguous_fields
+    return {
+        "kind": "agentic-workspace/plan-delegation-packet/v1",
+        "status": "ready" if delegation_ready else "ambiguous-fields" if ambiguous_fields else "missing-fields",
+        "delegation_ready": delegation_ready,
+        "delegation_recommended": cheap_bounded,
+        "active_execplan": active_surface,
+        "planning_revision": planning_revision,
+        "freshness_guard": {
+            "revision_id": planning_revision.get("revision_id"),
+            "state_hash": planning_revision.get("state_hash"),
+            "active_execplan_hash": planning_revision.get("active_execplan_hash"),
+            "delegate_return_must_cite_revision": True,
+        },
+        "owned_slice": requested_outcome,
+        "requested_outcome": requested_outcome,
+        "read_first_refs": read_first_refs,
+        "allowed_write_scope": allowed_scope,
+        "forbidden_scope": forbidden_scope,
+        "stop_conditions": stop_conditions,
+        "proof_commands": proof_commands,
+        "acceptance_criteria": acceptance_criteria,
+        "uncertainty_reporting": [
+            "report assumptions and uncertainty before implementation choices",
+            "stop on scope, proof, or authority drift instead of widening silently",
+        ],
+        "expected_evidence_on_return": [
+            "changed files",
+            "proof commands run and results",
+            "acceptance criteria status",
+            "uncertainty or stop-condition hits",
+            "residue or follow-up items",
+        ],
+        "return_contract": {
+            "required_fields": [
+                "changed_files",
+                "changed_surfaces",
+                "proof_run",
+                "proof_result",
+                "result",
+                "uncertainty",
+                "stop_condition_hits",
+                "residue",
+                "allowed_claims",
+                "planning_revision",
+            ],
+            "rule": "Delegation does not lower proof, review, closeout, or acceptance requirements.",
+        },
+        "missing_fields": missing,
+        "ambiguous_fields": ambiguous_fields,
+        "recommended_route": route if delegation_ready else "stay-local-until-plan-complete",
+        "cheap_bounded_executor_recommended": cheap_bounded,
+        "configured_low_cost_targets": [
+            target.name
+            for target in config.local_override.delegation_targets
+            if target.strength in {"weak", "standard"} and "manual" in target.execution_methods
+        ],
+        "source_fields": [
+            "active_execplan.canonical_core",
+            "active_execplan.execution_bounds",
+            "active_execplan.stop_conditions",
+            "active_execplan.validation_commands",
+            "active_execplan.completion_criteria",
+        ],
+        "handoff_prompt": "\n".join(
+            [
+                f"Owned slice: {requested_outcome}",
+                f"Read first: {', '.join(read_first_refs) if read_first_refs else '(none recorded)'}",
+                f"Allowed write scope: {', '.join(allowed_scope) if allowed_scope else '(missing)'}",
+                f"Forbidden scope: {', '.join(forbidden_scope) if forbidden_scope else '(none recorded)'}",
+                f"Stop conditions: {', '.join(stop_conditions) if stop_conditions else '(missing)'}",
+                f"Proof commands: {', '.join(proof_commands) if proof_commands else '(missing)'}",
+                f"Acceptance criteria: {', '.join(acceptance_criteria) if acceptance_criteria else '(missing)'}",
+                "Return: changed files, proof run/results, uncertainty, stop-condition hits, and residue.",
+            ]
+        ),
+        "authority_boundary": _authority_boundary_payload(
+            surface="plan_delegation_packet",
+            observed_by_aw=[f"active_execplan={active_surface}", f"missing_field_count={len(missing)}"],
+            recommended_by_aw=[route] if not missing else ["complete active plan fields before delegating"],
+            proof_hints=["proof commands and acceptance criteria copied from active planning/proof projection"],
+            agent_owned_decisions=["whether delegation is semantically appropriate", "which target receives the packet"],
+            rule="AW derives a handoff contract from checked-in planning fields; the agent owns route choice unless config explicitly automates it.",
+        ),
+    }
+
+
+def _python_test_file_facts(path: Path) -> dict[str, Any]:
+    if not path.exists() or path.suffix != ".py":
+        return {"test_function_count": 0, "parametrized_test_count": 0, "scenario_matrix_candidates": []}
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return {"test_function_count": 0, "parametrized_test_count": 0, "scenario_matrix_candidates": [], "parse_error": True}
+    test_functions: list[str] = []
+    parametrized: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test_"):
+            continue
+        test_functions.append(node.name)
+        for decorator in node.decorator_list:
+            text = ast.unparse(decorator) if hasattr(ast, "unparse") else ""
+            if "parametrize" in text:
+                parametrized.append(node.name)
+                break
+    prefixes: dict[str, int] = {}
+    for name in test_functions:
+        parts = name.split("_")
+        prefix = "_".join(parts[:4]) if len(parts) >= 4 else name
+        prefixes[prefix] = prefixes.get(prefix, 0) + 1
+    candidates = [prefix for prefix, count in sorted(prefixes.items()) if count >= 2]
+    return {
+        "test_function_count": len(test_functions),
+        "parametrized_test_count": len(parametrized),
+        "scenario_matrix_candidates": candidates[:8],
+        "sample_test_functions": test_functions[:8],
+    }
+
+
+def _test_strategy_check_payload(
+    *, target_root: Path, changed_paths: list[str], task_text: str | None, verification: dict[str, Any]
+) -> dict[str, Any]:
+    test_paths = [
+        path
+        for path in changed_paths
+        if Path(path).name.startswith("test_") and Path(path).suffix == ".py" and ("tests/" in path or path.startswith("tests/"))
+    ]
+    if not test_paths:
+        return {"kind": "agentic-workspace/test-strategy-check/v1", "status": "not-applicable", "changed_test_paths": []}
+    evidence_strategy = _as_dict(verification.get("evidence_strategy"))
+    proof_governance = _as_dict(evidence_strategy.get("proof_governance"))
+    proof_decision = _as_dict(evidence_strategy.get("proof_decision"))
+    regression_sprawl = _as_dict(evidence_strategy.get("regression_sprawl"))
+    hotspot_files = {str(path) for path in _list_payload(_as_dict(evidence_strategy.get("summary")).get("hotspot_files_touched"))}
+    files: list[dict[str, Any]] = []
+    hotspot_count = 0
+    matrix_count = 0
+    deleted_count = 0
+    for rel_path in test_paths:
+        absolute = target_root / rel_path
+        deleted = not absolute.exists()
+        facts = _python_test_file_facts(absolute)
+        hotspot = rel_path in hotspot_files or int(facts.get("test_function_count", 0) or 0) >= 8
+        if hotspot:
+            hotspot_count += 1
+        if deleted:
+            deleted_count += 1
+        if int(facts.get("parametrized_test_count", 0) or 0) or facts.get("scenario_matrix_candidates"):
+            matrix_count += 1
+        files.append(
+            {
+                "path": rel_path,
+                "deleted_or_missing": deleted,
+                "is_hotspot": hotspot,
+                "hotspot_source": "verification-evidence-strategy"
+                if rel_path in hotspot_files
+                else "local-test-function-count"
+                if hotspot
+                else "",
+                **facts,
+            }
+        )
+    task_lower = str(task_text or "").lower()
+    reviewer_requested = any(term in task_lower for term in ("review", "comment", "pr feedback", "requested coverage", "regression"))
+    return {
+        "kind": "agentic-workspace/test-strategy-check/v1",
+        "status": "advisory",
+        "changed_test_paths": test_paths,
+        "hotspot_file_count": hotspot_count,
+        "scenario_matrix_candidate_count": matrix_count,
+        "deleted_or_missing_test_file_count": deleted_count,
+        "files": files,
+        "reviewer_requested_coverage": reviewer_requested,
+        "verification_evidence_surfaces": {
+            "evidence_strategy_status": evidence_strategy.get("status", "unavailable"),
+            "proof_governance_status": proof_governance.get("status", "unavailable"),
+            "proof_decision_status": proof_decision.get("status", "unavailable"),
+            "regression_sprawl_status": regression_sprawl.get("status", "unavailable"),
+        },
+        "record_disposition_options": [
+            "matrix-merge",
+            "standalone-durable-contract-proof",
+            "conformance-or-contract-owned-proof",
+            "existing-proof-sufficient",
+            "temporary-with-follow-up-consolidation",
+        ],
+        "disposition_required_before_closeout": True,
+        "closeout_visibility": {
+            "missing_disposition_blocks_claim": "test-sustainability-reviewed",
+            "rule": "Advisory only during implementation; closeout/report should expose missing disposition when ordinary test mass changed.",
+        },
+        "agent_prompt": (
+            "Before adding or expanding standalone regression tests, record why the evidence belongs in a matrix, standalone "
+            "contract-boundary test, conformance/contract proof, existing proof, or follow-up consolidation."
+        ),
+        "blocking": False,
+        "authority_boundary": _authority_boundary_payload(
+            surface="test_strategy_check",
+            observed_by_aw=[
+                f"changed_test_path_count={len(test_paths)}",
+                f"hotspot_file_count={hotspot_count}",
+                f"scenario_matrix_candidate_count={matrix_count}",
+                f"deleted_or_missing_test_file_count={deleted_count}",
+            ],
+            recommended_by_aw=["record the testing evidence disposition before closeout"],
+            proof_hints=["evidence_strategy.proof_governance", "proof_decision", "regression_sprawl", "nearby parametrized tests"],
+            agent_owned_decisions=["whether a new test is justified", "which evidence disposition fits the host repo"],
+            rule="AW reports local test facts and asks for a disposition; it does not prescribe a testing strategy.",
+        ),
+    }
+
+
 def _implement_payload(
     *,
     target_root: Path,
@@ -25161,6 +25775,44 @@ def _implement_payload(
             task_text=task_text,
             assurance_requirements=assurance_for_verification,
         )
+    assurance_for_grounding = payload.get("assurance_requirements", {})
+    if not isinstance(assurance_for_grounding, dict):
+        assurance_for_grounding = _assurance_requirements_report_payload(
+            config=config,
+            active_planning_record=None,
+            task_text=task_text,
+            changed_paths=normalized_paths,
+        )
+    verification_for_grounding = payload.get("verification", {})
+    if not isinstance(verification_for_grounding, dict):
+        verification_for_grounding = _verification_report_payload(
+            target_root=target_root,
+            changed_paths=normalized_paths,
+            task_text=task_text,
+            assurance_requirements=assurance_for_grounding,
+        )
+    issue_scope_evidence = _as_dict(planning_safety_gate.get("issue_scope_evidence"))
+    payload["requirement_grounding"] = _requirement_grounding_payload(
+        target_root=target_root,
+        task_text=task_text,
+        changed_paths=normalized_paths,
+        active_planning_record=active_planning_record_for_intent,
+        issue_scope_evidence=issue_scope_evidence,
+        assurance_requirements=assurance_for_grounding,
+        verification=verification_for_grounding,
+    )
+    payload["plan_delegation_packet"] = _plan_delegation_packet_payload(
+        target_root=target_root,
+        config=config,
+        proof=proof if isinstance(proof, dict) else {},
+        task_text=task_text,
+    )
+    payload["test_strategy_check"] = _test_strategy_check_payload(
+        target_root=target_root,
+        changed_paths=normalized_paths,
+        task_text=task_text,
+        verification=verification_for_grounding,
+    )
     workflow_obligations = _workflow_obligations_report_payload(
         config=config,
         active_planning_record=active_planning_record_for_intent,
@@ -25306,6 +25958,9 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "context.reuse_pressure",
                 "context.guidance",
                 "context.delegation_decision",
+                "requirement_grounding",
+                "plan_delegation_packet",
+                "test_strategy_check",
                 "routine_work_context",
             ],
             agent_judgment="Agent owns semantic work shape and completion judgment after proof and acceptance reconciliation.",
@@ -25436,6 +26091,58 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "delegation_decision": _compact_start_delegation_decision(
                 execution_posture.get("delegation_decision", {}), include_manual_handoff_detail=False
             ),
+            "requirement_grounding": {
+                "status": payload.get("requirement_grounding", {}).get("status", "not-applicable")
+                if isinstance(payload.get("requirement_grounding"), dict)
+                else "not-applicable",
+                "requirement_ref_count": len(payload.get("requirement_grounding", {}).get("requirement_refs", []))
+                if isinstance(payload.get("requirement_grounding"), dict)
+                else 0,
+                "known_gap_count": len(payload.get("requirement_grounding", {}).get("known_gaps", []))
+                if isinstance(payload.get("requirement_grounding"), dict)
+                else 0,
+                "blocked_claims": payload.get("requirement_grounding", {}).get("closeout_claims", {}).get("blocked", [])
+                if isinstance(payload.get("requirement_grounding"), dict)
+                and isinstance(payload.get("requirement_grounding", {}).get("closeout_claims"), dict)
+                else [],
+                "detail_selector": "requirement_grounding",
+            },
+            "plan_delegation_packet": {
+                "status": payload.get("plan_delegation_packet", {}).get("status", "unavailable")
+                if isinstance(payload.get("plan_delegation_packet"), dict)
+                else "unavailable",
+                "delegation_ready": payload.get("plan_delegation_packet", {}).get("delegation_ready", False)
+                if isinstance(payload.get("plan_delegation_packet"), dict)
+                else False,
+                "delegation_recommended": payload.get("plan_delegation_packet", {}).get("delegation_recommended", False)
+                if isinstance(payload.get("plan_delegation_packet"), dict)
+                else False,
+                "recommended_route": payload.get("plan_delegation_packet", {}).get("recommended_route", "")
+                if isinstance(payload.get("plan_delegation_packet"), dict)
+                else "",
+                "missing_fields": payload.get("plan_delegation_packet", {}).get("missing_fields", [])
+                if isinstance(payload.get("plan_delegation_packet"), dict)
+                else [],
+                "ambiguous_fields": payload.get("plan_delegation_packet", {}).get("ambiguous_fields", [])
+                if isinstance(payload.get("plan_delegation_packet"), dict)
+                else [],
+                "detail_selector": "plan_delegation_packet",
+            },
+            "test_strategy_check": {
+                "status": payload.get("test_strategy_check", {}).get("status", "not-applicable")
+                if isinstance(payload.get("test_strategy_check"), dict)
+                else "not-applicable",
+                "changed_test_paths": payload.get("test_strategy_check", {}).get("changed_test_paths", [])
+                if isinstance(payload.get("test_strategy_check"), dict)
+                else [],
+                "hotspot_file_count": payload.get("test_strategy_check", {}).get("hotspot_file_count", 0)
+                if isinstance(payload.get("test_strategy_check"), dict)
+                else 0,
+                "scenario_matrix_candidate_count": payload.get("test_strategy_check", {}).get("scenario_matrix_candidate_count", 0)
+                if isinstance(payload.get("test_strategy_check"), dict)
+                else 0,
+                "detail_selector": "test_strategy_check",
+            },
         },
         "drill_down": {
             "ordinary_profile": "primary=next;proof=summary;context=selector-backed diagnostics",
@@ -25465,6 +26172,12 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "routine_work_context",
                 "context.delegation_decision",
                 "context.guidance",
+                "context.requirement_grounding",
+                "context.plan_delegation_packet",
+                "context.test_strategy_check",
+                "requirement_grounding",
+                "plan_delegation_packet",
+                "test_strategy_check",
             ],
         },
     }
@@ -32063,6 +32776,18 @@ def _selector_requests_reuse_pressure(select: str | None) -> bool:
     return any(token == "reuse_pressure" or token.startswith("reuse_pressure.") for token in _selector_tokens(select))
 
 
+def _selector_requests_requirement_grounding(select: str | None) -> bool:
+    return any(token == "requirement_grounding" or token.startswith("requirement_grounding.") for token in _selector_tokens(select))
+
+
+def _selector_requests_plan_delegation_packet(select: str | None) -> bool:
+    return any(token == "plan_delegation_packet" or token.startswith("plan_delegation_packet.") for token in _selector_tokens(select))
+
+
+def _selector_requests_test_strategy_check(select: str | None) -> bool:
+    return any(token == "test_strategy_check" or token.startswith("test_strategy_check.") for token in _selector_tokens(select))
+
+
 def _run_implement_context_adapter(args: argparse.Namespace) -> int:
     target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
     _validate_target_root(command_name="implement", target_root=target_root)
@@ -32080,6 +32805,9 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
     verification_selected = _selector_requests_verification(selected_fields)
     routine_work_context_selected = _selector_requests_routine_work_context(selected_fields)
     reuse_pressure_selected = _selector_requests_reuse_pressure(selected_fields)
+    requirement_grounding_selected = _selector_requests_requirement_grounding(selected_fields)
+    plan_delegation_packet_selected = _selector_requests_plan_delegation_packet(selected_fields)
+    test_strategy_check_selected = _selector_requests_test_strategy_check(selected_fields)
     full_payload = _implement_payload(
         target_root=target_root,
         changed_paths=list(getattr(args, "changed", []) or []),
@@ -32111,6 +32839,12 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
             payload["active_intent_contract"] = full_payload["active_intent_contract"]
         if _selector_requests(getattr(args, "select", None), "intent_satisfaction_matrix"):
             payload["intent_satisfaction_matrix"] = full_payload["intent_satisfaction_matrix"]
+        if requirement_grounding_selected:
+            payload["requirement_grounding"] = full_payload["requirement_grounding"]
+        if plan_delegation_packet_selected:
+            payload["plan_delegation_packet"] = full_payload["plan_delegation_packet"]
+        if test_strategy_check_selected:
+            payload["test_strategy_check"] = full_payload["test_strategy_check"]
         if reuse_pressure_selected:
             payload["reuse_pressure"] = _reuse_pressure_payload(
                 target_root=target_root,
@@ -35922,6 +36656,37 @@ def _proof_selection_for_changed_paths(
         proof_confidence=proof_confidence,
         manual_verification=manual_verification,
     )
+    active_planning_record_for_requirement = (
+        _active_planning_record_for_report_section(target_root=target_root) if target_root is not None else {}
+    )
+    issue_scope_evidence_for_requirement = (
+        _issue_scope_evidence_payload(
+            target_root=target_root,
+            config=config,
+            issue_refs=sorted(set(re.findall("#\\d+", task_text or ""))),
+        )
+        if target_root is not None and config is not None
+        else {"kind": "agentic-workspace/issue-scope-evidence/v1", "status": "not-applicable", "issue_refs": []}
+    )
+    requirement_grounding = _requirement_grounding_payload(
+        target_root=target_root or Path("."),
+        task_text=task_text,
+        changed_paths=changed_paths,
+        active_planning_record=active_planning_record_for_requirement,
+        issue_scope_evidence=issue_scope_evidence_for_requirement,
+        assurance_requirements=active_assurance_requirements,
+        verification=verification,
+    )
+    test_strategy_check = (
+        _test_strategy_check_payload(
+            target_root=target_root,
+            changed_paths=changed_paths,
+            task_text=task_text,
+            verification=verification,
+        )
+        if target_root is not None
+        else {"kind": "agentic-workspace/test-strategy-check/v1", "status": "unavailable", "changed_test_paths": []}
+    )
     proof_selection = {
         "kind": "proof-selection/v1",
         "changed_paths": changed_paths,
@@ -35974,6 +36739,8 @@ def _proof_selection_for_changed_paths(
         "intent_proof": intent_proof,
         "proof_confidence": proof_confidence,
         "proof_adequacy": proof_adequacy,
+        "requirement_grounding": requirement_grounding,
+        "test_strategy_check": test_strategy_check,
         "proof_route_selection": proof_route_decision,
         "proof_route_decision": proof_route_decision,
         "proof_route_explanation": proof_route_explanation,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -24936,6 +24936,13 @@ def _plan_string_list(record: dict[str, Any], *keys: str) -> list[str]:
     return _dedupe(values)
 
 
+def _plan_exact_list(record: dict[str, Any], *keys: str) -> list[str]:
+    values: list[str] = []
+    for item in _plan_string_list(record, *keys):
+        values.extend(part.strip() for part in re.split(r"[;,]", item) if part.strip())
+    return _dedupe(values)
+
+
 def _requirement_grounding_payload(
     *,
     target_root: Path,
@@ -25072,7 +25079,15 @@ def _requirement_grounding_payload(
         or interpretation.get("literal request")
         or ""
     ).strip()
+    explicit_grounding = _as_dict(active_planning_record.get("requirement_grounding"))
     design_effects = _plan_string_list(
+        explicit_grounding,
+        "design_effects",
+        "design_effect",
+        "constraints",
+        "implementation_constraints",
+    )
+    planning_context_fallback = _plan_string_list(
         active_planning_record,
         "canonical_core.hard_constraints",
         "canonical_core.agent_may_decide",
@@ -25124,7 +25139,7 @@ def _requirement_grounding_payload(
                 "source": "external-intent",
             }
         )
-    if deduped_refs and not (applicability or interpretation_summary or design_effects):
+    if deduped_refs and not (applicability or interpretation_summary or design_effects or planning_context_fallback):
         known_gaps.append(
             {
                 "gap": "requirement refs exist but no active planning interpretation or design effect was recorded",
@@ -25176,6 +25191,11 @@ def _requirement_grounding_payload(
             "confidence": "medium" if interpretation_summary else "low",
         },
         "design_effects": design_effects,
+        "planning_context_fallback": {
+            "status": "present" if planning_context_fallback else "absent",
+            "items": planning_context_fallback,
+            "rule": "Generic planning fields can help the agent reason, but they are not labeled as requirement-derived design effects.",
+        },
         "decisions": decisions,
         "verification_refs": verification_refs,
         "known_gaps": known_gaps,
@@ -25237,12 +25257,12 @@ def _plan_delegation_packet_payload(
         for item in _list_payload(record.get("references"))
         if isinstance(item, dict) and str(item.get("target") or item.get("label") or "").strip()
     ]
-    read_first_refs = _dedupe(read_first_refs + _plan_string_list(record, "context_budget.live working set"))
+    read_first_refs = _dedupe(read_first_refs + _plan_exact_list(record, "context_budget.live working set"))
     allowed_scope = _dedupe(
-        _plan_string_list(record, "canonical_core.touched_scope", "touched_paths")
-        + _plan_string_list(record, "execution_bounds.allowed paths")
+        _plan_exact_list(record, "canonical_core.touched_scope", "touched_paths")
+        + _plan_exact_list(record, "execution_bounds.allowed paths")
     )
-    forbidden_scope = _dedupe(_plan_string_list(record, "non_goals", "execution_bounds.stop before touching"))
+    forbidden_scope = _dedupe(_plan_exact_list(record, "non_goals", "execution_bounds.stop before touching"))
     stop_conditions = _dedupe(_plan_string_list(record, "stop_conditions.stop when", "stop_conditions.escalate on scope drift"))
     proof_commands = _dedupe(
         _plan_string_list(record, "validation_commands", "canonical_core.proof_expectations")
@@ -25268,8 +25288,6 @@ def _plan_delegation_packet_payload(
     }.items():
         joined = " ".join(values).lower()
         if any(marker in joined for marker in ("fill in", "<", ">", "tbd", "broad", "as needed")):
-            ambiguous_fields.append(field)
-        if field == "allowed_write_scope" and any(";" in value or "," in value for value in values):
             ambiguous_fields.append(field)
     ambiguous_fields = _dedupe(ambiguous_fields)
     route = "implementation-delegate"
@@ -26602,6 +26620,7 @@ def _archive_record_closeout_state(*, target_root: Path, relative_path: str) -> 
         }
     closure_check = _as_dict(record.get("closure_check"))
     intent_satisfaction = _as_dict(record.get("intent_satisfaction"))
+    intent_continuity = _as_dict(record.get("intent_continuity"))
     canonical_core = _as_dict(record.get("canonical_core"))
     required_continuation = _as_dict(record.get("required_continuation"))
     durable_residue = _as_dict(record.get("durable_residue"))
@@ -26629,10 +26648,11 @@ def _archive_record_closeout_state(*, target_root: Path, relative_path: str) -> 
     intent_satisfied = str(intent_satisfaction.get("was original intent fully satisfied?") or "").strip().lower()
     completed = status in {"completed", "complete", "closed", "done"}
     closed = closure_decision == "archive-and-close"
-    continuation_routed = closure_decision == "archive-but-keep-lane-open" and any(
+    continuation_owner_present = any(
         value not in {"", "none", "no", "false", "n/a", "na"}
         for value in [
             str(canonical_core.get("continuation_owner") or "").strip().lower(),
+            str(intent_continuity.get("continuation surface") or "").strip().lower(),
             str(required_continuation.get("owner surface") or "").strip().lower(),
             str(durable_residue.get("canonical owner now") or "").strip().lower(),
             str(execution_summary.get("follow-on routed to") or "").strip().lower(),
@@ -26641,6 +26661,7 @@ def _archive_record_closeout_state(*, target_root: Path, relative_path: str) -> 
     )
     no_open_larger_intent = larger_intent_status in {"", "satisfied", "complete", "completed", "closed", "done"}
     slice_scope = str(closure_check.get("closeout scope") or "").strip().lower() == "slice"
+    continuation_routed = continuation_owner_present and (closure_decision == "archive-but-keep-lane-open" or slice_scope)
     intent_done = intent_satisfied in {"", "yes", "true", "satisfied", "complete", "completed"} or (slice_scope and continuation_routed)
     eligible = completed and intent_done and ((closed and no_open_larger_intent) or continuation_routed)
     blockers = [
@@ -35763,7 +35784,16 @@ def _proof_confidence_payload(
     }
 
 
-def _proof_completion_options(*, required_commands: list[str], manual_verification: dict[str, Any] | None) -> list[dict[str, Any]]:
+def _proof_completion_options(
+    *, required_commands: list[str], manual_verification: dict[str, Any] | None, test_strategy_check: dict[str, Any] | None = None
+) -> list[dict[str, Any]]:
+    test_strategy_check = _as_dict(test_strategy_check)
+    test_strategy_missing = (
+        test_strategy_check.get("status") == "advisory"
+        and bool(test_strategy_check.get("disposition_required_before_closeout"))
+        and bool(test_strategy_check.get("changed_test_paths"))
+        and not test_strategy_check.get("recorded_disposition")
+    )
     options: list[dict[str, Any]] = [
         _completion_option(
             "run-proof",
@@ -35794,7 +35824,10 @@ def _proof_completion_options(*, required_commands: list[str], manual_verificati
         _completion_option(
             "route-residue",
             allowed=False,
-            why="proof selection does not decide durable residue; route residue during closeout_trust reconciliation",
+            why="test strategy disposition must be recorded before claiming test-sustainability review"
+            if test_strategy_missing
+            else "proof selection does not decide durable residue; route residue during closeout_trust reconciliation",
+            blocking_fields=["test_strategy_check.recorded_disposition"] if test_strategy_missing else None,
         ),
         _completion_option(
             "request-review",
@@ -36800,7 +36833,11 @@ def _proof_selection_for_changed_paths(
         ),
         "broaden_when": broaden_when,
         "escalate_when": escalate_when,
-        "completion_options": _proof_completion_options(required_commands=required_commands, manual_verification=manual_verification),
+        "completion_options": _proof_completion_options(
+            required_commands=required_commands,
+            manual_verification=manual_verification,
+            test_strategy_check=test_strategy_check,
+        ),
     }
     if routing_reductions:
         proof_selection["routing_reductions"] = routing_reductions

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1521,6 +1521,30 @@ def test_implement_allows_completed_archived_plan_residue_with_continuation_evid
             },
             {"larger_intent_status": "open", "closure_decision": "archive-but-keep-lane-open"},
         ),
+        (
+            "archived-slice-with-routed-parent",
+            ".agentic-workspace/planning/execplans/archive/routed-parent-slice.plan.json",
+            {
+                "schema_version": "execplan/v1",
+                "id": "routed-parent-slice",
+                "machine_readable_contract": {"execution": {"status": "completed"}},
+                "intent_continuity": {
+                    "this slice completes the larger intended outcome": "no",
+                    "continuation surface": "GitHub #1556",
+                },
+                "required_continuation": {
+                    "required follow-on for the larger intended outcome": "Complete the parent lane.",
+                    "owner surface": "GitHub #1556",
+                },
+                "intent_satisfaction": {"was original intent fully satisfied?": "no for parent lane; yes for slice"},
+                "closure_check": {
+                    "closeout scope": "slice",
+                    "larger-intent status": "open-routed-to-#1556",
+                    "closure decision": "archive-and-close",
+                },
+            },
+            {"larger_intent_status": "open-routed-to-#1556", "closure_decision": "archive-and-close"},
+        ),
     ]
     for label, archive_path, record, expected_record_fields in scenarios:
         _write(tmp_path / archive_path, json.dumps(record))
@@ -2153,6 +2177,7 @@ candidates = []
             "kind": "planning-execplan/v1",
             "title": "Requirement grounding",
             "traceability_refs": {"requirement_refs": ["docs/requirements.md#trace"]},
+            "requirement_grounding": {"design_effects": ["Requirement refs must remain distinct from agent interpretation."]},
             "intent_interpretation": {"chosen concrete what": "Carry requirement refs through planning and closeout."},
             "canonical_core": {
                 "hard_constraints": "Keep observed source separate from agent interpretation.",
@@ -2192,7 +2217,8 @@ candidates = []
     assert grounding["requirement_refs"][0]["source_metadata"]["trust_note"].startswith("routing/index metadata only")
     assert grounding["source_inventory_policy"]["not_a_requirement_corpus"] is True
     assert grounding["agent_interpretation"]["status"] == "present"
-    assert grounding["design_effects"] == ["Keep observed source separate from agent interpretation."]
+    assert grounding["design_effects"] == ["Requirement refs must remain distinct from agent interpretation."]
+    assert grounding["planning_context_fallback"]["items"] == ["Keep observed source separate from agent interpretation."]
     assert grounding["authority_boundary"]["agent_owned_decisions"]
 
 
@@ -2414,6 +2440,66 @@ candidates = []
     ]
 
 
+def test_implement_keeps_exact_semicolon_scope_delegation_ready(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "src" / "runtime.py", "VALUE = 1\n")
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "delegate-semicolon", status = "active", maturity = "active", surface = ".agentic-workspace/planning/execplans/delegate-semicolon.plan.json" }
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "delegate-semicolon.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Delegate semicolon slice",
+            "canonical_core": {
+                "requested_outcome": "Implement a bounded runtime packet.",
+                "touched_scope": ["src/runtime.py; tests/test_runtime.py"],
+                "proof_expectations": ["uv run pytest tests/test_runtime.py -q"],
+                "completion_criteria": ["Packet is projected."],
+            },
+            "stop_conditions": {"stop when": "proof fails"},
+        },
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/runtime.py",
+                "--task",
+                "Continue delegate-semicolon",
+                "--select",
+                "plan_delegation_packet",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    packet = json.loads(capsys.readouterr().out)["values"]["plan_delegation_packet"]
+    assert packet["delegation_ready"] is True
+    assert packet["ambiguous_fields"] == []
+    assert packet["allowed_write_scope"] == ["src/runtime.py", "tests/test_runtime.py"]
+
+
 def test_implement_refuses_ambiguous_plan_delegation_packet(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(tmp_path / "src" / "runtime.py", "VALUE = 1\n")
@@ -2616,6 +2702,26 @@ def test_proof_surfaces_test_strategy_check_for_closeout_visibility(tmp_path: Pa
     assert check["kind"] == "agentic-workspace/test-strategy-check/v1"
     assert check["status"] == "advisory"
     assert check["closeout_visibility"]["missing_disposition_blocks_claim"] == "test-sustainability-reviewed"
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "tests/test_runtime.py",
+                "--select",
+                "completion_options",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    options = json.loads(capsys.readouterr().out)["values"]["completion_options"]
+    route_residue = next(option for option in options if option["id"] == "route-residue")
+    assert route_residue["blocking_fields"] == ["test_strategy_check.recorded_disposition"]
 
 
 def test_implement_blocks_parent_lane_slice_without_lane_owner_artifact(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2110,6 +2110,514 @@ candidates = [
     assert "lane_shaping_gate" not in payload["context"]
 
 
+def test_implement_surfaces_requirement_grounding_chain(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "src" / "runtime.py", "VALUE = 1\n")
+    _write(
+        tmp_path / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json",
+        json.dumps(
+            {
+                "kind": "planning-external-intent-evidence/v1",
+                "items": [
+                    {
+                        "id": "#1556",
+                        "system": "tracker",
+                        "status": "open",
+                        "kind": "capability-lane",
+                        "title": "Support requirement-grounded agent work end to end",
+                    }
+                ],
+            }
+        ),
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "requirement-grounding", status = "active", maturity = "active", surface = ".agentic-workspace/planning/execplans/requirement-grounding.plan.json" }
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "requirement-grounding.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Requirement grounding",
+            "traceability_refs": {"requirement_refs": ["docs/requirements.md#trace"]},
+            "intent_interpretation": {"chosen concrete what": "Carry requirement refs through planning and closeout."},
+            "canonical_core": {
+                "hard_constraints": "Keep observed source separate from agent interpretation.",
+                "touched_scope": ["src/runtime.py"],
+                "proof_expectations": ["uv run pytest tests/test_workspace_implement_cli.py -q"],
+                "completion_criteria": ["Requirement grounding packet is visible."],
+            },
+            "validation_commands": ["uv run pytest tests/test_workspace_implement_cli.py -q"],
+            "completion_criteria": ["Requirement grounding packet is visible."],
+        },
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/runtime.py",
+                "--task",
+                "Implement #1556",
+                "--select",
+                "requirement_grounding",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    grounding = payload["values"]["requirement_grounding"]
+    assert grounding["kind"] == "agentic-workspace/requirement-grounding/v1"
+    assert grounding["status"] in {"ready", "attention"}
+    assert {item["ref"] for item in grounding["requirement_refs"]} >= {"#1556", "docs/requirements.md#trace"}
+    assert grounding["requirement_refs"][0]["source_metadata"]["trust_note"].startswith("routing/index metadata only")
+    assert grounding["source_inventory_policy"]["not_a_requirement_corpus"] is True
+    assert grounding["agent_interpretation"]["status"] == "present"
+    assert grounding["design_effects"] == ["Keep observed source separate from agent interpretation."]
+    assert grounding["authority_boundary"]["agent_owned_decisions"]
+
+
+def test_proof_surfaces_requirement_grounding_chain(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "src" / "runtime.py", "VALUE = 1\n")
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "proof-grounding", status = "active", maturity = "active", surface = ".agentic-workspace/planning/execplans/proof-grounding.plan.json" }
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "proof-grounding.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Proof grounding",
+            "traceability_refs": {"requirement_refs": ["docs/requirements.md#trace"]},
+        },
+    )
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/runtime.py",
+                "--select",
+                "requirement_grounding",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    grounding = json.loads(capsys.readouterr().out)["values"]["requirement_grounding"]
+    assert grounding["kind"] == "agentic-workspace/requirement-grounding/v1"
+    assert grounding["requirement_refs"][0]["ref"] == "docs/requirements.md#trace"
+    assert grounding["requirement_refs"][0]["source_metadata"]["freshness"] in {"repo-current", "external-or-unverified"}
+    assert grounding["closeout_claims"]["blocked"] == ["requirement-grounded-completion"]
+
+
+def test_requirement_grounding_reports_missing_sensitive_refs(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "runtime.py", "VALUE = 1\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/runtime.py",
+                "--task",
+                "Update privacy policy handling",
+                "--select",
+                "requirement_grounding",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    grounding = json.loads(capsys.readouterr().out)["values"]["requirement_grounding"]
+    assert grounding["status"] == "attention"
+    assert grounding["source_facts"]["sensitivity_signals"] == ["task-text-requirement-sensitive"]
+    assert grounding["known_gaps"][0]["gap"] == "task appears requirement-sensitive but no applicable requirement refs were selected"
+
+
+def test_report_section_surfaces_requirement_grounding_chain(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path)]) == 0
+    capsys.readouterr()
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "report-grounding", status = "active", maturity = "active", surface = ".agentic-workspace/planning/execplans/report-grounding.plan.json" }
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "report-grounding.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Report grounding",
+            "traceability_refs": {"requirement_refs": ["docs/requirements.md#report"]},
+            "intent_interpretation": {"chosen concrete what": "Report the requirement grounding chain."},
+            "canonical_core": {"hard_constraints": "Keep report facts separate from agent decisions."},
+        },
+    )
+
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(tmp_path),
+                "--section",
+                "requirement_grounding",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    grounding = json.loads(capsys.readouterr().out)["answer"]
+    assert grounding["kind"] == "agentic-workspace/requirement-grounding/v1"
+    assert grounding["status"] == "ready"
+    assert grounding["requirement_refs"][0]["ref"] == "docs/requirements.md#report"
+    assert grounding["source_inventory_policy"]["role"] == "compact-routing-index"
+    assert grounding["agent_interpretation"]["summary"] == "Report the requirement grounding chain."
+
+
+def test_implement_projects_ready_plan_delegation_packet(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "src" / "runtime.py", "VALUE = 1\n")
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "delegate-ready", status = "active", maturity = "active", surface = ".agentic-workspace/planning/execplans/delegate-ready.plan.json" }
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "delegate-ready.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Delegate ready slice",
+            "canonical_core": {
+                "requested_outcome": "Implement a bounded runtime packet.",
+                "touched_scope": ["src/runtime.py"],
+                "proof_expectations": ["uv run pytest tests/test_workspace_implement_cli.py -q"],
+                "completion_criteria": ["Packet is projected."],
+            },
+            "execution_bounds": {"allowed paths": "src/runtime.py", "stop before touching": "generated files"},
+            "stop_conditions": {"stop when": "proof fails"},
+            "validation_commands": ["uv run pytest tests/test_workspace_implement_cli.py -q"],
+            "completion_criteria": ["Packet is projected."],
+            "references": [{"target": "docs/design.md", "label": "Design"}],
+        },
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/runtime.py",
+                "--task",
+                "Continue delegate-ready",
+                "--select",
+                "plan_delegation_packet",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    packet = json.loads(capsys.readouterr().out)["values"]["plan_delegation_packet"]
+    assert packet["kind"] == "agentic-workspace/plan-delegation-packet/v1"
+    assert packet["delegation_ready"] is True
+    assert packet["delegation_recommended"] is True
+    assert packet["freshness_guard"]["delegate_return_must_cite_revision"] is True
+    assert packet["missing_fields"] == []
+    assert packet["recommended_route"] == "implementation-delegate"
+    assert "Allowed write scope: src/runtime.py" in packet["handoff_prompt"]
+    assert packet["return_contract"]["required_fields"] == [
+        "changed_files",
+        "changed_surfaces",
+        "proof_run",
+        "proof_result",
+        "result",
+        "uncertainty",
+        "stop_condition_hits",
+        "residue",
+        "allowed_claims",
+        "planning_revision",
+    ]
+
+
+def test_implement_refuses_ambiguous_plan_delegation_packet(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "src" / "runtime.py", "VALUE = 1\n")
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "delegate-ambiguous", status = "active", maturity = "active", surface = ".agentic-workspace/planning/execplans/delegate-ambiguous.plan.json" }
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "delegate-ambiguous.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Ambiguous delegate slice",
+            "canonical_core": {
+                "requested_outcome": "Implement a bounded runtime packet.",
+                "touched_scope": ["src/runtime.py; tests as needed"],
+                "proof_expectations": ["Fill in proof later."],
+                "completion_criteria": ["Packet is projected."],
+            },
+            "stop_conditions": {"stop when": "proof fails"},
+        },
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/runtime.py",
+                "--task",
+                "Continue delegate-ambiguous",
+                "--select",
+                "plan_delegation_packet",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    packet = json.loads(capsys.readouterr().out)["values"]["plan_delegation_packet"]
+    assert packet["status"] == "ambiguous-fields"
+    assert packet["delegation_ready"] is False
+    assert packet["delegation_recommended"] is False
+    assert set(packet["ambiguous_fields"]) >= {"allowed_write_scope", "proof_commands"}
+
+
+def test_implement_projects_validation_delegation_route(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "src" / "runtime.py", "VALUE = 1\n")
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "delegate-validation", status = "active", maturity = "active", surface = ".agentic-workspace/planning/execplans/delegate-validation.plan.json" }
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "delegate-validation.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Delegate validation slice",
+            "canonical_core": {
+                "requested_outcome": "Validate the bounded runtime packet.",
+                "touched_scope": ["src/runtime.py"],
+                "proof_expectations": ["uv run pytest tests/test_workspace_implement_cli.py -q"],
+                "completion_criteria": ["Validation result is reported."],
+            },
+            "stop_conditions": {"stop when": "proof fails"},
+        },
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/runtime.py",
+                "--task",
+                "Continue delegate-validation",
+                "--select",
+                "plan_delegation_packet",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    packet = json.loads(capsys.readouterr().out)["values"]["plan_delegation_packet"]
+    assert packet["delegation_ready"] is True
+    assert packet["recommended_route"] == "validation-delegate"
+
+
+def test_implement_surfaces_test_strategy_check_for_hotspot_tests(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / "tests" / "test_runtime.py",
+        """
+import pytest
+
+
+@pytest.mark.parametrize("case", ["a", "b"])
+def test_runtime_matrix_case(case):
+    assert case
+
+
+def test_runtime_warning_alpha(): assert True
+def test_runtime_warning_beta(): assert True
+def test_runtime_warning_gamma(): assert True
+def test_runtime_warning_delta(): assert True
+def test_runtime_warning_epsilon(): assert True
+def test_runtime_warning_zeta(): assert True
+def test_runtime_warning_eta(): assert True
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "tests/test_runtime.py",
+                "--task",
+                "Address review feedback by adding regression coverage",
+                "--select",
+                "test_strategy_check",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    check = json.loads(capsys.readouterr().out)["values"]["test_strategy_check"]
+    assert check["kind"] == "agentic-workspace/test-strategy-check/v1"
+    assert check["status"] == "advisory"
+    assert check["blocking"] is False
+    assert check["hotspot_file_count"] == 1
+    assert check["scenario_matrix_candidate_count"] == 1
+    assert check["reviewer_requested_coverage"] is True
+    assert check["disposition_required_before_closeout"] is True
+    assert check["verification_evidence_surfaces"]["proof_decision_status"]
+    assert "standalone-durable-contract-proof" in check["record_disposition_options"]
+    assert check["files"][0]["parametrized_test_count"] == 1
+
+
+def test_proof_surfaces_test_strategy_check_for_closeout_visibility(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "tests" / "test_runtime.py", "def test_runtime_contract():\n    assert True\n")
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "tests/test_runtime.py",
+                "--select",
+                "test_strategy_check",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    check = json.loads(capsys.readouterr().out)["values"]["test_strategy_check"]
+    assert check["kind"] == "agentic-workspace/test-strategy-check/v1"
+    assert check["status"] == "advisory"
+    assert check["closeout_visibility"]["missing_disposition_blocks_claim"] == "test-sustainability-reviewed"
+
+
 def test_implement_blocks_parent_lane_slice_without_lane_owner_artifact(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(tmp_path / "src" / "agentic_workspace" / "runtime.py", "VALUE = 1\n")


### PR DESCRIPTION
## Summary

- Add `requirement_grounding` projections across `implement`, `proof`, and lazy `report --section requirement_grounding`.
- Add plan-derived `plan_delegation_packet` with planning revision freshness, separate ready/recommended states, ambiguity refusal, structured return contract, and handoff prompt.
- Add advisory `test_strategy_check` tied to Verification evidence surfaces and expose it from `implement` and `proof` for closeout-visible test sustainability decisions.

## Issue comments addressed

- #1556: keeps requirement refs as compact routing/index metadata, includes source freshness metadata, surfaces missing grounding for requirement-sensitive work, and keeps applicability/interpretation/claim judgment agent/human-owned.
- #1559: derives delegation packet from active plan fields, includes planning revision guard, separates `delegation_ready` from `delegation_recommended`, refuses broad/ambiguous scope or proof, and structures return contract fields.
- #1560: reuses Verification evidence surfaces (`evidence_strategy`, `proof_governance`, `proof_decision`, `regression_sprawl`), aligns disposition vocabulary, captures reviewer-requested coverage signals, and makes missing disposition closeout-visible without blocking implementation.

## Proof

- `uv run pytest tests/test_workspace_implement_cli.py -q -k "requirement_grounding or plan_delegation_packet or test_strategy_check"`
- `uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_implement_cli.py`
- `make test-workspace`
- `make lint-workspace`

Closes #1559.
Closes #1560.
Advances #1556, but does not close it unless the owner accepts this as full operating-loop closure.