### PR TITLE
[codex] Fix release root wheel dependency resolution

### DIFF
--- a/.github/release-ownership.json
+++ b/.github/release-ownership.json
@@ -29,6 +29,7 @@
     "generated/",
     "packages/",
     "pyproject.toml",
+    "scripts/release/",
     "src/",
     "tests/test_release_workflows.py",
     "uv.lock"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           uv build --wheel --sdist --out-dir dist packages/verification
 
       - name: Run built package smoke tests
-        run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_wheel_imports_cli_module tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence -q
+        run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_wheel_imports_cli_module tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence tests/test_workspace_packaging.py::test_release_root_wheel_installs_workspace_stack_from_same_release_assets -q
 
       - name: Upload Agentic Workspace package artifacts
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/release-from-semver-label.yml
+++ b/.github/workflows/release-from-semver-label.yml
@@ -263,13 +263,17 @@ jobs:
           uv build --wheel --sdist --out-dir dist packages/memory
           uv build --wheel --sdist --out-dir dist packages/planning
           uv build --wheel --sdist --out-dir dist packages/verification
+          python scripts/release/patch_workspace_release_wheel.py \
+            --dist-dir dist \
+            --version "${{ steps.release-bump.outputs.version }}" \
+            --release-asset-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ steps.release-bump.outputs.tag }}"
           for package in generated/*/typescript; do
             (cd "$package" && npm pack --pack-destination "$GITHUB_WORKSPACE/dist")
           done
 
       - name: Prove built workspace stack installs outside source tree
         if: steps.release-bump.outputs.release_needed == 'true'
-        run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence -q
+        run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence tests/test_workspace_packaging.py::test_release_root_wheel_installs_workspace_stack_from_same_release_assets -q
 
       - name: Generate checksums and release manifest
         if: steps.release-bump.outputs.release_needed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,12 +68,16 @@ jobs:
           uv build --wheel --sdist --out-dir dist packages/memory
           uv build --wheel --sdist --out-dir dist packages/planning
           uv build --wheel --sdist --out-dir dist packages/verification
+          python scripts/release/patch_workspace_release_wheel.py \
+            --dist-dir dist \
+            --version "${GITHUB_REF_NAME#v}" \
+            --release-asset-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}"
           for package in generated/*/typescript; do
             (cd "$package" && npm test && npm pack --pack-destination "$GITHUB_WORKSPACE/dist")
           done
 
       - name: Run built package smoke tests
-        run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_wheel_imports_cli_module tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence -q
+        run: uv run pytest tests/test_workspace_packaging.py::test_installed_workspace_wheel_imports_cli_module tests/test_workspace_packaging.py::test_installed_workspace_stack_runs_fresh_repo_cli_sequence tests/test_workspace_packaging.py::test_release_root_wheel_installs_workspace_stack_from_same_release_assets -q
 
       - name: Generate checksums and release manifest
         env:

--- a/docs/release-and-versioning.md
+++ b/docs/release-and-versioning.md
@@ -11,7 +11,8 @@ The ordinary downstream path should be:
 
 1. CI proves the source tree.
 2. CI builds every workspace wheel, sdist, and TypeScript npm package tarball.
-3. CI proves installation from built artifacts outside the source tree.
+3. CI proves installation from built artifacts outside the source tree,
+   including the single-root-wheel public install path.
 4. CI publishes a GitHub Release tagged `vMAJOR.MINOR.PATCH`.
 5. The release contains all wheels, all sdists, all npm tarballs,
    `SHA256SUMS`, and `agentic-workspace-release-manifest.json`.
@@ -86,11 +87,15 @@ For merged package-affecting PRs, the release workflow:
 7. runs tests, lint, typecheck, generated package proof, TypeScript package
    tests, and package artifact proof against the release-normalized tree;
 8. builds every wheel, sdist, and TypeScript npm tarball;
-9. generates `SHA256SUMS`;
-10. generates `agentic-workspace-release-manifest.json`;
-11. verifies all release artifacts and metadata before publishing;
-12. commits only version normalization and lockfile changes as `Release vX.Y.Z`;
-13. pushes the tag and publishes the GitHub Release.
+9. patches the root Python wheel so its sibling AW dependencies resolve from
+   same-release GitHub wheel assets;
+10. proves the patched root wheel can install the complete workspace stack as a
+    single dependency;
+11. generates `SHA256SUMS`;
+12. generates `agentic-workspace-release-manifest.json`;
+13. verifies all release artifacts and metadata before publishing;
+14. commits only version normalization and lockfile changes as `Release vX.Y.Z`;
+15. pushes the tag and publishes the GitHub Release.
 
 The generated release manifest is intentionally not committed. It belongs to the
 release artifact set. The release commit must not mix product behavior changes
@@ -109,6 +114,15 @@ A manually pushed `vMAJOR.MINOR.PATCH` tag is allowed only when every shipped
 Python and TypeScript package already declares that exact version. The tag
 workflow builds the same artifact set, generates checksums and the release
 manifest, verifies them, and publishes the GitHub Release.
+
+## Python Install Shape
+
+Python packages are released as GitHub Release assets, not through a package
+index. The root `agentic-workspace` wheel is therefore patched during release so
+its `Requires-Dist` entries for `agentic-memory`, `agentic-planning`, and
+`agentic-verification` point to the same GitHub Release wheel assets with
+hashes. Host repositories should be able to depend on the public root wheel as a
+single normal dependency and let `uv sync` resolve the coordinated stack.
 
 ## All-Or-Nothing Invariant
 

--- a/scripts/release/patch_workspace_release_wheel.py
+++ b/scripts/release/patch_workspace_release_wheel.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import hashlib
+import io
+import shutil
+import tempfile
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
+
+
+DEPENDENCY_PACKAGES = {
+    "agentic-memory": "agentic_memory",
+    "agentic-planning": "agentic_planning",
+    "agentic-verification": "agentic_verification",
+}
+
+
+def sha256_hex(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _record_digest(data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    return "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _find_one(root: Path, pattern: str) -> Path:
+    matches = sorted(root.glob(pattern))
+    if len(matches) != 1:
+        raise SystemExit(f"Expected exactly one match for {pattern!r} in {root}, found {len(matches)}")
+    return matches[0]
+
+
+def _wheel_filename_for_package(*, dist_dir: Path, wheel_prefix: str, version: str) -> str:
+    return _find_one(dist_dir, f"{wheel_prefix}-{version}-*.whl").name
+
+
+def _dependency_requirements(*, dist_dir: Path, version: str, release_asset_base_url: str) -> list[str]:
+    base_url = release_asset_base_url.rstrip("/")
+    requirements: list[str] = []
+    for package_name, wheel_prefix in DEPENDENCY_PACKAGES.items():
+        wheel_name = _wheel_filename_for_package(dist_dir=dist_dir, wheel_prefix=wheel_prefix, version=version)
+        digest = sha256_hex(dist_dir / wheel_name)
+        requirements.append(f"Requires-Dist: {package_name} @ {base_url}/{wheel_name}#sha256={digest}")
+    return requirements
+
+
+def _patch_metadata(metadata: str, *, requirements: list[str]) -> str:
+    lines = [
+        line
+        for line in metadata.splitlines()
+        if not any(line == f"Requires-Dist: {package_name}" for package_name in DEPENDENCY_PACKAGES)
+    ]
+    insert_at = 0
+    for index, line in enumerate(lines):
+        if line.startswith("Requires-"):
+            insert_at = index + 1
+    lines[insert_at:insert_at] = requirements
+    return "\n".join(lines) + "\n"
+
+
+def patch_workspace_wheel(*, dist_dir: Path, version: str, release_asset_base_url: str) -> Path:
+    wheel_path = _find_one(dist_dir, f"agentic_workspace-{version}-*.whl")
+    requirements = _dependency_requirements(
+        dist_dir=dist_dir,
+        version=version,
+        release_asset_base_url=release_asset_base_url,
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        patched_path = Path(tmpdir) / wheel_path.name
+        with ZipFile(wheel_path, "r") as source, ZipFile(patched_path, "w", ZIP_DEFLATED) as target:
+            records: list[tuple[str, str, str]] = []
+            record_path = ""
+            for item in source.infolist():
+                data = source.read(item.filename)
+                if item.filename.endswith(".dist-info/METADATA"):
+                    data = _patch_metadata(data.decode("utf-8"), requirements=requirements).encode("utf-8")
+                if item.filename.endswith(".dist-info/RECORD"):
+                    record_path = item.filename
+                    continue
+                info = ZipInfo(item.filename, date_time=item.date_time)
+                info.compress_type = item.compress_type
+                info.external_attr = item.external_attr
+                target.writestr(info, data)
+                records.append((item.filename, _record_digest(data), str(len(data))))
+
+            if not record_path:
+                raise SystemExit(f"{wheel_path.name} has no RECORD file")
+            record_buffer = io.StringIO()
+            writer = csv.writer(record_buffer, lineterminator="\n")
+            writer.writerows(records)
+            writer.writerow((record_path, "", ""))
+            target.writestr(record_path, record_buffer.getvalue().encode("utf-8"))
+        shutil.move(str(patched_path), wheel_path)
+    return wheel_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Patch the root AW wheel to depend on same-release GitHub wheel assets.")
+    parser.add_argument("--dist-dir", default="dist")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--release-asset-base-url", required=True)
+    args = parser.parse_args(argv)
+
+    patched = patch_workspace_wheel(
+        dist_dir=Path(args.dist_dir),
+        version=args.version,
+        release_asset_base_url=args.release_asset_base_url,
+    )
+    print(f"Patched {patched}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -91,6 +91,7 @@ def test_package_affecting_scope_is_manifest_owned_and_covers_release_surfaces()
     assert "docs/release-and-versioning.md" in paths
     assert "generated/" in paths
     assert "packages/" in paths
+    assert "scripts/release/" in paths
     assert "src/" in paths
     assert "tests/test_release_workflows.py" in paths
     assert "uv.lock" in paths
@@ -145,6 +146,8 @@ def test_post_merge_release_workflow_bumps_all_packages_from_pr_label() -> None:
     assert "check_generated_command_packages.py" in workflow
     assert "npm test" in workflow
     assert "npm pack --pack-destination" in workflow
+    assert "scripts/release/patch_workspace_release_wheel.py" in workflow
+    assert "release-asset-base-url" in workflow
     assert "generated/workspace/typescript/package.json" in workflow
     assert "check_no_absolute_paths.py" in workflow
     assert "agentic-workspace-release-manifest.json" in workflow
@@ -182,6 +185,8 @@ def test_manual_release_workflow_verifies_all_package_versions_and_assets() -> N
     assert "uv build --wheel --sdist --out-dir dist packages/memory" in workflow
     assert "uv build --wheel --sdist --out-dir dist packages/planning" in workflow
     assert "uv build --wheel --sdist --out-dir dist packages/verification" in workflow
+    assert "scripts/release/patch_workspace_release_wheel.py" in workflow
+    assert "release-asset-base-url" in workflow
     assert "actions/setup-node@v6.4.0" in workflow
     assert 'node-version: "24"' in workflow
     assert "npm test && npm pack --pack-destination" in workflow

--- a/tests/test_workspace_packaging.py
+++ b/tests/test_workspace_packaging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import importlib.util
 import json
 import os
 import re
@@ -24,6 +25,7 @@ MODULE_PACKAGE_DIRS = (
     WORKSPACE_ROOT / "packages" / "planning",
     WORKSPACE_ROOT / "packages" / "verification",
 )
+RELEASE_WHEEL_PATCHER = WORKSPACE_ROOT / "scripts" / "release" / "patch_workspace_release_wheel.py"
 
 
 @contextlib.contextmanager
@@ -160,6 +162,7 @@ def test_ci_builds_and_uploads_root_package_artifacts() -> None:
     assert "uv build --wheel --sdist --out-dir dist packages/planning" in ci_text
     assert "uv build --wheel --sdist --out-dir dist packages/verification" in ci_text
     assert "test_installed_workspace_stack_runs_fresh_repo_cli_sequence" in ci_text
+    assert "test_release_root_wheel_installs_workspace_stack_from_same_release_assets" in ci_text
     assert "actions/upload-artifact@v7.0.1" in ci_text
 
 
@@ -181,6 +184,8 @@ def test_release_workflow_publishes_tagged_root_package_artifacts() -> None:
     assert "uv build --wheel --sdist --out-dir dist packages/memory" in release_text
     assert "uv build --wheel --sdist --out-dir dist packages/planning" in release_text
     assert "uv build --wheel --sdist --out-dir dist packages/verification" in release_text
+    assert "scripts/release/patch_workspace_release_wheel.py" in release_text
+    assert "test_release_root_wheel_installs_workspace_stack_from_same_release_assets" in release_text
     assert "agentic-workspace-release-manifest.json" in release_text
     assert "SHA256SUMS" in release_text
     assert "softprops/action-gh-release@v3.0.0" in release_text
@@ -272,6 +277,31 @@ def test_workspace_runtime_entrypoint_stays_off_command_generation() -> None:
 def test_installed_workspace_stack_runs_fresh_repo_cli_sequence(workspace_wheelhouse: list[Path], tmp_path: Path) -> None:
     workspace_exe = _install_workspace_stack_venv(wheelhouse=workspace_wheelhouse, tmpdir_path=tmp_path)
     assert _venv_site_package_entry_names(tmp_path / ".venv", "command_generation") == []
+    _assert_workspace_stack_runs_fresh_repo_cli_sequence(workspace_exe=workspace_exe, tmp_path=tmp_path)
+
+
+def test_release_root_wheel_installs_workspace_stack_from_same_release_assets(workspace_wheelhouse: list[Path], tmp_path: Path) -> None:
+    version = tomllib.loads((WORKSPACE_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+    release_dist = tmp_path / "release-dist"
+    release_dist.mkdir()
+    release_wheels = [release_dist / wheel.name for wheel in workspace_wheelhouse]
+    for source, target in zip(workspace_wheelhouse, release_wheels, strict=True):
+        target.write_bytes(source.read_bytes())
+
+    patcher = _load_release_wheel_patcher()
+    patched_root = patcher.patch_workspace_wheel(
+        dist_dir=release_dist,
+        version=version,
+        release_asset_base_url=release_dist.resolve().as_uri(),
+    )
+    workspace_exe = _install_workspace_root_release_venv(root_wheel=patched_root, tmpdir_path=tmp_path)
+    assert _venv_site_package_entry_names(tmp_path / ".venv-release", "agentic_memory")
+    assert _venv_site_package_entry_names(tmp_path / ".venv-release", "agentic_planning")
+    assert _venv_site_package_entry_names(tmp_path / ".venv-release", "agentic_verification")
+    _assert_workspace_stack_runs_fresh_repo_cli_sequence(workspace_exe=workspace_exe, tmp_path=tmp_path)
+
+
+def _assert_workspace_stack_runs_fresh_repo_cli_sequence(*, workspace_exe: Path, tmp_path: Path) -> None:
     target = tmp_path / "repo"
     target.mkdir()
     subprocess.run(["git", "init"], cwd=target, capture_output=True, text=True, check=True)
@@ -391,6 +421,42 @@ def _install_workspace_stack_venv(*, wheelhouse: list[Path], tmpdir_path: Path) 
         check=True,
     )
     return _venv_script(venv_path, "agentic-workspace")
+
+
+def _install_workspace_root_release_venv(*, root_wheel: Path, tmpdir_path: Path) -> Path:
+    venv_path = tmpdir_path / ".venv-release"
+    subprocess.run(
+        ["uv", "venv", str(venv_path)],
+        cwd=WORKSPACE_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    python_path = _venv_python(venv_path)
+    subprocess.run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(python_path),
+            str(root_wheel),
+        ],
+        cwd=WORKSPACE_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return _venv_script(venv_path, "agentic-workspace")
+
+
+def _load_release_wheel_patcher():
+    spec = importlib.util.spec_from_file_location("release_wheel_patcher_under_test", RELEASE_WHEEL_PATCHER)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 def _run_workspace_console_json(workspace_exe: Path, cwd: Path, *args: str) -> dict[str, object]:


### PR DESCRIPTION
## Summary

Closes #1629.

This fixes the GitHub-release install shape for the Python AW stack. The root `agentic-workspace` wheel is now patched during release so its sibling AW dependencies resolve from the same GitHub Release wheel assets with hashes, allowing a host repo to depend on the public root wheel as a single normal dependency.

## Changes

- Add `scripts/release/patch_workspace_release_wheel.py` to rewrite the root wheel `Requires-Dist` metadata and recompute `RECORD`.
- Run the patcher in both manual tag releases and post-merge semver releases before checksums/manifests are generated.
- Add a packaging proof that installs only the patched root wheel and verifies the full AW CLI stack runs in a fresh repo.
- Add that proof to CI and release workflow smoke checks.
- Document the GitHub-release Python install shape.

## Validation

- `uv run pytest tests/test_workspace_packaging.py::test_release_root_wheel_installs_workspace_stack_from_same_release_assets tests/test_workspace_packaging.py::test_ci_builds_and_uploads_root_package_artifacts tests/test_workspace_packaging.py::test_release_workflow_publishes_tagged_root_package_artifacts tests/test_release_workflows.py -q`
- `uv run python scripts/check/check_no_absolute_paths.py`
- `make lint-workspace`
- `make maintainer-surfaces`
- `make test-workspace`