### PR TITLE
Remove transitional primitive aliases from generated artifacts

### DIFF
--- a/generated/memory/python/command_package.json
+++ b/generated/memory/python/command_package.json
@@ -2639,7 +2639,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.9"
+      "version": "0.2.10"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/memory/python/primitives/primitive_executor.py
+++ b/generated/memory/python/primitives/primitive_executor.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import importlib
 import json
-import re
 import tomllib
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -67,20 +66,28 @@ def run_operation_steps(
     if not isinstance(steps, list):
         raise PrimitiveExecutionError("operation ir_plan.steps must be a list")
     fragments = operation_fragments(operation, error_type=PrimitiveExecutionError)
-    for raw_step in expand_operation_steps(steps, fragments=fragments, error_type=PrimitiveExecutionError):
+    for raw_step in expand_operation_steps(
+        steps, fragments=fragments, error_type=PrimitiveExecutionError
+    ):
         primitive = str(raw_step.get("uses", ""))
         arguments = raw_step.get("arguments", {})
         if not isinstance(arguments, dict):
-            raise PrimitiveExecutionError(f"step {raw_step.get('id', primitive)!r} arguments must be an object")
+            raise PrimitiveExecutionError(
+                f"step {raw_step.get('id', primitive)!r} arguments must be an object"
+            )
         if not _condition_matches(raw_step.get("when"), values=values):
             continue
         handler = custom_handlers.get(primitive)
         result = (
             handler(values, arguments, context)
             if handler is not None
-            else execute_primitive(primitive, values=values, arguments=arguments, context=context)
+            else execute_primitive(
+                primitive, values=values, arguments=arguments, context=context
+            )
         )
-        _store_step_result(values=values, outputs=raw_step.get("outputs", []), result=result)
+        _store_step_result(
+            values=values, outputs=raw_step.get("outputs", []), result=result
+        )
     return values
 
 
@@ -106,23 +113,13 @@ def execute_primitive(
         return _toml_table_counts(values=values, arguments=arguments, context=context)
     if primitive == "payload.assemble":
         return _assemble_payload(values=values, arguments=arguments)
-    if primitive == "payload.status":
-        return _payload_status(values=values, arguments=arguments, context=context)
-    if primitive == "payload.lifecycle-plan":
-        return _payload_lifecycle_plan(values=values, arguments=arguments, context=context)
-    if primitive == "payload.current-memory":
-        return _payload_current_memory(values=values, arguments=arguments, context=context)
-    if primitive == "payload.verify":
-        return _verify_payload(values=values, arguments=arguments, context=context)
     if primitive == "output.emit":
         return _emit_output(values=values, arguments=arguments)
-    if primitive == "output.emit.install-result":
-        return _emit_output(values=values, arguments={"text_style": "install-result"})
-    if primitive == "output.emit.current-memory":
-        return _emit_output(values=values, arguments={"text_style": "current-memory"})
     if primitive == "python.function.call":
         return _call_python_function(values=values, arguments=arguments)
-    return execute_host_primitive(primitive, values=values, arguments=arguments, context=context)
+    return execute_host_primitive(
+        primitive, values=values, arguments=arguments, context=context
+    )
 
 
 def _store_step_result(*, values: dict[str, Any], outputs: Any, result: Any) -> None:
@@ -142,7 +139,9 @@ def _store_step_result(*, values: dict[str, Any], outputs: Any, result: Any) -> 
         raise PrimitiveExecutionError("multi-output primitive results must be mappings")
     for output_name in output_names:
         if output_name not in result:
-            raise PrimitiveExecutionError(f"primitive result missing declared output: {output_name!r}")
+            raise PrimitiveExecutionError(
+                f"primitive result missing declared output: {output_name!r}"
+            )
         values[output_name] = result[output_name]
 
 
@@ -165,7 +164,9 @@ def _condition_matches(condition: Any, *, values: dict[str, Any]) -> bool:
     if keys == {"not"}:
         return not _condition_matches(condition["not"], values=values)
     if keys not in ({"value", "equals"}, {"value", "present"}):
-        raise PrimitiveExecutionError("step when condition must use exactly one of all, any, not, equals, or present")
+        raise PrimitiveExecutionError(
+            "step when condition must use exactly one of all, any, not, equals, or present"
+        )
     value_name = str(condition.get("value", ""))
     if not value_name:
         raise PrimitiveExecutionError("step when condition must declare a value name")
@@ -175,7 +176,9 @@ def _condition_matches(condition: Any, *, values: dict[str, Any]) -> bool:
     return (actual is not None) == bool(condition["present"])
 
 
-def _resolve_target_root(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> str:
+def _resolve_target_root(
+    *, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext
+) -> str:
     target = values.get("target") or "."
     target_root = (context.cwd / str(target)).resolve()
     if bool(arguments.get("must_exist", False)) and not target_root.exists():
@@ -193,11 +196,15 @@ def _read_text(*, arguments: dict[str, Any], context: PrimitiveContext) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _glob(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> list[dict[str, str]]:
+def _glob(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> list[dict[str, str]]:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     pattern = str(arguments.get("pattern", ""))
     if not pattern or Path(pattern).is_absolute() or ".." in Path(pattern).parts:
-        raise PrimitiveExecutionError(f"unsupported filesystem.glob pattern: {pattern!r}")
+        raise PrimitiveExecutionError(
+            f"unsupported filesystem.glob pattern: {pattern!r}"
+        )
     matches = []
     for path in root.glob(pattern):
         resolved = path.resolve()
@@ -207,7 +214,9 @@ def _glob(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[
     return sorted(matches, key=lambda item: item["relative_path"])
 
 
-def _exists(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> bool:
+def _exists(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> bool:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     path = _resolve_inside(root, str(arguments.get("path", "")))
     if str(arguments.get("kind", "any")) == "file":
@@ -222,11 +231,15 @@ def _parse_json(*, values: dict[str, Any], arguments: dict[str, Any]) -> Any:
     try:
         text = values[source_name]
     except KeyError as exc:
-        raise PrimitiveExecutionError(f"json.parse missing source value: {source_name!r}") from exc
+        raise PrimitiveExecutionError(
+            f"json.parse missing source value: {source_name!r}"
+        ) from exc
     return json.loads(str(text))
 
 
-def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
+def _toml_table_counts(
+    *, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext
+) -> dict[str, Any]:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     relative_path = str(arguments.get("path", ""))
     path = _resolve_inside(root, relative_path)
@@ -244,12 +257,20 @@ def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], con
         "path": relative_path,
     }
     if not path.exists():
-        return {"table_counts": counts, "table_present": False, "table_status": counts["status"]}
+        return {
+            "table_counts": counts,
+            "table_present": False,
+            "table_status": counts["status"],
+        }
     try:
         payload = tomllib.loads(path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError):
         counts["status"] = "invalid"
-        return {"table_counts": counts, "table_present": False, "table_status": counts["status"]}
+        return {
+            "table_counts": counts,
+            "table_present": False,
+            "table_status": counts["status"],
+        }
     records = payload.get(table_name, {}) if isinstance(payload, dict) else {}
     record_values = list(records.values()) if isinstance(records, dict) else []
     counts["status"] = "present"
@@ -265,10 +286,16 @@ def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], con
             counts["optional_count"] += 1
         if bool(record_payload.get(routing_only_field, False)):
             counts["routing_only_count"] += 1
-    return {"table_counts": counts, "table_present": True, "table_status": counts["status"]}
+    return {
+        "table_counts": counts,
+        "table_present": True,
+        "table_status": counts["status"],
+    }
 
 
-def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> dict[str, Any]:
+def _assemble_payload(
+    *, values: dict[str, Any], arguments: dict[str, Any]
+) -> dict[str, Any]:
     fields = arguments.get("fields", {})
     if not isinstance(fields, dict):
         raise PrimitiveExecutionError("payload.assemble fields must be an object")
@@ -293,11 +320,17 @@ def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> d
     if actions_from == "registry.skills":
         registry = values.get("registry", {})
         if not isinstance(registry, dict):
-            raise PrimitiveExecutionError("registry.skills payload source must be an object")
+            raise PrimitiveExecutionError(
+                "registry.skills payload source must be an object"
+            )
         payload["mode"] = str(fields.get("mode", "skills"))
-        payload["bootstrap_version"] = _resolve_dotted_value(registry, str(fields.get("bootstrap_version_from", "")))
+        payload["bootstrap_version"] = _resolve_dotted_value(
+            registry, str(fields.get("bootstrap_version_from", ""))
+        )
         payload["actions"] = []
-        for item in _list_of_objects(registry.get("skills", []), source="registry.skills"):
+        for item in _list_of_objects(
+            registry.get("skills", []), source="registry.skills"
+        ):
             skill_id = str(item.get("id", "")).strip()
             path = str(item.get("path", "")).strip()
             if not skill_id or not path:
@@ -320,493 +353,36 @@ def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> d
                 }
             )
         return payload
-    raise PrimitiveExecutionError(f"unsupported payload.assemble actions_from: {actions_from!r}")
+    raise PrimitiveExecutionError(
+        f"unsupported payload.assemble actions_from: {actions_from!r}"
+    )
 
 
-def _assemble_package_file_list(*, values: dict[str, Any], fields: Mapping[str, Any]) -> dict[str, Any]:
+def _assemble_package_file_list(
+    *, values: dict[str, Any], fields: Mapping[str, Any]
+) -> dict[str, Any]:
     files_from = str(fields.get("files_from", "files"))
-    bundled_skills_from = str(fields.get("bundled_skill_files_from", "bundled_skill_files"))
+    bundled_skills_from = str(
+        fields.get("bundled_skill_files_from", "bundled_skill_files")
+    )
     return {
         "files": _relative_path_list(values.get(files_from, []), source=files_from),
-        "default_files": _string_list(fields.get("default_files", []), source="payload.assemble fields.default_files"),
-        "optional_files": _string_list(fields.get("optional_files", []), source="payload.assemble fields.optional_files"),
-        "bundled_skill_files": _relative_path_list(values.get(bundled_skills_from, []), source=bundled_skills_from),
+        "default_files": _string_list(
+            fields.get("default_files", []),
+            source="payload.assemble fields.default_files",
+        ),
+        "optional_files": _string_list(
+            fields.get("optional_files", []),
+            source="payload.assemble fields.optional_files",
+        ),
+        "bundled_skill_files": _relative_path_list(
+            values.get(bundled_skills_from, []), source=bundled_skills_from
+        ),
         "optional_enable_commands": _string_list(
             fields.get("optional_enable_commands", []),
             source="payload.assemble fields.optional_enable_commands",
         ),
     }
-
-
-def _verify_payload(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    payload_root = context.root(str(arguments.get("payload_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.verify cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    manifest_path = str(policy.get("manifest_path", ""))
-    payload_paths = _payload_file_set(payload_root=payload_root, policy=policy)
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    payload_version = _read_version(payload_root / version_path)
-    actions: list[dict[str, str]] = []
-    if payload_version is None:
-        actions.append(_payload_action("manual review", version_path, "payload version marker is missing or invalid"))
-    elif payload_version != bootstrap_version:
-        actions.append(
-            _payload_action(
-                "manual review",
-                version_path,
-                f"payload version marker ({payload_version}) does not match installer bootstrap version ({bootstrap_version})",
-            )
-        )
-    _verify_upgrade_source(policy=policy, payload_root=payload_root, actions=actions)
-    for required in _string_list(policy.get("required_files", []), source="payload.verify required_files"):
-        present = required in payload_paths
-        actions.append(
-            _payload_action(
-                "current" if present else "manual review",
-                required,
-                "required payload file present" if present else "required payload file missing",
-                safety="safe" if present else "manual",
-                category="safe-update" if present else "contract-drift",
-            )
-        )
-    compatibility_files = _string_list(policy.get("compatibility_contract_files", []), source="payload.verify compatibility_contract_files")
-    helper_files = [
-        path
-        for path in _string_list(policy.get("required_files", []), source="payload.verify required_files")
-        if path not in set(compatibility_files)
-    ]
-    actions.append(
-        _payload_action(
-            "current",
-            manifest_path,
-            "compatibility contract files: " + ", ".join(compatibility_files),
-            safety="safe",
-            category="safe-update",
-        )
-    )
-    upgrade_path = str(policy.get("upgrade_source", {}).get("path", ""))
-    actions.append(
-        _payload_action(
-            "current",
-            upgrade_path,
-            "lower-stability helper files: " + ", ".join(helper_files),
-            safety="safe",
-            category="safe-update",
-        )
-    )
-    current_memory = policy.get("current_memory", {})
-    if not isinstance(current_memory, dict):
-        raise PrimitiveExecutionError("payload.verify current_memory must be an object")
-    current_prefix = str(current_memory.get("prefix", ""))
-    current_payload = {path for path in payload_paths if path.startswith(current_prefix)}
-    required_current = set(_string_list(current_memory.get("required", []), source="payload.verify current_memory.required"))
-    optional_current = set(_string_list(current_memory.get("optional", []), source="payload.verify current_memory.optional"))
-    for extra in sorted(current_payload - (required_current | optional_current)):
-        actions.append(_payload_action("manual review", extra, "local-only or unexpected current-memory note is in the shipped payload"))
-    for missing in sorted(required_current - current_payload):
-        actions.append(_payload_action("manual review", missing, "baseline current-memory note missing from shipped payload"))
-    for forbidden in _string_list(policy.get("forbidden_files", []), source="payload.verify forbidden_files"):
-        if forbidden in payload_paths:
-            actions.append(_payload_action("manual review", forbidden, "forbidden file is present in the shipped payload"))
-    for payload_path in sorted(payload_paths):
-        if any(
-            payload_path.startswith(prefix)
-            for prefix in _string_list(policy.get("forbidden_prefixes", []), source="payload.verify forbidden_prefixes")
-        ):
-            actions.append(_payload_action("manual review", payload_path, "forbidden path prefix is present in the shipped payload"))
-    if not _toml_file_valid(payload_root / manifest_path):
-        actions.append(_payload_action("manual review", manifest_path, "payload manifest is missing or invalid"))
-    _verify_guidance_fragments(policy=policy, payload_root=payload_root, actions=actions)
-    return {
-        "target_root": str(target_root),
-        "dry_run": True,
-        "mode": "full",
-        "message": "Payload verification",
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "actions": actions,
-        "route_summary": {},
-        "missing_note_hint": "",
-        "review_summary": {},
-        "review_cases": [],
-        "sync_summary": {},
-        "route_report_summary": {},
-        "route_report_feedback_cases": [],
-        "route_report_fixture_results": [],
-    }
-
-
-def _payload_status(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.status cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    manifest_path = str(policy.get("manifest_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    active = _memory_manifest_counts(target_root=target_root, manifest_path=manifest_path)
-    actions: list[dict[str, Any]] = []
-    workspace_notice = policy.get("workspace_orchestrator_notice", {})
-    if isinstance(workspace_notice, dict):
-        marker = str(workspace_notice.get("marker", "")).strip()
-        if marker and not (target_root / marker).exists():
-            actions.append(
-                _status_action(
-                    "warning",
-                    marker,
-                    str(workspace_notice.get("detail", "")),
-                    role=str(workspace_notice.get("role", "workspace-orchestration")),
-                    safety=str(workspace_notice.get("safety", "safe")),
-                    source=marker,
-                    category=str(workspace_notice.get("category", "safe-update")),
-                )
-            )
-    for raw_entry in _list_of_objects(policy.get("status_files", []), source="payload.status status_files"):
-        relative_path = str(raw_entry.get("path", ""))
-        present = (target_root / relative_path).exists()
-        role = str(raw_entry.get("role", ""))
-        safety = str(raw_entry.get("safety", "safe"))
-        kind = "present" if present else "missing"
-        detail = "file exists" if present else "file missing"
-        actions.append(
-            _status_action(
-                kind,
-                relative_path,
-                detail,
-                role=role,
-                safety=safety,
-                source=relative_path,
-                category=str(raw_entry.get("present_category" if present else "missing_category", ""))
-                or _infer_status_category(kind=kind, path=relative_path, detail=detail, role=role, safety=safety),
-            )
-        )
-    for obsolete in _string_list(policy.get("obsolete_files", []), source="payload.status obsolete_files"):
-        if (target_root / obsolete).exists():
-            actions.append(
-                _status_action(
-                    "obsolete",
-                    obsolete,
-                    "legacy shared file should be removed on upgrade",
-                    role="shared-replaceable",
-                    safety="safe",
-                    source=obsolete,
-                    category="obsolete-managed-file",
-                )
-            )
-    return {
-        "target_root": str(target_root),
-        "dry_run": bool(arguments.get("dry_run", False)),
-        "mode": "",
-        "message": str(arguments.get("message", "Status report")),
-        "health": "healthy" if active["status"] == "present" else "attention-needed",
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "action_count": len(actions),
-        "actions": actions,
-        "active": active,
-        "detail_command": str(arguments.get("detail_command", "")),
-    }
-
-
-def _payload_lifecycle_plan(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.lifecycle-plan cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    actions: list[dict[str, Any]] = []
-    workspace_notice = policy.get("workspace_orchestrator_notice", {})
-    if isinstance(workspace_notice, dict):
-        marker = str(workspace_notice.get("marker", "")).strip()
-        if marker and not (target_root / marker).exists():
-            actions.append(
-                _status_action(
-                    "warning",
-                    marker,
-                    str(workspace_notice.get("detail", "")),
-                    role=str(workspace_notice.get("role", "workspace-orchestration")),
-                    safety=str(workspace_notice.get("safety", "safe")),
-                    source=marker,
-                    category=str(workspace_notice.get("category", "safe-update")),
-                )
-            )
-    for raw_entry in _list_of_objects(policy.get("status_files", []), source="payload.lifecycle-plan status_files"):
-        relative_path = str(raw_entry.get("path", ""))
-        if not relative_path:
-            continue
-        exists = (target_root / relative_path).exists()
-        actions.append(
-            _status_action(
-                "preserve" if exists else str(arguments.get("missing_kind", "would copy")),
-                relative_path,
-                "already exists" if exists else str(arguments.get("missing_detail", "planned change")),
-                role=str(raw_entry.get("role", "")),
-                safety=str(raw_entry.get("safety", "safe")),
-                source=str(raw_entry.get("source", relative_path)),
-                category=str(raw_entry.get("category", "")) or "safe-update",
-            )
-        )
-    return {
-        "target_root": str(target_root),
-        "dry_run": bool(arguments.get("dry_run", True)),
-        "mode": str(arguments.get("mode", "")),
-        "message": str(arguments.get("message", "Install plan")),
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "actions": actions,
-    }
-
-
-def _payload_current_memory(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.current-memory cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    current_memory = policy.get("current_memory", {})
-    if not isinstance(current_memory, dict):
-        raise PrimitiveExecutionError("payload.current-memory current_memory policy must be an object")
-    note_paths = _string_list(current_memory.get("view_files", []), source="payload.current-memory current_memory.view_files")
-    notes: list[dict[str, Any]] = []
-    for relative_path in note_paths:
-        note_path = target_root / relative_path
-        exists = note_path.exists()
-        notes.append(
-            {
-                "path": relative_path,
-                "exists": exists,
-                "content": note_path.read_text(encoding="utf-8") if exists else "",
-            }
-        )
-    return {
-        "target_root": str(target_root),
-        "detected_version": _read_first_version(target_root, [version_path, legacy_version_path]),
-        "bootstrap_version": bootstrap_version,
-        "notes": notes,
-    }
-
-
-def _memory_manifest_counts(*, target_root: Path, manifest_path: str) -> dict[str, Any]:
-    counts = {
-        "status": "missing",
-        "note_count": 0,
-        "required_count": 0,
-        "optional_count": 0,
-        "routing_only_count": 0,
-        "path": manifest_path,
-    }
-    path = target_root / manifest_path
-    if not path.exists():
-        return counts
-    try:
-        payload = tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        counts["status"] = "invalid"
-        return counts
-    notes = payload.get("notes", {}) if isinstance(payload, dict) else {}
-    note_values = list(notes.values()) if isinstance(notes, dict) else []
-    counts["status"] = "present"
-    counts["note_count"] = len(note_values)
-    for note in note_values:
-        if not isinstance(note, dict):
-            continue
-        note_payload = cast(Mapping[str, Any], note)
-        relevance = str(note_payload.get("task_relevance", "")).strip().lower()
-        if relevance == "required":
-            counts["required_count"] += 1
-        elif relevance == "optional":
-            counts["optional_count"] += 1
-        if bool(note_payload.get("routing_only", False)):
-            counts["routing_only_count"] += 1
-    return counts
-
-
-def _status_action(
-    kind: str,
-    path: str,
-    detail: str,
-    *,
-    role: str,
-    safety: str,
-    source: str,
-    category: str,
-) -> dict[str, str]:
-    return {
-        "kind": kind,
-        "path": path,
-        "detail": detail,
-        "role": role,
-        "safety": safety,
-        "source": source,
-        "category": category,
-        "remediation_kind": "",
-        "remediation_target": "",
-        "remediation_reason": "",
-        "remediation_confidence": "",
-        "memory_action": "",
-        "match_source": "",
-    }
-
-
-def _infer_status_category(*, kind: str, path: str, detail: str, role: str, safety: str) -> str:
-    detail_lower = detail.lower()
-    if "placeholder" in detail_lower:
-        return "placeholder-review"
-    if role in {"payload-contract", "local-entrypoint"} or role.startswith("shared-"):
-        if kind in {"manual review", "missing"}:
-            return "contract-drift"
-    if kind in {"current", "present", "optional", "required", "warning"}:
-        return "safe-update"
-    if kind in {"manual review", "consider"}:
-        return "manual-review"
-    if safety == "safe":
-        return "safe-update"
-    return ""
-
-
-def _payload_file_set(*, payload_root: Path, policy: dict[str, Any]) -> set[str]:
-    aliases = {
-        str(item["source"]): str(item["target"])
-        for item in policy.get("payload_path_aliases", [])
-        if isinstance(item, dict) and isinstance(item.get("source"), str) and isinstance(item.get("target"), str)
-    }
-    payload_paths: set[str] = set()
-    for path in payload_root.rglob("*"):
-        if path.is_file():
-            relative = path.relative_to(payload_root).as_posix()
-            payload_paths.add(aliases.get(relative, relative))
-    return payload_paths
-
-
-def _payload_action(kind: str, path: str, detail: str, *, safety: str = "manual", category: str = "contract-drift") -> dict[str, str]:
-    return {
-        "kind": kind,
-        "path": path,
-        "detail": detail,
-        "role": "payload-contract",
-        "safety": safety,
-        "source": path,
-        "category": category,
-        "remediation_kind": "",
-        "remediation_target": "",
-        "remediation_reason": "",
-        "remediation_confidence": "",
-        "memory_action": "",
-        "match_source": "",
-    }
-
-
-def _verify_upgrade_source(*, policy: dict[str, Any], payload_root: Path, actions: list[dict[str, str]]) -> None:
-    upgrade_source = policy.get("upgrade_source", {})
-    if not isinstance(upgrade_source, dict):
-        raise PrimitiveExecutionError("payload.verify upgrade_source must be an object")
-    relative = str(upgrade_source.get("path", ""))
-    legacy_relative = str(upgrade_source.get("legacy_path", ""))
-    path = payload_root / relative
-    if not path.exists():
-        path = payload_root / legacy_relative
-    if not path.exists():
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata is missing from the payload"))
-        return
-    try:
-        data = tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata is not valid TOML"))
-        return
-    source_type = str(data.get("source_type", "")).strip()
-    if source_type not in set(_string_list(upgrade_source.get("allowed_source_types", []), source="payload.verify allowed_source_types")):
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata must declare source_type as git or local"))
-        return
-    for required in _string_list(upgrade_source.get("required_fields", []), source="payload.verify required_fields"):
-        if not str(data.get(required, "")).strip():
-            actions.append(_payload_action("manual review", relative, f"upgrade source metadata is missing {required}"))
-            return
-    for field_name, date_format in (upgrade_source.get("date_fields", {}) or {}).items():
-        value = str(data.get(str(field_name), "")).strip()
-        if value and str(date_format) == "YYYY-MM-DD" and not re.match(r"^\d{4}-\d{2}-\d{2}$", value):
-            actions.append(_payload_action("manual review", relative, f"upgrade source metadata has invalid {field_name}; use YYYY-MM-DD"))
-    for field_name in _string_list(upgrade_source.get("integer_fields", []), source="payload.verify integer_fields"):
-        if not isinstance(data.get(field_name, 30), int):
-            actions.append(
-                _payload_action("manual review", relative, f"upgrade source metadata has invalid {field_name}; use an integer day count")
-            )
-
-
-def _verify_guidance_fragments(*, policy: dict[str, Any], payload_root: Path, actions: list[dict[str, str]]) -> None:
-    raw_fragments = policy.get("guidance_fragments", {})
-    if not isinstance(raw_fragments, dict):
-        raise PrimitiveExecutionError("payload.verify guidance_fragments must be an object")
-    for relative, fragments in raw_fragments.items():
-        relative_path = str(relative)
-        path = payload_root / relative_path
-        if not path.exists():
-            continue
-        text = path.read_text(encoding="utf-8")
-        missing = [fragment for fragment in _string_list(fragments, source="payload.verify guidance fragments") if fragment not in text]
-        actions.append(
-            _payload_action(
-                "current" if not missing else "manual review",
-                relative_path,
-                "collaboration-safe current-note guidance present"
-                if not missing
-                else "current-note payload guidance is missing collaboration-safe wording",
-                safety="safe" if not missing else "manual",
-                category="safe-update" if not missing else "contract-drift",
-            )
-        )
-
-
-def _toml_file_valid(path: Path) -> bool:
-    if not path.exists():
-        return False
-    try:
-        tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return False
-    return True
-
-
-def _read_version(path: Path) -> int | None:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    match = re.search(r"^\s*Version:\s*(\d+)\s*$", text, re.MULTILINE)
-    return int(match.group(1)) if match else None
-
-
-def _read_first_version(root: Path, relative_paths: Sequence[str]) -> int | None:
-    for relative_path in relative_paths:
-        if not relative_path:
-            continue
-        version = _read_version(root / relative_path)
-        if version is not None:
-            return version
-    return None
 
 
 def _string_list(value: Any, *, source: str) -> list[str]:
@@ -828,7 +404,9 @@ def _relative_path_list(value: Any, *, source: str) -> list[str]:
             if isinstance(relative_path, str):
                 paths.append(relative_path)
                 continue
-        raise PrimitiveExecutionError(f"{source} entries must be strings or objects with relative_path")
+        raise PrimitiveExecutionError(
+            f"{source} entries must be strings or objects with relative_path"
+        )
     return paths
 
 
@@ -850,60 +428,91 @@ def _resolve_template(template: Any, *, values: dict[str, Any]) -> Any:
         elif isinstance(path, Sequence) and not isinstance(path, (str, bytes)):
             path_parts = [str(part) for part in path]
         else:
-            raise PrimitiveExecutionError("template $field path must be a string or sequence")
+            raise PrimitiveExecutionError(
+                "template $field path must be a string or sequence"
+            )
         value: Any = values.get(value_name)
         for part in path_parts:
             if not isinstance(value, Mapping) or part not in value:
-                raise PrimitiveExecutionError(f"template $field cannot resolve {value_name!r}.{'.'.join(path_parts)}")
+                raise PrimitiveExecutionError(
+                    f"template $field cannot resolve {value_name!r}.{'.'.join(path_parts)}"
+                )
             value = value[part]
         return value
     if set(template) == {"$count"}:
         counted = values.get(str(template["$count"]), [])
         if not isinstance(counted, Sequence) or isinstance(counted, (str, bytes)):
-            raise PrimitiveExecutionError(f"template count source must be a sequence: {template['$count']!r}")
+            raise PrimitiveExecutionError(
+                f"template count source must be a sequence: {template['$count']!r}"
+            )
         return len(counted)
     if "$exists_status" in template:
         spec = template["$exists_status"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $exists_status must be an object")
         value = bool(values.get(str(spec.get("value", ""))))
-        return spec.get("present", "present") if value else spec.get("missing", "missing")
+        return (
+            spec.get("present", "present") if value else spec.get("missing", "missing")
+        )
     if "$count_status" in template:
         spec = template["$count_status"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $count_status must be an object")
         counted = values.get(str(spec.get("value", "")), [])
         if not isinstance(counted, Sequence) or isinstance(counted, (str, bytes)):
-            raise PrimitiveExecutionError(f"template count source must be a sequence: {spec.get('value')!r}")
-        return spec.get("present", "present") if len(counted) else spec.get("missing", "missing")
+            raise PrimitiveExecutionError(
+                f"template count source must be a sequence: {spec.get('value')!r}"
+            )
+        return (
+            spec.get("present", "present")
+            if len(counted)
+            else spec.get("missing", "missing")
+        )
     if "$join_path" in template:
         spec = template["$join_path"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $join_path must be an object")
         base = Path(str(values.get(str(spec.get("base", "")), "")))
         return (base / str(spec.get("path", ""))).as_posix()
-    return {str(key): _resolve_template(value, values=values) for key, value in template.items()}
+    return {
+        str(key): _resolve_template(value, values=values)
+        for key, value in template.items()
+    }
 
 
-def _emit_output(*, values: dict[str, Any], arguments: dict[str, Any] | None = None) -> str:
+def _emit_output(
+    *, values: dict[str, Any], arguments: dict[str, Any] | None = None
+) -> str:
     arguments = arguments or {}
     result = _plain_output_result(values.get("result"))
     output_format = str(values.get("format") or "text")
     if output_format == "json":
         return json.dumps(result, indent=2, sort_keys=True) + "\n"
-    if str(arguments.get("text_style", "")) == "current-memory" and isinstance(result, dict):
+    if str(arguments.get("text_style", "")) == "current-memory" and isinstance(
+        result, dict
+    ):
         return _emit_current_memory_text(result)
-    if str(arguments.get("text_style", "")) == "install-result" and isinstance(result, dict):
+    if str(arguments.get("text_style", "")) == "install-result" and isinstance(
+        result, dict
+    ):
         return _emit_install_result_text(result)
-    if isinstance(result, dict) and isinstance(result.get("route_report_summary"), dict):
+    if isinstance(result, dict) and isinstance(
+        result.get("route_report_summary"), dict
+    ):
         return _emit_route_report_text(result)
     if isinstance(result, dict) and result.get("kind") == "memory-module-report/v1":
         return _emit_memory_report_text(result)
-    if isinstance(result, dict) and result.get("kind") == "planning-module-report/v1" and result.get("profile") == "tiny":
+    if (
+        isinstance(result, dict)
+        and result.get("kind") == "planning-module-report/v1"
+        and result.get("profile") == "tiny"
+    ):
         return _emit_planning_module_report_text(result)
     if not isinstance(result, dict):
         return f"{result}\n"
-    if isinstance(result.get("files"), list) and all(isinstance(item, str) for item in result["files"]):
+    if isinstance(result.get("files"), list) and all(
+        isinstance(item, str) for item in result["files"]
+    ):
         return "\n".join(result["files"]).rstrip() + "\n"
     lines = [str(result.get("message", ""))]
     for action in _list_of_objects(result.get("actions", []), source="result.actions"):
@@ -949,7 +558,9 @@ def _emit_install_result_text(result: dict[str, Any]) -> str:
         ):
             value = action.get(key)
             if value:
-                details.append(str(value) if not label_name else f"{label_name}={value}")
+                details.append(
+                    str(value) if not label_name else f"{label_name}={value}"
+                )
         detail = f" ({'; '.join(details)})" if details else ""
         lines.append(f"- {action.get('kind')}: {label}{detail}")
     return "\n".join(lines).rstrip() + "\n"
@@ -979,9 +590,13 @@ def _emit_route_report_text(result: dict[str, Any]) -> str:
     fixtures = summary.get("fixtures", {})
     lines = [str(result.get("message", "Routing report"))]
     if isinstance(feedback, Mapping):
-        lines.append(f"Feedback: {feedback.get('status', 'unknown')} ({feedback.get('path', '')})")
+        lines.append(
+            f"Feedback: {feedback.get('status', 'unknown')} ({feedback.get('path', '')})"
+        )
     if isinstance(fixtures, Mapping):
-        lines.append(f"Fixtures: {fixtures.get('status', 'unknown')} ({fixtures.get('fixture_count', 0)})")
+        lines.append(
+            f"Fixtures: {fixtures.get('status', 'unknown')} ({fixtures.get('fixture_count', 0)})"
+        )
     detail = summary.get("detail") or result.get("detail_command")
     if detail:
         lines.append(str(detail))
@@ -993,9 +608,15 @@ def _emit_memory_report_text(result: dict[str, Any]) -> str:
     active = result.get("active", {})
     habitual_pull = result.get("habitual_pull", {})
     next_action = result.get("next_action", {})
-    lines = ["Memory report", f"Target: {result.get('target_root', '')}", f"Health: {result.get('health', 'unknown')}"]
+    lines = [
+        "Memory report",
+        f"Target: {result.get('target_root', '')}",
+        f"Health: {result.get('health', 'unknown')}",
+    ]
     if isinstance(status, Mapping):
-        lines.append(f"Notes: {status.get('note_count', 0)} ({status.get('manifest_status', 'unknown')})")
+        lines.append(
+            f"Notes: {status.get('note_count', 0)} ({status.get('manifest_status', 'unknown')})"
+        )
     if isinstance(active, Mapping):
         lines.append(
             "Active: "
@@ -1039,11 +660,15 @@ def _call_python_function(*, values: dict[str, Any], arguments: dict[str, Any]) 
     import_module = str(arguments.get("import_module", "")).strip()
     function_name = str(arguments.get("function", "")).strip()
     if not import_module or not function_name:
-        raise PrimitiveExecutionError("python.function.call requires import_module and function")
+        raise PrimitiveExecutionError(
+            "python.function.call requires import_module and function"
+        )
     try:
         function = getattr(importlib.import_module(import_module), function_name)
     except (ImportError, AttributeError) as exc:
-        raise PrimitiveExecutionError(f"python.function.call cannot resolve {import_module}.{function_name}") from exc
+        raise PrimitiveExecutionError(
+            f"python.function.call cannot resolve {import_module}.{function_name}"
+        ) from exc
     kwargs = _resolve_call_kwargs(values=values, raw_kwargs=arguments.get("kwargs", {}))
     return function(**kwargs)
 
@@ -1059,12 +684,16 @@ def _resolve_call_kwargs(*, values: dict[str, Any], raw_kwargs: Any) -> dict[str
         if "value" in source:
             value_name = str(source["value"])
             if value_name not in values:
-                raise PrimitiveExecutionError(f"python.function.call cannot resolve value {value_name!r}")
+                raise PrimitiveExecutionError(
+                    f"python.function.call cannot resolve value {value_name!r}"
+                )
             kwargs[str(name)] = values[value_name]
         elif "literal" in source:
             kwargs[str(name)] = source["literal"]
         else:
-            raise PrimitiveExecutionError(f"python.function.call kwarg {name!r} must declare value or literal")
+            raise PrimitiveExecutionError(
+                f"python.function.call kwarg {name!r} must declare value or literal"
+            )
     return kwargs
 
 
@@ -1085,11 +714,15 @@ def _resolve_inside(root: Path, relative: str) -> Path:
     return candidate
 
 
-def _primitive_root(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> Path:
+def _primitive_root(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> Path:
     if "base_value" in arguments:
         value_name = str(arguments["base_value"])
         if value_name not in values:
-            raise PrimitiveExecutionError(f"unknown primitive base value: {value_name!r}")
+            raise PrimitiveExecutionError(
+                f"unknown primitive base value: {value_name!r}"
+            )
         return Path(str(values[value_name])).resolve()
     return context.root(str(arguments.get("root", "")))
 
@@ -1098,7 +731,9 @@ def _ensure_inside(root: Path, candidate: Path) -> None:
     try:
         candidate.relative_to(root)
     except ValueError as exc:
-        raise PrimitiveExecutionError(f"path escapes primitive root: {candidate}") from exc
+        raise PrimitiveExecutionError(
+            f"path escapes primitive root: {candidate}"
+        ) from exc
 
 
 def _list_of_objects(value: Any, *, source: str) -> list[dict[str, Any]]:

--- a/generated/memory/typescript/package.json
+++ b/generated/memory/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "0.2.9"
+        "version": "0.2.10"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/memory/typescript/resources/command_package.json
+++ b/generated/memory/typescript/resources/command_package.json
@@ -2639,7 +2639,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.9"
+      "version": "0.2.10"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/memory/typescript/src/runtime.mjs
+++ b/generated/memory/typescript/src/runtime.mjs
@@ -199,8 +199,7 @@ function executeHostDomainOperation(operationId, values) {
 
 function executePrimitive(primitive, values, args, operationId) {
   if (primitive === 'typescript.domain.execute') return executeHostDomainOperation(String(args.operation_id ?? operationId), values);
-  const rootResolvePrimitives = new Set(['path.target_root.resolve', ['workspace', 'root', 'resolve'].join('.')]);
-  if (rootResolvePrimitives.has(primitive)) {
+  if (primitive === 'path.target_root.resolve') {
     const targetRoot = resolve(String(values.target ?? '.'));
     if (args.must_exist && !existsSync(targetRoot)) throw new RuntimeError(`target root does not exist: ${targetRoot}`);
     if (args.must_be_dir && (!existsSync(targetRoot) || !statSync(targetRoot).isDirectory())) throw new RuntimeError(`target root is not a directory: ${targetRoot}`);
@@ -216,7 +215,7 @@ function executePrimitive(primitive, values, args, operationId) {
   if (primitive === 'filesystem.glob') return globFiles(valueRoot(args, values), String(args.pattern ?? '')).map((relative_path) => ({ relative_path }));
   if (primitive === 'json.parse') return JSON.parse(String(values[String(args.source ?? 'registry_text')]));
   if (primitive === 'payload.assemble') return assemblePayload(values, args);
-  if (primitive === 'output.emit' || primitive === 'output.emit.install-result' || primitive === 'output.emit.current-memory') return emitOutput(values);
+  if (primitive === 'output.emit') return emitOutput(values);
   return executeHostPrimitive(primitive, values, args, operationId);
 }
 

--- a/generated/planning/python/command_package.json
+++ b/generated/planning/python/command_package.json
@@ -3080,7 +3080,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.9"
+      "version": "0.2.10"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/planning/python/primitives/primitive_executor.py
+++ b/generated/planning/python/primitives/primitive_executor.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import importlib
 import json
-import re
 import tomllib
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -67,20 +66,28 @@ def run_operation_steps(
     if not isinstance(steps, list):
         raise PrimitiveExecutionError("operation ir_plan.steps must be a list")
     fragments = operation_fragments(operation, error_type=PrimitiveExecutionError)
-    for raw_step in expand_operation_steps(steps, fragments=fragments, error_type=PrimitiveExecutionError):
+    for raw_step in expand_operation_steps(
+        steps, fragments=fragments, error_type=PrimitiveExecutionError
+    ):
         primitive = str(raw_step.get("uses", ""))
         arguments = raw_step.get("arguments", {})
         if not isinstance(arguments, dict):
-            raise PrimitiveExecutionError(f"step {raw_step.get('id', primitive)!r} arguments must be an object")
+            raise PrimitiveExecutionError(
+                f"step {raw_step.get('id', primitive)!r} arguments must be an object"
+            )
         if not _condition_matches(raw_step.get("when"), values=values):
             continue
         handler = custom_handlers.get(primitive)
         result = (
             handler(values, arguments, context)
             if handler is not None
-            else execute_primitive(primitive, values=values, arguments=arguments, context=context)
+            else execute_primitive(
+                primitive, values=values, arguments=arguments, context=context
+            )
         )
-        _store_step_result(values=values, outputs=raw_step.get("outputs", []), result=result)
+        _store_step_result(
+            values=values, outputs=raw_step.get("outputs", []), result=result
+        )
     return values
 
 
@@ -106,23 +113,13 @@ def execute_primitive(
         return _toml_table_counts(values=values, arguments=arguments, context=context)
     if primitive == "payload.assemble":
         return _assemble_payload(values=values, arguments=arguments)
-    if primitive == "payload.status":
-        return _payload_status(values=values, arguments=arguments, context=context)
-    if primitive == "payload.lifecycle-plan":
-        return _payload_lifecycle_plan(values=values, arguments=arguments, context=context)
-    if primitive == "payload.current-memory":
-        return _payload_current_memory(values=values, arguments=arguments, context=context)
-    if primitive == "payload.verify":
-        return _verify_payload(values=values, arguments=arguments, context=context)
     if primitive == "output.emit":
         return _emit_output(values=values, arguments=arguments)
-    if primitive == "output.emit.install-result":
-        return _emit_output(values=values, arguments={"text_style": "install-result"})
-    if primitive == "output.emit.current-memory":
-        return _emit_output(values=values, arguments={"text_style": "current-memory"})
     if primitive == "python.function.call":
         return _call_python_function(values=values, arguments=arguments)
-    return execute_host_primitive(primitive, values=values, arguments=arguments, context=context)
+    return execute_host_primitive(
+        primitive, values=values, arguments=arguments, context=context
+    )
 
 
 def _store_step_result(*, values: dict[str, Any], outputs: Any, result: Any) -> None:
@@ -142,7 +139,9 @@ def _store_step_result(*, values: dict[str, Any], outputs: Any, result: Any) -> 
         raise PrimitiveExecutionError("multi-output primitive results must be mappings")
     for output_name in output_names:
         if output_name not in result:
-            raise PrimitiveExecutionError(f"primitive result missing declared output: {output_name!r}")
+            raise PrimitiveExecutionError(
+                f"primitive result missing declared output: {output_name!r}"
+            )
         values[output_name] = result[output_name]
 
 
@@ -165,7 +164,9 @@ def _condition_matches(condition: Any, *, values: dict[str, Any]) -> bool:
     if keys == {"not"}:
         return not _condition_matches(condition["not"], values=values)
     if keys not in ({"value", "equals"}, {"value", "present"}):
-        raise PrimitiveExecutionError("step when condition must use exactly one of all, any, not, equals, or present")
+        raise PrimitiveExecutionError(
+            "step when condition must use exactly one of all, any, not, equals, or present"
+        )
     value_name = str(condition.get("value", ""))
     if not value_name:
         raise PrimitiveExecutionError("step when condition must declare a value name")
@@ -175,7 +176,9 @@ def _condition_matches(condition: Any, *, values: dict[str, Any]) -> bool:
     return (actual is not None) == bool(condition["present"])
 
 
-def _resolve_target_root(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> str:
+def _resolve_target_root(
+    *, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext
+) -> str:
     target = values.get("target") or "."
     target_root = (context.cwd / str(target)).resolve()
     if bool(arguments.get("must_exist", False)) and not target_root.exists():
@@ -193,11 +196,15 @@ def _read_text(*, arguments: dict[str, Any], context: PrimitiveContext) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _glob(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> list[dict[str, str]]:
+def _glob(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> list[dict[str, str]]:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     pattern = str(arguments.get("pattern", ""))
     if not pattern or Path(pattern).is_absolute() or ".." in Path(pattern).parts:
-        raise PrimitiveExecutionError(f"unsupported filesystem.glob pattern: {pattern!r}")
+        raise PrimitiveExecutionError(
+            f"unsupported filesystem.glob pattern: {pattern!r}"
+        )
     matches = []
     for path in root.glob(pattern):
         resolved = path.resolve()
@@ -207,7 +214,9 @@ def _glob(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[
     return sorted(matches, key=lambda item: item["relative_path"])
 
 
-def _exists(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> bool:
+def _exists(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> bool:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     path = _resolve_inside(root, str(arguments.get("path", "")))
     if str(arguments.get("kind", "any")) == "file":
@@ -222,11 +231,15 @@ def _parse_json(*, values: dict[str, Any], arguments: dict[str, Any]) -> Any:
     try:
         text = values[source_name]
     except KeyError as exc:
-        raise PrimitiveExecutionError(f"json.parse missing source value: {source_name!r}") from exc
+        raise PrimitiveExecutionError(
+            f"json.parse missing source value: {source_name!r}"
+        ) from exc
     return json.loads(str(text))
 
 
-def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
+def _toml_table_counts(
+    *, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext
+) -> dict[str, Any]:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     relative_path = str(arguments.get("path", ""))
     path = _resolve_inside(root, relative_path)
@@ -244,12 +257,20 @@ def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], con
         "path": relative_path,
     }
     if not path.exists():
-        return {"table_counts": counts, "table_present": False, "table_status": counts["status"]}
+        return {
+            "table_counts": counts,
+            "table_present": False,
+            "table_status": counts["status"],
+        }
     try:
         payload = tomllib.loads(path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError):
         counts["status"] = "invalid"
-        return {"table_counts": counts, "table_present": False, "table_status": counts["status"]}
+        return {
+            "table_counts": counts,
+            "table_present": False,
+            "table_status": counts["status"],
+        }
     records = payload.get(table_name, {}) if isinstance(payload, dict) else {}
     record_values = list(records.values()) if isinstance(records, dict) else []
     counts["status"] = "present"
@@ -265,10 +286,16 @@ def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], con
             counts["optional_count"] += 1
         if bool(record_payload.get(routing_only_field, False)):
             counts["routing_only_count"] += 1
-    return {"table_counts": counts, "table_present": True, "table_status": counts["status"]}
+    return {
+        "table_counts": counts,
+        "table_present": True,
+        "table_status": counts["status"],
+    }
 
 
-def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> dict[str, Any]:
+def _assemble_payload(
+    *, values: dict[str, Any], arguments: dict[str, Any]
+) -> dict[str, Any]:
     fields = arguments.get("fields", {})
     if not isinstance(fields, dict):
         raise PrimitiveExecutionError("payload.assemble fields must be an object")
@@ -293,11 +320,17 @@ def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> d
     if actions_from == "registry.skills":
         registry = values.get("registry", {})
         if not isinstance(registry, dict):
-            raise PrimitiveExecutionError("registry.skills payload source must be an object")
+            raise PrimitiveExecutionError(
+                "registry.skills payload source must be an object"
+            )
         payload["mode"] = str(fields.get("mode", "skills"))
-        payload["bootstrap_version"] = _resolve_dotted_value(registry, str(fields.get("bootstrap_version_from", "")))
+        payload["bootstrap_version"] = _resolve_dotted_value(
+            registry, str(fields.get("bootstrap_version_from", ""))
+        )
         payload["actions"] = []
-        for item in _list_of_objects(registry.get("skills", []), source="registry.skills"):
+        for item in _list_of_objects(
+            registry.get("skills", []), source="registry.skills"
+        ):
             skill_id = str(item.get("id", "")).strip()
             path = str(item.get("path", "")).strip()
             if not skill_id or not path:
@@ -320,493 +353,36 @@ def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> d
                 }
             )
         return payload
-    raise PrimitiveExecutionError(f"unsupported payload.assemble actions_from: {actions_from!r}")
+    raise PrimitiveExecutionError(
+        f"unsupported payload.assemble actions_from: {actions_from!r}"
+    )
 
 
-def _assemble_package_file_list(*, values: dict[str, Any], fields: Mapping[str, Any]) -> dict[str, Any]:
+def _assemble_package_file_list(
+    *, values: dict[str, Any], fields: Mapping[str, Any]
+) -> dict[str, Any]:
     files_from = str(fields.get("files_from", "files"))
-    bundled_skills_from = str(fields.get("bundled_skill_files_from", "bundled_skill_files"))
+    bundled_skills_from = str(
+        fields.get("bundled_skill_files_from", "bundled_skill_files")
+    )
     return {
         "files": _relative_path_list(values.get(files_from, []), source=files_from),
-        "default_files": _string_list(fields.get("default_files", []), source="payload.assemble fields.default_files"),
-        "optional_files": _string_list(fields.get("optional_files", []), source="payload.assemble fields.optional_files"),
-        "bundled_skill_files": _relative_path_list(values.get(bundled_skills_from, []), source=bundled_skills_from),
+        "default_files": _string_list(
+            fields.get("default_files", []),
+            source="payload.assemble fields.default_files",
+        ),
+        "optional_files": _string_list(
+            fields.get("optional_files", []),
+            source="payload.assemble fields.optional_files",
+        ),
+        "bundled_skill_files": _relative_path_list(
+            values.get(bundled_skills_from, []), source=bundled_skills_from
+        ),
         "optional_enable_commands": _string_list(
             fields.get("optional_enable_commands", []),
             source="payload.assemble fields.optional_enable_commands",
         ),
     }
-
-
-def _verify_payload(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    payload_root = context.root(str(arguments.get("payload_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.verify cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    manifest_path = str(policy.get("manifest_path", ""))
-    payload_paths = _payload_file_set(payload_root=payload_root, policy=policy)
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    payload_version = _read_version(payload_root / version_path)
-    actions: list[dict[str, str]] = []
-    if payload_version is None:
-        actions.append(_payload_action("manual review", version_path, "payload version marker is missing or invalid"))
-    elif payload_version != bootstrap_version:
-        actions.append(
-            _payload_action(
-                "manual review",
-                version_path,
-                f"payload version marker ({payload_version}) does not match installer bootstrap version ({bootstrap_version})",
-            )
-        )
-    _verify_upgrade_source(policy=policy, payload_root=payload_root, actions=actions)
-    for required in _string_list(policy.get("required_files", []), source="payload.verify required_files"):
-        present = required in payload_paths
-        actions.append(
-            _payload_action(
-                "current" if present else "manual review",
-                required,
-                "required payload file present" if present else "required payload file missing",
-                safety="safe" if present else "manual",
-                category="safe-update" if present else "contract-drift",
-            )
-        )
-    compatibility_files = _string_list(policy.get("compatibility_contract_files", []), source="payload.verify compatibility_contract_files")
-    helper_files = [
-        path
-        for path in _string_list(policy.get("required_files", []), source="payload.verify required_files")
-        if path not in set(compatibility_files)
-    ]
-    actions.append(
-        _payload_action(
-            "current",
-            manifest_path,
-            "compatibility contract files: " + ", ".join(compatibility_files),
-            safety="safe",
-            category="safe-update",
-        )
-    )
-    upgrade_path = str(policy.get("upgrade_source", {}).get("path", ""))
-    actions.append(
-        _payload_action(
-            "current",
-            upgrade_path,
-            "lower-stability helper files: " + ", ".join(helper_files),
-            safety="safe",
-            category="safe-update",
-        )
-    )
-    current_memory = policy.get("current_memory", {})
-    if not isinstance(current_memory, dict):
-        raise PrimitiveExecutionError("payload.verify current_memory must be an object")
-    current_prefix = str(current_memory.get("prefix", ""))
-    current_payload = {path for path in payload_paths if path.startswith(current_prefix)}
-    required_current = set(_string_list(current_memory.get("required", []), source="payload.verify current_memory.required"))
-    optional_current = set(_string_list(current_memory.get("optional", []), source="payload.verify current_memory.optional"))
-    for extra in sorted(current_payload - (required_current | optional_current)):
-        actions.append(_payload_action("manual review", extra, "local-only or unexpected current-memory note is in the shipped payload"))
-    for missing in sorted(required_current - current_payload):
-        actions.append(_payload_action("manual review", missing, "baseline current-memory note missing from shipped payload"))
-    for forbidden in _string_list(policy.get("forbidden_files", []), source="payload.verify forbidden_files"):
-        if forbidden in payload_paths:
-            actions.append(_payload_action("manual review", forbidden, "forbidden file is present in the shipped payload"))
-    for payload_path in sorted(payload_paths):
-        if any(
-            payload_path.startswith(prefix)
-            for prefix in _string_list(policy.get("forbidden_prefixes", []), source="payload.verify forbidden_prefixes")
-        ):
-            actions.append(_payload_action("manual review", payload_path, "forbidden path prefix is present in the shipped payload"))
-    if not _toml_file_valid(payload_root / manifest_path):
-        actions.append(_payload_action("manual review", manifest_path, "payload manifest is missing or invalid"))
-    _verify_guidance_fragments(policy=policy, payload_root=payload_root, actions=actions)
-    return {
-        "target_root": str(target_root),
-        "dry_run": True,
-        "mode": "full",
-        "message": "Payload verification",
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "actions": actions,
-        "route_summary": {},
-        "missing_note_hint": "",
-        "review_summary": {},
-        "review_cases": [],
-        "sync_summary": {},
-        "route_report_summary": {},
-        "route_report_feedback_cases": [],
-        "route_report_fixture_results": [],
-    }
-
-
-def _payload_status(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.status cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    manifest_path = str(policy.get("manifest_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    active = _memory_manifest_counts(target_root=target_root, manifest_path=manifest_path)
-    actions: list[dict[str, Any]] = []
-    workspace_notice = policy.get("workspace_orchestrator_notice", {})
-    if isinstance(workspace_notice, dict):
-        marker = str(workspace_notice.get("marker", "")).strip()
-        if marker and not (target_root / marker).exists():
-            actions.append(
-                _status_action(
-                    "warning",
-                    marker,
-                    str(workspace_notice.get("detail", "")),
-                    role=str(workspace_notice.get("role", "workspace-orchestration")),
-                    safety=str(workspace_notice.get("safety", "safe")),
-                    source=marker,
-                    category=str(workspace_notice.get("category", "safe-update")),
-                )
-            )
-    for raw_entry in _list_of_objects(policy.get("status_files", []), source="payload.status status_files"):
-        relative_path = str(raw_entry.get("path", ""))
-        present = (target_root / relative_path).exists()
-        role = str(raw_entry.get("role", ""))
-        safety = str(raw_entry.get("safety", "safe"))
-        kind = "present" if present else "missing"
-        detail = "file exists" if present else "file missing"
-        actions.append(
-            _status_action(
-                kind,
-                relative_path,
-                detail,
-                role=role,
-                safety=safety,
-                source=relative_path,
-                category=str(raw_entry.get("present_category" if present else "missing_category", ""))
-                or _infer_status_category(kind=kind, path=relative_path, detail=detail, role=role, safety=safety),
-            )
-        )
-    for obsolete in _string_list(policy.get("obsolete_files", []), source="payload.status obsolete_files"):
-        if (target_root / obsolete).exists():
-            actions.append(
-                _status_action(
-                    "obsolete",
-                    obsolete,
-                    "legacy shared file should be removed on upgrade",
-                    role="shared-replaceable",
-                    safety="safe",
-                    source=obsolete,
-                    category="obsolete-managed-file",
-                )
-            )
-    return {
-        "target_root": str(target_root),
-        "dry_run": bool(arguments.get("dry_run", False)),
-        "mode": "",
-        "message": str(arguments.get("message", "Status report")),
-        "health": "healthy" if active["status"] == "present" else "attention-needed",
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "action_count": len(actions),
-        "actions": actions,
-        "active": active,
-        "detail_command": str(arguments.get("detail_command", "")),
-    }
-
-
-def _payload_lifecycle_plan(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.lifecycle-plan cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    actions: list[dict[str, Any]] = []
-    workspace_notice = policy.get("workspace_orchestrator_notice", {})
-    if isinstance(workspace_notice, dict):
-        marker = str(workspace_notice.get("marker", "")).strip()
-        if marker and not (target_root / marker).exists():
-            actions.append(
-                _status_action(
-                    "warning",
-                    marker,
-                    str(workspace_notice.get("detail", "")),
-                    role=str(workspace_notice.get("role", "workspace-orchestration")),
-                    safety=str(workspace_notice.get("safety", "safe")),
-                    source=marker,
-                    category=str(workspace_notice.get("category", "safe-update")),
-                )
-            )
-    for raw_entry in _list_of_objects(policy.get("status_files", []), source="payload.lifecycle-plan status_files"):
-        relative_path = str(raw_entry.get("path", ""))
-        if not relative_path:
-            continue
-        exists = (target_root / relative_path).exists()
-        actions.append(
-            _status_action(
-                "preserve" if exists else str(arguments.get("missing_kind", "would copy")),
-                relative_path,
-                "already exists" if exists else str(arguments.get("missing_detail", "planned change")),
-                role=str(raw_entry.get("role", "")),
-                safety=str(raw_entry.get("safety", "safe")),
-                source=str(raw_entry.get("source", relative_path)),
-                category=str(raw_entry.get("category", "")) or "safe-update",
-            )
-        )
-    return {
-        "target_root": str(target_root),
-        "dry_run": bool(arguments.get("dry_run", True)),
-        "mode": str(arguments.get("mode", "")),
-        "message": str(arguments.get("message", "Install plan")),
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "actions": actions,
-    }
-
-
-def _payload_current_memory(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.current-memory cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    current_memory = policy.get("current_memory", {})
-    if not isinstance(current_memory, dict):
-        raise PrimitiveExecutionError("payload.current-memory current_memory policy must be an object")
-    note_paths = _string_list(current_memory.get("view_files", []), source="payload.current-memory current_memory.view_files")
-    notes: list[dict[str, Any]] = []
-    for relative_path in note_paths:
-        note_path = target_root / relative_path
-        exists = note_path.exists()
-        notes.append(
-            {
-                "path": relative_path,
-                "exists": exists,
-                "content": note_path.read_text(encoding="utf-8") if exists else "",
-            }
-        )
-    return {
-        "target_root": str(target_root),
-        "detected_version": _read_first_version(target_root, [version_path, legacy_version_path]),
-        "bootstrap_version": bootstrap_version,
-        "notes": notes,
-    }
-
-
-def _memory_manifest_counts(*, target_root: Path, manifest_path: str) -> dict[str, Any]:
-    counts = {
-        "status": "missing",
-        "note_count": 0,
-        "required_count": 0,
-        "optional_count": 0,
-        "routing_only_count": 0,
-        "path": manifest_path,
-    }
-    path = target_root / manifest_path
-    if not path.exists():
-        return counts
-    try:
-        payload = tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        counts["status"] = "invalid"
-        return counts
-    notes = payload.get("notes", {}) if isinstance(payload, dict) else {}
-    note_values = list(notes.values()) if isinstance(notes, dict) else []
-    counts["status"] = "present"
-    counts["note_count"] = len(note_values)
-    for note in note_values:
-        if not isinstance(note, dict):
-            continue
-        note_payload = cast(Mapping[str, Any], note)
-        relevance = str(note_payload.get("task_relevance", "")).strip().lower()
-        if relevance == "required":
-            counts["required_count"] += 1
-        elif relevance == "optional":
-            counts["optional_count"] += 1
-        if bool(note_payload.get("routing_only", False)):
-            counts["routing_only_count"] += 1
-    return counts
-
-
-def _status_action(
-    kind: str,
-    path: str,
-    detail: str,
-    *,
-    role: str,
-    safety: str,
-    source: str,
-    category: str,
-) -> dict[str, str]:
-    return {
-        "kind": kind,
-        "path": path,
-        "detail": detail,
-        "role": role,
-        "safety": safety,
-        "source": source,
-        "category": category,
-        "remediation_kind": "",
-        "remediation_target": "",
-        "remediation_reason": "",
-        "remediation_confidence": "",
-        "memory_action": "",
-        "match_source": "",
-    }
-
-
-def _infer_status_category(*, kind: str, path: str, detail: str, role: str, safety: str) -> str:
-    detail_lower = detail.lower()
-    if "placeholder" in detail_lower:
-        return "placeholder-review"
-    if role in {"payload-contract", "local-entrypoint"} or role.startswith("shared-"):
-        if kind in {"manual review", "missing"}:
-            return "contract-drift"
-    if kind in {"current", "present", "optional", "required", "warning"}:
-        return "safe-update"
-    if kind in {"manual review", "consider"}:
-        return "manual-review"
-    if safety == "safe":
-        return "safe-update"
-    return ""
-
-
-def _payload_file_set(*, payload_root: Path, policy: dict[str, Any]) -> set[str]:
-    aliases = {
-        str(item["source"]): str(item["target"])
-        for item in policy.get("payload_path_aliases", [])
-        if isinstance(item, dict) and isinstance(item.get("source"), str) and isinstance(item.get("target"), str)
-    }
-    payload_paths: set[str] = set()
-    for path in payload_root.rglob("*"):
-        if path.is_file():
-            relative = path.relative_to(payload_root).as_posix()
-            payload_paths.add(aliases.get(relative, relative))
-    return payload_paths
-
-
-def _payload_action(kind: str, path: str, detail: str, *, safety: str = "manual", category: str = "contract-drift") -> dict[str, str]:
-    return {
-        "kind": kind,
-        "path": path,
-        "detail": detail,
-        "role": "payload-contract",
-        "safety": safety,
-        "source": path,
-        "category": category,
-        "remediation_kind": "",
-        "remediation_target": "",
-        "remediation_reason": "",
-        "remediation_confidence": "",
-        "memory_action": "",
-        "match_source": "",
-    }
-
-
-def _verify_upgrade_source(*, policy: dict[str, Any], payload_root: Path, actions: list[dict[str, str]]) -> None:
-    upgrade_source = policy.get("upgrade_source", {})
-    if not isinstance(upgrade_source, dict):
-        raise PrimitiveExecutionError("payload.verify upgrade_source must be an object")
-    relative = str(upgrade_source.get("path", ""))
-    legacy_relative = str(upgrade_source.get("legacy_path", ""))
-    path = payload_root / relative
-    if not path.exists():
-        path = payload_root / legacy_relative
-    if not path.exists():
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata is missing from the payload"))
-        return
-    try:
-        data = tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata is not valid TOML"))
-        return
-    source_type = str(data.get("source_type", "")).strip()
-    if source_type not in set(_string_list(upgrade_source.get("allowed_source_types", []), source="payload.verify allowed_source_types")):
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata must declare source_type as git or local"))
-        return
-    for required in _string_list(upgrade_source.get("required_fields", []), source="payload.verify required_fields"):
-        if not str(data.get(required, "")).strip():
-            actions.append(_payload_action("manual review", relative, f"upgrade source metadata is missing {required}"))
-            return
-    for field_name, date_format in (upgrade_source.get("date_fields", {}) or {}).items():
-        value = str(data.get(str(field_name), "")).strip()
-        if value and str(date_format) == "YYYY-MM-DD" and not re.match(r"^\d{4}-\d{2}-\d{2}$", value):
-            actions.append(_payload_action("manual review", relative, f"upgrade source metadata has invalid {field_name}; use YYYY-MM-DD"))
-    for field_name in _string_list(upgrade_source.get("integer_fields", []), source="payload.verify integer_fields"):
-        if not isinstance(data.get(field_name, 30), int):
-            actions.append(
-                _payload_action("manual review", relative, f"upgrade source metadata has invalid {field_name}; use an integer day count")
-            )
-
-
-def _verify_guidance_fragments(*, policy: dict[str, Any], payload_root: Path, actions: list[dict[str, str]]) -> None:
-    raw_fragments = policy.get("guidance_fragments", {})
-    if not isinstance(raw_fragments, dict):
-        raise PrimitiveExecutionError("payload.verify guidance_fragments must be an object")
-    for relative, fragments in raw_fragments.items():
-        relative_path = str(relative)
-        path = payload_root / relative_path
-        if not path.exists():
-            continue
-        text = path.read_text(encoding="utf-8")
-        missing = [fragment for fragment in _string_list(fragments, source="payload.verify guidance fragments") if fragment not in text]
-        actions.append(
-            _payload_action(
-                "current" if not missing else "manual review",
-                relative_path,
-                "collaboration-safe current-note guidance present"
-                if not missing
-                else "current-note payload guidance is missing collaboration-safe wording",
-                safety="safe" if not missing else "manual",
-                category="safe-update" if not missing else "contract-drift",
-            )
-        )
-
-
-def _toml_file_valid(path: Path) -> bool:
-    if not path.exists():
-        return False
-    try:
-        tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return False
-    return True
-
-
-def _read_version(path: Path) -> int | None:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    match = re.search(r"^\s*Version:\s*(\d+)\s*$", text, re.MULTILINE)
-    return int(match.group(1)) if match else None
-
-
-def _read_first_version(root: Path, relative_paths: Sequence[str]) -> int | None:
-    for relative_path in relative_paths:
-        if not relative_path:
-            continue
-        version = _read_version(root / relative_path)
-        if version is not None:
-            return version
-    return None
 
 
 def _string_list(value: Any, *, source: str) -> list[str]:
@@ -828,7 +404,9 @@ def _relative_path_list(value: Any, *, source: str) -> list[str]:
             if isinstance(relative_path, str):
                 paths.append(relative_path)
                 continue
-        raise PrimitiveExecutionError(f"{source} entries must be strings or objects with relative_path")
+        raise PrimitiveExecutionError(
+            f"{source} entries must be strings or objects with relative_path"
+        )
     return paths
 
 
@@ -850,60 +428,91 @@ def _resolve_template(template: Any, *, values: dict[str, Any]) -> Any:
         elif isinstance(path, Sequence) and not isinstance(path, (str, bytes)):
             path_parts = [str(part) for part in path]
         else:
-            raise PrimitiveExecutionError("template $field path must be a string or sequence")
+            raise PrimitiveExecutionError(
+                "template $field path must be a string or sequence"
+            )
         value: Any = values.get(value_name)
         for part in path_parts:
             if not isinstance(value, Mapping) or part not in value:
-                raise PrimitiveExecutionError(f"template $field cannot resolve {value_name!r}.{'.'.join(path_parts)}")
+                raise PrimitiveExecutionError(
+                    f"template $field cannot resolve {value_name!r}.{'.'.join(path_parts)}"
+                )
             value = value[part]
         return value
     if set(template) == {"$count"}:
         counted = values.get(str(template["$count"]), [])
         if not isinstance(counted, Sequence) or isinstance(counted, (str, bytes)):
-            raise PrimitiveExecutionError(f"template count source must be a sequence: {template['$count']!r}")
+            raise PrimitiveExecutionError(
+                f"template count source must be a sequence: {template['$count']!r}"
+            )
         return len(counted)
     if "$exists_status" in template:
         spec = template["$exists_status"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $exists_status must be an object")
         value = bool(values.get(str(spec.get("value", ""))))
-        return spec.get("present", "present") if value else spec.get("missing", "missing")
+        return (
+            spec.get("present", "present") if value else spec.get("missing", "missing")
+        )
     if "$count_status" in template:
         spec = template["$count_status"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $count_status must be an object")
         counted = values.get(str(spec.get("value", "")), [])
         if not isinstance(counted, Sequence) or isinstance(counted, (str, bytes)):
-            raise PrimitiveExecutionError(f"template count source must be a sequence: {spec.get('value')!r}")
-        return spec.get("present", "present") if len(counted) else spec.get("missing", "missing")
+            raise PrimitiveExecutionError(
+                f"template count source must be a sequence: {spec.get('value')!r}"
+            )
+        return (
+            spec.get("present", "present")
+            if len(counted)
+            else spec.get("missing", "missing")
+        )
     if "$join_path" in template:
         spec = template["$join_path"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $join_path must be an object")
         base = Path(str(values.get(str(spec.get("base", "")), "")))
         return (base / str(spec.get("path", ""))).as_posix()
-    return {str(key): _resolve_template(value, values=values) for key, value in template.items()}
+    return {
+        str(key): _resolve_template(value, values=values)
+        for key, value in template.items()
+    }
 
 
-def _emit_output(*, values: dict[str, Any], arguments: dict[str, Any] | None = None) -> str:
+def _emit_output(
+    *, values: dict[str, Any], arguments: dict[str, Any] | None = None
+) -> str:
     arguments = arguments or {}
     result = _plain_output_result(values.get("result"))
     output_format = str(values.get("format") or "text")
     if output_format == "json":
         return json.dumps(result, indent=2, sort_keys=True) + "\n"
-    if str(arguments.get("text_style", "")) == "current-memory" and isinstance(result, dict):
+    if str(arguments.get("text_style", "")) == "current-memory" and isinstance(
+        result, dict
+    ):
         return _emit_current_memory_text(result)
-    if str(arguments.get("text_style", "")) == "install-result" and isinstance(result, dict):
+    if str(arguments.get("text_style", "")) == "install-result" and isinstance(
+        result, dict
+    ):
         return _emit_install_result_text(result)
-    if isinstance(result, dict) and isinstance(result.get("route_report_summary"), dict):
+    if isinstance(result, dict) and isinstance(
+        result.get("route_report_summary"), dict
+    ):
         return _emit_route_report_text(result)
     if isinstance(result, dict) and result.get("kind") == "memory-module-report/v1":
         return _emit_memory_report_text(result)
-    if isinstance(result, dict) and result.get("kind") == "planning-module-report/v1" and result.get("profile") == "tiny":
+    if (
+        isinstance(result, dict)
+        and result.get("kind") == "planning-module-report/v1"
+        and result.get("profile") == "tiny"
+    ):
         return _emit_planning_module_report_text(result)
     if not isinstance(result, dict):
         return f"{result}\n"
-    if isinstance(result.get("files"), list) and all(isinstance(item, str) for item in result["files"]):
+    if isinstance(result.get("files"), list) and all(
+        isinstance(item, str) for item in result["files"]
+    ):
         return "\n".join(result["files"]).rstrip() + "\n"
     lines = [str(result.get("message", ""))]
     for action in _list_of_objects(result.get("actions", []), source="result.actions"):
@@ -949,7 +558,9 @@ def _emit_install_result_text(result: dict[str, Any]) -> str:
         ):
             value = action.get(key)
             if value:
-                details.append(str(value) if not label_name else f"{label_name}={value}")
+                details.append(
+                    str(value) if not label_name else f"{label_name}={value}"
+                )
         detail = f" ({'; '.join(details)})" if details else ""
         lines.append(f"- {action.get('kind')}: {label}{detail}")
     return "\n".join(lines).rstrip() + "\n"
@@ -979,9 +590,13 @@ def _emit_route_report_text(result: dict[str, Any]) -> str:
     fixtures = summary.get("fixtures", {})
     lines = [str(result.get("message", "Routing report"))]
     if isinstance(feedback, Mapping):
-        lines.append(f"Feedback: {feedback.get('status', 'unknown')} ({feedback.get('path', '')})")
+        lines.append(
+            f"Feedback: {feedback.get('status', 'unknown')} ({feedback.get('path', '')})"
+        )
     if isinstance(fixtures, Mapping):
-        lines.append(f"Fixtures: {fixtures.get('status', 'unknown')} ({fixtures.get('fixture_count', 0)})")
+        lines.append(
+            f"Fixtures: {fixtures.get('status', 'unknown')} ({fixtures.get('fixture_count', 0)})"
+        )
     detail = summary.get("detail") or result.get("detail_command")
     if detail:
         lines.append(str(detail))
@@ -993,9 +608,15 @@ def _emit_memory_report_text(result: dict[str, Any]) -> str:
     active = result.get("active", {})
     habitual_pull = result.get("habitual_pull", {})
     next_action = result.get("next_action", {})
-    lines = ["Memory report", f"Target: {result.get('target_root', '')}", f"Health: {result.get('health', 'unknown')}"]
+    lines = [
+        "Memory report",
+        f"Target: {result.get('target_root', '')}",
+        f"Health: {result.get('health', 'unknown')}",
+    ]
     if isinstance(status, Mapping):
-        lines.append(f"Notes: {status.get('note_count', 0)} ({status.get('manifest_status', 'unknown')})")
+        lines.append(
+            f"Notes: {status.get('note_count', 0)} ({status.get('manifest_status', 'unknown')})"
+        )
     if isinstance(active, Mapping):
         lines.append(
             "Active: "
@@ -1039,11 +660,15 @@ def _call_python_function(*, values: dict[str, Any], arguments: dict[str, Any]) 
     import_module = str(arguments.get("import_module", "")).strip()
     function_name = str(arguments.get("function", "")).strip()
     if not import_module or not function_name:
-        raise PrimitiveExecutionError("python.function.call requires import_module and function")
+        raise PrimitiveExecutionError(
+            "python.function.call requires import_module and function"
+        )
     try:
         function = getattr(importlib.import_module(import_module), function_name)
     except (ImportError, AttributeError) as exc:
-        raise PrimitiveExecutionError(f"python.function.call cannot resolve {import_module}.{function_name}") from exc
+        raise PrimitiveExecutionError(
+            f"python.function.call cannot resolve {import_module}.{function_name}"
+        ) from exc
     kwargs = _resolve_call_kwargs(values=values, raw_kwargs=arguments.get("kwargs", {}))
     return function(**kwargs)
 
@@ -1059,12 +684,16 @@ def _resolve_call_kwargs(*, values: dict[str, Any], raw_kwargs: Any) -> dict[str
         if "value" in source:
             value_name = str(source["value"])
             if value_name not in values:
-                raise PrimitiveExecutionError(f"python.function.call cannot resolve value {value_name!r}")
+                raise PrimitiveExecutionError(
+                    f"python.function.call cannot resolve value {value_name!r}"
+                )
             kwargs[str(name)] = values[value_name]
         elif "literal" in source:
             kwargs[str(name)] = source["literal"]
         else:
-            raise PrimitiveExecutionError(f"python.function.call kwarg {name!r} must declare value or literal")
+            raise PrimitiveExecutionError(
+                f"python.function.call kwarg {name!r} must declare value or literal"
+            )
     return kwargs
 
 
@@ -1085,11 +714,15 @@ def _resolve_inside(root: Path, relative: str) -> Path:
     return candidate
 
 
-def _primitive_root(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> Path:
+def _primitive_root(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> Path:
     if "base_value" in arguments:
         value_name = str(arguments["base_value"])
         if value_name not in values:
-            raise PrimitiveExecutionError(f"unknown primitive base value: {value_name!r}")
+            raise PrimitiveExecutionError(
+                f"unknown primitive base value: {value_name!r}"
+            )
         return Path(str(values[value_name])).resolve()
     return context.root(str(arguments.get("root", "")))
 
@@ -1098,7 +731,9 @@ def _ensure_inside(root: Path, candidate: Path) -> None:
     try:
         candidate.relative_to(root)
     except ValueError as exc:
-        raise PrimitiveExecutionError(f"path escapes primitive root: {candidate}") from exc
+        raise PrimitiveExecutionError(
+            f"path escapes primitive root: {candidate}"
+        ) from exc
 
 
 def _list_of_objects(value: Any, *, source: str) -> list[dict[str, Any]]:

--- a/generated/planning/typescript/package.json
+++ b/generated/planning/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "0.2.9"
+        "version": "0.2.10"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/planning/typescript/resources/command_package.json
+++ b/generated/planning/typescript/resources/command_package.json
@@ -3080,7 +3080,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.9"
+      "version": "0.2.10"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/planning/typescript/src/runtime.mjs
+++ b/generated/planning/typescript/src/runtime.mjs
@@ -199,8 +199,7 @@ function executeHostDomainOperation(operationId, values) {
 
 function executePrimitive(primitive, values, args, operationId) {
   if (primitive === 'typescript.domain.execute') return executeHostDomainOperation(String(args.operation_id ?? operationId), values);
-  const rootResolvePrimitives = new Set(['path.target_root.resolve', ['workspace', 'root', 'resolve'].join('.')]);
-  if (rootResolvePrimitives.has(primitive)) {
+  if (primitive === 'path.target_root.resolve') {
     const targetRoot = resolve(String(values.target ?? '.'));
     if (args.must_exist && !existsSync(targetRoot)) throw new RuntimeError(`target root does not exist: ${targetRoot}`);
     if (args.must_be_dir && (!existsSync(targetRoot) || !statSync(targetRoot).isDirectory())) throw new RuntimeError(`target root is not a directory: ${targetRoot}`);
@@ -216,7 +215,7 @@ function executePrimitive(primitive, values, args, operationId) {
   if (primitive === 'filesystem.glob') return globFiles(valueRoot(args, values), String(args.pattern ?? '')).map((relative_path) => ({ relative_path }));
   if (primitive === 'json.parse') return JSON.parse(String(values[String(args.source ?? 'registry_text')]));
   if (primitive === 'payload.assemble') return assemblePayload(values, args);
-  if (primitive === 'output.emit' || primitive === 'output.emit.install-result' || primitive === 'output.emit.current-memory') return emitOutput(values);
+  if (primitive === 'output.emit') return emitOutput(values);
   return executeHostPrimitive(primitive, values, args, operationId);
 }
 

--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -2,7 +2,7 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.9/command_generation-0.2.9-py3-none-any.whl#sha256=3f523ce3a7e97e615d8e61df83db649a825093125f8ac9838cb731f7e0615580"
+RUN python -m pip install --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.10/command_generation-0.2.10-py3-none-any.whl#sha256=6052bf6312aaf922bdd32b6dd5c9f18c8205bc51283cbc723e581d015b8f455b"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/python/Dockerfile.primitive-conformance
+++ b/generated/python/Dockerfile.primitive-conformance
@@ -2,6 +2,6 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.9/command_generation-0.2.9-py3-none-any.whl#sha256=3f523ce3a7e97e615d8e61df83db649a825093125f8ac9838cb731f7e0615580"
+RUN python -m pip install --no-cache-dir "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.10/command_generation-0.2.10-py3-none-any.whl#sha256=6052bf6312aaf922bdd32b6dd5c9f18c8205bc51283cbc723e581d015b8f455b"
 
 CMD ["python", "-m", "command_generation.primitive_conformance"]

--- a/generated/typescript.conformance.Dockerfile
+++ b/generated/typescript.conformance.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /work
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 python3-pip \
     && find /usr/lib/python3/dist-packages -name '*.pyc' -delete \
-    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.9/command_generation-0.2.9-py3-none-any.whl#sha256=3f523ce3a7e97e615d8e61df83db649a825093125f8ac9838cb731f7e0615580"
+    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.10/command_generation-0.2.10-py3-none-any.whl#sha256=6052bf6312aaf922bdd32b6dd5c9f18c8205bc51283cbc723e581d015b8f455b"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/verification/python/command_package.json
+++ b/generated/verification/python/command_package.json
@@ -99,7 +99,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.9"
+      "version": "0.2.10"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/verification/python/primitives/primitive_executor.py
+++ b/generated/verification/python/primitives/primitive_executor.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import importlib
 import json
-import re
 import tomllib
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -67,20 +66,28 @@ def run_operation_steps(
     if not isinstance(steps, list):
         raise PrimitiveExecutionError("operation ir_plan.steps must be a list")
     fragments = operation_fragments(operation, error_type=PrimitiveExecutionError)
-    for raw_step in expand_operation_steps(steps, fragments=fragments, error_type=PrimitiveExecutionError):
+    for raw_step in expand_operation_steps(
+        steps, fragments=fragments, error_type=PrimitiveExecutionError
+    ):
         primitive = str(raw_step.get("uses", ""))
         arguments = raw_step.get("arguments", {})
         if not isinstance(arguments, dict):
-            raise PrimitiveExecutionError(f"step {raw_step.get('id', primitive)!r} arguments must be an object")
+            raise PrimitiveExecutionError(
+                f"step {raw_step.get('id', primitive)!r} arguments must be an object"
+            )
         if not _condition_matches(raw_step.get("when"), values=values):
             continue
         handler = custom_handlers.get(primitive)
         result = (
             handler(values, arguments, context)
             if handler is not None
-            else execute_primitive(primitive, values=values, arguments=arguments, context=context)
+            else execute_primitive(
+                primitive, values=values, arguments=arguments, context=context
+            )
         )
-        _store_step_result(values=values, outputs=raw_step.get("outputs", []), result=result)
+        _store_step_result(
+            values=values, outputs=raw_step.get("outputs", []), result=result
+        )
     return values
 
 
@@ -106,23 +113,13 @@ def execute_primitive(
         return _toml_table_counts(values=values, arguments=arguments, context=context)
     if primitive == "payload.assemble":
         return _assemble_payload(values=values, arguments=arguments)
-    if primitive == "payload.status":
-        return _payload_status(values=values, arguments=arguments, context=context)
-    if primitive == "payload.lifecycle-plan":
-        return _payload_lifecycle_plan(values=values, arguments=arguments, context=context)
-    if primitive == "payload.current-memory":
-        return _payload_current_memory(values=values, arguments=arguments, context=context)
-    if primitive == "payload.verify":
-        return _verify_payload(values=values, arguments=arguments, context=context)
     if primitive == "output.emit":
         return _emit_output(values=values, arguments=arguments)
-    if primitive == "output.emit.install-result":
-        return _emit_output(values=values, arguments={"text_style": "install-result"})
-    if primitive == "output.emit.current-memory":
-        return _emit_output(values=values, arguments={"text_style": "current-memory"})
     if primitive == "python.function.call":
         return _call_python_function(values=values, arguments=arguments)
-    return execute_host_primitive(primitive, values=values, arguments=arguments, context=context)
+    return execute_host_primitive(
+        primitive, values=values, arguments=arguments, context=context
+    )
 
 
 def _store_step_result(*, values: dict[str, Any], outputs: Any, result: Any) -> None:
@@ -142,7 +139,9 @@ def _store_step_result(*, values: dict[str, Any], outputs: Any, result: Any) -> 
         raise PrimitiveExecutionError("multi-output primitive results must be mappings")
     for output_name in output_names:
         if output_name not in result:
-            raise PrimitiveExecutionError(f"primitive result missing declared output: {output_name!r}")
+            raise PrimitiveExecutionError(
+                f"primitive result missing declared output: {output_name!r}"
+            )
         values[output_name] = result[output_name]
 
 
@@ -165,7 +164,9 @@ def _condition_matches(condition: Any, *, values: dict[str, Any]) -> bool:
     if keys == {"not"}:
         return not _condition_matches(condition["not"], values=values)
     if keys not in ({"value", "equals"}, {"value", "present"}):
-        raise PrimitiveExecutionError("step when condition must use exactly one of all, any, not, equals, or present")
+        raise PrimitiveExecutionError(
+            "step when condition must use exactly one of all, any, not, equals, or present"
+        )
     value_name = str(condition.get("value", ""))
     if not value_name:
         raise PrimitiveExecutionError("step when condition must declare a value name")
@@ -175,7 +176,9 @@ def _condition_matches(condition: Any, *, values: dict[str, Any]) -> bool:
     return (actual is not None) == bool(condition["present"])
 
 
-def _resolve_target_root(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> str:
+def _resolve_target_root(
+    *, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext
+) -> str:
     target = values.get("target") or "."
     target_root = (context.cwd / str(target)).resolve()
     if bool(arguments.get("must_exist", False)) and not target_root.exists():
@@ -193,11 +196,15 @@ def _read_text(*, arguments: dict[str, Any], context: PrimitiveContext) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _glob(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> list[dict[str, str]]:
+def _glob(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> list[dict[str, str]]:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     pattern = str(arguments.get("pattern", ""))
     if not pattern or Path(pattern).is_absolute() or ".." in Path(pattern).parts:
-        raise PrimitiveExecutionError(f"unsupported filesystem.glob pattern: {pattern!r}")
+        raise PrimitiveExecutionError(
+            f"unsupported filesystem.glob pattern: {pattern!r}"
+        )
     matches = []
     for path in root.glob(pattern):
         resolved = path.resolve()
@@ -207,7 +214,9 @@ def _glob(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[
     return sorted(matches, key=lambda item: item["relative_path"])
 
 
-def _exists(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> bool:
+def _exists(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> bool:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     path = _resolve_inside(root, str(arguments.get("path", "")))
     if str(arguments.get("kind", "any")) == "file":
@@ -222,11 +231,15 @@ def _parse_json(*, values: dict[str, Any], arguments: dict[str, Any]) -> Any:
     try:
         text = values[source_name]
     except KeyError as exc:
-        raise PrimitiveExecutionError(f"json.parse missing source value: {source_name!r}") from exc
+        raise PrimitiveExecutionError(
+            f"json.parse missing source value: {source_name!r}"
+        ) from exc
     return json.loads(str(text))
 
 
-def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
+def _toml_table_counts(
+    *, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext
+) -> dict[str, Any]:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     relative_path = str(arguments.get("path", ""))
     path = _resolve_inside(root, relative_path)
@@ -244,12 +257,20 @@ def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], con
         "path": relative_path,
     }
     if not path.exists():
-        return {"table_counts": counts, "table_present": False, "table_status": counts["status"]}
+        return {
+            "table_counts": counts,
+            "table_present": False,
+            "table_status": counts["status"],
+        }
     try:
         payload = tomllib.loads(path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError):
         counts["status"] = "invalid"
-        return {"table_counts": counts, "table_present": False, "table_status": counts["status"]}
+        return {
+            "table_counts": counts,
+            "table_present": False,
+            "table_status": counts["status"],
+        }
     records = payload.get(table_name, {}) if isinstance(payload, dict) else {}
     record_values = list(records.values()) if isinstance(records, dict) else []
     counts["status"] = "present"
@@ -265,10 +286,16 @@ def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], con
             counts["optional_count"] += 1
         if bool(record_payload.get(routing_only_field, False)):
             counts["routing_only_count"] += 1
-    return {"table_counts": counts, "table_present": True, "table_status": counts["status"]}
+    return {
+        "table_counts": counts,
+        "table_present": True,
+        "table_status": counts["status"],
+    }
 
 
-def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> dict[str, Any]:
+def _assemble_payload(
+    *, values: dict[str, Any], arguments: dict[str, Any]
+) -> dict[str, Any]:
     fields = arguments.get("fields", {})
     if not isinstance(fields, dict):
         raise PrimitiveExecutionError("payload.assemble fields must be an object")
@@ -293,11 +320,17 @@ def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> d
     if actions_from == "registry.skills":
         registry = values.get("registry", {})
         if not isinstance(registry, dict):
-            raise PrimitiveExecutionError("registry.skills payload source must be an object")
+            raise PrimitiveExecutionError(
+                "registry.skills payload source must be an object"
+            )
         payload["mode"] = str(fields.get("mode", "skills"))
-        payload["bootstrap_version"] = _resolve_dotted_value(registry, str(fields.get("bootstrap_version_from", "")))
+        payload["bootstrap_version"] = _resolve_dotted_value(
+            registry, str(fields.get("bootstrap_version_from", ""))
+        )
         payload["actions"] = []
-        for item in _list_of_objects(registry.get("skills", []), source="registry.skills"):
+        for item in _list_of_objects(
+            registry.get("skills", []), source="registry.skills"
+        ):
             skill_id = str(item.get("id", "")).strip()
             path = str(item.get("path", "")).strip()
             if not skill_id or not path:
@@ -320,493 +353,36 @@ def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> d
                 }
             )
         return payload
-    raise PrimitiveExecutionError(f"unsupported payload.assemble actions_from: {actions_from!r}")
+    raise PrimitiveExecutionError(
+        f"unsupported payload.assemble actions_from: {actions_from!r}"
+    )
 
 
-def _assemble_package_file_list(*, values: dict[str, Any], fields: Mapping[str, Any]) -> dict[str, Any]:
+def _assemble_package_file_list(
+    *, values: dict[str, Any], fields: Mapping[str, Any]
+) -> dict[str, Any]:
     files_from = str(fields.get("files_from", "files"))
-    bundled_skills_from = str(fields.get("bundled_skill_files_from", "bundled_skill_files"))
+    bundled_skills_from = str(
+        fields.get("bundled_skill_files_from", "bundled_skill_files")
+    )
     return {
         "files": _relative_path_list(values.get(files_from, []), source=files_from),
-        "default_files": _string_list(fields.get("default_files", []), source="payload.assemble fields.default_files"),
-        "optional_files": _string_list(fields.get("optional_files", []), source="payload.assemble fields.optional_files"),
-        "bundled_skill_files": _relative_path_list(values.get(bundled_skills_from, []), source=bundled_skills_from),
+        "default_files": _string_list(
+            fields.get("default_files", []),
+            source="payload.assemble fields.default_files",
+        ),
+        "optional_files": _string_list(
+            fields.get("optional_files", []),
+            source="payload.assemble fields.optional_files",
+        ),
+        "bundled_skill_files": _relative_path_list(
+            values.get(bundled_skills_from, []), source=bundled_skills_from
+        ),
         "optional_enable_commands": _string_list(
             fields.get("optional_enable_commands", []),
             source="payload.assemble fields.optional_enable_commands",
         ),
     }
-
-
-def _verify_payload(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    payload_root = context.root(str(arguments.get("payload_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.verify cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    manifest_path = str(policy.get("manifest_path", ""))
-    payload_paths = _payload_file_set(payload_root=payload_root, policy=policy)
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    payload_version = _read_version(payload_root / version_path)
-    actions: list[dict[str, str]] = []
-    if payload_version is None:
-        actions.append(_payload_action("manual review", version_path, "payload version marker is missing or invalid"))
-    elif payload_version != bootstrap_version:
-        actions.append(
-            _payload_action(
-                "manual review",
-                version_path,
-                f"payload version marker ({payload_version}) does not match installer bootstrap version ({bootstrap_version})",
-            )
-        )
-    _verify_upgrade_source(policy=policy, payload_root=payload_root, actions=actions)
-    for required in _string_list(policy.get("required_files", []), source="payload.verify required_files"):
-        present = required in payload_paths
-        actions.append(
-            _payload_action(
-                "current" if present else "manual review",
-                required,
-                "required payload file present" if present else "required payload file missing",
-                safety="safe" if present else "manual",
-                category="safe-update" if present else "contract-drift",
-            )
-        )
-    compatibility_files = _string_list(policy.get("compatibility_contract_files", []), source="payload.verify compatibility_contract_files")
-    helper_files = [
-        path
-        for path in _string_list(policy.get("required_files", []), source="payload.verify required_files")
-        if path not in set(compatibility_files)
-    ]
-    actions.append(
-        _payload_action(
-            "current",
-            manifest_path,
-            "compatibility contract files: " + ", ".join(compatibility_files),
-            safety="safe",
-            category="safe-update",
-        )
-    )
-    upgrade_path = str(policy.get("upgrade_source", {}).get("path", ""))
-    actions.append(
-        _payload_action(
-            "current",
-            upgrade_path,
-            "lower-stability helper files: " + ", ".join(helper_files),
-            safety="safe",
-            category="safe-update",
-        )
-    )
-    current_memory = policy.get("current_memory", {})
-    if not isinstance(current_memory, dict):
-        raise PrimitiveExecutionError("payload.verify current_memory must be an object")
-    current_prefix = str(current_memory.get("prefix", ""))
-    current_payload = {path for path in payload_paths if path.startswith(current_prefix)}
-    required_current = set(_string_list(current_memory.get("required", []), source="payload.verify current_memory.required"))
-    optional_current = set(_string_list(current_memory.get("optional", []), source="payload.verify current_memory.optional"))
-    for extra in sorted(current_payload - (required_current | optional_current)):
-        actions.append(_payload_action("manual review", extra, "local-only or unexpected current-memory note is in the shipped payload"))
-    for missing in sorted(required_current - current_payload):
-        actions.append(_payload_action("manual review", missing, "baseline current-memory note missing from shipped payload"))
-    for forbidden in _string_list(policy.get("forbidden_files", []), source="payload.verify forbidden_files"):
-        if forbidden in payload_paths:
-            actions.append(_payload_action("manual review", forbidden, "forbidden file is present in the shipped payload"))
-    for payload_path in sorted(payload_paths):
-        if any(
-            payload_path.startswith(prefix)
-            for prefix in _string_list(policy.get("forbidden_prefixes", []), source="payload.verify forbidden_prefixes")
-        ):
-            actions.append(_payload_action("manual review", payload_path, "forbidden path prefix is present in the shipped payload"))
-    if not _toml_file_valid(payload_root / manifest_path):
-        actions.append(_payload_action("manual review", manifest_path, "payload manifest is missing or invalid"))
-    _verify_guidance_fragments(policy=policy, payload_root=payload_root, actions=actions)
-    return {
-        "target_root": str(target_root),
-        "dry_run": True,
-        "mode": "full",
-        "message": "Payload verification",
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "actions": actions,
-        "route_summary": {},
-        "missing_note_hint": "",
-        "review_summary": {},
-        "review_cases": [],
-        "sync_summary": {},
-        "route_report_summary": {},
-        "route_report_feedback_cases": [],
-        "route_report_fixture_results": [],
-    }
-
-
-def _payload_status(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.status cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    manifest_path = str(policy.get("manifest_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    active = _memory_manifest_counts(target_root=target_root, manifest_path=manifest_path)
-    actions: list[dict[str, Any]] = []
-    workspace_notice = policy.get("workspace_orchestrator_notice", {})
-    if isinstance(workspace_notice, dict):
-        marker = str(workspace_notice.get("marker", "")).strip()
-        if marker and not (target_root / marker).exists():
-            actions.append(
-                _status_action(
-                    "warning",
-                    marker,
-                    str(workspace_notice.get("detail", "")),
-                    role=str(workspace_notice.get("role", "workspace-orchestration")),
-                    safety=str(workspace_notice.get("safety", "safe")),
-                    source=marker,
-                    category=str(workspace_notice.get("category", "safe-update")),
-                )
-            )
-    for raw_entry in _list_of_objects(policy.get("status_files", []), source="payload.status status_files"):
-        relative_path = str(raw_entry.get("path", ""))
-        present = (target_root / relative_path).exists()
-        role = str(raw_entry.get("role", ""))
-        safety = str(raw_entry.get("safety", "safe"))
-        kind = "present" if present else "missing"
-        detail = "file exists" if present else "file missing"
-        actions.append(
-            _status_action(
-                kind,
-                relative_path,
-                detail,
-                role=role,
-                safety=safety,
-                source=relative_path,
-                category=str(raw_entry.get("present_category" if present else "missing_category", ""))
-                or _infer_status_category(kind=kind, path=relative_path, detail=detail, role=role, safety=safety),
-            )
-        )
-    for obsolete in _string_list(policy.get("obsolete_files", []), source="payload.status obsolete_files"):
-        if (target_root / obsolete).exists():
-            actions.append(
-                _status_action(
-                    "obsolete",
-                    obsolete,
-                    "legacy shared file should be removed on upgrade",
-                    role="shared-replaceable",
-                    safety="safe",
-                    source=obsolete,
-                    category="obsolete-managed-file",
-                )
-            )
-    return {
-        "target_root": str(target_root),
-        "dry_run": bool(arguments.get("dry_run", False)),
-        "mode": "",
-        "message": str(arguments.get("message", "Status report")),
-        "health": "healthy" if active["status"] == "present" else "attention-needed",
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "action_count": len(actions),
-        "actions": actions,
-        "active": active,
-        "detail_command": str(arguments.get("detail_command", "")),
-    }
-
-
-def _payload_lifecycle_plan(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.lifecycle-plan cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    actions: list[dict[str, Any]] = []
-    workspace_notice = policy.get("workspace_orchestrator_notice", {})
-    if isinstance(workspace_notice, dict):
-        marker = str(workspace_notice.get("marker", "")).strip()
-        if marker and not (target_root / marker).exists():
-            actions.append(
-                _status_action(
-                    "warning",
-                    marker,
-                    str(workspace_notice.get("detail", "")),
-                    role=str(workspace_notice.get("role", "workspace-orchestration")),
-                    safety=str(workspace_notice.get("safety", "safe")),
-                    source=marker,
-                    category=str(workspace_notice.get("category", "safe-update")),
-                )
-            )
-    for raw_entry in _list_of_objects(policy.get("status_files", []), source="payload.lifecycle-plan status_files"):
-        relative_path = str(raw_entry.get("path", ""))
-        if not relative_path:
-            continue
-        exists = (target_root / relative_path).exists()
-        actions.append(
-            _status_action(
-                "preserve" if exists else str(arguments.get("missing_kind", "would copy")),
-                relative_path,
-                "already exists" if exists else str(arguments.get("missing_detail", "planned change")),
-                role=str(raw_entry.get("role", "")),
-                safety=str(raw_entry.get("safety", "safe")),
-                source=str(raw_entry.get("source", relative_path)),
-                category=str(raw_entry.get("category", "")) or "safe-update",
-            )
-        )
-    return {
-        "target_root": str(target_root),
-        "dry_run": bool(arguments.get("dry_run", True)),
-        "mode": str(arguments.get("mode", "")),
-        "message": str(arguments.get("message", "Install plan")),
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "actions": actions,
-    }
-
-
-def _payload_current_memory(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.current-memory cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    current_memory = policy.get("current_memory", {})
-    if not isinstance(current_memory, dict):
-        raise PrimitiveExecutionError("payload.current-memory current_memory policy must be an object")
-    note_paths = _string_list(current_memory.get("view_files", []), source="payload.current-memory current_memory.view_files")
-    notes: list[dict[str, Any]] = []
-    for relative_path in note_paths:
-        note_path = target_root / relative_path
-        exists = note_path.exists()
-        notes.append(
-            {
-                "path": relative_path,
-                "exists": exists,
-                "content": note_path.read_text(encoding="utf-8") if exists else "",
-            }
-        )
-    return {
-        "target_root": str(target_root),
-        "detected_version": _read_first_version(target_root, [version_path, legacy_version_path]),
-        "bootstrap_version": bootstrap_version,
-        "notes": notes,
-    }
-
-
-def _memory_manifest_counts(*, target_root: Path, manifest_path: str) -> dict[str, Any]:
-    counts = {
-        "status": "missing",
-        "note_count": 0,
-        "required_count": 0,
-        "optional_count": 0,
-        "routing_only_count": 0,
-        "path": manifest_path,
-    }
-    path = target_root / manifest_path
-    if not path.exists():
-        return counts
-    try:
-        payload = tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        counts["status"] = "invalid"
-        return counts
-    notes = payload.get("notes", {}) if isinstance(payload, dict) else {}
-    note_values = list(notes.values()) if isinstance(notes, dict) else []
-    counts["status"] = "present"
-    counts["note_count"] = len(note_values)
-    for note in note_values:
-        if not isinstance(note, dict):
-            continue
-        note_payload = cast(Mapping[str, Any], note)
-        relevance = str(note_payload.get("task_relevance", "")).strip().lower()
-        if relevance == "required":
-            counts["required_count"] += 1
-        elif relevance == "optional":
-            counts["optional_count"] += 1
-        if bool(note_payload.get("routing_only", False)):
-            counts["routing_only_count"] += 1
-    return counts
-
-
-def _status_action(
-    kind: str,
-    path: str,
-    detail: str,
-    *,
-    role: str,
-    safety: str,
-    source: str,
-    category: str,
-) -> dict[str, str]:
-    return {
-        "kind": kind,
-        "path": path,
-        "detail": detail,
-        "role": role,
-        "safety": safety,
-        "source": source,
-        "category": category,
-        "remediation_kind": "",
-        "remediation_target": "",
-        "remediation_reason": "",
-        "remediation_confidence": "",
-        "memory_action": "",
-        "match_source": "",
-    }
-
-
-def _infer_status_category(*, kind: str, path: str, detail: str, role: str, safety: str) -> str:
-    detail_lower = detail.lower()
-    if "placeholder" in detail_lower:
-        return "placeholder-review"
-    if role in {"payload-contract", "local-entrypoint"} or role.startswith("shared-"):
-        if kind in {"manual review", "missing"}:
-            return "contract-drift"
-    if kind in {"current", "present", "optional", "required", "warning"}:
-        return "safe-update"
-    if kind in {"manual review", "consider"}:
-        return "manual-review"
-    if safety == "safe":
-        return "safe-update"
-    return ""
-
-
-def _payload_file_set(*, payload_root: Path, policy: dict[str, Any]) -> set[str]:
-    aliases = {
-        str(item["source"]): str(item["target"])
-        for item in policy.get("payload_path_aliases", [])
-        if isinstance(item, dict) and isinstance(item.get("source"), str) and isinstance(item.get("target"), str)
-    }
-    payload_paths: set[str] = set()
-    for path in payload_root.rglob("*"):
-        if path.is_file():
-            relative = path.relative_to(payload_root).as_posix()
-            payload_paths.add(aliases.get(relative, relative))
-    return payload_paths
-
-
-def _payload_action(kind: str, path: str, detail: str, *, safety: str = "manual", category: str = "contract-drift") -> dict[str, str]:
-    return {
-        "kind": kind,
-        "path": path,
-        "detail": detail,
-        "role": "payload-contract",
-        "safety": safety,
-        "source": path,
-        "category": category,
-        "remediation_kind": "",
-        "remediation_target": "",
-        "remediation_reason": "",
-        "remediation_confidence": "",
-        "memory_action": "",
-        "match_source": "",
-    }
-
-
-def _verify_upgrade_source(*, policy: dict[str, Any], payload_root: Path, actions: list[dict[str, str]]) -> None:
-    upgrade_source = policy.get("upgrade_source", {})
-    if not isinstance(upgrade_source, dict):
-        raise PrimitiveExecutionError("payload.verify upgrade_source must be an object")
-    relative = str(upgrade_source.get("path", ""))
-    legacy_relative = str(upgrade_source.get("legacy_path", ""))
-    path = payload_root / relative
-    if not path.exists():
-        path = payload_root / legacy_relative
-    if not path.exists():
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata is missing from the payload"))
-        return
-    try:
-        data = tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata is not valid TOML"))
-        return
-    source_type = str(data.get("source_type", "")).strip()
-    if source_type not in set(_string_list(upgrade_source.get("allowed_source_types", []), source="payload.verify allowed_source_types")):
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata must declare source_type as git or local"))
-        return
-    for required in _string_list(upgrade_source.get("required_fields", []), source="payload.verify required_fields"):
-        if not str(data.get(required, "")).strip():
-            actions.append(_payload_action("manual review", relative, f"upgrade source metadata is missing {required}"))
-            return
-    for field_name, date_format in (upgrade_source.get("date_fields", {}) or {}).items():
-        value = str(data.get(str(field_name), "")).strip()
-        if value and str(date_format) == "YYYY-MM-DD" and not re.match(r"^\d{4}-\d{2}-\d{2}$", value):
-            actions.append(_payload_action("manual review", relative, f"upgrade source metadata has invalid {field_name}; use YYYY-MM-DD"))
-    for field_name in _string_list(upgrade_source.get("integer_fields", []), source="payload.verify integer_fields"):
-        if not isinstance(data.get(field_name, 30), int):
-            actions.append(
-                _payload_action("manual review", relative, f"upgrade source metadata has invalid {field_name}; use an integer day count")
-            )
-
-
-def _verify_guidance_fragments(*, policy: dict[str, Any], payload_root: Path, actions: list[dict[str, str]]) -> None:
-    raw_fragments = policy.get("guidance_fragments", {})
-    if not isinstance(raw_fragments, dict):
-        raise PrimitiveExecutionError("payload.verify guidance_fragments must be an object")
-    for relative, fragments in raw_fragments.items():
-        relative_path = str(relative)
-        path = payload_root / relative_path
-        if not path.exists():
-            continue
-        text = path.read_text(encoding="utf-8")
-        missing = [fragment for fragment in _string_list(fragments, source="payload.verify guidance fragments") if fragment not in text]
-        actions.append(
-            _payload_action(
-                "current" if not missing else "manual review",
-                relative_path,
-                "collaboration-safe current-note guidance present"
-                if not missing
-                else "current-note payload guidance is missing collaboration-safe wording",
-                safety="safe" if not missing else "manual",
-                category="safe-update" if not missing else "contract-drift",
-            )
-        )
-
-
-def _toml_file_valid(path: Path) -> bool:
-    if not path.exists():
-        return False
-    try:
-        tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return False
-    return True
-
-
-def _read_version(path: Path) -> int | None:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    match = re.search(r"^\s*Version:\s*(\d+)\s*$", text, re.MULTILINE)
-    return int(match.group(1)) if match else None
-
-
-def _read_first_version(root: Path, relative_paths: Sequence[str]) -> int | None:
-    for relative_path in relative_paths:
-        if not relative_path:
-            continue
-        version = _read_version(root / relative_path)
-        if version is not None:
-            return version
-    return None
 
 
 def _string_list(value: Any, *, source: str) -> list[str]:
@@ -828,7 +404,9 @@ def _relative_path_list(value: Any, *, source: str) -> list[str]:
             if isinstance(relative_path, str):
                 paths.append(relative_path)
                 continue
-        raise PrimitiveExecutionError(f"{source} entries must be strings or objects with relative_path")
+        raise PrimitiveExecutionError(
+            f"{source} entries must be strings or objects with relative_path"
+        )
     return paths
 
 
@@ -850,60 +428,91 @@ def _resolve_template(template: Any, *, values: dict[str, Any]) -> Any:
         elif isinstance(path, Sequence) and not isinstance(path, (str, bytes)):
             path_parts = [str(part) for part in path]
         else:
-            raise PrimitiveExecutionError("template $field path must be a string or sequence")
+            raise PrimitiveExecutionError(
+                "template $field path must be a string or sequence"
+            )
         value: Any = values.get(value_name)
         for part in path_parts:
             if not isinstance(value, Mapping) or part not in value:
-                raise PrimitiveExecutionError(f"template $field cannot resolve {value_name!r}.{'.'.join(path_parts)}")
+                raise PrimitiveExecutionError(
+                    f"template $field cannot resolve {value_name!r}.{'.'.join(path_parts)}"
+                )
             value = value[part]
         return value
     if set(template) == {"$count"}:
         counted = values.get(str(template["$count"]), [])
         if not isinstance(counted, Sequence) or isinstance(counted, (str, bytes)):
-            raise PrimitiveExecutionError(f"template count source must be a sequence: {template['$count']!r}")
+            raise PrimitiveExecutionError(
+                f"template count source must be a sequence: {template['$count']!r}"
+            )
         return len(counted)
     if "$exists_status" in template:
         spec = template["$exists_status"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $exists_status must be an object")
         value = bool(values.get(str(spec.get("value", ""))))
-        return spec.get("present", "present") if value else spec.get("missing", "missing")
+        return (
+            spec.get("present", "present") if value else spec.get("missing", "missing")
+        )
     if "$count_status" in template:
         spec = template["$count_status"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $count_status must be an object")
         counted = values.get(str(spec.get("value", "")), [])
         if not isinstance(counted, Sequence) or isinstance(counted, (str, bytes)):
-            raise PrimitiveExecutionError(f"template count source must be a sequence: {spec.get('value')!r}")
-        return spec.get("present", "present") if len(counted) else spec.get("missing", "missing")
+            raise PrimitiveExecutionError(
+                f"template count source must be a sequence: {spec.get('value')!r}"
+            )
+        return (
+            spec.get("present", "present")
+            if len(counted)
+            else spec.get("missing", "missing")
+        )
     if "$join_path" in template:
         spec = template["$join_path"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $join_path must be an object")
         base = Path(str(values.get(str(spec.get("base", "")), "")))
         return (base / str(spec.get("path", ""))).as_posix()
-    return {str(key): _resolve_template(value, values=values) for key, value in template.items()}
+    return {
+        str(key): _resolve_template(value, values=values)
+        for key, value in template.items()
+    }
 
 
-def _emit_output(*, values: dict[str, Any], arguments: dict[str, Any] | None = None) -> str:
+def _emit_output(
+    *, values: dict[str, Any], arguments: dict[str, Any] | None = None
+) -> str:
     arguments = arguments or {}
     result = _plain_output_result(values.get("result"))
     output_format = str(values.get("format") or "text")
     if output_format == "json":
         return json.dumps(result, indent=2, sort_keys=True) + "\n"
-    if str(arguments.get("text_style", "")) == "current-memory" and isinstance(result, dict):
+    if str(arguments.get("text_style", "")) == "current-memory" and isinstance(
+        result, dict
+    ):
         return _emit_current_memory_text(result)
-    if str(arguments.get("text_style", "")) == "install-result" and isinstance(result, dict):
+    if str(arguments.get("text_style", "")) == "install-result" and isinstance(
+        result, dict
+    ):
         return _emit_install_result_text(result)
-    if isinstance(result, dict) and isinstance(result.get("route_report_summary"), dict):
+    if isinstance(result, dict) and isinstance(
+        result.get("route_report_summary"), dict
+    ):
         return _emit_route_report_text(result)
     if isinstance(result, dict) and result.get("kind") == "memory-module-report/v1":
         return _emit_memory_report_text(result)
-    if isinstance(result, dict) and result.get("kind") == "planning-module-report/v1" and result.get("profile") == "tiny":
+    if (
+        isinstance(result, dict)
+        and result.get("kind") == "planning-module-report/v1"
+        and result.get("profile") == "tiny"
+    ):
         return _emit_planning_module_report_text(result)
     if not isinstance(result, dict):
         return f"{result}\n"
-    if isinstance(result.get("files"), list) and all(isinstance(item, str) for item in result["files"]):
+    if isinstance(result.get("files"), list) and all(
+        isinstance(item, str) for item in result["files"]
+    ):
         return "\n".join(result["files"]).rstrip() + "\n"
     lines = [str(result.get("message", ""))]
     for action in _list_of_objects(result.get("actions", []), source="result.actions"):
@@ -949,7 +558,9 @@ def _emit_install_result_text(result: dict[str, Any]) -> str:
         ):
             value = action.get(key)
             if value:
-                details.append(str(value) if not label_name else f"{label_name}={value}")
+                details.append(
+                    str(value) if not label_name else f"{label_name}={value}"
+                )
         detail = f" ({'; '.join(details)})" if details else ""
         lines.append(f"- {action.get('kind')}: {label}{detail}")
     return "\n".join(lines).rstrip() + "\n"
@@ -979,9 +590,13 @@ def _emit_route_report_text(result: dict[str, Any]) -> str:
     fixtures = summary.get("fixtures", {})
     lines = [str(result.get("message", "Routing report"))]
     if isinstance(feedback, Mapping):
-        lines.append(f"Feedback: {feedback.get('status', 'unknown')} ({feedback.get('path', '')})")
+        lines.append(
+            f"Feedback: {feedback.get('status', 'unknown')} ({feedback.get('path', '')})"
+        )
     if isinstance(fixtures, Mapping):
-        lines.append(f"Fixtures: {fixtures.get('status', 'unknown')} ({fixtures.get('fixture_count', 0)})")
+        lines.append(
+            f"Fixtures: {fixtures.get('status', 'unknown')} ({fixtures.get('fixture_count', 0)})"
+        )
     detail = summary.get("detail") or result.get("detail_command")
     if detail:
         lines.append(str(detail))
@@ -993,9 +608,15 @@ def _emit_memory_report_text(result: dict[str, Any]) -> str:
     active = result.get("active", {})
     habitual_pull = result.get("habitual_pull", {})
     next_action = result.get("next_action", {})
-    lines = ["Memory report", f"Target: {result.get('target_root', '')}", f"Health: {result.get('health', 'unknown')}"]
+    lines = [
+        "Memory report",
+        f"Target: {result.get('target_root', '')}",
+        f"Health: {result.get('health', 'unknown')}",
+    ]
     if isinstance(status, Mapping):
-        lines.append(f"Notes: {status.get('note_count', 0)} ({status.get('manifest_status', 'unknown')})")
+        lines.append(
+            f"Notes: {status.get('note_count', 0)} ({status.get('manifest_status', 'unknown')})"
+        )
     if isinstance(active, Mapping):
         lines.append(
             "Active: "
@@ -1039,11 +660,15 @@ def _call_python_function(*, values: dict[str, Any], arguments: dict[str, Any]) 
     import_module = str(arguments.get("import_module", "")).strip()
     function_name = str(arguments.get("function", "")).strip()
     if not import_module or not function_name:
-        raise PrimitiveExecutionError("python.function.call requires import_module and function")
+        raise PrimitiveExecutionError(
+            "python.function.call requires import_module and function"
+        )
     try:
         function = getattr(importlib.import_module(import_module), function_name)
     except (ImportError, AttributeError) as exc:
-        raise PrimitiveExecutionError(f"python.function.call cannot resolve {import_module}.{function_name}") from exc
+        raise PrimitiveExecutionError(
+            f"python.function.call cannot resolve {import_module}.{function_name}"
+        ) from exc
     kwargs = _resolve_call_kwargs(values=values, raw_kwargs=arguments.get("kwargs", {}))
     return function(**kwargs)
 
@@ -1059,12 +684,16 @@ def _resolve_call_kwargs(*, values: dict[str, Any], raw_kwargs: Any) -> dict[str
         if "value" in source:
             value_name = str(source["value"])
             if value_name not in values:
-                raise PrimitiveExecutionError(f"python.function.call cannot resolve value {value_name!r}")
+                raise PrimitiveExecutionError(
+                    f"python.function.call cannot resolve value {value_name!r}"
+                )
             kwargs[str(name)] = values[value_name]
         elif "literal" in source:
             kwargs[str(name)] = source["literal"]
         else:
-            raise PrimitiveExecutionError(f"python.function.call kwarg {name!r} must declare value or literal")
+            raise PrimitiveExecutionError(
+                f"python.function.call kwarg {name!r} must declare value or literal"
+            )
     return kwargs
 
 
@@ -1085,11 +714,15 @@ def _resolve_inside(root: Path, relative: str) -> Path:
     return candidate
 
 
-def _primitive_root(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> Path:
+def _primitive_root(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> Path:
     if "base_value" in arguments:
         value_name = str(arguments["base_value"])
         if value_name not in values:
-            raise PrimitiveExecutionError(f"unknown primitive base value: {value_name!r}")
+            raise PrimitiveExecutionError(
+                f"unknown primitive base value: {value_name!r}"
+            )
         return Path(str(values[value_name])).resolve()
     return context.root(str(arguments.get("root", "")))
 
@@ -1098,7 +731,9 @@ def _ensure_inside(root: Path, candidate: Path) -> None:
     try:
         candidate.relative_to(root)
     except ValueError as exc:
-        raise PrimitiveExecutionError(f"path escapes primitive root: {candidate}") from exc
+        raise PrimitiveExecutionError(
+            f"path escapes primitive root: {candidate}"
+        ) from exc
 
 
 def _list_of_objects(value: Any, *, source: str) -> list[dict[str, Any]]:

--- a/generated/verification/typescript/package.json
+++ b/generated/verification/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "0.2.9"
+        "version": "0.2.10"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/verification/typescript/resources/command_package.json
+++ b/generated/verification/typescript/resources/command_package.json
@@ -99,7 +99,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.9"
+      "version": "0.2.10"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/verification/typescript/src/runtime.mjs
+++ b/generated/verification/typescript/src/runtime.mjs
@@ -199,8 +199,7 @@ function executeHostDomainOperation(operationId, values) {
 
 function executePrimitive(primitive, values, args, operationId) {
   if (primitive === 'typescript.domain.execute') return executeHostDomainOperation(String(args.operation_id ?? operationId), values);
-  const rootResolvePrimitives = new Set(['path.target_root.resolve', ['workspace', 'root', 'resolve'].join('.')]);
-  if (rootResolvePrimitives.has(primitive)) {
+  if (primitive === 'path.target_root.resolve') {
     const targetRoot = resolve(String(values.target ?? '.'));
     if (args.must_exist && !existsSync(targetRoot)) throw new RuntimeError(`target root does not exist: ${targetRoot}`);
     if (args.must_be_dir && (!existsSync(targetRoot) || !statSync(targetRoot).isDirectory())) throw new RuntimeError(`target root is not a directory: ${targetRoot}`);
@@ -216,7 +215,7 @@ function executePrimitive(primitive, values, args, operationId) {
   if (primitive === 'filesystem.glob') return globFiles(valueRoot(args, values), String(args.pattern ?? '')).map((relative_path) => ({ relative_path }));
   if (primitive === 'json.parse') return JSON.parse(String(values[String(args.source ?? 'registry_text')]));
   if (primitive === 'payload.assemble') return assemblePayload(values, args);
-  if (primitive === 'output.emit' || primitive === 'output.emit.install-result' || primitive === 'output.emit.current-memory') return emitOutput(values);
+  if (primitive === 'output.emit') return emitOutput(values);
   return executeHostPrimitive(primitive, values, args, operationId);
 }
 

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -4888,7 +4888,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.9"
+      "version": "0.2.10"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/workspace/python/primitives/primitive_executor.py
+++ b/generated/workspace/python/primitives/primitive_executor.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import importlib
 import json
-import re
 import tomllib
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -67,20 +66,28 @@ def run_operation_steps(
     if not isinstance(steps, list):
         raise PrimitiveExecutionError("operation ir_plan.steps must be a list")
     fragments = operation_fragments(operation, error_type=PrimitiveExecutionError)
-    for raw_step in expand_operation_steps(steps, fragments=fragments, error_type=PrimitiveExecutionError):
+    for raw_step in expand_operation_steps(
+        steps, fragments=fragments, error_type=PrimitiveExecutionError
+    ):
         primitive = str(raw_step.get("uses", ""))
         arguments = raw_step.get("arguments", {})
         if not isinstance(arguments, dict):
-            raise PrimitiveExecutionError(f"step {raw_step.get('id', primitive)!r} arguments must be an object")
+            raise PrimitiveExecutionError(
+                f"step {raw_step.get('id', primitive)!r} arguments must be an object"
+            )
         if not _condition_matches(raw_step.get("when"), values=values):
             continue
         handler = custom_handlers.get(primitive)
         result = (
             handler(values, arguments, context)
             if handler is not None
-            else execute_primitive(primitive, values=values, arguments=arguments, context=context)
+            else execute_primitive(
+                primitive, values=values, arguments=arguments, context=context
+            )
         )
-        _store_step_result(values=values, outputs=raw_step.get("outputs", []), result=result)
+        _store_step_result(
+            values=values, outputs=raw_step.get("outputs", []), result=result
+        )
     return values
 
 
@@ -106,23 +113,13 @@ def execute_primitive(
         return _toml_table_counts(values=values, arguments=arguments, context=context)
     if primitive == "payload.assemble":
         return _assemble_payload(values=values, arguments=arguments)
-    if primitive == "payload.status":
-        return _payload_status(values=values, arguments=arguments, context=context)
-    if primitive == "payload.lifecycle-plan":
-        return _payload_lifecycle_plan(values=values, arguments=arguments, context=context)
-    if primitive == "payload.current-memory":
-        return _payload_current_memory(values=values, arguments=arguments, context=context)
-    if primitive == "payload.verify":
-        return _verify_payload(values=values, arguments=arguments, context=context)
     if primitive == "output.emit":
         return _emit_output(values=values, arguments=arguments)
-    if primitive == "output.emit.install-result":
-        return _emit_output(values=values, arguments={"text_style": "install-result"})
-    if primitive == "output.emit.current-memory":
-        return _emit_output(values=values, arguments={"text_style": "current-memory"})
     if primitive == "python.function.call":
         return _call_python_function(values=values, arguments=arguments)
-    return execute_host_primitive(primitive, values=values, arguments=arguments, context=context)
+    return execute_host_primitive(
+        primitive, values=values, arguments=arguments, context=context
+    )
 
 
 def _store_step_result(*, values: dict[str, Any], outputs: Any, result: Any) -> None:
@@ -142,7 +139,9 @@ def _store_step_result(*, values: dict[str, Any], outputs: Any, result: Any) -> 
         raise PrimitiveExecutionError("multi-output primitive results must be mappings")
     for output_name in output_names:
         if output_name not in result:
-            raise PrimitiveExecutionError(f"primitive result missing declared output: {output_name!r}")
+            raise PrimitiveExecutionError(
+                f"primitive result missing declared output: {output_name!r}"
+            )
         values[output_name] = result[output_name]
 
 
@@ -165,7 +164,9 @@ def _condition_matches(condition: Any, *, values: dict[str, Any]) -> bool:
     if keys == {"not"}:
         return not _condition_matches(condition["not"], values=values)
     if keys not in ({"value", "equals"}, {"value", "present"}):
-        raise PrimitiveExecutionError("step when condition must use exactly one of all, any, not, equals, or present")
+        raise PrimitiveExecutionError(
+            "step when condition must use exactly one of all, any, not, equals, or present"
+        )
     value_name = str(condition.get("value", ""))
     if not value_name:
         raise PrimitiveExecutionError("step when condition must declare a value name")
@@ -175,7 +176,9 @@ def _condition_matches(condition: Any, *, values: dict[str, Any]) -> bool:
     return (actual is not None) == bool(condition["present"])
 
 
-def _resolve_target_root(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> str:
+def _resolve_target_root(
+    *, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext
+) -> str:
     target = values.get("target") or "."
     target_root = (context.cwd / str(target)).resolve()
     if bool(arguments.get("must_exist", False)) and not target_root.exists():
@@ -193,11 +196,15 @@ def _read_text(*, arguments: dict[str, Any], context: PrimitiveContext) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _glob(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> list[dict[str, str]]:
+def _glob(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> list[dict[str, str]]:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     pattern = str(arguments.get("pattern", ""))
     if not pattern or Path(pattern).is_absolute() or ".." in Path(pattern).parts:
-        raise PrimitiveExecutionError(f"unsupported filesystem.glob pattern: {pattern!r}")
+        raise PrimitiveExecutionError(
+            f"unsupported filesystem.glob pattern: {pattern!r}"
+        )
     matches = []
     for path in root.glob(pattern):
         resolved = path.resolve()
@@ -207,7 +214,9 @@ def _glob(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[
     return sorted(matches, key=lambda item: item["relative_path"])
 
 
-def _exists(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> bool:
+def _exists(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> bool:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     path = _resolve_inside(root, str(arguments.get("path", "")))
     if str(arguments.get("kind", "any")) == "file":
@@ -222,11 +231,15 @@ def _parse_json(*, values: dict[str, Any], arguments: dict[str, Any]) -> Any:
     try:
         text = values[source_name]
     except KeyError as exc:
-        raise PrimitiveExecutionError(f"json.parse missing source value: {source_name!r}") from exc
+        raise PrimitiveExecutionError(
+            f"json.parse missing source value: {source_name!r}"
+        ) from exc
     return json.loads(str(text))
 
 
-def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
+def _toml_table_counts(
+    *, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext
+) -> dict[str, Any]:
     root = _primitive_root(arguments=arguments, context=context, values=values)
     relative_path = str(arguments.get("path", ""))
     path = _resolve_inside(root, relative_path)
@@ -244,12 +257,20 @@ def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], con
         "path": relative_path,
     }
     if not path.exists():
-        return {"table_counts": counts, "table_present": False, "table_status": counts["status"]}
+        return {
+            "table_counts": counts,
+            "table_present": False,
+            "table_status": counts["status"],
+        }
     try:
         payload = tomllib.loads(path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError):
         counts["status"] = "invalid"
-        return {"table_counts": counts, "table_present": False, "table_status": counts["status"]}
+        return {
+            "table_counts": counts,
+            "table_present": False,
+            "table_status": counts["status"],
+        }
     records = payload.get(table_name, {}) if isinstance(payload, dict) else {}
     record_values = list(records.values()) if isinstance(records, dict) else []
     counts["status"] = "present"
@@ -265,10 +286,16 @@ def _toml_table_counts(*, values: dict[str, Any], arguments: dict[str, Any], con
             counts["optional_count"] += 1
         if bool(record_payload.get(routing_only_field, False)):
             counts["routing_only_count"] += 1
-    return {"table_counts": counts, "table_present": True, "table_status": counts["status"]}
+    return {
+        "table_counts": counts,
+        "table_present": True,
+        "table_status": counts["status"],
+    }
 
 
-def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> dict[str, Any]:
+def _assemble_payload(
+    *, values: dict[str, Any], arguments: dict[str, Any]
+) -> dict[str, Any]:
     fields = arguments.get("fields", {})
     if not isinstance(fields, dict):
         raise PrimitiveExecutionError("payload.assemble fields must be an object")
@@ -293,11 +320,17 @@ def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> d
     if actions_from == "registry.skills":
         registry = values.get("registry", {})
         if not isinstance(registry, dict):
-            raise PrimitiveExecutionError("registry.skills payload source must be an object")
+            raise PrimitiveExecutionError(
+                "registry.skills payload source must be an object"
+            )
         payload["mode"] = str(fields.get("mode", "skills"))
-        payload["bootstrap_version"] = _resolve_dotted_value(registry, str(fields.get("bootstrap_version_from", "")))
+        payload["bootstrap_version"] = _resolve_dotted_value(
+            registry, str(fields.get("bootstrap_version_from", ""))
+        )
         payload["actions"] = []
-        for item in _list_of_objects(registry.get("skills", []), source="registry.skills"):
+        for item in _list_of_objects(
+            registry.get("skills", []), source="registry.skills"
+        ):
             skill_id = str(item.get("id", "")).strip()
             path = str(item.get("path", "")).strip()
             if not skill_id or not path:
@@ -320,493 +353,36 @@ def _assemble_payload(*, values: dict[str, Any], arguments: dict[str, Any]) -> d
                 }
             )
         return payload
-    raise PrimitiveExecutionError(f"unsupported payload.assemble actions_from: {actions_from!r}")
+    raise PrimitiveExecutionError(
+        f"unsupported payload.assemble actions_from: {actions_from!r}"
+    )
 
 
-def _assemble_package_file_list(*, values: dict[str, Any], fields: Mapping[str, Any]) -> dict[str, Any]:
+def _assemble_package_file_list(
+    *, values: dict[str, Any], fields: Mapping[str, Any]
+) -> dict[str, Any]:
     files_from = str(fields.get("files_from", "files"))
-    bundled_skills_from = str(fields.get("bundled_skill_files_from", "bundled_skill_files"))
+    bundled_skills_from = str(
+        fields.get("bundled_skill_files_from", "bundled_skill_files")
+    )
     return {
         "files": _relative_path_list(values.get(files_from, []), source=files_from),
-        "default_files": _string_list(fields.get("default_files", []), source="payload.assemble fields.default_files"),
-        "optional_files": _string_list(fields.get("optional_files", []), source="payload.assemble fields.optional_files"),
-        "bundled_skill_files": _relative_path_list(values.get(bundled_skills_from, []), source=bundled_skills_from),
+        "default_files": _string_list(
+            fields.get("default_files", []),
+            source="payload.assemble fields.default_files",
+        ),
+        "optional_files": _string_list(
+            fields.get("optional_files", []),
+            source="payload.assemble fields.optional_files",
+        ),
+        "bundled_skill_files": _relative_path_list(
+            values.get(bundled_skills_from, []), source=bundled_skills_from
+        ),
         "optional_enable_commands": _string_list(
             fields.get("optional_enable_commands", []),
             source="payload.assemble fields.optional_enable_commands",
         ),
     }
-
-
-def _verify_payload(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    payload_root = context.root(str(arguments.get("payload_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.verify cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    manifest_path = str(policy.get("manifest_path", ""))
-    payload_paths = _payload_file_set(payload_root=payload_root, policy=policy)
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    payload_version = _read_version(payload_root / version_path)
-    actions: list[dict[str, str]] = []
-    if payload_version is None:
-        actions.append(_payload_action("manual review", version_path, "payload version marker is missing or invalid"))
-    elif payload_version != bootstrap_version:
-        actions.append(
-            _payload_action(
-                "manual review",
-                version_path,
-                f"payload version marker ({payload_version}) does not match installer bootstrap version ({bootstrap_version})",
-            )
-        )
-    _verify_upgrade_source(policy=policy, payload_root=payload_root, actions=actions)
-    for required in _string_list(policy.get("required_files", []), source="payload.verify required_files"):
-        present = required in payload_paths
-        actions.append(
-            _payload_action(
-                "current" if present else "manual review",
-                required,
-                "required payload file present" if present else "required payload file missing",
-                safety="safe" if present else "manual",
-                category="safe-update" if present else "contract-drift",
-            )
-        )
-    compatibility_files = _string_list(policy.get("compatibility_contract_files", []), source="payload.verify compatibility_contract_files")
-    helper_files = [
-        path
-        for path in _string_list(policy.get("required_files", []), source="payload.verify required_files")
-        if path not in set(compatibility_files)
-    ]
-    actions.append(
-        _payload_action(
-            "current",
-            manifest_path,
-            "compatibility contract files: " + ", ".join(compatibility_files),
-            safety="safe",
-            category="safe-update",
-        )
-    )
-    upgrade_path = str(policy.get("upgrade_source", {}).get("path", ""))
-    actions.append(
-        _payload_action(
-            "current",
-            upgrade_path,
-            "lower-stability helper files: " + ", ".join(helper_files),
-            safety="safe",
-            category="safe-update",
-        )
-    )
-    current_memory = policy.get("current_memory", {})
-    if not isinstance(current_memory, dict):
-        raise PrimitiveExecutionError("payload.verify current_memory must be an object")
-    current_prefix = str(current_memory.get("prefix", ""))
-    current_payload = {path for path in payload_paths if path.startswith(current_prefix)}
-    required_current = set(_string_list(current_memory.get("required", []), source="payload.verify current_memory.required"))
-    optional_current = set(_string_list(current_memory.get("optional", []), source="payload.verify current_memory.optional"))
-    for extra in sorted(current_payload - (required_current | optional_current)):
-        actions.append(_payload_action("manual review", extra, "local-only or unexpected current-memory note is in the shipped payload"))
-    for missing in sorted(required_current - current_payload):
-        actions.append(_payload_action("manual review", missing, "baseline current-memory note missing from shipped payload"))
-    for forbidden in _string_list(policy.get("forbidden_files", []), source="payload.verify forbidden_files"):
-        if forbidden in payload_paths:
-            actions.append(_payload_action("manual review", forbidden, "forbidden file is present in the shipped payload"))
-    for payload_path in sorted(payload_paths):
-        if any(
-            payload_path.startswith(prefix)
-            for prefix in _string_list(policy.get("forbidden_prefixes", []), source="payload.verify forbidden_prefixes")
-        ):
-            actions.append(_payload_action("manual review", payload_path, "forbidden path prefix is present in the shipped payload"))
-    if not _toml_file_valid(payload_root / manifest_path):
-        actions.append(_payload_action("manual review", manifest_path, "payload manifest is missing or invalid"))
-    _verify_guidance_fragments(policy=policy, payload_root=payload_root, actions=actions)
-    return {
-        "target_root": str(target_root),
-        "dry_run": True,
-        "mode": "full",
-        "message": "Payload verification",
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "actions": actions,
-        "route_summary": {},
-        "missing_note_hint": "",
-        "review_summary": {},
-        "review_cases": [],
-        "sync_summary": {},
-        "route_report_summary": {},
-        "route_report_feedback_cases": [],
-        "route_report_fixture_results": [],
-    }
-
-
-def _payload_status(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.status cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    manifest_path = str(policy.get("manifest_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    active = _memory_manifest_counts(target_root=target_root, manifest_path=manifest_path)
-    actions: list[dict[str, Any]] = []
-    workspace_notice = policy.get("workspace_orchestrator_notice", {})
-    if isinstance(workspace_notice, dict):
-        marker = str(workspace_notice.get("marker", "")).strip()
-        if marker and not (target_root / marker).exists():
-            actions.append(
-                _status_action(
-                    "warning",
-                    marker,
-                    str(workspace_notice.get("detail", "")),
-                    role=str(workspace_notice.get("role", "workspace-orchestration")),
-                    safety=str(workspace_notice.get("safety", "safe")),
-                    source=marker,
-                    category=str(workspace_notice.get("category", "safe-update")),
-                )
-            )
-    for raw_entry in _list_of_objects(policy.get("status_files", []), source="payload.status status_files"):
-        relative_path = str(raw_entry.get("path", ""))
-        present = (target_root / relative_path).exists()
-        role = str(raw_entry.get("role", ""))
-        safety = str(raw_entry.get("safety", "safe"))
-        kind = "present" if present else "missing"
-        detail = "file exists" if present else "file missing"
-        actions.append(
-            _status_action(
-                kind,
-                relative_path,
-                detail,
-                role=role,
-                safety=safety,
-                source=relative_path,
-                category=str(raw_entry.get("present_category" if present else "missing_category", ""))
-                or _infer_status_category(kind=kind, path=relative_path, detail=detail, role=role, safety=safety),
-            )
-        )
-    for obsolete in _string_list(policy.get("obsolete_files", []), source="payload.status obsolete_files"):
-        if (target_root / obsolete).exists():
-            actions.append(
-                _status_action(
-                    "obsolete",
-                    obsolete,
-                    "legacy shared file should be removed on upgrade",
-                    role="shared-replaceable",
-                    safety="safe",
-                    source=obsolete,
-                    category="obsolete-managed-file",
-                )
-            )
-    return {
-        "target_root": str(target_root),
-        "dry_run": bool(arguments.get("dry_run", False)),
-        "mode": "",
-        "message": str(arguments.get("message", "Status report")),
-        "health": "healthy" if active["status"] == "present" else "attention-needed",
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "action_count": len(actions),
-        "actions": actions,
-        "active": active,
-        "detail_command": str(arguments.get("detail_command", "")),
-    }
-
-
-def _payload_lifecycle_plan(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.lifecycle-plan cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    detected_version = _read_first_version(target_root, [version_path, legacy_version_path])
-    actions: list[dict[str, Any]] = []
-    workspace_notice = policy.get("workspace_orchestrator_notice", {})
-    if isinstance(workspace_notice, dict):
-        marker = str(workspace_notice.get("marker", "")).strip()
-        if marker and not (target_root / marker).exists():
-            actions.append(
-                _status_action(
-                    "warning",
-                    marker,
-                    str(workspace_notice.get("detail", "")),
-                    role=str(workspace_notice.get("role", "workspace-orchestration")),
-                    safety=str(workspace_notice.get("safety", "safe")),
-                    source=marker,
-                    category=str(workspace_notice.get("category", "safe-update")),
-                )
-            )
-    for raw_entry in _list_of_objects(policy.get("status_files", []), source="payload.lifecycle-plan status_files"):
-        relative_path = str(raw_entry.get("path", ""))
-        if not relative_path:
-            continue
-        exists = (target_root / relative_path).exists()
-        actions.append(
-            _status_action(
-                "preserve" if exists else str(arguments.get("missing_kind", "would copy")),
-                relative_path,
-                "already exists" if exists else str(arguments.get("missing_detail", "planned change")),
-                role=str(raw_entry.get("role", "")),
-                safety=str(raw_entry.get("safety", "safe")),
-                source=str(raw_entry.get("source", relative_path)),
-                category=str(raw_entry.get("category", "")) or "safe-update",
-            )
-        )
-    return {
-        "target_root": str(target_root),
-        "dry_run": bool(arguments.get("dry_run", True)),
-        "mode": str(arguments.get("mode", "")),
-        "message": str(arguments.get("message", "Install plan")),
-        "detected_version": detected_version,
-        "bootstrap_version": bootstrap_version,
-        "actions": actions,
-    }
-
-
-def _payload_current_memory(*, values: dict[str, Any], arguments: dict[str, Any], context: PrimitiveContext) -> dict[str, Any]:
-    policy_root = context.root(str(arguments.get("policy_root", "")))
-    policy_path = _resolve_inside(policy_root, str(arguments.get("policy_path", "")))
-    try:
-        policy = json.loads(policy_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PrimitiveExecutionError(f"payload.current-memory cannot load policy: {policy_path}") from exc
-    target_root = Path(str(values.get(str(arguments.get("target_root_value", "target_root")), context.cwd))).resolve()
-    bootstrap_version = int(policy.get("bootstrap_version", 0))
-    version_path = str(policy.get("version_path", ""))
-    legacy_version_path = str(policy.get("legacy_version_path", ""))
-    current_memory = policy.get("current_memory", {})
-    if not isinstance(current_memory, dict):
-        raise PrimitiveExecutionError("payload.current-memory current_memory policy must be an object")
-    note_paths = _string_list(current_memory.get("view_files", []), source="payload.current-memory current_memory.view_files")
-    notes: list[dict[str, Any]] = []
-    for relative_path in note_paths:
-        note_path = target_root / relative_path
-        exists = note_path.exists()
-        notes.append(
-            {
-                "path": relative_path,
-                "exists": exists,
-                "content": note_path.read_text(encoding="utf-8") if exists else "",
-            }
-        )
-    return {
-        "target_root": str(target_root),
-        "detected_version": _read_first_version(target_root, [version_path, legacy_version_path]),
-        "bootstrap_version": bootstrap_version,
-        "notes": notes,
-    }
-
-
-def _memory_manifest_counts(*, target_root: Path, manifest_path: str) -> dict[str, Any]:
-    counts = {
-        "status": "missing",
-        "note_count": 0,
-        "required_count": 0,
-        "optional_count": 0,
-        "routing_only_count": 0,
-        "path": manifest_path,
-    }
-    path = target_root / manifest_path
-    if not path.exists():
-        return counts
-    try:
-        payload = tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        counts["status"] = "invalid"
-        return counts
-    notes = payload.get("notes", {}) if isinstance(payload, dict) else {}
-    note_values = list(notes.values()) if isinstance(notes, dict) else []
-    counts["status"] = "present"
-    counts["note_count"] = len(note_values)
-    for note in note_values:
-        if not isinstance(note, dict):
-            continue
-        note_payload = cast(Mapping[str, Any], note)
-        relevance = str(note_payload.get("task_relevance", "")).strip().lower()
-        if relevance == "required":
-            counts["required_count"] += 1
-        elif relevance == "optional":
-            counts["optional_count"] += 1
-        if bool(note_payload.get("routing_only", False)):
-            counts["routing_only_count"] += 1
-    return counts
-
-
-def _status_action(
-    kind: str,
-    path: str,
-    detail: str,
-    *,
-    role: str,
-    safety: str,
-    source: str,
-    category: str,
-) -> dict[str, str]:
-    return {
-        "kind": kind,
-        "path": path,
-        "detail": detail,
-        "role": role,
-        "safety": safety,
-        "source": source,
-        "category": category,
-        "remediation_kind": "",
-        "remediation_target": "",
-        "remediation_reason": "",
-        "remediation_confidence": "",
-        "memory_action": "",
-        "match_source": "",
-    }
-
-
-def _infer_status_category(*, kind: str, path: str, detail: str, role: str, safety: str) -> str:
-    detail_lower = detail.lower()
-    if "placeholder" in detail_lower:
-        return "placeholder-review"
-    if role in {"payload-contract", "local-entrypoint"} or role.startswith("shared-"):
-        if kind in {"manual review", "missing"}:
-            return "contract-drift"
-    if kind in {"current", "present", "optional", "required", "warning"}:
-        return "safe-update"
-    if kind in {"manual review", "consider"}:
-        return "manual-review"
-    if safety == "safe":
-        return "safe-update"
-    return ""
-
-
-def _payload_file_set(*, payload_root: Path, policy: dict[str, Any]) -> set[str]:
-    aliases = {
-        str(item["source"]): str(item["target"])
-        for item in policy.get("payload_path_aliases", [])
-        if isinstance(item, dict) and isinstance(item.get("source"), str) and isinstance(item.get("target"), str)
-    }
-    payload_paths: set[str] = set()
-    for path in payload_root.rglob("*"):
-        if path.is_file():
-            relative = path.relative_to(payload_root).as_posix()
-            payload_paths.add(aliases.get(relative, relative))
-    return payload_paths
-
-
-def _payload_action(kind: str, path: str, detail: str, *, safety: str = "manual", category: str = "contract-drift") -> dict[str, str]:
-    return {
-        "kind": kind,
-        "path": path,
-        "detail": detail,
-        "role": "payload-contract",
-        "safety": safety,
-        "source": path,
-        "category": category,
-        "remediation_kind": "",
-        "remediation_target": "",
-        "remediation_reason": "",
-        "remediation_confidence": "",
-        "memory_action": "",
-        "match_source": "",
-    }
-
-
-def _verify_upgrade_source(*, policy: dict[str, Any], payload_root: Path, actions: list[dict[str, str]]) -> None:
-    upgrade_source = policy.get("upgrade_source", {})
-    if not isinstance(upgrade_source, dict):
-        raise PrimitiveExecutionError("payload.verify upgrade_source must be an object")
-    relative = str(upgrade_source.get("path", ""))
-    legacy_relative = str(upgrade_source.get("legacy_path", ""))
-    path = payload_root / relative
-    if not path.exists():
-        path = payload_root / legacy_relative
-    if not path.exists():
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata is missing from the payload"))
-        return
-    try:
-        data = tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata is not valid TOML"))
-        return
-    source_type = str(data.get("source_type", "")).strip()
-    if source_type not in set(_string_list(upgrade_source.get("allowed_source_types", []), source="payload.verify allowed_source_types")):
-        actions.append(_payload_action("manual review", relative, "upgrade source metadata must declare source_type as git or local"))
-        return
-    for required in _string_list(upgrade_source.get("required_fields", []), source="payload.verify required_fields"):
-        if not str(data.get(required, "")).strip():
-            actions.append(_payload_action("manual review", relative, f"upgrade source metadata is missing {required}"))
-            return
-    for field_name, date_format in (upgrade_source.get("date_fields", {}) or {}).items():
-        value = str(data.get(str(field_name), "")).strip()
-        if value and str(date_format) == "YYYY-MM-DD" and not re.match(r"^\d{4}-\d{2}-\d{2}$", value):
-            actions.append(_payload_action("manual review", relative, f"upgrade source metadata has invalid {field_name}; use YYYY-MM-DD"))
-    for field_name in _string_list(upgrade_source.get("integer_fields", []), source="payload.verify integer_fields"):
-        if not isinstance(data.get(field_name, 30), int):
-            actions.append(
-                _payload_action("manual review", relative, f"upgrade source metadata has invalid {field_name}; use an integer day count")
-            )
-
-
-def _verify_guidance_fragments(*, policy: dict[str, Any], payload_root: Path, actions: list[dict[str, str]]) -> None:
-    raw_fragments = policy.get("guidance_fragments", {})
-    if not isinstance(raw_fragments, dict):
-        raise PrimitiveExecutionError("payload.verify guidance_fragments must be an object")
-    for relative, fragments in raw_fragments.items():
-        relative_path = str(relative)
-        path = payload_root / relative_path
-        if not path.exists():
-            continue
-        text = path.read_text(encoding="utf-8")
-        missing = [fragment for fragment in _string_list(fragments, source="payload.verify guidance fragments") if fragment not in text]
-        actions.append(
-            _payload_action(
-                "current" if not missing else "manual review",
-                relative_path,
-                "collaboration-safe current-note guidance present"
-                if not missing
-                else "current-note payload guidance is missing collaboration-safe wording",
-                safety="safe" if not missing else "manual",
-                category="safe-update" if not missing else "contract-drift",
-            )
-        )
-
-
-def _toml_file_valid(path: Path) -> bool:
-    if not path.exists():
-        return False
-    try:
-        tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return False
-    return True
-
-
-def _read_version(path: Path) -> int | None:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    match = re.search(r"^\s*Version:\s*(\d+)\s*$", text, re.MULTILINE)
-    return int(match.group(1)) if match else None
-
-
-def _read_first_version(root: Path, relative_paths: Sequence[str]) -> int | None:
-    for relative_path in relative_paths:
-        if not relative_path:
-            continue
-        version = _read_version(root / relative_path)
-        if version is not None:
-            return version
-    return None
 
 
 def _string_list(value: Any, *, source: str) -> list[str]:
@@ -828,7 +404,9 @@ def _relative_path_list(value: Any, *, source: str) -> list[str]:
             if isinstance(relative_path, str):
                 paths.append(relative_path)
                 continue
-        raise PrimitiveExecutionError(f"{source} entries must be strings or objects with relative_path")
+        raise PrimitiveExecutionError(
+            f"{source} entries must be strings or objects with relative_path"
+        )
     return paths
 
 
@@ -850,60 +428,91 @@ def _resolve_template(template: Any, *, values: dict[str, Any]) -> Any:
         elif isinstance(path, Sequence) and not isinstance(path, (str, bytes)):
             path_parts = [str(part) for part in path]
         else:
-            raise PrimitiveExecutionError("template $field path must be a string or sequence")
+            raise PrimitiveExecutionError(
+                "template $field path must be a string or sequence"
+            )
         value: Any = values.get(value_name)
         for part in path_parts:
             if not isinstance(value, Mapping) or part not in value:
-                raise PrimitiveExecutionError(f"template $field cannot resolve {value_name!r}.{'.'.join(path_parts)}")
+                raise PrimitiveExecutionError(
+                    f"template $field cannot resolve {value_name!r}.{'.'.join(path_parts)}"
+                )
             value = value[part]
         return value
     if set(template) == {"$count"}:
         counted = values.get(str(template["$count"]), [])
         if not isinstance(counted, Sequence) or isinstance(counted, (str, bytes)):
-            raise PrimitiveExecutionError(f"template count source must be a sequence: {template['$count']!r}")
+            raise PrimitiveExecutionError(
+                f"template count source must be a sequence: {template['$count']!r}"
+            )
         return len(counted)
     if "$exists_status" in template:
         spec = template["$exists_status"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $exists_status must be an object")
         value = bool(values.get(str(spec.get("value", ""))))
-        return spec.get("present", "present") if value else spec.get("missing", "missing")
+        return (
+            spec.get("present", "present") if value else spec.get("missing", "missing")
+        )
     if "$count_status" in template:
         spec = template["$count_status"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $count_status must be an object")
         counted = values.get(str(spec.get("value", "")), [])
         if not isinstance(counted, Sequence) or isinstance(counted, (str, bytes)):
-            raise PrimitiveExecutionError(f"template count source must be a sequence: {spec.get('value')!r}")
-        return spec.get("present", "present") if len(counted) else spec.get("missing", "missing")
+            raise PrimitiveExecutionError(
+                f"template count source must be a sequence: {spec.get('value')!r}"
+            )
+        return (
+            spec.get("present", "present")
+            if len(counted)
+            else spec.get("missing", "missing")
+        )
     if "$join_path" in template:
         spec = template["$join_path"]
         if not isinstance(spec, dict):
             raise PrimitiveExecutionError("template $join_path must be an object")
         base = Path(str(values.get(str(spec.get("base", "")), "")))
         return (base / str(spec.get("path", ""))).as_posix()
-    return {str(key): _resolve_template(value, values=values) for key, value in template.items()}
+    return {
+        str(key): _resolve_template(value, values=values)
+        for key, value in template.items()
+    }
 
 
-def _emit_output(*, values: dict[str, Any], arguments: dict[str, Any] | None = None) -> str:
+def _emit_output(
+    *, values: dict[str, Any], arguments: dict[str, Any] | None = None
+) -> str:
     arguments = arguments or {}
     result = _plain_output_result(values.get("result"))
     output_format = str(values.get("format") or "text")
     if output_format == "json":
         return json.dumps(result, indent=2, sort_keys=True) + "\n"
-    if str(arguments.get("text_style", "")) == "current-memory" and isinstance(result, dict):
+    if str(arguments.get("text_style", "")) == "current-memory" and isinstance(
+        result, dict
+    ):
         return _emit_current_memory_text(result)
-    if str(arguments.get("text_style", "")) == "install-result" and isinstance(result, dict):
+    if str(arguments.get("text_style", "")) == "install-result" and isinstance(
+        result, dict
+    ):
         return _emit_install_result_text(result)
-    if isinstance(result, dict) and isinstance(result.get("route_report_summary"), dict):
+    if isinstance(result, dict) and isinstance(
+        result.get("route_report_summary"), dict
+    ):
         return _emit_route_report_text(result)
     if isinstance(result, dict) and result.get("kind") == "memory-module-report/v1":
         return _emit_memory_report_text(result)
-    if isinstance(result, dict) and result.get("kind") == "planning-module-report/v1" and result.get("profile") == "tiny":
+    if (
+        isinstance(result, dict)
+        and result.get("kind") == "planning-module-report/v1"
+        and result.get("profile") == "tiny"
+    ):
         return _emit_planning_module_report_text(result)
     if not isinstance(result, dict):
         return f"{result}\n"
-    if isinstance(result.get("files"), list) and all(isinstance(item, str) for item in result["files"]):
+    if isinstance(result.get("files"), list) and all(
+        isinstance(item, str) for item in result["files"]
+    ):
         return "\n".join(result["files"]).rstrip() + "\n"
     lines = [str(result.get("message", ""))]
     for action in _list_of_objects(result.get("actions", []), source="result.actions"):
@@ -949,7 +558,9 @@ def _emit_install_result_text(result: dict[str, Any]) -> str:
         ):
             value = action.get(key)
             if value:
-                details.append(str(value) if not label_name else f"{label_name}={value}")
+                details.append(
+                    str(value) if not label_name else f"{label_name}={value}"
+                )
         detail = f" ({'; '.join(details)})" if details else ""
         lines.append(f"- {action.get('kind')}: {label}{detail}")
     return "\n".join(lines).rstrip() + "\n"
@@ -979,9 +590,13 @@ def _emit_route_report_text(result: dict[str, Any]) -> str:
     fixtures = summary.get("fixtures", {})
     lines = [str(result.get("message", "Routing report"))]
     if isinstance(feedback, Mapping):
-        lines.append(f"Feedback: {feedback.get('status', 'unknown')} ({feedback.get('path', '')})")
+        lines.append(
+            f"Feedback: {feedback.get('status', 'unknown')} ({feedback.get('path', '')})"
+        )
     if isinstance(fixtures, Mapping):
-        lines.append(f"Fixtures: {fixtures.get('status', 'unknown')} ({fixtures.get('fixture_count', 0)})")
+        lines.append(
+            f"Fixtures: {fixtures.get('status', 'unknown')} ({fixtures.get('fixture_count', 0)})"
+        )
     detail = summary.get("detail") or result.get("detail_command")
     if detail:
         lines.append(str(detail))
@@ -993,9 +608,15 @@ def _emit_memory_report_text(result: dict[str, Any]) -> str:
     active = result.get("active", {})
     habitual_pull = result.get("habitual_pull", {})
     next_action = result.get("next_action", {})
-    lines = ["Memory report", f"Target: {result.get('target_root', '')}", f"Health: {result.get('health', 'unknown')}"]
+    lines = [
+        "Memory report",
+        f"Target: {result.get('target_root', '')}",
+        f"Health: {result.get('health', 'unknown')}",
+    ]
     if isinstance(status, Mapping):
-        lines.append(f"Notes: {status.get('note_count', 0)} ({status.get('manifest_status', 'unknown')})")
+        lines.append(
+            f"Notes: {status.get('note_count', 0)} ({status.get('manifest_status', 'unknown')})"
+        )
     if isinstance(active, Mapping):
         lines.append(
             "Active: "
@@ -1039,11 +660,15 @@ def _call_python_function(*, values: dict[str, Any], arguments: dict[str, Any]) 
     import_module = str(arguments.get("import_module", "")).strip()
     function_name = str(arguments.get("function", "")).strip()
     if not import_module or not function_name:
-        raise PrimitiveExecutionError("python.function.call requires import_module and function")
+        raise PrimitiveExecutionError(
+            "python.function.call requires import_module and function"
+        )
     try:
         function = getattr(importlib.import_module(import_module), function_name)
     except (ImportError, AttributeError) as exc:
-        raise PrimitiveExecutionError(f"python.function.call cannot resolve {import_module}.{function_name}") from exc
+        raise PrimitiveExecutionError(
+            f"python.function.call cannot resolve {import_module}.{function_name}"
+        ) from exc
     kwargs = _resolve_call_kwargs(values=values, raw_kwargs=arguments.get("kwargs", {}))
     return function(**kwargs)
 
@@ -1059,12 +684,16 @@ def _resolve_call_kwargs(*, values: dict[str, Any], raw_kwargs: Any) -> dict[str
         if "value" in source:
             value_name = str(source["value"])
             if value_name not in values:
-                raise PrimitiveExecutionError(f"python.function.call cannot resolve value {value_name!r}")
+                raise PrimitiveExecutionError(
+                    f"python.function.call cannot resolve value {value_name!r}"
+                )
             kwargs[str(name)] = values[value_name]
         elif "literal" in source:
             kwargs[str(name)] = source["literal"]
         else:
-            raise PrimitiveExecutionError(f"python.function.call kwarg {name!r} must declare value or literal")
+            raise PrimitiveExecutionError(
+                f"python.function.call kwarg {name!r} must declare value or literal"
+            )
     return kwargs
 
 
@@ -1085,11 +714,15 @@ def _resolve_inside(root: Path, relative: str) -> Path:
     return candidate
 
 
-def _primitive_root(*, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]) -> Path:
+def _primitive_root(
+    *, arguments: dict[str, Any], context: PrimitiveContext, values: dict[str, Any]
+) -> Path:
     if "base_value" in arguments:
         value_name = str(arguments["base_value"])
         if value_name not in values:
-            raise PrimitiveExecutionError(f"unknown primitive base value: {value_name!r}")
+            raise PrimitiveExecutionError(
+                f"unknown primitive base value: {value_name!r}"
+            )
         return Path(str(values[value_name])).resolve()
     return context.root(str(arguments.get("root", "")))
 
@@ -1098,7 +731,9 @@ def _ensure_inside(root: Path, candidate: Path) -> None:
     try:
         candidate.relative_to(root)
     except ValueError as exc:
-        raise PrimitiveExecutionError(f"path escapes primitive root: {candidate}") from exc
+        raise PrimitiveExecutionError(
+            f"path escapes primitive root: {candidate}"
+        ) from exc
 
 
 def _list_of_objects(value: Any, *, source: str) -> list[dict[str, Any]]:

--- a/generated/workspace/typescript/package.json
+++ b/generated/workspace/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "0.2.9"
+        "version": "0.2.10"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -4888,7 +4888,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.9"
+      "version": "0.2.10"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/workspace/typescript/src/runtime.mjs
+++ b/generated/workspace/typescript/src/runtime.mjs
@@ -199,8 +199,7 @@ function executeHostDomainOperation(operationId, values) {
 
 function executePrimitive(primitive, values, args, operationId) {
   if (primitive === 'typescript.domain.execute') return executeHostDomainOperation(String(args.operation_id ?? operationId), values);
-  const rootResolvePrimitives = new Set(['path.target_root.resolve', ['workspace', 'root', 'resolve'].join('.')]);
-  if (rootResolvePrimitives.has(primitive)) {
+  if (primitive === 'path.target_root.resolve') {
     const targetRoot = resolve(String(values.target ?? '.'));
     if (args.must_exist && !existsSync(targetRoot)) throw new RuntimeError(`target root does not exist: ${targetRoot}`);
     if (args.must_be_dir && (!existsSync(targetRoot) || !statSync(targetRoot).isDirectory())) throw new RuntimeError(`target root is not a directory: ${targetRoot}`);
@@ -216,7 +215,7 @@ function executePrimitive(primitive, values, args, operationId) {
   if (primitive === 'filesystem.glob') return globFiles(valueRoot(args, values), String(args.pattern ?? '')).map((relative_path) => ({ relative_path }));
   if (primitive === 'json.parse') return JSON.parse(String(values[String(args.source ?? 'registry_text')]));
   if (primitive === 'payload.assemble') return assemblePayload(values, args);
-  if (primitive === 'output.emit' || primitive === 'output.emit.install-result' || primitive === 'output.emit.current-memory') return emitOutput(values);
+  if (primitive === 'output.emit') return emitOutput(values);
   return executeHostPrimitive(primitive, values, args, operationId);
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ agentic-workspace = "agentic_workspace.cli:main"
 
 [dependency-groups]
 dev = [
-  "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.9/command_generation-0.2.9-py3-none-any.whl#sha256=3f523ce3a7e97e615d8e61df83db649a825093125f8ac9838cb731f7e0615580",
+  "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.10/command_generation-0.2.10-py3-none-any.whl#sha256=6052bf6312aaf922bdd32b6dd5c9f18c8205bc51283cbc723e581d015b8f455b",
   "jsonschema",
   "pre-commit",
   "pytest",

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -24,16 +24,6 @@
       "rule": "Reusable command-generation source must not import Agentic Workspace product modules. Product-specific literals in command-generation source require explicit accepted-coupling inventory with owner, reason, and migration path.",
       "accepted_couplings": [
         {
-          "id": "generic-output-compatibility-renderers",
-          "kind": "accepted-output-compatibility-boundary",
-          "paths": [
-            "command_generation/primitive_executor.py"
-          ],
-          "owner": "#892 python completion lane",
-          "reason": "The primitive executor owns generic JSON/text emission and keeps compact compatibility renderers for current memory and planning report payload shapes already routed through generated operation IR.",
-          "migration_path": "Keep only schema-generic output rendering in command-generation; move package-specific text compatibility to generated target-local resources or package runtime handlers when the compatibility surface stops being universal enough to share."
-        },
-        {
           "id": "portable-primitive-registry-legacy-ids",
           "kind": "accepted-primitive-id-vocabulary",
           "paths": [

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.9/command_generation-0.2.9-py3-none-any.whl" },
+    { name = "command-generation", url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.10/command_generation-0.2.10-py3-none-any.whl" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -144,13 +144,13 @@ wheels = [
 
 [[package]]
 name = "command-generation"
-version = "0.2.9"
-source = { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.9/command_generation-0.2.9-py3-none-any.whl" }
+version = "0.2.10"
+source = { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.10/command_generation-0.2.10-py3-none-any.whl" }
 dependencies = [
     { name = "jsonschema" },
 ]
 wheels = [
-    { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.9/command_generation-0.2.9-py3-none-any.whl", hash = "sha256:3f523ce3a7e97e615d8e61df83db649a825093125f8ac9838cb731f7e0615580" },
+    { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.10/command_generation-0.2.10-py3-none-any.whl", hash = "sha256:6052bf6312aaf922bdd32b6dd5c9f18c8205bc51283cbc723e581d015b8f455b" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Summary\n- consume command-generation v0.2.10, which retires transitional primitive runtime aliases from generic generated executor shells\n- regenerate Python and TypeScript command package artifacts so ordinary generated outputs no longer contain the old AW transitional IDs\n- remove the stale extraction-readiness accepted coupling for command_generation/primitive_executor.py\n- update conformance Dockerfiles to the v0.2.10 released wheel\n\nCloses #1638.\nCloses #1639.\n\n## Proof\n- make typecheck\n- make lint-workspace\n- make test-workspace\n- uv run pytest tests/test_generated_command_package_proof_runner.py -q\n- uv run pytest tests/test_workspace_cli.py -q\n- uv run python scripts/check/check_generated_command_packages.py\n- uv run python scripts/generate/generate_command_packages.py --check\n- uv run python scripts/generate/generate_command_adapters.py --check\n- uv run python scripts/check/run_operation_conformance_tests.py --target all\n- uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success\n- uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json\n- strict legacy primitive ID scan over src/scripts/packages/docs/generated, excluding explicit compatibility checker/test paths