### PR TITLE
Implement Memory dogfooding fixes

### DIFF
--- a/.agentic-workspace/memory/skills/memory-capture/SKILL.md
+++ b/.agentic-workspace/memory/skills/memory-capture/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: memory-capture
-description: Capture durable lessons into checked-in repository memory. Use when a task has revealed a reusable invariant, recurring failure, subsystem boundary, operator procedure, or other fact that should survive the current session and be written into the right memory note instead of left in chat or local scratch.
+description: Capture durable lessons into the right Memory or owner surface. Use when a task has revealed reusable knowledge that should survive the current session, including repo-shared facts for checked-in Memory and machine-local/runtime-specific lessons for local Memory.
 ---
 
 # Memory Capture
 
 This is a bootstrap-managed core skill shipped with the payload under `.agentic-workspace/memory/skills/`. Add repo-specific sibling skills under `.agentic-workspace/memory/repo/skills/` instead of customising this core skill unless the shared reusable procedure itself changed.
 
-Use this skill to turn a solved issue or discovered rule into the smallest correct checked-in memory update.
+Use this skill to turn a solved issue or discovered rule into the smallest correct capture or routing decision.
 
-It operates on durable memory files. It does not create a separate storage layer.
+It operates on Memory decisions. Repo-shared Memory is checked in under `.agentic-workspace/memory/repo/`; machine-local, user-local, runtime-specific, private, or low-confidence notes belong under local-only Memory such as `.agentic-workspace/local/memory/`.
 
 ## Workflow
 
@@ -21,17 +21,26 @@ It operates on durable memory files. It does not create a separate storage layer
    - what fact should survive this task
    - why it is likely to matter again
    - which files, commands, or surfaces it applies to
-3. Decide whether it belongs in memory at all.
+3. Decide whether it belongs in Memory at all.
    - Do not capture one-off troubleshooting steps, temporary task notes, or backlog state.
-4. Choose the primary home:
+4. Choose the storage authority before choosing a file:
+   - Use repo-shared Memory only for durable knowledge that should travel with the repository.
+   - Use local-only Memory for machine-local, user-local, runtime-specific, private, or low-confidence knowledge.
+   - Use Planning/status for active task state or continuation state.
+   - Use docs/config/tests/contracts for canonical policy, enforceable behavior, or proof obligations.
+   - Use review or issues for follow-up work that is not durable anti-rediscovery knowledge.
+5. For repo-shared Memory, choose the primary home:
    - `.agentic-workspace/memory/repo/domains/` for subsystem knowledge
    - `.agentic-workspace/memory/repo/invariants/` for things that must remain true
    - `.agentic-workspace/memory/repo/runbooks/` for durable operating procedures
    - `.agentic-workspace/memory/repo/mistakes/recurring-failures.md` for repeated failure patterns
    - `.agentic-workspace/memory/repo/decisions/` for longer-lived rationale when a README note is no longer enough
-5. Prefer editing an existing note over creating a new one.
+6. For local-only Memory, use the supported command path:
+   - `agentic-workspace memory create-note --slug <slug> --local --local-reason "<why local>" --summary "<lesson>" --target . --format json`
+   - Do not add local-only lessons to `.agentic-workspace/memory/repo/manifest.toml`.
+7. Prefer editing an existing note over creating a new one when the existing note clearly owns the lesson.
    - If the existing note is already large, broad, or a repeated merge hotspot, split the durable lesson into a focused note instead of adding to the same catch-all surface.
-6. Update note metadata and routing in the same change:
+8. Update repo note metadata and routing in the same change:
    - `Status`
    - `Applies to`
    - `Load when`
@@ -40,11 +49,11 @@ It operates on durable memory files. It does not create a separate storage layer
    - `Verify`
    - `Last confirmed`
    - `.agentic-workspace/memory/repo/manifest.toml` when used
-7. If the note set changed materially, update `.agentic-workspace/memory/repo/index.md`.
-8. If the repeated procedure is repo-specific rather than a durable fact, create a new repo-specific checked-in skill under `.agentic-workspace/memory/repo/skills/` instead of growing this core skill.
-9. Treat `.agentic-workspace/memory/WORKFLOW.md` as reference policy only when the capture touches the memory contract or policy boundary.
-10. Do not capture active state into shared current-memory notes. Put durable facts in the selected memory note, active state in planning/status, and transient context in local-only scratch.
-11. If the lesson is better understood as friction than durable truth, record that with manifest metadata and prefer an upstream remediation target over training contributors to depend on an ever-growing note.
+9. If the repo note set changed materially, update `.agentic-workspace/memory/repo/index.md`.
+10. If the repeated procedure is repo-specific rather than a durable fact, create a new repo-specific checked-in skill under `.agentic-workspace/memory/repo/skills/` instead of growing this core skill.
+11. Treat `.agentic-workspace/memory/WORKFLOW.md` as reference policy only when the capture touches the memory contract or policy boundary.
+12. Do not capture active state into shared current-memory notes. Put durable facts in the selected memory note, active state in planning/status, and transient context in local-only scratch.
+13. If the lesson is better understood as friction than durable truth, record that with manifest metadata and prefer an upstream remediation target over training contributors to depend on an ever-growing note.
 
 ## Capture test
 
@@ -54,21 +63,26 @@ Capture the lesson only if most of these are true:
 - the fact affects future code changes, operations, or review
 - the note will save future re-orientation time
 - the information can be kept concise and verifiable
+- the storage authority is clear: repo-shared, local-only, or routed elsewhere
 
 If not, leave it out of `/memory`.
 
 ## Guardrails
 
 - Keep durable knowledge in checked-in files so the result stays visible in git.
+- Keep local/runtime/user/environment-specific knowledge out of checked-in repo Memory; use local-only Memory or local scratch.
 - Do not create a new note when an existing note can be tightened instead.
 - Do not keep expanding one broad note when separate branches are likely to edit unrelated facts in it.
 - Do not put task state, backlog items, or one-off implementation history into memory.
 - Mark uncertain claims `Needs verification` instead of presenting them as settled.
 - Treat legacy `project-state.md` and `task-context.md` files as migration residue, not normal capture targets.
+- Do not use filenames, prompt words, or phrase markers as authority for the storage decision; use agent judgment over the evidence.
 
 ## Typical outputs
 
 - an updated invariant, domain note, runbook, or recurring-failures note
 - a new memory note when no suitable home exists
+- a local-only memory note when the lesson is machine-local or runtime-specific
+- a routed_elsewhere decision when docs, Planning, tests, contracts, config, review, or an issue is the better owner
 - refreshed note metadata and `Last confirmed`
 - an updated `.agentic-workspace/memory/repo/index.md` or `.agentic-workspace/memory/repo/manifest.toml` when routing changed

--- a/.agentic-workspace/memory/skills/memory-consultation-and-residue/SKILL.md
+++ b/.agentic-workspace/memory/skills/memory-consultation-and-residue/SKILL.md
@@ -32,7 +32,8 @@ It makes three decisions visible:
    - `dismissed`: the signal is one-off or too weak to keep
    - `follow_up_required`: the decision needs a later owner or proof
 3. Classify `durable_residue_decision`:
-   - `memory`
+   - `repo_memory`
+   - `local_memory`
    - `planning`
    - `docs`
    - `tests`
@@ -42,6 +43,7 @@ It makes three decisions visible:
    - `issue`
    - `dismissed`
    - `none_found`
+   - Treat legacy `memory` as an ambiguous compatibility label; prefer `repo_memory` or `local_memory` when recording a new decision.
 4. Classify `improvement_signal_status` when a repeated correction, missing guardrail, or workflow friction appears:
    - `passive`
    - `accumulating`
@@ -50,7 +52,8 @@ It makes three decisions visible:
    - `stale`
    - `resolved`
 5. Keep the proof separate from the write decision. Passing tests can prove behavior, but it does not prove Memory residue exists or that a memory write is appropriate.
-6. If the answer is `memory`, use `memory-capture` for the actual write. If the answer is `routed_elsewhere`, name the owning surface and do not create a memory note just to show activity.
+6. If the answer is `repo_memory` or `local_memory`, use `memory-capture` for the actual write. If the answer is `routed_elsewhere`, name the owning surface and do not create a memory note just to show activity.
+7. Use local-only Memory when the lesson is machine-local, user-local, runtime-specific, private, or low-confidence. Use repo-shared Memory only when the lesson should travel with the repository.
 
 ## Guardrails
 
@@ -62,6 +65,8 @@ It makes three decisions visible:
 - Do not call `dismissed` when the same issue has repeated or an explicit invariant/runbook/check would prevent rediscovery.
 - Do not overwrite Planning closeout. Planning owns active intent, sequencing, issue linkage, and completion claims.
 - Do not overwrite canonical docs, tests, contracts, or config when the durable fix belongs there.
+- Do not put local execution quirks into checked-in repo Memory just because they are useful to the current agent.
+- Do not use prompt keywords, filenames, or phrase markers as authority for a Memory write or storage decision.
 
 ## No-CLI fallback
 

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -45,6 +45,7 @@ Cheap implementer context for a bounded changed-path scope.
 | `memory_decision_packet.capture` | object | yes |  | Durable-learning capture status, candidate owner surfaces, and capture commands. |  |  |
 | `memory_decision_packet.authority_boundary` | object | yes |  | Boundary separating what AW observes and recommends from agent and human decisions. |  |  |
 | `memory_decision_packet.limits` | array of string | no |  | Guardrails preventing keyword-triggered policy, hidden writes, or bulk-read diligence claims. |  |  |
+| `memory_consult` | object | no |  | Memory consultation packet used to surface route-matched durable knowledge without bulk-reading Memory. |  |  |
 | `planning_revision` | object | no |  | Optimistic Planning state revision observed by this implementer read surface. |  |  |
 | `active_plan_reliance` | object | no |  | Permission signal separating command-written integrity, planning freshness, and active-plan reliance. |  |  |
 | `adaptive_routing` | object | yes |  | Machine-readable need classification, read budget, and escalation detail commands for this implementer packet. |  |  |

--- a/generated/memory/python/_contracts/operations/memory.create-note.apply.json
+++ b/generated/memory/python/_contracts/operations/memory.create-note.apply.json
@@ -35,6 +35,16 @@
       "required": false
     },
     {
+      "name": "local",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "local_reason",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "applies_to",
       "source": "cli-option",
       "required": false
@@ -169,6 +179,12 @@
           },
           "summary": {
             "value": "summary"
+          },
+          "local": {
+            "value": "local"
+          },
+          "local_reason": {
+            "value": "local_reason"
           },
           "applies_to": {
             "value": "applies_to"

--- a/generated/memory/python/adapter_commands.json
+++ b/generated/memory/python/adapter_commands.json
@@ -832,6 +832,22 @@
           "name": "summary"
         },
         {
+          "action": "store_true",
+          "flags": [
+            "--local"
+          ],
+          "help": "Create an ignored local-only note under .agentic-workspace/local/memory without updating the repo manifest.",
+          "name": "local"
+        },
+        {
+          "default": "",
+          "flags": [
+            "--local-reason"
+          ],
+          "help": "Reason this note is machine-local rather than repo-shared.",
+          "name": "local_reason"
+        },
+        {
           "default": [],
           "flags": [
             "--applies-to"

--- a/generated/memory/python/command_package.json
+++ b/generated/memory/python/command_package.json
@@ -1336,6 +1336,22 @@
             "name": "summary"
           },
           {
+            "action": "store_true",
+            "flags": [
+              "--local"
+            ],
+            "help": "Create an ignored local-only note under .agentic-workspace/local/memory without updating the repo manifest.",
+            "name": "local"
+          },
+          {
+            "default": "",
+            "flags": [
+              "--local-reason"
+            ],
+            "help": "Reason this note is machine-local rather than repo-shared.",
+            "name": "local_reason"
+          },
+          {
             "default": [],
             "flags": [
               "--applies-to"
@@ -3003,6 +3019,12 @@
             "folder": {
               "value": "folder"
             },
+            "local": {
+              "value": "local"
+            },
+            "local_reason": {
+              "value": "local_reason"
+            },
             "memory_role": {
               "value": "memory_role"
             },
@@ -3213,6 +3235,16 @@
           "arg": "note_type",
           "default": "domain",
           "name": "note_type"
+        },
+        {
+          "arg": "local",
+          "default": false,
+          "name": "local"
+        },
+        {
+          "arg": "local_reason",
+          "default": "",
+          "name": "local_reason"
         },
         {
           "arg": "applies_to",

--- a/generated/memory/python/operations/memory.create-note.apply.json
+++ b/generated/memory/python/operations/memory.create-note.apply.json
@@ -44,6 +44,16 @@
       "source": "cli-option"
     },
     {
+      "name": "local",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "local_reason",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
       "name": "applies_to",
       "required": false,
       "source": "cli-option"
@@ -120,6 +130,12 @@
           },
           "folder": {
             "value": "folder"
+          },
+          "local": {
+            "value": "local"
+          },
+          "local_reason": {
+            "value": "local_reason"
           },
           "memory_role": {
             "value": "memory_role"

--- a/generated/memory/python/primitives/operation_executor.py
+++ b/generated/memory/python/primitives/operation_executor.py
@@ -55,6 +55,8 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'title': getattr(args, 'title', None),
                 'folder': getattr(args, 'folder', 'domains'),
                 'note_type': getattr(args, 'note_type', 'domain'),
+                'local': getattr(args, 'local', False),
+                'local_reason': getattr(args, 'local_reason', ''),
                 'applies_to': getattr(args, 'applies_to', []),
                 'use_when': getattr(args, 'use_when', []),
                 'routes_from': getattr(args, 'routes_from', []),
@@ -109,6 +111,8 @@ def run_operation_callable(operation: dict[str, Any], values: Mapping[str, Any])
                 'title': values.get('title', None),
                 'folder': values.get('folder', 'domains'),
                 'note_type': values.get('note_type', 'domain'),
+                'local': values.get('local', False),
+                'local_reason': values.get('local_reason', ''),
                 'applies_to': values.get('applies_to', []),
                 'use_when': values.get('use_when', []),
                 'routes_from': values.get('routes_from', []),
@@ -317,7 +321,7 @@ def _handle_memory_capture_note_load(values: dict[str, Any], _arguments: dict[st
 def _handle_memory_note_create(values: dict[str, Any], _arguments: dict[str, Any], _context: PrimitiveContext) -> Any:
     from repo_memory_bootstrap.installer import create_memory_note
 
-    return create_memory_note(applies_to=values.get('applies_to'), dry_run=values.get('dry_run'), evidence=values.get('evidence'), folder=values.get('folder'), memory_role=values.get('memory_role'), note_type=values.get('note_type'), promotion_target=values.get('promotion_target'), promotion_trigger=values.get('promotion_trigger'), retention_after_promotion=values.get('retention_after_promotion'), routes_from=values.get('routes_from'), slug=values.get('slug'), stale_when=values.get('stale_when'), summary=values.get('summary'), target=values.get('target'), title=values.get('title'), use_when=values.get('use_when'))
+    return create_memory_note(applies_to=values.get('applies_to'), dry_run=values.get('dry_run'), evidence=values.get('evidence'), folder=values.get('folder'), local=values.get('local'), local_reason=values.get('local_reason'), memory_role=values.get('memory_role'), note_type=values.get('note_type'), promotion_target=values.get('promotion_target'), promotion_trigger=values.get('promotion_trigger'), retention_after_promotion=values.get('retention_after_promotion'), routes_from=values.get('routes_from'), slug=values.get('slug'), stale_when=values.get('stale_when'), summary=values.get('summary'), target=values.get('target'), title=values.get('title'), use_when=values.get('use_when'))
 
 
 def _handle_memory_route_load(values: dict[str, Any], _arguments: dict[str, Any], _context: PrimitiveContext) -> Any:

--- a/generated/memory/typescript/resources/_contracts/operations/memory.create-note.apply.json
+++ b/generated/memory/typescript/resources/_contracts/operations/memory.create-note.apply.json
@@ -35,6 +35,16 @@
       "required": false
     },
     {
+      "name": "local",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "local_reason",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "applies_to",
       "source": "cli-option",
       "required": false
@@ -169,6 +179,12 @@
           },
           "summary": {
             "value": "summary"
+          },
+          "local": {
+            "value": "local"
+          },
+          "local_reason": {
+            "value": "local_reason"
           },
           "applies_to": {
             "value": "applies_to"

--- a/generated/memory/typescript/resources/command_package.json
+++ b/generated/memory/typescript/resources/command_package.json
@@ -1336,6 +1336,22 @@
             "name": "summary"
           },
           {
+            "action": "store_true",
+            "flags": [
+              "--local"
+            ],
+            "help": "Create an ignored local-only note under .agentic-workspace/local/memory without updating the repo manifest.",
+            "name": "local"
+          },
+          {
+            "default": "",
+            "flags": [
+              "--local-reason"
+            ],
+            "help": "Reason this note is machine-local rather than repo-shared.",
+            "name": "local_reason"
+          },
+          {
             "default": [],
             "flags": [
               "--applies-to"

--- a/generated/memory/typescript/resources/operations/memory.create-note.apply.json
+++ b/generated/memory/typescript/resources/operations/memory.create-note.apply.json
@@ -44,6 +44,16 @@
       "source": "cli-option"
     },
     {
+      "name": "local",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "local_reason",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
       "name": "applies_to",
       "required": false,
       "source": "cli-option"
@@ -120,6 +130,12 @@
           },
           "folder": {
             "value": "folder"
+          },
+          "local": {
+            "value": "local"
+          },
+          "local_reason": {
+            "value": "local_reason"
           },
           "memory_role": {
             "value": "memory_role"

--- a/generated/memory/typescript/src/cli.mjs
+++ b/generated/memory/typescript/src/cli.mjs
@@ -863,6 +863,22 @@ const commandDefinitions = [
           "name": "summary"
         },
         {
+          "action": "store_true",
+          "flags": [
+            "--local"
+          ],
+          "help": "Create an ignored local-only note under .agentic-workspace/local/memory without updating the repo manifest.",
+          "name": "local"
+        },
+        {
+          "default": "",
+          "flags": [
+            "--local-reason"
+          ],
+          "help": "Reason this note is machine-local rather than repo-shared.",
+          "name": "local_reason"
+        },
+        {
           "default": [],
           "flags": [
             "--applies-to"

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -1778,6 +1778,171 @@
           ]
         },
         {
+          "help": "Create a repo-shared or local-only Memory note.",
+          "name": "create-note",
+          "options": [
+            {
+              "default": "",
+              "flags": [
+                "--slug"
+              ],
+              "help": "Memory note slug to create.",
+              "name": "slug"
+            },
+            {
+              "flags": [
+                "--title"
+              ],
+              "help": "Memory note title. Defaults to a title derived from the slug.",
+              "name": "title"
+            },
+            {
+              "default": "domains",
+              "flags": [
+                "--folder"
+              ],
+              "help": "Repo Memory folder under .agentic-workspace/memory/repo.",
+              "name": "folder"
+            },
+            {
+              "default": "domain",
+              "flags": [
+                "--note-type"
+              ],
+              "help": "Repo Memory note type recorded in the manifest.",
+              "name": "note_type"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--summary"
+              ],
+              "help": "Short note summary.",
+              "name": "summary"
+            },
+            {
+              "action": "store_true",
+              "flags": [
+                "--local"
+              ],
+              "help": "Create an ignored local-only note under .agentic-workspace/local/memory without updating the repo manifest.",
+              "name": "local"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--local-reason"
+              ],
+              "help": "Reason this note is machine-local rather than repo-shared.",
+              "name": "local_reason"
+            },
+            {
+              "default": [],
+              "flags": [
+                "--applies-to"
+              ],
+              "help": "Repo paths or surfaces this note applies to.",
+              "name": "applies_to",
+              "nargs": "*"
+            },
+            {
+              "default": [],
+              "flags": [
+                "--use-when"
+              ],
+              "help": "Routing hints for when to use this note.",
+              "name": "use_when",
+              "nargs": "*"
+            },
+            {
+              "default": [],
+              "flags": [
+                "--routes-from"
+              ],
+              "help": "Surfaces or files that should route to this note.",
+              "name": "routes_from",
+              "nargs": "*"
+            },
+            {
+              "default": [],
+              "flags": [
+                "--stale-when"
+              ],
+              "help": "Conditions that make this note stale.",
+              "name": "stale_when",
+              "nargs": "*"
+            },
+            {
+              "default": [],
+              "flags": [
+                "--evidence"
+              ],
+              "help": "Evidence references supporting this note.",
+              "name": "evidence",
+              "nargs": "*"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--memory-role"
+              ],
+              "help": "Memory role metadata.",
+              "name": "memory_role"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--promotion-target"
+              ],
+              "help": "Optional durable promotion target.",
+              "name": "promotion_target"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--promotion-trigger"
+              ],
+              "help": "Optional promotion trigger.",
+              "name": "promotion_trigger"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--retention-after-promotion"
+              ],
+              "help": "Retention policy after promotion.",
+              "name": "retention_after_promotion"
+            },
+            {
+              "action": "store_true",
+              "flags": [
+                "--dry-run"
+              ],
+              "help": "Show planned changes without writing files.",
+              "name": "dry_run"
+            },
+            {
+              "flags": [
+                "--target"
+              ],
+              "help": "Optional repository path.",
+              "name": "target"
+            },
+            {
+              "choices": [
+                "text",
+                "json"
+              ],
+              "default": "text",
+              "flags": [
+                "--format"
+              ],
+              "help": "Output format.",
+              "name": "format"
+            }
+          ]
+        },
+        {
           "help": "Report compact memory module state.",
           "name": "report",
           "options": [

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -1948,6 +1948,171 @@
             ]
           },
           {
+            "help": "Create a repo-shared or local-only Memory note.",
+            "name": "create-note",
+            "options": [
+              {
+                "default": "",
+                "flags": [
+                  "--slug"
+                ],
+                "help": "Memory note slug to create.",
+                "name": "slug"
+              },
+              {
+                "flags": [
+                  "--title"
+                ],
+                "help": "Memory note title. Defaults to a title derived from the slug.",
+                "name": "title"
+              },
+              {
+                "default": "domains",
+                "flags": [
+                  "--folder"
+                ],
+                "help": "Repo Memory folder under .agentic-workspace/memory/repo.",
+                "name": "folder"
+              },
+              {
+                "default": "domain",
+                "flags": [
+                  "--note-type"
+                ],
+                "help": "Repo Memory note type recorded in the manifest.",
+                "name": "note_type"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--summary"
+                ],
+                "help": "Short note summary.",
+                "name": "summary"
+              },
+              {
+                "action": "store_true",
+                "flags": [
+                  "--local"
+                ],
+                "help": "Create an ignored local-only note under .agentic-workspace/local/memory without updating the repo manifest.",
+                "name": "local"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--local-reason"
+                ],
+                "help": "Reason this note is machine-local rather than repo-shared.",
+                "name": "local_reason"
+              },
+              {
+                "default": [],
+                "flags": [
+                  "--applies-to"
+                ],
+                "help": "Repo paths or surfaces this note applies to.",
+                "name": "applies_to",
+                "nargs": "*"
+              },
+              {
+                "default": [],
+                "flags": [
+                  "--use-when"
+                ],
+                "help": "Routing hints for when to use this note.",
+                "name": "use_when",
+                "nargs": "*"
+              },
+              {
+                "default": [],
+                "flags": [
+                  "--routes-from"
+                ],
+                "help": "Surfaces or files that should route to this note.",
+                "name": "routes_from",
+                "nargs": "*"
+              },
+              {
+                "default": [],
+                "flags": [
+                  "--stale-when"
+                ],
+                "help": "Conditions that make this note stale.",
+                "name": "stale_when",
+                "nargs": "*"
+              },
+              {
+                "default": [],
+                "flags": [
+                  "--evidence"
+                ],
+                "help": "Evidence references supporting this note.",
+                "name": "evidence",
+                "nargs": "*"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--memory-role"
+                ],
+                "help": "Memory role metadata.",
+                "name": "memory_role"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--promotion-target"
+                ],
+                "help": "Optional durable promotion target.",
+                "name": "promotion_target"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--promotion-trigger"
+                ],
+                "help": "Optional promotion trigger.",
+                "name": "promotion_trigger"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--retention-after-promotion"
+                ],
+                "help": "Retention policy after promotion.",
+                "name": "retention_after_promotion"
+              },
+              {
+                "action": "store_true",
+                "flags": [
+                  "--dry-run"
+                ],
+                "help": "Show planned changes without writing files.",
+                "name": "dry_run"
+              },
+              {
+                "flags": [
+                  "--target"
+                ],
+                "help": "Optional repository path.",
+                "name": "target"
+              },
+              {
+                "choices": [
+                  "text",
+                  "json"
+                ],
+                "default": "text",
+                "flags": [
+                  "--format"
+                ],
+                "help": "Output format.",
+                "name": "format"
+              }
+            ]
+          },
+          {
             "help": "Report compact memory module state.",
             "name": "report",
             "options": [

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -1948,6 +1948,171 @@
             ]
           },
           {
+            "help": "Create a repo-shared or local-only Memory note.",
+            "name": "create-note",
+            "options": [
+              {
+                "default": "",
+                "flags": [
+                  "--slug"
+                ],
+                "help": "Memory note slug to create.",
+                "name": "slug"
+              },
+              {
+                "flags": [
+                  "--title"
+                ],
+                "help": "Memory note title. Defaults to a title derived from the slug.",
+                "name": "title"
+              },
+              {
+                "default": "domains",
+                "flags": [
+                  "--folder"
+                ],
+                "help": "Repo Memory folder under .agentic-workspace/memory/repo.",
+                "name": "folder"
+              },
+              {
+                "default": "domain",
+                "flags": [
+                  "--note-type"
+                ],
+                "help": "Repo Memory note type recorded in the manifest.",
+                "name": "note_type"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--summary"
+                ],
+                "help": "Short note summary.",
+                "name": "summary"
+              },
+              {
+                "action": "store_true",
+                "flags": [
+                  "--local"
+                ],
+                "help": "Create an ignored local-only note under .agentic-workspace/local/memory without updating the repo manifest.",
+                "name": "local"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--local-reason"
+                ],
+                "help": "Reason this note is machine-local rather than repo-shared.",
+                "name": "local_reason"
+              },
+              {
+                "default": [],
+                "flags": [
+                  "--applies-to"
+                ],
+                "help": "Repo paths or surfaces this note applies to.",
+                "name": "applies_to",
+                "nargs": "*"
+              },
+              {
+                "default": [],
+                "flags": [
+                  "--use-when"
+                ],
+                "help": "Routing hints for when to use this note.",
+                "name": "use_when",
+                "nargs": "*"
+              },
+              {
+                "default": [],
+                "flags": [
+                  "--routes-from"
+                ],
+                "help": "Surfaces or files that should route to this note.",
+                "name": "routes_from",
+                "nargs": "*"
+              },
+              {
+                "default": [],
+                "flags": [
+                  "--stale-when"
+                ],
+                "help": "Conditions that make this note stale.",
+                "name": "stale_when",
+                "nargs": "*"
+              },
+              {
+                "default": [],
+                "flags": [
+                  "--evidence"
+                ],
+                "help": "Evidence references supporting this note.",
+                "name": "evidence",
+                "nargs": "*"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--memory-role"
+                ],
+                "help": "Memory role metadata.",
+                "name": "memory_role"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--promotion-target"
+                ],
+                "help": "Optional durable promotion target.",
+                "name": "promotion_target"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--promotion-trigger"
+                ],
+                "help": "Optional promotion trigger.",
+                "name": "promotion_trigger"
+              },
+              {
+                "default": "",
+                "flags": [
+                  "--retention-after-promotion"
+                ],
+                "help": "Retention policy after promotion.",
+                "name": "retention_after_promotion"
+              },
+              {
+                "action": "store_true",
+                "flags": [
+                  "--dry-run"
+                ],
+                "help": "Show planned changes without writing files.",
+                "name": "dry_run"
+              },
+              {
+                "flags": [
+                  "--target"
+                ],
+                "help": "Optional repository path.",
+                "name": "target"
+              },
+              {
+                "choices": [
+                  "text",
+                  "json"
+                ],
+                "default": "text",
+                "flags": [
+                  "--format"
+                ],
+                "help": "Output format.",
+                "name": "format"
+              }
+            ]
+          },
+          {
             "help": "Report compact memory module state.",
             "name": "report",
             "options": [

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -1795,6 +1795,171 @@ const commandDefinitions = [
           ]
         },
         {
+          "help": "Create a repo-shared or local-only Memory note.",
+          "name": "create-note",
+          "options": [
+            {
+              "default": "",
+              "flags": [
+                "--slug"
+              ],
+              "help": "Memory note slug to create.",
+              "name": "slug"
+            },
+            {
+              "flags": [
+                "--title"
+              ],
+              "help": "Memory note title. Defaults to a title derived from the slug.",
+              "name": "title"
+            },
+            {
+              "default": "domains",
+              "flags": [
+                "--folder"
+              ],
+              "help": "Repo Memory folder under .agentic-workspace/memory/repo.",
+              "name": "folder"
+            },
+            {
+              "default": "domain",
+              "flags": [
+                "--note-type"
+              ],
+              "help": "Repo Memory note type recorded in the manifest.",
+              "name": "note_type"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--summary"
+              ],
+              "help": "Short note summary.",
+              "name": "summary"
+            },
+            {
+              "action": "store_true",
+              "flags": [
+                "--local"
+              ],
+              "help": "Create an ignored local-only note under .agentic-workspace/local/memory without updating the repo manifest.",
+              "name": "local"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--local-reason"
+              ],
+              "help": "Reason this note is machine-local rather than repo-shared.",
+              "name": "local_reason"
+            },
+            {
+              "default": [],
+              "flags": [
+                "--applies-to"
+              ],
+              "help": "Repo paths or surfaces this note applies to.",
+              "name": "applies_to",
+              "nargs": "*"
+            },
+            {
+              "default": [],
+              "flags": [
+                "--use-when"
+              ],
+              "help": "Routing hints for when to use this note.",
+              "name": "use_when",
+              "nargs": "*"
+            },
+            {
+              "default": [],
+              "flags": [
+                "--routes-from"
+              ],
+              "help": "Surfaces or files that should route to this note.",
+              "name": "routes_from",
+              "nargs": "*"
+            },
+            {
+              "default": [],
+              "flags": [
+                "--stale-when"
+              ],
+              "help": "Conditions that make this note stale.",
+              "name": "stale_when",
+              "nargs": "*"
+            },
+            {
+              "default": [],
+              "flags": [
+                "--evidence"
+              ],
+              "help": "Evidence references supporting this note.",
+              "name": "evidence",
+              "nargs": "*"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--memory-role"
+              ],
+              "help": "Memory role metadata.",
+              "name": "memory_role"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--promotion-target"
+              ],
+              "help": "Optional durable promotion target.",
+              "name": "promotion_target"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--promotion-trigger"
+              ],
+              "help": "Optional promotion trigger.",
+              "name": "promotion_trigger"
+            },
+            {
+              "default": "",
+              "flags": [
+                "--retention-after-promotion"
+              ],
+              "help": "Retention policy after promotion.",
+              "name": "retention_after_promotion"
+            },
+            {
+              "action": "store_true",
+              "flags": [
+                "--dry-run"
+              ],
+              "help": "Show planned changes without writing files.",
+              "name": "dry_run"
+            },
+            {
+              "flags": [
+                "--target"
+              ],
+              "help": "Optional repository path.",
+              "name": "target"
+            },
+            {
+              "choices": [
+                "text",
+                "json"
+              ],
+              "default": "text",
+              "flags": [
+                "--format"
+              ],
+              "help": "Output format.",
+              "name": "format"
+            }
+          ]
+        },
+        {
           "help": "Report compact memory module state.",
           "name": "report",
           "options": [

--- a/packages/memory/src/repo_memory_bootstrap/contracts/operations/memory.create-note.apply.json
+++ b/packages/memory/src/repo_memory_bootstrap/contracts/operations/memory.create-note.apply.json
@@ -35,6 +35,16 @@
       "required": false
     },
     {
+      "name": "local",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "local_reason",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "applies_to",
       "source": "cli-option",
       "required": false
@@ -169,6 +179,12 @@
           },
           "summary": {
             "value": "summary"
+          },
+          "local": {
+            "value": "local"
+          },
+          "local_reason": {
+            "value": "local_reason"
           },
           "applies_to": {
             "value": "applies_to"

--- a/packages/memory/src/repo_memory_bootstrap/installer.py
+++ b/packages/memory/src/repo_memory_bootstrap/installer.py
@@ -447,6 +447,8 @@ def create_memory_note(
     slug: str,
     title: str | None = None,
     target: str | Path | None = None,
+    local: bool = False,
+    local_reason: str = "",
     folder: str = "domains",
     note_type: str = "domain",
     summary: str = "",
@@ -464,19 +466,26 @@ def create_memory_note(
     target_root = resolve_target_root(target)
     safe_slug = _safe_note_slug(slug)
     safe_folder = _safe_note_slug(folder).replace(".", "-")
-    note_relative = Path(".agentic-workspace") / "memory" / "repo" / safe_folder / f"{safe_slug}.md"
+    note_relative = (
+        Path(".agentic-workspace") / "local" / "memory" / f"{safe_slug}.md"
+        if local
+        else Path(".agentic-workspace") / "memory" / "repo" / safe_folder / f"{safe_slug}.md"
+    )
     note_path = target_root / note_relative
     manifest_path = target_root / MANIFEST_PATH
-    result = _new_result(target_root, dry_run=dry_run, message=f"Create memory note '{safe_slug}'")
+    result = _new_result(target_root, dry_run=dry_run, message=f"Create {'local ' if local else ''}memory note '{safe_slug}'")
 
-    if not manifest_path.exists():
+    if local and not local_reason.strip():
+        result.add("manual review", note_path, "local memory creation requires --local-reason to record why this is not repo-shared")
+        return result
+    if not local and not manifest_path.exists():
         result.add("manual review", manifest_path, "memory manifest is missing; install or repair Memory before creating notes")
         return result
     if note_path.exists():
         result.add("manual review", note_path, "memory note already exists; choose a new slug or edit intentionally")
         return result
-    manifest = _load_memory_manifest(manifest_path)
-    if manifest is not None and any(note.path == note_relative for note in manifest.notes):
+    manifest = None if local else _load_memory_manifest(manifest_path)
+    if not local and manifest is not None and any(note.path == note_relative for note in manifest.notes):
         result.add("manual review", manifest_path, f"manifest already has a note entry for {note_relative.as_posix()}")
         return result
 
@@ -489,20 +498,34 @@ def create_memory_note(
     note_summary = summary.strip() or note_title
 
     if dry_run:
-        result.add("would create", note_path, "minimal Memory note markdown")
-        result.add("would update", manifest_path, "schema-valid manifest note entry")
+        result.add("would create", note_path, "minimal local-only Memory note markdown" if local else "minimal Memory note markdown")
+        if not local:
+            result.add("would update", manifest_path, "schema-valid manifest note entry")
         return result
 
     note_path.parent.mkdir(parents=True, exist_ok=True)
-    note_path.write_text(
-        _render_memory_note_template(
-            title=note_title,
-            summary=note_summary,
-            use_when=normalised_use_when,
-            evidence=normalised_evidence,
-        ),
-        encoding="utf-8",
+    rendered_note = _render_memory_note_template(
+        title=note_title,
+        summary=note_summary,
+        use_when=normalised_use_when,
+        evidence=normalised_evidence,
     )
+    if local:
+        local_metadata = (
+            "## Local-only authority\n\n"
+            "- Canonicality: local_only\n"
+            "- Authority: machine-local advisory context\n"
+            "- Repo authority: false\n"
+            f"- Local reason: {local_reason.strip()}\n\n"
+        )
+        if "## Purpose" in rendered_note:
+            rendered_note = rendered_note.replace("## Purpose\n\n", local_metadata + "## Purpose\n\n", 1)
+        else:
+            rendered_note = rendered_note + "\n\n" + local_metadata
+    note_path.write_text(rendered_note, encoding="utf-8")
+    if local:
+        result.add("created", note_path, "local-only Memory note markdown")
+        return result
     _append_manifest_note_entry(
         manifest_path=manifest_path,
         note_path=note_relative,
@@ -546,6 +569,13 @@ def _tokenize_capture_text(*values: str) -> set[str]:
         "that",
         "memory",
         "planning",
+        "repo",
+        "run",
+        "closeout",
+        "not",
+        "after",
+        "issue",
+        "github",
     }
     tokens: set[str] = set()
     for value in values:
@@ -620,6 +650,12 @@ def _capture_specificity_bonus(*, note: MemoryNoteRecord, files: tuple[str, ...]
 
 
 def _capture_candidate_view(note: MemoryNoteRecord, *, score: int, reasons: list[str]) -> dict[str, object]:
+    ownership_reasons = [
+        reason
+        for reason in reasons
+        if "--existing-note" in reason or "route here" in reason or "package-specific" in reason or "workspace-specific" in reason
+    ]
+    weak_reasons = [reason for reason in reasons if reason.startswith("summary/files share tokens:")]
     candidate: dict[str, object] = {
         "path": note.path.as_posix(),
         "score": score,
@@ -627,6 +663,9 @@ def _capture_candidate_view(note: MemoryNoteRecord, *, score: int, reasons: list
         "note_type": note.note_type,
         "memory_role": note.memory_role or "unclassified",
         "reasons": reasons[:4],
+        "evidence_class": "ownership-evidence" if ownership_reasons else "weak-similarity",
+        "ownership_evidence": ownership_reasons[:4],
+        "weak_similarity_hints": weak_reasons[:4],
     }
     if note.promotion_target:
         candidate["promotion_target"] = note.promotion_target
@@ -635,6 +674,27 @@ def _capture_candidate_view(note: MemoryNoteRecord, *, score: int, reasons: list
     if note.retention_after_promotion:
         candidate["retention_after_promotion"] = note.retention_after_promotion
     return candidate
+
+
+def _looks_like_local_memory_capture(*, summary: str, task: str | None, files: tuple[str, ...], surfaces: tuple[str, ...]) -> bool:
+    text = " ".join([summary, task or "", " ".join(files), " ".join(surfaces)]).lower()
+    local_markers = (
+        "machine-local",
+        "local-only",
+        "local execution",
+        "local shell",
+        "this windows",
+        "windows codex",
+        "codex desktop shell",
+        "bare python",
+        "python is unavailable",
+        "not on path",
+        "local runtime",
+        "environment-specific",
+        "user-local",
+        "private",
+    )
+    return any(marker in text for marker in local_markers)
 
 
 def suggest_memory_note_capture(
@@ -727,18 +787,35 @@ def suggest_memory_note_capture(
     candidates.sort(key=lambda item: (-int(item["score"]), str(item["path"])))
     best = candidates[0] if candidates else None
     force_reason = force_new_reason.strip()
-    if best and not force_reason:
+    strong_best = best if best and int(best.get("score", 0)) >= 20 else None
+    local_capture = _looks_like_local_memory_capture(
+        summary=summary,
+        task=task,
+        files=normalized_files,
+        surfaces=tuple(effective_surfaces),
+    )
+    create_command = (
+        f"agentic-memory create-note {safe_slug} --local --local-reason <why-local> --target ./repo --summary <text> --format json"
+        if local_capture
+        else f"agentic-memory create-note {safe_slug} --target ./repo --summary <text> --format json"
+    )
+
+    if strong_best and not force_reason:
         recommended_action = "update-existing-note"
-        next_command = f"open {best['path']} and update the existing note; keep manifest metadata aligned"
+        next_command = f"open {strong_best['path']} and update the existing note; keep manifest metadata aligned"
         reason = "an existing Memory note appears to own this durable learning"
-    elif best and force_reason:
+    elif strong_best and force_reason:
         recommended_action = "create-new-note-with-explicit-justification"
-        next_command = f"agentic-memory create-note {safe_slug} --target ./repo --summary <text> --format json"
+        next_command = create_command
         reason = "an existing candidate exists, but --force-new-reason records why a separate note is justified"
     else:
-        recommended_action = "create-new-note"
-        next_command = f"agentic-memory create-note {safe_slug} --target ./repo --summary <text> --format json"
-        reason = "no existing Memory note matched the capture request"
+        recommended_action = "create-local-note" if local_capture else "create-new-note"
+        next_command = create_command
+        reason = (
+            "the capture request appears local/runtime-specific, so local-only Memory is the safer default"
+            if local_capture
+            else "no existing Memory note matched the capture request"
+        )
 
     payload: dict[str, object] = {
         "kind": "agentic-memory/capture-recommendation/v1",
@@ -751,6 +828,13 @@ def suggest_memory_note_capture(
         "candidate_count": len(candidates),
         "candidates": candidates[:5],
         "non_memory_owner_routes": ["planning", "docs", "tests", "contracts", "config", "review", "issue"],
+        "memory_owner_routes": ["repo_memory", "local_memory"],
+        "storage_decision": {
+            "recommended_owner": "local_memory" if local_capture else "repo_memory",
+            "local_memory_command": f"agentic-memory create-note {safe_slug} --local --local-reason <why-local> --target ./repo --summary <text> --format json",
+            "repo_memory_command": f"agentic-memory create-note {safe_slug} --target ./repo --summary <text> --format json",
+            "rule": "Use local Memory for machine-local, user-local, runtime-specific, private, or low-confidence lessons; use repo Memory only for repo-shared durable knowledge.",
+        },
         "route_elsewhere_rule": (
             "Choose a non-Memory owner when the learning is task state, canonical policy, enforceable config, proof evidence, "
             "or backlog work rather than compact anti-rediscovery knowledge."
@@ -1612,18 +1696,23 @@ def route_memory(
             "route_context": {
                 "files": [],
                 "surfaces": [],
+                "explicit_surfaces": [],
+                "stage_surface": "",
+                "inferred_surfaces": [],
                 "stage": "",
                 "task_supplied": bool(task and task.strip()),
                 "task_used_for_matching": False,
-                "rule": "Files, explicit surfaces, and stage are route signals; task prose is context for the agent, not routing authority.",
+                "rule": "Files, explicit surfaces, and stage are route signals; task prose is context for the agent, not routing authority. route_context.surfaces is the merged matching set; explicit_surfaces preserves caller input.",
             },
         }
         return result
 
-    selected_surfaces = {_normalise_surface_name(surface) for surface in (surfaces or [])}
+    explicit_surfaces = sorted({_normalise_surface_name(surface) for surface in (surfaces or []) if _normalise_surface_name(surface)})
+    inferred_surfaces = sorted(_infer_surfaces_from_paths(files or []))
+    selected_surfaces = set(explicit_surfaces)
     if normalized_stage:
         selected_surfaces.add(normalized_stage)
-    selected_surfaces.update(_infer_surfaces_from_paths(files or []))
+    selected_surfaces.update(inferred_surfaces)
     manifest = _load_memory_manifest(target_root / MANIFEST_PATH)
     routing_baseline = _routing_baseline_paths(manifest)
     high_level_paths = set(_high_level_paths(manifest))
@@ -1708,10 +1797,13 @@ def route_memory(
     result.route_summary["route_context"] = {
         "files": list(files or []),
         "surfaces": sorted(selected_surfaces),
+        "explicit_surfaces": explicit_surfaces,
+        "stage_surface": normalized_stage,
+        "inferred_surfaces": inferred_surfaces,
         "stage": normalized_stage,
         "task_supplied": bool(task and task.strip()),
         "task_used_for_matching": False,
-        "rule": "Files, explicit surfaces, and stage are route signals; task prose is context for the agent, not routing authority.",
+        "rule": "Files, explicit surfaces, and stage are route signals; task prose is context for the agent, not routing authority. route_context.surfaces is the merged matching set; explicit_surfaces preserves caller input.",
     }
     result.route_summary["selected_note_trust"] = _selected_route_note_trust(
         manifest=manifest,

--- a/packages/memory/src/repo_memory_bootstrap/installer.py
+++ b/packages/memory/src/repo_memory_bootstrap/installer.py
@@ -787,7 +787,8 @@ def suggest_memory_note_capture(
     candidates.sort(key=lambda item: (-int(item["score"]), str(item["path"])))
     best = candidates[0] if candidates else None
     force_reason = force_new_reason.strip()
-    strong_best = best if best and int(best.get("score", 0)) >= 20 else None
+    best_score = best.get("score", 0) if best else 0
+    strong_best = best if isinstance(best_score, int) and best_score >= 20 else None
     local_capture = _looks_like_local_memory_capture(
         summary=summary,
         task=task,
@@ -852,7 +853,7 @@ def suggest_memory_note_capture(
         payload["promotion_metadata_guidance"] = promotion_guidance
         if promotion_guidance["metadata_required"]:
             payload["commands"] = [
-                *cast(list[str], payload["commands"]),
+                *payload["commands"],
                 "agentic-memory promotion-report --target ./repo --mode remediation --format json",
             ]
     return payload

--- a/packages/memory/tests/test_report.py
+++ b/packages/memory/tests/test_report.py
@@ -495,6 +495,38 @@ def test_memory_create_note_cli_writes_json_result(tmp_path: Path, capsys: pytes
     assert (target / ".agentic-workspace/memory/repo/domains/cli-routing.md").exists()
 
 
+def test_memory_create_note_cli_writes_local_note_without_manifest_update(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    target = tmp_path / "repo"
+    (target / ".git").mkdir(parents=True, exist_ok=True)
+    installer.install_bootstrap(target=target)
+    manifest_path = target / ".agentic-workspace/memory/repo/manifest.toml"
+    before = manifest_path.read_text(encoding="utf-8")
+
+    exit_code = cli.main(
+        [
+            "create-note",
+            "local-python-invocation",
+            "--target",
+            str(target),
+            "--summary",
+            "Bare python is unavailable in this local Windows Codex shell.",
+            "--local",
+            "--local-reason",
+            "machine-local shell PATH behavior",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    note_path = target / ".agentic-workspace/local/memory/local-python-invocation.md"
+    assert exit_code == 0
+    assert payload["actions"][0]["kind"] == "created"
+    assert note_path.exists()
+    assert "local_only" in note_path.read_text(encoding="utf-8")
+    assert manifest_path.read_text(encoding="utf-8") == before
+
+
 def test_memory_capture_note_prefers_existing_note(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     target = tmp_path / "repo"
     (target / ".git").mkdir(parents=True, exist_ok=True)
@@ -536,6 +568,34 @@ def test_memory_capture_note_prefers_existing_note(tmp_path: Path, capsys: pytes
     )
     cli_payload = json.loads(capsys.readouterr().out)
     assert cli_payload["recommended_action"] == "update-existing-note"
+
+
+def test_memory_capture_note_does_not_update_unrelated_note_from_weak_tokens(tmp_path: Path) -> None:
+    target = tmp_path / "repo"
+    (target / ".git").mkdir(parents=True, exist_ok=True)
+    installer.install_bootstrap(target=target)
+    installer.create_memory_note(
+        target=target,
+        slug="agent-judgment-over-keyword-matching",
+        folder="decisions",
+        note_type="decision",
+        summary="Agent judgment should not be replaced by keyword matching.",
+        applies_to=[".agentic-workspace/**"],
+        routes_from=["memory", "verification", "routing"],
+    )
+
+    payload = installer.suggest_memory_note_capture(
+        target=target,
+        slug="local-python-invocation",
+        summary="Bare python is unavailable in this local Windows Codex shell; use uv run python.",
+        task="Capture local shell execution memory for this Codex environment.",
+        surfaces=["python", "shell", "codex"],
+    )
+
+    assert payload["recommended_action"] == "create-local-note"
+    assert payload["storage_decision"]["recommended_owner"] == "local_memory"
+    assert "--local" in payload["commands"][0]
+    assert all(candidate["evidence_class"] != "ownership-evidence" for candidate in payload["candidates"])
 
 
 def test_memory_capture_note_surfaces_improvement_promotion_metadata(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/packages/memory/tests/test_routing.py
+++ b/packages/memory/tests/test_routing.py
@@ -146,6 +146,37 @@ surfaces = ["startup"]
     assert first.route_summary["route_context"]["task_used_for_matching"] is False
 
 
+def test_route_memory_preserves_explicit_surfaces_separately_from_stage(tmp_path: Path) -> None:
+    target = tmp_path / "repo"
+    (target / ".git").mkdir(parents=True, exist_ok=True)
+    installer.install_bootstrap(target=target)
+    installer.create_memory_note(
+        target=target,
+        slug="local-tooling",
+        summary="Local tooling invocation reminders.",
+        applies_to=["scripts/run_agentic_workspace.py"],
+        routes_from=["codex"],
+    )
+    manifest_path = target / ".agentic-workspace/memory/repo/manifest.toml"
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+    manifest_path.write_text(
+        manifest_text.replace('routes_from = ["codex"]', 'routes_from = ["codex"]\nsurfaces = ["codex"]'), encoding="utf-8"
+    )
+
+    result = installer.route_memory(
+        target=target,
+        surfaces=["python", "shell", "codex"],
+        stage="implement",
+        task="Run a Python helper script from PowerShell.",
+    )
+    context = result.route_summary["route_context"]
+
+    assert context["explicit_surfaces"] == ["codex", "python", "shell"]
+    assert context["stage_surface"] == "implement"
+    assert set(context["surfaces"]) >= {"codex", "python", "shell", "implement"}
+    assert any(action.match_source == "surface" and "codex" in action.detail for action in result.actions)
+
+
 def test_capture_note_exposes_non_memory_owner_routes(tmp_path: Path) -> None:
     target = tmp_path / "repo"
     (target / ".git").mkdir(parents=True, exist_ok=True)
@@ -180,6 +211,27 @@ routing_only = true
     assert "planning" in payload["non_memory_owner_routes"]
     assert "docs" in payload["non_memory_owner_routes"]
     assert payload["route_context"]["stage"] == "closeout"
+
+
+def test_route_memory_does_not_invent_test_remediation_for_plain_mistake_note(tmp_path: Path) -> None:
+    target = tmp_path / "repo"
+    (target / ".git").mkdir(parents=True, exist_ok=True)
+    installer.install_bootstrap(target=target)
+    installer.create_memory_note(
+        target=target,
+        slug="local-python-invocation",
+        folder="mistakes",
+        note_type="mistake",
+        summary="Bare python is unavailable in this local shell.",
+        applies_to=["scripts/run_agentic_workspace.py"],
+        routes_from=["python", "shell"],
+        memory_role="durable_truth",
+    )
+
+    result = installer.route_memory(target=target, surfaces=["python", "shell"])
+    pressure_actions = [action for action in result.actions if action.role == "improvement-pressure"]
+
+    assert pressure_actions == []
 
 
 def test_route_memory_exposes_selected_note_freshness_trust(tmp_path: Path) -> None:

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -1424,6 +1424,166 @@
           "mutates_state": true
         },
         {
+          "name": "create-note",
+          "help": "Create a repo-shared or local-only Memory note.",
+          "uses_option_groups": [
+            "format"
+          ],
+          "options": [
+            {
+              "name": "slug",
+              "flags": [
+                "--slug"
+              ],
+              "default": "",
+              "help": "Memory note slug to create."
+            },
+            {
+              "name": "title",
+              "flags": [
+                "--title"
+              ],
+              "help": "Memory note title. Defaults to a title derived from the slug."
+            },
+            {
+              "name": "folder",
+              "flags": [
+                "--folder"
+              ],
+              "default": "domains",
+              "help": "Repo Memory folder under .agentic-workspace/memory/repo."
+            },
+            {
+              "name": "note_type",
+              "flags": [
+                "--note-type"
+              ],
+              "default": "domain",
+              "help": "Repo Memory note type recorded in the manifest."
+            },
+            {
+              "name": "summary",
+              "flags": [
+                "--summary"
+              ],
+              "default": "",
+              "help": "Short note summary."
+            },
+            {
+              "name": "local",
+              "flags": [
+                "--local"
+              ],
+              "action": "store_true",
+              "help": "Create an ignored local-only note under .agentic-workspace/local/memory without updating the repo manifest."
+            },
+            {
+              "name": "local_reason",
+              "flags": [
+                "--local-reason"
+              ],
+              "default": "",
+              "help": "Reason this note is machine-local rather than repo-shared."
+            },
+            {
+              "name": "applies_to",
+              "flags": [
+                "--applies-to"
+              ],
+              "nargs": "*",
+              "default": [],
+              "help": "Repo paths or surfaces this note applies to."
+            },
+            {
+              "name": "use_when",
+              "flags": [
+                "--use-when"
+              ],
+              "nargs": "*",
+              "default": [],
+              "help": "Routing hints for when to use this note."
+            },
+            {
+              "name": "routes_from",
+              "flags": [
+                "--routes-from"
+              ],
+              "nargs": "*",
+              "default": [],
+              "help": "Surfaces or files that should route to this note."
+            },
+            {
+              "name": "stale_when",
+              "flags": [
+                "--stale-when"
+              ],
+              "nargs": "*",
+              "default": [],
+              "help": "Conditions that make this note stale."
+            },
+            {
+              "name": "evidence",
+              "flags": [
+                "--evidence"
+              ],
+              "nargs": "*",
+              "default": [],
+              "help": "Evidence references supporting this note."
+            },
+            {
+              "name": "memory_role",
+              "flags": [
+                "--memory-role"
+              ],
+              "default": "",
+              "help": "Memory role metadata."
+            },
+            {
+              "name": "promotion_target",
+              "flags": [
+                "--promotion-target"
+              ],
+              "default": "",
+              "help": "Optional durable promotion target."
+            },
+            {
+              "name": "promotion_trigger",
+              "flags": [
+                "--promotion-trigger"
+              ],
+              "default": "",
+              "help": "Optional promotion trigger."
+            },
+            {
+              "name": "retention_after_promotion",
+              "flags": [
+                "--retention-after-promotion"
+              ],
+              "default": "",
+              "help": "Retention policy after promotion."
+            },
+            {
+              "name": "dry_run",
+              "flags": [
+                "--dry-run"
+              ],
+              "action": "store_true",
+              "help": "Show planned changes without writing files."
+            },
+            {
+              "name": "target",
+              "flags": [
+                "--target"
+              ],
+              "help": "Optional repository path."
+            }
+          ],
+          "role": "core_context_router",
+          "audience": "ordinary_host_repo",
+          "classification_note": "Memory note creation front door",
+          "mutates_state": true
+        },
+        {
           "name": "report",
           "help": "Report compact memory module state.",
           "uses_option_groups": [

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -2626,6 +2626,171 @@
                 ]
               },
               {
+                "name": "create-note",
+                "help": "Create a repo-shared or local-only Memory note.",
+                "options": [
+                  {
+                    "name": "slug",
+                    "flags": [
+                      "--slug"
+                    ],
+                    "default": "",
+                    "help": "Memory note slug to create."
+                  },
+                  {
+                    "name": "title",
+                    "flags": [
+                      "--title"
+                    ],
+                    "help": "Memory note title. Defaults to a title derived from the slug."
+                  },
+                  {
+                    "name": "folder",
+                    "flags": [
+                      "--folder"
+                    ],
+                    "default": "domains",
+                    "help": "Repo Memory folder under .agentic-workspace/memory/repo."
+                  },
+                  {
+                    "name": "note_type",
+                    "flags": [
+                      "--note-type"
+                    ],
+                    "default": "domain",
+                    "help": "Repo Memory note type recorded in the manifest."
+                  },
+                  {
+                    "name": "summary",
+                    "flags": [
+                      "--summary"
+                    ],
+                    "default": "",
+                    "help": "Short note summary."
+                  },
+                  {
+                    "name": "local",
+                    "flags": [
+                      "--local"
+                    ],
+                    "action": "store_true",
+                    "help": "Create an ignored local-only note under .agentic-workspace/local/memory without updating the repo manifest."
+                  },
+                  {
+                    "name": "local_reason",
+                    "flags": [
+                      "--local-reason"
+                    ],
+                    "default": "",
+                    "help": "Reason this note is machine-local rather than repo-shared."
+                  },
+                  {
+                    "name": "applies_to",
+                    "flags": [
+                      "--applies-to"
+                    ],
+                    "nargs": "*",
+                    "default": [],
+                    "help": "Repo paths or surfaces this note applies to."
+                  },
+                  {
+                    "name": "use_when",
+                    "flags": [
+                      "--use-when"
+                    ],
+                    "nargs": "*",
+                    "default": [],
+                    "help": "Routing hints for when to use this note."
+                  },
+                  {
+                    "name": "routes_from",
+                    "flags": [
+                      "--routes-from"
+                    ],
+                    "nargs": "*",
+                    "default": [],
+                    "help": "Surfaces or files that should route to this note."
+                  },
+                  {
+                    "name": "stale_when",
+                    "flags": [
+                      "--stale-when"
+                    ],
+                    "nargs": "*",
+                    "default": [],
+                    "help": "Conditions that make this note stale."
+                  },
+                  {
+                    "name": "evidence",
+                    "flags": [
+                      "--evidence"
+                    ],
+                    "nargs": "*",
+                    "default": [],
+                    "help": "Evidence references supporting this note."
+                  },
+                  {
+                    "name": "memory_role",
+                    "flags": [
+                      "--memory-role"
+                    ],
+                    "default": "",
+                    "help": "Memory role metadata."
+                  },
+                  {
+                    "name": "promotion_target",
+                    "flags": [
+                      "--promotion-target"
+                    ],
+                    "default": "",
+                    "help": "Optional durable promotion target."
+                  },
+                  {
+                    "name": "promotion_trigger",
+                    "flags": [
+                      "--promotion-trigger"
+                    ],
+                    "default": "",
+                    "help": "Optional promotion trigger."
+                  },
+                  {
+                    "name": "retention_after_promotion",
+                    "flags": [
+                      "--retention-after-promotion"
+                    ],
+                    "default": "",
+                    "help": "Retention policy after promotion."
+                  },
+                  {
+                    "name": "dry_run",
+                    "flags": [
+                      "--dry-run"
+                    ],
+                    "action": "store_true",
+                    "help": "Show planned changes without writing files."
+                  },
+                  {
+                    "name": "target",
+                    "flags": [
+                      "--target"
+                    ],
+                    "help": "Optional repository path."
+                  },
+                  {
+                    "name": "format",
+                    "flags": [
+                      "--format"
+                    ],
+                    "choices": [
+                      "text",
+                      "json"
+                    ],
+                    "default": "text",
+                    "help": "Output format."
+                  }
+                ]
+              },
+              {
                 "name": "report",
                 "help": "Report compact memory module state.",
                 "options": [
@@ -9467,6 +9632,16 @@
               "default": "domain"
             },
             {
+              "name": "local",
+              "arg": "local",
+              "default": false
+            },
+            {
+              "name": "local_reason",
+              "arg": "local_reason",
+              "default": ""
+            },
+            {
               "name": "applies_to",
               "arg": "applies_to",
               "default": []
@@ -9928,6 +10103,12 @@
                 },
                 "summary": {
                   "value": "summary"
+                },
+                "local": {
+                  "value": "local"
+                },
+                "local_reason": {
+                  "value": "local_reason"
                 },
                 "applies_to": {
                   "value": "applies_to"
@@ -11380,6 +11561,22 @@
                 ],
                 "default": "",
                 "help": "Short note summary."
+              },
+              {
+                "name": "local",
+                "flags": [
+                  "--local"
+                ],
+                "action": "store_true",
+                "help": "Create an ignored local-only note under .agentic-workspace/local/memory without updating the repo manifest."
+              },
+              {
+                "name": "local_reason",
+                "flags": [
+                  "--local-reason"
+                ],
+                "default": "",
+                "help": "Reason this note is machine-local rather than repo-shared."
               },
               {
                 "name": "applies_to",

--- a/src/agentic_workspace/contracts/operation_contracts.json
+++ b/src/agentic_workspace/contracts/operation_contracts.json
@@ -489,6 +489,12 @@
       "path": "operations/verification.report.report.json",
       "command": "report",
       "migration_status": "runtime-consumed"
+    },
+    {
+      "id": "workspace.memory-create-note.apply",
+      "path": "operations/workspace.memory-create-note.apply.json",
+      "command": "memory",
+      "migration_status": "runtime-consumed"
     }
   ]
 }

--- a/src/agentic_workspace/contracts/operations/workspace.memory-create-note.apply.json
+++ b/src/agentic_workspace/contracts/operations/workspace.memory-create-note.apply.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "agentic-workspace/operation/v1",
+  "id": "workspace.memory-create-note.apply",
+  "command_surface": {
+    "program": "agentic-workspace",
+    "command": "memory",
+    "subcommand": "create-note",
+    "format_option": "format"
+  },
+  "summary": "Forward a workspace Memory create-note request to the Memory module command package.",
+  "classification": "lifecycle-mutation",
+  "inputs": [
+    {
+      "name": "slug",
+      "source": "cli-option",
+      "required": true
+    },
+    {
+      "name": "target",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "summary",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "local",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "local_reason",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "format",
+      "source": "cli-option",
+      "required": false
+    }
+  ],
+  "output": {
+    "kind": "text-or-json"
+  },
+  "effects": {
+    "read_only": false,
+    "destructive": false,
+    "idempotent": false,
+    "writes_repo_state": true,
+    "requires_preflight_gate": false
+  },
+  "locality": {
+    "requires_repo": true,
+    "network": "forbidden",
+    "outside_repo_writes": "forbidden"
+  },
+  "reads": [
+    {
+      "surface": "Memory module command metadata",
+      "required": true
+    },
+    {
+      "surface": "Memory manifest or local Memory directory",
+      "required": false
+    }
+  ],
+  "writes": [
+    {
+      "surface": "repo Memory note and manifest entry, or local Memory note when --local is provided",
+      "required": true
+    }
+  ],
+  "steps": [
+    {
+      "id": "resolve_root",
+      "uses": "workspace.root.resolve",
+      "description": "Resolve the target repository root."
+    },
+    {
+      "id": "forward_to_memory_module",
+      "uses": "memory.note.create",
+      "description": "Create the requested Memory note through the Memory module primitive."
+    },
+    {
+      "id": "emit_output",
+      "uses": "output.emit",
+      "description": "Emit the Memory module result through the workspace front door."
+    }
+  ],
+  "guards": [
+    "Do not create repo Memory for machine-local, user-local, runtime-specific, private, or low-confidence lessons.",
+    "Require --local-reason when --local is used.",
+    "Do not update the repo Memory manifest for local-only notes."
+  ],
+  "proof": [
+    "workspace memory create-note blackbox test exercises local dry-run routing",
+    "Memory create-note package tests cover local note creation without manifest mutation",
+    "generated command package checks remain fresh"
+  ],
+  "migration_status": "runtime-consumed"
+}

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -60,6 +60,11 @@
       "$ref": "#/$defs/memory_decision_packet",
       "description": "Command-backed Memory pull/capture decision packet that keeps semantic judgment with the agent."
     },
+    "memory_consult": {
+      "type": "object",
+      "description": "Memory consultation packet used to surface route-matched durable knowledge without bulk-reading Memory.",
+      "additionalProperties": true
+    },
     "planning_revision": {
       "type": "object",
       "description": "Optimistic Planning state revision observed by this implementer read surface.",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -3417,21 +3417,36 @@ def _planning_module_argv(args: argparse.Namespace) -> list[str]:
 def _memory_module_argv(args: argparse.Namespace) -> list[str]:
     command = str(args.memory_command)
     argv = [command]
-    if command == "capture-note" and getattr(args, "slug", None):
+    if command in {"capture-note", "create-note"} and getattr(args, "slug", None):
         argv.append(str(args.slug))
     for option, attr in (
         ("--target", "target"),
+        ("--title", "title"),
+        ("--folder", "folder"),
+        ("--note-type", "note_type"),
         ("--summary", "summary"),
         ("--task", "task"),
         ("--stage", "stage"),
         ("--existing-note", "existing_note"),
         ("--force-new-reason", "force_new_reason"),
         ("--mode", "mode"),
+        ("--memory-role", "memory_role"),
+        ("--promotion-target", "promotion_target"),
+        ("--promotion-trigger", "promotion_trigger"),
+        ("--retention-after-promotion", "retention_after_promotion"),
+        ("--local-reason", "local_reason"),
     ):
         _append_option(argv, option, getattr(args, attr, None))
+    _append_repeated_option(argv, "--applies-to", getattr(args, "applies_to", None))
+    _append_repeated_option(argv, "--use-when", getattr(args, "use_when", None))
+    _append_repeated_option(argv, "--routes-from", getattr(args, "routes_from", None))
+    _append_repeated_option(argv, "--stale-when", getattr(args, "stale_when", None))
+    _append_repeated_option(argv, "--evidence", getattr(args, "evidence", None))
     _append_repeated_option(argv, "--files", getattr(args, "files", None))
     _append_repeated_option(argv, "--surface", getattr(args, "surfaces", None))
     _append_repeated_option(argv, "--notes", getattr(args, "notes", None))
+    _append_flag(argv, "--local", bool(getattr(args, "local", False)))
+    _append_flag(argv, "--dry-run", bool(getattr(args, "dry_run", False)))
     _append_flag(argv, "--verbose", bool(getattr(args, "verbose", False)))
     _append_option(argv, "--format", getattr(args, "format", None))
     return argv
@@ -13675,7 +13690,17 @@ def _memory_consult_payload(
     return payload
 
 
-_MEMORY_DECISION_OWNER_SURFACES = ["memory", "planning", "docs", "tests", "contracts", "config", "review", "issue"]
+_MEMORY_DECISION_OWNER_SURFACES = [
+    "repo_memory",
+    "local_memory",
+    "planning",
+    "docs",
+    "tests",
+    "contracts",
+    "config",
+    "review",
+    "issue",
+]
 _MEMORY_PULL_STATUSES = {"not_checked", "checked_none", "relevant_notes_found", "stale", "unavailable", "dismissed"}
 _MEMORY_CAPTURE_STATUSES = {
     "not_evaluated",
@@ -13816,7 +13841,8 @@ def _memory_decision_packet_payload(
         capture_status == "not_evaluated"
         and stage == "closeout"
         and residue_owner
-        and residue_owner.lower() not in {"memory", ".agentic-workspace/memory", ".agentic-workspace/memory/repo"}
+        and residue_owner.lower()
+        not in {"memory", "repo_memory", "local_memory", ".agentic-workspace/memory", ".agentic-workspace/memory/repo"}
     ):
         capture_status = "routed_elsewhere"
     elif capture_status == "not_evaluated" and stage == "closeout" and _as_int(closeout.get("promotion_candidate_count")) > 0:
@@ -21508,6 +21534,21 @@ def _hydrate_selected_start_advisory_payloads(
 def _select_summary_payload(
     *, target_root: Path, select: str, task_text: str | None, changed_paths: list[str], planning_summary: Any, cli_invoke: str
 ) -> dict[str, Any]:
+    requested_fields = [field.strip() for field in select.split(",") if field.strip()]
+    if requested_fields and set(requested_fields) <= {"planning_revision"}:
+        from repo_planning_bootstrap.installer import planning_revision
+
+        selected = _select_payload_fields(
+            {"planning_revision": planning_revision(target_root)},
+            select=select,
+            source_command="summary",
+        )
+        selected["selection_cost"] = {
+            "profile_loaded": "tiny-direct",
+            "fallback_profile_loaded": False,
+            "rule": "planning_revision is served from the cheap revision primitive without loading broad summary detail.",
+        }
+        return selected
     tiny_summary = planning_summary(target=target_root.as_posix(), profile="tiny", task_text=task_text, changed_paths=changed_paths)
     if isinstance(tiny_summary, dict):
         tiny_summary["memory_consult"] = (
@@ -22987,9 +23028,17 @@ _CANDIDATE_RELEVANCE_STOPWORDS = {
     "different",
     "epic",
     "future",
+    "github",
     "implement",
     "implementation",
     "issue",
+    "issues",
+    "after",
+    "refresh",
+    "failure",
+    "fix",
+    "file",
+    "findings",
     "jumpstart",
     "lane",
     "planning",
@@ -23001,7 +23050,7 @@ _CANDIDATE_RELEVANCE_STOPWORDS = {
 }
 
 
-def _candidate_relevance_evidence(candidate: dict[str, Any], *, issue_refs: list[str], task_text: str | None) -> list[str]:
+def _candidate_relevance_payload(candidate: dict[str, Any], *, issue_refs: list[str], task_text: str | None) -> dict[str, list[str]]:
     candidate_text = " ".join(
         str(candidate.get(field, ""))
         for field in (
@@ -23016,15 +23065,20 @@ def _candidate_relevance_evidence(candidate: dict[str, Any], *, issue_refs: list
             "suggested_first_slice",
         )
     ).lower()
-    evidence: list[str] = []
+    strong_evidence: list[str] = []
+    weak_hints: list[str] = []
     for issue_ref in issue_refs:
         if issue_ref.lower() in candidate_text:
-            evidence.append(f"issue_ref:{issue_ref}")
+            strong_evidence.append(f"issue_ref:{issue_ref}")
     normalized_task = str(task_text or "").lower()
     for field in ("id", "lane_id"):
         value = str(candidate.get(field, "")).strip().lower()
         if value and value in normalized_task:
-            evidence.append(f"task_mentions_{field}:{value}")
+            strong_evidence.append(f"task_mentions_{field}:{value}")
+    for field in ("title",):
+        value = " ".join(str(candidate.get(field, "")).strip().lower().split())
+        if value and len(value) >= 8 and value in " ".join(normalized_task.split()):
+            strong_evidence.append(f"task_mentions_{field}:{value}")
     task_tokens = {
         token for token in re.findall(r"[a-z0-9]+", normalized_task) if len(token) >= 4 and token not in _CANDIDATE_RELEVANCE_STOPWORDS
     }
@@ -23033,8 +23087,12 @@ def _candidate_relevance_evidence(candidate: dict[str, Any], *, issue_refs: list
     }
     shared = sorted(task_tokens & candidate_tokens)
     if shared:
-        evidence.append("shared_task_terms:" + ",".join(shared[:5]))
-    return evidence
+        weak_hints.append("shared_task_terms:" + ",".join(shared[:5]))
+    return {"strong_evidence": strong_evidence, "weak_hints": weak_hints}
+
+
+def _candidate_relevance_evidence(candidate: dict[str, Any], *, issue_refs: list[str], task_text: str | None) -> list[str]:
+    return _candidate_relevance_payload(candidate, issue_refs=issue_refs, task_text=task_text)["strong_evidence"]
 
 
 def _planning_candidate_pressure_payload(
@@ -23062,7 +23120,9 @@ def _planning_candidate_pressure_payload(
     for candidate in roadmap_candidates:
         candidate_id = str(candidate.get("id", "")).strip()
         refs = sorted(_candidate_refs(candidate), key=lambda value: int(value.lstrip("#")) if value.lstrip("#").isdigit() else 0)
-        evidence = _candidate_relevance_evidence(candidate, issue_refs=issue_refs, task_text=task_text)
+        relevance_payload = _candidate_relevance_payload(candidate, issue_refs=issue_refs, task_text=task_text)
+        evidence = relevance_payload["strong_evidence"]
+        weak_hints = relevance_payload["weak_hints"]
         ref_statuses = {ref: external_status_by_ref.get(ref, "unknown") for ref in refs if ref in external_status_by_ref}
         closed_refs = [ref for ref, status in ref_statuses.items() if status in {"closed", "done", "merged", "retired"}]
         stale_or_closed = bool(refs and closed_refs and not issue_ref_set.intersection(refs))
@@ -23078,11 +23138,12 @@ def _planning_candidate_pressure_payload(
                 "title": str(candidate.get("title", "")),
                 "refs": refs,
                 "evidence": evidence,
+                "weak_lexical_hints": weak_hints,
                 "external_statuses": ref_statuses,
                 "relevance": "matched" if evidence and not stale_or_closed else "stale-or-closed" if stale_or_closed else "unmatched",
             }
     decomposition_relevance = {
-        str(candidate.get("lane_id", "")).strip(): _candidate_relevance_evidence(
+        str(candidate.get("lane_id", "")).strip(): _candidate_relevance_payload(
             candidate,
             issue_refs=issue_refs,
             task_text=task_text,
@@ -23090,7 +23151,9 @@ def _planning_candidate_pressure_payload(
         for candidate in decomposition_candidates
     }
     matched_decomposition = [
-        candidate for candidate in decomposition_candidates if decomposition_relevance.get(str(candidate.get("lane_id", "")).strip())
+        candidate
+        for candidate in decomposition_candidates
+        if decomposition_relevance.get(str(candidate.get("lane_id", "")).strip(), {}).get("strong_evidence")
     ]
     broad_shape = work_shape in {"lane", "epic"}
     promotion_required = False
@@ -23136,7 +23199,8 @@ def _planning_candidate_pressure_payload(
                 "id": lane_id,
                 "title": candidate.get("title", ""),
                 "decomposition": candidate.get("decomposition", ""),
-                "relevance_evidence": decomposition_relevance.get(lane_id, []),
+                "relevance_evidence": decomposition_relevance.get(lane_id, {}).get("strong_evidence", []),
+                "weak_lexical_hints": decomposition_relevance.get(lane_id, {}).get("weak_hints", []),
                 "command": _candidate_promotion_command(candidate_id=lane_id, config=config, planning_revision=planning_revision),
             }
         )
@@ -23171,7 +23235,8 @@ def _planning_candidate_pressure_payload(
                 {
                     "id": str(candidate.get("lane_id", "")).strip(),
                     "title": str(candidate.get("title", "")),
-                    "evidence": decomposition_relevance.get(str(candidate.get("lane_id", "")).strip(), []),
+                    "evidence": decomposition_relevance.get(str(candidate.get("lane_id", "")).strip(), {}).get("strong_evidence", []),
+                    "weak_lexical_hints": decomposition_relevance.get(str(candidate.get("lane_id", "")).strip(), {}).get("weak_hints", []),
                 }
                 for candidate in decomposition_candidates[:5]
             ],

--- a/tests/test_workspace_cli_blackbox.py
+++ b/tests/test_workspace_cli_blackbox.py
@@ -100,3 +100,28 @@ def test_blackbox_memory_capture_note_accepts_stage_and_task_context() -> None:
     assert "Traceback" not in f"{result.stdout}\n{result.stderr}"
     assert '"stage": "closeout"' in result.stdout
     assert '"task_supplied": true' in result.stdout
+
+
+def test_blackbox_memory_create_note_supports_local_dry_run() -> None:
+    result = _run_cli(
+        "memory",
+        "create-note",
+        "--target",
+        ".",
+        "--slug",
+        "blackbox-local-python-invocation-dry-run",
+        "--summary",
+        "Bare python is unavailable in this local shell.",
+        "--local",
+        "--local-reason",
+        "machine-local shell behavior",
+        "--dry-run",
+        "--format",
+        "json",
+        cwd=Path.cwd(),
+    )
+
+    assert result.returncode == 0
+    assert "Traceback" not in f"{result.stdout}\n{result.stderr}"
+    assert '"kind": "would create"' in result.stdout
+    assert ".agentic-workspace/local/memory/blackbox-local-python-invocation-dry-run.md" in result.stdout

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -94,7 +94,8 @@ def test_implement_surfaces_memory_decision_packet_for_changed_paths(tmp_path: P
     assert packet["pull"]["status"] == "checked_none"
     assert "--stage implement" in packet["pull"]["recommended_command"]
     assert "docs/package/knowledge-routing.md" in packet["pull"]["recommended_command"]
-    assert "memory" in packet["capture"]["candidate_owner_surfaces"]
+    assert "repo_memory" in packet["capture"]["candidate_owner_surfaces"]
+    assert "local_memory" in packet["capture"]["candidate_owner_surfaces"]
     assert "planning" in packet["capture"]["candidate_owner_surfaces"]
     assert packet["authority_boundary"]["agent_owns"]
 
@@ -2621,6 +2622,96 @@ candidates = [
         "github-1522-packaging-tests",
         "github-1523-generated-proof-tests",
     ]
+
+
+def test_implement_keeps_generic_github_issue_filing_terms_as_weak_hints(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "github-1501-memory-routing", maturity = "candidate", status = "next", refs = "GitHub #1501", title = "Memory routing lane", outcome = "Improve routing." },
+  { id = "github-1502-delegation", maturity = "candidate", status = "next", refs = "GitHub #1502", title = "Delegation lane", outcome = "Improve delegation." },
+]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                ".agentic-workspace/planning/state.toml",
+                "--task",
+                "File dogfooding friction findings as GitHub issues",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    pressure = json.loads(capsys.readouterr().out)["context"]["planning_safety_gate"]["candidate_pressure"]
+    assert pressure["status"] == "observed"
+    assert pressure["candidate_ids"] == []
+    assert pressure["relevance"]["roadmap"][0]["evidence"] == []
+    assert "weak_lexical_hints" in pressure["relevance"]["roadmap"][0]
+
+
+def test_implement_keeps_generic_ci_refresh_terms_as_weak_hints(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "generated-command-refresh", maturity = "candidate", status = "next", refs = "GitHub #1503", title = "Generated command cleanup after refresh", outcome = "Clean generated command tests." },
+  { id = "testing-inventory-refresh", maturity = "candidate", status = "next", refs = "GitHub #1504", title = "Testing inventory refresh", outcome = "Refresh testing inventory." },
+]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "packages/memory/src/repo_memory_bootstrap/installer.py",
+                "--task",
+                "Fix CI memory typecheck failure after dependency refresh",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    pressure = json.loads(capsys.readouterr().out)["context"]["planning_safety_gate"]["candidate_pressure"]
+    assert pressure["status"] == "observed"
+    assert pressure["candidate_ids"] == []
+    assert pressure["matched_roadmap_candidate_count"] == 0
+    assert all(item["evidence"] == [] for item in pressure["relevance"]["roadmap"])
 
 
 def test_implement_ignores_closed_external_intent_candidate_pressure(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -110,6 +110,8 @@ candidates = []
     assert packet["force"] == "not_applicable"
     assert packet["capture"]["status"] == "none_found"
     assert "planning" in packet["capture"]["candidate_owner_surfaces"]
+    assert "repo_memory" in packet["capture"]["candidate_owner_surfaces"]
+    assert "local_memory" in packet["capture"]["candidate_owner_surfaces"]
     assert packet["capture"]["agent_decision_required"] is False
 
 
@@ -147,6 +149,14 @@ def test_memory_decision_packet_closeout_states_are_pressure_driven() -> None:
         )
         for owner in ["planning", "docs", "tests", "contracts", "config", "review", "issue"]
     ]
+    local_memory = _memory_decision_packet_payload(
+        **base,
+        closeout_trust={
+            "trust": "lower-trust",
+            "lower_trust_closeout_count": 1,
+            "durable_residue_action": {"action": "route-durable-residue", "owner": "local_memory"},
+        },
+    )
     follow_up = _memory_decision_packet_payload(
         **base,
         closeout_trust={"trust": "lower-trust", "lower_trust_closeout_count": 1},
@@ -157,6 +167,7 @@ def test_memory_decision_packet_closeout_states_are_pressure_driven() -> None:
     assert dismissed["capture"]["status"] == "dismissed"
     assert capture["capture"]["status"] == "capture_candidate"
     assert {packet["capture"]["status"] for packet in routed_packets} == {"routed_elsewhere"}
+    assert local_memory["capture"]["status"] == "follow_up_required"
     assert follow_up["force"] == "required_at_closeout"
     assert follow_up["capture"]["status"] == "follow_up_required"
 
@@ -240,6 +251,30 @@ candidates = [
     )
     assert payload["execution_readiness"]["status"] == "narrow-direct-ready"
     assert payload["schema"]["select_command"] == "agentic-workspace summary --select <field.path> --format json"
+
+
+def test_workspace_summary_planning_revision_selector_stays_tiny(tmp_path: Path, capsys) -> None:
+    install_bootstrap(target=tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/planning/state.toml",
+        """
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+
+    exit_code = cli.main(["summary", "--target", str(tmp_path), "--select", "planning_revision", "--format", "json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["values"]["planning_revision"]["kind"] == "planning-revision/v1"
+    assert payload["selection_cost"]["profile_loaded"] == "tiny-direct"
+    assert payload["selection_cost"]["fallback_profile_loaded"] is False
 
 
 def test_workspace_summary_completion_task_surfaces_closeout_trust(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- add command-backed local Memory note creation and workspace `memory create-note` forwarding
- make capture recommendations distinguish strong ownership evidence from weak similarity, including local-vs-repo Memory routing
- preserve explicit/stage/inferred Memory route surfaces and demote generic planning lexical overlap to weak hints
- add targeted tests plus generated contract/package updates

## Validation
- `uv run pytest packages/memory/tests/test_report.py packages/memory/tests/test_routing.py tests/test_workspace_summary_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_cli_blackbox.py -q`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/check/check_no_absolute_paths.py`
- `uv run ruff check packages/memory/src/repo_memory_bootstrap/installer.py src/agentic_workspace/workspace_runtime_primitives.py packages/memory/tests/test_report.py packages/memory/tests/test_routing.py tests/test_workspace_summary_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_cli_blackbox.py`

Fixes #1587
Fixes #1588
Fixes #1589
Fixes #1590
Fixes #1591
Fixes #1592
Fixes #1593
Fixes #1594