### PR TITLE
Release TypeScript CLI packages with coordinated workspace versions

### DIFF
--- a/.github/release-ownership.json
+++ b/.github/release-ownership.json
@@ -12,6 +12,10 @@
     "packages/memory/pyproject.toml",
     "packages/planning/pyproject.toml",
     "packages/verification/pyproject.toml",
+    "generated/workspace/typescript/package.json",
+    "generated/memory/typescript/package.json",
+    "generated/planning/typescript/package.json",
+    "generated/verification/typescript/package.json",
     "uv.lock"
   ],
   "package_affecting_paths": [
@@ -64,6 +68,64 @@
       "sdist_prefix": "agentic_verification",
       "payload_schema": "agentic-workspace/verification-manifest/v1",
       "payload_provenance": ".agentic-workspace/verification/manifest.toml",
+      "generated_command_contract": "agentic-workspace/command-package-ir/v1"
+    }
+  ],
+  "typescript_packages": [
+    {
+      "name": "@agentic-workspace/workspace-cli",
+      "package_json": "generated/workspace/typescript/package.json",
+      "package_root": "generated/workspace/typescript",
+      "tarball_prefix": "agentic-workspace-workspace-cli",
+      "entrypoints": [
+        "agentic-workspace"
+      ],
+      "python_package": "agentic-workspace",
+      "runtime": "node",
+      "runtime_requirement": "node>=20",
+      "release_policy": "pack-and-publishable",
+      "generated_command_contract": "agentic-workspace/command-package-ir/v1"
+    },
+    {
+      "name": "@agentic-workspace/memory-cli",
+      "package_json": "generated/memory/typescript/package.json",
+      "package_root": "generated/memory/typescript",
+      "tarball_prefix": "agentic-workspace-memory-cli",
+      "entrypoints": [
+        "agentic-memory"
+      ],
+      "python_package": "agentic-memory",
+      "runtime": "node",
+      "runtime_requirement": "node>=20",
+      "release_policy": "pack-and-publishable",
+      "generated_command_contract": "agentic-workspace/command-package-ir/v1"
+    },
+    {
+      "name": "@agentic-workspace/planning-cli",
+      "package_json": "generated/planning/typescript/package.json",
+      "package_root": "generated/planning/typescript",
+      "tarball_prefix": "agentic-workspace-planning-cli",
+      "entrypoints": [
+        "agentic-planning"
+      ],
+      "python_package": "agentic-planning",
+      "runtime": "node",
+      "runtime_requirement": "node>=20",
+      "release_policy": "pack-and-publishable",
+      "generated_command_contract": "agentic-workspace/command-package-ir/v1"
+    },
+    {
+      "name": "@agentic-workspace/verification-cli",
+      "package_json": "generated/verification/typescript/package.json",
+      "package_root": "generated/verification/typescript",
+      "tarball_prefix": "agentic-workspace-verification-cli",
+      "entrypoints": [
+        "agentic-verification"
+      ],
+      "python_package": "agentic-verification",
+      "runtime": "node",
+      "runtime_requirement": "node>=20",
+      "release_policy": "pack-and-publishable",
       "generated_command_contract": "agentic-workspace/command-package-ir/v1"
     }
   ],

--- a/.github/workflows/release-from-semver-label.yml
+++ b/.github/workflows/release-from-semver-label.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+
       - name: Resolve release bump
         id: release-bump
         env:
@@ -60,6 +65,7 @@ jobs:
           watched_paths = tuple(ownership["package_affecting_paths"])
           semver_labels = set(ownership["semver_labels"])
           package_pyprojects = [package["pyproject"] for package in ownership["packages"]]
+          typescript_package_jsons = [package["package_json"] for package in ownership["typescript_packages"]]
           floor_version = ownership["first_coordinated_release"]["floor_version"]
 
           def run(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -80,6 +86,9 @@ jobs:
 
           def version_text(path: str) -> str:
               return tomllib.loads(Path(path).read_text(encoding="utf-8"))["project"]["version"]
+
+          def package_json_version_text(path: str) -> str:
+              return json.loads(Path(path).read_text(encoding="utf-8"))["version"]
 
           def bump_version(version: str, label: str) -> str:
               major, minor, patch = parse_version(version)
@@ -172,7 +181,9 @@ jobs:
           if event_name == "push" and associated_pr_numbers(event["after"]):
               skip_release("Package-affecting push is associated with a merged PR; pull_request.closed handles the release decision.")
 
-          versions = [version_text(path) for path in package_pyprojects]
+          versions = [version_text(path) for path in package_pyprojects] + [
+              package_json_version_text(path) for path in typescript_package_jsons
+          ]
           for version in versions:
               parse_version(version)
           current_package_floor = max_version(versions)
@@ -180,11 +191,14 @@ jobs:
           needs_first_normalization = parse_version(current_package_floor) < parse_version(floor_version)
 
           if event_name == "push":
-              if not any(path in changed for path in package_pyprojects):
+              version_files = [*package_pyprojects, *typescript_package_jsons]
+              if not any(path in changed for path in version_files):
                   skip_release(
                       "Package-affecting push has no semver-label context and no coordinated explicit version bump."
                   )
-              explicit_versions = {version_text(path) for path in package_pyprojects}
+              explicit_versions = {version_text(path) for path in package_pyprojects} | {
+                  package_json_version_text(path) for path in typescript_package_jsons
+              }
               if len(explicit_versions) != 1:
                   skip_release(f"Direct release push must set every package to the same version, got {sorted(explicit_versions)}.")
               current_version = explicit_versions.pop()
@@ -214,6 +228,11 @@ jobs:
                   re.sub(r'^version = "[^"]+"$', f'version = "{next_version}"', text, count=1, flags=re.MULTILINE),
                   encoding="utf-8",
               )
+          for package_json in typescript_package_jsons:
+              path = Path(package_json)
+              payload = json.loads(path.read_text(encoding="utf-8"))
+              payload["version"] = next_version
+              path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
           set_release_outputs(next_version)
           output("pr_number", pr_number)
           output("semver_label", selected[0])
@@ -235,6 +254,9 @@ jobs:
           make typecheck
           make verify
           uv run python scripts/check/check_generated_command_packages.py
+          for package in generated/*/typescript; do
+            (cd "$package" && npm test)
+          done
           uv run python scripts/check/check_no_absolute_paths.py
 
       - name: Build Agentic Workspace package artifacts
@@ -246,6 +268,9 @@ jobs:
           uv build --wheel --sdist --out-dir dist packages/memory
           uv build --wheel --sdist --out-dir dist packages/planning
           uv build --wheel --sdist --out-dir dist packages/verification
+          for package in generated/*/typescript; do
+            (cd "$package" && npm pack --pack-destination "$GITHUB_WORKSPACE/dist")
+          done
 
       - name: Prove built workspace stack installs outside source tree
         if: steps.release-bump.outputs.release_needed == 'true'
@@ -297,12 +322,40 @@ jobs:
               package_entries.append(
                   {
                       "name": package["name"],
+                      "ecosystem": "python",
                       "version": version,
                       "pyproject": package["pyproject"],
                       "wheel": {"asset": wheel.name, "sha256": sha256(wheel)},
                       "sdist": {"asset": sdist.name, "sha256": sha256(sdist)},
                       "payload_schema": package["payload_schema"],
                       "payload_provenance": package["payload_provenance"],
+                      "generated_command_contract": package["generated_command_contract"],
+                  }
+              )
+          for package in ownership["typescript_packages"]:
+              package_json = json.loads(Path(package["package_json"]).read_text(encoding="utf-8"))
+              declared = package_json["version"]
+              if declared != version:
+                  raise SystemExit(f"{package['package_json']} has version {declared}, expected {version}")
+              if package_json.get("private") is not False:
+                  raise SystemExit(f"{package['package_json']} must be publishable for coordinated release")
+              tarball = next(dist.glob(f"{package['tarball_prefix']}-{version}.tgz"), None)
+              if tarball is None:
+                  raise SystemExit(f"Missing npm tarball for {package['name']} {version}")
+              checksum_lines.append(f"{sha256(tarball)}  {tarball.name}")
+              package_entries.append(
+                  {
+                      "name": package["name"],
+                      "ecosystem": "npm",
+                      "version": version,
+                      "package_json": package["package_json"],
+                      "package_root": package["package_root"],
+                      "tarball": {"asset": tarball.name, "sha256": sha256(tarball)},
+                      "entrypoints": package["entrypoints"],
+                      "python_package": package["python_package"],
+                      "runtime": package["runtime"],
+                      "runtime_requirement": package["runtime_requirement"],
+                      "release_policy": package["release_policy"],
                       "generated_command_contract": package["generated_command_contract"],
                   }
               )
@@ -346,7 +399,9 @@ jobs:
           manifest = json.loads((dist / "agentic-workspace-release-manifest.json").read_text(encoding="utf-8"))
           if manifest["version"] != os.environ["RELEASE_VERSION"] or manifest["tag"] != os.environ["RELEASE_TAG"]:
               raise SystemExit("Release manifest version/tag mismatch")
-          if len(manifest["packages"]) != 4:
+          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
+          expected_package_count = len(ownership["packages"]) + len(ownership["typescript_packages"])
+          if len(manifest["packages"]) != expected_package_count:
               raise SystemExit("Release manifest must list every shipped package")
           checksums = {}
           for line in (dist / "SHA256SUMS").read_text(encoding="utf-8").splitlines():
@@ -354,8 +409,11 @@ jobs:
               checksums[asset] = digest
           required_assets = {"agentic-workspace-release-manifest.json"}
           for package in manifest["packages"]:
-              required_assets.add(package["wheel"]["asset"])
-              required_assets.add(package["sdist"]["asset"])
+              if package.get("ecosystem") == "npm":
+                  required_assets.add(package["tarball"]["asset"])
+              else:
+                  required_assets.add(package["wheel"]["asset"])
+                  required_assets.add(package["sdist"]["asset"])
           missing = sorted(required_assets - set(checksums))
           if missing:
               raise SystemExit(f"Missing checksums for release assets: {missing}")
@@ -370,7 +428,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml packages/memory/pyproject.toml packages/planning/pyproject.toml packages/verification/pyproject.toml uv.lock
+          git add pyproject.toml packages/memory/pyproject.toml packages/planning/pyproject.toml packages/verification/pyproject.toml generated/workspace/typescript/package.json generated/memory/typescript/package.json generated/planning/typescript/package.json generated/verification/typescript/package.json uv.lock
           RELEASE_DIFF="$(git diff --cached --name-only)"
           if [ -n "$RELEASE_DIFF" ]; then
             python - <<'PY'
@@ -403,6 +461,7 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
+            dist/*.tgz
             dist/SHA256SUMS
             dist/agentic-workspace-release-manifest.json
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+
       - name: Sync workspace dependencies
         run: make sync-all
 
@@ -44,6 +49,16 @@ jobs:
                       f"Release tag {tag!r} must match every package version; "
                       f"{package['pyproject']} declares {declared!r}"
                   )
+          for package in ownership["typescript_packages"]:
+              payload = json.loads(Path(package["package_json"]).read_text(encoding="utf-8"))
+              declared = payload["version"]
+              if declared != version:
+                  raise SystemExit(
+                      f"Release tag {tag!r} must match every TypeScript package version; "
+                      f"{package['package_json']} declares {declared!r}"
+                  )
+              if payload.get("private") is not False:
+                  raise SystemExit(f"{package['package_json']} must be publishable for coordinated release")
 
       - name: Build Agentic Workspace package artifacts
         run: |
@@ -53,6 +68,9 @@ jobs:
           uv build --wheel --sdist --out-dir dist packages/memory
           uv build --wheel --sdist --out-dir dist packages/planning
           uv build --wheel --sdist --out-dir dist packages/verification
+          for package in generated/*/typescript; do
+            (cd "$package" && npm test && npm pack --pack-destination "$GITHUB_WORKSPACE/dist")
+          done
 
       - name: Run built package smoke tests
         run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_wheel_imports_cli_module tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence -q
@@ -99,12 +117,40 @@ jobs:
               package_entries.append(
                   {
                       "name": package["name"],
+                      "ecosystem": "python",
                       "version": version,
                       "pyproject": package["pyproject"],
                       "wheel": {"asset": wheel.name, "sha256": sha256(wheel)},
                       "sdist": {"asset": sdist.name, "sha256": sha256(sdist)},
                       "payload_schema": package["payload_schema"],
                       "payload_provenance": package["payload_provenance"],
+                      "generated_command_contract": package["generated_command_contract"],
+                  }
+              )
+          for package in ownership["typescript_packages"]:
+              package_json = json.loads(Path(package["package_json"]).read_text(encoding="utf-8"))
+              declared = package_json["version"]
+              if declared != version:
+                  raise SystemExit(f"{package['package_json']} has version {declared}, expected {version}")
+              if package_json.get("private") is not False:
+                  raise SystemExit(f"{package['package_json']} must be publishable for coordinated release")
+              tarball = next(dist.glob(f"{package['tarball_prefix']}-{version}.tgz"), None)
+              if tarball is None:
+                  raise SystemExit(f"Missing npm tarball for {package['name']} {version}")
+              checksum_lines.append(f"{sha256(tarball)}  {tarball.name}")
+              package_entries.append(
+                  {
+                      "name": package["name"],
+                      "ecosystem": "npm",
+                      "version": version,
+                      "package_json": package["package_json"],
+                      "package_root": package["package_root"],
+                      "tarball": {"asset": tarball.name, "sha256": sha256(tarball)},
+                      "entrypoints": package["entrypoints"],
+                      "python_package": package["python_package"],
+                      "runtime": package["runtime"],
+                      "runtime_requirement": package["runtime_requirement"],
+                      "release_policy": package["release_policy"],
                       "generated_command_contract": package["generated_command_contract"],
                   }
               )
@@ -146,7 +192,9 @@ jobs:
           manifest = json.loads((dist / "agentic-workspace-release-manifest.json").read_text(encoding="utf-8"))
           if manifest["tag"] != os.environ["RELEASE_TAG"]:
               raise SystemExit("Release manifest tag mismatch")
-          if len(manifest["packages"]) != 4:
+          ownership = json.loads(Path(".github/release-ownership.json").read_text(encoding="utf-8"))
+          expected_package_count = len(ownership["packages"]) + len(ownership["typescript_packages"])
+          if len(manifest["packages"]) != expected_package_count:
               raise SystemExit("Release manifest must list every shipped package")
           checksums = {}
           for line in (dist / "SHA256SUMS").read_text(encoding="utf-8").splitlines():
@@ -154,8 +202,11 @@ jobs:
               checksums[asset] = digest
           required_assets = {"agentic-workspace-release-manifest.json"}
           for package in manifest["packages"]:
-              required_assets.add(package["wheel"]["asset"])
-              required_assets.add(package["sdist"]["asset"])
+              if package.get("ecosystem") == "npm":
+                  required_assets.add(package["tarball"]["asset"])
+              else:
+                  required_assets.add(package["wheel"]["asset"])
+                  required_assets.add(package["sdist"]["asset"])
           missing = sorted(required_assets - set(checksums))
           if missing:
               raise SystemExit(f"Missing checksums for release assets: {missing}")
@@ -171,6 +222,7 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
+            dist/*.tgz
             dist/SHA256SUMS
             dist/agentic-workspace-release-manifest.json
           generate_release_notes: true

--- a/docs/release-and-versioning.md
+++ b/docs/release-and-versioning.md
@@ -2,18 +2,19 @@
 
 Agentic Workspace uses coordinated workspace releases. The root
 `agentic-workspace` package, `agentic-memory`, `agentic-planning`, and
-`agentic-verification` release together under one semver tag.
+`agentic-verification` release together under one semver tag, with both Python
+and TypeScript CLI distributions treated as first-class release artifacts.
 
 ## Release Goal
 
 The ordinary downstream path should be:
 
 1. CI proves the source tree.
-2. CI builds every workspace wheel and sdist.
+2. CI builds every workspace wheel, sdist, and TypeScript npm package tarball.
 3. CI proves installation from built artifacts outside the source tree.
 4. CI publishes a GitHub Release tagged `vMAJOR.MINOR.PATCH`.
-5. The release contains all wheels, all sdists, `SHA256SUMS`, and
-   `agentic-workspace-release-manifest.json`.
+5. The release contains all wheels, all sdists, all npm tarballs,
+   `SHA256SUMS`, and `agentic-workspace-release-manifest.json`.
 6. Host repositories can verify release identity, payload provenance, checksums,
    generated-command contract version, and command-generation dependency from the
    manifest plus checksums.
@@ -21,8 +22,9 @@ The ordinary downstream path should be:
 ## Coordinated Version
 
 `pyproject.toml` at the repo root is the canonical version source. During a
-coordinated release, every shipped package `pyproject.toml` must be normalized to
-that same version before artifacts are built.
+coordinated release, every shipped Python package `pyproject.toml` and generated
+TypeScript CLI `package.json` must be normalized to that same version before
+artifacts are built.
 
 The current divergent package versions are release debt. The first coordinated
 release must choose a workspace-wide version that does not downgrade any shipped
@@ -40,8 +42,10 @@ docs together.
 - package-affecting paths;
 - semver labels;
 - release commit allowed paths;
-- shipped package list;
+- shipped Python and TypeScript package lists;
 - per-package artifact prefixes;
+- TypeScript package roots, tarball prefixes, runtime requirements, and publish
+  policy;
 - payload schema or installed-state provenance surfaces;
 - generated-command contract version;
 - first coordinated release floor.
@@ -75,11 +79,12 @@ For merged package-affecting PRs, the release workflow:
 2. detects package-affecting paths;
 3. reads the merged PR semver label;
 4. computes the next coordinated version, respecting the first-release floor;
-5. rewrites all package `pyproject.toml` versions to the same value;
+5. rewrites all package `pyproject.toml` and TypeScript `package.json` versions
+   to the same value;
 6. updates `uv.lock`;
-7. runs tests, lint, typecheck, generated package proof, and package artifact
-   proof;
-8. builds every wheel and sdist;
+7. runs tests, lint, typecheck, generated package proof, TypeScript package
+   tests, and package artifact proof;
+8. builds every wheel, sdist, and TypeScript npm tarball;
 9. generates `SHA256SUMS`;
 10. generates `agentic-workspace-release-manifest.json`;
 11. verifies all release artifacts and metadata before publishing;
@@ -95,24 +100,35 @@ release artifact set. The release commit must not mix product behavior changes
 with version normalization.
 
 Package-affecting direct pushes to `master` are allowed only as an explicit
-version-release path: all shipped package versions must already be updated to the
-same valid version that does not downgrade below the coordinated floor. A
-package-affecting push with neither a merged-PR semver label context nor an
-explicit coordinated version bump exits cleanly without publishing a release.
+version-release path: all shipped Python and TypeScript package versions must
+already be updated to the same valid version that does not downgrade below the
+coordinated floor. A package-affecting push with neither a merged-PR semver label
+context nor an explicit coordinated version bump exits cleanly without
+publishing a release.
 
 ## Manual Tag Release
 
 A manually pushed `vMAJOR.MINOR.PATCH` tag is allowed only when every shipped
-package already declares that exact version. The tag workflow builds the same
-artifact set, generates checksums and the release manifest, verifies them, and
-publishes the GitHub Release.
+Python and TypeScript package already declares that exact version. The tag
+workflow builds the same artifact set, generates checksums and the release
+manifest, verifies them, and publishes the GitHub Release.
 
 ## All-Or-Nothing Invariant
 
-Coordinated releases are all-or-nothing. If any package version, lockfile entry,
-generated artifact, wheel, sdist, checksum, release manifest entry, or install
-proof is inconsistent, the workflow must fail before creating or publishing the
-tag or release.
+Coordinated releases are all-or-nothing. If any Python package version,
+TypeScript package version, lockfile entry, generated artifact, wheel, sdist, npm
+tarball, checksum, release manifest entry, or install proof is inconsistent, the
+workflow must fail before creating or publishing the tag or release.
+
+## TypeScript CLI Packages
+
+Generated TypeScript CLI packages under `generated/*/typescript` are release
+surfaces, not private fixtures. They must remain publishable package manifests
+with explicit Node runtime requirements and public scoped-package publish
+configuration. Release workflows run each package's `npm test`, pack each package
+with `npm pack`, include the resulting `.tgz` files in `SHA256SUMS`, and list
+them in `agentic-workspace-release-manifest.json` with the same coordinated
+release version as the Python packages.
 
 ## Payload Provenance
 

--- a/generated/memory/typescript/package.json
+++ b/generated/memory/typescript/package.json
@@ -29,12 +29,18 @@
   "bin": {
     "agentic-memory": "./src/cli.mjs"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "files": [
     "src",
     "resources"
   ],
   "name": "@agentic-workspace/memory-cli",
-  "private": true,
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "node --test test/command-package.test.mjs"
   },

--- a/generated/planning/typescript/package.json
+++ b/generated/planning/typescript/package.json
@@ -29,12 +29,18 @@
   "bin": {
     "agentic-planning": "./src/cli.mjs"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "files": [
     "src",
     "resources"
   ],
   "name": "@agentic-workspace/planning-cli",
-  "private": true,
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "node --test test/command-package.test.mjs"
   },

--- a/generated/verification/typescript/package.json
+++ b/generated/verification/typescript/package.json
@@ -29,12 +29,18 @@
   "bin": {
     "agentic-verification": "./src/cli.mjs"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "files": [
     "src",
     "resources"
   ],
   "name": "@agentic-workspace/verification-cli",
-  "private": true,
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "node --test test/command-package.test.mjs"
   },

--- a/generated/workspace/typescript/package.json
+++ b/generated/workspace/typescript/package.json
@@ -29,12 +29,18 @@
   "bin": {
     "agentic-workspace": "./src/cli.mjs"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "files": [
     "src",
     "resources"
   ],
   "name": "@agentic-workspace/workspace-cli",
-  "private": true,
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "node --test test/command-package.test.mjs"
   },

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -19,6 +19,7 @@ SCHEMA_PATH = "command_generation:schemas/command_package_ir.schema.json"
 REGENERATE_COMMAND = "uv run python scripts/generate/generate_command_packages.py"
 TYPESCRIPT_RUNTIME_SUPPORT_PATH = "src/agentic_workspace/contracts/typescript_runtime_support.mjs"
 OPERATION_PRIMITIVES_PATH = "src/agentic_workspace/contracts/operation_primitives.json"
+RELEASE_OWNERSHIP_PATH = ".github/release-ownership.json"
 
 
 def _operation_refs(command: dict[str, object], inherited: dict[str, object] | None = None) -> list[dict[str, object]]:
@@ -239,6 +240,37 @@ def load_workspace_command_package_ir(*, repo_root: Path = REPO_ROOT) -> dict[st
     return load_command_package_ir(repo_root / SOURCE_PATH, command_package_schema_path())
 
 
+def _typescript_release_package_metadata(*, repo_root: Path) -> dict[str, dict[str, object]]:
+    ownership_path = repo_root / RELEASE_OWNERSHIP_PATH
+    if not ownership_path.is_file():
+        return {}
+    ownership = json.loads(ownership_path.read_text(encoding="utf-8"))
+    packages = ownership.get("typescript_packages", [])
+    return {
+        str(package["package_json"]): package
+        for package in packages
+        if isinstance(package, dict) and isinstance(package.get("package_json"), str)
+    }
+
+
+def _normalize_releaseable_typescript_package_json(
+    output: GeneratedOutput,
+    *,
+    release_metadata: dict[str, dict[str, object]],
+    repo_root: Path,
+) -> GeneratedOutput:
+    path = output.path if output.path.is_absolute() else repo_root / output.path
+    relative = path.relative_to(repo_root).as_posix()
+    metadata = release_metadata.get(relative)
+    if metadata is None:
+        return output
+    payload = json.loads(output.content)
+    payload["private"] = False
+    payload["engines"] = {"node": str(metadata.get("runtime_requirement", "node>=20")).removeprefix("node")}
+    payload["publishConfig"] = {"access": "public"}
+    return GeneratedOutput(output.path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
 def render_workspace_command_package_outputs(
     manifest: dict[str, object] | None = None,
     *,
@@ -252,7 +284,12 @@ def render_workspace_command_package_outputs(
         regenerate_command=REGENERATE_COMMAND,
         host_manifest=workspace_command_generation_host_manifest(repo_root=repo_root),
     )
-    return outputs
+    release_metadata = _typescript_release_package_metadata(repo_root=repo_root)
+    return [
+        _normalize_releaseable_typescript_package_json(output, release_metadata=release_metadata, repo_root=repo_root)
+        for output in outputs
+    ]
+
 
 
 def generate_workspace_command_packages(*, repo_root: Path = REPO_ROOT, check: bool) -> list[str]:

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -53,6 +53,23 @@ def test_release_ownership_manifest_declares_coordinated_workspace_packages() ->
         assert package["payload_provenance"]
         assert package["generated_command_contract"] == "agentic-workspace/command-package-ir/v1"
 
+    typescript_package_names = [package["name"] for package in ownership["typescript_packages"]]
+    assert typescript_package_names == [
+        "@agentic-workspace/workspace-cli",
+        "@agentic-workspace/memory-cli",
+        "@agentic-workspace/planning-cli",
+        "@agentic-workspace/verification-cli",
+    ]
+    for package in ownership["typescript_packages"]:
+        package_json = json.loads((ROOT / package["package_json"]).read_text(encoding="utf-8"))
+        assert package_json["name"] == package["name"]
+        assert package_json["private"] is False
+        assert package_json["publishConfig"]["access"] == "public"
+        assert package_json["engines"]["node"] == ">=20"
+        assert package["runtime_requirement"] == "node>=20"
+        assert package["release_policy"] == "pack-and-publishable"
+        assert package["generated_command_contract"] == "agentic-workspace/command-package-ir/v1"
+
 
 def test_package_affecting_scope_is_manifest_owned_and_covers_release_surfaces() -> None:
     paths = set(_ownership()["package_affecting_paths"])
@@ -106,11 +123,18 @@ def test_post_merge_release_workflow_bumps_all_packages_from_pr_label() -> None:
     assert "must have exactly one semver label before release" in workflow
     assert "for pyproject in package_pyprojects:" in workflow
     assert "uv lock" in workflow
+    assert "typescript_package_jsons" in workflow
+    assert "package_json_version_text" in workflow
+    assert "actions/setup-node@v6.4.0" in workflow
+    assert 'node-version: "24"' in workflow
     assert "make test-workspace" in workflow
     assert "make lint" in workflow
     assert "make typecheck" in workflow
     assert "make verify" in workflow
     assert "check_generated_command_packages.py" in workflow
+    assert "npm test" in workflow
+    assert "npm pack --pack-destination" in workflow
+    assert "generated/workspace/typescript/package.json" in workflow
     assert "check_no_absolute_paths.py" in workflow
     assert "agentic-workspace-release-manifest.json" in workflow
     assert "SHA256SUMS" in workflow
@@ -130,6 +154,10 @@ def test_manual_release_workflow_verifies_all_package_versions_and_assets() -> N
     assert "uv build --wheel --sdist --out-dir dist packages/memory" in workflow
     assert "uv build --wheel --sdist --out-dir dist packages/planning" in workflow
     assert "uv build --wheel --sdist --out-dir dist packages/verification" in workflow
+    assert "actions/setup-node@v6.4.0" in workflow
+    assert 'node-version: "24"' in workflow
+    assert "npm test && npm pack --pack-destination" in workflow
+    assert "typescript_packages" in workflow
     assert "agentic-workspace-release-manifest.json" in workflow
     assert "SHA256SUMS" in workflow
     assert "Missing checksums for release assets" in workflow
@@ -149,6 +177,7 @@ def test_release_asset_patterns_exclude_incidental_dist_files() -> None:
             "dist/agentic_workspace-0.4.0.tar.gz",
             "dist/agentic_memory-0.4.0-py3-none-any.whl",
             "dist/agentic_memory-0.4.0.tar.gz",
+            "dist/agentic-workspace-workspace-cli-0.4.0.tgz",
             "dist/agentic-workspace-release-manifest.json",
             "dist/SHA256SUMS",
             "dist/.gitignore",
@@ -160,6 +189,7 @@ def test_release_asset_patterns_exclude_incidental_dist_files() -> None:
         "dist/agentic_workspace-0.4.0.tar.gz",
         "dist/agentic_memory-0.4.0-py3-none-any.whl",
         "dist/agentic_memory-0.4.0.tar.gz",
+        "dist/agentic-workspace-workspace-cli-0.4.0.tgz",
         "dist/agentic-workspace-release-manifest.json",
         "dist/SHA256SUMS",
     ]
@@ -184,7 +214,14 @@ def test_release_workflows_prevent_coordinated_version_drift_at_release_time() -
     assert "Direct release push must set every package to the same version" in post_merge_workflow
     assert "would downgrade below floor" in post_merge_workflow
     assert "for pyproject in package_pyprojects:" in post_merge_workflow
+    assert "for package_json in typescript_package_jsons:" in post_merge_workflow
+    assert "version_files = [*package_pyprojects, *typescript_package_jsons]" in post_merge_workflow
+    assert 'payload["version"] = next_version' in post_merge_workflow
     assert sorted(ownership["release_commit_allowed_paths"]) == [
+        "generated/memory/typescript/package.json",
+        "generated/planning/typescript/package.json",
+        "generated/verification/typescript/package.json",
+        "generated/workspace/typescript/package.json",
         "packages/memory/pyproject.toml",
         "packages/planning/pyproject.toml",
         "packages/verification/pyproject.toml",


### PR DESCRIPTION
## Summary
- Add TypeScript/npm CLI packages to the coordinated release ownership manifest as first-class release surfaces.
- Normalize generated TypeScript package manifests to be publishable, public scoped packages with Node runtime metadata.
- Update post-merge and manual release workflows to version, test, pack, checksum, manifest, and publish npm tarballs alongside Python wheels/sdists.
- Extend release docs and tests to prove Python/npm release parity and prevent Python-only drift.

Fixes #1598

## Validation
- `uv run pytest tests/test_release_workflows.py -q`
- `uv run ruff check scripts/generate/workspace_command_generation.py tests/test_release_workflows.py`
- `uv run python scripts/check/check_generated_command_packages.py`
- `foreach ($p in Get-ChildItem generated/*/typescript -Directory) { Push-Location $p.FullName; npm test; if ($LASTEXITCODE -ne 0) { Pop-Location; exit $LASTEXITCODE }; Pop-Location }`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `make lint`
- `uv run python scripts/check/check_no_absolute_paths.py`