### PR TITLE
Run normal CI only for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches: [ main, master ]
 
 jobs:
   workspace-checks:

--- a/tests/test_workspace_packaging.py
+++ b/tests/test_workspace_packaging.py
@@ -171,6 +171,13 @@ def test_ci_runs_release_proof_typecheck_before_generated_verification() -> None
     assert ci_text.index("run: make typecheck") < ci_text.index("run: make verify-workspace")
 
 
+def test_normal_ci_is_pr_only() -> None:
+    ci_text = (WORKSPACE_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "  pull_request:" in ci_text
+    assert "  push:" not in ci_text
+
+
 def test_release_workflow_publishes_tagged_root_package_artifacts() -> None:
     release_text = (WORKSPACE_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 

--- a/tests/test_workspace_packaging.py
+++ b/tests/test_workspace_packaging.py
@@ -171,13 +171,6 @@ def test_ci_runs_release_proof_typecheck_before_generated_verification() -> None
     assert ci_text.index("run: make typecheck") < ci_text.index("run: make verify-workspace")
 
 
-def test_normal_ci_is_pr_only() -> None:
-    ci_text = (WORKSPACE_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-
-    assert "  pull_request:" in ci_text
-    assert "  push:" not in ci_text
-
-
 def test_release_workflow_publishes_tagged_root_package_artifacts() -> None:
     release_text = (WORKSPACE_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- remove the post-merge `push` trigger from normal CI
- keep CI checks on PRs, while the release workflow remains responsible for post-merge `master` pushes

## Proof
- YAML parse check for `.github/workflows/ci.yml`
- `make lint-workspace`