### PR TITLE
Tighten issue and PR completion guidance

### DIFF
--- a/.agentic-workspace/WORKFLOW.md
+++ b/.agentic-workspace/WORKFLOW.md
@@ -43,6 +43,8 @@ The agent still owns semantic judgment about intent clarity, direct/bounded/lane
 
 Do not treat prompt keywords, filenames, or prose markers as decision authority. Use skills, structured signals, selected-output sections, owner boundaries, and explicit hard gates to tell the agent what to consider and where to inspect. Leave reasoning and disposition decisions to the agent unless AW owns a named hard gate. If user guidance repeats often enough to shape future behavior, capture it in Memory and promote the stable rule into core guidance rather than relying on chat memory.
 
+When implementing an issue, satisfy the intended end state in the ordinary path. Do not treat a smaller change as complete merely because checks pass if that smaller change preserves the old ordinary-path behavior. If the full intended outcome appears larger than the issue safely permits, ask for clarification instead of closing the issue with a partial path.
+
 ## Structured Priority
 
 - Use `start` or `implement --changed` before prose when the CLI is available; use `summary`, `planning`, `skills`, and `proof --changed` when routed by the packet or task shape; reserve `preflight`, `defaults`, `config`, `modules`, `ownership`, `--verbose`, and `report` for recovery or deeper detail.

--- a/.agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py
+++ b/.agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py
@@ -27,7 +27,22 @@ TEMPLATE_BY_KIND = {
 COMPLETION_BOUNDARY_FIELDS = {
     "final_satisfaction",
     "evidence_required_for_final_completion",
+    "non_solutions",
+    "completion_rule",
 }
+
+DEFAULT_NON_SOLUTIONS = """The following do not close this issue unless explicitly listed in the acceptance criteria:
+
+- documenting the problem without changing the affected behavior;
+- adding an inventory without completing the requested change;
+- reclassifying or renaming the current behavior while preserving the old dependency/path;
+- adding a follow-up issue instead of completing the stated outcome;
+- changing tests to accept the current behavior rather than making the intended behavior true."""
+
+DEFAULT_COMPLETION_RULE = (
+    "A PR may close this issue only if the intended outcome is true in the ordinary path, "
+    "not merely documented, inventoried, reclassified, or deferred."
+)
 
 ISSUE_BODY_REQUEST_SCHEMA = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -187,6 +202,10 @@ def _field_label(item: dict[str, Any]) -> str:
 def _default_value(item: dict[str, Any]) -> str:
     item_type = str(item.get("type", ""))
     attributes = item.get("attributes")
+    if isinstance(attributes, dict):
+        value = str(attributes.get("value", "")).strip()
+        if value:
+            return value
     options = attributes.get("options") if isinstance(attributes, dict) else None
     if item_type == "dropdown" and isinstance(options, list) and options:
         first = options[0]
@@ -244,6 +263,10 @@ def _completion_boundary_default(*, field_id: str, fields: dict[str, str]) -> st
         if evidence_hint:
             return f"Final completion evidence must prove the final intended state, including: {evidence_hint}"
         return "Proof or review evidence must show the final intended outcome, not only a useful local change."
+    if field_id == "non_solutions":
+        return DEFAULT_NON_SOLUTIONS
+    if field_id == "completion_rule":
+        return DEFAULT_COMPLETION_RULE
     return ""
 
 

--- a/.github/ISSUE_TEMPLATE/01-direction-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/01-direction-proposal.yml
@@ -77,9 +77,27 @@ body:
   - type: textarea
     id: acceptance
     attributes:
-      label: Acceptance / success signal
-      description: How would we know this direction has been meaningfully advanced?
-      placeholder: Define what better looks like.
+      label: Acceptance criteria
+      description: What observable final-state requirements must be true?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_solutions
+    attributes:
+      label: Non-solutions
+      description: What does not close this issue unless explicitly listed in the acceptance criteria?
+      value: |
+        The following do not close this issue unless explicitly listed in the acceptance criteria:
+
+        - documenting the problem without changing the affected behavior;
+        - adding an inventory without completing the requested change;
+        - reclassifying or renaming the current behavior while preserving the old dependency/path;
+        - adding a follow-up issue instead of completing the stated outcome;
+        - changing tests to accept the current behavior rather than making the intended behavior true.
     validations:
       required: true
 
@@ -98,6 +116,15 @@ body:
       label: Evidence required for final completion
       description: What proof, review, or acceptance evidence is required before this issue can honestly close?
       placeholder: Name the evidence that proves the final intended state, not only local progress.
+    validations:
+      required: true
+
+  - type: textarea
+    id: completion_rule
+    attributes:
+      label: Completion rule
+      description: What condition permits a PR to close this issue?
+      value: A PR may close this issue only if the intended outcome is true in the ordinary path, not merely documented, inventoried, reclassified, or deferred.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/02-bug-regression.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug-regression.yml
@@ -54,6 +54,42 @@ body:
       required: true
 
   - type: textarea
+    id: intended_outcome
+    attributes:
+      label: Intended outcome
+      description: Describe the final corrected state that should be true after this issue is complete.
+      placeholder: Describe the ordinary-path behavior after the bug is fixed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What observable final-state requirements must be true?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_solutions
+    attributes:
+      label: Non-solutions
+      description: What does not close this issue unless explicitly listed in the acceptance criteria?
+      value: |
+        The following do not close this issue unless explicitly listed in the acceptance criteria:
+
+        - documenting the problem without changing the affected behavior;
+        - adding an inventory without completing the requested change;
+        - reclassifying or renaming the current behavior while preserving the old dependency/path;
+        - adding a follow-up issue instead of completing the stated outcome;
+        - changing tests to accept the current behavior rather than making the intended behavior true.
+    validations:
+      required: true
+
+  - type: textarea
     id: final_satisfaction
     attributes:
       label: Final satisfaction
@@ -68,6 +104,15 @@ body:
       label: Evidence required for final completion
       description: What proof, regression test, or review evidence is required before this bug can honestly close?
       placeholder: Name the evidence that proves the final expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: completion_rule
+    attributes:
+      label: Completion rule
+      description: What condition permits a PR to close this issue?
+      value: A PR may close this issue only if the intended outcome is true in the ordinary path, not merely documented, inventoried, reclassified, or deferred.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/03-review-friction.yml
+++ b/.github/ISSUE_TEMPLATE/03-review-friction.yml
@@ -82,10 +82,38 @@ body:
       required: true
 
   - type: textarea
-    id: outcome
+    id: intended_outcome
     attributes:
-      label: What cheaper correction should become possible?
+      label: Intended outcome
+      description: Describe the final state that should be true after this issue is complete.
       placeholder: Explain what should become easier after this is addressed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What observable final-state requirements must be true?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_solutions
+    attributes:
+      label: Non-solutions
+      description: What does not close this issue unless explicitly listed in the acceptance criteria?
+      value: |
+        The following do not close this issue unless explicitly listed in the acceptance criteria:
+
+        - documenting the problem without changing the affected behavior;
+        - adding an inventory without completing the requested change;
+        - reclassifying or renaming the current behavior while preserving the old dependency/path;
+        - adding a follow-up issue instead of completing the stated outcome;
+        - changing tests to accept the current behavior rather than making the intended behavior true.
     validations:
       required: true
 
@@ -104,5 +132,14 @@ body:
       label: Evidence required for final completion
       description: What proof, review, or dogfooding evidence is required before this issue can honestly close?
       placeholder: Name the evidence that proves the final desired signal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: completion_rule
+    attributes:
+      label: Completion rule
+      description: What condition permits a PR to close this issue?
+      value: A PR may close this issue only if the intended outcome is true in the ordinary path, not merely documented, inventoried, reclassified, or deferred.
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Completion audit
+
+- [ ] This PR makes the issue's intended outcome true in the ordinary path.
+- [ ] Any remaining old behavior is explicitly allowed by the issue acceptance criteria.
+- [ ] This PR does not rely only on documentation, inventory, reclassification, or a follow-up plan to close the issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Ordinary route:
 1. Use `uv run python scripts/run_agentic_workspace.py start --task "<task>" --format json` before non-trivial answers, edits, read-only workflow, config, delegation, or action-safety decisions.
 2. Use `uv run python scripts/run_agentic_workspace.py implement --changed <paths> --task "<task>" --format json` when changed paths are already known.
 3. Follow `next_safe_action`, `action_signals`, and `skills` before opening raw `.agentic-workspace` files or running drill-down commands.
+4. When implementing an issue, satisfy the intended end state in the ordinary path; ask for clarification instead of closing with a partial path when the full outcome appears larger than the issue safely permits.
 
 Boundaries:
 - The effective invocation comes from `.agentic-workspace/config.toml` `[workspace].cli_invoke`; `.agentic-workspace/config.local.toml` may override it.

--- a/src/agentic_workspace/_payload/.agentic-workspace/WORKFLOW.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/WORKFLOW.md
@@ -41,6 +41,8 @@ Active work is Work Shaping plus Planning Autopilot:
 
 The agent still owns semantic judgment about intent clarity, direct/bounded/lane/epic shape, proof proportionality, and completion claim level. Do not treat the command list as the workflow, and do not hand-edit Planning state when a command-owned mutation is available.
 
+When implementing an issue, satisfy the intended end state in the ordinary path. Do not treat a smaller change as complete merely because checks pass if that smaller change preserves the old ordinary-path behavior. If the full intended outcome appears larger than the issue safely permits, ask for clarification instead of closing the issue with a partial path.
+
 ## Structured Priority
 
 - Use `start` or `implement --changed` before prose when the CLI is available; use `summary`, `planning`, `skills`, and `proof --changed` when routed by the packet or task shape; reserve `preflight`, `defaults`, `config`, `modules`, `ownership`, `--verbose`, and `report` for recovery or deeper detail.

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -180,6 +180,7 @@ def workspace_pointer_block(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> str:
         f'1. Use `{effective_cli} start --task "<task>" --format json` before non-trivial answers, edits, read-only workflow, config, delegation, or action-safety decisions.\n'
         f'2. Use `{effective_cli} implement --changed <paths> --task "<task>" --format json` when changed paths are already known.\n'
         "3. Follow `next_safe_action`, `action_signals`, and `skills` before opening raw `.agentic-workspace` files or running drill-down commands.\n"
+        "4. When implementing an issue, satisfy the intended end state in the ordinary path; ask for clarification instead of closing with a partial path when the full outcome appears larger than the issue safely permits.\n"
         "\n"
         "Boundaries:\n"
         "- The effective invocation comes from `.agentic-workspace/config.toml` `[workspace].cli_invoke`; `.agentic-workspace/config.local.toml` may override it.\n"

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -8717,16 +8717,22 @@ def _completion_boundary_payload(
         "required_residual_intent": required_residual_intent,
         "evidence_required_for_final_completion": evidence_required,
         "issue_authoring_fields": [
+            "intended_outcome",
+            "acceptance",
+            "non_solutions",
             "final_satisfaction",
             "bounded_slice_success",
             "partial_pr_may_close",
             "required_follow_up_owner",
             "required_residual_intent",
             "evidence_required_for_final_completion",
+            "completion_rule",
         ],
         "closure_rule": (
             "Treat useful progress and final intended outcome satisfaction as separate claims. "
-            "A bounded slice may land only if remaining intent and owner are preserved; it closes the issue only when partial_pr_may_close is yes or final satisfaction evidence is present."
+            "When implementing an issue, satisfy the intended end state in the ordinary path; do not preserve old ordinary-path behavior unless the issue explicitly allows it. "
+            "A bounded slice may land only if remaining intent and owner are preserved; it closes the issue only when partial_pr_may_close is yes or final satisfaction evidence is present. "
+            "Ask for clarification when the full intended outcome appears larger than the issue safely permits."
         ),
         "default_rule": "Direction/proposal issues default partial_pr_may_close to no unless the issue author says otherwise.",
         "sources": [

--- a/tests/test_github_issue_body_agent_aid.py
+++ b/tests/test_github_issue_body_agent_aid.py
@@ -23,8 +23,12 @@ def _write_json(path: Path, payload: dict) -> None:
 
 def test_issue_templates_include_completion_boundary_fields() -> None:
     required_fields = {
+        "intended_outcome",
+        "acceptance",
+        "non_solutions",
         "final_satisfaction",
         "evidence_required_for_final_completion",
+        "completion_rule",
     }
 
     for template_path in sorted((_REPO_ROOT / ".github" / "ISSUE_TEMPLATE").glob("*.yml")):
@@ -53,9 +57,13 @@ def test_direction_issue_body_uses_repo_template_fields() -> None:
     assert rendered["title"] == "[Workspace]: Example"
     assert rendered["labels"] == ["planning"]
     assert "## Problem / intent\nMake the right issue shape cheap." in rendered["body"]
-    assert "## Acceptance / success signal\nGenerated body has template headings." in rendered["body"]
+    assert "## Acceptance criteria\nGenerated body has template headings." in rendered["body"]
     assert "## Final satisfaction\nFinal completion requires satisfying: Agents use the repo template fields." in rendered["body"]
     assert "## Evidence required for final completion\nFinal completion evidence must prove the final intended state" in rendered["body"]
+    assert (
+        "## Non-solutions\nThe following do not close this issue unless explicitly listed in the acceptance criteria:" in rendered["body"]
+    )
+    assert "## Completion rule\nA PR may close this issue only if the intended outcome is true in the ordinary path" in rendered["body"]
 
 
 def test_direction_issue_body_preserves_final_completion_fields() -> None:
@@ -88,7 +96,7 @@ def test_review_issue_body_defaults_dropdowns_and_labels() -> None:
             "observed_problem": "Issue creation bypassed templates.",
             "evidence": "#822 #823 #824",
             "desired_signal": "A cheap body scaffold.",
-            "outcome": "Agents preserve form fields.",
+            "intended_outcome": "Agents preserve form fields.",
         },
     )
 
@@ -97,6 +105,7 @@ def test_review_issue_body_defaults_dropdowns_and_labels() -> None:
     assert "## Issue kind\nReview / trust gap" in rendered["body"]
     assert "## Should the product absorb this first?\nYes" in rendered["body"]
     assert "## Final satisfaction\nFinal completion requires satisfying: Agents preserve form fields." in rendered["body"]
+    assert "## Acceptance criteria\nTODO:" in rendered["body"]
 
 
 def test_bug_issue_body_defaults_final_completion_fields() -> None:
@@ -106,6 +115,7 @@ def test_bug_issue_body_defaults_final_completion_fields() -> None:
         fields={
             "current_behavior": "The command claims final closure after a partial fix.",
             "expected_behavior": "The command preserves the remaining bug-fix intent.",
+            "intended_outcome": "The command preserves the remaining bug-fix intent.",
             "reproduction": "1. Run the closeout command.",
             "product_reasoning": "The package owns this guidance.",
         },
@@ -118,6 +128,15 @@ def test_bug_issue_body_defaults_final_completion_fields() -> None:
         in rendered["body"]
     )
     assert "## Evidence required for final completion\nFinal completion evidence must prove the final intended state" in rendered["body"]
+
+
+def test_pull_request_template_prompts_completion_audit() -> None:
+    template = (_REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(encoding="utf-8")
+
+    assert "## Completion audit" in template
+    assert "This PR makes the issue's intended outcome true in the ordinary path." in template
+    assert "Any remaining old behavior is explicitly allowed by the issue acceptance criteria." in template
+    assert "documentation, inventory, reclassification, or a follow-up plan" in template
 
 
 def test_issue_body_normalizes_duplicate_template_title_prefix() -> None:
@@ -214,7 +233,7 @@ def test_issue_body_renders_from_archived_lane_record(tmp_path: Path) -> None:
         },
     ]
     assert "## Problem / intent\nAvoid shell property extraction from lane objects." in rendered["body"]
-    assert "## Acceptance / success signal\nIssue-body tests prove source loading." in rendered["body"]
+    assert "## Acceptance criteria\nIssue-body tests prove source loading." in rendered["body"]
 
 
 def test_issue_body_renders_from_decomposition_candidate_lane(tmp_path: Path) -> None:

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -130,6 +130,7 @@ def test_workspace_workflow_is_projection_not_primary_authority() -> None:
         assert "`summary` owns active continuation" in text
         assert "`implement --changed` owns known changed-path work context" in text
         assert "`planning` owns routed state mutation" in text
+        assert "When implementing an issue, satisfy the intended end state in the ordinary path" in text
         assert "## Fallback Work Shape" in text
         assert "## Work Routing Gate" not in text
         assert (

--- a/tests/test_workspace_modules_cli.py
+++ b/tests/test_workspace_modules_cli.py
@@ -463,4 +463,5 @@ def test_workspace_agents_template_renders_resolved_cli_invocation() -> None:
     assert "- canonical_source: `.agentic-workspace/config.toml` and `uv run agentic-workspace start --target . --format json`" in rendered
     assert 'Use `uv run agentic-workspace start --task "<task>" --format json` before non-trivial answers' in rendered
     assert 'Use `uv run agentic-workspace implement --changed <paths> --task "<task>" --format json`' in rendered
+    assert "When implementing an issue, satisfy the intended end state in the ordinary path" in rendered
     assert "use the effective CLI invocation from `agentic-workspace start" not in rendered


### PR DESCRIPTION
## Summary

- add generic intended-outcome, acceptance, non-solution, and completion-rule sections to issue forms and generated issue bodies
- add a PR completion audit template for issue-closing PRs
- surface intended-outcome completion guidance in AGENTS, fallback workflow docs, and the completion-boundary packet

## Completion audit

- [x] This PR makes the issue's intended outcome true in the ordinary path.
- [x] Any remaining old behavior is explicitly allowed by the issue acceptance criteria.
- [x] This PR does not rely only on documentation, inventory, reclassification, or a follow-up plan to close the issue.

Closes #1635.
Closes #1636.
Closes #1637.

## Proof

- `uv run pytest tests/test_github_issue_body_agent_aid.py tests/test_workspace_modules_cli.py::test_workspace_agents_template_renders_resolved_cli_invocation tests/test_maintainer_surfaces.py::test_workspace_workflow_is_projection_not_primary_authority -q`
- `uv run ruff check .agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py src/agentic_workspace/config.py src/agentic_workspace/workspace_runtime_primitives.py tests/test_github_issue_body_agent_aid.py tests/test_workspace_modules_cli.py tests/test_maintainer_surfaces.py`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_agent_aids.py --quiet-success`
- `make test-workspace`
- `make lint-workspace`