### PR TITLE
Run semver release job only from master

### DIFF
--- a/.github/workflows/release-from-semver-label.yml
+++ b/.github/workflows/release-from-semver-label.yml
@@ -4,27 +4,21 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types:
-      - closed
-    branches:
-      - master
 
 permissions:
   contents: write
+  issues: read
   pull-requests: read
 
 jobs:
   release-from-label:
     name: Bump coordinated workspace version and tag merged package changes
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.base.ref || github.ref_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
@@ -47,7 +41,6 @@ jobs:
           BEFORE_SHA: ${{ github.event.before }}
           GITHUB_ACTOR: ${{ github.actor }}
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
@@ -133,24 +126,16 @@ jobs:
                   return []
               return result.stdout.splitlines()
 
-          event_name = os.environ["GITHUB_EVENT_NAME"]
-          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
-          message = os.environ.get("HEAD_COMMIT_MESSAGE", "")
-          if (
-              event_name == "push"
-              and os.environ["GITHUB_ACTOR"] == "github-actions[bot]"
-              and re.match(r"^Release v\d+\.\d+\.\d+$", message.strip())
-          ):
-              skip_release("Release bump commit detected; no additional release bump needed.")
+          def pr_label_names(pr_number: str) -> set[str]:
+              result = run(
+                  "gh",
+                  "api",
+                  f"repos/{os.environ['REPOSITORY']}/issues/{pr_number}/labels",
+              )
+              return {label["name"] for label in json.loads(result.stdout)}
 
-          pr_number = ""
-          selected: list[str] = []
-          if event_name == "pull_request":
-              pull_request = event.get("pull_request", {})
-              if not pull_request.get("merged"):
-                  skip_release("Pull request was closed without merge; no release bump needed.")
-              pr_number = str(pull_request["number"])
-              changed = run(
+          def pr_changed_files(pr_number: str) -> list[str]:
+              return run(
                   "gh",
                   "api",
                   f"repos/{os.environ['REPOSITORY']}/pulls/{pr_number}/files",
@@ -158,17 +143,30 @@ jobs:
                   "--jq",
                   ".[].filename",
               ).stdout.splitlines()
-              labels = {label["name"] for label in pull_request.get("labels", [])}
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          message = os.environ.get("HEAD_COMMIT_MESSAGE", "")
+          if (
+              os.environ["GITHUB_ACTOR"] == "github-actions[bot]"
+              and re.match(r"^Release v\d+\.\d+\.\d+$", message.strip())
+          ):
+              skip_release("Release bump commit detected; no additional release bump needed.")
+
+          pr_number = ""
+          selected: list[str] = []
+          associated_prs = associated_pr_numbers(event["after"])
+          if associated_prs:
+              pr_number = associated_prs[0]
+              changed = pr_changed_files(pr_number)
+              labels = pr_label_names(pr_number)
               selected = sorted(labels & semver_labels)
-          elif event_name == "push":
+          else:
               before = os.environ["BEFORE_SHA"]
               if not before or set(before) == {"0"}:
                   before = run("git", "rev-list", "--max-parents=0", "HEAD").stdout.splitlines()[0]
               elif run("git", "cat-file", "-e", f"{before}^{{commit}}", check=False).returncode != 0:
                   before = run("git", "rev-parse", "HEAD^").stdout.strip()
               changed = run("git", "diff", "--name-only", f"{before}...HEAD").stdout.splitlines()
-          else:
-              raise SystemExit(f"Unsupported release event: {event_name}")
 
           package_changed = any(
               path == watched or path.startswith(watched)
@@ -177,9 +175,6 @@ jobs:
           )
           if not package_changed:
               skip_release("No package-affecting changes detected; no release bump needed.")
-
-          if event_name == "push" and associated_pr_numbers(event["after"]):
-              skip_release("Package-affecting push is associated with a merged PR; pull_request.closed handles the release decision.")
 
           versions = [version_text(path) for path in package_pyprojects] + [
               package_json_version_text(path) for path in typescript_package_jsons
@@ -190,7 +185,7 @@ jobs:
           current_floor = max_version([current_package_floor, floor_version])
           needs_first_normalization = parse_version(current_package_floor) < parse_version(floor_version)
 
-          if event_name == "push":
+          if not pr_number:
               version_files = [*package_pyprojects, *typescript_package_jsons]
               if not any(path in changed for path in version_files):
                   skip_release(

--- a/docs/release-and-versioning.md
+++ b/docs/release-and-versioning.md
@@ -68,10 +68,11 @@ release workflow behavior.
 
 ## Post-Merge Release
 
-After a package-affecting PR merges to `master`, the release workflow runs from
-the `pull_request.closed` event and uses the event payload plus GitHub PR file
-metadata as the release decision source. It must not infer release intent by
-parsing merge commit messages.
+After a package-affecting PR merges to `master`, the release workflow runs only
+from the `master` push event. It uses GitHub commit-to-PR metadata plus PR file
+and label APIs as the release decision source. It must not infer release intent
+by parsing merge commit messages, and it must not publish from a PR event
+context.
 
 For merged package-affecting PRs, the release workflow:
 
@@ -83,17 +84,13 @@ For merged package-affecting PRs, the release workflow:
    to the same value;
 6. updates `uv.lock`;
 7. runs tests, lint, typecheck, generated package proof, TypeScript package
-   tests, and package artifact proof;
+   tests, and package artifact proof against the release-normalized tree;
 8. builds every wheel, sdist, and TypeScript npm tarball;
 9. generates `SHA256SUMS`;
 10. generates `agentic-workspace-release-manifest.json`;
 11. verifies all release artifacts and metadata before publishing;
 12. commits only version normalization and lockfile changes as `Release vX.Y.Z`;
 13. pushes the tag and publishes the GitHub Release.
-
-The companion `push` event created by a PR merge is ignored when GitHub commit
-metadata links it back to the merged PR; this avoids duplicate release handling
-without relying on merge commit message parsing.
 
 The generated release manifest is intentionally not committed. It belongs to the
 release artifact set. The release commit must not mix product behavior changes

--- a/scripts/generate/workspace_command_generation.py
+++ b/scripts/generate/workspace_command_generation.py
@@ -265,6 +265,14 @@ def _normalize_releaseable_typescript_package_json(
     if metadata is None:
         return output
     payload = json.loads(output.content)
+    existing_version = None
+    if path.is_file():
+        existing_payload = json.loads(path.read_text(encoding="utf-8"))
+        existing_version = existing_payload.get("version")
+    if isinstance(existing_version, str) and existing_version:
+        # The coordinated release workflow owns package versions; generation owns
+        # the publishable package shape around that checked-in release value.
+        payload["version"] = existing_version
     payload["private"] = False
     payload["engines"] = {"node": str(metadata.get("runtime_requirement", "node>=20")).removeprefix("node")}
     payload["publishConfig"] = {"access": "public"}

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import fnmatch
+import importlib.util
 import json
 import tomllib
 from pathlib import Path
@@ -8,6 +9,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_ROOT = ROOT / ".github" / "workflows"
 OWNERSHIP_PATH = ROOT / ".github" / "release-ownership.json"
+GENERATOR_PATH = ROOT / "scripts" / "generate" / "workspace_command_generation.py"
 
 
 def _ownership() -> dict[str, object]:
@@ -27,6 +29,15 @@ def _release_asset_patterns(workflow: str) -> list[str]:
 
 def _matching_release_assets(patterns: list[str], assets: list[str]) -> list[str]:
     return [asset for asset in assets if any(fnmatch.fnmatchcase(asset, pattern) for pattern in patterns)]
+
+
+def _load_workspace_command_generation():
+    spec = importlib.util.spec_from_file_location("workspace_command_generation_under_test", GENERATOR_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_release_ownership_manifest_declares_coordinated_workspace_packages() -> None:
@@ -103,19 +114,20 @@ def test_post_merge_release_workflow_bumps_all_packages_from_pr_label() -> None:
 
     assert "branches:" in workflow
     assert "master" in workflow
-    assert "pull_request:" in workflow
-    assert "closed" in workflow
-    assert "github.event.pull_request.merged == true" in workflow
+    assert "pull_request:" not in workflow
+    assert "github.event.pull_request" not in workflow
     assert "contents: write" in workflow
+    assert "issues: read" in workflow
     assert "pull-requests: read" in workflow
     assert ".github/release-ownership.json" in workflow
     assert 'ownership["packages"]' in workflow
     assert 'ownership["first_coordinated_release"]["floor_version"]' in workflow
-    assert 'pull_request.get("labels", [])' in workflow
+    assert "def pr_label_names(pr_number: str) -> set[str]:" in workflow
+    assert "/issues/{pr_number}/labels" in workflow
     assert ".[].filename" in workflow
     assert "associated_pr_numbers" in workflow
     assert "commits/{commit_sha}/pulls" in workflow
-    assert "pull_request.closed handles the release decision" in workflow
+    assert "Package-affecting push is associated with a merged PR" not in workflow
     assert "def skip_release(reason: str) -> None:" in workflow
     assert 'output("release_needed", "false")' in workflow
     assert "Merge pull request #" not in workflow
@@ -142,6 +154,23 @@ def test_post_merge_release_workflow_bumps_all_packages_from_pr_label() -> None:
     assert 'git commit -m "Release ${{ steps.release-bump.outputs.tag }}"' in workflow
     assert 'git push origin "${{ steps.release-bump.outputs.tag }}"' in workflow
     assert "softprops/action-gh-release@v3.0.0" in workflow
+
+
+def test_releaseable_typescript_package_generation_preserves_release_owned_versions() -> None:
+    generator = _load_workspace_command_generation()
+    rendered_by_path = {
+        output.path.relative_to(ROOT).as_posix(): json.loads(output.content)
+        for output in generator.render_workspace_command_package_outputs(repo_root=ROOT)
+        if output.path.name == "package.json" and "typescript" in output.path.as_posix()
+    }
+
+    for package in _ownership()["typescript_packages"]:
+        package_json_path = package["package_json"]
+        current = json.loads((ROOT / package_json_path).read_text(encoding="utf-8"))
+        rendered = rendered_by_path[package_json_path]
+        assert rendered["version"] == current["version"]
+        assert rendered["private"] is False
+        assert rendered["publishConfig"]["access"] == "public"
 
 
 def test_manual_release_workflow_verifies_all_package_versions_and_assets() -> None:


### PR DESCRIPTION
## Summary
- restrict the semver-label release workflow to `push` on `master`
- resolve merged PR semver labels from GitHub commit-to-PR metadata during the master push
- keep generated TypeScript package versions release-owned so generated freshness still passes after release normalization
- update release docs and workflow tests for the master-only release path

## Proof
- `uv run pytest tests/test_release_workflows.py -q`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run ruff check scripts/generate/workspace_command_generation.py tests/test_release_workflows.py`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_generated_command_packages.py --require-node`
- YAML parse check for `.github/workflows/release-from-semver-label.yml` and `.github/workflows/release.yml`