### PR TITLE
Move module front doors to generated handlers

### DIFF
--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -2,7 +2,7 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl#sha256=92886c2dbc06fb8651e26ccdeefa0c1446fb4e1614219b2db024ed487f09d762"
+RUN python -m pip install --no-cache-dir jsonschema "command-generation @ git+https://github.com/rickardvh/command-generation.git@234c80cf546d233851af9ee4e1e9fc444879c8e3"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/python/Dockerfile.primitive-conformance
+++ b/generated/python/Dockerfile.primitive-conformance
@@ -2,6 +2,6 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl#sha256=92886c2dbc06fb8651e26ccdeefa0c1446fb4e1614219b2db024ed487f09d762"
+RUN python -m pip install --no-cache-dir "command-generation @ git+https://github.com/rickardvh/command-generation.git@234c80cf546d233851af9ee4e1e9fc444879c8e3"
 
 CMD ["python", "-m", "command_generation.primitive_conformance"]

--- a/generated/typescript.conformance.Dockerfile
+++ b/generated/typescript.conformance.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /work
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 python3-pip \
     && find /usr/lib/python3/dist-packages -name '*.pyc' -delete \
-    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl#sha256=92886c2dbc06fb8651e26ccdeefa0c1446fb4e1614219b2db024ed487f09d762"
+    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ git+https://github.com/rickardvh/command-generation.git@234c80cf546d233851af9ee4e1e9fc444879c8e3"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -5177,34 +5177,664 @@
         "operation_id": "install.lifecycle"
       },
       {
-        "function": "_run_memory_front_door_adapter",
-        "import_module": "agentic_workspace.workspace_runtime_primitives",
-        "operation_id": "memory.front-door"
+        "command_attr": "memory_command",
+        "handler": "module_front_door",
+        "help_payload_function": "_memory_help_payload",
+        "help_payload_import_module": "agentic_workspace.workspace_runtime_primitives",
+        "help_text_function": "_print_memory_help",
+        "missing_module_message": "The memory module must be installed to use memory subcommands.",
+        "module_import": "repo_memory_bootstrap.cli",
+        "module_main": "main",
+        "module_program": "agentic-memory",
+        "operation_id": "memory.front-door",
+        "option_specs": [
+          {
+            "attr": "target",
+            "option": "--target"
+          },
+          {
+            "attr": "title",
+            "option": "--title"
+          },
+          {
+            "attr": "folder",
+            "option": "--folder"
+          },
+          {
+            "attr": "note_type",
+            "option": "--note-type"
+          },
+          {
+            "attr": "summary",
+            "option": "--summary"
+          },
+          {
+            "attr": "task",
+            "option": "--task"
+          },
+          {
+            "attr": "stage",
+            "option": "--stage"
+          },
+          {
+            "attr": "existing_note",
+            "option": "--existing-note"
+          },
+          {
+            "attr": "force_new_reason",
+            "option": "--force-new-reason"
+          },
+          {
+            "attr": "mode",
+            "option": "--mode"
+          },
+          {
+            "attr": "memory_role",
+            "option": "--memory-role"
+          },
+          {
+            "attr": "promotion_target",
+            "option": "--promotion-target"
+          },
+          {
+            "attr": "promotion_trigger",
+            "option": "--promotion-trigger"
+          },
+          {
+            "attr": "retention_after_promotion",
+            "option": "--retention-after-promotion"
+          },
+          {
+            "attr": "local_reason",
+            "option": "--local-reason"
+          },
+          {
+            "attr": "applies_to",
+            "kind": "repeated_group",
+            "option": "--applies-to"
+          },
+          {
+            "attr": "use_when",
+            "kind": "repeated_group",
+            "option": "--use-when"
+          },
+          {
+            "attr": "routes_from",
+            "kind": "repeated_group",
+            "option": "--routes-from"
+          },
+          {
+            "attr": "stale_when",
+            "kind": "repeated_group",
+            "option": "--stale-when"
+          },
+          {
+            "attr": "evidence",
+            "kind": "repeated_group",
+            "option": "--evidence"
+          },
+          {
+            "attr": "files",
+            "kind": "repeated_group",
+            "option": "--files"
+          },
+          {
+            "attr": "surfaces",
+            "kind": "repeated_group",
+            "option": "--surface"
+          },
+          {
+            "attr": "notes",
+            "kind": "repeated_group",
+            "option": "--notes"
+          },
+          {
+            "attr": "local",
+            "kind": "flag",
+            "option": "--local"
+          },
+          {
+            "attr": "dry_run",
+            "kind": "flag",
+            "option": "--dry-run"
+          },
+          {
+            "attr": "verbose",
+            "kind": "flag",
+            "option": "--verbose"
+          },
+          {
+            "attr": "format",
+            "option": "--format"
+          }
+        ],
+        "positionals": [
+          {
+            "attr": "slug",
+            "commands": [
+              "capture-note",
+              "create-note"
+            ]
+          }
+        ],
+        "stdout_replacements": [
+          {
+            "new": "agentic-workspace memory ",
+            "old": "agentic-memory "
+          }
+        ]
       },
       {
-        "function": "_run_modules_report_adapter",
+        "arguments": [
+          {
+            "attr": "format",
+            "kind": "attr",
+            "name": "format_name"
+          },
+          {
+            "allow_none": true,
+            "attr": "target",
+            "default_current": false,
+            "kind": "target_root",
+            "name": "target_root",
+            "validate_command": "modules"
+          },
+          {
+            "default": "tiny",
+            "kind": "diagnostic_profile",
+            "name": "profile"
+          }
+        ],
+        "function": "_emit_modules",
+        "handler": "argparse_function_call",
         "import_module": "agentic_workspace.workspace_runtime_primitives",
-        "operation_id": "modules.report"
+        "operation_id": "modules.report",
+        "result": "return_zero",
+        "support_import_module": "agentic_workspace.workspace_runtime_primitives"
       },
       {
-        "function": "_run_ownership_report_adapter",
+        "arguments": [
+          {
+            "attr": "format",
+            "kind": "attr",
+            "name": "format_name"
+          },
+          {
+            "attr": "target",
+            "kind": "target_root",
+            "name": "target_root",
+            "validate_command": "ownership"
+          },
+          {
+            "kind": "module_descriptors",
+            "name": "descriptors"
+          },
+          {
+            "attr": "concern",
+            "kind": "attr",
+            "name": "concern"
+          },
+          {
+            "attr": "path",
+            "kind": "attr",
+            "name": "repo_path"
+          }
+        ],
+        "function": "_emit_ownership",
+        "handler": "argparse_function_call",
         "import_module": "agentic_workspace.workspace_runtime_primitives",
-        "operation_id": "ownership.report"
+        "operation_id": "ownership.report",
+        "result": "return_zero",
+        "support_import_module": "agentic_workspace.workspace_runtime_primitives"
       },
       {
-        "function": "_run_planning_front_door_adapter",
-        "import_module": "agentic_workspace.workspace_runtime_primitives",
-        "operation_id": "planning.front-door"
+        "command_attr": "planning_command",
+        "handler": "module_front_door",
+        "help_payload_function": "_planning_help_payload",
+        "help_payload_import_module": "agentic_workspace.workspace_runtime_primitives",
+        "help_text_function": "_print_planning_help",
+        "local_command_handlers": [
+          {
+            "command": "decision-scaffold",
+            "function": "_run_planning_decision_adapter",
+            "import_module": "agentic_workspace.workspace_runtime_primitives"
+          },
+          {
+            "command": "decision-promote",
+            "function": "_run_planning_decision_adapter",
+            "import_module": "agentic_workspace.workspace_runtime_primitives"
+          }
+        ],
+        "missing_module_message": "The planning module must be installed to use planning subcommands.",
+        "module_import": "repo_planning_bootstrap.cli",
+        "module_main": "main",
+        "module_program": "agentic-planning",
+        "operation_id": "planning.front-door",
+        "option_specs": [
+          {
+            "attr": "id",
+            "option": "--id"
+          },
+          {
+            "attr": "title",
+            "option": "--title"
+          },
+          {
+            "attr": "source",
+            "option": "--source"
+          },
+          {
+            "attr": "artifact",
+            "option": "--artifact"
+          },
+          {
+            "attr": "target",
+            "option": "--target"
+          },
+          {
+            "attr": "plan_slug",
+            "option": "--plan-slug"
+          },
+          {
+            "attr": "scope",
+            "option": "--scope"
+          },
+          {
+            "attr": "classification",
+            "option": "--classification"
+          },
+          {
+            "attr": "route",
+            "option": "--route"
+          },
+          {
+            "attr": "current_slice",
+            "option": "--current-slice"
+          },
+          {
+            "attr": "proof",
+            "option": "--proof"
+          },
+          {
+            "attr": "residual_work",
+            "option": "--residual-work"
+          },
+          {
+            "attr": "parent_contribution",
+            "option": "--parent-contribution"
+          },
+          {
+            "attr": "parent_close_permission",
+            "option": "--parent-close-permission"
+          },
+          {
+            "attr": "next_owner",
+            "option": "--next-owner"
+          },
+          {
+            "attr": "skipped_reason",
+            "option": "--skipped-reason"
+          },
+          {
+            "attr": "expected_savings",
+            "option": "--expected-savings"
+          },
+          {
+            "attr": "actual_friction",
+            "option": "--actual-friction"
+          },
+          {
+            "attr": "proof_result",
+            "option": "--proof-result"
+          },
+          {
+            "attr": "quality_concern",
+            "option": "--quality-concern"
+          },
+          {
+            "attr": "decomposition_adjustment",
+            "option": "--decomposition-adjustment"
+          },
+          {
+            "attr": "reason",
+            "option": "--reason"
+          },
+          {
+            "attr": "issue",
+            "option": "--issue"
+          },
+          {
+            "attr": "parent_lane_closeout",
+            "option": "--parent-lane-closeout"
+          },
+          {
+            "attr": "closure_decision",
+            "option": "--closure-decision"
+          },
+          {
+            "attr": "intent_satisfied",
+            "option": "--intent-satisfied"
+          },
+          {
+            "attr": "unsolved_intent",
+            "option": "--unsolved-intent"
+          },
+          {
+            "attr": "intent_evidence",
+            "option": "--intent-evidence"
+          },
+          {
+            "attr": "closure_reason",
+            "option": "--closure-reason"
+          },
+          {
+            "attr": "closure_evidence",
+            "option": "--closure-evidence"
+          },
+          {
+            "attr": "reopen_trigger",
+            "option": "--reopen-trigger"
+          },
+          {
+            "attr": "discard_summary",
+            "option": "--discard-summary"
+          },
+          {
+            "attr": "continuation_summary",
+            "option": "--continuation-summary"
+          },
+          {
+            "attr": "claim_level",
+            "option": "--claim-level"
+          },
+          {
+            "attr": "intent_status",
+            "option": "--intent-status"
+          },
+          {
+            "attr": "residue",
+            "option": "--residue"
+          },
+          {
+            "attr": "proof_from",
+            "option": "--proof-from"
+          },
+          {
+            "attr": "residue_owner",
+            "option": "--residue-owner"
+          },
+          {
+            "attr": "what_happened",
+            "option": "--what-happened"
+          },
+          {
+            "attr": "scope_touched",
+            "option": "--scope-touched"
+          },
+          {
+            "attr": "changed_surfaces",
+            "option": "--changed-surfaces"
+          },
+          {
+            "attr": "review_summary",
+            "option": "--review-summary"
+          },
+          {
+            "attr": "outcome_summary",
+            "option": "--outcome-summary"
+          },
+          {
+            "attr": "expect_planning_revision",
+            "option": "--expect-planning-revision"
+          },
+          {
+            "attr": "activate",
+            "kind": "flag",
+            "option": "--activate"
+          },
+          {
+            "attr": "queue",
+            "kind": "flag",
+            "option": "--queue"
+          },
+          {
+            "attr": "switch_active",
+            "kind": "flag",
+            "option": "--switch-active"
+          },
+          {
+            "attr": "prep_only",
+            "kind": "flag",
+            "option": "--prep-only"
+          },
+          {
+            "attr": "overwrite",
+            "kind": "flag",
+            "option": "--overwrite"
+          },
+          {
+            "attr": "remove_source",
+            "kind": "flag",
+            "option": "--remove-source"
+          },
+          {
+            "attr": "dry_run",
+            "kind": "flag",
+            "option": "--dry-run"
+          },
+          {
+            "attr": "render_markdown",
+            "kind": "flag",
+            "option": "--render-markdown"
+          },
+          {
+            "attr": "apply_cleanup",
+            "kind": "flag",
+            "option": "--apply-cleanup"
+          },
+          {
+            "attr": "prepare_closeout",
+            "kind": "flag",
+            "option": "--prepare-closeout"
+          },
+          {
+            "attr": "retain_archive",
+            "kind": "flag",
+            "option": "--retain-archive"
+          },
+          {
+            "attr": "discard_archive",
+            "kind": "flag",
+            "option": "--discard-archive"
+          },
+          {
+            "attr": "verbose",
+            "kind": "flag",
+            "option": "--verbose"
+          },
+          {
+            "attr": "paths",
+            "fallback_attr": "path",
+            "kind": "repeated",
+            "option": "--path"
+          },
+          {
+            "attr": "format",
+            "option": "--format"
+          }
+        ],
+        "positionals": [
+          {
+            "attr": "item_id",
+            "commands": [
+              "promote-to-plan"
+            ]
+          },
+          {
+            "attr": "lane",
+            "commands": [
+              "lane-promote",
+              "lane-activate",
+              "lane-close",
+              "lane-archive"
+            ]
+          },
+          {
+            "attr": "plan",
+            "commands": [
+              "archive-plan",
+              "closeout"
+            ]
+          },
+          {
+            "attr": "item",
+            "commands": [
+              "close-item"
+            ]
+          },
+          {
+            "attr": "slug",
+            "commands": [
+              "create-review"
+            ]
+          }
+        ],
+        "stdout_replacements": [
+          {
+            "new": "agentic-workspace reconcile ",
+            "old": "agentic-planning reconcile "
+          },
+          {
+            "new": "agentic-workspace summary ",
+            "old": "agentic-planning summary "
+          },
+          {
+            "new": "agentic-workspace doctor ",
+            "old": "agentic-planning doctor "
+          },
+          {
+            "new": "agentic-workspace planning ",
+            "old": "agentic-planning "
+          },
+          {
+            "new": "agentic-workspace memory ",
+            "old": "agentic-memory "
+          }
+        ]
       },
       {
-        "function": "_run_preflight_report_adapter",
+        "arguments": [
+          {
+            "attr": "target",
+            "kind": "target_root",
+            "name": "target_root",
+            "validate_command": "preflight"
+          },
+          {
+            "attr": "active_only",
+            "kind": "bool_attr",
+            "name": "active_only"
+          },
+          {
+            "attr": "task",
+            "kind": "attr",
+            "name": "task_text"
+          },
+          {
+            "default": "tiny",
+            "kind": "diagnostic_profile",
+            "name": "profile"
+          }
+        ],
+        "emit_payload": {
+          "format_attr": "format",
+          "function": "_emit_payload",
+          "import_module": "agentic_workspace.workspace_runtime_primitives"
+        },
+        "function": "_run_preflight_command",
+        "handler": "argparse_function_call",
         "import_module": "agentic_workspace.workspace_runtime_primitives",
-        "operation_id": "preflight.report"
+        "operation_id": "preflight.report",
+        "result": "emit_payload",
+        "support_import_module": "agentic_workspace.workspace_runtime_primitives"
       },
       {
-        "function": "_run_proof_report_adapter",
+        "arguments": [
+          {
+            "attr": "format",
+            "kind": "attr",
+            "name": "format_name"
+          },
+          {
+            "attr": "target",
+            "kind": "target_root",
+            "name": "target_root",
+            "validate_command": "proof"
+          },
+          {
+            "kind": "module_descriptors",
+            "name": "descriptors"
+          },
+          {
+            "attr": "route",
+            "kind": "attr",
+            "name": "route"
+          },
+          {
+            "attr": "current",
+            "kind": "bool_attr",
+            "name": "current_only"
+          },
+          {
+            "attr": "changed",
+            "kind": "list_attr",
+            "name": "changed_paths"
+          },
+          {
+            "default": "tiny",
+            "kind": "diagnostic_profile",
+            "name": "profile"
+          },
+          {
+            "attr": "select",
+            "kind": "attr",
+            "name": "select"
+          },
+          {
+            "attr": "record_receipt",
+            "kind": "bool_attr",
+            "name": "record_receipt"
+          },
+          {
+            "attr": "receipt_command",
+            "default": "",
+            "kind": "attr",
+            "name": "receipt_command"
+          },
+          {
+            "attr": "receipt_result",
+            "default": "",
+            "kind": "attr",
+            "name": "receipt_result"
+          },
+          {
+            "attr": "receipt_plan",
+            "default": "",
+            "kind": "attr",
+            "name": "receipt_plan"
+          },
+          {
+            "attr": "dry_run",
+            "kind": "bool_attr",
+            "name": "dry_run"
+          }
+        ],
+        "function": "_emit_proof",
+        "handler": "argparse_function_call",
         "import_module": "agentic_workspace.workspace_runtime_primitives",
-        "operation_id": "proof.report"
+        "operation_id": "proof.report",
+        "result": "return_zero",
+        "support_import_module": "agentic_workspace.workspace_runtime_primitives"
       },
       {
         "function": "_run_reconcile_report_adapter",
@@ -5222,9 +5852,37 @@
         "operation_id": "setup.guidance"
       },
       {
-        "function": "_run_skills_report_adapter",
+        "arguments": [
+          {
+            "attr": "format",
+            "kind": "attr",
+            "name": "format_name"
+          },
+          {
+            "allow_none": true,
+            "attr": "target",
+            "default_current": false,
+            "kind": "target_root",
+            "name": "target_root",
+            "validate_command": "skills"
+          },
+          {
+            "attr": "task",
+            "kind": "attr",
+            "name": "task_text"
+          },
+          {
+            "attr": "select",
+            "kind": "attr",
+            "name": "select"
+          }
+        ],
+        "function": "_emit_skills",
+        "handler": "argparse_function_call",
         "import_module": "agentic_workspace.workspace_runtime_primitives",
-        "operation_id": "skills.report"
+        "operation_id": "skills.report",
+        "result": "return_zero",
+        "support_import_module": "agentic_workspace.workspace_runtime_primitives"
       },
       {
         "function": "_run_start_context_adapter",

--- a/generated/workspace/python/commands/memory_front_door.py
+++ b/generated/workspace/python/commands/memory_front_door.py
@@ -17,12 +17,72 @@ from collections.abc import Mapping
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
+import contextlib
+import io
+import json
+from ..cli import build_generated_parser
 
 
 def run(args: argparse.Namespace) -> int:
-    from ..primitives.workspace_runtime import _run_memory_front_door_adapter
+    command_value = getattr(args, 'memory_command', None)
+    if not command_value:
+        from agentic_workspace.workspace_runtime_primitives import _memory_help_payload as help_payload_function
 
-    return _run_memory_front_door_adapter(args)
+        payload = help_payload_function(target=getattr(args, 'target', None))
+        if getattr(args, 'format', None) == 'json':
+            print(json.dumps(payload, indent=2))
+        else:
+            from agentic_workspace.workspace_runtime_primitives import _print_memory_help as help_text_function
+
+            help_text_function(payload)
+        return 0
+    local_handlers = {}
+    local_handler = local_handlers.get(str(command_value))
+    if local_handler is not None:
+        module_name, function_name = local_handler
+        module = __import__(module_name, fromlist=[function_name])
+        return getattr(module, function_name)(args)
+    argv = ['agentic-memory'] if False else []
+    argv.append(str(command_value))
+    for commands, attr in [(['capture-note', 'create-note'], 'slug')]:
+        if str(command_value) in commands:
+            value = getattr(args, attr, None)
+            if value is not None and value != '' and value != []:
+                argv.append(str(value))
+    for option, attr, fallback_attr, kind in [('--target', 'target', '', 'value'), ('--title', 'title', '', 'value'), ('--folder', 'folder', '', 'value'), ('--note-type', 'note_type', '', 'value'), ('--summary', 'summary', '', 'value'), ('--task', 'task', '', 'value'), ('--stage', 'stage', '', 'value'), ('--existing-note', 'existing_note', '', 'value'), ('--force-new-reason', 'force_new_reason', '', 'value'), ('--mode', 'mode', '', 'value'), ('--memory-role', 'memory_role', '', 'value'), ('--promotion-target', 'promotion_target', '', 'value'), ('--promotion-trigger', 'promotion_trigger', '', 'value'), ('--retention-after-promotion', 'retention_after_promotion', '', 'value'), ('--local-reason', 'local_reason', '', 'value'), ('--applies-to', 'applies_to', '', 'repeated_group'), ('--use-when', 'use_when', '', 'repeated_group'), ('--routes-from', 'routes_from', '', 'repeated_group'), ('--stale-when', 'stale_when', '', 'repeated_group'), ('--evidence', 'evidence', '', 'repeated_group'), ('--files', 'files', '', 'repeated_group'), ('--surface', 'surfaces', '', 'repeated_group'), ('--notes', 'notes', '', 'repeated_group'), ('--local', 'local', '', 'flag'), ('--dry-run', 'dry_run', '', 'flag'), ('--verbose', 'verbose', '', 'flag'), ('--format', 'format', '', 'value')]:
+        value = getattr(args, attr, None)
+        if (value is None or value == [] or value == '') and fallback_attr:
+            value = getattr(args, fallback_attr, None)
+        if kind == 'flag':
+            if bool(value):
+                argv.append(option)
+        elif kind == 'repeated':
+            if isinstance(value, str):
+                value = [value]
+            for item in value or []:
+                argv.extend([option, str(item)])
+        elif kind == 'repeated_group':
+            if isinstance(value, str):
+                value = [value]
+            if value:
+                argv.append(option)
+                argv.extend(str(item) for item in value)
+        elif value is not None and value != '' and value != []:
+            argv.extend([option, str(value)])
+    try:
+        module = __import__('repo_memory_bootstrap.cli', fromlist=['main'])
+        module_main = getattr(module, 'main')
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            result = module_main(argv)
+        output = buffer.getvalue()
+        for old, new in [('agentic-memory ', 'agentic-workspace memory ')]:
+            output = output.replace(old, new)
+        print(output, end='')
+        return int(result or 0)
+    except ImportError:
+        build_generated_parser().error('The memory module must be installed to use memory subcommands.')
+        return 2
 
 
 def invoke(_values: Mapping[str, Any]) -> object:

--- a/generated/workspace/python/commands/modules_report.py
+++ b/generated/workspace/python/commands/modules_report.py
@@ -20,9 +20,15 @@ from collections.abc import Mapping
 
 
 def run(args: argparse.Namespace) -> int:
-    from ..primitives.workspace_runtime import _run_modules_report_adapter
-
-    return _run_modules_report_adapter(args)
+    from agentic_workspace.workspace_runtime_primitives import _diagnostic_profile, _resolve_target_root, _validate_target_root
+    _arg_0_format_name = getattr(args, 'format', None)
+    _arg_1_target_root = _resolve_target_root(getattr(args, 'target', None)) if getattr(args, 'target', None) else None
+    if _arg_1_target_root is not None:
+        _validate_target_root(command_name='modules', target_root=_arg_1_target_root)
+    _arg_2_profile = _diagnostic_profile(args, default='tiny')
+    from agentic_workspace.workspace_runtime_primitives import _emit_modules
+    _emit_modules(format_name=_arg_0_format_name, target_root=_arg_1_target_root, profile=_arg_2_profile)
+    return 0
 
 
 def invoke(_values: Mapping[str, Any]) -> object:

--- a/generated/workspace/python/commands/ownership_report.py
+++ b/generated/workspace/python/commands/ownership_report.py
@@ -20,9 +20,19 @@ from collections.abc import Mapping
 
 
 def run(args: argparse.Namespace) -> int:
-    from ..primitives.workspace_runtime import _run_ownership_report_adapter
-
-    return _run_ownership_report_adapter(args)
+    from agentic_workspace.workspace_runtime_primitives import _module_operations, _resolve_target_root, _validate_descriptor_contract, _validate_target_root
+    _arg_0_format_name = getattr(args, 'format', None)
+    _arg_1_target_root = _resolve_target_root(getattr(args, 'target', None))
+    if _arg_1_target_root is None:
+        raise ValueError('target root resolution returned None')
+    _validate_target_root(command_name='ownership', target_root=_arg_1_target_root)
+    _arg_2_descriptors = _module_operations()
+    _validate_descriptor_contract(_arg_2_descriptors)
+    _arg_3_concern = getattr(args, 'concern', None)
+    _arg_4_repo_path = getattr(args, 'path', None)
+    from agentic_workspace.workspace_runtime_primitives import _emit_ownership
+    _emit_ownership(format_name=_arg_0_format_name, target_root=_arg_1_target_root, descriptors=_arg_2_descriptors, concern=_arg_3_concern, repo_path=_arg_4_repo_path)
+    return 0
 
 
 def invoke(_values: Mapping[str, Any]) -> object:

--- a/generated/workspace/python/commands/planning_front_door.py
+++ b/generated/workspace/python/commands/planning_front_door.py
@@ -17,12 +17,72 @@ from collections.abc import Mapping
 # Command behavior changes belong in src/agentic_workspace/contracts/command_package_ir.json and the referenced operation contract.
 # Regenerate with: uv run python scripts/generate/generate_command_packages.py
 
+import contextlib
+import io
+import json
+from ..cli import build_generated_parser
 
 
 def run(args: argparse.Namespace) -> int:
-    from ..primitives.workspace_runtime import _run_planning_front_door_adapter
+    command_value = getattr(args, 'planning_command', None)
+    if not command_value:
+        from agentic_workspace.workspace_runtime_primitives import _planning_help_payload as help_payload_function
 
-    return _run_planning_front_door_adapter(args)
+        payload = help_payload_function(target=getattr(args, 'target', None))
+        if getattr(args, 'format', None) == 'json':
+            print(json.dumps(payload, indent=2))
+        else:
+            from agentic_workspace.workspace_runtime_primitives import _print_planning_help as help_text_function
+
+            help_text_function(payload)
+        return 0
+    local_handlers = {'decision-scaffold': ('agentic_workspace.workspace_runtime_primitives', '_run_planning_decision_adapter'), 'decision-promote': ('agentic_workspace.workspace_runtime_primitives', '_run_planning_decision_adapter')}
+    local_handler = local_handlers.get(str(command_value))
+    if local_handler is not None:
+        module_name, function_name = local_handler
+        module = __import__(module_name, fromlist=[function_name])
+        return getattr(module, function_name)(args)
+    argv = ['agentic-planning'] if False else []
+    argv.append(str(command_value))
+    for commands, attr in [(['promote-to-plan'], 'item_id'), (['lane-promote', 'lane-activate', 'lane-close', 'lane-archive'], 'lane'), (['archive-plan', 'closeout'], 'plan'), (['close-item'], 'item'), (['create-review'], 'slug')]:
+        if str(command_value) in commands:
+            value = getattr(args, attr, None)
+            if value is not None and value != '' and value != []:
+                argv.append(str(value))
+    for option, attr, fallback_attr, kind in [('--id', 'id', '', 'value'), ('--title', 'title', '', 'value'), ('--source', 'source', '', 'value'), ('--artifact', 'artifact', '', 'value'), ('--target', 'target', '', 'value'), ('--plan-slug', 'plan_slug', '', 'value'), ('--scope', 'scope', '', 'value'), ('--classification', 'classification', '', 'value'), ('--route', 'route', '', 'value'), ('--current-slice', 'current_slice', '', 'value'), ('--proof', 'proof', '', 'value'), ('--residual-work', 'residual_work', '', 'value'), ('--parent-contribution', 'parent_contribution', '', 'value'), ('--parent-close-permission', 'parent_close_permission', '', 'value'), ('--next-owner', 'next_owner', '', 'value'), ('--skipped-reason', 'skipped_reason', '', 'value'), ('--expected-savings', 'expected_savings', '', 'value'), ('--actual-friction', 'actual_friction', '', 'value'), ('--proof-result', 'proof_result', '', 'value'), ('--quality-concern', 'quality_concern', '', 'value'), ('--decomposition-adjustment', 'decomposition_adjustment', '', 'value'), ('--reason', 'reason', '', 'value'), ('--issue', 'issue', '', 'value'), ('--parent-lane-closeout', 'parent_lane_closeout', '', 'value'), ('--closure-decision', 'closure_decision', '', 'value'), ('--intent-satisfied', 'intent_satisfied', '', 'value'), ('--unsolved-intent', 'unsolved_intent', '', 'value'), ('--intent-evidence', 'intent_evidence', '', 'value'), ('--closure-reason', 'closure_reason', '', 'value'), ('--closure-evidence', 'closure_evidence', '', 'value'), ('--reopen-trigger', 'reopen_trigger', '', 'value'), ('--discard-summary', 'discard_summary', '', 'value'), ('--continuation-summary', 'continuation_summary', '', 'value'), ('--claim-level', 'claim_level', '', 'value'), ('--intent-status', 'intent_status', '', 'value'), ('--residue', 'residue', '', 'value'), ('--proof-from', 'proof_from', '', 'value'), ('--residue-owner', 'residue_owner', '', 'value'), ('--what-happened', 'what_happened', '', 'value'), ('--scope-touched', 'scope_touched', '', 'value'), ('--changed-surfaces', 'changed_surfaces', '', 'value'), ('--review-summary', 'review_summary', '', 'value'), ('--outcome-summary', 'outcome_summary', '', 'value'), ('--expect-planning-revision', 'expect_planning_revision', '', 'value'), ('--activate', 'activate', '', 'flag'), ('--queue', 'queue', '', 'flag'), ('--switch-active', 'switch_active', '', 'flag'), ('--prep-only', 'prep_only', '', 'flag'), ('--overwrite', 'overwrite', '', 'flag'), ('--remove-source', 'remove_source', '', 'flag'), ('--dry-run', 'dry_run', '', 'flag'), ('--render-markdown', 'render_markdown', '', 'flag'), ('--apply-cleanup', 'apply_cleanup', '', 'flag'), ('--prepare-closeout', 'prepare_closeout', '', 'flag'), ('--retain-archive', 'retain_archive', '', 'flag'), ('--discard-archive', 'discard_archive', '', 'flag'), ('--verbose', 'verbose', '', 'flag'), ('--path', 'paths', 'path', 'repeated'), ('--format', 'format', '', 'value')]:
+        value = getattr(args, attr, None)
+        if (value is None or value == [] or value == '') and fallback_attr:
+            value = getattr(args, fallback_attr, None)
+        if kind == 'flag':
+            if bool(value):
+                argv.append(option)
+        elif kind == 'repeated':
+            if isinstance(value, str):
+                value = [value]
+            for item in value or []:
+                argv.extend([option, str(item)])
+        elif kind == 'repeated_group':
+            if isinstance(value, str):
+                value = [value]
+            if value:
+                argv.append(option)
+                argv.extend(str(item) for item in value)
+        elif value is not None and value != '' and value != []:
+            argv.extend([option, str(value)])
+    try:
+        module = __import__('repo_planning_bootstrap.cli', fromlist=['main'])
+        module_main = getattr(module, 'main')
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            result = module_main(argv)
+        output = buffer.getvalue()
+        for old, new in [('agentic-planning reconcile ', 'agentic-workspace reconcile '), ('agentic-planning summary ', 'agentic-workspace summary '), ('agentic-planning doctor ', 'agentic-workspace doctor '), ('agentic-planning ', 'agentic-workspace planning '), ('agentic-memory ', 'agentic-workspace memory ')]:
+            output = output.replace(old, new)
+        print(output, end='')
+        return int(result or 0)
+    except ImportError:
+        build_generated_parser().error('The planning module must be installed to use planning subcommands.')
+        return 2
 
 
 def invoke(_values: Mapping[str, Any]) -> object:

--- a/generated/workspace/python/commands/preflight_report.py
+++ b/generated/workspace/python/commands/preflight_report.py
@@ -20,9 +20,19 @@ from collections.abc import Mapping
 
 
 def run(args: argparse.Namespace) -> int:
-    from ..primitives.workspace_runtime import _run_preflight_report_adapter
-
-    return _run_preflight_report_adapter(args)
+    from agentic_workspace.workspace_runtime_primitives import _diagnostic_profile, _resolve_target_root, _validate_target_root
+    _arg_0_target_root = _resolve_target_root(getattr(args, 'target', None))
+    if _arg_0_target_root is None:
+        raise ValueError('target root resolution returned None')
+    _validate_target_root(command_name='preflight', target_root=_arg_0_target_root)
+    _arg_1_active_only = bool(getattr(args, 'active_only', False))
+    _arg_2_task_text = getattr(args, 'task', None)
+    _arg_3_profile = _diagnostic_profile(args, default='tiny')
+    from agentic_workspace.workspace_runtime_primitives import _run_preflight_command
+    payload = _run_preflight_command(target_root=_arg_0_target_root, active_only=_arg_1_active_only, task_text=_arg_2_task_text, profile=_arg_3_profile)
+    from agentic_workspace.workspace_runtime_primitives import _emit_payload
+    _emit_payload(payload=payload, format_name=getattr(args, 'format', 'text'))
+    return 0
 
 
 def invoke(_values: Mapping[str, Any]) -> object:

--- a/generated/workspace/python/commands/proof_report.py
+++ b/generated/workspace/python/commands/proof_report.py
@@ -20,9 +20,27 @@ from collections.abc import Mapping
 
 
 def run(args: argparse.Namespace) -> int:
-    from ..primitives.workspace_runtime import _run_proof_report_adapter
-
-    return _run_proof_report_adapter(args)
+    from agentic_workspace.workspace_runtime_primitives import _diagnostic_profile, _module_operations, _resolve_target_root, _validate_descriptor_contract, _validate_target_root
+    _arg_0_format_name = getattr(args, 'format', None)
+    _arg_1_target_root = _resolve_target_root(getattr(args, 'target', None))
+    if _arg_1_target_root is None:
+        raise ValueError('target root resolution returned None')
+    _validate_target_root(command_name='proof', target_root=_arg_1_target_root)
+    _arg_2_descriptors = _module_operations()
+    _validate_descriptor_contract(_arg_2_descriptors)
+    _arg_3_route = getattr(args, 'route', None)
+    _arg_4_current_only = bool(getattr(args, 'current', False))
+    _arg_5_changed_paths = list(getattr(args, 'changed', []) or [])
+    _arg_6_profile = _diagnostic_profile(args, default='tiny')
+    _arg_7_select = getattr(args, 'select', None)
+    _arg_8_record_receipt = bool(getattr(args, 'record_receipt', False))
+    _arg_9_receipt_command = getattr(args, 'receipt_command', '')
+    _arg_10_receipt_result = getattr(args, 'receipt_result', '')
+    _arg_11_receipt_plan = getattr(args, 'receipt_plan', '')
+    _arg_12_dry_run = bool(getattr(args, 'dry_run', False))
+    from agentic_workspace.workspace_runtime_primitives import _emit_proof
+    _emit_proof(format_name=_arg_0_format_name, target_root=_arg_1_target_root, descriptors=_arg_2_descriptors, route=_arg_3_route, current_only=_arg_4_current_only, changed_paths=_arg_5_changed_paths, profile=_arg_6_profile, select=_arg_7_select, record_receipt=_arg_8_record_receipt, receipt_command=_arg_9_receipt_command, receipt_result=_arg_10_receipt_result, receipt_plan=_arg_11_receipt_plan, dry_run=_arg_12_dry_run)
+    return 0
 
 
 def invoke(_values: Mapping[str, Any]) -> object:

--- a/generated/workspace/python/commands/skills_report.py
+++ b/generated/workspace/python/commands/skills_report.py
@@ -20,9 +20,16 @@ from collections.abc import Mapping
 
 
 def run(args: argparse.Namespace) -> int:
-    from ..primitives.workspace_runtime import _run_skills_report_adapter
-
-    return _run_skills_report_adapter(args)
+    from agentic_workspace.workspace_runtime_primitives import _resolve_target_root, _validate_target_root
+    _arg_0_format_name = getattr(args, 'format', None)
+    _arg_1_target_root = _resolve_target_root(getattr(args, 'target', None)) if getattr(args, 'target', None) else None
+    if _arg_1_target_root is not None:
+        _validate_target_root(command_name='skills', target_root=_arg_1_target_root)
+    _arg_2_task_text = getattr(args, 'task', None)
+    _arg_3_select = getattr(args, 'select', None)
+    from agentic_workspace.workspace_runtime_primitives import _emit_skills
+    _emit_skills(format_name=_arg_0_format_name, target_root=_arg_1_target_root, task_text=_arg_2_task_text, select=_arg_3_select)
+    return 0
 
 
 def invoke(_values: Mapping[str, Any]) -> object:

--- a/generated/workspace/python/primitives/workspace_runtime.py
+++ b/generated/workspace/python/primitives/workspace_runtime.py
@@ -295,42 +295,6 @@ def _run_lifecycle_report_adapter(*args: Any, **kwargs: Any) -> Any:
     return source_function(*args, **kwargs)
 
 
-def _run_memory_front_door_adapter(*args: Any, **kwargs: Any) -> Any:
-    from agentic_workspace.workspace_runtime_primitives import _run_memory_front_door_adapter as source_function
-
-    return source_function(*args, **kwargs)
-
-
-def _run_modules_report_adapter(*args: Any, **kwargs: Any) -> Any:
-    from agentic_workspace.workspace_runtime_primitives import _run_modules_report_adapter as source_function
-
-    return source_function(*args, **kwargs)
-
-
-def _run_ownership_report_adapter(*args: Any, **kwargs: Any) -> Any:
-    from agentic_workspace.workspace_runtime_primitives import _run_ownership_report_adapter as source_function
-
-    return source_function(*args, **kwargs)
-
-
-def _run_planning_front_door_adapter(*args: Any, **kwargs: Any) -> Any:
-    from agentic_workspace.workspace_runtime_primitives import _run_planning_front_door_adapter as source_function
-
-    return source_function(*args, **kwargs)
-
-
-def _run_preflight_report_adapter(*args: Any, **kwargs: Any) -> Any:
-    from agentic_workspace.workspace_runtime_primitives import _run_preflight_report_adapter as source_function
-
-    return source_function(*args, **kwargs)
-
-
-def _run_proof_report_adapter(*args: Any, **kwargs: Any) -> Any:
-    from agentic_workspace.workspace_runtime_primitives import _run_proof_report_adapter as source_function
-
-    return source_function(*args, **kwargs)
-
-
 def _run_reconcile_report_adapter(*args: Any, **kwargs: Any) -> Any:
     from agentic_workspace.workspace_runtime_primitives import _run_reconcile_report_adapter as source_function
 
@@ -345,12 +309,6 @@ def _run_report_combined_adapter(*args: Any, **kwargs: Any) -> Any:
 
 def _run_setup_guidance_adapter(*args: Any, **kwargs: Any) -> Any:
     from agentic_workspace.workspace_runtime_primitives import _run_setup_guidance_adapter as source_function
-
-    return source_function(*args, **kwargs)
-
-
-def _run_skills_report_adapter(*args: Any, **kwargs: Any) -> Any:
-    from agentic_workspace.workspace_runtime_primitives import _run_skills_report_adapter as source_function
 
     return source_function(*args, **kwargs)
 
@@ -402,16 +360,9 @@ __all__ = [
     '_run_init_lifecycle_adapter',
     '_run_lifecycle_mutation_adapter',
     '_run_lifecycle_report_adapter',
-    '_run_memory_front_door_adapter',
-    '_run_modules_report_adapter',
-    '_run_ownership_report_adapter',
-    '_run_planning_front_door_adapter',
-    '_run_preflight_report_adapter',
-    '_run_proof_report_adapter',
     '_run_reconcile_report_adapter',
     '_run_report_combined_adapter',
     '_run_setup_guidance_adapter',
-    '_run_skills_report_adapter',
     '_run_start_context_adapter',
     '_run_summary_report_adapter',
     '_select_workspace_operation_defaults',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ agentic-workspace = "agentic_workspace.cli:main"
 
 [dependency-groups]
 dev = [
-  "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl#sha256=92886c2dbc06fb8651e26ccdeefa0c1446fb4e1614219b2db024ed487f09d762",
+  "command-generation @ git+https://github.com/rickardvh/command-generation.git@234c80cf546d233851af9ee4e1e9fc444879c8e3",
   "jsonschema",
   "pre-commit",
   "pytest",

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -120,6 +120,7 @@ PYTHON_COMPLETION_EXPECTED_PROOF_SUBSTRINGS = {
 }
 PYTHON_OPERATION_EXECUTION_FINAL_STATUSES = {
     "portable-codegen-primitive-executed",
+    "generated-runtime-handler",
     "domain-runtime-primitive-via-ir",
     "accepted-hand-owned-runtime-primitive",
 }
@@ -1575,7 +1576,7 @@ def _validate_full_python_completion_executable_ownership(ir: dict[str, object])
             "source is still present and must be proven permanent or retired: "
             f"{existing_runtime_source!r}"
         )
-    runtime_imports = _generated_command_module_package_runtime_imports()
+    runtime_imports = _generated_command_module_package_runtime_imports(ir)
     if runtime_imports:
         errors.append(
             "command_package_ir.json cannot claim full Python generated CLI completion while generated command modules "
@@ -1617,7 +1618,36 @@ def _generated_runtime_facade_package_runtime_imports() -> list[str]:
     return findings
 
 
-def _generated_command_module_package_runtime_imports() -> list[str]:
+def _module_name_for_operation(operation_id: str) -> str:
+    return re.sub(r"[^0-9A-Za-z]+", "_", operation_id).strip("_")
+
+
+def _generated_runtime_handler_command_module_paths(ir: dict[str, object]) -> set[str]:
+    paths: set[str] = set()
+    package_roots = {
+        "root-workspace": "workspace",
+        "planning-bootstrap": "planning",
+        "memory-bootstrap": "memory",
+        "verification-cli": "verification",
+    }
+    for package in ir.get("packages", []):
+        if not isinstance(package, dict):
+            continue
+        package_id = str(package.get("id") or "")
+        generated_root = package_roots.get(package_id)
+        binding = package.get("python_runtime_binding", {})
+        if not generated_root or not isinstance(binding, dict):
+            continue
+        for handler in binding.get("runtime_module_handlers", []):
+            if not isinstance(handler, dict) or handler.get("handler") not in {"module_front_door", "argparse_function_call"}:
+                continue
+            operation_id = str(handler.get("operation_id") or "")
+            if operation_id:
+                paths.add(f"generated/{generated_root}/python/commands/{_module_name_for_operation(operation_id)}.py")
+    return paths
+
+
+def _generated_command_module_package_runtime_imports(ir: dict[str, object]) -> list[str]:
     forbidden_imports = (
         "from agentic_workspace.workspace_runtime_primitives import",
         "from repo_planning_bootstrap.runtime_projection import",
@@ -1625,6 +1655,7 @@ def _generated_command_module_package_runtime_imports() -> list[str]:
         "from repo_planning_bootstrap.installer import",
         "from repo_memory_bootstrap.installer import",
     )
+    allowed_generated_runtime_handler_paths = _generated_runtime_handler_command_module_paths(ir)
     findings: list[str] = []
     for commands_dir in (
         REPO_ROOT / "generated" / "workspace" / "python" / "commands",
@@ -1634,9 +1665,12 @@ def _generated_command_module_package_runtime_imports() -> list[str]:
         if not commands_dir.is_dir():
             continue
         for path in sorted(commands_dir.glob("*.py")):
+            relative_path = path.relative_to(REPO_ROOT).as_posix()
+            if relative_path in allowed_generated_runtime_handler_paths:
+                continue
             text = path.read_text(encoding="utf-8")
             if any(import_text in text for import_text in forbidden_imports):
-                findings.append(path.relative_to(REPO_ROOT).as_posix())
+                findings.append(relative_path)
     return findings
 
 

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -505,33 +505,663 @@
           },
           {
             "operation_id": "memory.front-door",
-            "import_module": "agentic_workspace.workspace_runtime_primitives",
-            "function": "_run_memory_front_door_adapter"
+            "handler": "module_front_door",
+            "command_attr": "memory_command",
+            "module_import": "repo_memory_bootstrap.cli",
+            "module_main": "main",
+            "module_program": "agentic-memory",
+            "help_payload_import_module": "agentic_workspace.workspace_runtime_primitives",
+            "help_payload_function": "_memory_help_payload",
+            "help_text_function": "_print_memory_help",
+            "missing_module_message": "The memory module must be installed to use memory subcommands.",
+            "stdout_replacements": [
+              {
+                "old": "agentic-memory ",
+                "new": "agentic-workspace memory "
+              }
+            ],
+            "positionals": [
+              {
+                "commands": [
+                  "capture-note",
+                  "create-note"
+                ],
+                "attr": "slug"
+              }
+            ],
+            "option_specs": [
+              {
+                "option": "--target",
+                "attr": "target"
+              },
+              {
+                "option": "--title",
+                "attr": "title"
+              },
+              {
+                "option": "--folder",
+                "attr": "folder"
+              },
+              {
+                "option": "--note-type",
+                "attr": "note_type"
+              },
+              {
+                "option": "--summary",
+                "attr": "summary"
+              },
+              {
+                "option": "--task",
+                "attr": "task"
+              },
+              {
+                "option": "--stage",
+                "attr": "stage"
+              },
+              {
+                "option": "--existing-note",
+                "attr": "existing_note"
+              },
+              {
+                "option": "--force-new-reason",
+                "attr": "force_new_reason"
+              },
+              {
+                "option": "--mode",
+                "attr": "mode"
+              },
+              {
+                "option": "--memory-role",
+                "attr": "memory_role"
+              },
+              {
+                "option": "--promotion-target",
+                "attr": "promotion_target"
+              },
+              {
+                "option": "--promotion-trigger",
+                "attr": "promotion_trigger"
+              },
+              {
+                "option": "--retention-after-promotion",
+                "attr": "retention_after_promotion"
+              },
+              {
+                "option": "--local-reason",
+                "attr": "local_reason"
+              },
+              {
+                "option": "--applies-to",
+                "attr": "applies_to",
+                "kind": "repeated_group"
+              },
+              {
+                "option": "--use-when",
+                "attr": "use_when",
+                "kind": "repeated_group"
+              },
+              {
+                "option": "--routes-from",
+                "attr": "routes_from",
+                "kind": "repeated_group"
+              },
+              {
+                "option": "--stale-when",
+                "attr": "stale_when",
+                "kind": "repeated_group"
+              },
+              {
+                "option": "--evidence",
+                "attr": "evidence",
+                "kind": "repeated_group"
+              },
+              {
+                "option": "--files",
+                "attr": "files",
+                "kind": "repeated_group"
+              },
+              {
+                "option": "--surface",
+                "attr": "surfaces",
+                "kind": "repeated_group"
+              },
+              {
+                "option": "--notes",
+                "attr": "notes",
+                "kind": "repeated_group"
+              },
+              {
+                "option": "--local",
+                "attr": "local",
+                "kind": "flag"
+              },
+              {
+                "option": "--dry-run",
+                "attr": "dry_run",
+                "kind": "flag"
+              },
+              {
+                "option": "--verbose",
+                "attr": "verbose",
+                "kind": "flag"
+              },
+              {
+                "option": "--format",
+                "attr": "format"
+              }
+            ]
           },
           {
             "operation_id": "modules.report",
+            "handler": "argparse_function_call",
             "import_module": "agentic_workspace.workspace_runtime_primitives",
-            "function": "_run_modules_report_adapter"
+            "function": "_emit_modules",
+            "support_import_module": "agentic_workspace.workspace_runtime_primitives",
+            "result": "return_zero",
+            "arguments": [
+              {
+                "name": "format_name",
+                "kind": "attr",
+                "attr": "format"
+              },
+              {
+                "name": "target_root",
+                "kind": "target_root",
+                "attr": "target",
+                "default_current": false,
+                "allow_none": true,
+                "validate_command": "modules"
+              },
+              {
+                "name": "profile",
+                "kind": "diagnostic_profile",
+                "default": "tiny"
+              }
+            ]
           },
           {
             "operation_id": "ownership.report",
+            "handler": "argparse_function_call",
             "import_module": "agentic_workspace.workspace_runtime_primitives",
-            "function": "_run_ownership_report_adapter"
+            "function": "_emit_ownership",
+            "support_import_module": "agentic_workspace.workspace_runtime_primitives",
+            "result": "return_zero",
+            "arguments": [
+              {
+                "name": "format_name",
+                "kind": "attr",
+                "attr": "format"
+              },
+              {
+                "name": "target_root",
+                "kind": "target_root",
+                "attr": "target",
+                "validate_command": "ownership"
+              },
+              {
+                "name": "descriptors",
+                "kind": "module_descriptors"
+              },
+              {
+                "name": "concern",
+                "kind": "attr",
+                "attr": "concern"
+              },
+              {
+                "name": "repo_path",
+                "kind": "attr",
+                "attr": "path"
+              }
+            ]
           },
           {
             "operation_id": "planning.front-door",
-            "import_module": "agentic_workspace.workspace_runtime_primitives",
-            "function": "_run_planning_front_door_adapter"
+            "handler": "module_front_door",
+            "command_attr": "planning_command",
+            "module_import": "repo_planning_bootstrap.cli",
+            "module_main": "main",
+            "module_program": "agentic-planning",
+            "help_payload_import_module": "agentic_workspace.workspace_runtime_primitives",
+            "help_payload_function": "_planning_help_payload",
+            "help_text_function": "_print_planning_help",
+            "missing_module_message": "The planning module must be installed to use planning subcommands.",
+            "stdout_replacements": [
+              {
+                "old": "agentic-planning reconcile ",
+                "new": "agentic-workspace reconcile "
+              },
+              {
+                "old": "agentic-planning summary ",
+                "new": "agentic-workspace summary "
+              },
+              {
+                "old": "agentic-planning doctor ",
+                "new": "agentic-workspace doctor "
+              },
+              {
+                "old": "agentic-planning ",
+                "new": "agentic-workspace planning "
+              },
+              {
+                "old": "agentic-memory ",
+                "new": "agentic-workspace memory "
+              }
+            ],
+            "local_command_handlers": [
+              {
+                "command": "decision-scaffold",
+                "import_module": "agentic_workspace.workspace_runtime_primitives",
+                "function": "_run_planning_decision_adapter"
+              },
+              {
+                "command": "decision-promote",
+                "import_module": "agentic_workspace.workspace_runtime_primitives",
+                "function": "_run_planning_decision_adapter"
+              }
+            ],
+            "positionals": [
+              {
+                "commands": [
+                  "promote-to-plan"
+                ],
+                "attr": "item_id"
+              },
+              {
+                "commands": [
+                  "lane-promote",
+                  "lane-activate",
+                  "lane-close",
+                  "lane-archive"
+                ],
+                "attr": "lane"
+              },
+              {
+                "commands": [
+                  "archive-plan",
+                  "closeout"
+                ],
+                "attr": "plan"
+              },
+              {
+                "commands": [
+                  "close-item"
+                ],
+                "attr": "item"
+              },
+              {
+                "commands": [
+                  "create-review"
+                ],
+                "attr": "slug"
+              }
+            ],
+            "option_specs": [
+              {
+                "option": "--id",
+                "attr": "id"
+              },
+              {
+                "option": "--title",
+                "attr": "title"
+              },
+              {
+                "option": "--source",
+                "attr": "source"
+              },
+              {
+                "option": "--artifact",
+                "attr": "artifact"
+              },
+              {
+                "option": "--target",
+                "attr": "target"
+              },
+              {
+                "option": "--plan-slug",
+                "attr": "plan_slug"
+              },
+              {
+                "option": "--scope",
+                "attr": "scope"
+              },
+              {
+                "option": "--classification",
+                "attr": "classification"
+              },
+              {
+                "option": "--route",
+                "attr": "route"
+              },
+              {
+                "option": "--current-slice",
+                "attr": "current_slice"
+              },
+              {
+                "option": "--proof",
+                "attr": "proof"
+              },
+              {
+                "option": "--residual-work",
+                "attr": "residual_work"
+              },
+              {
+                "option": "--parent-contribution",
+                "attr": "parent_contribution"
+              },
+              {
+                "option": "--parent-close-permission",
+                "attr": "parent_close_permission"
+              },
+              {
+                "option": "--next-owner",
+                "attr": "next_owner"
+              },
+              {
+                "option": "--skipped-reason",
+                "attr": "skipped_reason"
+              },
+              {
+                "option": "--expected-savings",
+                "attr": "expected_savings"
+              },
+              {
+                "option": "--actual-friction",
+                "attr": "actual_friction"
+              },
+              {
+                "option": "--proof-result",
+                "attr": "proof_result"
+              },
+              {
+                "option": "--quality-concern",
+                "attr": "quality_concern"
+              },
+              {
+                "option": "--decomposition-adjustment",
+                "attr": "decomposition_adjustment"
+              },
+              {
+                "option": "--reason",
+                "attr": "reason"
+              },
+              {
+                "option": "--issue",
+                "attr": "issue"
+              },
+              {
+                "option": "--parent-lane-closeout",
+                "attr": "parent_lane_closeout"
+              },
+              {
+                "option": "--closure-decision",
+                "attr": "closure_decision"
+              },
+              {
+                "option": "--intent-satisfied",
+                "attr": "intent_satisfied"
+              },
+              {
+                "option": "--unsolved-intent",
+                "attr": "unsolved_intent"
+              },
+              {
+                "option": "--intent-evidence",
+                "attr": "intent_evidence"
+              },
+              {
+                "option": "--closure-reason",
+                "attr": "closure_reason"
+              },
+              {
+                "option": "--closure-evidence",
+                "attr": "closure_evidence"
+              },
+              {
+                "option": "--reopen-trigger",
+                "attr": "reopen_trigger"
+              },
+              {
+                "option": "--discard-summary",
+                "attr": "discard_summary"
+              },
+              {
+                "option": "--continuation-summary",
+                "attr": "continuation_summary"
+              },
+              {
+                "option": "--claim-level",
+                "attr": "claim_level"
+              },
+              {
+                "option": "--intent-status",
+                "attr": "intent_status"
+              },
+              {
+                "option": "--residue",
+                "attr": "residue"
+              },
+              {
+                "option": "--proof-from",
+                "attr": "proof_from"
+              },
+              {
+                "option": "--residue-owner",
+                "attr": "residue_owner"
+              },
+              {
+                "option": "--what-happened",
+                "attr": "what_happened"
+              },
+              {
+                "option": "--scope-touched",
+                "attr": "scope_touched"
+              },
+              {
+                "option": "--changed-surfaces",
+                "attr": "changed_surfaces"
+              },
+              {
+                "option": "--review-summary",
+                "attr": "review_summary"
+              },
+              {
+                "option": "--outcome-summary",
+                "attr": "outcome_summary"
+              },
+              {
+                "option": "--expect-planning-revision",
+                "attr": "expect_planning_revision"
+              },
+              {
+                "option": "--activate",
+                "attr": "activate",
+                "kind": "flag"
+              },
+              {
+                "option": "--queue",
+                "attr": "queue",
+                "kind": "flag"
+              },
+              {
+                "option": "--switch-active",
+                "attr": "switch_active",
+                "kind": "flag"
+              },
+              {
+                "option": "--prep-only",
+                "attr": "prep_only",
+                "kind": "flag"
+              },
+              {
+                "option": "--overwrite",
+                "attr": "overwrite",
+                "kind": "flag"
+              },
+              {
+                "option": "--remove-source",
+                "attr": "remove_source",
+                "kind": "flag"
+              },
+              {
+                "option": "--dry-run",
+                "attr": "dry_run",
+                "kind": "flag"
+              },
+              {
+                "option": "--render-markdown",
+                "attr": "render_markdown",
+                "kind": "flag"
+              },
+              {
+                "option": "--apply-cleanup",
+                "attr": "apply_cleanup",
+                "kind": "flag"
+              },
+              {
+                "option": "--prepare-closeout",
+                "attr": "prepare_closeout",
+                "kind": "flag"
+              },
+              {
+                "option": "--retain-archive",
+                "attr": "retain_archive",
+                "kind": "flag"
+              },
+              {
+                "option": "--discard-archive",
+                "attr": "discard_archive",
+                "kind": "flag"
+              },
+              {
+                "option": "--verbose",
+                "attr": "verbose",
+                "kind": "flag"
+              },
+              {
+                "option": "--path",
+                "attr": "paths",
+                "fallback_attr": "path",
+                "kind": "repeated"
+              },
+              {
+                "option": "--format",
+                "attr": "format"
+              }
+            ]
           },
           {
             "operation_id": "preflight.report",
+            "handler": "argparse_function_call",
             "import_module": "agentic_workspace.workspace_runtime_primitives",
-            "function": "_run_preflight_report_adapter"
+            "function": "_run_preflight_command",
+            "support_import_module": "agentic_workspace.workspace_runtime_primitives",
+            "result": "emit_payload",
+            "emit_payload": {
+              "import_module": "agentic_workspace.workspace_runtime_primitives",
+              "function": "_emit_payload",
+              "format_attr": "format"
+            },
+            "arguments": [
+              {
+                "name": "target_root",
+                "kind": "target_root",
+                "attr": "target",
+                "validate_command": "preflight"
+              },
+              {
+                "name": "active_only",
+                "kind": "bool_attr",
+                "attr": "active_only"
+              },
+              {
+                "name": "task_text",
+                "kind": "attr",
+                "attr": "task"
+              },
+              {
+                "name": "profile",
+                "kind": "diagnostic_profile",
+                "default": "tiny"
+              }
+            ]
           },
           {
             "operation_id": "proof.report",
+            "handler": "argparse_function_call",
             "import_module": "agentic_workspace.workspace_runtime_primitives",
-            "function": "_run_proof_report_adapter"
+            "function": "_emit_proof",
+            "support_import_module": "agentic_workspace.workspace_runtime_primitives",
+            "result": "return_zero",
+            "arguments": [
+              {
+                "name": "format_name",
+                "kind": "attr",
+                "attr": "format"
+              },
+              {
+                "name": "target_root",
+                "kind": "target_root",
+                "attr": "target",
+                "validate_command": "proof"
+              },
+              {
+                "name": "descriptors",
+                "kind": "module_descriptors"
+              },
+              {
+                "name": "route",
+                "kind": "attr",
+                "attr": "route"
+              },
+              {
+                "name": "current_only",
+                "kind": "bool_attr",
+                "attr": "current"
+              },
+              {
+                "name": "changed_paths",
+                "kind": "list_attr",
+                "attr": "changed"
+              },
+              {
+                "name": "profile",
+                "kind": "diagnostic_profile",
+                "default": "tiny"
+              },
+              {
+                "name": "select",
+                "kind": "attr",
+                "attr": "select"
+              },
+              {
+                "name": "record_receipt",
+                "kind": "bool_attr",
+                "attr": "record_receipt"
+              },
+              {
+                "name": "receipt_command",
+                "kind": "attr",
+                "attr": "receipt_command",
+                "default": ""
+              },
+              {
+                "name": "receipt_result",
+                "kind": "attr",
+                "attr": "receipt_result",
+                "default": ""
+              },
+              {
+                "name": "receipt_plan",
+                "kind": "attr",
+                "attr": "receipt_plan",
+                "default": ""
+              },
+              {
+                "name": "dry_run",
+                "kind": "bool_attr",
+                "attr": "dry_run"
+              }
+            ]
           },
           {
             "operation_id": "reconcile.report",
@@ -550,8 +1180,36 @@
           },
           {
             "operation_id": "skills.report",
+            "handler": "argparse_function_call",
             "import_module": "agentic_workspace.workspace_runtime_primitives",
-            "function": "_run_skills_report_adapter"
+            "function": "_emit_skills",
+            "support_import_module": "agentic_workspace.workspace_runtime_primitives",
+            "result": "return_zero",
+            "arguments": [
+              {
+                "name": "format_name",
+                "kind": "attr",
+                "attr": "format"
+              },
+              {
+                "name": "target_root",
+                "kind": "target_root",
+                "attr": "target",
+                "default_current": false,
+                "allow_none": true,
+                "validate_command": "skills"
+              },
+              {
+                "name": "task_text",
+                "kind": "attr",
+                "attr": "task"
+              },
+              {
+                "name": "select",
+                "kind": "attr",
+                "attr": "select"
+              }
+            ]
           },
           {
             "operation_id": "start.context",

--- a/src/agentic_workspace/contracts/python_operation_execution_inventory.json
+++ b/src/agentic_workspace/contracts/python_operation_execution_inventory.json
@@ -4,6 +4,7 @@
   "status_meanings": {
     "portable-codegen-primitive-executed": "Generated Python command loads a generated operation artifact whose steps are implemented by codegen-owned portable primitives only.",
     "domain-runtime-primitive-via-ir": "Generated Python command loads a generated operation artifact and executes it through codegen-owned dataflow, but one or more steps are package-domain runtime primitives rather than portable codegen primitives.",
+    "generated-runtime-handler": "Generated Python command executes a command-generation rendered runtime handler from declarative metadata without an AW-owned _run_* adapter, while delegated package CLIs retain their own command semantics.",
     "accepted-hand-owned-runtime-primitive": "Generated Python parser/dispatch/interface metadata selects an operation id, then a thin _run_*_adapter delegates to hand-owned package runtime primitives. Each accepted entry must declare runtime_boundary_class and runtime_boundary_reason so full completion can distinguish package-specific judgment/live inspection/mutation orchestration from generic deterministic runtime debt.",
     "compatibility-runtime-handler": "Temporary unaccepted fallback status; full Python completion must reject this status.",
     "runtime_boundary_class": "Classifies accepted hand-owned runtime entries as package-specific-judgment, live-workspace-inspection, mutation-orchestration, front-door-dispatch, provider-integration, or generic-deterministic-runtime-debt. generic-deterministic-runtime-debt blocks full-generated-cli-complete."
@@ -429,18 +430,16 @@
       "command": "memory",
       "generated_transport": "generated/workspace/python/cli.py",
       "operation_contract": "operations/memory.front-door.json",
-      "primitive_executor": null,
+      "primitive_executor": "command_generation/module_front_door",
       "hand_owned_runtime_code": [
-        "memory.front_door.dispatch",
-        "module generated CLI fallback",
-        "output emission mechanics"
+        "none; command-generation renders module_front_door help, delegation argv, stdout rewrite, and missing-module handling from command_package_ir.json"
       ],
-      "status": "accepted-hand-owned-runtime-primitive",
+      "status": "generated-runtime-handler",
       "conformance_ref": "memory.front-door.process",
-      "runtime_boundary_class": "front-door-dispatch",
-      "runtime_boundary_reason": "The root command delegates to the module front door, including commands outside this Python generated CLI completion lane.",
-      "what_would_make_portable_later": "Represent this operation as schema-backed IR steps using codegen-owned primitives for the deterministic portions and keep only irreducible package judgment behind an explicit domain primitive.",
-      "generic_behavior_audit": "Classified as front-door-dispatch; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+      "generated_handler": "module_front_door",
+      "handler_contract_owner": "command-generation",
+      "delegated_runtime_owner": "agentic-memory CLI",
+      "generic_behavior_audit": "Command-generation owns the front-door adapter mechanics from declarative metadata; the delegated Memory CLI owns package command semantics."
     },
     {
       "operation_id": "memory.list-files.report",
@@ -703,18 +702,22 @@
       "command": "modules",
       "generated_transport": "generated/workspace/python/cli.py",
       "operation_contract": "operations/modules.report.json",
-      "primitive_executor": null,
+      "primitive_executor": "command_generation/argparse_function_call",
       "hand_owned_runtime_code": [
         "workspace.target-root.resolve",
         "workspace.modules.inspect",
         "output emission mechanics"
       ],
-      "status": "accepted-hand-owned-runtime-primitive",
+      "status": "generated-runtime-handler",
       "conformance_ref": "modules.report.process",
-      "runtime_boundary_class": "live-workspace-inspection",
-      "runtime_boundary_reason": "Module inspection detects installed module state and descriptors in the target repository.",
-      "what_would_make_portable_later": "Represent this operation as schema-backed IR steps using codegen-owned primitives for the deterministic portions and keep only irreducible package judgment behind an explicit domain primitive.",
-      "generic_behavior_audit": "Classified as live-workspace-inspection; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+      "runtime_boundary_class": "generated-runtime-handler",
+      "runtime_boundary_reason": "Command-generation owns argparse argument mapping, target/profile setup, and command-level dispatch from declarative runtime_module_handlers metadata; AW runtime primitives retain package-specific payload and emission semantics.",
+      "what_would_make_portable_later": "Already generated at the command handler level; remaining imported runtime functions are explicit package-domain payload or emitter primitives.",
+      "generic_behavior_audit": "Command-generation owns the deterministic adapter mechanics from declarative metadata; AW-owned runtime functions own semantic payload construction, validation policy, live inspection, or output policy as named imports.",
+      "completion_blockers": [],
+      "primitive_refs": [
+        "runtime_module_handler:modules.report"
+      ]
     },
     {
       "operation_id": "ownership.report",
@@ -722,18 +725,22 @@
       "command": "ownership",
       "generated_transport": "generated/workspace/python/cli.py",
       "operation_contract": "operations/ownership.report.json",
-      "primitive_executor": null,
+      "primitive_executor": "command_generation/argparse_function_call",
       "hand_owned_runtime_code": [
         "workspace.target-root.resolve",
         "ownership.answer.resolve",
         "output emission mechanics"
       ],
-      "status": "accepted-hand-owned-runtime-primitive",
+      "status": "generated-runtime-handler",
       "conformance_ref": "ownership.report.process",
-      "runtime_boundary_class": "package-specific-judgment",
-      "runtime_boundary_reason": "Ownership answers apply package-specific ownership policy and route resolution.",
-      "what_would_make_portable_later": "Represent this operation as schema-backed IR steps using codegen-owned primitives for the deterministic portions and keep only irreducible package judgment behind an explicit domain primitive.",
-      "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+      "runtime_boundary_class": "generated-runtime-handler",
+      "runtime_boundary_reason": "Command-generation owns argparse argument mapping, target/profile setup, and command-level dispatch from declarative runtime_module_handlers metadata; AW runtime primitives retain package-specific payload and emission semantics.",
+      "what_would_make_portable_later": "Already generated at the command handler level; remaining imported runtime functions are explicit package-domain payload or emitter primitives.",
+      "generic_behavior_audit": "Command-generation owns the deterministic adapter mechanics from declarative metadata; AW-owned runtime functions own semantic payload construction, validation policy, live inspection, or output policy as named imports.",
+      "completion_blockers": [],
+      "primitive_refs": [
+        "runtime_module_handler:ownership.report"
+      ]
     },
     {
       "operation_id": "planning.adopt.lifecycle",
@@ -888,18 +895,16 @@
       "command": "planning",
       "generated_transport": "generated/workspace/python/cli.py",
       "operation_contract": "operations/planning.front-door.json",
-      "primitive_executor": null,
+      "primitive_executor": "command_generation/module_front_door",
       "hand_owned_runtime_code": [
-        "planning.front_door.dispatch",
-        "module generated CLI fallback",
-        "output emission mechanics"
+        "none; command-generation renders module_front_door help, delegation argv, stdout rewrite, local override routing, and missing-module handling from command_package_ir.json"
       ],
-      "status": "accepted-hand-owned-runtime-primitive",
+      "status": "generated-runtime-handler",
       "conformance_ref": "planning.front-door.process",
-      "runtime_boundary_class": "front-door-dispatch",
-      "runtime_boundary_reason": "The root command delegates to the module front door, including commands outside this Python generated CLI completion lane.",
-      "what_would_make_portable_later": "Represent this operation as schema-backed IR steps using codegen-owned primitives for the deterministic portions and keep only irreducible package judgment behind an explicit domain primitive.",
-      "generic_behavior_audit": "Classified as front-door-dispatch; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+      "generated_handler": "module_front_door",
+      "handler_contract_owner": "command-generation",
+      "delegated_runtime_owner": "agentic-planning CLI",
+      "generic_behavior_audit": "Command-generation owns the front-door adapter mechanics from declarative metadata; the delegated Planning CLI owns package command semantics."
     },
     {
       "operation_id": "planning.handoff.report",
@@ -1319,7 +1324,7 @@
       "command": "preflight",
       "generated_transport": "generated/workspace/python/cli.py",
       "operation_contract": "operations/preflight.report.json",
-      "primitive_executor": null,
+      "primitive_executor": "command_generation/argparse_function_call",
       "hand_owned_runtime_code": [
         "workspace.target-root.resolve",
         "workspace.defaults.load",
@@ -1329,12 +1334,16 @@
         "preflight.context.assemble",
         "output emission mechanics"
       ],
-      "status": "accepted-hand-owned-runtime-primitive",
+      "status": "generated-runtime-handler",
       "conformance_ref": "preflight.report.process",
-      "runtime_boundary_class": "package-specific-judgment",
-      "runtime_boundary_reason": "Preflight context assembly applies package startup, planning, proof, and token policy.",
-      "what_would_make_portable_later": "Represent this operation as schema-backed IR steps using codegen-owned primitives for the deterministic portions and keep only irreducible package judgment behind an explicit domain primitive.",
-      "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+      "runtime_boundary_class": "generated-runtime-handler",
+      "runtime_boundary_reason": "Command-generation owns argparse argument mapping, target/profile setup, and command-level dispatch from declarative runtime_module_handlers metadata; AW runtime primitives retain package-specific payload and emission semantics.",
+      "what_would_make_portable_later": "Already generated at the command handler level; remaining imported runtime functions are explicit package-domain payload or emitter primitives.",
+      "generic_behavior_audit": "Command-generation owns the deterministic adapter mechanics from declarative metadata; AW-owned runtime functions own semantic payload construction, validation policy, live inspection, or output policy as named imports.",
+      "completion_blockers": [],
+      "primitive_refs": [
+        "runtime_module_handler:preflight.report"
+      ]
     },
     {
       "operation_id": "prompt.init",
@@ -1411,7 +1420,7 @@
       "command": "proof",
       "generated_transport": "generated/workspace/python/cli.py",
       "operation_contract": "operations/proof.report.json",
-      "primitive_executor": null,
+      "primitive_executor": "command_generation/argparse_function_call",
       "hand_owned_runtime_code": [
         "workspace.target-root.resolve",
         "proof.routes.resolve",
@@ -1420,12 +1429,16 @@
         "output.fields.select",
         "output emission mechanics"
       ],
-      "status": "accepted-hand-owned-runtime-primitive",
+      "status": "generated-runtime-handler",
       "conformance_ref": "proof.report.process",
-      "runtime_boundary_class": "package-specific-judgment",
-      "runtime_boundary_reason": "Proof route selection applies package-specific proof policy, changed-path routing, and durable-surface review.",
-      "what_would_make_portable_later": "Represent this operation as schema-backed IR steps using codegen-owned primitives for the deterministic portions and keep only irreducible package judgment behind an explicit domain primitive.",
-      "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+      "runtime_boundary_class": "generated-runtime-handler",
+      "runtime_boundary_reason": "Command-generation owns argparse argument mapping, target/profile setup, and command-level dispatch from declarative runtime_module_handlers metadata; AW runtime primitives retain package-specific payload and emission semantics.",
+      "what_would_make_portable_later": "Already generated at the command handler level; remaining imported runtime functions are explicit package-domain payload or emitter primitives.",
+      "generic_behavior_audit": "Command-generation owns the deterministic adapter mechanics from declarative metadata; AW-owned runtime functions own semantic payload construction, validation policy, live inspection, or output policy as named imports.",
+      "completion_blockers": [],
+      "primitive_refs": [
+        "runtime_module_handler:proof.report"
+      ]
     },
     {
       "operation_id": "reconcile.report",
@@ -1495,19 +1508,23 @@
       "command": "skills",
       "generated_transport": "generated/workspace/python/cli.py",
       "operation_contract": "operations/skills.report.json",
-      "primitive_executor": null,
+      "primitive_executor": "command_generation/argparse_function_call",
       "hand_owned_runtime_code": [
         "workspace.target-root.resolve",
         "skills.registry.inspect",
         "output.fields.select",
         "output emission mechanics"
       ],
-      "status": "accepted-hand-owned-runtime-primitive",
+      "status": "generated-runtime-handler",
       "conformance_ref": "skills.report.process",
-      "runtime_boundary_class": "package-specific-judgment",
-      "runtime_boundary_reason": "Skill recommendation and ranking applies package-specific registry and task-routing policy.",
-      "what_would_make_portable_later": "Represent this operation as schema-backed IR steps using codegen-owned primitives for the deterministic portions and keep only irreducible package judgment behind an explicit domain primitive.",
-      "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
+      "runtime_boundary_class": "generated-runtime-handler",
+      "runtime_boundary_reason": "Command-generation owns argparse argument mapping, target/profile setup, and command-level dispatch from declarative runtime_module_handlers metadata; AW runtime primitives retain package-specific payload and emission semantics.",
+      "what_would_make_portable_later": "Already generated at the command handler level; remaining imported runtime functions are explicit package-domain payload or emitter primitives.",
+      "generic_behavior_audit": "Command-generation owns the deterministic adapter mechanics from declarative metadata; AW-owned runtime functions own semantic payload construction, validation policy, live inspection, or output policy as named imports.",
+      "completion_blockers": [],
+      "primitive_refs": [
+        "runtime_module_handler:skills.report"
+      ]
     },
     {
       "operation_id": "start.context",
@@ -1664,5 +1681,5 @@
       "generic_behavior_audit": "Classified as mutation-orchestration; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior."
     }
   ],
-  "completion_rule": "Python completion can be claimed only when every generated Python operation is inventoried as portable-codegen-primitive-executed, domain-runtime-primitive-via-ir, or accepted-hand-owned-runtime-primitive; domain-runtime-primitive-via-ir and accepted-hand-owned-runtime-primitive entries are transitional unless their audit proves they do not hide generic deterministic runtime debt."
+  "completion_rule": "Python completion can be claimed only when every generated Python operation is inventoried as portable-codegen-primitive-executed, generated-runtime-handler, domain-runtime-primitive-via-ir, or accepted-hand-owned-runtime-primitive; domain-runtime-primitive-via-ir and accepted-hand-owned-runtime-primitive entries are transitional unless their audit proves they do not hide generic deterministic runtime debt."
 }

--- a/src/agentic_workspace/contracts/python_runtime_projection_inventory.json
+++ b/src/agentic_workspace/contracts/python_runtime_projection_inventory.json
@@ -81,16 +81,9 @@
       "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_init_lifecycle_adapter|agentic_workspace.workspace_runtime_primitives|_run_init_lifecycle_adapter",
       "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_lifecycle_mutation_adapter|agentic_workspace.workspace_runtime_primitives|_run_lifecycle_mutation_adapter",
       "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_lifecycle_report_adapter|agentic_workspace.workspace_runtime_primitives|_run_lifecycle_report_adapter",
-      "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_memory_front_door_adapter|agentic_workspace.workspace_runtime_primitives|_run_memory_front_door_adapter",
-      "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_modules_report_adapter|agentic_workspace.workspace_runtime_primitives|_run_modules_report_adapter",
-      "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_ownership_report_adapter|agentic_workspace.workspace_runtime_primitives|_run_ownership_report_adapter",
-      "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_planning_front_door_adapter|agentic_workspace.workspace_runtime_primitives|_run_planning_front_door_adapter",
-      "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_preflight_report_adapter|agentic_workspace.workspace_runtime_primitives|_run_preflight_report_adapter",
-      "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_proof_report_adapter|agentic_workspace.workspace_runtime_primitives|_run_proof_report_adapter",
       "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_reconcile_report_adapter|agentic_workspace.workspace_runtime_primitives|_run_reconcile_report_adapter",
       "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_report_combined_adapter|agentic_workspace.workspace_runtime_primitives|_run_report_combined_adapter",
       "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_setup_guidance_adapter|agentic_workspace.workspace_runtime_primitives|_run_setup_guidance_adapter",
-      "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_skills_report_adapter|agentic_workspace.workspace_runtime_primitives|_run_skills_report_adapter",
       "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_start_context_adapter|agentic_workspace.workspace_runtime_primitives|_run_start_context_adapter",
       "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_summary_report_adapter|agentic_workspace.workspace_runtime_primitives|_run_summary_report_adapter",
       "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_select_workspace_operation_fields|agentic_workspace.workspace_runtime_primitives|_select_workspace_operation_fields"
@@ -2030,174 +2023,6 @@
       {
         "binding_kind": "runtime-facade-call",
         "facade_path": "generated/workspace/python/primitives/workspace_runtime.py",
-        "facade_symbol": "_run_memory_front_door_adapter",
-        "source_module": "agentic_workspace.workspace_runtime_primitives",
-        "source_symbol": "_run_memory_front_door_adapter",
-        "owner_package": "workspace package runtime boundary",
-        "operation_ids": [
-          "memory.front-door"
-        ],
-        "primitive_refs": [
-          "runtime_module_handler:memory.front-door"
-        ],
-        "runtime_boundary_class": "front-door-dispatch",
-        "why_not_generic_deterministic": "The symbol owns module front-door dispatch across installed package boundaries rather than deterministic target-executor logic.",
-        "conformance_ref": "memory.front-door.process",
-        "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as front-door-dispatch; the adapter loads the installed Memory module CLI, preserves module-owned command semantics, and rewrites host-facing command text. This is cross-package integration policy, not deterministic file/data/template/schema/output behavior.",
-        "minimization_category": "front-door-dispatch-extraction-candidate",
-        "minimization_route": "keep-as-hand-owned-primitive",
-        "minimization_owner": "workspace package runtime boundary for cross-package module front-door integration",
-        "minimization_tracking_issue": "#1449",
-        "stale_when": "Stale when command-generation has a stable cross-package module-dispatch primitive that can load optional installed modules, preserve module CLI semantics, rewrite host-facing command text, and report absent-module recovery without package runtime policy.",
-        "direct_edit_reasons_allowed": [
-          "existing-primitive-bugfix",
-          "new-primitive-implementation"
-        ]
-      },
-      {
-        "binding_kind": "runtime-facade-call",
-        "facade_path": "generated/workspace/python/primitives/workspace_runtime.py",
-        "facade_symbol": "_run_modules_report_adapter",
-        "source_module": "agentic_workspace.workspace_runtime_primitives",
-        "source_symbol": "_run_modules_report_adapter",
-        "owner_package": "workspace package runtime boundary",
-        "operation_ids": [
-          "modules.report"
-        ],
-        "primitive_refs": [
-          "runtime_module_handler:modules.report"
-        ],
-        "runtime_boundary_class": "live-workspace-inspection",
-        "why_not_generic_deterministic": "The symbol owns live workspace inspection and policy interpretation over target state rather than deterministic target-executor logic.",
-        "conformance_ref": "modules.report.process",
-        "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as live-workspace-inspection; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
-        "minimization_category": "live-workspace-inspection",
-        "minimization_route": "keep-as-hand-owned-primitive",
-        "minimization_owner": "package runtime primitive owner for live repository inspection semantics",
-        "minimization_tracking_issue": "#1364",
-        "stale_when": "Stale when the live inspection can be expressed as stable IR inputs plus portable filesystem/schema primitives without losing current-checkout semantics.",
-        "direct_edit_reasons_allowed": [
-          "existing-primitive-bugfix",
-          "new-primitive-implementation"
-        ]
-      },
-      {
-        "binding_kind": "runtime-facade-call",
-        "facade_path": "generated/workspace/python/primitives/workspace_runtime.py",
-        "facade_symbol": "_run_ownership_report_adapter",
-        "source_module": "agentic_workspace.workspace_runtime_primitives",
-        "source_symbol": "_run_ownership_report_adapter",
-        "owner_package": "workspace package runtime boundary",
-        "operation_ids": [
-          "ownership.report"
-        ],
-        "primitive_refs": [
-          "runtime_module_handler:ownership.report"
-        ],
-        "runtime_boundary_class": "package-specific-judgment",
-        "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
-        "conformance_ref": "ownership.report.process",
-        "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
-        "minimization_category": "package-specific-judgment",
-        "minimization_route": "keep-as-hand-owned-primitive",
-        "minimization_owner": "package runtime primitive owner for semantic package judgment",
-        "minimization_tracking_issue": "#1364",
-        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
-        "direct_edit_reasons_allowed": [
-          "existing-primitive-bugfix",
-          "new-primitive-implementation"
-        ]
-      },
-      {
-        "binding_kind": "runtime-facade-call",
-        "facade_path": "generated/workspace/python/primitives/workspace_runtime.py",
-        "facade_symbol": "_run_planning_front_door_adapter",
-        "source_module": "agentic_workspace.workspace_runtime_primitives",
-        "source_symbol": "_run_planning_front_door_adapter",
-        "owner_package": "workspace package runtime boundary",
-        "operation_ids": [
-          "planning.front-door"
-        ],
-        "primitive_refs": [
-          "runtime_module_handler:planning.front-door"
-        ],
-        "runtime_boundary_class": "front-door-dispatch",
-        "why_not_generic_deterministic": "The symbol owns module front-door dispatch across installed package boundaries rather than deterministic target-executor logic.",
-        "conformance_ref": "planning.front-door.process",
-        "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as front-door-dispatch; the adapter loads the installed Planning module CLI, preserves module-owned command semantics, rewrites host-facing command text, and routes planning decision subcommands through workspace-owned decision adapters. This is cross-package integration policy, not deterministic file/data/template/schema/output behavior.",
-        "minimization_category": "front-door-dispatch-extraction-candidate",
-        "minimization_route": "keep-as-hand-owned-primitive",
-        "minimization_owner": "workspace package runtime boundary for cross-package module front-door integration",
-        "minimization_tracking_issue": "#1449",
-        "stale_when": "Stale when command-generation has a stable cross-package module-dispatch primitive that can load optional installed modules, preserve module CLI semantics, rewrite host-facing command text, route workspace-owned decision adapters, and report absent-module recovery without package runtime policy.",
-        "direct_edit_reasons_allowed": [
-          "existing-primitive-bugfix",
-          "new-primitive-implementation"
-        ]
-      },
-      {
-        "binding_kind": "runtime-facade-call",
-        "facade_path": "generated/workspace/python/primitives/workspace_runtime.py",
-        "facade_symbol": "_run_preflight_report_adapter",
-        "source_module": "agentic_workspace.workspace_runtime_primitives",
-        "source_symbol": "_run_preflight_report_adapter",
-        "owner_package": "workspace package runtime boundary",
-        "operation_ids": [
-          "preflight.report"
-        ],
-        "primitive_refs": [
-          "runtime_module_handler:preflight.report"
-        ],
-        "runtime_boundary_class": "package-specific-judgment",
-        "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
-        "conformance_ref": "preflight.report.process",
-        "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
-        "minimization_category": "package-specific-judgment",
-        "minimization_route": "keep-as-hand-owned-primitive",
-        "minimization_owner": "package runtime primitive owner for semantic package judgment",
-        "minimization_tracking_issue": "#1364",
-        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
-        "direct_edit_reasons_allowed": [
-          "existing-primitive-bugfix",
-          "new-primitive-implementation"
-        ]
-      },
-      {
-        "binding_kind": "runtime-facade-call",
-        "facade_path": "generated/workspace/python/primitives/workspace_runtime.py",
-        "facade_symbol": "_run_proof_report_adapter",
-        "source_module": "agentic_workspace.workspace_runtime_primitives",
-        "source_symbol": "_run_proof_report_adapter",
-        "owner_package": "workspace package runtime boundary",
-        "operation_ids": [
-          "proof.report"
-        ],
-        "primitive_refs": [
-          "runtime_module_handler:proof.report"
-        ],
-        "runtime_boundary_class": "package-specific-judgment",
-        "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
-        "conformance_ref": "proof.report.process",
-        "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
-        "minimization_category": "package-specific-judgment",
-        "minimization_route": "keep-as-hand-owned-primitive",
-        "minimization_owner": "package runtime primitive owner for semantic package judgment",
-        "minimization_tracking_issue": "#1364",
-        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
-        "direct_edit_reasons_allowed": [
-          "existing-primitive-bugfix",
-          "new-primitive-implementation"
-        ]
-      },
-      {
-        "binding_kind": "runtime-facade-call",
-        "facade_path": "generated/workspace/python/primitives/workspace_runtime.py",
         "facade_symbol": "_run_reconcile_report_adapter",
         "source_module": "agentic_workspace.workspace_runtime_primitives",
         "source_symbol": "_run_reconcile_report_adapter",
@@ -2274,34 +2099,6 @@
         "minimization_owner": "package runtime primitive owner for live repository inspection semantics",
         "minimization_tracking_issue": "#1364",
         "stale_when": "Stale when the live inspection can be expressed as stable IR inputs plus portable filesystem/schema primitives without losing current-checkout semantics.",
-        "direct_edit_reasons_allowed": [
-          "existing-primitive-bugfix",
-          "new-primitive-implementation"
-        ]
-      },
-      {
-        "binding_kind": "runtime-facade-call",
-        "facade_path": "generated/workspace/python/primitives/workspace_runtime.py",
-        "facade_symbol": "_run_skills_report_adapter",
-        "source_module": "agentic_workspace.workspace_runtime_primitives",
-        "source_symbol": "_run_skills_report_adapter",
-        "owner_package": "workspace package runtime boundary",
-        "operation_ids": [
-          "skills.report"
-        ],
-        "primitive_refs": [
-          "runtime_module_handler:skills.report"
-        ],
-        "runtime_boundary_class": "package-specific-judgment",
-        "why_not_generic_deterministic": "The symbol owns package-specific policy, compatibility, or payload judgment behind an explicit operation primitive boundary rather than generic deterministic target-executor logic.",
-        "conformance_ref": "skills.report.process",
-        "status": "accepted-permanent-package-domain-boundary",
-        "generic_behavior_audit": "Classified as package-specific-judgment; current proof requires this entry to name hand-owned runtime code and explain why it is not generic deterministic file/data/template/schema/output behavior.",
-        "minimization_category": "package-specific-judgment",
-        "minimization_route": "keep-as-hand-owned-primitive",
-        "minimization_owner": "package runtime primitive owner for semantic package judgment",
-        "minimization_tracking_issue": "#1364",
-        "stale_when": "Stale when the semantic judgment becomes stable declarative dataflow or a portable primitive contract shared across packages.",
         "direct_edit_reasons_allowed": [
           "existing-primitive-bugfix",
           "new-primitive-implementation"

--- a/src/agentic_workspace/contracts/schemas/command_package_ir.schema.json
+++ b/src/agentic_workspace/contracts/schemas/command_package_ir.schema.json
@@ -3,6 +3,7 @@
   "$id": "command-generation/command-package-ir.schema.json",
   "title": "Command Generation Command Package IR",
   "description": "Intermediate representation for generating command package metadata and language/runtime adapters.",
+  "x-agentic-workspace-doc-role": "contract-reference",
   "type": "object",
   "required": [
     "schema_version",
@@ -463,27 +464,306 @@
             "runtime_module_handlers": {
               "type": "array",
               "items": {
-                "type": "object",
-                "required": [
-                  "operation_id",
-                  "import_module",
-                  "function"
-                ],
-                "properties": {
-                  "operation_id": {
-                    "type": "string",
-                    "minLength": 1
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": [
+                      "operation_id",
+                      "import_module",
+                      "function"
+                    ],
+                    "properties": {
+                      "operation_id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "import_module": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "function": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                      }
+                    },
+                    "additionalProperties": false
                   },
-                  "import_module": {
-                    "type": "string",
-                    "minLength": 1
+                  {
+                    "type": "object",
+                    "required": [
+                      "operation_id",
+                      "handler",
+                      "import_module",
+                      "function"
+                    ],
+                    "properties": {
+                      "operation_id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "handler": {
+                        "const": "argparse_function_call"
+                      },
+                      "import_module": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "function": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                      },
+                      "support_import_module": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "result": {
+                        "enum": [
+                          "return_zero",
+                          "return_int",
+                          "emit_payload"
+                        ]
+                      },
+                      "emit_payload": {
+                        "type": "object",
+                        "properties": {
+                          "import_module": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "function": {
+                            "type": "string",
+                            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                          },
+                          "format_attr": {
+                            "type": "string",
+                            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "arguments": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "kind"
+                          ],
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                            },
+                            "kind": {
+                              "enum": [
+                                "attr",
+                                "bool_attr",
+                                "list_attr",
+                                "target_root",
+                                "diagnostic_profile",
+                                "module_descriptors"
+                              ]
+                            },
+                            "attr": {
+                              "type": "string",
+                              "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                            },
+                            "default": {},
+                            "default_current": {
+                              "type": "boolean"
+                            },
+                            "allow_none": {
+                              "type": "boolean"
+                            },
+                            "validate_command": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "validate": {
+                              "type": "boolean"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
                   },
-                  "function": {
-                    "type": "string",
-                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                  {
+                    "type": "object",
+                    "required": [
+                      "operation_id",
+                      "handler",
+                      "command_attr",
+                      "module_import",
+                      "module_program",
+                      "help_payload_import_module",
+                      "help_payload_function",
+                      "help_text_function",
+                      "missing_module_message"
+                    ],
+                    "properties": {
+                      "operation_id": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "handler": {
+                        "const": "module_front_door"
+                      },
+                      "command_attr": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                      },
+                      "target_attr": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                      },
+                      "format_attr": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                      },
+                      "module_import": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "module_main": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                      },
+                      "module_program": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "include_module_program": {
+                        "type": "boolean"
+                      },
+                      "help_payload_import_module": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "help_payload_function": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                      },
+                      "help_text_import_module": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "help_text_function": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                      },
+                      "missing_module_message": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "stdout_replacements": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "old",
+                            "new"
+                          ],
+                          "properties": {
+                            "old": {
+                              "type": "string"
+                            },
+                            "new": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "option_specs": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "option",
+                            "attr"
+                          ],
+                          "properties": {
+                            "option": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "attr": {
+                              "type": "string",
+                              "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                            },
+                            "fallback_attr": {
+                              "type": "string",
+                              "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                            },
+                            "kind": {
+                              "enum": [
+                                "value",
+                                "flag",
+                                "repeated",
+                                "repeated_group"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "positionals": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "commands",
+                            "attr"
+                          ],
+                          "properties": {
+                            "commands": {
+                              "type": "array",
+                              "minItems": 1,
+                              "items": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "attr": {
+                              "type": "string",
+                              "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "local_command_handlers": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "command",
+                            "import_module",
+                            "function"
+                          ],
+                          "properties": {
+                            "command": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "import_module": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "function": {
+                              "type": "string",
+                              "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
                   }
-                },
-                "additionalProperties": false
+                ]
               },
               "description": "Operation handlers rendered into a generated runtime handler map by importing named runtime primitive functions."
             },
@@ -1511,6 +1791,5 @@
       "description": "Ordered non empty strings entries used by this contract."
     }
   },
-  "x-command-generation-doc-role": "contract-reference",
-  "x-agentic-workspace-doc-role": "contract-reference"
+  "x-command-generation-doc-role": "contract-reference"
 }

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -8,14 +8,12 @@ from __future__ import annotations
 
 import argparse
 import ast
-import contextlib
 import copy
 import difflib
 import fnmatch
 import hashlib
 import importlib
 import importlib.metadata
-import io
 import json
 import os
 import re
@@ -3347,197 +3345,6 @@ def _print_memory_help(payload: dict[str, Any]) -> None:
     print("Rules:")
     for rule in payload["rules"]:
         print(f"- {rule}")
-
-
-def _append_option(argv: list[str], name: str, value: Any) -> None:
-    if value is not None and value != "" and (value != []):
-        argv.extend([name, str(value)])
-
-
-def _append_repeated_option(argv: list[str], name: str, values: Any) -> None:
-    if isinstance(values, list) and values:
-        argv.append(name)
-        argv.extend((str(value) for value in values))
-
-
-def _append_flag(argv: list[str], name: str, enabled: bool) -> None:
-    if enabled:
-        argv.append(name)
-
-
-def _planning_module_argv(args: argparse.Namespace) -> list[str]:
-    command = str(args.planning_command)
-    argv = [command]
-    if command == "promote-to-plan":
-        argv.append(str(args.item_id))
-    elif command in {"lane-promote", "lane-activate", "lane-close", "lane-archive"} and getattr(args, "lane", None):
-        argv.append(str(args.lane))
-    elif command in {"archive-plan", "closeout"} and getattr(args, "plan", None):
-        argv.append(str(args.plan))
-    elif command == "close-item" and getattr(args, "item", None):
-        argv.append(str(args.item))
-    elif command == "create-review" and getattr(args, "slug", None):
-        argv.append(str(args.slug))
-    for option, attr in (
-        ("--id", "id"),
-        ("--title", "title"),
-        ("--source", "source"),
-        ("--artifact", "artifact"),
-        ("--target", "target"),
-        ("--plan-slug", "plan_slug"),
-        ("--scope", "scope"),
-        ("--classification", "classification"),
-        ("--route", "route"),
-        ("--current-slice", "current_slice"),
-        ("--proof", "proof"),
-        ("--residual-work", "residual_work"),
-        ("--parent-contribution", "parent_contribution"),
-        ("--parent-close-permission", "parent_close_permission"),
-        ("--next-owner", "next_owner"),
-        ("--skipped-reason", "skipped_reason"),
-        ("--expected-savings", "expected_savings"),
-        ("--actual-friction", "actual_friction"),
-        ("--proof-result", "proof_result"),
-        ("--quality-concern", "quality_concern"),
-        ("--decomposition-adjustment", "decomposition_adjustment"),
-        ("--reason", "reason"),
-        ("--issue", "issue"),
-        ("--parent-lane-closeout", "parent_lane_closeout"),
-        ("--closure-decision", "closure_decision"),
-        ("--intent-satisfied", "intent_satisfied"),
-        ("--unsolved-intent", "unsolved_intent"),
-        ("--intent-evidence", "intent_evidence"),
-        ("--closure-reason", "closure_reason"),
-        ("--closure-evidence", "closure_evidence"),
-        ("--reopen-trigger", "reopen_trigger"),
-        ("--discard-summary", "discard_summary"),
-        ("--continuation-summary", "continuation_summary"),
-        ("--claim-level", "claim_level"),
-        ("--intent-status", "intent_status"),
-        ("--residue", "residue"),
-        ("--proof-from", "proof_from"),
-        ("--residue-owner", "residue_owner"),
-        ("--what-happened", "what_happened"),
-        ("--scope-touched", "scope_touched"),
-        ("--changed-surfaces", "changed_surfaces"),
-        ("--review-summary", "review_summary"),
-        ("--outcome-summary", "outcome_summary"),
-        ("--expect-planning-revision", "expect_planning_revision"),
-    ):
-        _append_option(argv, option, getattr(args, attr, None))
-    if command == "delegation-decision":
-        _append_option(argv, "--plan", getattr(args, "plan", None))
-    for option, attr in (
-        ("--activate", "activate"),
-        ("--queue", "queue"),
-        ("--switch-active", "switch_active"),
-        ("--prep-only", "prep_only"),
-        ("--overwrite", "overwrite"),
-        ("--remove-source", "remove_source"),
-        ("--dry-run", "dry_run"),
-        ("--render-markdown", "render_markdown"),
-        ("--apply-cleanup", "apply_cleanup"),
-        ("--prepare-closeout", "prepare_closeout"),
-        ("--retain-archive", "retain_archive"),
-        ("--discard-archive", "discard_archive"),
-        ("--verbose", "verbose"),
-    ):
-        _append_flag(argv, option, bool(getattr(args, attr, False)))
-    path_values = getattr(args, "paths", None) or getattr(args, "path", None) or []
-    if isinstance(path_values, str):
-        path_values = [path_values]
-    for path in path_values:
-        _append_option(argv, "--path", path)
-    _append_option(argv, "--format", getattr(args, "format", None))
-    return argv
-
-
-def _memory_module_argv(args: argparse.Namespace) -> list[str]:
-    command = str(args.memory_command)
-    argv = [command]
-    if command in {"capture-note", "create-note"} and getattr(args, "slug", None):
-        argv.append(str(args.slug))
-    for option, attr in (
-        ("--target", "target"),
-        ("--title", "title"),
-        ("--folder", "folder"),
-        ("--note-type", "note_type"),
-        ("--summary", "summary"),
-        ("--task", "task"),
-        ("--stage", "stage"),
-        ("--existing-note", "existing_note"),
-        ("--force-new-reason", "force_new_reason"),
-        ("--mode", "mode"),
-        ("--memory-role", "memory_role"),
-        ("--promotion-target", "promotion_target"),
-        ("--promotion-trigger", "promotion_trigger"),
-        ("--retention-after-promotion", "retention_after_promotion"),
-        ("--local-reason", "local_reason"),
-    ):
-        _append_option(argv, option, getattr(args, attr, None))
-    _append_repeated_option(argv, "--applies-to", getattr(args, "applies_to", None))
-    _append_repeated_option(argv, "--use-when", getattr(args, "use_when", None))
-    _append_repeated_option(argv, "--routes-from", getattr(args, "routes_from", None))
-    _append_repeated_option(argv, "--stale-when", getattr(args, "stale_when", None))
-    _append_repeated_option(argv, "--evidence", getattr(args, "evidence", None))
-    _append_repeated_option(argv, "--files", getattr(args, "files", None))
-    _append_repeated_option(argv, "--surface", getattr(args, "surfaces", None))
-    _append_repeated_option(argv, "--notes", getattr(args, "notes", None))
-    _append_flag(argv, "--local", bool(getattr(args, "local", False)))
-    _append_flag(argv, "--dry-run", bool(getattr(args, "dry_run", False)))
-    _append_flag(argv, "--verbose", bool(getattr(args, "verbose", False)))
-    _append_option(argv, "--format", getattr(args, "format", None))
-    return argv
-
-
-def _run_planning_front_door(args: argparse.Namespace) -> int:
-    planning_main = _load_generated_cli_module("agentic-planning").main
-    buffer = io.StringIO()
-    with contextlib.redirect_stdout(buffer):
-        result = planning_main(_planning_module_argv(args))
-    print(_rewrite_module_cli_commands(buffer.getvalue()), end="")
-    return result
-
-
-def _run_memory_front_door(args: argparse.Namespace) -> int:
-    memory_main = _load_generated_cli_module("agentic-memory").main
-    buffer = io.StringIO()
-    with contextlib.redirect_stdout(buffer):
-        result = memory_main(_memory_module_argv(args))
-    print(buffer.getvalue().replace("agentic-memory ", "agentic-workspace memory "), end="")
-    return result
-
-
-def _run_planning_front_door_adapter(args: argparse.Namespace) -> int:
-    if not getattr(args, "planning_command", None):
-        payload = _planning_help_payload(target=getattr(args, "target", None))
-        if getattr(args, "format", None) == "json":
-            print(json.dumps(payload, indent=2))
-        else:
-            _print_planning_help(payload)
-        return 0
-    if getattr(args, "planning_command", None) in {"decision-scaffold", "decision-promote"}:
-        return _run_planning_decision_adapter(args)
-    try:
-        return _run_planning_front_door(args)
-    except ImportError:
-        build_generated_parser().error("The planning module must be installed to use planning subcommands.")
-        return 2
-
-
-def _run_memory_front_door_adapter(args: argparse.Namespace) -> int:
-    if not getattr(args, "memory_command", None):
-        payload = _memory_help_payload(target=getattr(args, "target", None))
-        if getattr(args, "format", None) == "json":
-            print(json.dumps(payload, indent=2))
-        else:
-            _print_memory_help(payload)
-        return 0
-    try:
-        return _run_memory_front_door(args)
-    except ImportError:
-        build_generated_parser().error("The memory module must be installed to use memory subcommands.")
-        return 2
 
 
 def _print_planning_help(payload: dict[str, Any]) -> None:
@@ -34250,14 +34057,6 @@ def _emit_proof(
             print(f"- {item}")
 
 
-def _run_modules_report_adapter(args: argparse.Namespace) -> int:
-    target_root = _resolve_target_root(args.target) if args.target else None
-    if target_root is not None:
-        _validate_target_root(command_name="modules", target_root=target_root)
-    _emit_modules(format_name=args.format, target_root=target_root, profile=_diagnostic_profile(args, default="tiny"))
-    return 0
-
-
 def _run_start_context_adapter(args: argparse.Namespace) -> int:
     target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
     _validate_target_root(command_name="start", target_root=target_root)
@@ -34474,67 +34273,6 @@ def _run_implement_context_adapter(args: argparse.Namespace) -> int:
     if getattr(args, "select", None):
         payload = _select_payload_fields(payload, select=getattr(args, "select"), source_command="implement")
     _emit_payload(payload=payload, format_name=args.format)
-    return 0
-
-
-def _run_preflight_report_adapter(args: argparse.Namespace) -> int:
-    target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
-    _validate_target_root(command_name="preflight", target_root=target_root)
-    payload = _run_preflight_command(
-        target_root=target_root,
-        active_only=bool(getattr(args, "active_only", False)),
-        task_text=getattr(args, "task", None),
-        profile=_diagnostic_profile(args, default="tiny"),
-    )
-    _emit_payload(payload=payload, format_name=args.format)
-    return 0
-
-
-def _run_proof_report_adapter(args: argparse.Namespace) -> int:
-    descriptors = _module_operations()
-    _validate_descriptor_contract(descriptors)
-    target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
-    _validate_target_root(command_name="proof", target_root=target_root)
-    _emit_proof(
-        format_name=args.format,
-        target_root=target_root,
-        descriptors=descriptors,
-        route=getattr(args, "route", None),
-        current_only=bool(getattr(args, "current", False)),
-        changed_paths=list(getattr(args, "changed", []) or []),
-        profile=_diagnostic_profile(args, default="tiny"),
-        select=getattr(args, "select", None),
-        record_receipt=bool(getattr(args, "record_receipt", False)),
-        receipt_command=str(getattr(args, "receipt_command", "") or ""),
-        receipt_result=str(getattr(args, "receipt_result", "") or ""),
-        receipt_plan=str(getattr(args, "receipt_plan", "") or ""),
-        dry_run=bool(getattr(args, "dry_run", False)),
-    )
-    return 0
-
-
-def _run_ownership_report_adapter(args: argparse.Namespace) -> int:
-    descriptors = _module_operations()
-    _validate_descriptor_contract(descriptors)
-    target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
-    _validate_target_root(command_name="ownership", target_root=target_root)
-    _emit_ownership(
-        format_name=args.format,
-        target_root=target_root,
-        descriptors=descriptors,
-        concern=getattr(args, "concern", None),
-        repo_path=getattr(args, "path", None),
-    )
-    return 0
-
-
-def _run_skills_report_adapter(args: argparse.Namespace) -> int:
-    target_root = _resolve_target_root(args.target) if args.target else None
-    if target_root is not None:
-        _validate_target_root(command_name="skills", target_root=target_root)
-    _emit_skills(
-        format_name=args.format, target_root=target_root, task_text=getattr(args, "task", None), select=getattr(args, "select", None)
-    )
     return 0
 
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -140,22 +140,17 @@ def test_defaults_text_uses_tiny_router_payload(capsys) -> None:
 
 
 def test_planning_front_door_forwards_lane_lifecycle_positionals(monkeypatch, tmp_path: Path, capsys) -> None:
-    import agentic_workspace.workspace_runtime_primitives as runtime
-
     forwarded: list[list[str]] = []
 
-    class FakePlanningModule:
-        @staticmethod
-        def main(argv: list[str]) -> int:
-            forwarded.append(argv)
-            print(json.dumps({"argv": argv}))
-            return 0
+    def fake_planning_main(argv: list[str]) -> int:
+        forwarded.append(argv)
+        print(json.dumps({"argv": argv}))
+        return 0
 
     def option_value(argv: list[str], option: str) -> str:
         return argv[argv.index(option) + 1]
 
-    loader_name = "_load_" + "generated_cli_" + "module"
-    monkeypatch.setattr(runtime, loader_name, lambda module: FakePlanningModule)
+    monkeypatch.setattr("repo_planning_bootstrap.cli.main", fake_planning_main)
 
     assert (
         cli.main(

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", url = "https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl" },
+    { name = "command-generation", git = "https://github.com/rickardvh/command-generation.git?rev=234c80cf546d233851af9ee4e1e9fc444879c8e3" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -145,16 +145,10 @@ wheels = [
 [[package]]
 name = "command-generation"
 version = "1.0.0rc1"
-source = { url = "https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl" }
+source = { git = "https://github.com/rickardvh/command-generation.git?rev=234c80cf546d233851af9ee4e1e9fc444879c8e3#234c80cf546d233851af9ee4e1e9fc444879c8e3" }
 dependencies = [
     { name = "jsonschema" },
 ]
-wheels = [
-    { url = "https://github.com/rickardvh/command-generation/releases/download/v1.0.0rc1/command_generation-1.0.0rc1-py3-none-any.whl", hash = "sha256:92886c2dbc06fb8651e26ccdeefa0c1446fb4e1614219b2db024ed487f09d762" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "jsonschema", specifier = ">=4.26.0" }]
 
 [[package]]
 name = "coverage"


### PR DESCRIPTION
## Summary
- pin command-generation to rickardvh/command-generation#66 / 234c80cf546d233851af9ee4e1e9fc444879c8e3
- add and consume generated runtime handlers for module front doors and generic argparse function calls
- replace memory/planning front-door hand-owned adapters with `module_front_door` metadata
- replace modules, ownership, preflight, proof, and skills workspace wrapper adapters with `argparse_function_call` metadata
- remove retired runtime boundary entries and mark generated handler operations as `generated-runtime-handler`

## #1649 status
This advances #1649 but does not close it.

Current movement from the lane baseline:
- accepted runtime symbols: 85 -> 75
- workspace package runtime boundaries: 26 -> 19
- `front-door-dispatch-extraction-candidate`: 2 -> 0
- remaining hand-owned runtime symbols: 75

The remaining workspace symbols own report routing, lifecycle mutation policy, startup/implement/summary shaping, provider integration, or operation primitive semantics. The simple generated-wrapper family is now exhausted in this PR; deeper reductions need additional generic control-operation support or true semantic decomposition of package primitives.

## Proof
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make schema-reference-docs`
- `uv run python scripts/generate/generate_command_packages.py --check`