### PR TITLE
[codex] Enforce command-generation artifact provenance

### DIFF
--- a/generated/memory/python/command_package.json
+++ b/generated/memory/python/command_package.json
@@ -2636,6 +2636,21 @@
       "status": "generated"
     }
   ],
+  "generation_metadata": {
+    "generator": {
+      "package": "command-generation",
+      "version": "0.2.4"
+    },
+    "schema_version": "command-generation/generated-artifact-metadata/v1",
+    "source_ir": {
+      "schema_version": "command-generation/command-package-ir/v1"
+    },
+    "target": {
+      "kind": "python",
+      "layout_version": "command-generation/python-target-layout/v1",
+      "package_name": "agentic-memory"
+    }
+  },
   "id": "memory-bootstrap",
   "operation_contract_root": "packages/memory/src/repo_memory_bootstrap/contracts",
   "package_role": "memory-module-cli",

--- a/generated/memory/typescript/package.json
+++ b/generated/memory/typescript/package.json
@@ -6,6 +6,21 @@
     "effectiveRuntimeCommand": null,
     "fixtureOnly": false,
     "generated": true,
+    "generationMetadata": {
+      "generator": {
+        "package": "command-generation",
+        "version": "0.2.4"
+      },
+      "schema_version": "command-generation/generated-artifact-metadata/v1",
+      "source_ir": {
+        "schema_version": "command-generation/command-package-ir/v1"
+      },
+      "target": {
+        "kind": "typescript",
+        "layout_version": "command-generation/typescript-target-layout/v1",
+        "package_name": "@agentic-workspace/memory-cli"
+      }
+    },
     "generationStatus": "mutation-capable-adapter",
     "maturity": {
       "id": "mutation-capable-adapter",

--- a/generated/memory/typescript/resources/command_package.json
+++ b/generated/memory/typescript/resources/command_package.json
@@ -2636,6 +2636,21 @@
       "status": "generated"
     }
   ],
+  "generation_metadata": {
+    "generator": {
+      "package": "command-generation",
+      "version": "0.2.4"
+    },
+    "schema_version": "command-generation/generated-artifact-metadata/v1",
+    "source_ir": {
+      "schema_version": "command-generation/command-package-ir/v1"
+    },
+    "target": {
+      "kind": "typescript",
+      "layout_version": "command-generation/typescript-target-layout/v1",
+      "package_name": "@agentic-workspace/memory-cli"
+    }
+  },
   "id": "memory-bootstrap",
   "operation_contract_root": "packages/memory/src/repo_memory_bootstrap/contracts",
   "package_role": "memory-module-cli",

--- a/generated/planning/python/command_package.json
+++ b/generated/planning/python/command_package.json
@@ -3077,6 +3077,21 @@
       "status": "generated"
     }
   ],
+  "generation_metadata": {
+    "generator": {
+      "package": "command-generation",
+      "version": "0.2.4"
+    },
+    "schema_version": "command-generation/generated-artifact-metadata/v1",
+    "source_ir": {
+      "schema_version": "command-generation/command-package-ir/v1"
+    },
+    "target": {
+      "kind": "python",
+      "layout_version": "command-generation/python-target-layout/v1",
+      "package_name": "agentic-planning"
+    }
+  },
   "id": "planning-bootstrap",
   "operation_contract_root": "packages/planning/src/repo_planning_bootstrap/contracts",
   "package_role": "planning-module-cli",

--- a/generated/planning/typescript/package.json
+++ b/generated/planning/typescript/package.json
@@ -6,6 +6,21 @@
     "effectiveRuntimeCommand": null,
     "fixtureOnly": false,
     "generated": true,
+    "generationMetadata": {
+      "generator": {
+        "package": "command-generation",
+        "version": "0.2.4"
+      },
+      "schema_version": "command-generation/generated-artifact-metadata/v1",
+      "source_ir": {
+        "schema_version": "command-generation/command-package-ir/v1"
+      },
+      "target": {
+        "kind": "typescript",
+        "layout_version": "command-generation/typescript-target-layout/v1",
+        "package_name": "@agentic-workspace/planning-cli"
+      }
+    },
     "generationStatus": "mutation-capable-adapter",
     "maturity": {
       "id": "mutation-capable-adapter",

--- a/generated/planning/typescript/resources/command_package.json
+++ b/generated/planning/typescript/resources/command_package.json
@@ -3077,6 +3077,21 @@
       "status": "generated"
     }
   ],
+  "generation_metadata": {
+    "generator": {
+      "package": "command-generation",
+      "version": "0.2.4"
+    },
+    "schema_version": "command-generation/generated-artifact-metadata/v1",
+    "source_ir": {
+      "schema_version": "command-generation/command-package-ir/v1"
+    },
+    "target": {
+      "kind": "typescript",
+      "layout_version": "command-generation/typescript-target-layout/v1",
+      "package_name": "@agentic-workspace/planning-cli"
+    }
+  },
   "id": "planning-bootstrap",
   "operation_contract_root": "packages/planning/src/repo_planning_bootstrap/contracts",
   "package_role": "planning-module-cli",

--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -2,7 +2,7 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl#sha256=0c7e1ec9aa78cc95154cca6cef7cfacb2c72c5abca4fa2cfdcb404e8aba5b72e"
+RUN python -m pip install --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.4/command_generation-0.2.4-py3-none-any.whl#sha256=462640f5e260ac9566dac525aae2d26a8d45d80722c8e4e60207418a3c45b8ee"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/python/Dockerfile.primitive-conformance
+++ b/generated/python/Dockerfile.primitive-conformance
@@ -2,6 +2,6 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl#sha256=0c7e1ec9aa78cc95154cca6cef7cfacb2c72c5abca4fa2cfdcb404e8aba5b72e"
+RUN python -m pip install --no-cache-dir "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.4/command_generation-0.2.4-py3-none-any.whl#sha256=462640f5e260ac9566dac525aae2d26a8d45d80722c8e4e60207418a3c45b8ee"
 
 CMD ["python", "-m", "command_generation.primitive_conformance"]

--- a/generated/typescript.conformance.Dockerfile
+++ b/generated/typescript.conformance.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /work
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 python3-pip \
     && find /usr/lib/python3/dist-packages -name '*.pyc' -delete \
-    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl#sha256=0c7e1ec9aa78cc95154cca6cef7cfacb2c72c5abca4fa2cfdcb404e8aba5b72e"
+    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.4/command_generation-0.2.4-py3-none-any.whl#sha256=462640f5e260ac9566dac525aae2d26a8d45d80722c8e4e60207418a3c45b8ee"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/verification/python/command_package.json
+++ b/generated/verification/python/command_package.json
@@ -96,6 +96,21 @@
       "status": "generated"
     }
   ],
+  "generation_metadata": {
+    "generator": {
+      "package": "command-generation",
+      "version": "0.2.4"
+    },
+    "schema_version": "command-generation/generated-artifact-metadata/v1",
+    "source_ir": {
+      "schema_version": "command-generation/command-package-ir/v1"
+    },
+    "target": {
+      "kind": "python",
+      "layout_version": "command-generation/python-target-layout/v1",
+      "package_name": "agentic-verification"
+    }
+  },
   "id": "verification-cli",
   "operation_contract_root": "packages/verification/src/repo_verification_bootstrap/contracts",
   "package_role": "verification-module-cli",

--- a/generated/verification/typescript/package.json
+++ b/generated/verification/typescript/package.json
@@ -6,6 +6,21 @@
     "effectiveRuntimeCommand": null,
     "fixtureOnly": false,
     "generated": true,
+    "generationMetadata": {
+      "generator": {
+        "package": "command-generation",
+        "version": "0.2.4"
+      },
+      "schema_version": "command-generation/generated-artifact-metadata/v1",
+      "source_ir": {
+        "schema_version": "command-generation/command-package-ir/v1"
+      },
+      "target": {
+        "kind": "typescript",
+        "layout_version": "command-generation/typescript-target-layout/v1",
+        "package_name": "@agentic-workspace/verification-cli"
+      }
+    },
     "generationStatus": "runtime-backed-read-only-adapter",
     "maturity": {
       "id": "runtime-backed-read-only-adapter",

--- a/generated/verification/typescript/resources/command_package.json
+++ b/generated/verification/typescript/resources/command_package.json
@@ -96,6 +96,21 @@
       "status": "generated"
     }
   ],
+  "generation_metadata": {
+    "generator": {
+      "package": "command-generation",
+      "version": "0.2.4"
+    },
+    "schema_version": "command-generation/generated-artifact-metadata/v1",
+    "source_ir": {
+      "schema_version": "command-generation/command-package-ir/v1"
+    },
+    "target": {
+      "kind": "typescript",
+      "layout_version": "command-generation/typescript-target-layout/v1",
+      "package_name": "@agentic-workspace/verification-cli"
+    }
+  },
   "id": "verification-cli",
   "operation_contract_root": "packages/verification/src/repo_verification_bootstrap/contracts",
   "package_role": "verification-module-cli",

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -4885,6 +4885,21 @@
       "status": "generated"
     }
   ],
+  "generation_metadata": {
+    "generator": {
+      "package": "command-generation",
+      "version": "0.2.4"
+    },
+    "schema_version": "command-generation/generated-artifact-metadata/v1",
+    "source_ir": {
+      "schema_version": "command-generation/command-package-ir/v1"
+    },
+    "target": {
+      "kind": "python",
+      "layout_version": "command-generation/python-target-layout/v1",
+      "package_name": "agentic-workspace"
+    }
+  },
   "id": "root-workspace",
   "operation_contract_root": "src/agentic_workspace/contracts",
   "package_role": "root-workspace-cli",

--- a/generated/workspace/typescript/package.json
+++ b/generated/workspace/typescript/package.json
@@ -6,6 +6,21 @@
     "effectiveRuntimeCommand": null,
     "fixtureOnly": false,
     "generated": true,
+    "generationMetadata": {
+      "generator": {
+        "package": "command-generation",
+        "version": "0.2.4"
+      },
+      "schema_version": "command-generation/generated-artifact-metadata/v1",
+      "source_ir": {
+        "schema_version": "command-generation/command-package-ir/v1"
+      },
+      "target": {
+        "kind": "typescript",
+        "layout_version": "command-generation/typescript-target-layout/v1",
+        "package_name": "@agentic-workspace/workspace-cli"
+      }
+    },
     "generationStatus": "mutation-capable-adapter",
     "maturity": {
       "id": "mutation-capable-adapter",

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -4885,6 +4885,21 @@
       "status": "generated"
     }
   ],
+  "generation_metadata": {
+    "generator": {
+      "package": "command-generation",
+      "version": "0.2.4"
+    },
+    "schema_version": "command-generation/generated-artifact-metadata/v1",
+    "source_ir": {
+      "schema_version": "command-generation/command-package-ir/v1"
+    },
+    "target": {
+      "kind": "typescript",
+      "layout_version": "command-generation/typescript-target-layout/v1",
+      "package_name": "@agentic-workspace/workspace-cli"
+    }
+  },
   "id": "root-workspace",
   "operation_contract_root": "src/agentic_workspace/contracts",
   "package_role": "root-workspace-cli",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ agentic-workspace = "agentic_workspace.cli:main"
 
 [dependency-groups]
 dev = [
-  "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl#sha256=0c7e1ec9aa78cc95154cca6cef7cfacb2c72c5abca4fa2cfdcb404e8aba5b72e",
+  "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.4/command_generation-0.2.4-py3-none-any.whl#sha256=462640f5e260ac9566dac525aae2d26a8d45d80722c8e4e60207418a3c45b8ee",
   "jsonschema",
   "pre-commit",
   "pytest",

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -181,7 +181,13 @@ PYTHON_OUTPUT_BOUNDARY_AUDIT_REQUIRED_PHRASES = (
     "not accepted as generic output",
 )
 COMMAND_GENERATION_RELEASE_BASE_URL = "https://github.com/rickardvh/command-generation/releases/download"
-COMMAND_GENERATION_COMPATIBLE_RANGE = ">=0.2.0,<0.3.0"
+COMMAND_GENERATION_COMPATIBLE_RANGE = ">=0.2.4,<0.3.0"
+COMMAND_GENERATION_METADATA_SCHEMA_VERSION = "command-generation/generated-artifact-metadata/v1"
+COMMAND_GENERATION_SOURCE_IR_SCHEMA_VERSION = "command-generation/command-package-ir/v1"
+COMMAND_GENERATION_TARGET_LAYOUT_VERSION = {
+    "python": "command-generation/python-target-layout/v1",
+    "typescript": "command-generation/typescript-target-layout/v1",
+}
 REQUIRED_PORTABLE_PRIMITIVE_CONFORMANCE = {
     "path.target_root.resolve",
     "filesystem.read",
@@ -2122,6 +2128,7 @@ def _runtime_boundary_minimization_report(metrics: dict[str, object]) -> dict[st
 def _generated_target_freshness_report(ir: dict[str, object]) -> dict[str, object]:
     outputs = list(render_workspace_command_package_outputs(ir, repo_root=REPO_ROOT))
     package_target_counts: dict[str, int] = {}
+    metadata_errors = _validate_generated_artifact_generation_metadata(ir)
 
     def target_family_for_path(path: Path) -> str | None:
         relative_path = path.relative_to(REPO_ROOT).as_posix()
@@ -2151,6 +2158,18 @@ def _generated_target_freshness_report(ir: dict[str, object]) -> dict[str, objec
         "stale_output_count_by_family": generic_report["stale_output_count_by_family"],
         "stale_outputs_by_family": generic_report["stale_outputs_by_family"],
         "missing_target_families": generic_report["missing_target_families"],
+        "generation_metadata": {
+            "kind": "command-generation/generated-artifact-metadata-proof/v1",
+            "status": "fresh" if not metadata_errors else "mismatch",
+            "expected_generator": {
+                "package": "command-generation",
+                "version": _command_generation_package_provenance()["declared_version"],
+            },
+            "expected_source_ir_schema_version": COMMAND_GENERATION_SOURCE_IR_SCHEMA_VERSION,
+            "expected_target_layout_versions": dict(COMMAND_GENERATION_TARGET_LAYOUT_VERSION),
+            "error_count": len(metadata_errors),
+            "errors": metadata_errors,
+        },
         "freshness_check_command": "uv run python scripts/generate/generate_command_packages.py --check",
         "refresh_command": "uv run python scripts/generate/generate_command_packages.py",
         "validation_command": "uv run python scripts/check/check_generated_command_packages.py",
@@ -3205,11 +3224,18 @@ def _validate_generated_python_target_layout() -> list[str]:
     return errors
 
 
+def _command_package_resource(package: dict[str, object], target: dict[str, object]) -> dict[str, object]:
+    resource = dict(package)
+    resource["generation_metadata"] = _expected_generation_metadata(package, target)
+    return resource
+
+
 def _target_scoped_command_package_resource(package: dict[str, object], target: dict[str, object]) -> dict[str, object]:
     scoped = dict(package)
     scoped["targets"] = [dict(target)]
     if target.get("kind") != "python":
         scoped.pop("python_runtime_binding", None)
+    scoped["generation_metadata"] = _expected_generation_metadata(package, target)
     scoped["target_resource_scope"] = {
         "kind": "command-generation/target-scoped-package-resource/v1",
         "target_kind": str(target.get("kind", "")),
@@ -3282,6 +3308,115 @@ def _validate_command_generation_release_provenance() -> list[str]:
             errors.append(f"{relative_path} command-generation install URL must match pyproject.toml released package URL")
         if "command-generation.git@" in text or "git+https://github.com/rickardvh/command-generation.git" in text:
             errors.append(f"{relative_path} must not install command-generation from a Git source ref")
+    return errors
+
+
+def _expected_generation_metadata(package: dict[str, object], target: dict[str, object]) -> dict[str, object]:
+    return {
+        "schema_version": COMMAND_GENERATION_METADATA_SCHEMA_VERSION,
+        "generator": {
+            "package": "command-generation",
+            "version": _command_generation_package_provenance()["declared_version"],
+        },
+        "source_ir": {
+            "schema_version": COMMAND_GENERATION_SOURCE_IR_SCHEMA_VERSION,
+        },
+        "target": {
+            "kind": str(target.get("kind", "")),
+            "package_name": str(target.get("package_name", "")),
+            "layout_version": COMMAND_GENERATION_TARGET_LAYOUT_VERSION.get(str(target.get("kind", "")), ""),
+        },
+    }
+
+
+def _validate_generation_metadata_payload(
+    *,
+    relative_path: str,
+    metadata: object,
+    expected: dict[str, object],
+) -> list[str]:
+    if not isinstance(metadata, dict):
+        return [f"{relative_path} is missing generation metadata"]
+    errors: list[str] = []
+    actual_generator = metadata.get("generator")
+    expected_generator = expected.get("generator")
+    if actual_generator != expected_generator:
+        errors.append(f"{relative_path} generation metadata has unexpected generator: {actual_generator!r}, expected {expected_generator!r}")
+    actual_source_ir = metadata.get("source_ir")
+    expected_source_ir = expected.get("source_ir")
+    if actual_source_ir != expected_source_ir:
+        errors.append(f"{relative_path} generation metadata has unexpected source_ir: {actual_source_ir!r}, expected {expected_source_ir!r}")
+    actual_target = metadata.get("target")
+    expected_target = expected.get("target")
+    if actual_target != expected_target:
+        errors.append(f"{relative_path} generation metadata has unexpected target layout: {actual_target!r}, expected {expected_target!r}")
+    if metadata.get("schema_version") != expected.get("schema_version"):
+        errors.append(
+            f"{relative_path} generation metadata has unexpected schema_version: "
+            f"{metadata.get('schema_version')!r}, expected {expected.get('schema_version')!r}"
+        )
+    return errors
+
+
+def _validate_generated_artifact_generation_metadata(ir: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+    if ir.get("schema_version") != COMMAND_GENERATION_SOURCE_IR_SCHEMA_VERSION:
+        errors.append(
+            "canonical command package IR schema mismatch: "
+            f"{ir.get('schema_version')!r}, expected {COMMAND_GENERATION_SOURCE_IR_SCHEMA_VERSION!r}"
+        )
+    if not _command_generation_package_provenance().get("compatible"):
+        errors.append("generated artifact metadata cannot be trusted until command-generation package provenance is compatible")
+    for package in ir.get("packages", []):
+        if not isinstance(package, dict):
+            continue
+        for target in package.get("targets", []):
+            if not isinstance(target, dict):
+                continue
+            target_kind = str(target.get("kind", ""))
+            if str(target.get("generation_status", "")) == "deferred":
+                continue
+            if target_kind not in COMMAND_GENERATION_TARGET_LAYOUT_VERSION:
+                errors.append(f"{package.get('id')} has unsupported generated target kind {target_kind!r}")
+                continue
+            generated_root = REPO_ROOT / str(target.get("generated_root", ""))
+            expected = _expected_generation_metadata(package, target)
+            if target_kind == "python":
+                resource_path = generated_root / "command_package.json"
+                relative_path = resource_path.relative_to(REPO_ROOT).as_posix()
+                if not resource_path.is_file():
+                    errors.append(f"{relative_path} is missing")
+                    continue
+                payload = json.loads(resource_path.read_text(encoding="utf-8"))
+                errors.extend(
+                    _validate_generation_metadata_payload(
+                        relative_path=relative_path,
+                        metadata=payload.get("generation_metadata"),
+                        expected=expected,
+                    )
+                )
+            elif target_kind == "typescript":
+                resource_path = generated_root / "resources" / "command_package.json"
+                package_json_path = generated_root / "package.json"
+                for path, pointer in (
+                    (resource_path, ("generation_metadata",)),
+                    (package_json_path, ("agenticWorkspace", "generationMetadata")),
+                ):
+                    relative_path = path.relative_to(REPO_ROOT).as_posix()
+                    if not path.is_file():
+                        errors.append(f"{relative_path} is missing")
+                        continue
+                    payload = json.loads(path.read_text(encoding="utf-8"))
+                    metadata: object = payload
+                    for key in pointer:
+                        metadata = metadata.get(key) if isinstance(metadata, dict) else None
+                    errors.extend(
+                        _validate_generation_metadata_payload(
+                            relative_path=relative_path,
+                            metadata=metadata,
+                            expected=expected,
+                        )
+                    )
     return errors
 
 
@@ -4104,7 +4239,7 @@ def _validate_static_surfaces() -> list[str]:
                 except json.JSONDecodeError as exc:
                     errors.append(f"{generated_root}/{resource_name} is invalid JSON: {exc}")
                     continue
-                if resource_name == "command_package.json" and payload != package:
+                if resource_name == "command_package.json" and payload != _command_package_resource(package, python_target):
                     errors.append(f"{generated_root}/command_package.json drifted from command_package_ir.json package {package_id!r}")
                 if resource_name == "adapter_commands.json":
                     expected_adapter_commands = []
@@ -4156,6 +4291,7 @@ def _validate_static_surfaces() -> list[str]:
         errors.extend(_validate_planning_generated_force_include_classification())
         errors.extend(_validate_generated_python_commands_absent_from_handwritten_parsers())
         errors.extend(_validate_no_shared_python_function_call_operation_ir())
+        errors.extend(_validate_generated_artifact_generation_metadata(ir))
         errors.extend(_validate_generated_cli_compatibility_vocabulary())
         forbidden_generated_entrypoints = [
             "src/agentic_workspace/generated_cli_package.py",

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -42,6 +42,16 @@
           "owner": "#1204 command-generation primitive registry",
           "reason": "The package-owned registry declares legacy primitive identifiers so host manifests can prove support and unsupported states during extraction.",
           "migration_path": "Keep primitive identifiers schema-backed and deprecate host-specific names only through explicit registry migrations."
+        },
+        {
+          "id": "legacy-ir-schema-canonicalization",
+          "kind": "accepted-schema-compatibility-boundary",
+          "paths": [
+            "command_generation/ir.py"
+          ],
+          "owner": "#1626 generated artifact provenance",
+          "reason": "The package-owned IR loader accepts the historical Agentic Workspace schema identity and canonicalizes it to command-generation/command-package-ir/v1 before validation and rendering.",
+          "migration_path": "Keep host-side proof asserting the canonical command-generation schema after loading; remove this coupling once checked-in AW command-package IR no longer uses the legacy schema identity."
         }
       ]
     },

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -495,6 +495,14 @@ def test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundarie
     )
     assert f"command_generation-{provenance['declared_version']}-py3-none-any.whl" in provenance["dependency_url"]
     assert "#sha256=" in provenance["dependency_url"]
+    metadata = target_freshness["generation_metadata"]
+    assert metadata["kind"] == "command-generation/generated-artifact-metadata-proof/v1"
+    assert metadata["status"] == "fresh"
+    assert metadata["expected_generator"] == {"package": "command-generation", "version": provenance["declared_version"]}
+    assert metadata["expected_source_ir_schema_version"] == "command-generation/command-package-ir/v1"
+    assert metadata["expected_target_layout_versions"]["python"] == "command-generation/python-target-layout/v1"
+    assert metadata["expected_target_layout_versions"]["typescript"] == "command-generation/typescript-target-layout/v1"
+    assert metadata["errors"] == []
     assert target_freshness["target_families"] == ["python", "typescript"]
     assert target_freshness["rendered_output_count_by_family"]["python"] > 0
     assert target_freshness["rendered_output_count_by_family"]["typescript"] > 0
@@ -528,6 +536,44 @@ def test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundarie
     assert "memory.install.lifecycle" in {
         operation["operation_id"] for operation in lifecycle_metrics["codegen_default_dry_run_operations"]
     }
+
+
+def test_generated_artifact_metadata_rejects_unexpected_generator_version() -> None:
+    errors = _checker_case_errors(
+        """
+        ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
+        original = checker.json.loads
+        def fake_loads(text):
+            payload = original(text)
+            if isinstance(payload, dict) and isinstance(payload.get("generation_metadata"), dict):
+                payload = copy.deepcopy(payload)
+                payload["generation_metadata"]["generator"]["version"] = "0.0.0"
+            return payload
+        checker.json.loads = fake_loads
+        _emit({"errors": checker._validate_generated_artifact_generation_metadata(ir)})
+        """
+    )
+
+    assert any("generation metadata has unexpected generator" in error for error in errors)
+
+
+def test_generated_artifact_metadata_rejects_unsupported_target_layout() -> None:
+    errors = _checker_case_errors(
+        """
+        ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
+        original = checker.json.loads
+        def fake_loads(text):
+            payload = original(text)
+            if isinstance(payload, dict) and isinstance(payload.get("generation_metadata"), dict):
+                payload = copy.deepcopy(payload)
+                payload["generation_metadata"]["target"]["layout_version"] = "command-generation/python-target-layout/v0"
+            return payload
+        checker.json.loads = fake_loads
+        _emit({"errors": checker._validate_generated_artifact_generation_metadata(ir)})
+        """
+    )
+
+    assert any("generation metadata has unexpected target layout" in error for error in errors)
 
 
 def test_lifecycle_dry_run_generation_regression_is_blocked() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl" },
+    { name = "command-generation", url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.4/command_generation-0.2.4-py3-none-any.whl" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -144,13 +144,13 @@ wheels = [
 
 [[package]]
 name = "command-generation"
-version = "0.2.0"
-source = { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl" }
+version = "0.2.4"
+source = { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.4/command_generation-0.2.4-py3-none-any.whl" }
 dependencies = [
     { name = "jsonschema" },
 ]
 wheels = [
-    { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.0/command_generation-0.2.0-py3-none-any.whl", hash = "sha256:0c7e1ec9aa78cc95154cca6cef7cfacb2c72c5abca4fa2cfdcb404e8aba5b72e" },
+    { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.4/command_generation-0.2.4-py3-none-any.whl", hash = "sha256:462640f5e260ac9566dac525aae2d26a8d45d80722c8e4e60207418a3c45b8ee" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Summary

- Updates the AW dev dependency pin from `command-generation` v0.2.0 to the released v0.2.4 wheel and refreshes generated command artifacts.
- Enforces generated artifact metadata in the generated-package proof: generator package/version, canonical source IR schema, and Python/TypeScript target layout versions.
- Records the upstream legacy IR schema canonicalization boundary in the existing extraction-readiness inventory instead of keeping an AW-local compatibility bridge.

Closes #1625.
Closes #1626.

## Validation

- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `make maintainer-surfaces`
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run pytest tests/test_generated_command_package_proof_runner.py::test_static_generated_package_proof_accepts_current_static_surfaces tests/test_generated_command_package_proof_runner.py::test_generated_artifact_metadata_rejects_unexpected_generator_version tests/test_generated_command_package_proof_runner.py::test_generated_artifact_metadata_rejects_unsupported_target_layout tests/test_command_generation_integration.py -q`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_no_absolute_paths.py`
