### PR TITLE
[codex] Add subsystem-scoped assurance grounding

### DIFF
--- a/.agentic-workspace/config.toml
+++ b/.agentic-workspace/config.toml
@@ -21,8 +21,72 @@ default_level = "medium"
 agent_may_escalate = true
 agent_may_deescalate = false
 strict_closeout = true
-proof_profiles = {}
 test_data_policy = {}
+
+[assurance.proof_profiles.workspace_behavior]
+required_commands = ["make test-workspace", "make lint-workspace"]
+optional_commands = ["uv run python scripts/run_agentic_workspace.py proof --target . --current --format json"]
+review_aids = ["Compare selected proof to changed ownership subsystem and claim boundary."]
+
+[assurance.proof_profiles.verification_behavior]
+required_commands = ["uv run pytest packages/verification/tests -q"]
+optional_commands = ["uv run python scripts/run_agentic_workspace.py report --target . --section verification --format json"]
+review_aids = ["Confirm Verification reports facts and questions without making agent-owned proof decisions."]
+
+[assurance.proof_profiles.test_evidence_change]
+required_commands = ["make test-workspace", "make lint-workspace"]
+optional_commands = ["uv run python scripts/run_agentic_workspace.py report --target . --section verification --format json"]
+review_aids = ["Record or inspect the Verification proof-decision route when ordinary tests grow, shrink, or move."]
+
+[assurance.requirements.test_evidence_change_decision]
+level = "high"
+applies_to_paths = ["tests/**", "packages/**/tests/**", "docs/maintainer/test-knowledge-inventory.md", "docs/maintainer/testing-strategy.md"]
+applies_to_task_markers = ["test reduction", "regression test", "ordinary test", "conformance test", "proof decision"]
+authority_refs = ["docs/maintainer/testing-strategy.md", "docs/maintainer/test-knowledge-inventory.md"]
+required_evidence = ["verification_proof_decision_review"]
+proof_profile = "test_evidence_change"
+review_owner = "maintainer"
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+notes = "Changing ordinary test evidence should explain the trust question and replacement/retention decision instead of relying on test count alone."
+
+[assurance.requirements.closeout_intent_satisfaction]
+level = "high"
+applies_to_paths = ["packages/planning/src/**/archive*.py", "packages/planning/src/**/closeout*.py", "packages/planning/tests/**/test_archive*.py", "tests/test_workspace_summary_cli.py", "tests/test_workspace_implement_cli.py"]
+applies_to_task_markers = ["closeout", "intent satisfaction", "parent lane", "completion claim"]
+authority_refs = [".agentic-workspace/OWNERSHIP.toml#subsystems.planning", ".agentic-workspace/planning/skills/planning-closeout-trust/SKILL.md"]
+required_evidence = ["intent_satisfaction_review", "closeout_trust_review"]
+proof_profile = "workspace_behavior"
+workflow_obligation_refs = ["commit_after_proof"]
+review_owner = "maintainer"
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete", "close-parent-lane"]
+notes = "Planning and closeout behavior changes need explicit intent-satisfaction and residue-routing evidence before broad completion claims."
+
+[assurance.requirements.workspace_runtime_routing]
+level = "high"
+applies_to_paths = ["src/agentic_workspace/workspace_runtime_primitives.py"]
+applies_to_task_markers = ["workspace runtime", "requirement grounding", "delegation", "assurance"]
+authority_refs = [".agentic-workspace/OWNERSHIP.toml#subsystems.workspace-cli-runtime", "src/agentic_workspace/workspace_runtime_primitives.py"]
+required_evidence = ["workspace_runtime_proof", "tiny_surface_compatibility_review"]
+proof_profile = "workspace_behavior"
+workflow_obligation_refs = ["adapter_surface_refresh"]
+review_owner = "maintainer"
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete"]
+notes = "Workspace runtime routing changes need focused runtime proof and compact-output compatibility review before broad completion claims."
+
+[assurance.requirements.model_harness_evidence]
+level = "high"
+applies_to_paths = ["tools/model-cli-harness/**", "scripts/model_cli_harness/**", "docs/maintainer/test-knowledge-inventory.md"]
+applies_to_task_markers = ["model cli harness", "harness scorer", "test knowledge inventory"]
+authority_refs = [".agentic-workspace/OWNERSHIP.toml#subsystems.model-cli-harness", "docs/maintainer/test-knowledge-inventory.md"]
+required_evidence = ["model_harness_scorer_proof", "test_knowledge_inventory_review"]
+proof_profile = "test_evidence_change"
+review_owner = "maintainer"
+force = "required-before-closeout"
+blocking_claims = ["claim-work-complete"]
+notes = "Model harness and test-knowledge changes need scorer proof and inventory review before broad completion claims."
 
 [cli_compatibility]
 enforcement = "advisory"

--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -1,0 +1,36 @@
+{
+  "command_generation": {
+    "package": "command-generation",
+    "runtime_required": false,
+    "source": "released-wheel",
+    "source_identity": "python-environment:command_generation",
+    "version": "0.1.0"
+  },
+  "installed_at": "2026-06-16T14:13:26+00:00",
+  "installed_by": {
+    "package": "agentic-workspace",
+    "source": "local-source",
+    "source_class": "source-checkout",
+    "source_identity": "git:599804297f0e",
+    "version": "0.1.0"
+  },
+  "kind": "agentic-workspace/payload-provenance/v1",
+  "payload_files": [
+    ".agentic-workspace/WORKFLOW.md",
+    ".agentic-workspace/OWNERSHIP.toml",
+    ".agentic-workspace/docs/jumpstart-contract.md",
+    ".agentic-workspace/docs/module-map.md",
+    ".agentic-workspace/docs/setup-findings-contract.md",
+    ".agentic-workspace/skills/REGISTRY.json",
+    ".agentic-workspace/skills/workspace-startup/SKILL.md",
+    ".agentic-workspace/skills/workspace-intent-discovery/SKILL.md",
+    ".agentic-workspace/skills/workspace-work-shape/SKILL.md",
+    ".agentic-workspace/skills/workspace-proof-selection/SKILL.md",
+    ".agentic-workspace/skills/workspace-transition-gates/SKILL.md",
+    ".agentic-workspace/skills/workspace-operating-loop/SKILL.md",
+    ".agentic-workspace/skills/workspace-setup-jumpstart/SKILL.md",
+    ".agentic-workspace/system-intent/WORKFLOW.md"
+  ],
+  "payload_schema": "agentic-workspace/payload/v1",
+  "rule": "Repo payload provenance records the executable/source identity that installed or last synced the AW payload."
+}

--- a/.agentic-workspace/skills/REGISTRY.json
+++ b/.agentic-workspace/skills/REGISTRY.json
@@ -235,6 +235,9 @@
           "seed surfaces",
           "durable surfaces",
           "workspace surfaces",
+          "assurance onboarding",
+          "verification onboarding",
+          "verification manifest",
           "new repo adoption"
         ],
         "phrases": [
@@ -244,6 +247,9 @@
           "post-bootstrap setup",
           "populate surfaces",
           "seed surfaces",
+          "populate assurance",
+          "populate verification",
+          "seed verification manifest",
           "newly installed workspace",
           "after install",
           "new repo adoption"

--- a/.agentic-workspace/skills/workspace-setup-jumpstart/SKILL.md
+++ b/.agentic-workspace/skills/workspace-setup-jumpstart/SKILL.md
@@ -27,8 +27,13 @@ When the task is to populate durable workspace surfaces after bootstrap, handle 
 - `.agentic-workspace/OWNERSHIP.toml`: keep package-managed module roots, managed surfaces, fences, and authority surfaces generic; add host-specific `[[subsystems]]` only from inspected repo structure, test commands, ownership boundaries, or clear user direction. Do not copy subsystem entries from the Agentic Workspace source repo into a host repo.
 - `.agentic-workspace/system-intent/intent.toml`: run `agentic-workspace system-intent --target . --sync --format json` first, then refine only reviewable interpreted fields that are supported by named repo intent sources such as `README.md`, `SYSTEM_INTENT.md`, product docs, or explicit user direction. Do not mechanically summarize every source file.
 - `.agentic-workspace/system-intent/subsystems.toml`: add scoped durable intent only for subsystem ids already declared in `.agentic-workspace/OWNERSHIP.toml [[subsystems]]`. Leave `subsystems = []` when no host subsystem boundary is clear.
+- `.agentic-workspace/config.toml [assurance]`: run `agentic-workspace defaults --section assurance_onboarding --format json` before seeding assurance. Add proof profiles, requirements, or subsystem profiles only when an inspected host-owned source names the risk, requirement, evidence burden, proof route, or claim boundary. Subsystem profiles must use existing `.agentic-workspace/OWNERSHIP.toml [[subsystems]]` ids.
+- `.agentic-workspace/verification/manifest.toml`: run `agentic-workspace defaults --section verification_onboarding --format json` before seeding Verification. Add protocols, scenarios, proof routes, bundles, or known gaps only when the host repo has a repeatable proof need that ordinary test or command selection does not already express.
+- `.agentic-workspace/verification/proof-strategy.toml`: seed only enum hints that the host repo explicitly owns. Do not summarize strategy prose or infer policy from filenames.
 
 Population rule: host repo values must be derived from the host repo. Package defaults may provide schema shape and managed-surface ownership, but not source-repo product intent, source-repo subsystem ids, source paths, proof commands, or issue references.
+
+Assurance and Verification population rule: AW surfaces questions and templates; the agent decides whether evidence is strong enough to write anything. Prefer leaving these surfaces absent over creating generic placeholder obligations.
 
 ## Seed Bias
 

--- a/.agentic-workspace/verification/manifest.toml
+++ b/.agentic-workspace/verification/manifest.toml
@@ -47,6 +47,75 @@ fail_evidence_labels = [
 ]
 automation_hint = "uv run python scripts/check/check_generated_command_packages.py --docker-conformance --require-docker"
 
+[scenarios.closeout_intent_satisfaction_review]
+protocol_id = "closeout_intent_satisfaction"
+title = "Closeout intent-satisfaction review"
+steps = [
+  "Inspect the task acceptance, closeout trust, and continuation surfaces for the changed work.",
+  "Confirm proof success is separated from semantic intent satisfaction.",
+  "Confirm any remaining parent-lane or follow-up work is routed explicitly before broad completion claims.",
+]
+expected_observations = [
+  "Completion claims name delivered behavior, proof, and unresolved residue.",
+  "No parent or lane intent is closed only because a local slice passed tests.",
+]
+pass_evidence_labels = [
+  "intent_satisfaction_review",
+  "closeout_trust_review",
+]
+fail_evidence_labels = [
+  "missing_intent_satisfaction_review",
+  "unrouted_closeout_residue",
+]
+automation_hint = "uv run python scripts/run_agentic_workspace.py report --target . --section closeout_trust --format json"
+manual_boundary = "The agent decides whether the user intent is satisfied; Verification only records the repeatable review route."
+
+[scenarios.requirement_grounding_delegation_review]
+protocol_id = "requirement_grounding_delegation"
+title = "Requirement grounding and delegation review"
+steps = [
+  "Inspect implement or proof output for requirement_grounding, delegation_decision, and plan_delegation_packet fields.",
+  "Confirm requirement refs remain source observations and agent interpretation remains separate.",
+  "Confirm delegation is surfaced as a route decision with evidence, not skipped silently when a plan or policy expects it.",
+]
+expected_observations = [
+  "Requirement refs identify observed source or planning evidence.",
+  "Agent-owned interpretation and delegation decisions remain explicit.",
+]
+pass_evidence_labels = [
+  "requirement_grounding_review",
+  "delegation_route_review",
+]
+fail_evidence_labels = [
+  "missing_requirement_grounding_review",
+  "silent_delegation_skip",
+]
+automation_hint = "uv run python scripts/run_agentic_workspace.py implement --changed <paths> --select requirement_grounding,context.delegation_decision,context.plan_delegation_packet --format json"
+manual_boundary = "The agent decides fit and sufficiency; Verification only names the repeatable inspection route."
+
+[scenarios.test_evidence_decision_review]
+protocol_id = "test_evidence_decision"
+title = "Test evidence decision review"
+steps = [
+  "Run or inspect the Verification evidence_strategy report for changed test files.",
+  "Record the trust question, evidence owner, durability, and prune or replacement condition when ordinary tests grow, shrink, or move.",
+  "Confirm test-count changes are not used as a substitute for evidence ownership and replacement reasoning.",
+]
+expected_observations = [
+  "The proof-decision review explains why retained, merged, converted, added, or pruned evidence is sufficient.",
+  "The report keeps decisions agent-owned and does not infer host strategy from prose.",
+]
+pass_evidence_labels = [
+  "verification_proof_decision_review",
+  "test_evidence_owner_review",
+]
+fail_evidence_labels = [
+  "missing_verification_proof_decision",
+  "test_count_only_completion_claim",
+]
+automation_hint = "uv run python scripts/run_agentic_workspace.py report --target . --section verification --format json"
+manual_boundary = "A live .agentic-workspace/verification/proof-decision.json should be agent-authored for the specific test-evidence change, not prefilled as standing policy."
+
 [protocols.generated_adapter_conformance]
 title = "Generated adapter conformance"
 purpose = "Keep generated command package adapters honest across generated Python and TypeScript surfaces without making Verification the proof authority."
@@ -118,6 +187,159 @@ review_aids = [
   "Do not let stale generated adapter evidence satisfy changed command_package_ir, generator, checker, or generated-root changes.",
 ]
 
+[protocols.closeout_intent_satisfaction]
+title = "Closeout intent satisfaction"
+purpose = "Make completion-honesty and residue-routing review repeatable for planning and closeout behavior without letting Verification decide semantic satisfaction."
+applies_to_paths = [
+  "packages/planning/src/**/archive*.py",
+  "packages/planning/src/**/closeout*.py",
+  "packages/planning/tests/**/test_archive*.py",
+  "src/agentic_workspace/workspace_runtime_primitives.py",
+  "tests/test_workspace_summary_cli.py",
+  "tests/test_workspace_implement_cli.py",
+]
+applies_to_task_markers = [
+  "closeout",
+  "intent satisfaction",
+  "parent lane",
+  "residue",
+  "completion claim",
+]
+assurance_requirement_refs = []
+scenario_refs = ["closeout_intent_satisfaction_review"]
+steps = [
+  "Inspect closeout trust and intent-satisfaction surfaces.",
+  "Compare delivered behavior, proof, and remaining continuation claims.",
+]
+expected_evidence = [
+  "intent_satisfaction_review",
+  "closeout_trust_review",
+]
+review_owner = "maintainer"
+authority_refs = [
+  ".agentic-workspace/docs/reporting-contract.md",
+  ".agentic-workspace/planning/skills/planning-closeout-trust/SKILL.md",
+  "src/agentic_workspace/workspace_runtime_primitives.py",
+]
+stale_when = [
+  "packages/planning/src/**/archive*.py",
+  "packages/planning/src/**/closeout*.py",
+  "packages/planning/tests/**/test_archive*.py",
+  "src/agentic_workspace/workspace_runtime_primitives.py",
+]
+retention = "retain-summary"
+non_goals = [
+  "Verification does not decide whether the user is satisfied.",
+  "Verification does not close parent lanes.",
+]
+commands = [
+  "uv run python scripts/run_agentic_workspace.py report --target . --section closeout_trust --format json",
+]
+review_aids = [
+  "Use this route when closeout, archive, continuation, or completion-honesty semantics changed.",
+]
+
+[protocols.requirement_grounding_delegation]
+title = "Requirement grounding and delegation"
+purpose = "Keep requirement-grounding and delegation support inspectable without turning Verification into the decision maker."
+applies_to_paths = [
+  ".agentic-workspace/config.toml",
+  ".agentic-workspace/OWNERSHIP.toml",
+  "src/agentic_workspace/workspace_runtime_primitives.py",
+  "tests/test_workspace_config_cli.py",
+  "tests/test_workspace_implement_cli.py",
+]
+applies_to_task_markers = [
+  "requirement grounding",
+  "delegation",
+  "assurance",
+  "subsystem profile",
+  "handoff",
+]
+assurance_requirement_refs = []
+scenario_refs = ["requirement_grounding_delegation_review"]
+steps = [
+  "Inspect requirement grounding and delegation report fields for the changed paths.",
+  "Confirm AW surfaces facts and questions while the agent owns the route decision.",
+]
+expected_evidence = [
+  "requirement_grounding_review",
+  "delegation_route_review",
+]
+review_owner = "maintainer"
+authority_refs = [
+  ".agentic-workspace/config.toml",
+  ".agentic-workspace/OWNERSHIP.toml",
+  "src/agentic_workspace/workspace_runtime_primitives.py",
+]
+stale_when = [
+  ".agentic-workspace/config.toml",
+  ".agentic-workspace/OWNERSHIP.toml",
+  "src/agentic_workspace/workspace_runtime_primitives.py",
+]
+retention = "retain-summary"
+non_goals = [
+  "Verification does not choose whether to delegate.",
+  "Verification does not promote source observations into requirements.",
+]
+commands = [
+  "uv run python scripts/run_agentic_workspace.py implement --changed <paths> --select requirement_grounding,context.delegation_decision,context.plan_delegation_packet --format json",
+]
+review_aids = [
+  "Use this route when requirement refs, subsystem assurance, delegation policy, or handoff packets changed.",
+]
+
+[protocols.test_evidence_decision]
+title = "Test evidence decision"
+purpose = "Make ordinary test growth, reduction, movement, and conformance conversion explainable by evidence ownership instead of raw test count."
+applies_to_paths = [
+  "tests/**",
+  "packages/**/tests/**",
+  "docs/maintainer/testing-strategy.md",
+  "docs/maintainer/test-knowledge-inventory.md",
+]
+applies_to_task_markers = [
+  "test reduction",
+  "regression test",
+  "ordinary test",
+  "conformance test",
+  "proof decision",
+]
+assurance_requirement_refs = ["test_evidence_change_decision"]
+scenario_refs = ["test_evidence_decision_review"]
+steps = [
+  "Inspect evidence_strategy, regression_sprawl, and proof_decision report fields.",
+  "Record or review agent-authored proof-decision evidence when ordinary tests change materially.",
+]
+expected_evidence = [
+  "verification_proof_decision_review",
+  "test_evidence_owner_review",
+]
+review_owner = "maintainer"
+authority_refs = [
+  "docs/maintainer/testing-strategy.md",
+  "docs/maintainer/test-knowledge-inventory.md",
+  "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py",
+]
+stale_when = [
+  "tests/**",
+  "packages/**/tests/**",
+  "docs/maintainer/testing-strategy.md",
+  "docs/maintainer/test-knowledge-inventory.md",
+  "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py",
+]
+retention = "retain-summary"
+non_goals = [
+  "Verification does not authorize deletion by itself.",
+  "Verification does not infer host strategy from prose or filenames.",
+]
+commands = [
+  "uv run python scripts/run_agentic_workspace.py report --target . --section verification --format json",
+]
+review_aids = [
+  "Use this route before claiming test-count reduction, pruning, conversion, or new regression tests are sufficient.",
+]
+
 [proof_routes.generated_adapter_conformance]
 protocol_refs = ["generated_adapter_conformance"]
 scenario_refs = [
@@ -136,3 +358,40 @@ review_aids = [
 ]
 proof_lane_hint = "generated-adapter-conformance"
 reason = "Generated command package changes need repeatable local and Docker conformance evidence."
+
+[proof_routes.closeout_intent_satisfaction]
+protocol_refs = ["closeout_intent_satisfaction"]
+scenario_refs = ["closeout_intent_satisfaction_review"]
+commands = [
+  "uv run python scripts/run_agentic_workspace.py report --target . --section closeout_trust --format json",
+]
+review_aids = [
+  "Compare proof success, delivered behavior, user intent, and remaining continuation before broad completion claims.",
+]
+proof_lane_hint = "closeout-intent-satisfaction"
+reason = "Closeout and planning behavior changes need repeatable completion-honesty evidence."
+
+[proof_routes.requirement_grounding_delegation]
+protocol_refs = ["requirement_grounding_delegation"]
+scenario_refs = ["requirement_grounding_delegation_review"]
+commands = [
+  "uv run python scripts/run_agentic_workspace.py implement --changed <paths> --select requirement_grounding,context.delegation_decision,context.plan_delegation_packet --format json",
+]
+review_aids = [
+  "Confirm source observations, agent interpretation, and delegation route decisions remain separate.",
+]
+proof_lane_hint = "requirement-grounding-delegation"
+reason = "Requirement-grounding, assurance, and delegation changes need explicit route-review evidence."
+
+[proof_routes.test_evidence_decision]
+protocol_refs = ["test_evidence_decision"]
+scenario_refs = ["test_evidence_decision_review"]
+assurance_requirement_refs = ["test_evidence_change_decision"]
+commands = [
+  "uv run python scripts/run_agentic_workspace.py report --target . --section verification --format json",
+]
+review_aids = [
+  "Record a live proof-decision when ordinary test evidence materially changes.",
+]
+proof_lane_hint = "test-evidence-decision"
+reason = "Test evidence changes need trust-question and replacement-evidence review beyond raw test counts."

--- a/docs/jumpstart-contract.md
+++ b/docs/jumpstart-contract.md
@@ -30,6 +30,10 @@ For mature repos, prefer compact contract-like surfaces over broad prose mirrors
 
 Do not bulk-import README files, issue backlogs, generated references, or design prose simply because they exist. Link to canonical docs instead of copying them when the document is already discoverable and not expensive to reconstruct.
 
+Assurance and Verification are durable seed candidates only when the host repo provides concrete evidence. Use `agentic-workspace defaults --section assurance_onboarding --format json` and `agentic-workspace defaults --section verification_onboarding --format json` before writing those surfaces. The agent should seed assurance requirements, subsystem profiles, verification protocols, proof routes, or known gaps only from inspected host-owned sources such as ownership boundaries, requirement docs, existing proof commands, runbooks, review practice, or explicit user direction.
+
+Leave assurance or verification absent when the only available input is generic risk language, filenames, or Agentic Workspace source-repo policy. A missing durable surface is better than a placeholder obligation that future agents treat as authority.
+
 ## Proof
 
 Before claiming setup follow-through, show:

--- a/docs/reference/workspace-config.md
+++ b/docs/reference/workspace-config.md
@@ -91,6 +91,20 @@ Repo-owned Agentic Workspace configuration stored in .agentic-workspace/config.t
 | `assurance.requirements.<name>.dismissal.reason` | string | yes |  | Why the requirement was waived, dismissed, or found not applicable. |  |  |
 | `assurance.requirements.<name>.dismissal.owner` | string | yes |  | Repo-local owner or role accountable for the waiver or dismissal. |  |  |
 | `assurance.requirements.<name>.notes` | string | no |  | Optional repo-local note about this requirement. |  |  |
+| `assurance.subsystem_profiles` | object | no | `{}` | Subsystem-scoped assurance profiles keyed by existing .agentic-workspace/OWNERSHIP.toml subsystem ids. |  |  |
+| `assurance.subsystem_profiles.<name>` | object | no |  | One host-owned assurance profile for an ownership subsystem. |  | x-agentic-workspace-unknown-properties: "warn" |
+| `assurance.subsystem_profiles.<name>.assurance_level` | enum `"low"`, `"medium"`, `"high"`, `"critical"` | yes |  | Repo-interpreted assurance level for the matched subsystem. |  |  |
+| `assurance.subsystem_profiles.<name>.level` | enum `"low"`, `"medium"`, `"high"`, `"critical"` | no |  | Alias for assurance_level. |  |  |
+| `assurance.subsystem_profiles.<name>.scope_refs` | array of string | no | `[]` | Existing subsystem scope refs that activate this profile, such as ownership.subsystems.<id> or subsystem:<id>. The profile id is also treated as a scope ref. |  |  |
+| `assurance.subsystem_profiles.<name>.requirement_refs` | array of string | no | `[]` | Repo-owned requirement refs normally applying to this subsystem. |  |  |
+| `assurance.subsystem_profiles.<name>.required_evidence` | array of string | no | `[]` | Free-form repo vocabulary naming evidence expected before supported subsystem claims. |  |  |
+| `assurance.subsystem_profiles.<name>.proof_profile` | string | no |  | Optional assurance.proof_profiles id to add when this subsystem profile is active. |  |  |
+| `assurance.subsystem_profiles.<name>.workflow_obligation_refs` | array of string | no | `[]` | Workflow obligation ids related to this subsystem profile. |  |  |
+| `assurance.subsystem_profiles.<name>.review_owner` | string | no |  | Repo-local owner label for review or waiver decisions. |  |  |
+| `assurance.subsystem_profiles.<name>.force` | enum `"informational"`, `"recommended"`, `"required-before-closeout"`, `"blocking"` | yes |  | How strongly this subsystem profile affects guidance and closeout claim gates. |  |  |
+| `assurance.subsystem_profiles.<name>.blocked_without_evidence` | array of string | no | `[]` | Claim ids or labels blocked while required subsystem evidence is missing. |  |  |
+| `assurance.subsystem_profiles.<name>.claim_boundary` | string | no |  | Human-readable boundary for claims supported by this subsystem profile. |  |  |
+| `assurance.subsystem_profiles.<name>.notes` | string | no |  | Optional repo-local note about this subsystem profile. |  |  |
 | `assurance.test_data_policy` | object | no | `{}` | Repo-specific policy for test data, privacy, fixtures, or generated samples. |  | x-agentic-workspace-unknown-properties: "warn" |
 | `cli_compatibility` | object | no | `{}` | Expected CLI identity and posture for commands executed in this repo. |  | x-agentic-workspace-doc-role: "maintainer"<br>x-agentic-workspace-unknown-properties: "warn" |
 | `cli_compatibility.enforcement` | enum `"off"`, `"advisory"`, `"blocking"` | no | `"off"` | How strictly CLI compatibility expectations should be enforced. |  |  |

--- a/docs/reference/workspace-config.md
+++ b/docs/reference/workspace-config.md
@@ -95,7 +95,7 @@ Repo-owned Agentic Workspace configuration stored in .agentic-workspace/config.t
 | `assurance.subsystem_profiles.<name>` | object | no |  | One host-owned assurance profile for an ownership subsystem. |  | x-agentic-workspace-unknown-properties: "warn" |
 | `assurance.subsystem_profiles.<name>.assurance_level` | enum `"low"`, `"medium"`, `"high"`, `"critical"` | yes |  | Repo-interpreted assurance level for the matched subsystem. |  |  |
 | `assurance.subsystem_profiles.<name>.level` | enum `"low"`, `"medium"`, `"high"`, `"critical"` | no |  | Alias for assurance_level. |  |  |
-| `assurance.subsystem_profiles.<name>.scope_refs` | array of string | no | `[]` | Existing subsystem scope refs that activate this profile, such as ownership.subsystems.<id> or subsystem:<id>. The profile id is also treated as a scope ref. |  |  |
+| `assurance.subsystem_profiles.<name>.scope_refs` | array of string | no | `[]` | Additional refs for the existing ownership subsystem that may activate this profile, such as ownership.subsystems.<id> or subsystem:<id>. The profile id must already be declared in .agentic-workspace/OWNERSHIP.toml [[subsystems]]. |  |  |
 | `assurance.subsystem_profiles.<name>.requirement_refs` | array of string | no | `[]` | Repo-owned requirement refs normally applying to this subsystem. |  |  |
 | `assurance.subsystem_profiles.<name>.required_evidence` | array of string | no | `[]` | Free-form repo vocabulary naming evidence expected before supported subsystem claims. |  |  |
 | `assurance.subsystem_profiles.<name>.proof_profile` | string | no |  | Optional assurance.proof_profiles id to add when this subsystem profile is active. |  |  |

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -174,6 +174,50 @@ Without host-owned structured strategy enums or configuration, dispositions rema
 The report does not delete tests, prove semantic equivalence, require a manifest
 extension, or create a universal testing strategy for the host repository.
 
+## Subsystem-Scoped Assurance
+
+Assurance can also be scoped through the host repo's existing ownership model.
+Profiles live in `.agentic-workspace/config.toml` under
+`[assurance.subsystem_profiles.<subsystem-id>]`, where `<subsystem-id>` must refer
+to a subsystem id from `.agentic-workspace/OWNERSHIP.toml`.
+
+This does not create a second taxonomy. Ownership still decides what subsystem a
+path or active plan touches; the profile only says what evidence burden applies
+when that subsystem is in scope.
+
+```toml
+[assurance.subsystem_profiles.audit-log]
+assurance_level = "high"
+requirement_refs = ["docs/system-requirements.md#auditability"]
+required_evidence = ["requirement_grounding", "manual_review"]
+proof_profile = "audit"
+force = "required-before-closeout"
+blocked_without_evidence = ["requirement-grounded-completion"]
+claim_boundary = "subsystem-scoped"
+review_owner = "security-review"
+```
+
+`agentic-workspace implement`, `agentic-workspace report`, and
+`agentic-workspace proof` expose the effective subsystem assurance state under
+`assurance_requirements.subsystem_assurance`. The payload reports matched
+subsystem ids, the conservatively composed effective assurance level, required
+and missing evidence, requirement refs, claim boundaries, and the claims blocked
+until evidence is present. Matching profiles are projected as assurance
+requirements with ids like `subsystem:audit-log`, so existing proof-profile and
+Verification routing can consume them without a separate command.
+
+Changed paths match subsystem profiles through `.agentic-workspace/OWNERSHIP.toml`
+path ownership. Active plans may also match by naming the subsystem in explicit
+scope fields such as `canonical_core.touched_scope` with values like
+`subsystem:audit-log`. Multiple matched profiles compose conservatively: the
+highest assurance level is reported, and missing evidence is the union of all
+matched required evidence.
+
+Subsystem assurance remains diagnostic and host-neutral. It surfaces the evidence
+burden and claim boundary for the agent; it does not prove that the evidence is
+sufficient, invent a global compliance rule, or apply high-assurance requirements
+to unrelated subsystems.
+
 ## Manifest Shape
 
 ```toml

--- a/generated/workspace/python/_contracts/payload.json
+++ b/generated/workspace/python/_contracts/payload.json
@@ -518,11 +518,26 @@
   "assurance_onboarding": {
     "command": "agentic-workspace defaults --section assurance_onboarding --format json",
     "configured_profile_count": 0,
+    "configured_requirement_count": 0,
+    "configured_subsystem_profile_count": 0,
     "has_test_data_policy": false,
     "host_ref_count": 0,
+    "jumpstart_route": "Use workspace-setup-jumpstart after setup discovery; seed only profiles supported by inspected host repo evidence.",
     "proof_command": "agentic-workspace proof --target ./repo --changed <paths> --format json",
     "report_command": "agentic-workspace report --target ./repo --section closeout_trust --format json",
     "rule": "Host repos own assurance truth; Agentic Workspace only routes levels, gates, refs, proof profiles, and compact evidence state.",
+    "candidate_seed_surfaces": [
+      ".agentic-workspace/config.toml [assurance.proof_profiles]",
+      ".agentic-workspace/config.toml [assurance.requirements]",
+      ".agentic-workspace/config.toml [assurance.subsystem_profiles]"
+    ],
+    "seed_questions": [
+      "Which host-owned source declares the risk, requirement, or review burden?",
+      "Which changed paths or ownership subsystem ids should activate it?",
+      "What evidence label must exist before broad claims are honest?",
+      "Which proof profile or verification protocol should be selected, if any?",
+      "What claim boundary remains when the evidence is missing?"
+    ],
     "smallest_useful_config": [
       "[assurance]",
       "default_level = \"medium\"",
@@ -531,14 +546,62 @@
       "[assurance.proof_profiles.example]",
       "required_commands = [\"uv run pytest tests -q\"]",
       "optional_commands = []",
-      "review_aids = []"
+      "review_aids = []",
+      "",
+      "[assurance.subsystem_profiles.example-subsystem]",
+      "assurance_level = \"high\"",
+      "requirement_refs = [\"docs/requirements.md#example\"]",
+      "required_evidence = [\"requirement_grounding\"]",
+      "force = \"required-before-closeout\""
     ],
     "states": {
       "absent": "no host assurance profile is configured; low-risk installs stay cheap",
-      "partial": "some assurance fields exist, but add at least one proof profile plus a host-owned ref or test-data policy",
-      "usable": "at least one proof profile and one host-owned authority or test-data policy are configured"
+      "partial": "some assurance fields exist, but add host-owned refs, evidence labels, or test-data policy before relying on them",
+      "usable": "at least one proof profile, assurance requirement, or subsystem profile is tied to host-owned authority or test-data policy"
     },
     "status": "absent"
+  },
+  "verification_onboarding": {
+    "status": "available",
+    "command": "agentic-workspace defaults --section verification_onboarding --format json",
+    "report_command": "agentic-workspace report --target ./repo --section verification --format json",
+    "proof_command": "agentic-workspace proof --target ./repo --changed <paths> --format json",
+    "rule": "Verification jumpstart surfaces candidate protocols, scenarios, proof routes, evidence bundles, and known gaps from host evidence; the agent decides what to seed.",
+    "candidate_seed_surfaces": [
+      ".agentic-workspace/verification/manifest.toml",
+      ".agentic-workspace/verification/proof-strategy.toml",
+      ".agentic-workspace/verification/proof-decision.json"
+    ],
+    "seed_questions": [
+      "Which host workflow needs bounded repeatable verification outside ordinary tests?",
+      "What protocol, scenario, expected evidence, and review owner make the proof repeatable?",
+      "Which command or manual review route produces the evidence?",
+      "Which known gaps block broad closeout claims until replacement evidence exists?",
+      "Which proof-strategy enum hints are host-owned and useful without interpreting prose?"
+    ],
+    "smallest_useful_manifest": [
+      "schema_version = \"agentic-workspace/verification-manifest/v1\"",
+      "",
+      "[protocols.example_review]",
+      "title = \"Example review\"",
+      "purpose = \"Repeatable host-owned verification when ordinary tests are not enough.\"",
+      "applies_to_paths = [\"src/example/**\"]",
+      "scenario_refs = [\"example_walkthrough\"]",
+      "expected_evidence = [\"example_review_passed\"]",
+      "review_owner = \"example-review\"",
+      "",
+      "[scenarios.example_walkthrough]",
+      "protocol_id = \"example_review\"",
+      "title = \"Example walkthrough\"",
+      "steps = [\"Inspect the changed behavior\"]",
+      "expected_observations = [\"The host-owned expectation still holds\"]"
+    ],
+    "jumpstart_boundary": [
+      "Do not create a manifest from filenames alone.",
+      "Do not encode AW's source-repo verification policy into the host repo.",
+      "Prefer no manifest over a generic manifest with no host-owned proof route.",
+      "Record gaps when useful evidence is known but not yet available."
+    ]
   },
   "authority_hierarchy": {
     "inspect": "agentic-workspace report --target ./repo --section authority_hierarchy --format json",

--- a/generated/workspace/typescript/resources/_contracts/payload.json
+++ b/generated/workspace/typescript/resources/_contracts/payload.json
@@ -518,11 +518,26 @@
   "assurance_onboarding": {
     "command": "agentic-workspace defaults --section assurance_onboarding --format json",
     "configured_profile_count": 0,
+    "configured_requirement_count": 0,
+    "configured_subsystem_profile_count": 0,
     "has_test_data_policy": false,
     "host_ref_count": 0,
+    "jumpstart_route": "Use workspace-setup-jumpstart after setup discovery; seed only profiles supported by inspected host repo evidence.",
     "proof_command": "agentic-workspace proof --target ./repo --changed <paths> --format json",
     "report_command": "agentic-workspace report --target ./repo --section closeout_trust --format json",
     "rule": "Host repos own assurance truth; Agentic Workspace only routes levels, gates, refs, proof profiles, and compact evidence state.",
+    "candidate_seed_surfaces": [
+      ".agentic-workspace/config.toml [assurance.proof_profiles]",
+      ".agentic-workspace/config.toml [assurance.requirements]",
+      ".agentic-workspace/config.toml [assurance.subsystem_profiles]"
+    ],
+    "seed_questions": [
+      "Which host-owned source declares the risk, requirement, or review burden?",
+      "Which changed paths or ownership subsystem ids should activate it?",
+      "What evidence label must exist before broad claims are honest?",
+      "Which proof profile or verification protocol should be selected, if any?",
+      "What claim boundary remains when the evidence is missing?"
+    ],
     "smallest_useful_config": [
       "[assurance]",
       "default_level = \"medium\"",
@@ -531,14 +546,62 @@
       "[assurance.proof_profiles.example]",
       "required_commands = [\"uv run pytest tests -q\"]",
       "optional_commands = []",
-      "review_aids = []"
+      "review_aids = []",
+      "",
+      "[assurance.subsystem_profiles.example-subsystem]",
+      "assurance_level = \"high\"",
+      "requirement_refs = [\"docs/requirements.md#example\"]",
+      "required_evidence = [\"requirement_grounding\"]",
+      "force = \"required-before-closeout\""
     ],
     "states": {
       "absent": "no host assurance profile is configured; low-risk installs stay cheap",
-      "partial": "some assurance fields exist, but add at least one proof profile plus a host-owned ref or test-data policy",
-      "usable": "at least one proof profile and one host-owned authority or test-data policy are configured"
+      "partial": "some assurance fields exist, but add host-owned refs, evidence labels, or test-data policy before relying on them",
+      "usable": "at least one proof profile, assurance requirement, or subsystem profile is tied to host-owned authority or test-data policy"
     },
     "status": "absent"
+  },
+  "verification_onboarding": {
+    "status": "available",
+    "command": "agentic-workspace defaults --section verification_onboarding --format json",
+    "report_command": "agentic-workspace report --target ./repo --section verification --format json",
+    "proof_command": "agentic-workspace proof --target ./repo --changed <paths> --format json",
+    "rule": "Verification jumpstart surfaces candidate protocols, scenarios, proof routes, evidence bundles, and known gaps from host evidence; the agent decides what to seed.",
+    "candidate_seed_surfaces": [
+      ".agentic-workspace/verification/manifest.toml",
+      ".agentic-workspace/verification/proof-strategy.toml",
+      ".agentic-workspace/verification/proof-decision.json"
+    ],
+    "seed_questions": [
+      "Which host workflow needs bounded repeatable verification outside ordinary tests?",
+      "What protocol, scenario, expected evidence, and review owner make the proof repeatable?",
+      "Which command or manual review route produces the evidence?",
+      "Which known gaps block broad closeout claims until replacement evidence exists?",
+      "Which proof-strategy enum hints are host-owned and useful without interpreting prose?"
+    ],
+    "smallest_useful_manifest": [
+      "schema_version = \"agentic-workspace/verification-manifest/v1\"",
+      "",
+      "[protocols.example_review]",
+      "title = \"Example review\"",
+      "purpose = \"Repeatable host-owned verification when ordinary tests are not enough.\"",
+      "applies_to_paths = [\"src/example/**\"]",
+      "scenario_refs = [\"example_walkthrough\"]",
+      "expected_evidence = [\"example_review_passed\"]",
+      "review_owner = \"example-review\"",
+      "",
+      "[scenarios.example_walkthrough]",
+      "protocol_id = \"example_review\"",
+      "title = \"Example walkthrough\"",
+      "steps = [\"Inspect the changed behavior\"]",
+      "expected_observations = [\"The host-owned expectation still holds\"]"
+    ],
+    "jumpstart_boundary": [
+      "Do not create a manifest from filenames alone.",
+      "Do not encode AW's source-repo verification policy into the host repo.",
+      "Prefer no manifest over a generic manifest with no host-owned proof route.",
+      "Record gaps when useful evidence is known but not yet available."
+    ]
   },
   "authority_hierarchy": {
     "inspect": "agentic-workspace report --target ./repo --section authority_hierarchy --format json",

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json
@@ -235,6 +235,9 @@
           "seed surfaces",
           "durable surfaces",
           "workspace surfaces",
+          "assurance onboarding",
+          "verification onboarding",
+          "verification manifest",
           "new repo adoption"
         ],
         "phrases": [
@@ -244,6 +247,9 @@
           "post-bootstrap setup",
           "populate surfaces",
           "seed surfaces",
+          "populate assurance",
+          "populate verification",
+          "seed verification manifest",
           "newly installed workspace",
           "after install",
           "new repo adoption"

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-setup-jumpstart/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-setup-jumpstart/SKILL.md
@@ -27,8 +27,13 @@ When the task is to populate durable workspace surfaces after bootstrap, handle 
 - `.agentic-workspace/OWNERSHIP.toml`: keep package-managed module roots, managed surfaces, fences, and authority surfaces generic; add host-specific `[[subsystems]]` only from inspected repo structure, test commands, ownership boundaries, or clear user direction. Do not copy subsystem entries from the Agentic Workspace source repo into a host repo.
 - `.agentic-workspace/system-intent/intent.toml`: run `agentic-workspace system-intent --target . --sync --format json` first, then refine only reviewable interpreted fields that are supported by named repo intent sources such as `README.md`, `SYSTEM_INTENT.md`, product docs, or explicit user direction. Do not mechanically summarize every source file.
 - `.agentic-workspace/system-intent/subsystems.toml`: add scoped durable intent only for subsystem ids already declared in `.agentic-workspace/OWNERSHIP.toml [[subsystems]]`. Leave `subsystems = []` when no host subsystem boundary is clear.
+- `.agentic-workspace/config.toml [assurance]`: run `agentic-workspace defaults --section assurance_onboarding --format json` before seeding assurance. Add proof profiles, requirements, or subsystem profiles only when an inspected host-owned source names the risk, requirement, evidence burden, proof route, or claim boundary. Subsystem profiles must use existing `.agentic-workspace/OWNERSHIP.toml [[subsystems]]` ids.
+- `.agentic-workspace/verification/manifest.toml`: run `agentic-workspace defaults --section verification_onboarding --format json` before seeding Verification. Add protocols, scenarios, proof routes, bundles, or known gaps only when the host repo has a repeatable proof need that ordinary test or command selection does not already express.
+- `.agentic-workspace/verification/proof-strategy.toml`: seed only enum hints that the host repo explicitly owns. Do not summarize strategy prose or infer policy from filenames.
 
 Population rule: host repo values must be derived from the host repo. Package defaults may provide schema shape and managed-surface ownership, but not source-repo product intent, source-repo subsystem ids, source paths, proof commands, or issue references.
+
+Assurance and Verification population rule: AW surfaces questions and templates; the agent decides whether evidence is strong enough to write anything. Prefer leaving these surfaces absent over creating generic placeholder obligations.
 
 ## Seed Bias
 

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -350,6 +350,22 @@ class AssuranceRequirement:
 
 
 @dataclass(frozen=True)
+class AssuranceSubsystemProfile:
+    id: str
+    assurance_level: str
+    scope_refs: tuple[str, ...]
+    requirement_refs: tuple[str, ...]
+    required_evidence: tuple[str, ...]
+    proof_profile: str | None
+    workflow_obligation_refs: tuple[str, ...]
+    review_owner: str | None
+    force: str
+    blocked_without_evidence: tuple[str, ...]
+    claim_boundary: str | None
+    notes: str | None
+
+
+@dataclass(frozen=True)
 class AssuranceConfig:
     default_level: str
     default_level_source: str
@@ -358,6 +374,7 @@ class AssuranceConfig:
     strict_closeout: bool
     proof_profiles: tuple[AssuranceProofProfile, ...]
     requirements: tuple[AssuranceRequirement, ...]
+    subsystem_profiles: tuple[AssuranceSubsystemProfile, ...]
     test_data_policy: dict[str, Any]
     decision_record_target: str | None
     decision_record_format: str | None
@@ -787,6 +804,72 @@ def _load_assurance_requirements(
     return (tuple(requirement for requirement in requirements if requirement.id), warnings)
 
 
+def _load_assurance_subsystem_profiles(
+    *,
+    raw_profiles: Any,
+    config_path: Path,
+) -> tuple[tuple[AssuranceSubsystemProfile, ...], list[str]]:
+    warnings: list[str] = []
+    if raw_profiles is None:
+        raw_profiles = {}
+    if not isinstance(raw_profiles, dict):
+        raise WorkspaceUsageError(f"{config_path.as_posix()} [assurance.subsystem_profiles] section must be a table.")
+    profiles: list[AssuranceSubsystemProfile] = []
+    supported_fields = {
+        "assurance_level",
+        "level",
+        "scope_refs",
+        "requirement_refs",
+        "required_evidence",
+        "proof_profile",
+        "workflow_obligation_refs",
+        "review_owner",
+        "force",
+        "blocked_without_evidence",
+        "claim_boundary",
+        "notes",
+    }
+    for profile_id, raw_profile in sorted(raw_profiles.items()):
+        profile_path = Path(f"{config_path.as_posix()} assurance.subsystem_profiles.{profile_id}")
+        if not isinstance(raw_profile, dict):
+            raise WorkspaceUsageError(f"{profile_path.as_posix()} must be a table.")
+        unknown_profile = sorted(set(raw_profile) - supported_fields)
+        if unknown_profile:
+            warnings.append(f"{profile_path.as_posix()} contains unsupported field(s): {', '.join(unknown_profile)}.")
+        level_value = raw_profile.get("assurance_level", raw_profile.get("level"))
+        profiles.append(
+            AssuranceSubsystemProfile(
+                id=str(profile_id).strip(),
+                assurance_level=require_required_enum(
+                    payload={**raw_profile, "assurance_level": level_value},
+                    key="assurance_level",
+                    config_path=profile_path,
+                    allowed=SUPPORTED_ASSURANCE_LEVELS,
+                ),
+                scope_refs=require_optional_string_list(payload=raw_profile, key="scope_refs", config_path=profile_path),
+                requirement_refs=require_optional_string_list(payload=raw_profile, key="requirement_refs", config_path=profile_path),
+                required_evidence=require_optional_string_list(payload=raw_profile, key="required_evidence", config_path=profile_path),
+                proof_profile=require_optional_string(payload=raw_profile, key="proof_profile", config_path=profile_path),
+                workflow_obligation_refs=require_optional_string_list(
+                    payload=raw_profile, key="workflow_obligation_refs", config_path=profile_path
+                ),
+                review_owner=require_optional_string(payload=raw_profile, key="review_owner", config_path=profile_path),
+                force=require_required_enum(
+                    payload=raw_profile,
+                    key="force",
+                    config_path=profile_path,
+                    allowed=SUPPORTED_WORKFLOW_OBLIGATION_FORCES,
+                ),
+                blocked_without_evidence=require_optional_string_list(
+                    payload=raw_profile, key="blocked_without_evidence", config_path=profile_path
+                ),
+                claim_boundary=require_optional_string(payload=raw_profile, key="claim_boundary", config_path=profile_path),
+                notes=require_optional_string(payload=raw_profile, key="notes", config_path=profile_path),
+            )
+        )
+    return (tuple(profile for profile in profiles if profile.id), warnings)
+
+
 def _load_assurance_config(*, raw_assurance: Any, config_path: Path) -> tuple[AssuranceConfig, list[str]]:
     warnings: list[str] = []
     if raw_assurance is None:
@@ -800,6 +883,7 @@ def _load_assurance_config(*, raw_assurance: Any, config_path: Path) -> tuple[As
         "strict_closeout",
         "proof_profiles",
         "requirements",
+        "subsystem_profiles",
         "test_data_policy",
         "decision_record_target",
         "decision_record_format",
@@ -853,6 +937,11 @@ def _load_assurance_config(*, raw_assurance: Any, config_path: Path) -> tuple[As
         config_path=config_path,
     )
     warnings.extend(requirement_warnings)
+    subsystem_profiles, subsystem_profile_warnings = _load_assurance_subsystem_profiles(
+        raw_profiles=raw_assurance.get("subsystem_profiles", {}),
+        config_path=config_path,
+    )
+    warnings.extend(subsystem_profile_warnings)
     return (
         AssuranceConfig(
             default_level=default_level,
@@ -862,6 +951,7 @@ def _load_assurance_config(*, raw_assurance: Any, config_path: Path) -> tuple[As
             strict_closeout=_require_bool(payload=raw_assurance, key="strict_closeout", default=False, config_path=config_path),
             proof_profiles=tuple(profile for profile in profiles if profile.id),
             requirements=requirements,
+            subsystem_profiles=subsystem_profiles,
             test_data_policy={str(key): value for key, value in raw_test_data_policy.items()},
             decision_record_target=str(decision_record_target).strip() if decision_record_target is not None else None,
             decision_record_format=str(decision_record_format).strip() if decision_record_format is not None else None,

--- a/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
@@ -541,7 +541,7 @@
                 ]
               },
               "scope_refs": {
-                "description": "Existing subsystem scope refs that activate this profile, such as ownership.subsystems.<id> or subsystem:<id>. The profile id is also treated as a scope ref.",
+                "description": "Additional refs for the existing ownership subsystem that may activate this profile, such as ownership.subsystems.<id> or subsystem:<id>. The profile id must already be declared in .agentic-workspace/OWNERSHIP.toml [[subsystems]].",
                 "type": "array",
                 "items": {
                   "type": "string",

--- a/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
@@ -509,6 +509,120 @@
             "additionalProperties": true
           }
         },
+        "subsystem_profiles": {
+          "description": "Subsystem-scoped assurance profiles keyed by existing .agentic-workspace/OWNERSHIP.toml subsystem ids.",
+          "type": "object",
+          "default": {},
+          "additionalProperties": {
+            "type": "object",
+            "description": "One host-owned assurance profile for an ownership subsystem.",
+            "x-agentic-workspace-unknown-properties": "warn",
+            "required": [
+              "assurance_level",
+              "force"
+            ],
+            "properties": {
+              "assurance_level": {
+                "description": "Repo-interpreted assurance level for the matched subsystem.",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high",
+                  "critical"
+                ]
+              },
+              "level": {
+                "description": "Alias for assurance_level.",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high",
+                  "critical"
+                ]
+              },
+              "scope_refs": {
+                "description": "Existing subsystem scope refs that activate this profile, such as ownership.subsystems.<id> or subsystem:<id>. The profile id is also treated as a scope ref.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "requirement_refs": {
+                "description": "Repo-owned requirement refs normally applying to this subsystem.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "required_evidence": {
+                "description": "Free-form repo vocabulary naming evidence expected before supported subsystem claims.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "proof_profile": {
+                "description": "Optional assurance.proof_profiles id to add when this subsystem profile is active.",
+                "type": "string",
+                "minLength": 1
+              },
+              "workflow_obligation_refs": {
+                "description": "Workflow obligation ids related to this subsystem profile.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "review_owner": {
+                "description": "Repo-local owner label for review or waiver decisions.",
+                "type": "string",
+                "minLength": 1
+              },
+              "force": {
+                "description": "How strongly this subsystem profile affects guidance and closeout claim gates.",
+                "enum": [
+                  "informational",
+                  "recommended",
+                  "required-before-closeout",
+                  "blocking"
+                ]
+              },
+              "blocked_without_evidence": {
+                "description": "Claim ids or labels blocked while required subsystem evidence is missing.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "default": []
+              },
+              "claim_boundary": {
+                "description": "Human-readable boundary for claims supported by this subsystem profile.",
+                "type": "string",
+                "minLength": 1
+              },
+              "notes": {
+                "description": "Optional repo-local note about this subsystem profile.",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "additionalProperties": true
+          }
+        },
         "test_data_policy": {
           "description": "Repo-specific policy for test data, privacy, fixtures, or generated samples.",
           "type": "object",

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -191,6 +191,18 @@
       "checked_in_justification": "Canonical checked-in structured input used by package behavior, validation, packaging, or repo policy."
     },
     {
+      "pattern": ".agentic-workspace/payload-provenance.json",
+      "format": "json",
+      "owner": "workspace-lifecycle",
+      "status": "typed-validator-backed",
+      "schema_or_validator": "agentic_workspace.workspace_runtime_primitives._read_payload_provenance",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Payload provenance records the AW executable/source identity that last synced the repo payload and is consumed by installed-state compatibility checks.",
+      "storage_class": "source-of-truth",
+      "checked_in_justification": "Compact payload provenance is checked in so startup can distinguish observed-compatible payload state from missing-provenance upgrade noise."
+    },
+    {
       "pattern": ".agentic-workspace/agent-aids/**/manifest.json",
       "format": "json",
       "owner": "agent-aids",

--- a/src/agentic_workspace/contracts/workspace_defaults/payload.json
+++ b/src/agentic_workspace/contracts/workspace_defaults/payload.json
@@ -518,11 +518,26 @@
   "assurance_onboarding": {
     "command": "agentic-workspace defaults --section assurance_onboarding --format json",
     "configured_profile_count": 0,
+    "configured_requirement_count": 0,
+    "configured_subsystem_profile_count": 0,
     "has_test_data_policy": false,
     "host_ref_count": 0,
+    "jumpstart_route": "Use workspace-setup-jumpstart after setup discovery; seed only profiles supported by inspected host repo evidence.",
     "proof_command": "agentic-workspace proof --target ./repo --changed <paths> --format json",
     "report_command": "agentic-workspace report --target ./repo --section closeout_trust --format json",
     "rule": "Host repos own assurance truth; Agentic Workspace only routes levels, gates, refs, proof profiles, and compact evidence state.",
+    "candidate_seed_surfaces": [
+      ".agentic-workspace/config.toml [assurance.proof_profiles]",
+      ".agentic-workspace/config.toml [assurance.requirements]",
+      ".agentic-workspace/config.toml [assurance.subsystem_profiles]"
+    ],
+    "seed_questions": [
+      "Which host-owned source declares the risk, requirement, or review burden?",
+      "Which changed paths or ownership subsystem ids should activate it?",
+      "What evidence label must exist before broad claims are honest?",
+      "Which proof profile or verification protocol should be selected, if any?",
+      "What claim boundary remains when the evidence is missing?"
+    ],
     "smallest_useful_config": [
       "[assurance]",
       "default_level = \"medium\"",
@@ -531,14 +546,62 @@
       "[assurance.proof_profiles.example]",
       "required_commands = [\"uv run pytest tests -q\"]",
       "optional_commands = []",
-      "review_aids = []"
+      "review_aids = []",
+      "",
+      "[assurance.subsystem_profiles.example-subsystem]",
+      "assurance_level = \"high\"",
+      "requirement_refs = [\"docs/requirements.md#example\"]",
+      "required_evidence = [\"requirement_grounding\"]",
+      "force = \"required-before-closeout\""
     ],
     "states": {
       "absent": "no host assurance profile is configured; low-risk installs stay cheap",
-      "partial": "some assurance fields exist, but add at least one proof profile plus a host-owned ref or test-data policy",
-      "usable": "at least one proof profile and one host-owned authority or test-data policy are configured"
+      "partial": "some assurance fields exist, but add host-owned refs, evidence labels, or test-data policy before relying on them",
+      "usable": "at least one proof profile, assurance requirement, or subsystem profile is tied to host-owned authority or test-data policy"
     },
     "status": "absent"
+  },
+  "verification_onboarding": {
+    "status": "available",
+    "command": "agentic-workspace defaults --section verification_onboarding --format json",
+    "report_command": "agentic-workspace report --target ./repo --section verification --format json",
+    "proof_command": "agentic-workspace proof --target ./repo --changed <paths> --format json",
+    "rule": "Verification jumpstart surfaces candidate protocols, scenarios, proof routes, evidence bundles, and known gaps from host evidence; the agent decides what to seed.",
+    "candidate_seed_surfaces": [
+      ".agentic-workspace/verification/manifest.toml",
+      ".agentic-workspace/verification/proof-strategy.toml",
+      ".agentic-workspace/verification/proof-decision.json"
+    ],
+    "seed_questions": [
+      "Which host workflow needs bounded repeatable verification outside ordinary tests?",
+      "What protocol, scenario, expected evidence, and review owner make the proof repeatable?",
+      "Which command or manual review route produces the evidence?",
+      "Which known gaps block broad closeout claims until replacement evidence exists?",
+      "Which proof-strategy enum hints are host-owned and useful without interpreting prose?"
+    ],
+    "smallest_useful_manifest": [
+      "schema_version = \"agentic-workspace/verification-manifest/v1\"",
+      "",
+      "[protocols.example_review]",
+      "title = \"Example review\"",
+      "purpose = \"Repeatable host-owned verification when ordinary tests are not enough.\"",
+      "applies_to_paths = [\"src/example/**\"]",
+      "scenario_refs = [\"example_walkthrough\"]",
+      "expected_evidence = [\"example_review_passed\"]",
+      "review_owner = \"example-review\"",
+      "",
+      "[scenarios.example_walkthrough]",
+      "protocol_id = \"example_review\"",
+      "title = \"Example walkthrough\"",
+      "steps = [\"Inspect the changed behavior\"]",
+      "expected_observations = [\"The host-owned expectation still holds\"]"
+    ],
+    "jumpstart_boundary": [
+      "Do not create a manifest from filenames alone.",
+      "Do not encode AW's source-repo verification policy into the host repo.",
+      "Prefer no manifest over a generic manifest with no host-owned proof route.",
+      "Record gaps when useful evidence is known but not yet available."
+    ]
   },
   "authority_hierarchy": {
     "inspect": "agentic-workspace report --target ./repo --section authority_hierarchy --format json",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -1060,16 +1060,13 @@ def _assurance_onboarding_payload(*, assurance: AssuranceConfig | None = None) -
     host_refs = []
     if assurance is not None:
         host_refs = [ref for ref in [assurance.decision_record_target, assurance.invariant_registry, assurance.risk_registry] if ref]
+        for requirement in configured_requirements:
+            host_refs.extend(requirement.authority_refs)
+        for profile in subsystem_profiles:
+            host_refs.extend(profile.requirement_refs)
+        host_refs = _dedupe(host_refs)
     has_test_policy = bool(assurance.test_data_policy) if assurance is not None else False
-    any_configured = bool(
-        configured_profiles
-        or configured_requirements
-        or subsystem_profiles
-        or host_refs
-        or has_test_policy
-        or (assurance is not None and assurance.default_level_source != "product-default")
-        or (assurance is not None and assurance.strict_closeout)
-    )
+    any_configured = bool(configured_profiles or configured_requirements or subsystem_profiles or host_refs or has_test_policy)
     usable = bool((configured_profiles or configured_requirements or subsystem_profiles) and (host_refs or has_test_policy))
     status = "usable" if usable else "partial" if any_configured else "absent"
     return {

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -22347,10 +22347,14 @@ _CANDIDATE_RELEVANCE_STOPWORDS = {
     "implement",
     "implementation",
     "issue",
+    "jumpstart",
     "lane",
     "planning",
+    "repo",
     "task",
+    "this",
     "work",
+    "workspace",
 }
 
 
@@ -32830,11 +32834,46 @@ def _setup_payload(
         non_interactive=False,
         config=config,
     )
+    installed_modules = [entry["name"] for entry in status_payload.get("registry", []) if entry.get("installed")]
+    setup_warnings: list[str] = []
+    optional_module_notices: list[str] = []
+    for warning in status_payload.get("warnings", []):
+        warning_text = str(warning)
+        if "installed module 'verification' is not enabled" in warning_text and "verification" in installed_modules:
+            optional_module_notices.append(
+                "Verification is installed and available as an optional module; it is not part of the default enabled module set."
+            )
+        else:
+            setup_warnings.append(warning_text)
+    setup_status_payload = {**status_payload, "warnings": setup_warnings}
     discovery = setup_discovery_payload(
-        target_root=target_root, status_payload=status_payload, active_todo_surface=_active_todo_surface(target_root=target_root)
+        target_root=target_root, status_payload=setup_status_payload, active_todo_surface=_active_todo_surface(target_root=target_root)
     )
     proof_route_hints = _load_proof_route_hints(target_root=target_root)
     findings_input = _setup_findings_input_payload(target_root=target_root)
+    assurance_onboarding = _assurance_onboarding_payload(assurance=config.assurance)
+    verification_manifest_present = (target_root / ".agentic-workspace" / "verification" / "manifest.toml").exists()
+    onboarding_routes = {
+        "assurance": {
+            "status": assurance_onboarding.get("status", "absent"),
+            "command": "agentic-workspace defaults --section assurance_onboarding --format json",
+            "report_command": "agentic-workspace report --target ./repo --section assurance_requirements --format json",
+            "seed_when": "only after inspected host-owned evidence names the requirement, proof route, evidence label, or claim boundary",
+            "candidate_seed_surfaces": assurance_onboarding.get("candidate_seed_surfaces", []),
+        },
+        "verification": {
+            "status": "configured" if verification_manifest_present else "available",
+            "command": "agentic-workspace defaults --section verification_onboarding --format json",
+            "report_command": "agentic-workspace report --target ./repo --section verification --format json",
+            "seed_when": "only for repeatable host proof needs not already expressed by ordinary tests or proof selection",
+            "candidate_seed_surfaces": [
+                ".agentic-workspace/verification/manifest.toml",
+                ".agentic-workspace/verification/proof-strategy.toml",
+                ".agentic-workspace/verification/proof-decision.json",
+            ],
+        },
+        "rule": "Setup surfaces onboarding questions and seed candidates; the agent decides whether host evidence is strong enough to write anything.",
+    }
     mature_repo = _repo_looks_setup_mature(target_root=target_root)
     if mature_repo:
         startup_file = config.agent_instructions_file
@@ -32843,7 +32882,14 @@ def _setup_payload(
             "summary": "No new seed surfaces are needed; the repo already has the core setup orientation surfaces.",
             "reason": f"{startup_file}, .agentic-workspace/planning/state.toml, .agentic-workspace/planning/agent-manifest.json, and .agentic-workspace/memory/repo/index.md are already present.",
         }
-        next_action = {"summary": "No new seed surfaces needed", "commands": ["agentic-workspace report --target ./repo --format json"]}
+        next_action = {
+            "summary": "No new core seed surfaces needed; inspect onboarding routes before adding assurance or verification seeds",
+            "commands": [
+                "agentic-workspace report --target ./repo --format json",
+                "agentic-workspace defaults --section assurance_onboarding --format json",
+                "agentic-workspace defaults --section verification_onboarding --format json",
+            ],
+        }
     else:
         prioritized = discovery["memory_candidates"] + discovery["planning_candidates"] + discovery["ambiguous"]
         prioritized.sort(key=lambda item: item["confidence"], reverse=True)
@@ -32857,7 +32903,11 @@ def _setup_payload(
             orientation["reason"] = best["reason"]
         next_action = {
             "summary": "Review the compact report surfaces",
-            "commands": ["agentic-workspace report --target ./repo --format json"],
+            "commands": [
+                "agentic-workspace report --target ./repo --format json",
+                "agentic-workspace defaults --section assurance_onboarding --format json",
+                "agentic-workspace defaults --section verification_onboarding --format json",
+            ],
         }
     if findings_input.get("status") == "loaded":
         promotable_count = sum((len(items) for items in findings_input["promotable"].values()))
@@ -32892,12 +32942,14 @@ def _setup_payload(
             "hint_count": len(proof_route_hints.get("hints", [])),
             "rule": "Setup reports lifecycle-discovered advisory proof route hints; proof still live-confirms them before command selection.",
         },
+        "onboarding_routes": onboarding_routes,
         "next_action": next_action,
         "discovery": discovery,
         "current": {
-            "installed_modules": [entry["name"] for entry in status_payload.get("registry", []) if entry.get("installed")],
-            "warnings": list(status_payload.get("warnings", [])),
-            "needs_review": list(status_payload.get("needs_review", [])),
+            "installed_modules": installed_modules,
+            "warnings": setup_warnings,
+            "optional_module_notices": optional_module_notices,
+            "needs_review": [item for item in status_payload.get("needs_review", []) if str(item) in setup_warnings],
             "stale_generated_surfaces": list(status_payload.get("stale_generated_surfaces", [])),
         },
     }

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -1135,6 +1135,203 @@ def _assurance_requirement_payloads(config: WorkspaceConfig | None) -> list[dict
     return payloads
 
 
+def _assurance_subsystem_profile_payloads(config: WorkspaceConfig | None) -> list[dict[str, Any]]:
+    profiles = list(config.assurance.subsystem_profiles) if config is not None else []
+    payloads: list[dict[str, Any]] = []
+    for profile in profiles:
+        payloads.append(
+            {
+                "id": profile.id,
+                "subsystem_id": profile.id,
+                "level": profile.assurance_level,
+                "scope_refs": list(profile.scope_refs),
+                "requirement_refs": list(profile.requirement_refs),
+                "required_evidence": list(profile.required_evidence),
+                "proof_profile": profile.proof_profile,
+                "workflow_obligation_refs": list(profile.workflow_obligation_refs),
+                "review_owner": profile.review_owner,
+                "force": profile.force,
+                "blocking_claims": list(profile.blocked_without_evidence),
+                "claim_boundary": profile.claim_boundary,
+                "notes": profile.notes,
+            }
+        )
+    return payloads
+
+
+def _assurance_level_rank(level: str) -> int:
+    return {"low": 0, "medium": 1, "high": 2, "critical": 3}.get(str(level).strip(), 0)
+
+
+def _assurance_profile_scope_tokens(profile: dict[str, Any]) -> set[str]:
+    subsystem_id = str(profile.get("subsystem_id") or profile.get("id") or "").strip()
+    tokens = {subsystem_id, f"subsystem:{subsystem_id}", f"ownership.subsystems.{subsystem_id}"}
+    tokens.update(str(item).strip() for item in _list_payload(profile.get("scope_refs")) if str(item).strip())
+    return {token for token in tokens if token}
+
+
+def _subsystem_assurance_payload(
+    *,
+    config: WorkspaceConfig | None,
+    target_root: Path | None,
+    changed_paths: list[str] | None,
+    active_planning_record: dict[str, Any] | None,
+    planning_facts: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    configured = _assurance_subsystem_profile_payloads(config)
+    normalized_paths = _normalize_changed_paths(changed_paths or [])
+    ownership_matches = (
+        _subsystem_matches_for_changed_paths(target_root=target_root, changed_paths=normalized_paths)
+        if target_root is not None
+        else {
+            "kind": "agentic-workspace/subsystem-ownership-selection/v1",
+            "status": "unavailable",
+            "matched_subsystems": [],
+        }
+    )
+    matched_subsystems = [item for item in _list_payload(ownership_matches.get("matched_subsystems")) if isinstance(item, dict)]
+    matched_tokens = {
+        token
+        for subsystem in matched_subsystems
+        for token in (
+            str(subsystem.get("id") or "").strip(),
+            f"subsystem:{str(subsystem.get('id') or '').strip()}",
+            f"ownership.subsystems.{str(subsystem.get('id') or '').strip()}",
+        )
+        if token and not token.endswith(".")
+    }
+    plan_scope = set()
+    if isinstance(active_planning_record, dict):
+        plan_scope.update(_plan_exact_list(active_planning_record, "canonical_core.touched_scope", "touched_paths"))
+        plan_scope.update(_plan_exact_list(active_planning_record, "execution_bounds.allowed paths"))
+        plan_scope.update(str(item).strip() for item in _list_payload(active_planning_record.get("subsystems")) if str(item).strip())
+    profile_matches: list[dict[str, Any]] = []
+    facts = planning_facts if isinstance(planning_facts, dict) else _assurance_requirement_planning_facts(active_planning_record)
+    evidence_by_requirement = facts.get("evidence_by_requirement", {}) if isinstance(facts, dict) else {}
+    for profile in configured:
+        scope_tokens = _assurance_profile_scope_tokens(profile)
+        matched_scope_tokens = sorted(scope_tokens & matched_tokens)
+        matched_plan_scope = sorted(scope_tokens & plan_scope)
+        if not matched_scope_tokens and not matched_plan_scope:
+            continue
+        subsystem_id = str(profile.get("subsystem_id") or profile.get("id") or "").strip()
+        requirement_id = f"subsystem:{subsystem_id}"
+        evidence_present = []
+        if isinstance(evidence_by_requirement, dict):
+            evidence_present = [
+                str(item).strip()
+                for item in _list_payload(evidence_by_requirement.get(requirement_id, evidence_by_requirement.get(subsystem_id, [])))
+                if str(item).strip()
+            ]
+        required_evidence = [str(item).strip() for item in _list_payload(profile.get("required_evidence")) if str(item).strip()]
+        missing_evidence = [item for item in required_evidence if item not in evidence_present]
+        matched_subsystem = next((item for item in matched_subsystems if str(item.get("id") or "").strip() == subsystem_id), {})
+        applies_because = _dedupe(
+            [
+                *(f"changed path matched subsystem {subsystem_id}" for _ in matched_scope_tokens[:1]),
+                *(f"active plan scope matched {item}" for item in matched_plan_scope),
+            ]
+        )
+        state = "satisfied" if not missing_evidence else "review-required" if profile.get("review_owner") else "missing-evidence"
+        profile_matches.append(
+            {
+                **profile,
+                "requirement_id": requirement_id,
+                "subsystem": {
+                    "id": subsystem_id,
+                    "matched_paths": _list_payload(matched_subsystem.get("matched_paths")),
+                    "matched_patterns": _list_payload(matched_subsystem.get("matched_patterns")),
+                    "owns": _list_payload(matched_subsystem.get("owns")),
+                    "does_not_own": _list_payload(matched_subsystem.get("does_not_own")),
+                },
+                "applies_because": applies_because,
+                "evidence_status": {
+                    "requirement_id": requirement_id,
+                    "state": state,
+                    "level": str(profile.get("level", DEFAULT_ASSURANCE_LEVEL)),
+                    "applies_because": applies_because,
+                    "authority_refs": _list_payload(profile.get("requirement_refs")),
+                    "required_evidence": required_evidence,
+                    "evidence_present": evidence_present,
+                    "missing_evidence": missing_evidence,
+                    "waiver": {"status": "none"},
+                    "dismissal": {"status": "none"},
+                    "proof_profile": profile.get("proof_profile"),
+                    "workflow_obligation_refs": _list_payload(profile.get("workflow_obligation_refs")),
+                    "review_owner": profile.get("review_owner"),
+                    "force": str(profile.get("force", "recommended")),
+                    "blocking_claims": _list_payload(profile.get("blocking_claims")),
+                    "claim_boundary": profile.get("claim_boundary"),
+                    "subsystem_id": subsystem_id,
+                    "next_action": {
+                        "id": "record-subsystem-assurance-evidence" if missing_evidence else "none",
+                        "why": "Subsystem-scoped assurance evidence is missing before broad subsystem claims."
+                        if missing_evidence
+                        else "No missing subsystem assurance evidence is currently projected.",
+                    },
+                },
+            }
+        )
+    effective_level = "none"
+    if profile_matches:
+        effective_level = max(
+            (str(profile.get("level", DEFAULT_ASSURANCE_LEVEL)) for profile in profile_matches), key=_assurance_level_rank
+        )
+    missing_required = [
+        profile
+        for profile in profile_matches
+        if _as_dict(profile.get("evidence_status")).get("state") in {"missing-evidence", "review-required"}
+        and str(profile.get("force", "recommended")) in {"required-before-closeout", "blocking"}
+    ]
+    return {
+        "kind": "agentic-workspace/subsystem-assurance/v1",
+        "status": "attention" if missing_required else "matched" if profile_matches else "configured" if configured else "absent",
+        "configured_count": len(configured),
+        "matched_count": len(profile_matches),
+        "effective_assurance_level": effective_level,
+        "matched_subsystem_ids": [str(profile.get("subsystem_id")) for profile in profile_matches],
+        "matched_profiles": profile_matches,
+        "evidence_status": [_as_dict(profile.get("evidence_status")) for profile in profile_matches],
+        "required_evidence": _dedupe(
+            [
+                str(item).strip()
+                for profile in profile_matches
+                for item in _list_payload(profile.get("required_evidence"))
+                if str(item).strip()
+            ]
+        ),
+        "missing_evidence": _dedupe(
+            [
+                str(item).strip()
+                for profile in profile_matches
+                for item in _list_payload(_as_dict(profile.get("evidence_status")).get("missing_evidence"))
+                if str(item).strip()
+            ]
+        ),
+        "requirement_refs": _dedupe(
+            [
+                str(item).strip()
+                for profile in profile_matches
+                for item in _list_payload(profile.get("requirement_refs"))
+                if str(item).strip()
+            ]
+        ),
+        "blocked_claims": _dedupe(
+            [
+                str(item).strip()
+                for profile in profile_matches
+                for item in _list_payload(profile.get("blocking_claims"))
+                if str(item).strip()
+            ]
+        ),
+        "claim_boundaries": _dedupe(
+            [str(profile.get("claim_boundary")).strip() for profile in profile_matches if str(profile.get("claim_boundary") or "").strip()]
+        ),
+        "ownership_selection": ownership_matches,
+        "rule": "Subsystem assurance profiles are scoped by existing ownership subsystem ids; AW surfaces obligations and evidence gaps but does not certify subsystem safety or compliance.",
+    }
+
+
 def _assurance_requirement_planning_facts(active_planning_record: dict[str, Any] | None) -> dict[str, Any]:
     if not isinstance(active_planning_record, dict):
         return {
@@ -1274,12 +1471,20 @@ def _assurance_status_for_requirement(
 def _assurance_requirements_report_payload(
     *,
     config: WorkspaceConfig | None,
+    target_root: Path | None = None,
     active_planning_record: dict[str, Any] | None = None,
     task_text: str | None = None,
     changed_paths: list[str] | None = None,
 ) -> dict[str, Any]:
     configured = _assurance_requirement_payloads(config)
     planning_facts = _assurance_requirement_planning_facts(active_planning_record)
+    subsystem_assurance = _subsystem_assurance_payload(
+        config=config,
+        target_root=target_root,
+        changed_paths=changed_paths,
+        active_planning_record=active_planning_record,
+        planning_facts=planning_facts,
+    )
     matching: list[dict[str, Any]] = []
     active: list[dict[str, Any]] = []
     evidence_status: list[dict[str, Any]] = []
@@ -1328,6 +1533,55 @@ def _assurance_requirements_report_payload(
                 }
             )
             evidence_status.append(status)
+    for profile in _list_payload(subsystem_assurance.get("matched_profiles")):
+        if not isinstance(profile, dict):
+            continue
+        subsystem_id = str(profile.get("subsystem_id") or profile.get("id") or "").strip()
+        requirement_id = str(profile.get("requirement_id") or f"subsystem:{subsystem_id}")
+        profile_status = _as_dict(profile.get("evidence_status"))
+        active.append(
+            {
+                "id": requirement_id,
+                "level": str(profile.get("level", DEFAULT_ASSURANCE_LEVEL)),
+                "applies_to_paths": [],
+                "applies_to_task_markers": [],
+                "applies_to_planning_refs": [],
+                "applies_to_proof_profiles": [],
+                "applies_to_risk_refs": [],
+                "applies_to_invariant_refs": [],
+                "authority_refs": _list_payload(profile.get("requirement_refs")),
+                "required_evidence": _list_payload(profile.get("required_evidence")),
+                "proof_profile": profile.get("proof_profile"),
+                "workflow_obligation_refs": _list_payload(profile.get("workflow_obligation_refs")),
+                "review_owner": profile.get("review_owner"),
+                "force": str(profile.get("force", "recommended")),
+                "blocking_claims": _list_payload(profile.get("blocking_claims")),
+                "waiver": {"status": "none"},
+                "dismissal": {"status": "none"},
+                "notes": profile.get("notes"),
+                "source": "subsystem_assurance",
+                "subsystem_id": subsystem_id,
+                "subsystem": profile.get("subsystem", {}),
+                "claim_boundary": profile.get("claim_boundary"),
+                "applies_because": _list_payload(profile.get("applies_because")),
+                "authority_boundary": _authority_boundary_payload(
+                    surface="assurance_requirements.subsystem_profile",
+                    observed_by_aw=[
+                        f"configured subsystem assurance profile {subsystem_id}",
+                        *_list_payload(profile.get("applies_because")),
+                    ],
+                    recommended_by_aw=["honor subsystem-scoped evidence and claim-boundary obligations before closeout"],
+                    agent_owned_decisions=[
+                        "whether the current task intent is satisfied",
+                        "whether evidence is sufficient to claim subsystem-scoped completion",
+                    ],
+                    human_owned_decisions=["waiver, acceptance, or final subsystem safety/compliance claims"],
+                    rule="Subsystem assurance matches are scoped through host-owned ownership subsystems; AW reports obligations and does not certify safety.",
+                ),
+            }
+        )
+        if profile_status:
+            evidence_status.append(profile_status)
     required_missing = [
         item
         for item in evidence_status
@@ -1336,7 +1590,13 @@ def _assurance_requirements_report_payload(
     ]
     return {
         "kind": "agentic-workspace/assurance-requirements/v1",
-        "status": "attention" if required_missing else "matched" if active else "configured" if configured else "absent",
+        "status": "attention"
+        if required_missing
+        else "matched"
+        if active
+        else "configured"
+        if configured or subsystem_assurance.get("configured_count")
+        else "absent",
         "rule": "Repo-declared assurance requirements are domain-generic routing and claim-boundary facts; AW does not certify compliance.",
         "authority_boundary": _authority_boundary_payload(
             surface="assurance_requirements",
@@ -1349,12 +1609,15 @@ def _assurance_requirements_report_payload(
             human_owned_decisions=["waiver, dismissal, or final acceptance for configured assurance exceptions"],
             rule="Assurance requirements are configured claim-boundary evidence; AW does not classify the task's semantic intent.",
         ),
-        "configured_count": len(configured),
+        "configured_count": len(configured) + int(subsystem_assurance.get("configured_count", 0) or 0),
+        "configured_requirement_count": len(configured),
+        "configured_subsystem_profile_count": subsystem_assurance.get("configured_count", 0),
         "active_count": len(active),
         "missing_required_evidence_count": len(required_missing),
         "configured": configured,
         "active": active,
         "evidence_status": evidence_status,
+        "subsystem_assurance": subsystem_assurance,
         "match_evidence": {
             "observed_scope_source": ", ".join(
                 source
@@ -1368,6 +1631,7 @@ def _assurance_requirements_report_payload(
             or "no active planning record, task text, or changed paths",
             "match_count": len(active),
             "matching": matching,
+            "subsystem_profile_match_count": subsystem_assurance.get("matched_count", 0),
         },
         "supported_blocking_claims": list(SUPPORTED_ASSURANCE_REQUIREMENT_BLOCKING_CLAIMS),
     }
@@ -1380,6 +1644,7 @@ def _compact_assurance_requirements(value: Any) -> dict[str, Any]:
     active = active if isinstance(active, list) else []
     evidence_status = value.get("evidence_status", [])
     evidence_status = evidence_status if isinstance(evidence_status, list) else []
+    subsystem_assurance = _as_dict(value.get("subsystem_assurance"))
     required_missing = [
         item for item in evidence_status if isinstance(item, dict) and item.get("state") in {"missing-evidence", "review-required"}
     ]
@@ -1407,6 +1672,14 @@ def _compact_assurance_requirements(value: Any) -> dict[str, Any]:
             for item in active[:3]
             if isinstance(item, dict)
         ],
+        "subsystem_assurance": {
+            "status": subsystem_assurance.get("status", "absent"),
+            "matched_count": subsystem_assurance.get("matched_count", 0),
+            "effective_assurance_level": subsystem_assurance.get("effective_assurance_level", "none"),
+            "matched_subsystem_ids": subsystem_assurance.get("matched_subsystem_ids", []),
+            "missing_evidence": subsystem_assurance.get("missing_evidence", []),
+            "blocked_claims": subsystem_assurance.get("blocked_claims", []),
+        },
         "evidence_status": [
             {
                 key: item.get(key)
@@ -7674,6 +7947,7 @@ def _run_report_command(
     )
     assurance_requirements = _assurance_requirements_report_payload(
         config=config,
+        target_root=target_root,
         active_planning_record=raw_active_planning_record or active_planning_record,
     )
     verification = _verification_report_payload(
@@ -11294,6 +11568,7 @@ def _run_lazy_report_section_command(
     if normalized in {"assurance_requirements", "verification", "requirement_grounding", "applicable_intent"}:
         assurance_requirements = _assurance_requirements_report_payload(
             config=config,
+            target_root=target_root,
             active_planning_record=active_planning_record,
         )
         verification = _verification_report_payload(
@@ -11384,6 +11659,7 @@ def _run_lazy_report_section_command(
         )
         assurance_requirements = _assurance_requirements_report_payload(
             config=config,
+            target_root=target_root,
             active_planning_record=active_planning_record,
         )
         verification = _verification_report_payload(
@@ -11739,6 +12015,7 @@ def _run_report_router_command(
     )
     assurance_requirements = _assurance_requirements_report_payload(
         config=config,
+        target_root=target_root,
         active_planning_record=active_planning_record,
     )
     verification = _verification_report_payload(
@@ -15284,7 +15561,7 @@ def _report_closeout_trust_payload(
         )
         intent_proof_check = _intent_proof_check_payload(planning_report={}, target_root=target_root)
         architecture_decision_closeout = _architecture_decision_closeout_payload(planning_report={}, target_root=target_root, config=config)
-        assurance_requirements = _assurance_requirements_report_payload(config=config)
+        assurance_requirements = _assurance_requirements_report_payload(config=config, target_root=target_root)
         verification = _verification_report_payload(
             target_root=target_root,
             assurance_requirements=assurance_requirements,
@@ -15369,7 +15646,7 @@ def _report_closeout_trust_payload(
         architecture_decision_closeout = _architecture_decision_closeout_payload(
             planning_report=planning_report, target_root=target_root, config=config
         )
-        assurance_requirements = _assurance_requirements_report_payload(config=config)
+        assurance_requirements = _assurance_requirements_report_payload(config=config, target_root=target_root)
         verification = _verification_report_payload(
             target_root=target_root,
             assurance_requirements=assurance_requirements,
@@ -15503,6 +15780,7 @@ def _report_closeout_trust_payload(
     )
     assurance_requirements = _assurance_requirements_report_payload(
         config=config,
+        target_root=target_root,
         active_planning_record=raw_active_planning_record,
     )
     verification = _verification_report_payload(
@@ -19939,6 +20217,7 @@ def _start_payload(
     compact_workflow_obligations = _compact_start_workflow_obligations(workflow_obligations)
     assurance_requirements = _assurance_requirements_report_payload(
         config=config,
+        target_root=target_root,
         active_planning_record=planning_record if isinstance(planning_record, dict) else None,
         task_text=task_text,
         changed_paths=changed_paths,
@@ -21641,6 +21920,7 @@ def _start_tiny_payload_fast(
         payload["cli_compatibility"] = cli_compatibility
     assurance_requirements = _assurance_requirements_report_payload(
         config=config,
+        target_root=target_root,
         active_planning_record=None,
         task_text=task_text,
         changed_paths=changed_paths,
@@ -25107,6 +25387,31 @@ def _requirement_grounding_payload(
                     },
                 }
             )
+    subsystem_assurance = _as_dict(assurance_requirements.get("subsystem_assurance"))
+    for profile in _list_payload(subsystem_assurance.get("matched_profiles")):
+        if not isinstance(profile, dict):
+            continue
+        subsystem_id = str(profile.get("subsystem_id") or profile.get("id") or "").strip()
+        for ref in _list_payload(profile.get("requirement_refs")):
+            text = str(ref).strip()
+            if not text:
+                continue
+            requirement_refs.append(
+                {
+                    "ref": text,
+                    "source_type": "subsystem-assurance-profile",
+                    "authority": "repo-configured-subsystem-requirement-ref",
+                    "title": f"Subsystem assurance profile {subsystem_id}",
+                    "provenance": f"assurance.subsystem_profiles.{subsystem_id}",
+                    "source_metadata": {
+                        "source_revision": _git_source_identity(target_root),
+                        "fetched_at": "",
+                        "excerpt_hash": "",
+                        "freshness": "repo-current",
+                        "trust_note": "routing/index metadata only; AW does not copy or store the requirement corpus",
+                    },
+                }
+            )
     seen_refs: set[tuple[str, str]] = set()
     deduped_refs: list[dict[str, Any]] = []
     for item in requirement_refs:
@@ -25133,6 +25438,22 @@ def _requirement_grounding_payload(
                 "authority": "configured-route" if because else "agent-review-required",
             }
         )
+    for profile in _list_payload(subsystem_assurance.get("matched_profiles")):
+        if not isinstance(profile, dict):
+            continue
+        subsystem_id = str(profile.get("subsystem_id") or profile.get("id") or "").strip()
+        because = [str(item).strip() for item in _list_payload(profile.get("applies_because")) if str(item).strip()]
+        ref = f"subsystem:{subsystem_id}" if subsystem_id else str(profile.get("id") or "").strip()
+        if ref:
+            applicability.append(
+                {
+                    "ref": ref,
+                    "state": "applicable" if because else "unknown",
+                    "why": "; ".join(because) if because else "Matched subsystem assurance profile without a recorded path rationale.",
+                    "confidence": "medium" if because else "low",
+                    "authority": "subsystem-assurance-profile",
+                }
+            )
     applicable_intent = _as_dict(active_planning_record.get("applicable_intents") or active_planning_record.get("applicable_intent"))
     for source in _list_payload(applicable_intent.get("sources")):
         if not isinstance(source, dict):
@@ -25208,6 +25529,19 @@ def _requirement_grounding_payload(
                 "source": "verification",
             }
         )
+    for status in _list_payload(subsystem_assurance.get("evidence_status")):
+        if not isinstance(status, dict):
+            continue
+        missing_evidence = [str(item).strip() for item in _list_payload(status.get("missing_evidence")) if str(item).strip()]
+        if missing_evidence:
+            known_gaps.append(
+                {
+                    "gap": f"subsystem assurance evidence missing for {status.get('requirement_id')}: {', '.join(missing_evidence)}",
+                    "blocked_claims": [str(item).strip() for item in _list_payload(status.get("blocking_claims")) if str(item).strip()],
+                    "source": "subsystem-assurance",
+                    "subsystem_id": status.get("subsystem_id"),
+                }
+            )
     missing_refs = [str(item).strip() for item in _list_payload(issue_scope_evidence.get("missing_issue_refs")) if str(item).strip()]
     for ref in missing_refs:
         known_gaps.append(
@@ -25231,6 +25565,8 @@ def _requirement_grounding_payload(
         sensitivity_signals.append("task-text-requirement-sensitive")
     if assurance_requirements.get("active_count"):
         sensitivity_signals.append("active-assurance-requirements")
+    if subsystem_assurance.get("matched_count"):
+        sensitivity_signals.append("matched-subsystem-assurance")
     if verification.get("active_count"):
         sensitivity_signals.append("active-verification-routes")
     if sensitivity_signals and not deduped_refs:
@@ -25283,8 +25619,18 @@ def _requirement_grounding_payload(
             "task_issue_refs": sorted(set(re.findall("#\\d+", task_text or ""))),
             "active_plan_present": bool(active_planning_record),
             "assurance_active_count": assurance_requirements.get("active_count", 0),
+            "subsystem_assurance_matched_count": subsystem_assurance.get("matched_count", 0),
             "verification_active_count": verification.get("active_count", 0),
             "sensitivity_signals": sensitivity_signals,
+        },
+        "subsystem_assurance": {
+            "status": subsystem_assurance.get("status", "absent"),
+            "effective_assurance_level": subsystem_assurance.get("effective_assurance_level", "none"),
+            "matched_subsystem_ids": subsystem_assurance.get("matched_subsystem_ids", []),
+            "required_evidence": subsystem_assurance.get("required_evidence", []),
+            "missing_evidence": subsystem_assurance.get("missing_evidence", []),
+            "blocked_claims": subsystem_assurance.get("blocked_claims", []),
+            "claim_boundaries": subsystem_assurance.get("claim_boundaries", []),
         },
         "source_inventory_policy": {
             "role": "compact-routing-index",
@@ -26003,6 +26349,7 @@ def _implement_payload(
     if include_assurance_requirements:
         payload["assurance_requirements"] = _assurance_requirements_report_payload(
             config=config,
+            target_root=target_root,
             active_planning_record=None,
             task_text=task_text,
             changed_paths=normalized_paths,
@@ -26012,6 +26359,7 @@ def _implement_payload(
         if not isinstance(assurance_for_verification, dict):
             assurance_for_verification = _assurance_requirements_report_payload(
                 config=config,
+                target_root=target_root,
                 active_planning_record=None,
                 task_text=task_text,
                 changed_paths=normalized_paths,
@@ -26026,6 +26374,7 @@ def _implement_payload(
     if not isinstance(assurance_for_grounding, dict):
         assurance_for_grounding = _assurance_requirements_report_payload(
             config=config,
+            target_root=target_root,
             active_planning_record=None,
             task_text=task_text,
             changed_paths=normalized_paths,
@@ -36571,6 +36920,7 @@ def _proof_selection_for_changed_paths(
     active_assurance_requirements = (
         _assurance_requirements_report_payload(
             config=config,
+            target_root=target_root,
             active_planning_record=planning_assurance if planning_assurance.get("status") == "present" else None,
             task_text=task_text,
             changed_paths=changed_paths,
@@ -39155,6 +39505,7 @@ def _config_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
                 for profile in assurance.proof_profiles
             ],
             "requirements": _assurance_requirement_payloads(config),
+            "subsystem_profiles": _assurance_subsystem_profile_payloads(config),
             "test_data_policy": dict(assurance.test_data_policy),
             "decision_record_target": assurance.decision_record_target,
             "invariant_registry": assurance.invariant_registry,
@@ -39232,6 +39583,7 @@ def _compact_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "agent_may_deescalate": assurance["agent_may_deescalate"],
             "configured_proof_profile_count": len(assurance["proof_profiles"]),
             "configured_requirement_count": len(assurance.get("requirements", [])),
+            "configured_subsystem_profile_count": len(assurance.get("subsystem_profiles", [])),
         },
         "local_runtime": {
             "local_override_path": local_override["path"],

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -1055,29 +1055,47 @@ def _runtime_artifact_shim_pattern_payload() -> dict[str, Any]:
 
 def _assurance_onboarding_payload(*, assurance: AssuranceConfig | None = None) -> dict[str, Any]:
     configured_profiles = list(assurance.proof_profiles) if assurance is not None else []
+    configured_requirements = list(assurance.requirements) if assurance is not None else []
+    subsystem_profiles = list(assurance.subsystem_profiles) if assurance is not None else []
     host_refs = []
     if assurance is not None:
         host_refs = [ref for ref in [assurance.decision_record_target, assurance.invariant_registry, assurance.risk_registry] if ref]
     has_test_policy = bool(assurance.test_data_policy) if assurance is not None else False
     any_configured = bool(
         configured_profiles
-        or (assurance is not None and assurance.requirements)
+        or configured_requirements
+        or subsystem_profiles
         or host_refs
         or has_test_policy
         or (assurance is not None and assurance.default_level_source != "product-default")
         or (assurance is not None and assurance.strict_closeout)
     )
-    usable = bool(configured_profiles and (host_refs or has_test_policy))
+    usable = bool((configured_profiles or configured_requirements or subsystem_profiles) and (host_refs or has_test_policy))
     status = "usable" if usable else "partial" if any_configured else "absent"
     return {
         "status": status,
         "command": "agentic-workspace defaults --section assurance_onboarding --format json",
         "report_command": "agentic-workspace report --target ./repo --section closeout_trust --format json",
         "proof_command": "agentic-workspace proof --target ./repo --changed <paths> --format json",
+        "jumpstart_route": "Use workspace-setup-jumpstart after setup discovery; seed only profiles supported by inspected host repo evidence.",
         "rule": "Host repos own assurance truth; Agentic Workspace only routes levels, gates, refs, proof profiles, and compact evidence state.",
         "configured_profile_count": len(configured_profiles),
+        "configured_requirement_count": len(configured_requirements),
+        "configured_subsystem_profile_count": len(subsystem_profiles),
         "host_ref_count": len(host_refs),
         "has_test_data_policy": has_test_policy,
+        "candidate_seed_surfaces": [
+            ".agentic-workspace/config.toml [assurance.proof_profiles]",
+            ".agentic-workspace/config.toml [assurance.requirements]",
+            ".agentic-workspace/config.toml [assurance.subsystem_profiles]",
+        ],
+        "seed_questions": [
+            "Which host-owned source declares the risk, requirement, or review burden?",
+            "Which changed paths or ownership subsystem ids should activate it?",
+            "What evidence label must exist before broad claims are honest?",
+            "Which proof profile or verification protocol should be selected, if any?",
+            "What claim boundary remains when the evidence is missing?",
+        ],
         "smallest_useful_config": [
             "[assurance]",
             'default_level = "medium"',
@@ -1087,11 +1105,17 @@ def _assurance_onboarding_payload(*, assurance: AssuranceConfig | None = None) -
             'required_commands = ["uv run pytest tests -q"]',
             "optional_commands = []",
             "review_aids = []",
+            "",
+            "[assurance.subsystem_profiles.example-subsystem]",
+            'assurance_level = "high"',
+            'requirement_refs = ["docs/requirements.md#example"]',
+            'required_evidence = ["requirement_grounding"]',
+            'force = "required-before-closeout"',
         ],
         "states": {
             "absent": "no host assurance profile is configured; low-risk installs stay cheap",
-            "partial": "some assurance fields exist, but add at least one proof profile plus a host-owned ref or test-data policy",
-            "usable": "at least one proof profile and one host-owned authority or test-data policy are configured",
+            "partial": "some assurance fields exist, but add host-owned refs, evidence labels, or test-data policy before relying on them",
+            "usable": "at least one proof profile, assurance requirement, or subsystem profile is tied to host-owned authority or test-data policy",
         },
     }
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -1200,6 +1200,28 @@ def _subsystem_assurance_payload(
     planning_facts: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     configured = _assurance_subsystem_profile_payloads(config)
+    ownership_subsystems = _load_ownership_subsystems(target_root=target_root)
+    declared_subsystem_ids = {
+        str(subsystem.get("id") or "").strip() for subsystem in ownership_subsystems if str(subsystem.get("id") or "").strip()
+    }
+    invalid_profiles = [
+        {
+            "id": str(profile.get("subsystem_id") or profile.get("id") or "").strip(),
+            "reason": "subsystem profile id is not declared in .agentic-workspace/OWNERSHIP.toml [[subsystems]]",
+            "surface": ".agentic-workspace/config.toml [assurance.subsystem_profiles]",
+            "authority_surface": ".agentic-workspace/OWNERSHIP.toml [[subsystems]]",
+        }
+        for profile in configured
+        if str(profile.get("subsystem_id") or profile.get("id") or "").strip()
+        and str(profile.get("subsystem_id") or profile.get("id") or "").strip() not in declared_subsystem_ids
+    ]
+    invalid_profile_ids = {str(profile.get("id") or "").strip() for profile in invalid_profiles if str(profile.get("id") or "").strip()}
+    active_configured = [
+        profile
+        for profile in configured
+        if str(profile.get("subsystem_id") or profile.get("id") or "").strip()
+        and str(profile.get("subsystem_id") or profile.get("id") or "").strip() in declared_subsystem_ids
+    ]
     normalized_paths = _normalize_changed_paths(changed_paths or [])
     ownership_matches = (
         _subsystem_matches_for_changed_paths(target_root=target_root, changed_paths=normalized_paths)
@@ -1229,7 +1251,7 @@ def _subsystem_assurance_payload(
     profile_matches: list[dict[str, Any]] = []
     facts = planning_facts if isinstance(planning_facts, dict) else _assurance_requirement_planning_facts(active_planning_record)
     evidence_by_requirement = facts.get("evidence_by_requirement", {}) if isinstance(facts, dict) else {}
-    for profile in configured:
+    for profile in active_configured:
         scope_tokens = _assurance_profile_scope_tokens(profile)
         matched_scope_tokens = sorted(scope_tokens & matched_tokens)
         matched_plan_scope = sorted(scope_tokens & plan_scope)
@@ -1306,8 +1328,23 @@ def _subsystem_assurance_payload(
     ]
     return {
         "kind": "agentic-workspace/subsystem-assurance/v1",
-        "status": "attention" if missing_required else "matched" if profile_matches else "configured" if configured else "absent",
+        "status": "attention"
+        if missing_required
+        else "matched"
+        if profile_matches
+        else "configured"
+        if active_configured
+        else "invalid-config"
+        if invalid_profiles
+        else "absent",
         "configured_count": len(configured),
+        "active_configured_count": len(active_configured),
+        "invalid_profile_count": len(invalid_profiles),
+        "invalid_profiles": invalid_profiles,
+        "warnings": [
+            f"assurance.subsystem_profiles.{profile_id} is ignored because {profile_id!r} is not declared in .agentic-workspace/OWNERSHIP.toml [[subsystems]]."
+            for profile_id in sorted(invalid_profile_ids)
+        ],
         "matched_count": len(profile_matches),
         "effective_assurance_level": effective_level,
         "matched_subsystem_ids": [str(profile.get("subsystem_id")) for profile in profile_matches],

--- a/tests/test_workspace_config_cli.py
+++ b/tests/test_workspace_config_cli.py
@@ -381,7 +381,7 @@ default_level = "medium"
     assert cli.main(["config", "--verbose", "--target", str(tmp_path), "--format", "json"]) == 0
 
     partial = json.loads(capsys.readouterr().out)
-    assert partial["assurance"]["onboarding"]["status"] == "partial"
+    assert partial["assurance"]["onboarding"]["status"] == "absent"
     assert partial["assurance"]["onboarding"]["configured_profile_count"] == 0
     assert partial["assurance"]["onboarding"]["configured_subsystem_profile_count"] == 0
 
@@ -392,7 +392,6 @@ schema_version = 1
 
 [assurance]
 default_level = "medium"
-decision_record_target = "docs/decisions/"
 
 [assurance.proof_profiles.security]
 required_commands = ["uv run pytest tests/security -q"]

--- a/tests/test_workspace_config_cli.py
+++ b/tests/test_workspace_config_cli.py
@@ -383,6 +383,7 @@ default_level = "medium"
     partial = json.loads(capsys.readouterr().out)
     assert partial["assurance"]["onboarding"]["status"] == "partial"
     assert partial["assurance"]["onboarding"]["configured_profile_count"] == 0
+    assert partial["assurance"]["onboarding"]["configured_subsystem_profile_count"] == 0
 
     _write(
         tmp_path / ".agentic-workspace/config.toml",
@@ -397,6 +398,12 @@ decision_record_target = "docs/decisions/"
 required_commands = ["uv run pytest tests/security -q"]
 optional_commands = []
 review_aids = []
+
+[assurance.subsystem_profiles.audit-log]
+assurance_level = "high"
+requirement_refs = ["docs/requirements.md#auditability"]
+required_evidence = ["requirement_grounding"]
+force = "required-before-closeout"
 """,
     )
 
@@ -405,7 +412,9 @@ review_aids = []
     usable = json.loads(capsys.readouterr().out)
     assert usable["assurance"]["onboarding"]["status"] == "usable"
     assert usable["assurance"]["onboarding"]["configured_profile_count"] == 1
+    assert usable["assurance"]["onboarding"]["configured_subsystem_profile_count"] == 1
     assert usable["assurance"]["onboarding"]["host_ref_count"] == 1
+    assert ".agentic-workspace/config.toml [assurance.subsystem_profiles]" in usable["assurance"]["onboarding"]["candidate_seed_surfaces"]
 
 
 def test_config_command_reports_assurance_requirements(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_defaults_cli.py
+++ b/tests/test_workspace_defaults_cli.py
@@ -293,6 +293,9 @@ def test_defaults_command_reports_machine_readable_default_routes_as_json(capsys
     assert payload["assurance_onboarding"]["status"] == "absent"
     assert payload["assurance_onboarding"]["command"] == "agentic-workspace defaults --section assurance_onboarding --format json"
     assert payload["assurance_onboarding"]["states"]["usable"].startswith("at least one proof profile")
+    assert ".agentic-workspace/config.toml [assurance.subsystem_profiles]" in payload["assurance_onboarding"]["candidate_seed_surfaces"]
+    assert payload["verification_onboarding"]["command"] == "agentic-workspace defaults --section verification_onboarding --format json"
+    assert ".agentic-workspace/verification/manifest.toml" in payload["verification_onboarding"]["candidate_seed_surfaces"]
     assert payload["ownership_mapping"]["canonical_doc"] == ".agentic-workspace/docs/ownership-authority-contract.md"
     assert payload["ownership_mapping"]["command"] == "agentic-workspace ownership --target ./repo --format json"
     assert payload["ownership_mapping"]["ledger"] == ".agentic-workspace/OWNERSHIP.toml"
@@ -782,6 +785,18 @@ def test_defaults_section_selector_returns_agent_aid_storage_answer(capsys) -> N
         "source-checkout-only",
     ]
     assert "agentic-workspace defaults --format json" in payload["refs"]
+
+
+def test_defaults_section_selector_returns_verification_onboarding_answer(capsys) -> None:
+    assert cli.main(["defaults", "--verbose", "--section", "verification_onboarding", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["profile"] == "compact-contract-answer/v1"
+    assert payload["surface"] == "defaults"
+    assert payload["selector"] == {"section": "verification_onboarding"}
+    assert payload["answer"]["command"] == "agentic-workspace defaults --section verification_onboarding --format json"
+    assert payload["answer"]["candidate_seed_surfaces"][0] == ".agentic-workspace/verification/manifest.toml"
+    assert "Do not create a manifest from filenames alone." in payload["answer"]["jumpstart_boundary"]
 
 
 def test_defaults_section_selector_returns_clarification_answer(capsys) -> None:

--- a/tests/test_workspace_doctor_status_cli.py
+++ b/tests/test_workspace_doctor_status_cli.py
@@ -255,6 +255,7 @@ def test_setup_surfaces_assurance_verification_onboarding_without_optional_modul
 
     payload = json.loads(capsys.readouterr().out)
     routes = payload["onboarding_routes"]
+    assert routes["assurance"]["status"] == "absent"
     assert routes["assurance"]["command"] == "agentic-workspace defaults --section assurance_onboarding --format json"
     assert routes["assurance"]["report_command"] == (
         "agentic-workspace report --target ./repo --section assurance_requirements --format json"

--- a/tests/test_workspace_doctor_status_cli.py
+++ b/tests/test_workspace_doctor_status_cli.py
@@ -240,6 +240,37 @@ def test_doctor_promotes_safe_module_lifecycle_repairs_for_missing_memory_templa
     assert doctor_payload["repair_plan"]["status"] == "safe-action-available"
 
 
+def test_setup_surfaces_assurance_verification_onboarding_without_optional_module_residue(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    _write(
+        target / ".agentic-workspace" / "verification" / "manifest.toml",
+        'schema_version = "agentic-workspace/verification-manifest/v1"\n',
+    )
+    capsys.readouterr()
+
+    assert cli.main(["setup", "--target", str(target), "--non-interactive", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    routes = payload["onboarding_routes"]
+    assert routes["assurance"]["command"] == "agentic-workspace defaults --section assurance_onboarding --format json"
+    assert routes["assurance"]["report_command"] == (
+        "agentic-workspace report --target ./repo --section assurance_requirements --format json"
+    )
+    assert routes["verification"]["status"] == "configured"
+    assert routes["verification"]["command"] == "agentic-workspace defaults --section verification_onboarding --format json"
+    assert routes["verification"]["report_command"] == "agentic-workspace report --target ./repo --section verification --format json"
+    assert payload["current"]["installed_modules"]
+    assert not any("installed module 'verification' is not enabled" in warning for warning in payload["current"]["warnings"])
+    assert payload["current"]["optional_module_notices"] == [
+        "Verification is installed and available as an optional module; it is not part of the default enabled module set."
+    ]
+    assert "agentic-workspace defaults --section assurance_onboarding --format json" in payload["next_action"]["commands"]
+    assert "agentic-workspace defaults --section verification_onboarding --format json" in payload["next_action"]["commands"]
+
+
 def test_doctor_module_filter_does_not_require_llms_adapter(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2464,6 +2464,50 @@ candidates = [
     assert "lane_shaping_gate" not in payload["context"]
 
 
+def test_start_does_not_promote_roadmap_candidates_from_generic_jumpstart_terms(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "github-1601-workspace-cleanup", maturity = "candidate", status = "next", priority = "P2", refs = "GitHub #1601", title = "Workspace cleanup", outcome = "Improve repo maintenance surfaces.", reason = "Open issue.", promotion_signal = "Promote before implementation.", suggested_first_slice = "Shape cleanup." },
+  { id = "github-1602-setup-followup", maturity = "candidate", status = "next", priority = "P2", refs = "GitHub #1602", title = "Setup follow-up", outcome = "Review jumpstart residue in this repo.", reason = "Open issue.", promotion_signal = "Promote before implementation.", suggested_first_slice = "Shape setup." },
+]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Run workspace setup jumpstart on this repo for dogfooding",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["next_safe_action"]["implementation_allowed"] is True
+    assert payload["action_signals"]["allowed_next_action"] != "select-or-promote-candidate-lane"
+    assert payload["context"]["planning"]["workflow_sufficiency"]["sufficiency_result"] != "candidate-lane-promotion-required"
+    assert "planning_safety_gate" not in payload["context"]["planning"]
+    assert "lane_shaping_gate" not in payload["context"]
+
+
 def test_implement_surfaces_requirement_grounding_chain(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(tmp_path / "src" / "runtime.py", "VALUE = 1\n")

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -239,6 +239,229 @@ blocking_claims = ["claim-work-complete", "close-parent-lane"]
     assert requirements["evidence_status"][0]["missing_evidence"] == ["authority_consulted"]
 
 
+def test_implement_scopes_assurance_by_matched_subsystem(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "OWNERSHIP.toml",
+        """
+[[subsystems]]
+id = "audit-log"
+paths = ["src/audit/**"]
+owns = ["audit trail semantics"]
+proof = ["make audit-proof"]
+
+[[subsystems]]
+id = "docs-rendering"
+paths = ["docs/**"]
+owns = ["documentation rendering"]
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.subsystem_profiles.audit-log]
+assurance_level = "high"
+scope_refs = ["ownership.subsystems.audit-log"]
+requirement_refs = ["docs/system-requirements.md#auditability"]
+required_evidence = ["requirement_grounding", "manual_review"]
+proof_profile = "audit"
+force = "required-before-closeout"
+blocked_without_evidence = ["auditability-complete", "requirement-grounded-completion"]
+claim_boundary = "subsystem-scoped"
+review_owner = "security-review"
+
+[assurance.subsystem_profiles.docs-rendering]
+assurance_level = "low"
+required_evidence = ["docs_review"]
+force = "recommended"
+blocked_without_evidence = ["docs-rendering-complete"]
+claim_boundary = "changed-scope"
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/audit/events.py",
+                "--select",
+                "assurance_requirements,requirement_grounding",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    values = json.loads(capsys.readouterr().out)["values"]
+    assurance = values["assurance_requirements"]
+    subsystem = assurance["subsystem_assurance"]
+    assert subsystem["status"] == "attention"
+    assert subsystem["matched_subsystem_ids"] == ["audit-log"]
+    assert subsystem["effective_assurance_level"] == "high"
+    assert subsystem["missing_evidence"] == ["requirement_grounding", "manual_review"]
+    assert assurance["active"][0]["id"] == "subsystem:audit-log"
+    grounding = values["requirement_grounding"]
+    assert grounding["subsystem_assurance"]["effective_assurance_level"] == "high"
+    assert "matched-subsystem-assurance" in grounding["source_facts"]["sensitivity_signals"]
+    assert "requirement-grounded-completion" in grounding["closeout_claims"]["blocked"]
+
+
+def test_implement_does_not_inherit_unmatched_high_assurance_subsystem(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "OWNERSHIP.toml",
+        """
+[[subsystems]]
+id = "audit-log"
+paths = ["src/audit/**"]
+
+[[subsystems]]
+id = "docs-rendering"
+paths = ["docs/**"]
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.subsystem_profiles.audit-log]
+assurance_level = "high"
+required_evidence = ["manual_review"]
+force = "required-before-closeout"
+blocked_without_evidence = ["auditability-complete"]
+
+[assurance.subsystem_profiles.docs-rendering]
+assurance_level = "low"
+required_evidence = ["docs_review"]
+force = "recommended"
+blocked_without_evidence = ["docs-rendering-complete"]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "docs/guide.md",
+                "--select",
+                "assurance_requirements",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    subsystem = json.loads(capsys.readouterr().out)["values"]["assurance_requirements"]["subsystem_assurance"]
+    assert subsystem["matched_subsystem_ids"] == ["docs-rendering"]
+    assert subsystem["effective_assurance_level"] == "low"
+    assert "manual_review" not in subsystem["missing_evidence"]
+
+
+def test_implement_composes_multiple_subsystem_assurance_profiles_conservatively(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "OWNERSHIP.toml",
+        """
+[[subsystems]]
+id = "audit-log"
+paths = ["src/shared/**"]
+
+[[subsystems]]
+id = "analytics"
+paths = ["src/shared/**"]
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.subsystem_profiles.audit-log]
+assurance_level = "critical"
+required_evidence = ["tamper_review"]
+force = "blocking"
+blocked_without_evidence = ["security-complete"]
+
+[assurance.subsystem_profiles.analytics]
+assurance_level = "medium"
+required_evidence = ["metric_review"]
+force = "recommended"
+blocked_without_evidence = ["analytics-complete"]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/shared/event.py",
+                "--select",
+                "assurance_requirements",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    subsystem = json.loads(capsys.readouterr().out)["values"]["assurance_requirements"]["subsystem_assurance"]
+    assert subsystem["matched_subsystem_ids"] == ["analytics", "audit-log"]
+    assert subsystem["effective_assurance_level"] == "critical"
+    assert set(subsystem["missing_evidence"]) == {"metric_review", "tamper_review"}
+
+
+def test_implement_reports_no_subsystem_profile_without_extra_burden(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "OWNERSHIP.toml",
+        """
+[[subsystems]]
+id = "ordinary"
+paths = ["src/ordinary/**"]
+""",
+    )
+    _write(tmp_path / ".agentic-workspace/config.toml", "schema_version = 1\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/ordinary/model.py",
+                "--select",
+                "assurance_requirements",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    assurance = json.loads(capsys.readouterr().out)["values"]["assurance_requirements"]
+    assert assurance["status"] == "absent"
+    assert assurance["subsystem_assurance"]["status"] == "absent"
+
+
 def test_implement_keeps_unmatched_assurance_requirements_out_of_tiny_output(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
@@ -2472,6 +2695,99 @@ candidates = []
     assert grounding["requirement_refs"][0]["ref"] == "docs/requirements.md#report"
     assert grounding["source_inventory_policy"]["role"] == "compact-routing-index"
     assert grounding["agent_interpretation"]["summary"] == "Report the requirement grounding chain."
+
+
+def test_report_section_scopes_subsystem_assurance_from_active_plan(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path)]) == 0
+    capsys.readouterr()
+    _write(
+        tmp_path / ".agentic-workspace" / "OWNERSHIP.toml",
+        """
+[[subsystems]]
+id = "audit-log"
+paths = ["src/audit/**"]
+owns = ["audit trail semantics"]
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance.subsystem_profiles.audit-log]
+assurance_level = "high"
+requirement_refs = ["docs/system-requirements.md#auditability"]
+required_evidence = ["requirement_grounding"]
+force = "required-before-closeout"
+blocked_without_evidence = ["requirement-grounded-completion"]
+claim_boundary = "subsystem-scoped"
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "audit-plan", status = "active", maturity = "active", surface = ".agentic-workspace/planning/execplans/audit-plan.plan.json" }
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "audit-plan.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Audit plan",
+            "canonical_core": {"touched_scope": ["subsystem:audit-log"]},
+            "traceability_refs": {"requirement_refs": ["docs/system-requirements.md#auditability"]},
+        },
+    )
+
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(tmp_path),
+                "--section",
+                "assurance_requirements",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    assurance = json.loads(capsys.readouterr().out)["answer"]
+    assert assurance["status"] == "attention"
+    assert assurance["active"][0]["id"] == "subsystem:audit-log"
+    assert assurance["subsystem_assurance"]["matched_subsystem_ids"] == ["audit-log"]
+
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(tmp_path),
+                "--section",
+                "requirement_grounding",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    grounding = json.loads(capsys.readouterr().out)["answer"]
+    assert grounding["subsystem_assurance"]["effective_assurance_level"] == "high"
+    assert grounding["applicability"][0]["ref"] == "subsystem:audit-log"
+    assert "requirement-grounded-completion" in grounding["closeout_claims"]["blocked"]
 
 
 def test_implement_projects_ready_plan_delegation_packet(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -370,6 +370,59 @@ blocked_without_evidence = ["docs-rendering-complete"]
     assert "manual_review" not in subsystem["missing_evidence"]
 
 
+def test_implement_ignores_subsystem_profile_not_declared_in_ownership(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "OWNERSHIP.toml",
+        """
+[[subsystems]]
+id = "ordinary"
+paths = ["src/audit/**"]
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[assurance.subsystem_profiles.audit-log]
+assurance_level = "high"
+required_evidence = ["manual_review"]
+force = "required-before-closeout"
+blocked_without_evidence = ["auditability-complete"]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/audit/events.py",
+                "--select",
+                "assurance_requirements",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    subsystem = json.loads(capsys.readouterr().out)["values"]["assurance_requirements"]["subsystem_assurance"]
+    assert subsystem["status"] == "invalid-config"
+    assert subsystem["configured_count"] == 1
+    assert subsystem["active_configured_count"] == 0
+    assert subsystem["invalid_profile_count"] == 1
+    assert subsystem["invalid_profiles"][0]["id"] == "audit-log"
+    assert subsystem["matched_count"] == 0
+    assert subsystem["matched_subsystem_ids"] == []
+    assert subsystem["missing_evidence"] == []
+    assert "audit-log" in subsystem["warnings"][0]
+
+
 def test_implement_composes_multiple_subsystem_assurance_profiles_conservatively(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
@@ -2832,6 +2885,82 @@ candidates = []
     assert grounding["subsystem_assurance"]["effective_assurance_level"] == "high"
     assert grounding["applicability"][0]["ref"] == "subsystem:audit-log"
     assert "requirement-grounded-completion" in grounding["closeout_claims"]["blocked"]
+
+
+def test_report_section_ignores_active_plan_scope_for_unknown_subsystem_profile(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path)]) == 0
+    capsys.readouterr()
+    _write(
+        tmp_path / ".agentic-workspace" / "OWNERSHIP.toml",
+        """
+[[subsystems]]
+id = "ordinary"
+paths = ["src/ordinary/**"]
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance.subsystem_profiles.audit-log]
+assurance_level = "high"
+required_evidence = ["requirement_grounding"]
+force = "required-before-closeout"
+blocked_without_evidence = ["requirement-grounded-completion"]
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "audit-plan", status = "active", maturity = "active", surface = ".agentic-workspace/planning/execplans/audit-plan.plan.json" }
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "audit-plan.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "title": "Audit plan",
+            "canonical_core": {"touched_scope": ["subsystem:audit-log"]},
+        },
+    )
+
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(tmp_path),
+                "--section",
+                "assurance_requirements",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    assurance = json.loads(capsys.readouterr().out)["answer"]
+    subsystem = assurance["subsystem_assurance"]
+    assert assurance["status"] == "configured"
+    assert assurance["active"] == []
+    assert subsystem["status"] == "invalid-config"
+    assert subsystem["invalid_profiles"][0]["id"] == "audit-log"
+    assert subsystem["matched_count"] == 0
+    assert subsystem["matched_subsystem_ids"] == []
+    assert subsystem["missing_evidence"] == []
 
 
 def test_implement_projects_ready_plan_delegation_packet(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -1293,6 +1293,64 @@ blocking_claims = ["claim-work-complete", "close-parent-lane"]
     assert lane["applies_because"] == ["changed path matched db/migrations/**"]
 
 
+def test_proof_changed_includes_matched_subsystem_assurance_profile(tmp_path: Path, capsys) -> None:
+    _write(
+        tmp_path / ".agentic-workspace" / "OWNERSHIP.toml",
+        """
+[[subsystems]]
+id = "audit-log"
+paths = ["src/audit/**"]
+owns = ["audit trail semantics"]
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance.proof_profiles.audit]
+required_commands = ["uv run pytest tests/audit -q"]
+optional_commands = ["uv run pytest tests/audit_integration -q"]
+review_aids = ["docs/reviews/audit.md"]
+
+[assurance.subsystem_profiles.audit-log]
+assurance_level = "high"
+requirement_refs = ["docs/system-requirements.md#auditability"]
+required_evidence = ["requirement_grounding", "manual_review"]
+proof_profile = "audit"
+force = "required-before-closeout"
+blocked_without_evidence = ["auditability-complete"]
+claim_boundary = "subsystem-scoped"
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--verbose",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/audit/events.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    assert "uv run pytest tests/audit -q" in answer["required_commands"]
+    assert "uv run pytest tests/audit_integration -q" in answer["optional_commands"]
+    subsystem = answer["assurance_requirements"]["subsystem_assurance"]
+    assert subsystem["matched_subsystem_ids"] == ["audit-log"]
+    assert subsystem["effective_assurance_level"] == "high"
+    lane = [item for item in answer["selected_lanes"] if item.get("requirement_id") == "subsystem:audit-log"][0]
+    assert lane["proof_profile"] == "audit"
+    assert lane["applies_because"] == ["changed path matched subsystem audit-log"]
+
+
 def test_proof_current_includes_active_planning_assurance_requirement_profile(tmp_path: Path, capsys) -> None:
     from repo_planning_bootstrap import installer as planning_installer
 

--- a/tests/test_workspace_proof_generated_packages_cli.py
+++ b/tests/test_workspace_proof_generated_packages_cli.py
@@ -154,11 +154,18 @@ def test_proof_changed_selector_routes_contract_only_changes_to_focused_lane(cap
         select="selected_lanes,required_commands",
     )
 
-    assert [lane["id"] for lane in answer["selected_lanes"]] == ["contract_tooling"]
+    assert [lane["id"] for lane in answer["selected_lanes"]] == [
+        "contract_tooling",
+        "assurance-requirement:test_evidence_change_decision",
+        "verification:test_evidence_decision",
+    ]
     assert answer["required_commands"] == [
         "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
         "uv run python scripts/check/check_structured_file_inventory.py --quiet-success",
         "uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py",
+        "make test-workspace",
+        "make lint-workspace",
+        "uv run python scripts/run_agentic_workspace.py report --target . --section verification --format json",
     ]
     assert "generated_cli_freshness" not in answer
     assert "uv run pytest tests -q" not in answer["required_commands"]

--- a/tests/test_workspace_skills_cli.py
+++ b/tests/test_workspace_skills_cli.py
@@ -347,6 +347,40 @@ def test_skills_command_recommends_setup_jumpstart_for_mature_repo_seeding(tmp_p
     assert payload["recommendations"][0]["source_kind"] == "installed-workspace-skills"
     assert payload["recommendations"][0]["scope"] == "routed-support"
     assert "pre-write and pre-seed discovery" in Path("docs/jumpstart-contract.md").read_text(encoding="utf-8")
+    skill_text = Path(".agentic-workspace/skills/workspace-setup-jumpstart/SKILL.md").read_text(encoding="utf-8")
+    assert "defaults --section assurance_onboarding" in skill_text
+    assert "defaults --section verification_onboarding" in skill_text
+
+
+def test_skills_command_recommends_jumpstart_for_assurance_verification_population(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "skills",
+                "--target",
+                str(target),
+                "--task",
+                "jumpstart assurance onboarding and verification onboarding for a mature repo",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["recommendations"][0]["id"] == "workspace-setup-jumpstart"
+    jumpstart = next(skill for skill in payload["skills"] if skill["id"] == "workspace-setup-jumpstart")
+    nouns = jumpstart["activation_hints"]["nouns"]
+    assert "assurance onboarding" in nouns
+    assert "verification onboarding" in nouns
 
 
 def test_skills_command_recommends_memory_router_for_note_selection_task(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Adds subsystem-scoped assurance profiles keyed by existing `.agentic-workspace/OWNERSHIP.toml` subsystem ids, then projects matched profiles through the existing assurance, requirement grounding, Verification, report, and proof surfaces.

This closes the remaining requirement-grounded work by making source-to-scope-to-evidence flow explicit without turning Verification into a policy engine: AW surfaces matched subsystem burden, missing evidence, claim boundaries, and proof-profile routing; the agent still owns the reasoning and closeout decision.

Closes #1556.
Closes #1567.

## Validation

- `uv run pytest tests/test_workspace_implement_cli.py tests/test_workspace_proof_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make maintainer-surfaces`
- `make schema-reference-docs`
- `uv run python scripts/run_agentic_workspace.py proof --target . --current --format json`
- `uv run python scripts/run_agentic_workspace.py summary --format json`
