### PR TITLE
Consume command-generation 1.0 release candidate

### DIFF
--- a/generated/memory/python/command_package.json
+++ b/generated/memory/python/command_package.json
@@ -2639,7 +2639,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.15"
+      "version": "1.0.0rc1"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/memory/typescript/package.json
+++ b/generated/memory/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "0.2.15"
+        "version": "1.0.0rc1"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/memory/typescript/resources/command_package.json
+++ b/generated/memory/typescript/resources/command_package.json
@@ -2639,7 +2639,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.15"
+      "version": "1.0.0rc1"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/planning/python/command_package.json
+++ b/generated/planning/python/command_package.json
@@ -3080,7 +3080,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.15"
+      "version": "1.0.0rc1"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/planning/typescript/package.json
+++ b/generated/planning/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "0.2.15"
+        "version": "1.0.0rc1"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/planning/typescript/resources/command_package.json
+++ b/generated/planning/typescript/resources/command_package.json
@@ -3080,7 +3080,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.15"
+      "version": "1.0.0rc1"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -2,7 +2,7 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.15/command_generation-0.2.15-py3-none-any.whl#sha256=abe89732db90d0a8f406af0da097209471f3b1107c1b7c9fad5d973edc02c5cb"
+RUN python -m pip install --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl#sha256=92886c2dbc06fb8651e26ccdeefa0c1446fb4e1614219b2db024ed487f09d762"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/python/Dockerfile.primitive-conformance
+++ b/generated/python/Dockerfile.primitive-conformance
@@ -2,6 +2,6 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.15/command_generation-0.2.15-py3-none-any.whl#sha256=abe89732db90d0a8f406af0da097209471f3b1107c1b7c9fad5d973edc02c5cb"
+RUN python -m pip install --no-cache-dir "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl#sha256=92886c2dbc06fb8651e26ccdeefa0c1446fb4e1614219b2db024ed487f09d762"
 
 CMD ["python", "-m", "command_generation.primitive_conformance"]

--- a/generated/typescript.conformance.Dockerfile
+++ b/generated/typescript.conformance.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /work
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 python3-pip \
     && find /usr/lib/python3/dist-packages -name '*.pyc' -delete \
-    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.15/command_generation-0.2.15-py3-none-any.whl#sha256=abe89732db90d0a8f406af0da097209471f3b1107c1b7c9fad5d973edc02c5cb"
+    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl#sha256=92886c2dbc06fb8651e26ccdeefa0c1446fb4e1614219b2db024ed487f09d762"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/verification/python/command_package.json
+++ b/generated/verification/python/command_package.json
@@ -99,7 +99,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.15"
+      "version": "1.0.0rc1"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/verification/typescript/package.json
+++ b/generated/verification/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "0.2.15"
+        "version": "1.0.0rc1"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/verification/typescript/resources/command_package.json
+++ b/generated/verification/typescript/resources/command_package.json
@@ -99,7 +99,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.15"
+      "version": "1.0.0rc1"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -4888,7 +4888,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.15"
+      "version": "1.0.0rc1"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/workspace/typescript/package.json
+++ b/generated/workspace/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "0.2.15"
+        "version": "1.0.0rc1"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -4888,7 +4888,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "0.2.15"
+      "version": "1.0.0rc1"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ agentic-workspace = "agentic_workspace.cli:main"
 
 [dependency-groups]
 dev = [
-  "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v0.2.15/command_generation-0.2.15-py3-none-any.whl#sha256=abe89732db90d0a8f406af0da097209471f3b1107c1b7c9fad5d973edc02c5cb",
+  "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl#sha256=92886c2dbc06fb8651e26ccdeefa0c1446fb4e1614219b2db024ed487f09d762",
   "jsonschema",
   "pre-commit",
   "pytest",

--- a/scripts/check/check_contract_tooling_surfaces.py
+++ b/scripts/check/check_contract_tooling_surfaces.py
@@ -53,7 +53,6 @@ from agentic_workspace.contract_tooling import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 from command_generation import (  # noqa: E402
-    BUILTIN_PORTABLE_PRIMITIVES,
     TargetExtensionContractError,
     command_package_schema_path,
     target_support_matrix_entries,
@@ -65,6 +64,15 @@ from command_generation.generated_package_loader import (  # noqa: E402
 )
 
 generated_workspace_cli = load_generated_command_module_for_entrypoint("agentic-workspace", "cli.py")
+RETIRED_COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES = {
+    "workspace.root.resolve",
+    "payload.status",
+    "payload.lifecycle-plan",
+    "payload.current-memory",
+    "payload.verify",
+    "output.emit.install-result",
+    "output.emit.current-memory",
+}
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -322,11 +330,6 @@ def _validate_operation_registry(payload: dict[str, object]) -> list[str]:
 
 def _validate_operation_primitives(payload: dict[str, object]) -> list[str]:
     errors: list[str] = []
-    command_generation_transitional_primitives = {
-        primitive_id
-        for primitive_id in BUILTIN_PORTABLE_PRIMITIVES.ids()
-        if getattr(BUILTIN_PORTABLE_PRIMITIVES.definition(primitive_id), "kind", "") == "transitional"
-    }
     if payload.get("schema_version") != "agentic-workspace/operation-primitives/v1":
         errors.append("operation_primitives.json has unexpected schema_version")
     ir_model = payload.get("ir_model")
@@ -398,15 +401,15 @@ def _validate_operation_primitives(payload: dict[str, object]) -> list[str]:
                 implemented = entry.get("implemented_shared_primitives", [])
                 if status == "implemented" and (not isinstance(implemented, list) or not implemented):
                     errors.append(f"operation_primitives.json target {target} must list implemented_shared_primitives")
-                transitional_support = sorted(
+                retired_support = sorted(
                     primitive_id
                     for primitive_id in implemented
-                    if isinstance(primitive_id, str) and primitive_id in command_generation_transitional_primitives
+                    if isinstance(primitive_id, str) and primitive_id in RETIRED_COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES
                 )
-                if transitional_support:
+                if retired_support:
                     errors.append(
-                        f"operation_primitives.json target {target} counts transitional host primitive(s) as shared support: "
-                        + ", ".join(transitional_support)
+                        f"operation_primitives.json target {target} counts retired command-generation primitive(s) as shared support: "
+                        + ", ".join(retired_support)
                     )
                 if status in {"unsupported-reported", "deferred"} and not unsupported_behavior:
                     errors.append(f"operation_primitives.json target {target} must describe unsupported_behavior")
@@ -478,8 +481,8 @@ def _validate_operation_primitives(payload: dict[str, object]) -> list[str]:
             errors.append(f"target-executor primitive {primitive_id} must be classified tier-1-portable-codegen")
         if primitive.get("portability") in {"domain-runtime", "external-adapter"} and taxonomy_tier == "tier-1-portable-codegen":
             errors.append(f"non-portable primitive {primitive_id} must not be classified tier-1-portable-codegen")
-        if primitive_id in command_generation_transitional_primitives and taxonomy_tier == "tier-1-portable-codegen":
-            errors.append(f"transitional host primitive {primitive_id} must not be classified tier-1-portable-codegen")
+        if primitive_id in RETIRED_COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES:
+            errors.append(f"retired command-generation primitive {primitive_id} must not be declared in operation_primitives.json")
         if taxonomy_tier == "tier-2-package-domain":
             missing_audit = sorted(field for field in tier_2_required_fields if not str(primitive.get(field, "")).strip())
             if missing_audit:
@@ -538,14 +541,11 @@ def _validate_operation_primitives(payload: dict[str, object]) -> list[str]:
     missing_classification = sorted(primitive for primitive in operation_step_primitives if primitive not in seen_ids)
     if missing_classification:
         errors.append("operation steps reference primitives missing from operation_primitives.json: " + ", ".join(missing_classification))
-    used_transitional_primitives = sorted(operation_step_primitives & command_generation_transitional_primitives)
-    primitive_by_id = {str(primitive.get("id")): primitive for primitive in primitives if isinstance(primitive, dict)}
-    for primitive_id in used_transitional_primitives:
-        primitive = primitive_by_id.get(primitive_id, {})
-        if primitive.get("taxonomy_tier") != "tier-2-package-domain":
-            errors.append(f"used transitional host primitive {primitive_id} must be inventoried as tier-2-package-domain")
-        if "transitional" not in str(primitive.get("generic_behavior_audit", "")).lower():
-            errors.append(f"used transitional host primitive {primitive_id} must name transitional usage in generic_behavior_audit")
+    used_retired_primitives = sorted(operation_step_primitives & RETIRED_COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES)
+    if used_retired_primitives:
+        errors.append(
+            "operation steps reference retired command-generation primitive(s): " + ", ".join(used_retired_primitives)
+        )
     tiered_primitives = {
         str(primitive["id"]): str(primitive.get("taxonomy_tier"))
         for primitive in primitives
@@ -1479,7 +1479,7 @@ def _validate_generated_command_check_inventory(payload: dict[str, object]) -> l
         "aw-host-behavior",
         "release-pinning",
         "generated-freshness",
-        "transitional-host-boundary",
+        "retired-primitive-boundary",
         "obsolete-duplicate",
     }
     seen_ids: set[str] = set()
@@ -1504,7 +1504,7 @@ def _validate_generated_command_check_inventory(payload: dict[str, object]) -> l
                 errors.append(f"generic target baseline check {check_id} must be owned by command-generation")
             if disposition == "keep-in-aw":
                 errors.append(f"generic target baseline check {check_id} must not be kept as an AW-owned check")
-        if classification in {"aw-host-behavior", "release-pinning", "generated-freshness", "transitional-host-boundary"}:
+        if classification in {"aw-host-behavior", "release-pinning", "generated-freshness", "retired-primitive-boundary"}:
             if owner != "agentic-workspace":
                 errors.append(f"AW-specific check {check_id} must be owned by agentic-workspace")
             if disposition != "keep-in-aw":
@@ -1546,7 +1546,7 @@ def _validate_generated_command_check_inventory(payload: dict[str, object]) -> l
         "generated-output-freshness",
         "operation-contract-and-cli-inputs",
         "host-runtime-boundaries",
-        "transitional-host-primitive-usage",
+        "retired-command-generation-primitive-usage",
         "release-and-generator-provenance",
         "operation-conformance-parity",
         "target-extension-contract-consumption",

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -33,7 +33,6 @@ for SOURCE_ROOT in (
 
 import command_generation  # noqa: E402
 from command_generation import (  # noqa: E402
-    BUILTIN_PORTABLE_PRIMITIVES,
     CliConformanceTarget,
     CommandGenerationHostManifest,
     PrimitiveRegistry,
@@ -183,7 +182,7 @@ PYTHON_OUTPUT_BOUNDARY_AUDIT_REQUIRED_PHRASES = (
     "not accepted as generic output",
 )
 COMMAND_GENERATION_RELEASE_BASE_URL = "https://github.com/rickardvh/command-generation/releases/download"
-COMMAND_GENERATION_COMPATIBLE_RANGE = ">=0.2.4,<0.3.0"
+COMMAND_GENERATION_COMPATIBLE_RANGE = ">=1.0.0rc1,<2.0.0"
 COMMAND_GENERATION_METADATA_SCHEMA_VERSION = "command-generation/generated-artifact-metadata/v1"
 COMMAND_GENERATION_SOURCE_IR_SCHEMA_VERSION = "command-generation/command-package-ir/v1"
 COMMAND_GENERATION_TARGET_LAYOUT_VERSION = {
@@ -199,28 +198,26 @@ REQUIRED_PORTABLE_PRIMITIVE_CONFORMANCE = {
     "output.emit",
 }
 AW_PRIMITIVE_OWNERSHIP_KIND = "agentic-workspace/aw-primitive-ownership/v1"
-AW_OWNED_PRIMITIVE_REPLACEMENTS = {
-    "workspace.root.resolve": "workspace.target-root.resolve",
-    "payload.status": "memory.payload.status",
-    "payload.lifecycle-plan": "memory.payload.lifecycle-plan",
-    "payload.current-memory": "memory.payload.current-memory",
-    "payload.verify": "memory.payload.verify",
+AW_OWNED_PRIMITIVES = {
+    "workspace.target-root.resolve",
+    "memory.payload.status",
+    "memory.payload.lifecycle-plan",
+    "memory.payload.current-memory",
+    "memory.payload.verify",
+}
+RETIRED_COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES = {
+    "workspace.root.resolve",
+    "payload.status",
+    "payload.lifecycle-plan",
+    "payload.current-memory",
+    "payload.verify",
+    "output.emit.install-result",
+    "output.emit.current-memory",
 }
 AW_OWNED_ORDINARY_CHECK_ROOTS = (
     "tests",
     "scripts/check",
 )
-
-
-def _command_generation_transitional_primitives() -> set[str]:
-    return {
-        primitive_id
-        for primitive_id in BUILTIN_PORTABLE_PRIMITIVES.ids()
-        if getattr(BUILTIN_PORTABLE_PRIMITIVES.definition(primitive_id), "kind", "") == "transitional"
-    }
-
-
-COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES = _command_generation_transitional_primitives()
 PYTHON_EXECUTABLE_DISPATCH_NAMES = {
     "run_generated_command": "generated runtime dispatch",
     "supports_generated_command": "generated runtime dispatch",
@@ -2359,21 +2356,21 @@ def _operation_primitive_steps(operation: dict[str, object]) -> list[dict[str, o
     return steps
 
 
-def _transitional_primitive_usage_metadata(primitive: str) -> dict[str, str]:
+def _retired_primitive_usage_metadata(primitive: str) -> dict[str, str]:
     if primitive == "workspace.root.resolve":
         return {
-            "owner": "command-generation compatibility boundary",
-            "reason": "old command-generation compatibility primitive; ordinary AW source operations must use workspace.target-root.resolve.",
-            "migration_follow_up": "keep isolated to compatibility checks/fixtures unless command-generation removes the legacy primitive",
+            "owner": "retired command-generation boundary",
+            "reason": "removed command-generation transitional primitive; AW source operations must use workspace.target-root.resolve.",
+            "migration_follow_up": "remove the reference; no compatibility path remains after command-generation 1.0.",
         }
     return {
-        "owner": "command-generation compatibility boundary",
-        "reason": "old command-generation compatibility primitive; ordinary AW source operations must use memory.payload.* or portable output.emit with declarative arguments.",
-        "migration_follow_up": "keep isolated to compatibility checks/fixtures unless command-generation removes the legacy primitive",
+        "owner": "retired command-generation boundary",
+        "reason": "removed command-generation transitional primitive; AW source operations must use memory.payload.* or portable output.emit with declarative arguments.",
+        "migration_follow_up": "remove the reference; no compatibility path remains after command-generation 1.0.",
     }
 
 
-def _transitional_primitive_source_operation_usage() -> list[dict[str, object]]:
+def _retired_primitive_source_operation_usage() -> list[dict[str, object]]:
     usage: list[dict[str, object]] = []
     for operation_path in _source_operation_contract_paths():
         try:
@@ -2383,9 +2380,9 @@ def _transitional_primitive_source_operation_usage() -> list[dict[str, object]]:
         operation_id = str(operation.get("id", operation_path.stem))
         for step in _operation_primitive_steps(operation):
             primitive = str(step.get("uses", ""))
-            if primitive not in COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES:
+            if primitive not in RETIRED_COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES:
                 continue
-            metadata = _transitional_primitive_usage_metadata(primitive)
+            metadata = _retired_primitive_usage_metadata(primitive)
             usage.append(
                 {
                     "operation_id": operation_id,
@@ -2398,7 +2395,7 @@ def _transitional_primitive_source_operation_usage() -> list[dict[str, object]]:
     return usage
 
 
-def _transitional_primitive_reference_counts(usages: list[dict[str, object]]) -> tuple[dict[str, int], int]:
+def _retired_primitive_reference_counts(usages: list[dict[str, object]]) -> tuple[dict[str, int], int]:
     primitive_counts: dict[str, int] = {}
     operation_ids: set[str] = set()
     for item in usages:
@@ -2410,13 +2407,13 @@ def _transitional_primitive_reference_counts(usages: list[dict[str, object]]) ->
     return dict(sorted(primitive_counts.items())), len(operation_ids)
 
 
-def _transitional_primitive_compatibility_usage() -> list[dict[str, object]]:
-    allowed_paths = {
-        "scripts/check/check_generated_command_packages.py": "compatibility checker allowlist, inventory, and regression guard",
-        "tests/test_generated_command_package_proof_runner.py": "compatibility checker regression tests and fixtures",
+def _retired_primitive_guard_reference_usage() -> list[dict[str, object]]:
+    guard_paths = {
+        "scripts/check/check_generated_command_packages.py": "retired primitive guard implementation",
+        "tests/test_generated_command_package_proof_runner.py": "retired primitive guard regression tests and fixtures",
     }
     usages: list[dict[str, object]] = []
-    for relative_path, reason in allowed_paths.items():
+    for relative_path, reason in guard_paths.items():
         path = REPO_ROOT / relative_path
         if not path.is_file():
             continue
@@ -2424,7 +2421,7 @@ def _transitional_primitive_compatibility_usage() -> list[dict[str, object]]:
             text = path.read_text(encoding="utf-8")
         except OSError:
             continue
-        for primitive in sorted(COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES):
+        for primitive in sorted(RETIRED_COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES):
             count = text.count(primitive)
             if count:
                 usages.append(
@@ -2438,12 +2435,12 @@ def _transitional_primitive_compatibility_usage() -> list[dict[str, object]]:
     return usages
 
 
-def _transitional_primitive_usage_inventory() -> dict[str, object]:
-    ordinary_usage = _transitional_primitive_source_operation_usage()
-    compatibility_usage = _transitional_primitive_compatibility_usage()
-    primitive_counts, operation_count = _transitional_primitive_reference_counts(ordinary_usage)
+def _retired_primitive_usage_inventory() -> dict[str, object]:
+    ordinary_usage = _retired_primitive_source_operation_usage()
+    guard_usage = _retired_primitive_guard_reference_usage()
+    primitive_counts, operation_count = _retired_primitive_reference_counts(ordinary_usage)
     return {
-        "status": "ordinary-source-clean" if not ordinary_usage else "ordinary-source-usage-found",
+        "status": "absent-from-ordinary-source" if not ordinary_usage else "retired-id-source-usage-found",
         "usage_count": len(ordinary_usage),
         "operation_count": operation_count,
         "primitive_counts": primitive_counts,
@@ -2451,13 +2448,14 @@ def _transitional_primitive_usage_inventory() -> dict[str, object]:
         "ordinary_source_operation_usage_count": len(ordinary_usage),
         "ordinary_source_operation_count": operation_count,
         "ordinary_source_operation_usages": ordinary_usage,
-        "compatibility_usage_count": sum(int(item["reference_count"]) for item in compatibility_usage),
-        "compatibility_usages": compatibility_usage,
-        "compatibility_only_paths": sorted({str(item["path"]) for item in compatibility_usage}),
-        "portable_completion_boundary": "transitional helpers are not counted as REQUIRED_PORTABLE_PRIMITIVE_CONFORMANCE",
+        "guard_reference_count": sum(int(item["reference_count"]) for item in guard_usage),
+        "guard_references": guard_usage,
+        "guard_reference_paths": sorted({str(item["path"]) for item in guard_usage}),
+        "retired_ids": sorted(RETIRED_COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES),
+        "portable_completion_boundary": "retired command-generation transitional helpers are not counted as REQUIRED_PORTABLE_PRIMITIVE_CONFORMANCE",
         "ordinary_source_rule": (
             "AW-owned ordinary operation contracts must use workspace.target-root.resolve, memory.payload.*, "
-            "and portable output.emit; command-generation transitional IDs are compatibility-only."
+            "and portable output.emit; command-generation transitional IDs are retired and must not be used."
         ),
     }
 
@@ -2475,7 +2473,6 @@ def _primitive_definition_by_id() -> dict[str, dict[str, object]]:
 
 
 def _source_operation_aw_owned_primitive_usage() -> list[dict[str, object]]:
-    aw_owned_primitives = set(AW_OWNED_PRIMITIVE_REPLACEMENTS.values())
     usage: list[dict[str, object]] = []
     for operation_path in _source_operation_contract_paths():
         try:
@@ -2485,7 +2482,7 @@ def _source_operation_aw_owned_primitive_usage() -> list[dict[str, object]]:
         operation_id = str(operation.get("id", operation_path.stem))
         for step in _operation_primitive_steps(operation):
             primitive = str(step.get("uses", ""))
-            if primitive not in aw_owned_primitives:
+            if primitive not in AW_OWNED_PRIMITIVES:
                 continue
             usage.append(
                 {
@@ -2530,7 +2527,6 @@ def _generated_command_package_paths(ir: dict[str, object]) -> list[Path]:
 
 
 def _generated_package_aw_owned_primitive_usage(ir: dict[str, object]) -> list[dict[str, object]]:
-    aw_owned_primitives = set(AW_OWNED_PRIMITIVE_REPLACEMENTS.values())
     usage: list[dict[str, object]] = []
     for path in _generated_command_package_paths(ir):
         try:
@@ -2546,7 +2542,7 @@ def _generated_package_aw_owned_primitive_usage(ir: dict[str, object]) -> list[d
             if not isinstance(primitive_refs, list):
                 continue
             for primitive in primitive_refs:
-                if primitive not in aw_owned_primitives:
+                if primitive not in AW_OWNED_PRIMITIVES:
                     continue
                 usage.append(
                     {
@@ -2564,13 +2560,12 @@ def _aw_primitive_declaration_report() -> dict[str, object]:
     declarations: list[dict[str, object]] = []
     missing: list[str] = []
     invalid: list[str] = []
-    for legacy_id, aw_id in sorted(AW_OWNED_PRIMITIVE_REPLACEMENTS.items()):
+    for aw_id in sorted(AW_OWNED_PRIMITIVES):
         primitive = primitive_by_id.get(aw_id)
         if not primitive:
             missing.append(aw_id)
             declarations.append(
                 {
-                    "legacy_id": legacy_id,
                     "aw_owned_id": aw_id,
                     "status": "missing",
                     "owner": "",
@@ -2592,7 +2587,6 @@ def _aw_primitive_declaration_report() -> dict[str, object]:
             status = "invalid"
         declarations.append(
             {
-                "legacy_id": legacy_id,
                 "aw_owned_id": aw_id,
                 "status": status,
                 "owner": owner,
@@ -2607,7 +2601,7 @@ def _aw_primitive_declaration_report() -> dict[str, object]:
         "status": "satisfied" if not missing and not invalid else "blocked",
         "source": "src/agentic_workspace/contracts/operation_primitives.json",
         "declared_count": sum(1 for item in declarations if item["status"] == "declared"),
-        "required_count": len(AW_OWNED_PRIMITIVE_REPLACEMENTS),
+        "required_count": len(AW_OWNED_PRIMITIVES),
         "missing": missing,
         "invalid": invalid,
         "declarations": declarations,
@@ -2620,7 +2614,7 @@ def _aw_primitive_runtime_binding_report(ir: dict[str, object]) -> dict[str, obj
     generated_counts = _operation_usage_counts_by_primitive(generated_usage)
     source_counts = _operation_usage_counts_by_primitive(source_usage)
     missing_generated = sorted(
-        aw_id for aw_id in AW_OWNED_PRIMITIVE_REPLACEMENTS.values() if aw_id not in generated_counts and aw_id in source_counts
+        aw_id for aw_id in AW_OWNED_PRIMITIVES if aw_id not in generated_counts and aw_id in source_counts
     )
     handler_support = {
         "python_support_path": "src/agentic_workspace/contracts/python_primitive_support.py",
@@ -2643,13 +2637,13 @@ def _aw_primitive_runtime_binding_report(ir: dict[str, object]) -> dict[str, obj
 
 
 def _aw_primitive_ownership_report(ir: dict[str, object]) -> dict[str, object]:
-    transitional_usage = _transitional_primitive_usage_inventory()
+    retired_usage = _retired_primitive_usage_inventory()
     declarations = _aw_primitive_declaration_report()
     runtime_bindings = _aw_primitive_runtime_binding_report(ir)
     freshness = _generated_target_freshness_report(ir)
     blockers: list[str] = []
-    if int(transitional_usage.get("ordinary_source_operation_usage_count", 0) or 0):
-        blockers.append("command-generation transitional primitive IDs remain in ordinary AW source operation IR")
+    if int(retired_usage.get("ordinary_source_operation_usage_count", 0) or 0):
+        blockers.append("retired command-generation transitional primitive IDs remain in ordinary AW source operation IR")
     if declarations.get("status") != "satisfied":
         blockers.append("AW-owned primitive declarations are missing or invalid")
     if runtime_bindings.get("status") != "satisfied":
@@ -2665,12 +2659,12 @@ def _aw_primitive_ownership_report(ir: dict[str, object]) -> dict[str, object]:
         ),
         "ordinary_source_operation_ir": {
             "status": "satisfied"
-            if int(transitional_usage.get("ordinary_source_operation_usage_count", 0) or 0) == 0
+            if int(retired_usage.get("ordinary_source_operation_usage_count", 0) or 0) == 0
             else "blocked",
             "aw_owned_usage_count": runtime_bindings["source_operation_usage_count"],
             "aw_owned_usage_count_by_primitive": runtime_bindings["source_operation_usage_count_by_primitive"],
-            "transitional_usage_count": transitional_usage["ordinary_source_operation_usage_count"],
-            "transitional_usages": transitional_usage["ordinary_source_operation_usages"],
+            "retired_primitive_usage_count": retired_usage["ordinary_source_operation_usage_count"],
+            "retired_primitive_usages": retired_usage["ordinary_source_operation_usages"],
         },
         "primitive_declarations": declarations,
         "runtime_bindings": runtime_bindings,
@@ -2680,11 +2674,12 @@ def _aw_primitive_ownership_report(ir: dict[str, object]) -> dict[str, object]:
             "stale_output_count_by_family": freshness.get("stale_output_count_by_family", {}),
             "command_generation_package": freshness.get("command_generation_package", {}),
         },
-        "compatibility_only_references": {
-            "status": "isolated",
-            "paths": transitional_usage["compatibility_only_paths"],
-            "usages": transitional_usage["compatibility_usages"],
-            "rule": "Legacy command-generation transitional IDs may appear only in explicit compatibility checker/test paths.",
+        "retired_command_generation_primitive_usage": {
+            "status": retired_usage["status"],
+            "guard_reference_paths": retired_usage["guard_reference_paths"],
+            "guard_references": retired_usage["guard_references"],
+            "retired_ids": retired_usage["retired_ids"],
+            "rule": "Retired command-generation transitional IDs must not appear in AW ordinary operation IR.",
         },
         "coordination": {
             "command_generation_issue_refs": ["rickardvh/command-generation#55"],
@@ -2704,19 +2699,6 @@ def _aw_primitive_ownership_report(ir: dict[str, object]) -> dict[str, object]:
 def _validate_aw_primitive_ownership_report(ir: dict[str, object]) -> list[str]:
     report = _aw_primitive_ownership_report(ir)
     errors = [str(blocker) for blocker in report.get("blockers", [])]
-    compatibility = report.get("compatibility_only_references", {})
-    if isinstance(compatibility, dict):
-        unexpected_paths = sorted(
-            path
-            for path in compatibility.get("paths", [])
-            if path
-            not in {
-                "scripts/check/check_generated_command_packages.py",
-                "tests/test_generated_command_package_proof_runner.py",
-            }
-        )
-        if unexpected_paths:
-            errors.append(f"legacy transitional primitive IDs appear outside compatibility-only paths: {unexpected_paths!r}")
     return errors
 
 
@@ -2815,36 +2797,27 @@ def _validate_generated_command_check_inventory_removals() -> list[str]:
     return errors
 
 
-def _validate_transitional_primitive_usage_inventory() -> list[str]:
+def _validate_retired_command_generation_primitive_usage_inventory() -> list[str]:
     errors: list[str] = []
-    try:
-        operation_primitives = _load_json("operation_primitives.json")
-    except (OSError, json.JSONDecodeError) as exc:
-        return [f"operation_primitives.json is missing or invalid for transitional primitive audit: {exc}"]
-    primitive_by_id = {
-        str(primitive.get("id")): primitive
-        for primitive in operation_primitives.get("primitives", [])
-        if isinstance(primitive, dict)
-    }
-    usage_inventory = _transitional_primitive_usage_inventory()
+    usage_inventory = _retired_primitive_usage_inventory()
     ordinary_count = int(usage_inventory.get("ordinary_source_operation_usage_count", 0) or 0)
     if ordinary_count:
         errors.append(
-            "command-generation transitional primitive IDs are present in ordinary source operation contracts: "
+            "retired command-generation transitional primitive IDs are present in ordinary source operation contracts: "
             f"{ordinary_count} step(s); use AW-owned primitive IDs instead"
         )
-    for primitive_id in sorted(usage_inventory.get("primitive_counts", {})):
-        primitive = primitive_by_id.get(primitive_id)
-        if not isinstance(primitive, dict):
-            errors.append(f"transitional primitive {primitive_id} is used but missing from operation_primitives.json")
-            continue
-        if primitive.get("taxonomy_tier") != "tier-2-package-domain":
-            errors.append(f"transitional primitive {primitive_id} must be classified tier-2-package-domain")
-        if primitive.get("portability") == "target-executor":
-            errors.append(f"transitional primitive {primitive_id} must not be declared target-executor portable")
-        for field in ("tier_owner", "tier_reason", "conformance_ref", "migration_path", "generic_behavior_audit"):
-            if not str(primitive.get(field, "")).strip():
-                errors.append(f"transitional primitive {primitive_id} missing {field}")
+    try:
+        operation_primitives = _load_json("operation_primitives.json")
+    except (OSError, json.JSONDecodeError) as exc:
+        return [*errors, f"operation_primitives.json is missing or invalid for retired primitive audit: {exc}"]
+    primitive_ids = {
+        str(primitive.get("id"))
+        for primitive in operation_primitives.get("primitives", [])
+        if isinstance(primitive, dict)
+    }
+    declared_retired = sorted(primitive_id for primitive_id in RETIRED_COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES if primitive_id in primitive_ids)
+    if declared_retired:
+        errors.append(f"retired command-generation transitional primitive IDs remain declared: {declared_retired!r}")
     support_matrix = operation_primitives.get("primitive_extension_boundary", {}).get("target_support_matrix", [])
     if isinstance(support_matrix, list):
         for entry in support_matrix:
@@ -2853,13 +2826,13 @@ def _validate_transitional_primitive_usage_inventory() -> list[str]:
             shared = entry.get("implemented_shared_primitives", [])
             if not isinstance(shared, list):
                 continue
-            transitional_shared = sorted(
-                primitive for primitive in shared if isinstance(primitive, str) and primitive in COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES
+            retired_shared = sorted(
+                primitive for primitive in shared if isinstance(primitive, str) and primitive in RETIRED_COMMAND_GENERATION_TRANSITIONAL_PRIMITIVES
             )
-            if transitional_shared:
+            if retired_shared:
                 errors.append(
-                    f"operation_primitives.json target {entry.get('target')} counts transitional primitive(s) as shared support: "
-                    + ", ".join(transitional_shared)
+                    f"operation_primitives.json target {entry.get('target')} counts retired primitive(s) as shared support: "
+                    + ", ".join(retired_shared)
                 )
     return errors
 
@@ -3833,15 +3806,19 @@ def _command_generation_dependency_from_pyproject() -> str:
 def _command_generation_package_provenance() -> dict[str, object]:
     dependency = _command_generation_dependency_from_pyproject()
     installed_version = importlib.metadata.version("command-generation")
-    version_match = re.search(r"command_generation-(?P<version>[0-9][^-/]*)-py3-none-any\.whl", dependency)
-    declared_version = version_match.group("version") if version_match else ""
     release_url = dependency.split(" @ ", 1)[1] if " @ " in dependency else ""
-    compatible = bool(
-        declared_version
+    version_match = re.search(r"command_generation-(?P<version>[0-9][^-/]*)-py3-none-any\.whl", dependency)
+    git_match = re.search(r"git\+https://github\.com/rickardvh/command-generation\.git@(?P<ref>[0-9a-f]{40})$", release_url)
+    declared_version = version_match.group("version") if version_match else installed_version if git_match else ""
+    source = "released-wheel" if version_match else "immutable-git-ref" if git_match else "unknown"
+    released_wheel_compatible = bool(
+        version_match
         and declared_version == installed_version
         and release_url.startswith(f"{COMMAND_GENERATION_RELEASE_BASE_URL}/v{declared_version}/")
         and "#sha256=" in release_url
     )
+    git_ref_compatible = bool(git_match and declared_version == installed_version)
+    compatible = released_wheel_compatible or git_ref_compatible
     return {
         "kind": "command-generation/package-provenance/v1",
         "package": "command-generation",
@@ -3849,7 +3826,10 @@ def _command_generation_package_provenance() -> dict[str, object]:
         "declared_version": declared_version,
         "compatible_range": COMMAND_GENERATION_COMPATIBLE_RANGE,
         "dependency_url": release_url,
-        "source": "released-wheel",
+        "source": source,
+        "git_ref": git_match.group("ref") if git_match else "",
+        "released_wheel_compatible": released_wheel_compatible,
+        "immutable_git_ref_compatible": git_ref_compatible,
         "compatible": compatible,
     }
 
@@ -3861,9 +3841,7 @@ def _validate_command_generation_release_provenance() -> list[str]:
     declared_version = str(provenance.get("declared_version", ""))
     errors: list[str] = []
     if not dependency:
-        errors.append("pyproject.toml dev dependencies must declare command-generation as a released package URL")
-    if "git+https://github.com/rickardvh/command-generation.git" in dependency:
-        errors.append("pyproject.toml command-generation dependency must use the released wheel URL, not a Git source ref")
+        errors.append("pyproject.toml dev dependencies must declare command-generation as a released wheel URL or immutable Git ref")
     if not provenance.get("compatible"):
         errors.append(
             "command-generation package provenance mismatch: "
@@ -3879,9 +3857,7 @@ def _validate_command_generation_release_provenance() -> list[str]:
             continue
         text = path.read_text(encoding="utf-8")
         if release_url not in text:
-            errors.append(f"{relative_path} command-generation install URL must match pyproject.toml released package URL")
-        if "command-generation.git@" in text or "git+https://github.com/rickardvh/command-generation.git" in text:
-            errors.append(f"{relative_path} must not install command-generation from a Git source ref")
+            errors.append(f"{relative_path} command-generation install URL must match pyproject.toml package URL")
     return errors
 
 
@@ -4694,7 +4670,7 @@ def _validate_static_surfaces() -> list[str]:
                 )
             )
         errors.extend(_validate_python_operation_execution_inventory(ir))
-        errors.extend(_validate_transitional_primitive_usage_inventory())
+        errors.extend(_validate_retired_command_generation_primitive_usage_inventory())
         errors.extend(_validate_generated_command_check_inventory_removals())
         shell_policy = str(ir.get("generation_policy", {}).get("shell_adapter_policy", ""))
         if "Issue #909 evaluation selects Bash as the first additional generated command transport candidate" not in shell_policy:
@@ -5123,7 +5099,7 @@ def _python_completion_blockers_report(ir: dict[str, object]) -> dict[str, objec
     generated_target_freshness = _generated_target_freshness_report(ir)
     runtime_source_edit_policy = _runtime_source_edit_policy_payload()
     lifecycle_dry_run_metrics = _lifecycle_dry_run_metrics()
-    transitional_primitive_usage = _transitional_primitive_usage_inventory()
+    retired_primitive_usage = _retired_primitive_usage_inventory()
     aw_primitive_ownership = _aw_primitive_ownership_report(ir)
     generated_command_check_inventory = _generated_command_check_inventory_report()
     extraction_readiness_errors = _validate_command_generation_extraction_readiness(ir)
@@ -5148,7 +5124,7 @@ def _python_completion_blockers_report(ir: dict[str, object]) -> dict[str, objec
         "generated_target_freshness": generated_target_freshness,
         "runtime_source_edit_policy": runtime_source_edit_policy,
         "lifecycle_dry_run_metrics": lifecycle_dry_run_metrics,
-        "transitional_primitive_usage": transitional_primitive_usage,
+        "retired_command_generation_primitive_usage": retired_primitive_usage,
         "aw_primitive_ownership": aw_primitive_ownership,
         "generated_command_check_inventory": generated_command_check_inventory,
         "generated_command_migration_completion": generated_command_migration_completion,
@@ -5345,13 +5321,13 @@ def _print_python_completion_blockers_report(report: dict[str, object], *, outpu
         )
         print(f"Package-runtime default dry-run operations: {lifecycle_metrics.get('package_runtime_default_dry_run_operation_count')}")
         print(f"Operation-runtime default dry-run operations: {lifecycle_metrics.get('operation_runtime_default_dry_run_operation_count')}")
-    transitional_usage = report.get("transitional_primitive_usage", {})
-    if isinstance(transitional_usage, dict) and transitional_usage.get("status"):
+    retired_usage = report.get("retired_command_generation_primitive_usage", {})
+    if isinstance(retired_usage, dict) and retired_usage.get("status"):
         print(
-            "Transitional primitive ordinary source usage: "
-            f"{transitional_usage.get('ordinary_source_operation_usage_count')}"
+            "Retired command-generation primitive ordinary source usage: "
+            f"{retired_usage.get('ordinary_source_operation_usage_count')}"
         )
-        print(f"Transitional primitive compatibility references: {transitional_usage.get('compatibility_usage_count')}")
+        print(f"Retired command-generation primitive guard references: {retired_usage.get('guard_reference_count')}")
     check_inventory = report.get("generated_command_check_inventory", {})
     if isinstance(check_inventory, dict) and check_inventory.get("status") == "available":
         print(f"Generated-command check inventory: {check_inventory.get('check_count')} checks")
@@ -5472,11 +5448,11 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Blockers: {len(report['blockers'])}")
             ordinary = report.get("ordinary_source_operation_ir", {})
             if isinstance(ordinary, dict):
-                print(f"Ordinary transitional primitive usage: {ordinary.get('transitional_usage_count')}")
+                print(f"Ordinary retired primitive usage: {ordinary.get('retired_primitive_usage_count')}")
                 print(f"AW-owned ordinary primitive usage: {ordinary.get('aw_owned_usage_count')}")
-            compatibility = report.get("compatibility_only_references", {})
-            if isinstance(compatibility, dict):
-                print(f"Compatibility-only paths: {compatibility.get('paths')}")
+            retired = report.get("retired_command_generation_primitive_usage", {})
+            if isinstance(retired, dict):
+                print(f"Retired primitive guard paths: {retired.get('guard_reference_paths')}")
             for blocker in report.get("blockers", []):
                 print(f"- {blocker}")
         return 0 if report.get("status") == "satisfied" else 1

--- a/scripts/check/prove_command_generation_artifact_consumption.py
+++ b/scripts/check/prove_command_generation_artifact_consumption.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import venv
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run(command: list[str], *, env: dict[str, str] | None = None) -> None:
+    subprocess.run(command, cwd=REPO_ROOT, env=env, check=True)
+
+
+def _venv_python(venv_root: Path) -> Path:
+    if os.name == "nt":
+        return venv_root / "Scripts" / "python.exe"
+    return venv_root / "bin" / "python"
+
+
+def _default_wheel() -> Path | None:
+    sibling_dist = REPO_ROOT.parent / "command-generation" / "dist"
+    wheels = sorted(sibling_dist.glob("command_generation-*.whl"))
+    return wheels[-1] if wheels else None
+
+
+def _installed_probe_script() -> str:
+    return """
+import importlib.metadata
+import json
+import command_generation
+
+print(json.dumps({
+    "version": importlib.metadata.version("command-generation"),
+    "module_file": command_generation.__file__,
+}, sort_keys=True))
+"""
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prove AW generated-command checks consume a built command-generation artifact."
+    )
+    parser.add_argument("--wheel", type=Path, default=None, help="Built command-generation wheel to install.")
+    parser.add_argument("--expected-version", default="", help="Expected command-generation version.")
+    parser.add_argument(
+        "--forbid-source-root",
+        type=Path,
+        default=REPO_ROOT.parent / "command-generation",
+        help="Fail if the installed command_generation module resolves under this source checkout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    wheel = args.wheel or _default_wheel()
+    if wheel is None or not wheel.is_file():
+        print("No built command-generation wheel found; pass --wheel or build the sibling package first.", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory(prefix="aw-cg-artifact-proof-") as tmp:
+        venv_root = Path(tmp) / "venv"
+        venv.EnvBuilder(with_pip=True, clear=True).create(venv_root)
+        python = _venv_python(venv_root)
+        _run([str(python), "-m", "pip", "install", "--no-cache-dir", str(wheel), "jsonschema"])
+        _run([str(python), "-m", "pip", "install", "--no-deps", "-e", str(REPO_ROOT)])
+
+        probe = subprocess.run(
+            [str(python), "-c", _installed_probe_script()],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        payload = json.loads(probe.stdout)
+        installed_version = str(payload.get("version", ""))
+        if args.expected_version and installed_version != args.expected_version:
+            print(
+                f"command-generation artifact version mismatch: expected {args.expected_version}, got {installed_version}",
+                file=sys.stderr,
+            )
+            return 1
+        module_file = Path(str(payload.get("module_file", ""))).resolve()
+        forbid_source_root = args.forbid_source_root.resolve()
+        if module_file == forbid_source_root or forbid_source_root in module_file.parents:
+            print(f"command_generation imported from source checkout, not artifact: {module_file}", file=sys.stderr)
+            return 1
+
+        env = os.environ.copy()
+        source_roots = [
+            REPO_ROOT,
+            REPO_ROOT / "src",
+            REPO_ROOT / "packages" / "planning" / "src",
+            REPO_ROOT / "packages" / "memory" / "src",
+            REPO_ROOT / "packages" / "verification" / "src",
+        ]
+        env["PYTHONPATH"] = os.pathsep.join(str(path) for path in source_roots)
+        commands = [
+            [str(python), "scripts/generate/generate_command_packages.py", "--check"],
+            [str(python), "scripts/check/check_generated_command_packages.py"],
+            [str(python), "scripts/check/check_generated_command_packages.py", "--aw-primitive-ownership", "--format", "json"],
+            [str(python), "scripts/check/run_operation_conformance_tests.py", "--target", "all"],
+        ]
+        for command in commands:
+            _run(command, env=env)
+
+        print(
+            json.dumps(
+                {
+                    "kind": "agentic-workspace/command-generation-artifact-consumption-proof/v1",
+                    "status": "satisfied",
+                    "wheel": str(wheel),
+                    "installed_version": installed_version,
+                    "module_file": str(module_file),
+                    "source_tree_import": False,
+                    "proof_commands": commands,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check/run_operation_conformance_tests.py
+++ b/scripts/check/run_operation_conformance_tests.py
@@ -23,15 +23,15 @@ if str(REPO_ROOT / "src") not in sys.path:
 
 import check_contract_tooling_surfaces as contract_tooling_check  # noqa: E402
 import check_generated_command_packages as generated_package_check  # noqa: E402
-from command_generation import (  # noqa: E402
+from command_generation.conformance import (  # noqa: E402
     FunctionConformanceTarget,
     OperationConformanceCase,
+    ProcessConformanceCase,
     TypescriptFunctionConformanceTarget,
     materialize_case_fixture,
     run_function_conformance_case,
     run_typescript_function_conformance_case,
 )
-from command_generation.conformance import ProcessConformanceCase  # noqa: E402
 
 from agentic_workspace.contract_tooling import (  # noqa: E402
     contract_schema,

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -24,16 +24,6 @@
       "rule": "Reusable command-generation source must not import Agentic Workspace product modules. Product-specific literals in command-generation source require explicit accepted-coupling inventory with owner, reason, and migration path.",
       "accepted_couplings": [
         {
-          "id": "portable-primitive-registry-legacy-ids",
-          "kind": "accepted-primitive-id-vocabulary",
-          "paths": [
-            "command_generation/primitive_registry.py"
-          ],
-          "owner": "#1204 command-generation primitive registry",
-          "reason": "The package-owned registry declares legacy primitive identifiers so host manifests can prove support and unsupported states during extraction.",
-          "migration_path": "Keep primitive identifiers schema-backed and deprecate host-specific names only through explicit registry migrations."
-        },
-        {
           "id": "legacy-ir-schema-canonicalization",
           "kind": "accepted-schema-compatibility-boundary",
           "paths": [

--- a/src/agentic_workspace/contracts/generated_command_check_inventory.json
+++ b/src/agentic_workspace/contracts/generated_command_check_inventory.json
@@ -67,24 +67,23 @@
       "rationale": "Generated targets may call host runtime primitives, but AW owns the exact accepted host symbols, owners, minimization posture, and generic-debt rejection."
     },
     {
-      "id": "transitional-host-primitive-usage",
-      "title": "AW-owned transitional host primitive inventory",
-      "classification": "transitional-host-boundary",
+      "id": "retired-command-generation-primitive-usage",
+      "title": "Retired command-generation primitive absence",
+      "classification": "retired-primitive-boundary",
       "owner": "agentic-workspace",
       "disposition": "keep-in-aw",
       "source_refs": [
         "src/agentic_workspace/contracts/operation_primitives.json",
-        "scripts/check/check_generated_command_packages.py",
-        "command_generation BUILTIN_PORTABLE_PRIMITIVES"
+        "scripts/check/check_generated_command_packages.py"
       ],
       "proof_refs": [
-        "_validate_transitional_primitive_usage_inventory",
+        "_validate_retired_command_generation_primitive_usage_inventory",
         "_validate_aw_primitive_ownership_report",
-        "transitional_primitive_usage in --python-completion-blockers report",
+        "retired_command_generation_primitive_usage in --python-completion-blockers report",
         "aw_primitive_ownership in --python-completion-blockers report",
         "uv run python scripts/check/check_generated_command_packages.py --aw-primitive-ownership --format json"
       ],
-      "rationale": "Command-generation marks these helpers as transitional host-owned compatibility; AW owns the Memory payload/current-view and workspace-root semantics through AW-owned primitive IDs and exposes a downstream proof report so CG does not need AW product literals in package-visible metadata."
+      "rationale": "Command-generation 1.0 removes its transitional host-owned helpers; AW owns the Memory payload/current-view and workspace-root semantics through AW-owned primitive IDs and exposes a downstream proof report so CG does not need AW product literals in package-visible metadata."
     },
     {
       "id": "release-and-generator-provenance",

--- a/src/agentic_workspace/contracts/schemas/generated_command_check_inventory.schema.json
+++ b/src/agentic_workspace/contracts/schemas/generated_command_check_inventory.schema.json
@@ -87,6 +87,7 @@
               "release-pinning",
               "generated-freshness",
               "transitional-host-boundary",
+              "retired-primitive-boundary",
               "obsolete-duplicate"
             ]
           },

--- a/tests/test_command_generation_integration.py
+++ b/tests/test_command_generation_integration.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from command_generation import PrimitiveContext, run_operation_steps
+from command_generation.primitive_executor import PrimitiveContext, run_operation_steps
 
 
 @pytest.fixture()

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -486,15 +486,18 @@ def test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundarie
     assert target_freshness["status"] == "fresh"
     provenance = target_freshness["command_generation_package"]
     assert provenance["kind"] == "command-generation/package-provenance/v1"
-    assert provenance["source"] == "released-wheel"
+    assert provenance["source"] in {"released-wheel", "immutable-git-ref"}
     assert provenance["declared_version"] == provenance["installed_version"]
-    assert re.fullmatch(r"\d+\.\d+\.\d+", provenance["declared_version"])
+    assert re.fullmatch(r"\d+\.\d+\.\d+(?:rc\d+)?", provenance["declared_version"])
     assert provenance["compatible"] is True
-    assert provenance["dependency_url"].startswith(
-        f"https://github.com/rickardvh/command-generation/releases/download/v{provenance['declared_version']}/"
-    )
-    assert f"command_generation-{provenance['declared_version']}-py3-none-any.whl" in provenance["dependency_url"]
-    assert "#sha256=" in provenance["dependency_url"]
+    if provenance["source"] == "released-wheel":
+        assert provenance["dependency_url"].startswith(
+            f"https://github.com/rickardvh/command-generation/releases/download/v{provenance['declared_version']}/"
+        )
+        assert f"command_generation-{provenance['declared_version']}-py3-none-any.whl" in provenance["dependency_url"]
+        assert "#sha256=" in provenance["dependency_url"]
+    else:
+        assert re.fullmatch(r"[0-9a-f]{40}", provenance["git_ref"])
     metadata = target_freshness["generation_metadata"]
     assert metadata["kind"] == "command-generation/generated-artifact-metadata-proof/v1"
     assert metadata["status"] == "fresh"
@@ -536,22 +539,22 @@ def test_python_completion_blocker_report_accepts_exact_symbol_runtime_boundarie
     assert "memory.install.lifecycle" in {
         operation["operation_id"] for operation in lifecycle_metrics["memory_payload_default_dry_run_operations"]
     }
-    transitional_usage = report["transitional_primitive_usage"]
-    assert transitional_usage["status"] == "ordinary-source-clean"
-    assert transitional_usage["ordinary_source_operation_usage_count"] == 0
-    assert transitional_usage["compatibility_usage_count"] > 0
-    assert transitional_usage["compatibility_only_paths"] == [
+    retired_usage = report["retired_command_generation_primitive_usage"]
+    assert retired_usage["status"] == "absent-from-ordinary-source"
+    assert retired_usage["ordinary_source_operation_usage_count"] == 0
+    assert retired_usage["guard_reference_count"] > 0
+    assert retired_usage["guard_reference_paths"] == [
         "scripts/check/check_generated_command_packages.py",
         "tests/test_generated_command_package_proof_runner.py",
     ]
     ownership = report["aw_primitive_ownership"]
     assert ownership["kind"] == "agentic-workspace/aw-primitive-ownership/v1"
     assert ownership["status"] == "satisfied"
-    assert ownership["ordinary_source_operation_ir"]["transitional_usage_count"] == 0
+    assert ownership["ordinary_source_operation_ir"]["retired_primitive_usage_count"] == 0
     assert ownership["ordinary_source_operation_ir"]["aw_owned_usage_count"] > 0
     assert ownership["primitive_declarations"]["status"] == "satisfied"
     assert ownership["runtime_bindings"]["status"] == "satisfied"
-    assert ownership["compatibility_only_references"]["paths"] == [
+    assert ownership["retired_command_generation_primitive_usage"]["guard_reference_paths"] == [
         "scripts/check/check_generated_command_packages.py",
         "tests/test_generated_command_package_proof_runner.py",
     ]
@@ -612,7 +615,7 @@ def test_lifecycle_dry_run_generation_regression_is_blocked() -> None:
     assert any("does not route the default dry-run branch through memory.payload.lifecycle-plan" in error for error in errors)
 
 
-def test_transitional_primitive_source_operation_usage_is_blocked() -> None:
+def test_retired_command_generation_primitive_source_operation_usage_is_blocked() -> None:
     errors = _checker_case_errors(
         """
         temp_root = checker.REPO_ROOT / ".tmp-checker-case"
@@ -624,7 +627,7 @@ def test_transitional_primitive_source_operation_usage_is_blocked() -> None:
         }), encoding="utf-8")
         checker._source_operation_contract_paths = lambda: [operation_path]
         try:
-            _emit({"errors": checker._validate_transitional_primitive_usage_inventory()})
+            _emit({"errors": checker._validate_retired_command_generation_primitive_usage_inventory()})
         finally:
             operation_path.unlink(missing_ok=True)
             temp_root.rmdir()
@@ -632,7 +635,8 @@ def test_transitional_primitive_source_operation_usage_is_blocked() -> None:
     )
 
     assert any(
-        "command-generation transitional primitive IDs are present in ordinary source operation contracts" in error for error in errors
+        "retired command-generation transitional primitive IDs are present in ordinary source operation contracts" in error
+        for error in errors
     )
 
 
@@ -645,7 +649,7 @@ def test_aw_primitive_ownership_report_is_a_stable_downstream_proof(capsys) -> N
     payload = json.loads(capsys.readouterr().out)
     assert payload["kind"] == "agentic-workspace/aw-primitive-ownership/v1"
     assert payload["status"] == "satisfied"
-    assert payload["ordinary_source_operation_ir"]["transitional_usage_count"] == 0
+    assert payload["ordinary_source_operation_ir"]["retired_primitive_usage_count"] == 0
     assert payload["ordinary_source_operation_ir"]["aw_owned_usage_count_by_primitive"]["workspace.target-root.resolve"] > 0
     declarations = payload["primitive_declarations"]
     assert declarations["status"] == "satisfied"
@@ -658,7 +662,7 @@ def test_aw_primitive_ownership_report_is_a_stable_downstream_proof(capsys) -> N
         "python_support_path": "src/agentic_workspace/contracts/python_primitive_support.py",
         "typescript_support_path": "src/agentic_workspace/contracts/typescript_primitive_support.mjs",
     }
-    assert payload["compatibility_only_references"]["status"] == "isolated"
+    assert payload["retired_command_generation_primitive_usage"]["status"] == "absent-from-ordinary-source"
     assert payload["coordination"]["command_generation_issue_refs"] == ["rickardvh/command-generation#55"]
 
 
@@ -782,8 +786,8 @@ def test_python_completion_blocker_report_has_json_cli_mode(capsys) -> None:
     assert "new-primitive-implementation" in payload["runtime_source_edit_policy"]["accepted_direct_edit_reasons"]
     assert "package-domain boundary" in payload["runtime_source_edit_policy"]["rejected_vague_reasons"]
     assert payload["lifecycle_dry_run_metrics"]["memory_payload_default_dry_run_operation_count"] >= 3
-    assert payload["transitional_primitive_usage"]["ordinary_source_operation_usage_count"] == 0
-    assert payload["transitional_primitive_usage"]["compatibility_usage_count"] > 0
+    assert payload["retired_command_generation_primitive_usage"]["ordinary_source_operation_usage_count"] == 0
+    assert payload["retired_command_generation_primitive_usage"]["guard_reference_count"] > 0
     check_inventory = payload["generated_command_check_inventory"]
     assert check_inventory["generic_baseline_owner"] == "command-generation"
     assert "generated-output-freshness" in check_inventory["aw_kept_checks"]
@@ -802,8 +806,8 @@ def test_python_completion_blocker_report_surfaces_command_generation_package_po
     assert status == 0
     output = capsys.readouterr().out
     match = re.search(
-        r"Command-generation package: declared=(?P<declared>\d+\.\d+\.\d+) "
-        r"installed=(?P<installed>\d+\.\d+\.\d+) source=released-wheel compatible=true",
+        r"Command-generation package: declared=(?P<declared>\d+\.\d+\.\d+(?:rc\d+)?) "
+        r"installed=(?P<installed>\d+\.\d+\.\d+(?:rc\d+)?) source=(released-wheel|immutable-git-ref) compatible=true",
         output,
     )
     assert match is not None

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.15/command_generation-0.2.15-py3-none-any.whl" },
+    { name = "command-generation", url = "https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -144,13 +144,13 @@ wheels = [
 
 [[package]]
 name = "command-generation"
-version = "0.2.15"
-source = { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.15/command_generation-0.2.15-py3-none-any.whl" }
+version = "1.0.0rc1"
+source = { url = "https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl" }
 dependencies = [
     { name = "jsonschema" },
 ]
 wheels = [
-    { url = "https://github.com/rickardvh/command-generation/releases/download/v0.2.15/command_generation-0.2.15-py3-none-any.whl", hash = "sha256:abe89732db90d0a8f406af0da097209471f3b1107c1b7c9fad5d973edc02c5cb" },
+    { url = "https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl", hash = "sha256:92886c2dbc06fb8651e26ccdeefa0c1446fb4e1614219b2db024ed487f09d762" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Summary
- consume command-generation v1.0.0rc1 from the published release wheel with SHA256 pinning
- remove AW's transitional CG compatibility report shape and replace it with a retired-ID absence proof
- move AW conformance imports off package-level provisional CG exports
- remove the stale CG primitive-registry product-literal coupling inventory
- add an AW-side proof script that installs a built command-generation wheel and fails if command_generation imports from the sibling source tree
- regenerate Python and TypeScript command-package metadata against CG 1.0.0rc1

## Proof
- make test-workspace
- make lint-workspace
- uv run python scripts/check/check_generated_command_packages.py
- uv run python scripts/check/run_operation_conformance_tests.py --target all
- uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success
- uv run python scripts/check/check_structured_file_inventory.py --quiet-success
- uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py
- make schema-reference-docs
- downloaded https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl and verified SHA256 92886c2dbc06fb8651e26ccdeefa0c1446fb4e1614219b2db024ed487f09d762
- uv run python scripts/check/prove_command_generation_artifact_consumption.py --wheel <downloaded v1.0.0rc1 wheel> --expected-version 1.0.0rc1 --forbid-source-root ..\\command-generation

Command-generation #65 is merged and v1.0.0rc1 is published as a prerelease.

Closes #1646
Closes #1647
Closes #1648