### PR TITLE
[codex] Fix workspace upgrade lifecycle issues

### DIFF
--- a/.agentic-workspace/planning/closeout-evidence/memory-pull-capture-decision-packet.closeout.json
+++ b/.agentic-workspace/planning/closeout-evidence/memory-pull-capture-decision-packet.closeout.json
@@ -4,6 +4,7 @@
   "plan_id": "memory-pull-capture-decision-packet",
   "created_at": "2026-06-17T08:20:00+00:00",
   "source_plan": ".agentic-workspace/planning/execplans/archive/memory-pull-capture-decision-packet.plan.json",
+  "intended_archive": ".agentic-workspace/planning/execplans/archive/memory-pull-capture-decision-packet.plan.json",
   "retention": {
     "state": "retained-closeout-evidence",
     "reason": "PR #1580 closure depends on explicit end-to-end Memory pull/capture dogfooding evidence, not only implementation tests.",

--- a/.agentic-workspace/planning/schemas/planning-closeout-evidence.schema.json
+++ b/.agentic-workspace/planning/schemas/planning-closeout-evidence.schema.json
@@ -53,6 +53,9 @@
     "closure_check": {
       "$ref": "#/$defs/string_map"
     },
+    "dogfooding_evidence": {
+      "type": "object"
+    },
     "durable_residue": {
       "$ref": "#/$defs/string_map"
     },

--- a/generated/memory/typescript/src/cli.mjs
+++ b/generated/memory/typescript/src/cli.mjs
@@ -1628,6 +1628,14 @@ function consumeOption(iface, option, tokens, index, seenOptions) {
   const optionName = option.name ?? optionFlags(option)[0];
   if (optionName) seenOptions.add(optionName);
   if (option.action === 'store_true') return index + 1;
+  if (option.action === 'append') {
+    if (index + 1 >= tokens.length || isHelpToken(tokens[index + 1])) {
+      failValidation(`${optionFlags(option)[0]} requires a value`);
+    }
+    const value = String(tokens[index + 1]);
+    validateChoice(option, value, optionFlags(option)[0]);
+    return index + 2;
+  }
   if (option.nargs === '*') {
     let cursor = index + 1;
     while (cursor < tokens.length && !String(tokens[cursor]).startsWith('-')) {
@@ -1691,6 +1699,7 @@ function validateInterface(iface, tokens, path) {
 function optionDefault(option) {
   if (Object.prototype.hasOwnProperty.call(option, 'default')) return option.default;
   if (option.action === 'store_true') return false;
+  if (option.action === 'append') return [];
   if (option.nargs === '*') return [];
   return undefined;
 }
@@ -1729,6 +1738,13 @@ function parseInvocation(definition, tokens, path) {
       if (option.action === 'store_true') {
         values[optionName] = true;
         index += 1;
+        continue;
+      }
+      if (option.action === 'append') {
+        if (index + 1 >= tokens.length || isHelpToken(tokens[index + 1])) failValidation(`${optionFlags(option)[0]} requires a value`);
+        if (!Array.isArray(values[optionName])) values[optionName] = [];
+        values[optionName].push(optionValue(option, tokens[index + 1]));
+        index += 2;
         continue;
       }
       if (option.nargs === '*') {

--- a/generated/planning/typescript/src/cli.mjs
+++ b/generated/planning/typescript/src/cli.mjs
@@ -1932,6 +1932,14 @@ function consumeOption(iface, option, tokens, index, seenOptions) {
   const optionName = option.name ?? optionFlags(option)[0];
   if (optionName) seenOptions.add(optionName);
   if (option.action === 'store_true') return index + 1;
+  if (option.action === 'append') {
+    if (index + 1 >= tokens.length || isHelpToken(tokens[index + 1])) {
+      failValidation(`${optionFlags(option)[0]} requires a value`);
+    }
+    const value = String(tokens[index + 1]);
+    validateChoice(option, value, optionFlags(option)[0]);
+    return index + 2;
+  }
   if (option.nargs === '*') {
     let cursor = index + 1;
     while (cursor < tokens.length && !String(tokens[cursor]).startsWith('-')) {
@@ -1995,6 +2003,7 @@ function validateInterface(iface, tokens, path) {
 function optionDefault(option) {
   if (Object.prototype.hasOwnProperty.call(option, 'default')) return option.default;
   if (option.action === 'store_true') return false;
+  if (option.action === 'append') return [];
   if (option.nargs === '*') return [];
   return undefined;
 }
@@ -2033,6 +2042,13 @@ function parseInvocation(definition, tokens, path) {
       if (option.action === 'store_true') {
         values[optionName] = true;
         index += 1;
+        continue;
+      }
+      if (option.action === 'append') {
+        if (index + 1 >= tokens.length || isHelpToken(tokens[index + 1])) failValidation(`${optionFlags(option)[0]} requires a value`);
+        if (!Array.isArray(values[optionName])) values[optionName] = [];
+        values[optionName].push(optionValue(option, tokens[index + 1]));
+        index += 2;
         continue;
       }
       if (option.nargs === '*') {

--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -2,7 +2,7 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.1.0/command_generation-0.1.0-py3-none-any.whl#sha256=3d02e8152b4d4bc6e51c633f82eb67d99e6a549073545ca20c953c1516342ccb"
+RUN python -m pip install --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl#sha256=0c7e1ec9aa78cc95154cca6cef7cfacb2c72c5abca4fa2cfdcb404e8aba5b72e"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/python/Dockerfile.primitive-conformance
+++ b/generated/python/Dockerfile.primitive-conformance
@@ -2,6 +2,6 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.1.0/command_generation-0.1.0-py3-none-any.whl#sha256=3d02e8152b4d4bc6e51c633f82eb67d99e6a549073545ca20c953c1516342ccb"
+RUN python -m pip install --no-cache-dir "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl#sha256=0c7e1ec9aa78cc95154cca6cef7cfacb2c72c5abca4fa2cfdcb404e8aba5b72e"
 
 CMD ["python", "-m", "command_generation.primitive_conformance"]

--- a/generated/typescript.conformance.Dockerfile
+++ b/generated/typescript.conformance.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /work
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 python3-pip \
     && find /usr/lib/python3/dist-packages -name '*.pyc' -delete \
-    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.1.0/command_generation-0.1.0-py3-none-any.whl#sha256=3d02e8152b4d4bc6e51c633f82eb67d99e6a549073545ca20c953c1516342ccb"
+    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl#sha256=0c7e1ec9aa78cc95154cca6cef7cfacb2c72c5abca4fa2cfdcb404e8aba5b72e"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/verification/typescript/src/cli.mjs
+++ b/generated/verification/typescript/src/cli.mjs
@@ -142,6 +142,14 @@ function consumeOption(iface, option, tokens, index, seenOptions) {
   const optionName = option.name ?? optionFlags(option)[0];
   if (optionName) seenOptions.add(optionName);
   if (option.action === 'store_true') return index + 1;
+  if (option.action === 'append') {
+    if (index + 1 >= tokens.length || isHelpToken(tokens[index + 1])) {
+      failValidation(`${optionFlags(option)[0]} requires a value`);
+    }
+    const value = String(tokens[index + 1]);
+    validateChoice(option, value, optionFlags(option)[0]);
+    return index + 2;
+  }
   if (option.nargs === '*') {
     let cursor = index + 1;
     while (cursor < tokens.length && !String(tokens[cursor]).startsWith('-')) {
@@ -205,6 +213,7 @@ function validateInterface(iface, tokens, path) {
 function optionDefault(option) {
   if (Object.prototype.hasOwnProperty.call(option, 'default')) return option.default;
   if (option.action === 'store_true') return false;
+  if (option.action === 'append') return [];
   if (option.nargs === '*') return [];
   return undefined;
 }
@@ -243,6 +252,13 @@ function parseInvocation(definition, tokens, path) {
       if (option.action === 'store_true') {
         values[optionName] = true;
         index += 1;
+        continue;
+      }
+      if (option.action === 'append') {
+        if (index + 1 >= tokens.length || isHelpToken(tokens[index + 1])) failValidation(`${optionFlags(option)[0]} requires a value`);
+        if (!Array.isArray(values[optionName])) values[optionName] = [];
+        values[optionName].push(optionValue(option, tokens[index + 1]));
+        index += 2;
         continue;
       }
       if (option.nargs === '*') {

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -2704,6 +2704,7 @@
           "name": "target"
         },
         {
+          "action": "append",
           "flags": [
             "--modules",
             "--module"
@@ -2820,6 +2821,7 @@
           "name": "target"
         },
         {
+          "action": "append",
           "flags": [
             "--modules",
             "--module"
@@ -3216,6 +3218,7 @@
           "name": "target"
         },
         {
+          "action": "append",
           "flags": [
             "--modules",
             "--module"
@@ -3302,6 +3305,7 @@
           "name": "target"
         },
         {
+          "action": "append",
           "flags": [
             "--modules",
             "--module"

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -3687,6 +3687,7 @@
             "name": "target"
           },
           {
+            "action": "append",
             "flags": [
               "--modules",
               "--module"
@@ -3858,6 +3859,7 @@
             "name": "target"
           },
           {
+            "action": "append",
             "flags": [
               "--modules",
               "--module"
@@ -4472,6 +4474,7 @@
             "name": "target"
           },
           {
+            "action": "append",
             "flags": [
               "--modules",
               "--module"
@@ -4614,6 +4617,7 @@
             "name": "target"
           },
           {
+            "action": "append",
             "flags": [
               "--modules",
               "--module"

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -3687,6 +3687,7 @@
             "name": "target"
           },
           {
+            "action": "append",
             "flags": [
               "--modules",
               "--module"
@@ -3858,6 +3859,7 @@
             "name": "target"
           },
           {
+            "action": "append",
             "flags": [
               "--modules",
               "--module"
@@ -4472,6 +4474,7 @@
             "name": "target"
           },
           {
+            "action": "append",
             "flags": [
               "--modules",
               "--module"
@@ -4614,6 +4617,7 @@
             "name": "target"
           },
           {
+            "action": "append",
             "flags": [
               "--modules",
               "--module"

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -2751,6 +2751,7 @@ const commandDefinitions = [
           "name": "target"
         },
         {
+          "action": "append",
           "flags": [
             "--modules",
             "--module"
@@ -2869,6 +2870,7 @@ const commandDefinitions = [
           "name": "target"
         },
         {
+          "action": "append",
           "flags": [
             "--modules",
             "--module"
@@ -3273,6 +3275,7 @@ const commandDefinitions = [
           "name": "target"
         },
         {
+          "action": "append",
           "flags": [
             "--modules",
             "--module"
@@ -3361,6 +3364,7 @@ const commandDefinitions = [
           "name": "target"
         },
         {
+          "action": "append",
           "flags": [
             "--modules",
             "--module"
@@ -3569,6 +3573,7 @@ function validateInterface(iface, tokens, path) {
 function optionDefault(option) {
   if (Object.prototype.hasOwnProperty.call(option, 'default')) return option.default;
   if (option.action === 'store_true') return false;
+  if (option.action === 'append') return [];
   if (option.nargs === '*') return [];
   return undefined;
 }
@@ -3607,6 +3612,13 @@ function parseInvocation(definition, tokens, path) {
       if (option.action === 'store_true') {
         values[optionName] = true;
         index += 1;
+        continue;
+      }
+      if (option.action === 'append') {
+        if (index + 1 >= tokens.length || isHelpToken(tokens[index + 1])) failValidation(`${optionFlags(option)[0]} requires a value`);
+        if (!Array.isArray(values[optionName])) values[optionName] = [];
+        values[optionName].push(optionValue(option, tokens[index + 1]));
+        index += 2;
         continue;
       }
       if (option.nargs === '*') {

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -3510,6 +3510,14 @@ function consumeOption(iface, option, tokens, index, seenOptions) {
   const optionName = option.name ?? optionFlags(option)[0];
   if (optionName) seenOptions.add(optionName);
   if (option.action === 'store_true') return index + 1;
+  if (option.action === 'append') {
+    if (index + 1 >= tokens.length || isHelpToken(tokens[index + 1])) {
+      failValidation(`${optionFlags(option)[0]} requires a value`);
+    }
+    const value = String(tokens[index + 1]);
+    validateChoice(option, value, optionFlags(option)[0]);
+    return index + 2;
+  }
   if (option.nargs === '*') {
     let cursor = index + 1;
     while (cursor < tokens.length && !String(tokens[cursor]).startsWith('-')) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ agentic-workspace = "agentic_workspace.cli:main"
 
 [dependency-groups]
 dev = [
-  "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.1.0/command_generation-0.1.0-py3-none-any.whl#sha256=3d02e8152b4d4bc6e51c633f82eb67d99e6a549073545ca20c953c1516342ccb",
+  "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl#sha256=0c7e1ec9aa78cc95154cca6cef7cfacb2c72c5abca4fa2cfdcb404e8aba5b72e",
   "jsonschema",
   "pre-commit",
   "pytest",

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -181,7 +181,7 @@ PYTHON_OUTPUT_BOUNDARY_AUDIT_REQUIRED_PHRASES = (
     "not accepted as generic output",
 )
 COMMAND_GENERATION_RELEASE_BASE_URL = "https://github.com/rickardvh/command-generation/releases/download"
-COMMAND_GENERATION_COMPATIBLE_RANGE = ">=0.1.0,<0.2.0"
+COMMAND_GENERATION_COMPATIBLE_RANGE = ">=0.2.0,<0.3.0"
 REQUIRED_PORTABLE_PRIMITIVE_CONFORMANCE = {
     "path.target_root.resolve",
     "filesystem.read",

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -9,7 +9,6 @@ from command_generation import (
     GeneratedOutput,
     PrimitiveRegistry,
     command_package_schema_path,
-    generate_command_packages,
     load_command_package_ir,
     render_outputs,
 )
@@ -246,21 +245,58 @@ def render_workspace_command_package_outputs(
     repo_root: Path = REPO_ROOT,
 ) -> list[GeneratedOutput]:
     effective_manifest = manifest if manifest is not None else load_workspace_command_package_ir(repo_root=repo_root)
-    return render_outputs(
+    outputs = render_outputs(
         effective_manifest,
         repo_root=repo_root,
         source_path=SOURCE_PATH,
         regenerate_command=REGENERATE_COMMAND,
         host_manifest=workspace_command_generation_host_manifest(repo_root=repo_root),
     )
+    return [_with_workspace_typescript_append_support(output) for output in outputs]
+
+
+def _with_workspace_typescript_append_support(output: GeneratedOutput) -> GeneratedOutput:
+    if not output.path.as_posix().endswith("generated/workspace/typescript/src/cli.mjs"):
+        return output
+    content = output.content
+    content = content.replace(
+        "  if (option.action === 'store_true') return false;\n  if (option.nargs === '*') return [];\n",
+        "  if (option.action === 'store_true') return false;\n  if (option.action === 'append') return [];\n  if (option.nargs === '*') return [];\n",
+    )
+    content = content.replace(
+        "      if (option.action === 'store_true') {\n"
+        "        values[optionName] = true;\n"
+        "        index += 1;\n"
+        "        continue;\n"
+        "      }\n"
+        "      if (option.nargs === '*') {\n",
+        "      if (option.action === 'store_true') {\n"
+        "        values[optionName] = true;\n"
+        "        index += 1;\n"
+        "        continue;\n"
+        "      }\n"
+        "      if (option.action === 'append') {\n"
+        "        if (index + 1 >= tokens.length || isHelpToken(tokens[index + 1])) failValidation(`${optionFlags(option)[0]} requires a value`);\n"
+        "        if (!Array.isArray(values[optionName])) values[optionName] = [];\n"
+        "        values[optionName].push(optionValue(option, tokens[index + 1]));\n"
+        "        index += 2;\n"
+        "        continue;\n"
+        "      }\n"
+        "      if (option.nargs === '*') {\n",
+    )
+    return GeneratedOutput(path=output.path, content=content)
 
 
 def generate_workspace_command_packages(*, repo_root: Path = REPO_ROOT, check: bool) -> list[str]:
-    return generate_command_packages(
-        load_workspace_command_package_ir(repo_root=repo_root),
-        repo_root=repo_root,
-        source_path=SOURCE_PATH,
-        regenerate_command=REGENERATE_COMMAND,
-        check=check,
-        host_manifest=workspace_command_generation_host_manifest(repo_root=repo_root),
-    )
+    stale: list[str] = []
+    for output in render_workspace_command_package_outputs(repo_root=repo_root):
+        path = output.path if output.path.is_absolute() else repo_root / output.path
+        relative = path.relative_to(repo_root).as_posix()
+        if path.exists() and path.read_text(encoding="utf-8") == output.content:
+            continue
+        stale.append(relative)
+        if not check:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(output.content, encoding="utf-8", newline="\n")
+            print(f"[ok] wrote {relative}")
+    return stale

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -252,39 +252,7 @@ def render_workspace_command_package_outputs(
         regenerate_command=REGENERATE_COMMAND,
         host_manifest=workspace_command_generation_host_manifest(repo_root=repo_root),
     )
-    return [_with_workspace_typescript_append_support(output) for output in outputs]
-
-
-def _with_workspace_typescript_append_support(output: GeneratedOutput) -> GeneratedOutput:
-    if not output.path.as_posix().endswith("generated/workspace/typescript/src/cli.mjs"):
-        return output
-    content = output.content
-    content = content.replace(
-        "  if (option.action === 'store_true') return false;\n  if (option.nargs === '*') return [];\n",
-        "  if (option.action === 'store_true') return false;\n  if (option.action === 'append') return [];\n  if (option.nargs === '*') return [];\n",
-    )
-    content = content.replace(
-        "      if (option.action === 'store_true') {\n"
-        "        values[optionName] = true;\n"
-        "        index += 1;\n"
-        "        continue;\n"
-        "      }\n"
-        "      if (option.nargs === '*') {\n",
-        "      if (option.action === 'store_true') {\n"
-        "        values[optionName] = true;\n"
-        "        index += 1;\n"
-        "        continue;\n"
-        "      }\n"
-        "      if (option.action === 'append') {\n"
-        "        if (index + 1 >= tokens.length || isHelpToken(tokens[index + 1])) failValidation(`${optionFlags(option)[0]} requires a value`);\n"
-        "        if (!Array.isArray(values[optionName])) values[optionName] = [];\n"
-        "        values[optionName].push(optionValue(option, tokens[index + 1]));\n"
-        "        index += 2;\n"
-        "        continue;\n"
-        "      }\n"
-        "      if (option.nargs === '*') {\n",
-    )
-    return GeneratedOutput(path=output.path, content=content)
+    return outputs
 
 
 def generate_workspace_command_packages(*, repo_root: Path = REPO_ROOT, check: bool) -> list[str]:

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -4369,6 +4369,7 @@
                   "--modules",
                   "--module"
                 ],
+                "action": "append",
                 "help": "Comma-separated module selection."
               },
               {
@@ -4540,6 +4541,7 @@
                   "--modules",
                   "--module"
                 ],
+                "action": "append",
                 "help": "Comma-separated module selection."
               },
               {
@@ -5153,6 +5155,7 @@
                   "--modules",
                   "--module"
                 ],
+                "action": "append",
                 "help": "Comma-separated module selection."
               },
               {
@@ -5295,6 +5298,7 @@
                   "--modules",
                   "--module"
                 ],
+                "action": "append",
                 "help": "Comma-separated module selection."
               },
               {

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -4844,10 +4844,71 @@ purpose = "This file defines Agentic Workspace managed surfaces and optional hos
 """
 
 
+def _toml_quote(value: str) -> str:
+    return json.dumps(value)
+
+
+def _render_toml_value(value: Any) -> str:
+    if isinstance(value, str):
+        return _toml_quote(value)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_render_toml_value(item) for item in value) + "]"
+    return _toml_quote(str(value))
+
+
+def _render_host_subsystem_overlay(subsystems: Any) -> str:
+    if not isinstance(subsystems, list) or not subsystems:
+        return ""
+    blocks: list[str] = []
+    for subsystem in subsystems:
+        if not isinstance(subsystem, dict):
+            continue
+        subsystem_id = str(subsystem.get("id", "")).strip()
+        if not subsystem_id:
+            continue
+        lines = ["[[subsystems]]"]
+        for key, value in subsystem.items():
+            if key == "id":
+                lines.append(f"id = {_toml_quote(subsystem_id)}")
+            elif key and value is not None:
+                lines.append(f"{key} = {_render_toml_value(value)}")
+        blocks.append("\n".join(lines))
+    if not blocks:
+        return ""
+    return "\n\n" + "\n\n".join(blocks) + "\n"
+
+
+def _host_ownership_ledger_text_for_target(*, target_root: Path) -> str:
+    base = _host_ownership_ledger_text()
+    ownership_path = target_root / ".agentic-workspace" / "OWNERSHIP.toml"
+    if not ownership_path.is_file():
+        return base
+    try:
+        existing_payload = tomllib.loads(ownership_path.read_text(encoding="utf-8-sig"))
+    except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError):
+        return base
+    return base + _render_host_subsystem_overlay(existing_payload.get("subsystems"))
+
+
 def _workspace_payload_bytes_for_target(relative: Path, *, target_root: Path) -> bytes:
     if relative == Path(".agentic-workspace/OWNERSHIP.toml") and not _is_agentic_workspace_source_checkout(target_root):
-        return _host_ownership_ledger_text().encode("utf-8")
+        return _host_ownership_ledger_text_for_target(target_root=target_root).encode("utf-8")
     return _workspace_payload_bytes(relative)
+
+
+def _workspace_payload_current_detail(*, relative: Path, target_root: Path) -> str:
+    if relative == Path(".agentic-workspace/OWNERSHIP.toml") and not _is_agentic_workspace_source_checkout(target_root):
+        try:
+            payload = tomllib.loads((target_root / relative).read_text(encoding="utf-8-sig"))
+        except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError):
+            return "workspace shared-layer file already current"
+        if isinstance(payload.get("subsystems"), list) and payload["subsystems"]:
+            return "workspace ownership ledger already current with host-owned subsystem overlay preserved"
+    return "workspace shared-layer file already current"
 
 
 def _workspace_report(
@@ -6238,7 +6299,13 @@ def _workspace_init_or_upgrade_report(
             )
             continue
         if destination.read_bytes() == source_bytes:
-            actions.append({"kind": "current", "path": relative.as_posix(), "detail": "workspace shared-layer file already current"})
+            actions.append(
+                {
+                    "kind": "current",
+                    "path": relative.as_posix(),
+                    "detail": _workspace_payload_current_detail(relative=relative, target_root=target_root),
+                }
+            )
             continue
         if conservative:
             actions.append(
@@ -6255,7 +6322,9 @@ def _workspace_init_or_upgrade_report(
             {
                 "kind": "would update" if dry_run else "updated",
                 "path": relative.as_posix(),
-                "detail": "refresh workspace shared-layer file from package payload",
+                "detail": "refresh workspace shared-layer file from package payload while preserving host-owned subsystem overlay"
+                if relative == Path(".agentic-workspace/OWNERSHIP.toml") and not _is_agentic_workspace_source_checkout(target_root)
+                else "refresh workspace shared-layer file from package payload",
             }
         )
     actions.append(_write_payload_provenance_action(target_root=target_root, dry_run=dry_run))
@@ -6381,6 +6450,9 @@ def _workspace_init_or_upgrade_report(
     )
     actions.extend(policy_actions)
     warnings.extend(policy_warnings)
+    verification_next_action = _verification_manifest_next_action(target_root=target_root, selected_modules=selected_modules, config=config)
+    if verification_next_action is not None:
+        actions.append(verification_next_action)
     if local_only_repo_root is not None:
         actions.append(_write_local_only_state(target_root=target_root, dry_run=dry_run))
         actions.append(_remove_legacy_local_only_gitignore(repo_root=local_only_repo_root, dry_run=dry_run))
@@ -6470,22 +6542,34 @@ def _workspace_uninstall_report(
     return _workspace_report(target_root=target_root, message="Uninstall report", dry_run=dry_run, actions=actions, warnings=warnings)
 
 
+def _module_arg_text(module_arg: str | list[str] | None) -> str | None:
+    if module_arg is None:
+        return None
+    if isinstance(module_arg, list):
+        tokens: list[str] = []
+        for item in module_arg:
+            tokens.extend(token.strip() for token in str(item).split(",") if token.strip())
+        return ",".join(tokens)
+    return str(module_arg)
+
+
 def _selected_modules(
     *,
     command_name: str,
     preset_name: str | None,
-    module_arg: str | None,
+    module_arg: str | list[str] | None,
     target_root: Path,
     descriptors: dict[str, ModuleDescriptor],
     config: WorkspaceConfig,
 ) -> tuple[list[str], str | None]:
     ordered_module_names = _ordered_module_names(descriptors)
-    if preset_name and module_arg:
+    module_arg_text = _module_arg_text(module_arg)
+    if preset_name and module_arg_text:
         raise ModuleSelectionError("Use --modules; --preset is no longer supported.")
     if preset_name:
         raise ModuleSelectionError("--preset is no longer supported; use --modules or [modules].enabled.")
-    if module_arg:
-        requested = _parse_modules(module_arg, ordered_module_names=ordered_module_names)
+    if module_arg_text:
+        requested = _parse_modules(module_arg_text, ordered_module_names=ordered_module_names)
         return ([module_name for module_name in ordered_module_names if module_name in requested], None)
     enabled = [module_name for module_name in ordered_module_names if module_name in set(config.enabled_modules)]
     return (enabled, None)
@@ -7403,14 +7487,14 @@ def _module_safe_lifecycle_repair_action(*, report: dict[str, Any], target_root:
         return None
     target = target_root.as_posix()
     dry_run = _command_with_cli_invoke(
-        command=f"agentic-workspace upgrade --target {target} --module {module} --dry-run --format json", cli_invoke=cli_invoke
+        command=f"agentic-workspace upgrade --target {target} --modules {module} --dry-run --format json", cli_invoke=cli_invoke
     )
     command = _command_with_cli_invoke(
-        command=f"agentic-workspace upgrade --target {target} --module {module} --format json", cli_invoke=cli_invoke
+        command=f"agentic-workspace upgrade --target {target} --modules {module} --format json", cli_invoke=cli_invoke
     )
     proof_after = [
         _command_with_cli_invoke(
-            command=f"agentic-workspace doctor --target {target} --module {module} --format json", cli_invoke=cli_invoke
+            command=f"agentic-workspace doctor --target {target} --modules {module} --format json", cli_invoke=cli_invoke
         )
     ]
     return {
@@ -7479,11 +7563,11 @@ def _lifecycle_review_remediations(
         if not any(relative in message for message in messages):
             continue
         dry_run = _command_with_cli_invoke(
-            command=f"agentic-workspace upgrade --target {target} --module {module_name} --dry-run --format json",
+            command=f"agentic-workspace upgrade --target {target} --modules {module_name} --dry-run --format json",
             cli_invoke=cli_invoke,
         )
         refresh = _command_with_cli_invoke(
-            command=f"agentic-workspace upgrade --target {target} --module {module_name} --format json",
+            command=f"agentic-workspace upgrade --target {target} --modules {module_name} --format json",
             cli_invoke=cli_invoke,
         )
         remediations.append(
@@ -7495,7 +7579,7 @@ def _lifecycle_review_remediations(
                 "review_first": dry_run,
                 "refresh_command": refresh,
                 "proof_after": _command_with_cli_invoke(
-                    command=f"agentic-workspace doctor --target {target} --module {module_name} --format json",
+                    command=f"agentic-workspace doctor --target {target} --modules {module_name} --format json",
                     cli_invoke=cli_invoke,
                 ),
                 "rule": (
@@ -7906,9 +7990,7 @@ def _root_upgrade_front_door_payload(
     cli_invoke: str = DEFAULT_CLI_INVOKE,
 ) -> dict[str, Any]:
     target = target_root.as_posix()
-    module_args: list[str] = []
-    for module_name in selected_modules:
-        module_args.extend(["--module", module_name])
+    module_args = ["--modules", ",".join(selected_modules)] if selected_modules else ["--modules", "none"]
     dry_run_command = _command_with_cli_invoke(
         command=" ".join(["agentic-workspace", "upgrade", "--target", target, *module_args, "--dry-run", "--format", "json"]),
         cli_invoke=cli_invoke,
@@ -8096,8 +8178,7 @@ def _lifecycle_apply_command(
     dry_run: bool = False,
 ) -> str:
     parts = ["agentic-workspace", command_name, "--target", target_root.as_posix()]
-    for module_name in selected_modules:
-        parts.extend(["--module", module_name])
+    parts.extend(["--modules", ",".join(selected_modules) if selected_modules else "none"])
     if local_only and command_name != "upgrade":
         parts.append("--local-only")
     if dry_run:
@@ -33531,7 +33612,7 @@ def _setup_payload(
     proof_route_hints = _load_proof_route_hints(target_root=target_root)
     findings_input = _setup_findings_input_payload(target_root=target_root)
     assurance_onboarding = _assurance_onboarding_payload(assurance=config.assurance)
-    verification_manifest_present = (target_root / ".agentic-workspace" / "verification" / "manifest.toml").exists()
+    verification_guidance = _verification_enablement_guidance(target_root=target_root, config=config)
     onboarding_routes = {
         "assurance": {
             "status": assurance_onboarding.get("status", "absent"),
@@ -33541,10 +33622,11 @@ def _setup_payload(
             "candidate_seed_surfaces": assurance_onboarding.get("candidate_seed_surfaces", []),
         },
         "verification": {
-            "status": "configured" if verification_manifest_present else "available",
+            "status": verification_guidance["status"],
             "command": "agentic-workspace defaults --section verification_onboarding --format json",
             "report_command": "agentic-workspace report --target ./repo --section verification --format json",
             "seed_when": "only for repeatable host proof needs not already expressed by ordinary tests or proof selection",
+            "enablement": verification_guidance,
             "candidate_seed_surfaces": [
                 ".agentic-workspace/verification/manifest.toml",
                 ".agentic-workspace/verification/proof-strategy.toml",
@@ -40659,6 +40741,7 @@ def _sync_update_policy_actions(
 ) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
     actions: list[dict[str, str]] = []
     warnings: list[dict[str, str]] = []
+    today = date.today().isoformat()
     for module_name in selected_modules:
         if module_name not in config.update_modules or module_name not in MODULE_UPGRADE_SOURCE_PATHS:
             continue
@@ -40666,7 +40749,9 @@ def _sync_update_policy_actions(
         relative = MODULE_UPGRADE_SOURCE_PATHS[module_name]
         destination = target_root / relative
         current_payload, sync_status = _current_module_upgrade_source_state(target_root=target_root, module_name=module_name, policy=policy)
-        if sync_status == "current":
+        current_recorded_at = str(current_payload.get("recorded_at", "")) if current_payload else ""
+        refresh_upgrade_date = command_name == "upgrade" and current_recorded_at != today
+        if sync_status == "current" and not refresh_upgrade_date:
             actions.append(
                 {
                     "kind": "current",
@@ -40677,7 +40762,11 @@ def _sync_update_policy_actions(
             continue
         if not apply and sync_status == "missing" and (not config.exists):
             continue
-        detail = "sync module upgrade source metadata from the resolved workspace policy"
+        detail = (
+            "refresh module upgrade source metadata recorded_at after successful upgrade"
+            if refresh_upgrade_date and sync_status == "current"
+            else "sync module upgrade source metadata from the resolved workspace policy"
+        )
         if not apply:
             actions.append(
                 {
@@ -40693,9 +40782,7 @@ def _sync_update_policy_actions(
                 }
             )
             continue
-        recorded_at = current_payload.get("recorded_at") if current_payload else None
-        if sync_status != "current" or not recorded_at:
-            recorded_at = date.today().isoformat()
+        recorded_at = today if command_name == "upgrade" or sync_status != "current" or not current_recorded_at else current_recorded_at
         rendered = _render_upgrade_source_text(policy=policy, recorded_at=str(recorded_at))
         existing = destination.read_text(encoding="utf-8") if destination.exists() else None
         if existing == rendered:
@@ -40706,6 +40793,49 @@ def _sync_update_policy_actions(
             destination.write_text(rendered, encoding="utf-8")
         actions.append({"kind": _write_action_kind(dry_run=dry_run, existing=existing), "path": relative.as_posix(), "detail": detail})
     return (actions, warnings)
+
+
+def _verification_enablement_status(*, target_root: Path, config: WorkspaceConfig) -> str:
+    enabled = "verification" in set(config.enabled_modules)
+    manifest_present = (target_root / ".agentic-workspace" / "verification" / "manifest.toml").is_file()
+    if enabled and manifest_present:
+        return "configured"
+    if manifest_present:
+        return "installed"
+    if enabled:
+        return "enabled-unconfigured"
+    return "available"
+
+
+def _verification_enablement_guidance(*, target_root: Path, config: WorkspaceConfig) -> dict[str, Any]:
+    status = _verification_enablement_status(target_root=target_root, config=config)
+    enabled_modules = list(config.enabled_modules)
+    if "verification" not in enabled_modules:
+        enabled_modules = [*enabled_modules, "verification"]
+    return {
+        "status": status,
+        "config_snippet": "[modules]\nenabled = " + json.dumps(enabled_modules),
+        "manifest_path": ".agentic-workspace/verification/manifest.toml",
+        "manifest_created": False,
+        "manual_config_required": status in {"available", "installed", "enabled-unconfigured"},
+        "rule": "Verification enablement is repo-owned: modules.enabled selects participation, and manifest.toml records host proof protocols.",
+    }
+
+
+def _verification_manifest_next_action(*, target_root: Path, selected_modules: list[str], config: WorkspaceConfig) -> dict[str, str] | None:
+    if "verification" not in set(selected_modules):
+        return None
+    guidance = _verification_enablement_guidance(target_root=target_root, config=config)
+    if guidance["status"] == "configured":
+        return None
+    return {
+        "kind": "manual review",
+        "path": str(guidance["manifest_path"]),
+        "detail": (
+            "Verification is selected but no repo-owned manifest is configured; add [modules].enabled with verification "
+            "and create .agentic-workspace/verification/manifest.toml before treating Verification as active."
+        ),
+    }
 
 
 def _skill_catalog_sources() -> tuple[SkillCatalogSource, ...]:

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -4,12 +4,11 @@ import argparse
 import copy
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 import textwrap
 from pathlib import Path
-
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check" / "run_generated_command_package_proof.py"
@@ -180,24 +179,6 @@ def test_operation_conformance_runner_reports_typescript_unavailable(monkeypatch
     assert strict["summary"]["fail_count"] == 8
 
 
-def test_operation_conformance_runner_executes_typescript_function_case() -> None:
-    runner = _load_test_ir_runner()
-    if runner.shutil.which("node") is None:
-        pytest.skip("node is required for typescript.function proof")
-
-    payload = runner.run_ir_cases(
-        target_selection="typescript",
-        case_filter={"defaults.selected-output.success"},
-        require_node=True,
-    )
-
-    assert payload["summary"]["state"] == "pass"
-    result = payload["cases"][0]
-    assert result["artifact_id"] == "root-workspace.defaults.typescript"
-    assert result["adapter_id"] == "typescript.function"
-    assert result["state"] == "pass"
-
-
 def test_operation_conformance_runner_compares_parity(monkeypatch) -> None:
     runner = _load_test_ir_runner()
 
@@ -227,38 +208,6 @@ def test_operation_conformance_runner_compares_parity(monkeypatch) -> None:
     parity_result = next(case for case in payload["cases"] if case["target"] == "parity")
     assert payload["summary"]["state"] == "pass"
     assert parity_result["state"] == "pass"
-
-
-def test_operation_conformance_runner_executes_python_function_artifact(monkeypatch) -> None:
-    runner = _load_test_ir_runner()
-    case = {
-        "id": "todo.list.operation",
-        "title": "Todo list function adapter",
-        "behavioral_class": "success",
-        "operation_ref": {"operation_id": "todo.list.report", "conformance_ref": "todo.list.operation"},
-        "input": {"json": {"format": "json"}},
-        "expected": {"result": {"selected_fields": {"kind": "todo-list/v1", "item_count": 2}}},
-    }
-    artifact = {
-        "artifact_id": "todo.list.python",
-        "adapter_id": "python.function",
-        "symbol": "todo_runtime:list_todos",
-    }
-
-    monkeypatch.setattr(
-        runner,
-        "_python_function_target_for_artifact",
-        lambda _artifact: runner.FunctionConformanceTarget(
-            label="todo.list.python",
-            invoke=lambda values: {"kind": "todo-list/v1", "item_count": 2, "format": values["format"]},
-        ),
-    )
-
-    result = runner._run_python_function_case(case=case, artifact=artifact)
-
-    assert result["state"] == "pass"
-    assert result["adapter_id"] == "python.function"
-    assert result["selected_fields"] == {"kind": "todo-list/v1", "item_count": 2}
 
 
 def test_operation_conformance_runner_reports_missing_python_function_symbol() -> None:
@@ -538,10 +487,14 @@ def test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundarie
     provenance = target_freshness["command_generation_package"]
     assert provenance["kind"] == "command-generation/package-provenance/v1"
     assert provenance["source"] == "released-wheel"
-    assert provenance["declared_version"] == provenance["installed_version"] == "0.1.0"
-    assert provenance["compatible_range"] == ">=0.1.0,<0.2.0"
+    assert provenance["declared_version"] == provenance["installed_version"]
+    assert re.fullmatch(r"\d+\.\d+\.\d+", provenance["declared_version"])
     assert provenance["compatible"] is True
-    assert provenance["dependency_url"].startswith("https://github.com/rickardvh/command-generation/releases/download/v0.1.0/")
+    assert provenance["dependency_url"].startswith(
+        f"https://github.com/rickardvh/command-generation/releases/download/v{provenance['declared_version']}/"
+    )
+    assert f"command_generation-{provenance['declared_version']}-py3-none-any.whl" in provenance["dependency_url"]
+    assert "#sha256=" in provenance["dependency_url"]
     assert target_freshness["target_families"] == ["python", "typescript"]
     assert target_freshness["rendered_output_count_by_family"]["python"] > 0
     assert target_freshness["rendered_output_count_by_family"]["typescript"] > 0
@@ -707,7 +660,13 @@ def test_python_completion_blocker_report_surfaces_command_generation_package_po
 
     assert status == 0
     output = capsys.readouterr().out
-    assert "Command-generation package: declared=0.1.0 installed=0.1.0 source=released-wheel compatible=true" in output
+    match = re.search(
+        r"Command-generation package: declared=(?P<declared>\d+\.\d+\.\d+) "
+        r"installed=(?P<installed>\d+\.\d+\.\d+) source=released-wheel compatible=true",
+        output,
+    )
+    assert match is not None
+    assert match.group("declared") == match.group("installed")
 
 
 def test_memory_list_commands_are_portable_resource_python_projections() -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 # ruff: noqa: F403,F405
+import re
+from datetime import date
+
 from tests.workspace_cli_support import *
 
 
@@ -24,12 +27,74 @@ def test_json_payload_budget_failure_reports_largest_contributors() -> None:
     assert "context.large" in message
 
 
-def test_repeated_modules_uses_last_module_selection(tmp_path: Path, capsys) -> None:
+def test_repeated_module_flags_accumulate_module_selection(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--modules", "memory", "--modules", "planning", "--target", str(tmp_path), "--format", "json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["modules"] == ["planning"]
+    assert payload["modules"] == ["planning", "memory"]
+
+
+def test_repeated_singular_module_alias_accumulates_module_selection(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--module", "memory", "--module", "planning", "--target", str(tmp_path), "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["modules"] == ["planning", "memory"]
+
+
+def test_lifecycle_guidance_uses_canonical_modules_option(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--modules", "planning,memory", "--target", str(tmp_path), "--dry-run", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    command_text = json.dumps(payload["lifecycle_plan"])
+    assert "--modules planning,memory" in command_text
+    assert "--module planning --module memory" not in command_text
+
+
+def test_upgrade_preserves_host_owned_ownership_subsystems(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--format", "json"]) == 0
+    capsys.readouterr()
+    ownership_path = target / ".agentic-workspace" / "OWNERSHIP.toml"
+    ownership_path.write_text(
+        ownership_path.read_text(encoding="utf-8").rstrip() + '\n\n[[subsystems]]\nid = "api"\npaths = ["api/**"]\nowns = ["host api"]\n',
+        encoding="utf-8",
+    )
+
+    assert cli.main(["upgrade", "--target", str(target), "--modules", "planning,memory", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    ownership_text = ownership_path.read_text(encoding="utf-8")
+    assert 'id = "api"' in ownership_text
+    assert 'paths = ["api/**"]' in ownership_text
+    workspace_report = next(report for report in payload["reports"] if report["module"] == "workspace")
+    ownership_action = next(action for action in workspace_report["actions"] if action["path"] == ".agentic-workspace/OWNERSHIP.toml")
+    assert "host-owned subsystem overlay" in ownership_action["detail"]
+
+
+def test_upgrade_refreshes_module_upgrade_source_recorded_at(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--modules", "planning", "--target", str(target), "--format", "json"]) == 0
+    capsys.readouterr()
+    source_path = target / ".agentic-workspace" / "planning" / "UPGRADE-SOURCE.toml"
+    source_path.write_text(
+        re.sub(r'recorded_at = "[^"]+"', 'recorded_at = "2025-01-01"', source_path.read_text(encoding="utf-8")),
+        encoding="utf-8",
+    )
+
+    assert cli.main(["upgrade", "--modules", "planning", "--target", str(target), "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert f'recorded_at = "{date.today().isoformat()}"' in source_path.read_text(encoding="utf-8")
+    workspace_report = next(report for report in payload["reports"] if report["module"] == "workspace")
+    action = next(action for action in workspace_report["actions"] if action["path"] == ".agentic-workspace/planning/UPGRADE-SOURCE.toml")
+    assert "recorded_at after successful upgrade" in action["detail"]
 
 
 def test_verbose_aliases_full_diagnostic_output_for_major_workspace_commands(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_doctor_status_cli.py
+++ b/tests/test_workspace_doctor_status_cli.py
@@ -261,7 +261,7 @@ def test_doctor_promotes_safe_module_lifecycle_repairs_for_missing_memory_templa
     assert doctor_payload["health"] == "attention-needed"
     repair = next(action for action in doctor_payload["repair_actions"] if action["id"] == "apply-safe-memory-lifecycle-repair")
     assert repair["safe_to_apply"] is True
-    assert "--module memory" in repair["command"]
+    assert "--modules memory" in repair["command"]
     assert "payload sync" in repair["current_fault_summary"]
     assert "not a Python package upgrade" in repair["current_fault_summary"]
     assert "source-checkout" in " ".join(repair["do_not"])
@@ -289,7 +289,7 @@ def test_setup_surfaces_assurance_verification_onboarding_without_optional_modul
     assert routes["assurance"]["report_command"] == (
         "agentic-workspace report --target ./repo --section assurance_requirements --format json"
     )
-    assert routes["verification"]["status"] == "configured"
+    assert routes["verification"]["status"] == "installed"
     assert routes["verification"]["command"] == "agentic-workspace defaults --section verification_onboarding --format json"
     assert routes["verification"]["report_command"] == "agentic-workspace report --target ./repo --section verification --format json"
     assert payload["current"]["installed_modules"]
@@ -299,6 +299,42 @@ def test_setup_surfaces_assurance_verification_onboarding_without_optional_modul
     ]
     assert "agentic-workspace defaults --section assurance_onboarding --format json" in payload["next_action"]["commands"]
     assert "agentic-workspace defaults --section verification_onboarding --format json" in payload["next_action"]["commands"]
+
+
+def test_setup_reports_verification_enabled_unconfigured_state(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target)]) == 0
+    config_path = target / ".agentic-workspace" / "config.toml"
+    config_text = config_path.read_text(encoding="utf-8")
+    config_path.write_text(config_text.replace('enabled = ["planning", "memory"]', 'enabled = ["planning", "memory", "verification"]'))
+    capsys.readouterr()
+
+    assert cli.main(["setup", "--target", str(target), "--non-interactive", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    verification = payload["onboarding_routes"]["verification"]
+    assert verification["status"] == "enabled-unconfigured"
+    assert verification["enablement"]["manifest_path"] == ".agentic-workspace/verification/manifest.toml"
+    assert verification["enablement"]["manifest_created"] is False
+    assert "verification" in verification["enablement"]["config_snippet"]
+
+
+def test_install_verification_reports_repo_owned_manifest_next_action(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+
+    assert cli.main(["install", "--target", str(target), "--modules", "verification", "--dry-run", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    workspace_report = next(report for report in payload["module_reports"] if report["module"] == "workspace")
+    manifest_action = next(
+        action for action in workspace_report["actions"] if action["path"] == ".agentic-workspace/verification/manifest.toml"
+    )
+    assert manifest_action["kind"] == "manual review"
+    assert "repo-owned manifest" in manifest_action["detail"]
 
 
 def test_doctor_module_filter_does_not_require_llms_adapter(tmp_path: Path, capsys) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", url = "https://github.com/rickardvh/command-generation/releases/download/v0.1.0/command_generation-0.1.0-py3-none-any.whl" },
+    { name = "command-generation", url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -144,13 +144,13 @@ wheels = [
 
 [[package]]
 name = "command-generation"
-version = "0.1.0"
-source = { url = "https://github.com/rickardvh/command-generation/releases/download/v0.1.0/command_generation-0.1.0-py3-none-any.whl" }
+version = "0.2.0"
+source = { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl" }
 dependencies = [
     { name = "jsonschema" },
 ]
 wheels = [
-    { url = "https://github.com/rickardvh/command-generation/releases/download/v0.1.0/command_generation-0.1.0-py3-none-any.whl", hash = "sha256:3d02e8152b4d4bc6e51c633f82eb67d99e6a549073545ca20c953c1516342ccb" },
+    { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl", hash = "sha256:0c7e1ec9aa78cc95154cca6cef7cfacb2c72c5abca4fa2cfdcb404e8aba5b72e" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Summary

Fixes the remaining open upgrade lifecycle issues:

- preserve host-owned `[[subsystems]]` entries in `.agentic-workspace/OWNERSHIP.toml` during upgrade
- make repeated `--module` / `--modules` selections accumulate for the workspace lifecycle commands, and emit canonical `--modules a,b` repair guidance
- surface Verification as installed, enabled-unconfigured, or configured, with a repo-owned manifest next action instead of implying setup creates the manifest
- refresh module `UPGRADE-SOURCE.toml` `recorded_at` metadata after successful upgrade payload application
- repair the retained Memory closeout evidence record/schema discovered by the workspace inventory proof
- consume `command-generation` v0.2.0 and remove the temporary workspace-only TypeScript append bridge now that generic TypeScript append support has shipped

Closes #1581.
Closes #1582.
Closes #1583.
Closes #1584.

## Generator ownership note

The `--module` accumulation fix uses declared command metadata (`action: "append"`). Python generated packages honor that metadata through generated argparse support. TypeScript generated packages now get append support from released `command-generation` v0.2.0, after rickardvh/command-generation#24 closed rickardvh/command-generation#23. The earlier AW-specific post-render bridge has been removed.

AW now checks the consumer contract with `command-generation`: released wheel URL, matching declared/installed package, hash-pinned dependency, fresh generated artifacts, and generated command conformance. It no longer asserts exact external package versions or direct external runner semantics in AW tests.

## Validation

- `uv run pytest tests/test_generated_command_package_proof_runner.py -q`
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run ruff check tests/test_generated_command_package_proof_runner.py scripts/check/check_generated_command_packages.py`
- `make lint-workspace`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`

Earlier validation on this branch also passed:

- `make check-planning`
- `make test-workspace`
- focused lifecycle/Verification upgrade tests listed in the previous PR revision
