### PR TITLE
Adopt coordinated workspace releases

### DIFF
--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -32,5 +32,11 @@
     ".agentic-workspace/system-intent/WORKFLOW.md"
   ],
   "payload_schema": "agentic-workspace/payload/v1",
-  "rule": "Repo payload provenance records the executable/source identity that installed or last synced the AW payload."
+  "release_identity": {
+    "package": "agentic-workspace",
+    "release_model": "coordinated-workspace",
+    "tag": "v0.1.0",
+    "version": "0.1.0"
+  },
+  "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/.github/release-ownership.json
+++ b/.github/release-ownership.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "agentic-workspace/release-ownership/v1",
+  "release_model": "coordinated-workspace",
+  "canonical_version_source": "pyproject.toml",
+  "semver_labels": [
+    "semver:major",
+    "semver:minor",
+    "semver:patch"
+  ],
+  "release_commit_allowed_paths": [
+    "pyproject.toml",
+    "packages/memory/pyproject.toml",
+    "packages/planning/pyproject.toml",
+    "packages/verification/pyproject.toml",
+    "uv.lock"
+  ],
+  "package_affecting_paths": [
+    ".github/release-ownership.json",
+    ".github/release.yml",
+    ".github/workflows/ci.yml",
+    ".github/workflows/pr-semver-label.yml",
+    ".github/workflows/release-from-semver-label.yml",
+    ".github/workflows/release.yml",
+    "docs/release-and-versioning.md",
+    "generated/",
+    "packages/",
+    "pyproject.toml",
+    "src/",
+    "tests/test_release_workflows.py",
+    "uv.lock"
+  ],
+  "packages": [
+    {
+      "name": "agentic-workspace",
+      "pyproject": "pyproject.toml",
+      "wheel_prefix": "agentic_workspace",
+      "sdist_prefix": "agentic_workspace",
+      "payload_schema": "agentic-workspace/payload/v1",
+      "payload_provenance": ".agentic-workspace/payload-provenance.json",
+      "generated_command_contract": "agentic-workspace/command-package-ir/v1"
+    },
+    {
+      "name": "agentic-memory",
+      "pyproject": "packages/memory/pyproject.toml",
+      "wheel_prefix": "agentic_memory",
+      "sdist_prefix": "agentic_memory",
+      "payload_schema": "agentic-memory/payload/v1",
+      "payload_provenance": ".agentic-workspace/memory/UPGRADE-SOURCE.toml",
+      "generated_command_contract": "agentic-workspace/command-package-ir/v1"
+    },
+    {
+      "name": "agentic-planning",
+      "pyproject": "packages/planning/pyproject.toml",
+      "wheel_prefix": "agentic_planning",
+      "sdist_prefix": "agentic_planning",
+      "payload_schema": "agentic-planning/payload/v1",
+      "payload_provenance": ".agentic-workspace/planning/UPGRADE-SOURCE.toml",
+      "generated_command_contract": "agentic-workspace/command-package-ir/v1"
+    },
+    {
+      "name": "agentic-verification",
+      "pyproject": "packages/verification/pyproject.toml",
+      "wheel_prefix": "agentic_verification",
+      "sdist_prefix": "agentic_verification",
+      "payload_schema": "agentic-workspace/verification-manifest/v1",
+      "payload_provenance": ".agentic-workspace/verification/manifest.toml",
+      "generated_command_contract": "agentic-workspace/command-package-ir/v1"
+    }
+  ],
+  "first_coordinated_release": {
+    "floor_version": "0.4.0",
+    "rule": "The first coordinated release must not downgrade any package version."
+  }
+}

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  categories:
+    - title: Compatibility-significant changes
+      labels:
+        - schema
+        - generated-runtime
+        - conformance
+        - compatibility
+    - title: Major changes
+      labels:
+        - semver:major
+    - title: Minor changes
+      labels:
+        - semver:minor
+    - title: Patch changes
+      labels:
+        - semver:patch
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/pr-semver-label.yml
+++ b/.github/workflows/pr-semver-label.yml
@@ -1,0 +1,88 @@
+name: PR Semver Label
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  require-semver-label:
+    name: Require semver label for package changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Validate semver label
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_PATH: ${{ github.event_path }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
+          watched_paths = tuple(ownership["package_affecting_paths"])
+          semver_labels = set(ownership["semver_labels"])
+
+          subprocess.run(
+              ["git", "fetch", "origin", f"{os.environ['BASE_REF']}:refs/remotes/origin/{os.environ['BASE_REF']}"],
+              check=True,
+          )
+          base = subprocess.run(
+              ["git", "merge-base", "HEAD", f"origin/{os.environ['BASE_REF']}"],
+              check=True,
+              capture_output=True,
+              text=True,
+          ).stdout.strip()
+          changed = subprocess.run(
+              ["git", "diff", "--name-only", f"{base}...HEAD"],
+              check=True,
+              capture_output=True,
+              text=True,
+          ).stdout.splitlines()
+          package_changed = any(
+              path == watched or path.startswith(watched)
+              for path in changed
+              for watched in watched_paths
+          )
+
+          if not package_changed:
+              print("No package-affecting changes detected; semver label not required.")
+              raise SystemExit(0)
+
+          with open(os.environ["EVENT_PATH"], encoding="utf-8") as handle:
+              event = json.load(handle)
+          labels = {label["name"] for label in event["pull_request"].get("labels", [])}
+          selected = sorted(labels & semver_labels)
+
+          if len(selected) != 1:
+              print(
+                  "Package-affecting PRs must have exactly one semver label: "
+                  + ", ".join(sorted(semver_labels)),
+                  file=sys.stderr,
+              )
+              print(f"Current semver labels: {selected or 'none'}", file=sys.stderr)
+              print("Changed package paths:", file=sys.stderr)
+              for path in changed:
+                  if any(path == watched or path.startswith(watched) for watched in watched_paths):
+                      print(f"  {path}", file=sys.stderr)
+              raise SystemExit(1)
+
+          print(f"Semver label accepted: {selected[0]}")
+          PY

--- a/.github/workflows/release-from-semver-label.yml
+++ b/.github/workflows/release-from-semver-label.yml
@@ -4,21 +4,27 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
 
 permissions:
   contents: write
-  issues: read
   pull-requests: read
 
 jobs:
   release-from-label:
     name: Bump coordinated workspace version and tag merged package changes
+    if: github.event_name == 'push' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref || github.ref_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
@@ -36,6 +42,8 @@ jobs:
           BEFORE_SHA: ${{ github.event.before }}
           GITHUB_ACTOR: ${{ github.actor }}
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
         run: |
@@ -96,29 +104,73 @@ jobs:
               output("version", version)
               output("tag", f"v{version}")
 
-          message = os.environ["HEAD_COMMIT_MESSAGE"]
-          if os.environ["GITHUB_ACTOR"] == "github-actions[bot]" and re.match(r"^Release v\d+\.\d+\.\d+$", message.strip()):
-              print("Release bump commit detected; no additional release bump needed.")
+          def skip_release(reason: str) -> None:
+              print(f"::notice::{reason}")
               output("release_needed", "false")
               raise SystemExit(0)
 
-          pr_match = re.search(r"Merge pull request #(\d+)", message) or re.search(r"\(#(\d+)\)", message)
-          before = os.environ["BEFORE_SHA"]
-          if not before or set(before) == {"0"}:
-              before = run("git", "rev-list", "--max-parents=0", "HEAD").stdout.splitlines()[0]
-          elif run("git", "cat-file", "-e", f"{before}^{{commit}}", check=False).returncode != 0:
-              before = run("git", "rev-parse", "HEAD^").stdout.strip()
+          def associated_pr_numbers(commit_sha: str) -> list[str]:
+              result = run(
+                  "gh",
+                  "api",
+                  "-H",
+                  "Accept: application/vnd.github+json",
+                  f"repos/{os.environ['REPOSITORY']}/commits/{commit_sha}/pulls",
+                  "--jq",
+                  ".[].number",
+                  check=False,
+              )
+              if result.returncode != 0:
+                  return []
+              return result.stdout.splitlines()
 
-          changed = run("git", "diff", "--name-only", f"{before}...HEAD").stdout.splitlines()
+          event_name = os.environ["GITHUB_EVENT_NAME"]
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          message = os.environ.get("HEAD_COMMIT_MESSAGE", "")
+          if (
+              event_name == "push"
+              and os.environ["GITHUB_ACTOR"] == "github-actions[bot]"
+              and re.match(r"^Release v\d+\.\d+\.\d+$", message.strip())
+          ):
+              skip_release("Release bump commit detected; no additional release bump needed.")
+
+          pr_number = ""
+          selected: list[str] = []
+          if event_name == "pull_request":
+              pull_request = event.get("pull_request", {})
+              if not pull_request.get("merged"):
+                  skip_release("Pull request was closed without merge; no release bump needed.")
+              pr_number = str(pull_request["number"])
+              changed = run(
+                  "gh",
+                  "api",
+                  f"repos/{os.environ['REPOSITORY']}/pulls/{pr_number}/files",
+                  "--paginate",
+                  "--jq",
+                  ".[].filename",
+              ).stdout.splitlines()
+              labels = {label["name"] for label in pull_request.get("labels", [])}
+              selected = sorted(labels & semver_labels)
+          elif event_name == "push":
+              before = os.environ["BEFORE_SHA"]
+              if not before or set(before) == {"0"}:
+                  before = run("git", "rev-list", "--max-parents=0", "HEAD").stdout.splitlines()[0]
+              elif run("git", "cat-file", "-e", f"{before}^{{commit}}", check=False).returncode != 0:
+                  before = run("git", "rev-parse", "HEAD^").stdout.strip()
+              changed = run("git", "diff", "--name-only", f"{before}...HEAD").stdout.splitlines()
+          else:
+              raise SystemExit(f"Unsupported release event: {event_name}")
+
           package_changed = any(
               path == watched or path.startswith(watched)
               for path in changed
               for watched in watched_paths
           )
           if not package_changed:
-              print("No package-affecting changes detected; no release bump needed.")
-              output("release_needed", "false")
-              raise SystemExit(0)
+              skip_release("No package-affecting changes detected; no release bump needed.")
+
+          if event_name == "push" and associated_pr_numbers(event["after"]):
+              skip_release("Package-affecting push is associated with a merged PR; pull_request.closed handles the release decision.")
 
           versions = [version_text(path) for path in package_pyprojects]
           for version in versions:
@@ -127,32 +179,25 @@ jobs:
           current_floor = max_version([current_package_floor, floor_version])
           needs_first_normalization = parse_version(current_package_floor) < parse_version(floor_version)
 
-          if not pr_match:
+          if event_name == "push":
               if not any(path in changed for path in package_pyprojects):
-                  print("Package-affecting direct push did not change package versions; skipping release.")
-                  output("release_needed", "false")
-                  raise SystemExit(0)
+                  skip_release(
+                      "Package-affecting push has no semver-label context and no coordinated explicit version bump."
+                  )
               explicit_versions = {version_text(path) for path in package_pyprojects}
               if len(explicit_versions) != 1:
-                  raise SystemExit(f"Direct release push must set every package to the same version, got {sorted(explicit_versions)}")
+                  skip_release(f"Direct release push must set every package to the same version, got {sorted(explicit_versions)}.")
               current_version = explicit_versions.pop()
               if parse_version(current_version) < parse_version(current_floor):
-                  raise SystemExit(f"Direct release version {current_version} would downgrade below floor {current_floor}")
+                  skip_release(f"Direct release version {current_version} would downgrade below floor {current_floor}.")
               tag = f"v{current_version}"
               if run("git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}", check=False).returncode == 0:
-                  print(f"Explicit release version {current_version} already has tag {tag}; skipping release.")
-                  output("release_needed", "false")
-                  raise SystemExit(0)
+                  skip_release(f"Explicit release version {current_version} already has tag {tag}; skipping release.")
               set_release_outputs(current_version)
               raise SystemExit(0)
 
-          pr_number = pr_match.group(1)
-          labels_json = run("gh", "api", f"repos/{os.environ['REPOSITORY']}/issues/{pr_number}/labels").stdout
-          labels = {label["name"] for label in json.loads(labels_json)}
-          selected = sorted(labels & semver_labels)
           if len(selected) != 1:
-              print(f"PR #{pr_number} must have exactly one semver label before release; got {selected or 'none'}.", file=sys.stderr)
-              raise SystemExit(1)
+              skip_release(f"PR #{pr_number} must have exactly one semver label before release; got {selected or 'none'}.")
 
           if needs_first_normalization:
               next_version = floor_version
@@ -160,7 +205,7 @@ jobs:
               next_version = bump_version(current_floor, selected[0])
           tag = f"v{next_version}"
           if run("git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}", check=False).returncode == 0:
-              raise SystemExit(f"Release tag {tag} already exists.")
+              skip_release(f"Release tag {tag} already exists; skipping release.")
 
           for pyproject in package_pyprojects:
               path = Path(pyproject)

--- a/.github/workflows/release-from-semver-label.yml
+++ b/.github/workflows/release-from-semver-label.yml
@@ -1,0 +1,364 @@
+name: Release From Semver Label
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: read
+
+jobs:
+  release-from-label:
+    name: Bump coordinated workspace version and tag merged package changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Resolve release bump
+        id: release-bump
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
+          watched_paths = tuple(ownership["package_affecting_paths"])
+          semver_labels = set(ownership["semver_labels"])
+          package_pyprojects = [package["pyproject"] for package in ownership["packages"]]
+          floor_version = ownership["first_coordinated_release"]["floor_version"]
+
+          def run(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+              return subprocess.run(args, check=check, capture_output=True, text=True)
+
+          def output(name: str, value: str) -> None:
+              with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+                  handle.write(f"{name}={value}\n")
+
+          def parse_version(version: str) -> tuple[int, int, int]:
+              try:
+                  parts = tuple(int(part) for part in version.split("."))
+              except ValueError:
+                  raise SystemExit(f"Package version must be numeric semver, got {version!r}")
+              if len(parts) != 3:
+                  raise SystemExit(f"Package version must be MAJOR.MINOR.PATCH, got {version!r}")
+              return parts
+
+          def version_text(path: str) -> str:
+              return tomllib.loads(Path(path).read_text(encoding="utf-8"))["project"]["version"]
+
+          def bump_version(version: str, label: str) -> str:
+              major, minor, patch = parse_version(version)
+              if label == "semver:major":
+                  major += 1
+                  minor = 0
+                  patch = 0
+              elif label == "semver:minor":
+                  minor += 1
+                  patch = 0
+              elif label == "semver:patch":
+                  patch += 1
+              else:
+                  raise SystemExit(f"Unsupported semver label: {label}")
+              return f"{major}.{minor}.{patch}"
+
+          def max_version(versions: list[str]) -> str:
+              return sorted(versions, key=parse_version)[-1]
+
+          def set_release_outputs(version: str) -> None:
+              output("release_needed", "true")
+              output("version", version)
+              output("tag", f"v{version}")
+
+          message = os.environ["HEAD_COMMIT_MESSAGE"]
+          if os.environ["GITHUB_ACTOR"] == "github-actions[bot]" and re.match(r"^Release v\d+\.\d+\.\d+$", message.strip()):
+              print("Release bump commit detected; no additional release bump needed.")
+              output("release_needed", "false")
+              raise SystemExit(0)
+
+          pr_match = re.search(r"Merge pull request #(\d+)", message) or re.search(r"\(#(\d+)\)", message)
+          before = os.environ["BEFORE_SHA"]
+          if not before or set(before) == {"0"}:
+              before = run("git", "rev-list", "--max-parents=0", "HEAD").stdout.splitlines()[0]
+          elif run("git", "cat-file", "-e", f"{before}^{{commit}}", check=False).returncode != 0:
+              before = run("git", "rev-parse", "HEAD^").stdout.strip()
+
+          changed = run("git", "diff", "--name-only", f"{before}...HEAD").stdout.splitlines()
+          package_changed = any(
+              path == watched or path.startswith(watched)
+              for path in changed
+              for watched in watched_paths
+          )
+          if not package_changed:
+              print("No package-affecting changes detected; no release bump needed.")
+              output("release_needed", "false")
+              raise SystemExit(0)
+
+          versions = [version_text(path) for path in package_pyprojects]
+          for version in versions:
+              parse_version(version)
+          current_package_floor = max_version(versions)
+          current_floor = max_version([current_package_floor, floor_version])
+          needs_first_normalization = parse_version(current_package_floor) < parse_version(floor_version)
+
+          if not pr_match:
+              if not any(path in changed for path in package_pyprojects):
+                  print("Package-affecting direct push did not change package versions; skipping release.")
+                  output("release_needed", "false")
+                  raise SystemExit(0)
+              explicit_versions = {version_text(path) for path in package_pyprojects}
+              if len(explicit_versions) != 1:
+                  raise SystemExit(f"Direct release push must set every package to the same version, got {sorted(explicit_versions)}")
+              current_version = explicit_versions.pop()
+              if parse_version(current_version) < parse_version(current_floor):
+                  raise SystemExit(f"Direct release version {current_version} would downgrade below floor {current_floor}")
+              tag = f"v{current_version}"
+              if run("git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}", check=False).returncode == 0:
+                  print(f"Explicit release version {current_version} already has tag {tag}; skipping release.")
+                  output("release_needed", "false")
+                  raise SystemExit(0)
+              set_release_outputs(current_version)
+              raise SystemExit(0)
+
+          pr_number = pr_match.group(1)
+          labels_json = run("gh", "api", f"repos/{os.environ['REPOSITORY']}/issues/{pr_number}/labels").stdout
+          labels = {label["name"] for label in json.loads(labels_json)}
+          selected = sorted(labels & semver_labels)
+          if len(selected) != 1:
+              print(f"PR #{pr_number} must have exactly one semver label before release; got {selected or 'none'}.", file=sys.stderr)
+              raise SystemExit(1)
+
+          if needs_first_normalization:
+              next_version = floor_version
+          else:
+              next_version = bump_version(current_floor, selected[0])
+          tag = f"v{next_version}"
+          if run("git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}", check=False).returncode == 0:
+              raise SystemExit(f"Release tag {tag} already exists.")
+
+          for pyproject in package_pyprojects:
+              path = Path(pyproject)
+              text = path.read_text(encoding="utf-8")
+              path.write_text(
+                  re.sub(r'^version = "[^"]+"$', f'version = "{next_version}"', text, count=1, flags=re.MULTILINE),
+                  encoding="utf-8",
+              )
+          set_release_outputs(next_version)
+          output("pr_number", pr_number)
+          output("semver_label", selected[0])
+          PY
+
+      - name: Update lockfile
+        if: steps.release-bump.outputs.release_needed == 'true'
+        run: uv lock
+
+      - name: Install development dependencies
+        if: steps.release-bump.outputs.release_needed == 'true'
+        run: make sync-all
+
+      - name: Run coordinated release proof
+        if: steps.release-bump.outputs.release_needed == 'true'
+        run: |
+          make test-workspace
+          make lint
+          make typecheck
+          make verify
+          uv run python scripts/check/check_generated_command_packages.py
+          uv run python scripts/check/check_no_absolute_paths.py
+
+      - name: Build Agentic Workspace package artifacts
+        if: steps.release-bump.outputs.release_needed == 'true'
+        run: |
+          rm -rf dist
+          mkdir -p dist
+          uv build --wheel --sdist --out-dir dist
+          uv build --wheel --sdist --out-dir dist packages/memory
+          uv build --wheel --sdist --out-dir dist packages/planning
+          uv build --wheel --sdist --out-dir dist packages/verification
+
+      - name: Prove built workspace stack installs outside source tree
+        if: steps.release-bump.outputs.release_needed == 'true'
+        run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence -q
+
+      - name: Generate checksums and release manifest
+        if: steps.release-bump.outputs.release_needed == 'true'
+        env:
+          RELEASE_VERSION: ${{ steps.release-bump.outputs.version }}
+          RELEASE_TAG: ${{ steps.release-bump.outputs.tag }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          import tomllib
+          from pathlib import Path
+
+          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
+          command_generation_dependency = ""
+          root_pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          for dependency in root_pyproject.get("dependency-groups", {}).get("dev", []):
+              if str(dependency).startswith("command-generation @ "):
+                  command_generation_dependency = str(dependency)
+                  break
+          command_generation_version = ""
+          match = re.search(r"command_generation-(?P<version>[0-9][^-/]*)-py3-none-any\\.whl", command_generation_dependency)
+          if match:
+              command_generation_version = match.group("version")
+
+          def sha256(path: Path) -> str:
+              return hashlib.sha256(path.read_bytes()).hexdigest()
+
+          dist = Path("dist")
+          checksum_lines = []
+          package_entries = []
+          version = os.environ["RELEASE_VERSION"]
+          for package in ownership["packages"]:
+              declared = tomllib.loads(Path(package["pyproject"]).read_text(encoding="utf-8"))["project"]["version"]
+              if declared != version:
+                  raise SystemExit(f"{package['pyproject']} has version {declared}, expected {version}")
+              wheel = next(dist.glob(f"{package['wheel_prefix']}-{version}-*.whl"), None)
+              sdist = next(dist.glob(f"{package['sdist_prefix']}-{version}.tar.gz"), None)
+              if wheel is None or sdist is None:
+                  raise SystemExit(f"Missing wheel or sdist for {package['name']} {version}")
+              for artifact in (wheel, sdist):
+                  checksum_lines.append(f"{sha256(artifact)}  {artifact.name}")
+              package_entries.append(
+                  {
+                      "name": package["name"],
+                      "version": version,
+                      "pyproject": package["pyproject"],
+                      "wheel": {"asset": wheel.name, "sha256": sha256(wheel)},
+                      "sdist": {"asset": sdist.name, "sha256": sha256(sdist)},
+                      "payload_schema": package["payload_schema"],
+                      "payload_provenance": package["payload_provenance"],
+                      "generated_command_contract": package["generated_command_contract"],
+                  }
+              )
+
+          manifest = {
+              "kind": "agentic-workspace/coordinated-release-manifest/v1",
+              "release_model": ownership["release_model"],
+              "version": version,
+              "tag": os.environ["RELEASE_TAG"],
+              "all_or_nothing": True,
+              "packages": package_entries,
+              "command_generation": {
+                  "dependency": command_generation_dependency,
+                  "version": command_generation_version,
+                  "runtime_required": False,
+              },
+              "release_ownership": {
+                  "path": ".github/release-ownership.json",
+                  "schema_version": ownership["schema_version"],
+              },
+          }
+          manifest_path = dist / "agentic-workspace-release-manifest.json"
+          manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          checksum_lines.append(f"{sha256(manifest_path)}  {manifest_path.name}")
+          (dist / "SHA256SUMS").write_text("\n".join(checksum_lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Verify release artifacts
+        if: steps.release-bump.outputs.release_needed == 'true'
+        env:
+          RELEASE_VERSION: ${{ steps.release-bump.outputs.version }}
+          RELEASE_TAG: ${{ steps.release-bump.outputs.tag }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          dist = Path("dist")
+          manifest = json.loads((dist / "agentic-workspace-release-manifest.json").read_text(encoding="utf-8"))
+          if manifest["version"] != os.environ["RELEASE_VERSION"] or manifest["tag"] != os.environ["RELEASE_TAG"]:
+              raise SystemExit("Release manifest version/tag mismatch")
+          if len(manifest["packages"]) != 4:
+              raise SystemExit("Release manifest must list every shipped package")
+          checksums = {}
+          for line in (dist / "SHA256SUMS").read_text(encoding="utf-8").splitlines():
+              digest, asset = line.split("  ", 1)
+              checksums[asset] = digest
+          required_assets = {"agentic-workspace-release-manifest.json"}
+          for package in manifest["packages"]:
+              required_assets.add(package["wheel"]["asset"])
+              required_assets.add(package["sdist"]["asset"])
+          missing = sorted(required_assets - set(checksums))
+          if missing:
+              raise SystemExit(f"Missing checksums for release assets: {missing}")
+          for asset in required_assets:
+              digest = hashlib.sha256((dist / asset).read_bytes()).hexdigest()
+              if checksums[asset] != digest:
+                  raise SystemExit(f"Checksum mismatch for {asset}")
+          PY
+
+      - name: Commit version bump and push release tag
+        if: steps.release-bump.outputs.release_needed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml packages/memory/pyproject.toml packages/planning/pyproject.toml packages/verification/pyproject.toml uv.lock
+          RELEASE_DIFF="$(git diff --cached --name-only)"
+          if [ -n "$RELEASE_DIFF" ]; then
+            python - <<'PY'
+          import json
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
+          allowed = set(ownership["release_commit_allowed_paths"])
+          staged = set(subprocess.run(["git", "diff", "--cached", "--name-only"], check=True, capture_output=True, text=True).stdout.splitlines())
+          unexpected = sorted(staged - allowed)
+          if unexpected:
+              print(f"Release commit contains disallowed product changes: {unexpected}", file=sys.stderr)
+              raise SystemExit(1)
+          PY
+            git commit -m "Release ${{ steps.release-bump.outputs.tag }}"
+          fi
+          git tag "${{ steps.release-bump.outputs.tag }}"
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/master)" ]; then
+            git push origin HEAD:master
+          fi
+          git push origin "${{ steps.release-bump.outputs.tag }}"
+
+      - name: Publish GitHub release
+        if: steps.release-bump.outputs.release_needed == 'true'
+        uses: softprops/action-gh-release@v3.0.0
+        with:
+          tag_name: ${{ steps.release-bump.outputs.tag }}
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+            dist/SHA256SUMS
+            dist/agentic-workspace-release-manifest.json
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,17 +30,25 @@ jobs:
         shell: python
         run: |
           import os
+          import json
           import tomllib
           from pathlib import Path
 
           tag = os.environ["GITHUB_REF_NAME"]
-          version = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
-          expected = f"v{version}"
-          if tag != expected:
-              raise SystemExit(f"Release tag {tag!r} must match pyproject.toml version {expected!r}")
+          version = tag.removeprefix("v")
+          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
+          for package in ownership["packages"]:
+              declared = tomllib.loads(Path(package["pyproject"]).read_text(encoding="utf-8"))["project"]["version"]
+              if declared != version:
+                  raise SystemExit(
+                      f"Release tag {tag!r} must match every package version; "
+                      f"{package['pyproject']} declares {declared!r}"
+                  )
 
       - name: Build Agentic Workspace package artifacts
         run: |
+          rm -rf dist
+          mkdir -p dist
           uv build --wheel --sdist --out-dir dist
           uv build --wheel --sdist --out-dir dist packages/memory
           uv build --wheel --sdist --out-dir dist packages/planning
@@ -49,8 +57,121 @@ jobs:
       - name: Run built package smoke tests
         run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_wheel_imports_cli_module tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence -q
 
+      - name: Generate checksums and release manifest
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          import tomllib
+          from pathlib import Path
+
+          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
+          version = os.environ["RELEASE_TAG"].removeprefix("v")
+          root_pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          command_generation_dependency = ""
+          for dependency in root_pyproject.get("dependency-groups", {}).get("dev", []):
+              if str(dependency).startswith("command-generation @ "):
+                  command_generation_dependency = str(dependency)
+                  break
+          match = re.search(r"command_generation-(?P<version>[0-9][^-/]*)-py3-none-any\\.whl", command_generation_dependency)
+          command_generation_version = match.group("version") if match else ""
+
+          def sha256(path: Path) -> str:
+              return hashlib.sha256(path.read_bytes()).hexdigest()
+
+          dist = Path("dist")
+          checksum_lines = []
+          package_entries = []
+          for package in ownership["packages"]:
+              declared = tomllib.loads(Path(package["pyproject"]).read_text(encoding="utf-8"))["project"]["version"]
+              if declared != version:
+                  raise SystemExit(f"{package['pyproject']} has version {declared}, expected {version}")
+              wheel = next(dist.glob(f"{package['wheel_prefix']}-{version}-*.whl"), None)
+              sdist = next(dist.glob(f"{package['sdist_prefix']}-{version}.tar.gz"), None)
+              if wheel is None or sdist is None:
+                  raise SystemExit(f"Missing wheel or sdist for {package['name']} {version}")
+              for artifact in (wheel, sdist):
+                  checksum_lines.append(f"{sha256(artifact)}  {artifact.name}")
+              package_entries.append(
+                  {
+                      "name": package["name"],
+                      "version": version,
+                      "pyproject": package["pyproject"],
+                      "wheel": {"asset": wheel.name, "sha256": sha256(wheel)},
+                      "sdist": {"asset": sdist.name, "sha256": sha256(sdist)},
+                      "payload_schema": package["payload_schema"],
+                      "payload_provenance": package["payload_provenance"],
+                      "generated_command_contract": package["generated_command_contract"],
+                  }
+              )
+
+          manifest = {
+              "kind": "agentic-workspace/coordinated-release-manifest/v1",
+              "release_model": ownership["release_model"],
+              "version": version,
+              "tag": os.environ["RELEASE_TAG"],
+              "all_or_nothing": True,
+              "packages": package_entries,
+              "command_generation": {
+                  "dependency": command_generation_dependency,
+                  "version": command_generation_version,
+                  "runtime_required": False,
+              },
+              "release_ownership": {
+                  "path": ".github/release-ownership.json",
+                  "schema_version": ownership["schema_version"],
+              },
+          }
+          manifest_path = dist / "agentic-workspace-release-manifest.json"
+          manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          checksum_lines.append(f"{sha256(manifest_path)}  {manifest_path.name}")
+          (dist / "SHA256SUMS").write_text("\n".join(checksum_lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Verify release artifacts
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          dist = Path("dist")
+          manifest = json.loads((dist / "agentic-workspace-release-manifest.json").read_text(encoding="utf-8"))
+          if manifest["tag"] != os.environ["RELEASE_TAG"]:
+              raise SystemExit("Release manifest tag mismatch")
+          if len(manifest["packages"]) != 4:
+              raise SystemExit("Release manifest must list every shipped package")
+          checksums = {}
+          for line in (dist / "SHA256SUMS").read_text(encoding="utf-8").splitlines():
+              digest, asset = line.split("  ", 1)
+              checksums[asset] = digest
+          required_assets = {"agentic-workspace-release-manifest.json"}
+          for package in manifest["packages"]:
+              required_assets.add(package["wheel"]["asset"])
+              required_assets.add(package["sdist"]["asset"])
+          missing = sorted(required_assets - set(checksums))
+          if missing:
+              raise SystemExit(f"Missing checksums for release assets: {missing}")
+          for asset in required_assets:
+              digest = hashlib.sha256((dist / asset).read_bytes()).hexdigest()
+              if checksums[asset] != digest:
+                  raise SystemExit(f"Checksum mismatch for {asset}")
+          PY
+
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@v3.0.0
         with:
-          files: dist/*
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+            dist/SHA256SUMS
+            dist/agentic-workspace-release-manifest.json
           generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/docs/release-and-versioning.md
+++ b/docs/release-and-versioning.md
@@ -1,0 +1,109 @@
+# Release And Versioning
+
+Agentic Workspace uses coordinated workspace releases. The root
+`agentic-workspace` package, `agentic-memory`, `agentic-planning`, and
+`agentic-verification` release together under one semver tag.
+
+## Release Goal
+
+The ordinary downstream path should be:
+
+1. CI proves the source tree.
+2. CI builds every workspace wheel and sdist.
+3. CI proves installation from built artifacts outside the source tree.
+4. CI publishes a GitHub Release tagged `vMAJOR.MINOR.PATCH`.
+5. The release contains all wheels, all sdists, `SHA256SUMS`, and
+   `agentic-workspace-release-manifest.json`.
+6. Host repositories can verify release identity, payload provenance, checksums,
+   generated-command contract version, and command-generation dependency from the
+   manifest plus checksums.
+
+## Coordinated Version
+
+`pyproject.toml` at the repo root is the canonical version source. During a
+coordinated release, every shipped package `pyproject.toml` must be normalized to
+that same version before artifacts are built.
+
+The current divergent package versions are release debt. The first coordinated
+release must choose a workspace-wide version that does not downgrade any shipped
+package. The checked-in release ownership manifest records the current floor:
+`0.4.0`.
+
+Independent package releases are out of scope until the repo explicitly changes
+release model and updates the release ownership manifest, workflows, tests, and
+docs together.
+
+## Release Ownership Manifest
+
+`.github/release-ownership.json` owns the machine-readable release policy:
+
+- package-affecting paths;
+- semver labels;
+- release commit allowed paths;
+- shipped package list;
+- per-package artifact prefixes;
+- payload schema or installed-state provenance surfaces;
+- generated-command contract version;
+- first coordinated release floor.
+
+Workflows and tests should read this manifest instead of carrying separate
+workflow-local path lists.
+
+## Semver Labels
+
+Package-affecting PRs must have exactly one semver label:
+
+- `semver:major`
+- `semver:minor`
+- `semver:patch`
+
+The semver label is the maintainer-owned compatibility decision. Docs-only or
+planning-only changes can skip a semver label unless they affect packaged
+behavior, compatibility, release policy, generated outputs, shipped payloads, or
+release workflow behavior.
+
+## Post-Merge Release
+
+After a package-affecting PR merges to `master`, the release workflow:
+
+1. reads `.github/release-ownership.json`;
+2. detects package-affecting paths;
+3. reads the merged PR semver label;
+4. computes the next coordinated version, respecting the first-release floor;
+5. rewrites all package `pyproject.toml` versions to the same value;
+6. updates `uv.lock`;
+7. runs tests, lint, typecheck, generated package proof, and package artifact
+   proof;
+8. builds every wheel and sdist;
+9. generates `SHA256SUMS`;
+10. generates `agentic-workspace-release-manifest.json`;
+11. verifies all release artifacts and metadata before publishing;
+12. commits only version normalization and lockfile changes as `Release vX.Y.Z`;
+13. pushes the tag and publishes the GitHub Release.
+
+The generated release manifest is intentionally not committed. It belongs to the
+release artifact set. The release commit must not mix product behavior changes
+with version normalization.
+
+## Manual Tag Release
+
+A manually pushed `vMAJOR.MINOR.PATCH` tag is allowed only when every shipped
+package already declares that exact version. The tag workflow builds the same
+artifact set, generates checksums and the release manifest, verifies them, and
+publishes the GitHub Release.
+
+## All-Or-Nothing Invariant
+
+Coordinated releases are all-or-nothing. If any package version, lockfile entry,
+generated artifact, wheel, sdist, checksum, release manifest entry, or install
+proof is inconsistent, the workflow must fail before creating or publishing the
+tag or release.
+
+## Payload Provenance
+
+The coordinated workspace release version is the AW release identity. Workspace
+payload provenance records it as `release_identity`, and installed-state
+compatibility compares that payload provenance against the current executable
+version. Host repositories should be able to answer which AW release installed or
+last refreshed `.agentic-workspace/` without reconstructing state from release
+notes or package filenames.

--- a/docs/release-and-versioning.md
+++ b/docs/release-and-versioning.md
@@ -64,7 +64,12 @@ release workflow behavior.
 
 ## Post-Merge Release
 
-After a package-affecting PR merges to `master`, the release workflow:
+After a package-affecting PR merges to `master`, the release workflow runs from
+the `pull_request.closed` event and uses the event payload plus GitHub PR file
+metadata as the release decision source. It must not infer release intent by
+parsing merge commit messages.
+
+For merged package-affecting PRs, the release workflow:
 
 1. reads `.github/release-ownership.json`;
 2. detects package-affecting paths;
@@ -81,9 +86,19 @@ After a package-affecting PR merges to `master`, the release workflow:
 12. commits only version normalization and lockfile changes as `Release vX.Y.Z`;
 13. pushes the tag and publishes the GitHub Release.
 
+The companion `push` event created by a PR merge is ignored when GitHub commit
+metadata links it back to the merged PR; this avoids duplicate release handling
+without relying on merge commit message parsing.
+
 The generated release manifest is intentionally not committed. It belongs to the
 release artifact set. The release commit must not mix product behavior changes
 with version normalization.
+
+Package-affecting direct pushes to `master` are allowed only as an explicit
+version-release path: all shipped package versions must already be updated to the
+same valid version that does not downgrade below the coordinated floor. A
+package-affecting push with neither a merged-PR semver label context nor an
+explicit coordinated version bump exits cleanly without publishing a release.
 
 ## Manual Tag Release
 

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -1595,6 +1595,18 @@
       "checked_in_justification": "Host repository tooling metadata consumed by the external platform or developer tools."
     },
     {
+      "pattern": ".github/release.yml",
+      "format": "yml",
+      "owner": "github-integration",
+      "status": "source-checkout-diagnostic",
+      "schema_or_validator": "GitHub release notes category configuration",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Host-repo release notes configuration is platform metadata, not package runtime state.",
+      "storage_class": "platform-tooling",
+      "checked_in_justification": "Host repository tooling metadata consumed by the external platform or developer tools."
+    },
+    {
       "pattern": ".pre-commit-config.yaml",
       "format": "yaml",
       "owner": "developer-tooling",

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -203,6 +203,18 @@
       "checked_in_justification": "Compact payload provenance is checked in so startup can distinguish observed-compatible payload state from missing-provenance upgrade noise."
     },
     {
+      "pattern": ".github/release-ownership.json",
+      "format": "json",
+      "owner": "release",
+      "status": "typed-validator-backed",
+      "schema_or_validator": "release ownership checker: uv run pytest tests/test_release_workflows.py -q",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Machine-readable coordinated release ownership manifest used by semver-label and release workflows.",
+      "storage_class": "source-of-truth",
+      "checked_in_justification": "Release automation, docs, and tests use this manifest as the source of truth for package-affecting paths and shipped package metadata."
+    },
+    {
       "pattern": ".agentic-workspace/agent-aids/**/manifest.json",
       "format": "json",
       "owner": "agent-aids",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -411,11 +411,20 @@ def _payload_provenance_payload(*, target_root: Path) -> dict[str, Any]:
     return {
         "kind": "agentic-workspace/payload-provenance/v1",
         "payload_schema": WORKSPACE_PAYLOAD_SCHEMA,
+        "release_identity": {
+            "release_model": "coordinated-workspace",
+            "package": "agentic-workspace",
+            "version": __version__,
+            "tag": f"v{__version__}",
+        },
         "installed_by": _payload_installer_identity(target_root=target_root),
         "command_generation": _command_generation_package_identity(),
         "installed_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
         "payload_files": [relative.as_posix() for relative in WORKSPACE_PAYLOAD_FILES],
-        "rule": "Repo payload provenance records the executable/source identity that installed or last synced the AW payload.",
+        "rule": (
+            "Repo payload provenance records the coordinated AW release identity and executable/source identity "
+            "that installed or last synced the AW payload."
+        ),
     }
 
 
@@ -457,6 +466,26 @@ def _validate_payload_provenance(payload: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     if payload.get("payload_schema") != WORKSPACE_PAYLOAD_SCHEMA:
         errors.append("payload_schema must be agentic-workspace/payload/v1")
+    release_identity = payload.get("release_identity")
+    if not isinstance(release_identity, dict):
+        errors.append("release_identity must be an object")
+    else:
+        required_release_identity = {
+            "release_model": "coordinated-workspace",
+            "package": "agentic-workspace",
+            "version": None,
+            "tag": None,
+        }
+        for field, expected in required_release_identity.items():
+            value = release_identity.get(field)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"release_identity.{field} must be a non-empty string")
+            elif isinstance(expected, str) and value != expected:
+                errors.append(f"release_identity.{field} must be {expected}")
+        version = release_identity.get("version") if isinstance(release_identity.get("version"), str) else ""
+        tag = release_identity.get("tag") if isinstance(release_identity.get("tag"), str) else ""
+        if version and tag and tag != f"v{version}":
+            errors.append("release_identity.tag must match release_identity.version")
     installed_by = payload.get("installed_by")
     if not isinstance(installed_by, dict):
         errors.append("installed_by must be an object")
@@ -714,8 +743,15 @@ def _installed_state_compatibility_payload(
     payload_warnings = list((summary or {}).get("warnings", []))
     provenance_status = _read_payload_provenance(target_root=config.target_root)
     provenance_payload = provenance_status.get("payload") if isinstance(provenance_status.get("payload"), dict) else {}
+    release_identity = provenance_payload.get("release_identity", {}) if isinstance(provenance_payload, dict) else {}
     installed_by = provenance_payload.get("installed_by", {}) if isinstance(provenance_payload, dict) else {}
-    installed_version = str(installed_by.get("version", "")) if isinstance(installed_by, dict) else ""
+    installed_version = (
+        str(release_identity.get("version", ""))
+        if isinstance(release_identity, dict) and release_identity.get("version")
+        else str(installed_by.get("version", ""))
+        if isinstance(installed_by, dict)
+        else ""
+    )
     current_identity = _payload_installer_identity(target_root=config.target_root)
     initialized_payload_present = (config.target_root / WORKSPACE_CONFIG_PATH).is_file() or bool(installed_modules)
     payload_provenance_drift = "none"
@@ -786,6 +822,7 @@ def _installed_state_compatibility_payload(
         },
         "payload": {
             "status": payload_status,
+            "release_identity": release_identity if isinstance(release_identity, dict) else {},
             "selected_modules": list(selected_modules),
             "installed_modules": list(installed_modules),
             "warning_count": len(payload_warnings),

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import fnmatch
+import json
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_ROOT = ROOT / ".github" / "workflows"
+OWNERSHIP_PATH = ROOT / ".github" / "release-ownership.json"
+
+
+def _ownership() -> dict[str, object]:
+    return json.loads(OWNERSHIP_PATH.read_text(encoding="utf-8"))
+
+
+def _release_asset_patterns(workflow: str) -> list[str]:
+    lines = workflow.splitlines()
+    files_line = lines.index("          files: |")
+    patterns: list[str] = []
+    for line in lines[files_line + 1 :]:
+        if not line.startswith("            "):
+            break
+        patterns.append(line.strip())
+    return patterns
+
+
+def _matching_release_assets(patterns: list[str], assets: list[str]) -> list[str]:
+    return [asset for asset in assets if any(fnmatch.fnmatchcase(asset, pattern) for pattern in patterns)]
+
+
+def test_release_ownership_manifest_declares_coordinated_workspace_packages() -> None:
+    ownership = _ownership()
+
+    assert ownership["schema_version"] == "agentic-workspace/release-ownership/v1"
+    assert ownership["release_model"] == "coordinated-workspace"
+    assert ownership["canonical_version_source"] == "pyproject.toml"
+    assert ownership["semver_labels"] == ["semver:major", "semver:minor", "semver:patch"]
+    assert ownership["first_coordinated_release"]["floor_version"] == "0.4.0"
+
+    package_names = [package["name"] for package in ownership["packages"]]
+    assert package_names == [
+        "agentic-workspace",
+        "agentic-memory",
+        "agentic-planning",
+        "agentic-verification",
+    ]
+    for package in ownership["packages"]:
+        assert package["pyproject"]
+        assert package["wheel_prefix"]
+        assert package["sdist_prefix"]
+        assert package["payload_schema"]
+        assert package["payload_provenance"]
+        assert package["generated_command_contract"] == "agentic-workspace/command-package-ir/v1"
+
+
+def test_package_affecting_scope_is_manifest_owned_and_covers_release_surfaces() -> None:
+    paths = set(_ownership()["package_affecting_paths"])
+
+    assert ".github/release-ownership.json" in paths
+    assert ".github/workflows/pr-semver-label.yml" in paths
+    assert ".github/workflows/release-from-semver-label.yml" in paths
+    assert ".github/workflows/release.yml" in paths
+    assert "docs/release-and-versioning.md" in paths
+    assert "generated/" in paths
+    assert "packages/" in paths
+    assert "src/" in paths
+    assert "tests/test_release_workflows.py" in paths
+    assert "uv.lock" in paths
+
+
+def test_pr_semver_label_workflow_uses_release_ownership_manifest() -> None:
+    workflow = (WORKFLOW_ROOT / "pr-semver-label.yml").read_text(encoding="utf-8")
+
+    assert "pull_request:" in workflow
+    assert "labeled" in workflow
+    assert "unlabeled" in workflow
+    assert ".github/release-ownership.json" in workflow
+    assert 'ownership["package_affecting_paths"]' in workflow
+    assert 'ownership["semver_labels"]' in workflow
+    assert "must have exactly one semver label" in workflow
+
+
+def test_post_merge_release_workflow_bumps_all_packages_from_pr_label() -> None:
+    workflow = (WORKFLOW_ROOT / "release-from-semver-label.yml").read_text(encoding="utf-8")
+
+    assert "branches:" in workflow
+    assert "master" in workflow
+    assert "contents: write" in workflow
+    assert "issues: read" in workflow
+    assert "pull-requests: read" in workflow
+    assert ".github/release-ownership.json" in workflow
+    assert 'ownership["packages"]' in workflow
+    assert 'ownership["first_coordinated_release"]["floor_version"]' in workflow
+    assert "Merge pull request #(\\d+)" in workflow
+    assert "Package-affecting direct push did not change package versions" in workflow
+    assert "must have exactly one semver label before release" in workflow
+    assert "for pyproject in package_pyprojects:" in workflow
+    assert "uv lock" in workflow
+    assert "make test-workspace" in workflow
+    assert "make lint" in workflow
+    assert "make typecheck" in workflow
+    assert "make verify" in workflow
+    assert "check_generated_command_packages.py" in workflow
+    assert "check_no_absolute_paths.py" in workflow
+    assert "agentic-workspace-release-manifest.json" in workflow
+    assert "SHA256SUMS" in workflow
+    assert "Release commit contains disallowed product changes" in workflow
+    assert 'git commit -m "Release ${{ steps.release-bump.outputs.tag }}"' in workflow
+    assert 'git push origin "${{ steps.release-bump.outputs.tag }}"' in workflow
+    assert "softprops/action-gh-release@v3.0.0" in workflow
+
+
+def test_manual_release_workflow_verifies_all_package_versions_and_assets() -> None:
+    workflow = (WORKFLOW_ROOT / "release.yml").read_text(encoding="utf-8")
+
+    assert '"v[0-9]+.[0-9]+.[0-9]+"' in workflow
+    assert ".github/release-ownership.json" in workflow
+    assert "must match every package version" in workflow
+    assert "uv build --wheel --sdist --out-dir dist" in workflow
+    assert "uv build --wheel --sdist --out-dir dist packages/memory" in workflow
+    assert "uv build --wheel --sdist --out-dir dist packages/planning" in workflow
+    assert "uv build --wheel --sdist --out-dir dist packages/verification" in workflow
+    assert "agentic-workspace-release-manifest.json" in workflow
+    assert "SHA256SUMS" in workflow
+    assert "Missing checksums for release assets" in workflow
+    assert "softprops/action-gh-release@v3.0.0" in workflow
+    assert "fail_on_unmatched_files: true" in workflow
+
+
+def test_release_asset_patterns_exclude_incidental_dist_files() -> None:
+    workflow = (WORKFLOW_ROOT / "release.yml").read_text(encoding="utf-8")
+
+    patterns = _release_asset_patterns(workflow)
+
+    assert _matching_release_assets(
+        patterns,
+        [
+            "dist/agentic_workspace-0.4.0-py3-none-any.whl",
+            "dist/agentic_workspace-0.4.0.tar.gz",
+            "dist/agentic_memory-0.4.0-py3-none-any.whl",
+            "dist/agentic_memory-0.4.0.tar.gz",
+            "dist/agentic-workspace-release-manifest.json",
+            "dist/SHA256SUMS",
+            "dist/.gitignore",
+            "dist/default.gitignore",
+            "dist/agentic_workspace-0.4.0-py3-none-any.whl.sha256",
+        ],
+    ) == [
+        "dist/agentic_workspace-0.4.0-py3-none-any.whl",
+        "dist/agentic_workspace-0.4.0.tar.gz",
+        "dist/agentic_memory-0.4.0-py3-none-any.whl",
+        "dist/agentic_memory-0.4.0.tar.gz",
+        "dist/agentic-workspace-release-manifest.json",
+        "dist/SHA256SUMS",
+    ]
+
+
+def test_release_notes_classify_compatibility_significant_changes() -> None:
+    release_config = (ROOT / ".github" / "release.yml").read_text(encoding="utf-8")
+
+    assert "Compatibility-significant changes" in release_config
+    assert "schema" in release_config
+    assert "generated-runtime" in release_config
+    assert "conformance" in release_config
+    assert "compatibility" in release_config
+
+
+def test_release_workflows_prevent_coordinated_version_drift_at_release_time() -> None:
+    ownership = _ownership()
+    release_workflow = (WORKFLOW_ROOT / "release.yml").read_text(encoding="utf-8")
+    post_merge_workflow = (WORKFLOW_ROOT / "release-from-semver-label.yml").read_text(encoding="utf-8")
+
+    assert "if declared != version:" in release_workflow
+    assert "Direct release push must set every package to the same version" in post_merge_workflow
+    assert "would downgrade below floor" in post_merge_workflow
+    assert "for pyproject in package_pyprojects:" in post_merge_workflow
+    assert sorted(ownership["release_commit_allowed_paths"]) == [
+        "packages/memory/pyproject.toml",
+        "packages/planning/pyproject.toml",
+        "packages/verification/pyproject.toml",
+        "pyproject.toml",
+        "uv.lock",
+    ]
+
+
+def test_post_merge_release_uses_floor_for_first_coordinated_normalization() -> None:
+    workflow = (WORKFLOW_ROOT / "release-from-semver-label.yml").read_text(encoding="utf-8")
+
+    assert "needs_first_normalization" in workflow
+    assert "current_package_floor" in workflow
+    assert "next_version = floor_version" in workflow
+    assert "else:" in workflow
+    assert "next_version = bump_version(current_floor, selected[0])" in workflow
+
+
+def test_current_versions_have_no_downgrade_floor_for_first_coordinated_release() -> None:
+    ownership = _ownership()
+    versions = [
+        tomllib.loads((ROOT / package["pyproject"]).read_text(encoding="utf-8"))["project"]["version"] for package in ownership["packages"]
+    ]
+    floor = ownership["first_coordinated_release"]["floor_version"]
+
+    assert tuple(int(part) for part in floor.split(".")) >= max(tuple(int(part) for part in version.split(".")) for version in versions)

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -86,14 +86,23 @@ def test_post_merge_release_workflow_bumps_all_packages_from_pr_label() -> None:
 
     assert "branches:" in workflow
     assert "master" in workflow
+    assert "pull_request:" in workflow
+    assert "closed" in workflow
+    assert "github.event.pull_request.merged == true" in workflow
     assert "contents: write" in workflow
-    assert "issues: read" in workflow
     assert "pull-requests: read" in workflow
     assert ".github/release-ownership.json" in workflow
     assert 'ownership["packages"]' in workflow
     assert 'ownership["first_coordinated_release"]["floor_version"]' in workflow
-    assert "Merge pull request #(\\d+)" in workflow
-    assert "Package-affecting direct push did not change package versions" in workflow
+    assert 'pull_request.get("labels", [])' in workflow
+    assert ".[].filename" in workflow
+    assert "associated_pr_numbers" in workflow
+    assert "commits/{commit_sha}/pulls" in workflow
+    assert "pull_request.closed handles the release decision" in workflow
+    assert "def skip_release(reason: str) -> None:" in workflow
+    assert 'output("release_needed", "false")' in workflow
+    assert "Merge pull request #" not in workflow
+    assert "Package-affecting push has no semver-label context and no coordinated explicit version bump" in workflow
     assert "must have exactly one semver label before release" in workflow
     assert "for pyproject in package_pyprojects:" in workflow
     assert "uv lock" in workflow

--- a/tests/test_workspace_packaging.py
+++ b/tests/test_workspace_packaging.py
@@ -167,11 +167,14 @@ def test_release_workflow_publishes_tagged_root_package_artifacts() -> None:
     release_text = (WORKSPACE_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
     assert '"v[0-9]+.[0-9]+.[0-9]+"' in release_text
-    assert "Release tag {tag!r} must match pyproject.toml version {expected!r}" in release_text
+    assert "must match every package version" in release_text
+    assert ".github/release-ownership.json" in release_text
     assert "uv build --wheel --sdist --out-dir dist" in release_text
     assert "uv build --wheel --sdist --out-dir dist packages/memory" in release_text
     assert "uv build --wheel --sdist --out-dir dist packages/planning" in release_text
     assert "uv build --wheel --sdist --out-dir dist packages/verification" in release_text
+    assert "agentic-workspace-release-manifest.json" in release_text
+    assert "SHA256SUMS" in release_text
     assert "softprops/action-gh-release@v3.0.0" in release_text
 
 


### PR DESCRIPTION
## Summary
- Add a checked-in release ownership manifest that defines the coordinated workspace package set, semver labels, package-affecting paths, release commit scope, and first release floor.
- Add PR semver-label enforcement plus post-merge release automation that bumps all workspace packages together, proves the all-or-nothing release, builds every wheel/sdist, emits `agentic-workspace-release-manifest.json` and `SHA256SUMS`, constrains the release commit, tags, and publishes.
- Update manual tag release validation/assets, installed-state payload provenance release identity, structured inventory, release docs, and static release workflow tests.

Fixes #1596

## Validation
- `uv run pytest tests/test_release_workflows.py tests/test_workspace_packaging.py::test_release_workflow_publishes_tagged_root_package_artifacts -q`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py tests/test_release_workflows.py tests/test_workspace_packaging.py`
- `uv run python scripts/check/check_no_absolute_paths.py`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `make lint`
- YAML parse for `.github/workflows/pr-semver-label.yml`, `.github/workflows/release-from-semver-label.yml`, `.github/workflows/release.yml`, and `.github/release.yml`