### PR TITLE
[codex] Add status select support

### DIFF
--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -3073,6 +3073,13 @@
           ],
           "help": "Emit all module lifecycle status detail. Prefer default output for ordinary health routing.",
           "name": "verbose"
+        },
+        {
+          "flags": [
+            "--select"
+          ],
+          "help": "Return only comma-separated top-level or dotted JSON fields from the full command payload. Prefer this over --verbose when one or a few fields are needed.",
+          "name": "select"
         }
       ]
     },

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -4218,6 +4218,13 @@
             ],
             "help": "Emit all module lifecycle status detail. Prefer default output for ordinary health routing.",
             "name": "verbose"
+          },
+          {
+            "flags": [
+              "--select"
+            ],
+            "help": "Return only comma-separated top-level or dotted JSON fields from the full command payload. Prefer this over --verbose when one or a few fields are needed.",
+            "name": "select"
           }
         ]
       },
@@ -4230,6 +4237,7 @@
           "target root resolution",
           "module selection",
           "status report assembly",
+          "field selection",
           "output emission"
         ],
         "target_specific": [
@@ -4254,6 +4262,7 @@
           "workspace.root.resolve",
           "workspace.selection.resolve",
           "workspace.report.assemble",
+          "output.fields.select",
           "output.emit"
         ]
       },

--- a/generated/workspace/python/generated_command_adapters.json
+++ b/generated/workspace/python/generated_command_adapters.json
@@ -734,6 +734,7 @@
           "workspace.root.resolve",
           "workspace.selection.resolve",
           "workspace.report.assemble",
+          "output.fields.select",
           "output.emit"
         ]
       },

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -4218,6 +4218,13 @@
             ],
             "help": "Emit all module lifecycle status detail. Prefer default output for ordinary health routing.",
             "name": "verbose"
+          },
+          {
+            "flags": [
+              "--select"
+            ],
+            "help": "Return only comma-separated top-level or dotted JSON fields from the full command payload. Prefer this over --verbose when one or a few fields are needed.",
+            "name": "select"
           }
         ]
       },
@@ -4230,6 +4237,7 @@
           "target root resolution",
           "module selection",
           "status report assembly",
+          "field selection",
           "output emission"
         ],
         "target_specific": [
@@ -4254,6 +4262,7 @@
           "workspace.root.resolve",
           "workspace.selection.resolve",
           "workspace.report.assemble",
+          "output.fields.select",
           "output.emit"
         ]
       },

--- a/generated/workspace/typescript/resources/operations/status.report.json
+++ b/generated/workspace/typescript/resources/operations/status.report.json
@@ -11,7 +11,8 @@
     "writes_repo_state": false
   },
   "guards": [
-    "Status must remain read-only."
+    "Status must remain read-only.",
+    "Prefer --select for exact field drill-down and --verbose only for broad diagnostics."
   ],
   "id": "status.report",
   "inputs": [
@@ -32,6 +33,11 @@
     },
     {
       "name": "verbose",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "select",
       "required": false,
       "source": "cli-option"
     },
@@ -80,7 +86,8 @@
   },
   "proof": [
     "operation contract validates against operation.schema.json",
-    "status command tests remain compatible"
+    "status command tests remain compatible",
+    "status --select command tests cover compact selected-output payloads"
   ],
   "reads": [
     {
@@ -94,6 +101,10 @@
     {
       "required": false,
       "surface": "verbose flag for broad diagnostic output"
+    },
+    {
+      "required": false,
+      "surface": "field selector for exact JSON drill-down"
     }
   ],
   "schema_version": "agentic-workspace/operation/v1",
@@ -112,6 +123,11 @@
       "description": "Assemble status report.",
       "id": "assemble_report",
       "uses": "workspace.report.assemble"
+    },
+    {
+      "description": "Return only requested JSON fields when --select is provided.",
+      "id": "select_fields",
+      "uses": "output.fields.select"
     },
     {
       "description": "Emit status report.",

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -3126,6 +3126,13 @@ const commandDefinitions = [
           ],
           "help": "Emit all module lifecycle status detail. Prefer default output for ordinary health routing.",
           "name": "verbose"
+        },
+        {
+          "flags": [
+            "--select"
+          ],
+          "help": "Return only comma-separated top-level or dotted JSON fields from the full command payload. Prefer this over --verbose when one or a few fields are needed.",
+          "name": "select"
         }
       ]
     },

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -2169,6 +2169,13 @@
           ],
           "action": "store_true",
           "help": "Emit all module lifecycle status detail. Prefer default output for ordinary health routing."
+        },
+        {
+          "name": "select",
+          "flags": [
+            "--select"
+          ],
+          "help": "Return only comma-separated top-level or dotted JSON fields from the full command payload. Prefer this over --verbose when one or a few fields are needed."
         }
       ],
       "role": "core_lifecycle",

--- a/src/agentic_workspace/contracts/command_adapter_generation.json
+++ b/src/agentic_workspace/contracts/command_adapter_generation.json
@@ -5444,6 +5444,7 @@
           "workspace.root.resolve",
           "workspace.selection.resolve",
           "workspace.report.assemble",
+          "output.fields.select",
           "output.emit"
         ]
       },
@@ -5497,6 +5498,7 @@
           "target root resolution",
           "module selection",
           "status report assembly",
+          "field selection",
           "output emission"
         ]
       },

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -4895,6 +4895,13 @@
                 ],
                 "action": "store_true",
                 "help": "Emit all module lifecycle status detail. Prefer default output for ordinary health routing."
+              },
+              {
+                "name": "select",
+                "flags": [
+                  "--select"
+                ],
+                "help": "Return only comma-separated top-level or dotted JSON fields from the full command payload. Prefer this over --verbose when one or a few fields are needed."
               }
             ]
           },
@@ -4908,6 +4915,7 @@
               "workspace.root.resolve",
               "workspace.selection.resolve",
               "workspace.report.assemble",
+              "output.fields.select",
               "output.emit"
             ]
           },
@@ -4945,6 +4953,7 @@
               "target root resolution",
               "module selection",
               "status report assembly",
+              "field selection",
               "output emission"
             ]
           }

--- a/src/agentic_workspace/contracts/operations/status.report.json
+++ b/src/agentic_workspace/contracts/operations/status.report.json
@@ -28,6 +28,11 @@
       "required": false
     },
     {
+      "name": "select",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "format",
       "source": "cli-option",
       "required": false
@@ -60,6 +65,10 @@
     {
       "surface": "verbose flag for broad diagnostic output",
       "required": false
+    },
+    {
+      "surface": "field selector for exact JSON drill-down",
+      "required": false
     }
   ],
   "writes": [],
@@ -80,17 +89,24 @@
       "description": "Assemble status report."
     },
     {
+      "id": "select_fields",
+      "uses": "output.fields.select",
+      "description": "Return only requested JSON fields when --select is provided."
+    },
+    {
       "id": "emit_output",
       "uses": "output.emit",
       "description": "Emit status report."
     }
   ],
   "guards": [
-    "Status must remain read-only."
+    "Status must remain read-only.",
+    "Prefer --select for exact field drill-down and --verbose only for broad diagnostics."
   ],
   "proof": [
     "operation contract validates against operation.schema.json",
-    "status command tests remain compatible"
+    "status command tests remain compatible",
+    "status --select command tests cover compact selected-output payloads"
   ],
   "migration_status": "draft-contract-only"
 }

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -21306,8 +21306,8 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         selectors.extend(
             selector for selector in drill_down.get("available_selectors", []) if isinstance(selector, str) and selector not in selectors
         )
-    if selectors:
-        return selectors
+    if isinstance(payload, dict):
+        selectors.extend(str(key) for key in payload if str(key) not in selectors)
     discovered: list[str] = []
 
     def visit(value: Any, prefix: str) -> None:
@@ -21324,7 +21324,8 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
                     visit(child, path)
 
     visit(payload, "")
-    return discovered
+    selectors.extend(selector for selector in discovered if selector not in selectors)
+    return selectors
 
 
 def _skill_catalog_summary_from_payload(skills_payload: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_workspace_doctor_status_cli.py
+++ b/tests/test_workspace_doctor_status_cli.py
@@ -603,6 +603,56 @@ def test_doctor_select_reports_available_fields_for_missing_selector(tmp_path: P
     assert "next_action" in payload["available_selectors"]
 
 
+def test_status_select_returns_requested_fields(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "status",
+                "--target",
+                str(target),
+                "--format",
+                "json",
+                "--select",
+                "health,installed_modules,warnings",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "agentic-workspace/selected-output/v1"
+    assert payload["source_command"] == "status"
+    assert payload["values"]["health"] == "healthy"
+    assert payload["values"]["installed_modules"]
+    assert payload["values"]["warnings"] == []
+    assert "available_selectors" not in payload
+
+
+def test_status_select_reports_available_fields_for_missing_selector(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["status", "--target", str(target), "--format", "json", "--select", "missing.field"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "agentic-workspace/selected-output/v1"
+    assert payload["source_command"] == "status"
+    assert payload["missing"] == ["missing.field"]
+    assert payload["selector_rule"].startswith("Comma-separated dot paths")
+    assert "health" in payload["available_selectors"]
+    assert "installed_modules" in payload["available_selectors"]
+    assert "warnings" in payload["available_selectors"]
+
+
 def test_doctor_reports_cli_executable_drift_with_concrete_next_action(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()


### PR DESCRIPTION
## Summary

- Add `--select` to `agentic-workspace status` through the CLI command manifest, operation contract, adapter generation manifest, and command package IR.
- Regenerate the Python and TypeScript workspace command projections so status accepts selected-output JSON fields.
- Improve missing-selector diagnostics so valid top-level payload fields such as `installed_modules` and `warnings` are advertised before nested detail fills the selector list.
- Add status selector tests for requested fields and missing-selector available-field reporting.

Closes #1577.

## Validation

- `uv run pytest tests/test_workspace_doctor_status_cli.py::test_status_select_returns_requested_fields tests/test_workspace_doctor_status_cli.py::test_status_select_reports_available_fields_for_missing_selector -q`
- `uv run python scripts/run_agentic_workspace.py status --target . --format json --select health,installed_modules,warnings`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`