### PR TITLE
Fix dogfooding ordinary-loop routing gaps

### DIFF
--- a/docs/maintainer/proof-command-inventory.json
+++ b/docs/maintainer/proof-command-inventory.json
@@ -1,0 +1,47 @@
+{
+  "kind": "agentic-workspace/documented-proof-command-inventory/v1",
+  "sources": [
+    "AGENTS.md",
+    "README.md",
+    ".agentic-workspace/verification/manifest.toml",
+    "docs/maintainer/contributor-playbook.md",
+    "docs/maintainer/generated-command-check-inventory.md",
+    "docs/maintainer/maintainer-commands.md",
+    "docs/maintainer/test-knowledge-inventory.md"
+  ],
+  "commands": [
+    {
+      "id": "generated-command-packages-static",
+      "command": "uv run python scripts/check/check_generated_command_packages.py",
+      "status": "runnable",
+      "source_refs": [
+        "docs/maintainer/contributor-playbook.md",
+        "docs/maintainer/test-knowledge-inventory.md"
+      ]
+    },
+    {
+      "id": "generated-command-python-conformance",
+      "command": "uv run python scripts/check/check_generated_command_packages.py --python-conformance",
+      "status": "runnable",
+      "source_refs": [
+        "docs/maintainer/contributor-playbook.md",
+        "docs/maintainer/maintainer-commands.md"
+      ]
+    },
+    {
+      "id": "legacy-primitive-conformance-script",
+      "command": "uv run python tests/primitive_conformance.py",
+      "status": "obsolete",
+      "source_refs": [
+        "AGENTS.md",
+        "README.md",
+        ".agentic-workspace/verification/manifest.toml",
+        "docs/maintainer/contributor-playbook.md",
+        "docs/maintainer/generated-command-check-inventory.md",
+        "docs/maintainer/maintainer-commands.md",
+        "docs/maintainer/test-knowledge-inventory.md"
+      ],
+      "replacement": "uv run python scripts/check/check_generated_command_packages.py --python-conformance"
+    }
+  ]
+}

--- a/generated/memory/python/_contracts/operations/memory.route.report.json
+++ b/generated/memory/python/_contracts/operations/memory.route.report.json
@@ -25,6 +25,11 @@
       "required": false
     },
     {
+      "name": "pending_command",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "task",
       "source": "cli-option",
       "required": false
@@ -100,6 +105,9 @@
           },
           "surfaces": {
             "value": "surface"
+          },
+          "pending_command": {
+            "value": "pending_command"
           },
           "task": {
             "value": "task"

--- a/generated/memory/python/adapter_commands.json
+++ b/generated/memory/python/adapter_commands.json
@@ -1209,6 +1209,14 @@
         {
           "default": "",
           "flags": [
+            "--pending-command"
+          ],
+          "help": "Pending local command to route as structured execution-surface context before running it.",
+          "name": "pending_command"
+        },
+        {
+          "default": "",
+          "flags": [
             "--task"
           ],
           "help": "Task text for route context. Task prose is not routing authority.",

--- a/generated/memory/python/command_package.json
+++ b/generated/memory/python/command_package.json
@@ -1965,6 +1965,14 @@
           {
             "default": "",
             "flags": [
+              "--pending-command"
+            ],
+            "help": "Pending local command to route as structured execution-surface context before running it.",
+            "name": "pending_command"
+          },
+          {
+            "default": "",
+            "flags": [
               "--task"
             ],
             "help": "Task text for route context. Task prose is not routing authority.",
@@ -3061,6 +3069,9 @@
             "files": {
               "value": "files"
             },
+            "pending_command": {
+              "value": "pending_command"
+            },
             "stage": {
               "value": "stage"
             },
@@ -3189,6 +3200,11 @@
           "arg": "surface",
           "default": [],
           "name": "surface"
+        },
+        {
+          "arg": "pending_command",
+          "default": "",
+          "name": "pending_command"
         },
         {
           "arg": "task",

--- a/generated/memory/python/operations/memory.route.report.json
+++ b/generated/memory/python/operations/memory.route.report.json
@@ -34,6 +34,11 @@
       "source": "cli-option"
     },
     {
+      "name": "pending_command",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
       "name": "task",
       "required": false,
       "source": "cli-option"
@@ -56,6 +61,9 @@
         "arguments": {
           "files": {
             "value": "files"
+          },
+          "pending_command": {
+            "value": "pending_command"
           },
           "stage": {
             "value": "stage"

--- a/generated/memory/python/primitives/operation_executor.py
+++ b/generated/memory/python/primitives/operation_executor.py
@@ -48,6 +48,7 @@ def run_operation_ir(operation: dict[str, Any], args: argparse.Namespace) -> int
                 'notes': getattr(args, 'notes', None),
                 'files': getattr(args, 'files', []),
                 'surface': getattr(args, 'surface', []),
+                'pending_command': getattr(args, 'pending_command', ''),
                 'task': getattr(args, 'task', ''),
                 'stage': getattr(args, 'stage', ''),
                 'mode': getattr(args, 'mode', None),
@@ -104,6 +105,7 @@ def run_operation_callable(operation: dict[str, Any], values: Mapping[str, Any])
                 'notes': values.get('notes', None),
                 'files': values.get('files', []),
                 'surface': values.get('surface', []),
+                'pending_command': values.get('pending_command', ''),
                 'task': values.get('task', ''),
                 'stage': values.get('stage', ''),
                 'mode': values.get('mode', None),
@@ -320,7 +322,7 @@ def _handle_memory_note_create(values: dict[str, Any], _arguments: dict[str, Any
 def _handle_memory_route_load(values: dict[str, Any], _arguments: dict[str, Any], _context: PrimitiveContext) -> Any:
     from repo_memory_bootstrap.installer import route_memory
 
-    return route_memory(files=values.get('files'), stage=values.get('stage'), surfaces=values.get('surface'), target=values.get('target'), task=values.get('task'))
+    return route_memory(files=values.get('files'), pending_command=values.get('pending_command'), stage=values.get('stage'), surfaces=values.get('surface'), target=values.get('target'), task=values.get('task'))
 
 
 def _handle_memory_sync_memory_load(values: dict[str, Any], _arguments: dict[str, Any], _context: PrimitiveContext) -> Any:

--- a/generated/memory/typescript/resources/_contracts/operations/memory.route.report.json
+++ b/generated/memory/typescript/resources/_contracts/operations/memory.route.report.json
@@ -25,6 +25,11 @@
       "required": false
     },
     {
+      "name": "pending_command",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "task",
       "source": "cli-option",
       "required": false
@@ -100,6 +105,9 @@
           },
           "surfaces": {
             "value": "surface"
+          },
+          "pending_command": {
+            "value": "pending_command"
           },
           "task": {
             "value": "task"

--- a/generated/memory/typescript/resources/command_package.json
+++ b/generated/memory/typescript/resources/command_package.json
@@ -1965,6 +1965,14 @@
           {
             "default": "",
             "flags": [
+              "--pending-command"
+            ],
+            "help": "Pending local command to route as structured execution-surface context before running it.",
+            "name": "pending_command"
+          },
+          {
+            "default": "",
+            "flags": [
               "--task"
             ],
             "help": "Task text for route context. Task prose is not routing authority.",

--- a/generated/memory/typescript/resources/operations/memory.route.report.json
+++ b/generated/memory/typescript/resources/operations/memory.route.report.json
@@ -34,6 +34,11 @@
       "source": "cli-option"
     },
     {
+      "name": "pending_command",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
       "name": "task",
       "required": false,
       "source": "cli-option"
@@ -56,6 +61,9 @@
         "arguments": {
           "files": {
             "value": "files"
+          },
+          "pending_command": {
+            "value": "pending_command"
           },
           "stage": {
             "value": "stage"

--- a/generated/memory/typescript/src/cli.mjs
+++ b/generated/memory/typescript/src/cli.mjs
@@ -1250,6 +1250,14 @@ const commandDefinitions = [
         {
           "default": "",
           "flags": [
+            "--pending-command"
+          ],
+          "help": "Pending local command to route as structured execution-surface context before running it.",
+          "name": "pending_command"
+        },
+        {
+          "default": "",
+          "flags": [
             "--task"
           ],
           "help": "Task text for route context. Task prose is not routing authority.",

--- a/packages/memory/src/repo_memory_bootstrap/contracts/operations/memory.route.report.json
+++ b/packages/memory/src/repo_memory_bootstrap/contracts/operations/memory.route.report.json
@@ -25,6 +25,11 @@
       "required": false
     },
     {
+      "name": "pending_command",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "task",
       "source": "cli-option",
       "required": false
@@ -100,6 +105,9 @@
           },
           "surfaces": {
             "value": "surface"
+          },
+          "pending_command": {
+            "value": "pending_command"
           },
           "task": {
             "value": "task"

--- a/packages/memory/src/repo_memory_bootstrap/installer.py
+++ b/packages/memory/src/repo_memory_bootstrap/installer.py
@@ -676,25 +676,8 @@ def _capture_candidate_view(note: MemoryNoteRecord, *, score: int, reasons: list
     return candidate
 
 
-def _looks_like_local_memory_capture(*, summary: str, task: str | None, files: tuple[str, ...], surfaces: tuple[str, ...]) -> bool:
-    text = " ".join([summary, task or "", " ".join(files), " ".join(surfaces)]).lower()
-    local_markers = (
-        "machine-local",
-        "local-only",
-        "local execution",
-        "local shell",
-        "this windows",
-        "windows codex",
-        "codex desktop shell",
-        "bare python",
-        "python is unavailable",
-        "not on path",
-        "local runtime",
-        "environment-specific",
-        "user-local",
-        "private",
-    )
-    return any(marker in text for marker in local_markers)
+def _local_memory_capture_requested(*, surfaces: tuple[str, ...]) -> bool:
+    return "local_memory" in {_normalise_surface_name(surface) for surface in surfaces}
 
 
 def suggest_memory_note_capture(
@@ -789,12 +772,7 @@ def suggest_memory_note_capture(
     force_reason = force_new_reason.strip()
     best_score = best.get("score", 0) if best else 0
     strong_best = best if isinstance(best_score, int) and best_score >= 20 else None
-    local_capture = _looks_like_local_memory_capture(
-        summary=summary,
-        task=task,
-        files=normalized_files,
-        surfaces=tuple(effective_surfaces),
-    )
+    local_capture = _local_memory_capture_requested(surfaces=tuple(effective_surfaces))
     create_command = (
         f"agentic-memory create-note {safe_slug} --local --local-reason <why-local> --target ./repo --summary <text> --format json"
         if local_capture
@@ -813,7 +791,7 @@ def suggest_memory_note_capture(
         recommended_action = "create-local-note" if local_capture else "create-new-note"
         next_command = create_command
         reason = (
-            "the capture request appears local/runtime-specific, so local-only Memory is the safer default"
+            "the capture request supplied the explicit local_memory surface, so local-only Memory is the safer default"
             if local_capture
             else "no existing Memory note matched the capture request"
         )
@@ -1672,17 +1650,19 @@ def route_memory(
     target: str | Path | None = None,
     files: list[str] | None = None,
     surfaces: list[str] | None = None,
+    pending_command: str | None = None,
     task: str | None = None,
     stage: str | None = None,
 ) -> InstallResult:
     target_root = resolve_target_root(target)
     result = _new_result(target_root, dry_run=True, message="Memory routing suggestions")
     normalized_stage = _normalise_surface_name(stage or "")
+    pending_command_supplied = bool(pending_command and pending_command.strip())
     if not files and not surfaces and not normalized_stage:
         result.add(
             "manual review",
             target_root / Path(".agentic-workspace/memory/repo/index.md"),
-            "provide --files, --surface, or --stage to request routing suggestions",
+            "provide --files, --surface, or --stage to request routing suggestions; --pending-command is context only",
             role="memory-route",
             safety="manual",
             source=".agentic-workspace/memory/repo/index.md",
@@ -1700,10 +1680,11 @@ def route_memory(
                 "explicit_surfaces": [],
                 "stage_surface": "",
                 "inferred_surfaces": [],
+                "pending_command_supplied": pending_command_supplied,
                 "stage": "",
                 "task_supplied": bool(task and task.strip()),
                 "task_used_for_matching": False,
-                "rule": "Files, explicit surfaces, and stage are route signals; task prose is context for the agent, not routing authority. route_context.surfaces is the merged matching set; explicit_surfaces preserves caller input.",
+                "rule": "Files, explicit surfaces, and stage are route signals; task prose and pending command text are context for the agent, not routing authority. route_context.surfaces is the merged matching set; explicit_surfaces preserves caller input.",
             },
         }
         return result
@@ -1801,10 +1782,11 @@ def route_memory(
         "explicit_surfaces": explicit_surfaces,
         "stage_surface": normalized_stage,
         "inferred_surfaces": inferred_surfaces,
+        "pending_command_supplied": pending_command_supplied,
         "stage": normalized_stage,
         "task_supplied": bool(task and task.strip()),
         "task_used_for_matching": False,
-        "rule": "Files, explicit surfaces, and stage are route signals; task prose is context for the agent, not routing authority. route_context.surfaces is the merged matching set; explicit_surfaces preserves caller input.",
+        "rule": "Files, explicit surfaces, and stage are route signals; task prose and pending command text are context for the agent, not routing authority. route_context.surfaces is the merged matching set; explicit_surfaces preserves caller input.",
     }
     result.route_summary["selected_note_trust"] = _selected_route_note_trust(
         manifest=manifest,

--- a/packages/memory/tests/test_report.py
+++ b/packages/memory/tests/test_report.py
@@ -584,18 +584,27 @@ def test_memory_capture_note_does_not_update_unrelated_note_from_weak_tokens(tmp
         routes_from=["memory", "verification", "routing"],
     )
 
-    payload = installer.suggest_memory_note_capture(
+    prose_only = installer.suggest_memory_note_capture(
         target=target,
         slug="local-python-invocation",
         summary="Bare python is unavailable in this local Windows Codex shell; use uv run python.",
         task="Capture local shell execution memory for this Codex environment.",
         surfaces=["python", "shell", "codex"],
     )
+    explicit_local = installer.suggest_memory_note_capture(
+        target=target,
+        slug="local-python-invocation",
+        summary="Bare python is unavailable in this local Windows Codex shell; use uv run python.",
+        task="Capture local shell execution memory for this Codex environment.",
+        surfaces=["python", "shell", "codex", "local_memory"],
+    )
 
-    assert payload["recommended_action"] == "create-local-note"
-    assert payload["storage_decision"]["recommended_owner"] == "local_memory"
-    assert "--local" in payload["commands"][0]
-    assert all(candidate["evidence_class"] != "ownership-evidence" for candidate in payload["candidates"])
+    assert prose_only["recommended_action"] == "create-new-note"
+    assert prose_only["storage_decision"]["recommended_owner"] == "repo_memory"
+    assert explicit_local["recommended_action"] == "create-local-note"
+    assert explicit_local["storage_decision"]["recommended_owner"] == "local_memory"
+    assert "--local" in explicit_local["commands"][0]
+    assert all(candidate["evidence_class"] != "ownership-evidence" for candidate in explicit_local["candidates"])
 
 
 def test_memory_capture_note_surfaces_improvement_promotion_metadata(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/packages/memory/tests/test_routing.py
+++ b/packages/memory/tests/test_routing.py
@@ -177,6 +177,64 @@ def test_route_memory_preserves_explicit_surfaces_separately_from_stage(tmp_path
     assert any(action.match_source == "surface" and "codex" in action.detail for action in result.actions)
 
 
+def test_route_memory_keeps_pending_command_context_separate_from_explicit_surfaces(tmp_path: Path) -> None:
+    target = tmp_path / "repo"
+    (target / ".git").mkdir(parents=True, exist_ok=True)
+    note = target / ".agentic-workspace" / "local" / "memory" / "local-python-invocation.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    (target / ".agentic-workspace" / "memory" / "repo").mkdir(parents=True, exist_ok=True)
+    (target / ".agentic-workspace" / "memory" / "repo" / "index.md").write_text(_memory_index_text(), encoding="utf-8")
+    note.write_text("# Local Python Invocation\n", encoding="utf-8")
+    (target / ".agentic-workspace" / "memory" / "repo" / "manifest.toml").write_text(
+        """
+version = 1
+
+[notes.".agentic-workspace/memory/repo/index.md"]
+note_type = "routing"
+canonical_home = ".agentic-workspace/memory/repo/index.md"
+authority = "canonical"
+audience = "human+agent"
+canonicality = "agent_only"
+task_relevance = "required"
+routing_only = true
+
+[notes.".agentic-workspace/local/memory/local-python-invocation.md"]
+note_type = "mistake"
+canonical_home = ".agentic-workspace/local/memory/local-python-invocation.md"
+authority = "local"
+audience = "agent"
+canonicality = "local_only"
+task_relevance = "optional"
+routes_from = ["python", "shell", "local-tooling"]
+surfaces = ["python", "shell", "local-tooling"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    routed = installer.route_memory(
+        target=target,
+        pending_command="python - <<'PY'",
+        surfaces=["python", "shell"],
+        task="memory memory memory",
+    )
+    command_only = installer.route_memory(target=target, pending_command="python - <<'PY'")
+    task_only = installer.route_memory(target=target, task="python shell local tooling")
+
+    routed_sources = {action.source for action in routed.actions}
+    command_only_sources = {action.source for action in command_only.actions}
+    task_only_sources = {action.source for action in task_only.actions}
+    context = routed.route_summary["route_context"]
+
+    assert ".agentic-workspace/local/memory/local-python-invocation.md" in routed_sources
+    assert ".agentic-workspace/local/memory/local-python-invocation.md" not in command_only_sources
+    assert ".agentic-workspace/local/memory/local-python-invocation.md" not in task_only_sources
+    assert context["explicit_surfaces"] == ["python", "shell"]
+    assert "command_surfaces" not in context
+    assert context["pending_command_supplied"] is True
+    assert context["task_used_for_matching"] is False
+
+
 def test_capture_note_exposes_non_memory_owner_routes(tmp_path: Path) -> None:
     target = tmp_path / "repo"
     (target / ".git").mkdir(parents=True, exist_ok=True)

--- a/scripts/check/check_contract_tooling_surfaces.py
+++ b/scripts/check/check_contract_tooling_surfaces.py
@@ -2282,6 +2282,58 @@ def _validate_product_managed_enclave() -> list[str]:
     return errors
 
 
+def _validate_documented_proof_command_inventory(
+    *,
+    repo_root: Path = REPO_ROOT,
+    inventory_path: Path | None = None,
+) -> list[str]:
+    inventory = inventory_path or repo_root / "docs" / "maintainer" / "proof-command-inventory.json"
+    errors: list[str] = []
+    try:
+        payload = json.loads(inventory.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return [f"{inventory.relative_to(repo_root).as_posix()} could not be read: {exc}"]
+    except json.JSONDecodeError as exc:
+        return [f"{inventory.relative_to(repo_root).as_posix()} is invalid JSON: {exc}"]
+    if payload.get("kind") != "agentic-workspace/documented-proof-command-inventory/v1":
+        errors.append("proof-command-inventory kind drifted")
+    source_paths = [str(item) for item in payload.get("sources", []) if isinstance(item, str) and item.strip()]
+    source_texts: dict[str, str] = {}
+    for source in source_paths:
+        path = repo_root / source
+        if not path.is_file():
+            errors.append(f"inventory source is missing: {source}")
+            continue
+        source_texts[source] = path.read_text(encoding="utf-8")
+    allowed_statuses = {"runnable", "obsolete", "removed"}
+    for raw_command in payload.get("commands", []):
+        if not isinstance(raw_command, dict):
+            errors.append("inventory command entries must be objects")
+            continue
+        command_id = str(raw_command.get("id") or "<missing-id>")
+        command = str(raw_command.get("command") or "").strip()
+        status = str(raw_command.get("status") or "").strip()
+        refs = [str(item) for item in raw_command.get("source_refs", []) if isinstance(item, str) and item.strip()]
+        if not command:
+            errors.append(f"{command_id} must declare command text")
+            continue
+        if status not in allowed_statuses:
+            errors.append(f"{command_id} status must be one of: {', '.join(sorted(allowed_statuses))}")
+            continue
+        for ref in refs:
+            if ref not in source_texts:
+                errors.append(f"{command_id} references unknown or missing source {ref}")
+        if status == "runnable":
+            missing_refs = [ref for ref in refs if command not in source_texts.get(ref, "")]
+            if missing_refs:
+                errors.append(f"{command_id} runnable command is missing from source refs: {', '.join(missing_refs)}")
+        if status == "obsolete":
+            stale_refs = [ref for ref, text in source_texts.items() if command in text]
+            if stale_refs:
+                errors.append(f"{command_id} obsolete command still appears in ordinary routing sources: {', '.join(stale_refs)}")
+    return errors
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     checks: list[tuple[str, list[str]]] = [
@@ -2295,6 +2347,7 @@ def main(argv: list[str] | None = None) -> int:
         ("contract_inventory owner choice", _validate_contract_inventory_owner_choice()),
         ("review artifacts startup hygiene", _validate_review_artifacts_not_startup_inputs()),
         ("product-managed enclave", _validate_product_managed_enclave()),
+        ("documented proof command inventory", _validate_documented_proof_command_inventory()),
         ("compact answer sample", _validate(_sample_compact_answer(), "compact_contract_answer.schema.json")),
         ("workspace report sample", _validate(_sample_report_payload(), "workspace_report.schema.json")),
         ("workspace config sample", _validate(_sample_workspace_config_payload(), "workspace_config.schema.json")),

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -1217,6 +1217,14 @@
               "help": "Explicit routing surfaces."
             },
             {
+              "name": "pending_command",
+              "flags": [
+                "--pending-command"
+              ],
+              "default": "",
+              "help": "Pending local command to route as structured execution-surface context before running it."
+            },
+            {
               "name": "task",
               "flags": [
                 "--task"

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -10204,6 +10204,11 @@
               "default": []
             },
             {
+              "name": "pending_command",
+              "arg": "pending_command",
+              "default": ""
+            },
+            {
               "name": "task",
               "arg": "task",
               "default": ""
@@ -10746,6 +10751,9 @@
                 },
                 "surfaces": {
                   "value": "surface"
+                },
+                "pending_command": {
+                  "value": "pending_command"
                 },
                 "task": {
                   "value": "task"
@@ -12789,6 +12797,14 @@
                 "nargs": "*",
                 "default": [],
                 "help": "Explicit routing surfaces."
+              },
+              {
+                "name": "pending_command",
+                "flags": [
+                  "--pending-command"
+                ],
+                "default": "",
+                "help": "Pending local command to route as structured execution-surface context before running it."
               },
               {
                 "name": "task",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -20325,7 +20325,7 @@ def _compact_start_delegation_decision(value: Any, *, include_manual_handoff_det
     config_changes_effective_behavior = isinstance(config_effect, dict) and (
         config_effect.get("configured_delegation_mode") != config_effect.get("delegation_mode")
         or config_effect.get("disabled_reason") not in (None, "")
-        or config_effect.get("safe_to_auto_run_commands") is False
+        or (config_effect.get("configured_delegation_mode") == "auto" and config_effect.get("safe_to_auto_run_commands") is False)
         or (
             isinstance(manual_external_relay, dict)
             and manual_external_relay.get("target_kind") == "manual-external"
@@ -20443,6 +20443,24 @@ def _compact_start_delegation_decision(value: Any, *, include_manual_handoff_det
                 {key: next_step.get(key) for key in next_step_keys if key in next_step} if isinstance(next_step, dict) else next_step
             )
     return compact
+
+
+def _delegation_decision_requires_attention(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    route = value.get("recommended_route") or value.get("decision")
+    required = value.get("required_next_action")
+    if route not in {"", None, "stay-local"} or required not in {"", None, "continue-local"}:
+        return True
+    config_effect = value.get("config_effect", {})
+    if isinstance(config_effect, dict) and (
+        config_effect.get("configured_delegation_mode") != config_effect.get("delegation_mode")
+        or config_effect.get("disabled_reason") not in (None, "")
+        or (config_effect.get("configured_delegation_mode") == "auto" and config_effect.get("safe_to_auto_run_commands") is False)
+    ):
+        return True
+    audit = value.get("auto_delegation_audit", {})
+    return isinstance(audit, dict) and audit.get("must_report_if_not_run") is True
 
 
 def _compact_effort_guidance(value: dict[str, Any]) -> dict[str, Any]:
@@ -21978,7 +21996,10 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     delegation_config_changes_behavior = isinstance(delegation_config_effect, dict) and (
         delegation_config_effect.get("configured_delegation_mode") != delegation_config_effect.get("delegation_mode")
         or delegation_config_effect.get("disabled_reason") not in (None, "")
-        or delegation_config_effect.get("safe_to_auto_run_commands") is False
+        or (
+            delegation_config_effect.get("configured_delegation_mode") == "auto"
+            and delegation_config_effect.get("safe_to_auto_run_commands") is False
+        )
     )
     if isinstance(delegation, dict) and (delegation_route not in {"", None, "stay-local"} or delegation_config_changes_behavior):
         context["delegation_decision"] = _compact_start_delegation_decision(delegation, include_manual_handoff_detail=False)
@@ -27254,6 +27275,18 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     if not (isinstance(reuse_pressure, dict) and reuse_pressure.get("status") == "deferred"):
         context_reuse_pressure["state"] = reuse_pressure.get("state") if isinstance(reuse_pressure, dict) else None
         context_reuse_pressure["summary"] = reuse_pressure.get("summary") if isinstance(reuse_pressure, dict) else None
+    delegation_decision = execution_posture.get("delegation_decision", {}) if isinstance(execution_posture, dict) else {}
+    delegation_attention = _delegation_decision_requires_attention(delegation_decision)
+    advisory_selectors = [
+        "context.reuse_pressure",
+        "context.guidance",
+        "requirement_grounding",
+        "plan_delegation_packet",
+        "test_strategy_check",
+        "routine_work_context",
+    ]
+    if delegation_attention:
+        advisory_selectors.insert(2, "context.delegation_decision")
     detail_commands = {
         "full_context": _command_with_cli_invoke(
             command="agentic-workspace implement --verbose --changed <paths> --format json", cli_invoke=config.cli_invoke
@@ -27317,15 +27350,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     else []
                 ),
             ],
-            advisory_selectors=[
-                "context.reuse_pressure",
-                "context.guidance",
-                "context.delegation_decision",
-                "requirement_grounding",
-                "plan_delegation_packet",
-                "test_strategy_check",
-                "routine_work_context",
-            ],
+            advisory_selectors=advisory_selectors,
             agent_judgment="Agent owns semantic work shape and completion judgment after proof and acceptance reconciliation.",
         ),
         "next": {
@@ -27452,8 +27477,10 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "planning_safety": planning_safety_gate.get("status") if isinstance(planning_safety_gate, dict) else None,
                 "rule": "AW exposes facts, blockers, and guidelines; the agent owns work-shape and proof proportionality judgment.",
             },
-            "delegation_decision": _compact_start_delegation_decision(
-                execution_posture.get("delegation_decision", {}), include_manual_handoff_detail=False
+            **(
+                {"delegation_decision": _compact_start_delegation_decision(delegation_decision, include_manual_handoff_detail=False)}
+                if delegation_attention
+                else {}
             ),
             "requirement_grounding": {
                 "status": payload.get("requirement_grounding", {}).get("status", "not-applicable")
@@ -27555,6 +27582,8 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
         if isinstance(selectors, list):
             drill_down["available_selectors"] = [item for item in selectors if item != selector]
 
+    if not delegation_attention:
+        remove_available_selector("context.delegation_decision")
     if isinstance(payload.get("generated_surface_trust"), dict) and payload["generated_surface_trust"].get("status") == "present":
         tiny_context = projected.get("context", {})
         if isinstance(tiny_context, dict):
@@ -34060,6 +34089,10 @@ def _emit_proof(
 def _run_start_context_adapter(args: argparse.Namespace) -> int:
     target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
     _validate_target_root(command_name="start", target_root=target_root)
+    if args.format == "json":
+        if recovery_payload := _obsolete_default_preset_start_recovery_payload(target_root=target_root):
+            _emit_payload(payload=recovery_payload, format_name=args.format)
+            return 0
     start_profile = "full" if getattr(args, "verbose", False) else getattr(args, "profile", None)
     task_text = getattr(args, "task", None)
     selected_fields = getattr(args, "select", None)
@@ -34081,6 +34114,83 @@ def _run_start_context_adapter(args: argparse.Namespace) -> int:
         payload = _select_payload_fields(payload, select=selected_fields, source_command="start")
     _emit_payload(payload=payload, format_name=args.format)
     return 0
+
+
+def _raw_config_cli_invoke(*, target_root: Path, config_payload: dict[str, Any]) -> str:
+    cli_invoke = DEFAULT_CLI_INVOKE
+    raw_workspace = config_payload.get("workspace", {})
+    if isinstance(raw_workspace, dict) and isinstance(raw_workspace.get("cli_invoke"), str) and raw_workspace["cli_invoke"].strip():
+        cli_invoke = raw_workspace["cli_invoke"].strip()
+    local_config_path = target_root / WORKSPACE_LOCAL_CONFIG_PATH
+    if local_config_path.exists():
+        try:
+            local_payload = tomllib.loads(local_config_path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError):
+            return cli_invoke
+        local_workspace = local_payload.get("workspace", {})
+        if (
+            isinstance(local_workspace, dict)
+            and isinstance(local_workspace.get("cli_invoke"), str)
+            and local_workspace["cli_invoke"].strip()
+        ):
+            cli_invoke = local_workspace["cli_invoke"].strip()
+    return cli_invoke
+
+
+def _obsolete_default_preset_start_recovery_payload(*, target_root: Path) -> dict[str, Any] | None:
+    config_path = target_root / WORKSPACE_CONFIG_PATH
+    if not config_path.exists():
+        return None
+    try:
+        payload = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    raw_workspace = payload.get("workspace", {})
+    if not isinstance(raw_workspace, dict) or "default_preset" not in raw_workspace:
+        return None
+    preset = raw_workspace.get("default_preset")
+    modules = payload.get("modules", {})
+    has_replacement = isinstance(modules, dict) and isinstance(modules.get("enabled"), list)
+    repair_safe = has_replacement
+    cli_invoke = _raw_config_cli_invoke(target_root=target_root, config_payload=payload)
+    return {
+        "kind": "agentic-workspace/start-recovery/v1",
+        "status": "recovery-required",
+        "target": ".",
+        "problem": {
+            "kind": "agentic-workspace/config-migration/v1",
+            "config_path": WORKSPACE_CONFIG_PATH.as_posix(),
+            "obsolete_field": "workspace.default_preset",
+            "observed_value": preset,
+            "reason": "workspace.default_preset is no longer accepted by Agentic Workspace config loading.",
+            "replacement": "[modules] enabled = [...]",
+            "config_valid": False,
+        },
+        "automated_repair": {
+            "safe": repair_safe,
+            "reason": "replacement modules.enabled is already present" if repair_safe else "module selection cannot be inferred safely",
+        },
+        "next_safe_action": {
+            "next_safe_action": "repair-config-before-work",
+            "implementation_allowed": False,
+            "read_only_allowed": True,
+            "proof_required": False,
+            "closure_blockers": ["stale workspace config blocks ordinary startup routing"],
+            "recommended_action": (
+                f"Edit {WORKSPACE_CONFIG_PATH.as_posix()} to remove [workspace].default_preset and declare [modules] enabled = [...]."
+            ),
+        },
+        "recovery_packet": {
+            "kind": "agentic-workspace/config-recovery-packet/v1",
+            "source": WORKSPACE_CONFIG_PATH.as_posix(),
+            "blocked_because": "ordinary start cannot load authoritative workspace config while obsolete fields remain",
+            "next_safe_command": _command_with_cli_invoke(
+                command="agentic-workspace config --target . --format json", cli_invoke=cli_invoke
+            ),
+            "agent_owns": ["choose the correct module list from repo context or ask the maintainer when unclear"],
+            "human_owns": ["confirm module intent when the stale preset cannot be mapped safely"],
+        },
+    }
 
 
 def _run_summary_report_adapter(args: argparse.Namespace) -> int:

--- a/tests/test_contract_tooling_surfaces.py
+++ b/tests/test_contract_tooling_surfaces.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check" / "check_contract_tooling_surfaces.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_contract_tooling_surfaces", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_documented_proof_command_inventory_rejects_stale_obsolete_command(tmp_path: Path) -> None:
+    module = _load_module()
+    docs = tmp_path / "docs" / "maintainer"
+    docs.mkdir(parents=True)
+    (tmp_path / "AGENTS.md").write_text("Use uv run python tests/primitive_conformance.py\n", encoding="utf-8")
+    inventory = docs / "proof-command-inventory.json"
+    inventory.write_text(
+        json.dumps(
+            {
+                "kind": "agentic-workspace/documented-proof-command-inventory/v1",
+                "sources": ["AGENTS.md"],
+                "commands": [
+                    {
+                        "id": "legacy-primitive-conformance-script",
+                        "command": "uv run python tests/primitive_conformance.py",
+                        "status": "obsolete",
+                        "source_refs": ["AGENTS.md"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    errors = module._validate_documented_proof_command_inventory(repo_root=tmp_path, inventory_path=inventory)
+
+    assert errors == ["legacy-primitive-conformance-script obsolete command still appears in ordinary routing sources: AGENTS.md"]
+
+
+def test_documented_proof_command_inventory_accepts_runnable_source_ref(tmp_path: Path) -> None:
+    module = _load_module()
+    docs = tmp_path / "docs" / "maintainer"
+    docs.mkdir(parents=True)
+    command = "uv run python scripts/check/check_generated_command_packages.py"
+    (docs / "maintainer-commands.md").write_text(f"Run `{command}`.\n", encoding="utf-8")
+    inventory = docs / "proof-command-inventory.json"
+    inventory.write_text(
+        json.dumps(
+            {
+                "kind": "agentic-workspace/documented-proof-command-inventory/v1",
+                "sources": ["docs/maintainer/maintainer-commands.md"],
+                "commands": [
+                    {
+                        "id": "generated-command-packages-static",
+                        "command": command,
+                        "status": "runnable",
+                        "source_refs": ["docs/maintainer/maintainer-commands.md"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert module._validate_documented_proof_command_inventory(repo_root=tmp_path, inventory_path=inventory) == []

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -301,6 +301,59 @@ def test_start_surfaces_memory_decision_packet(tmp_path: Path, capsys) -> None:
     assert "No keyword-triggered Memory requirement." in packet["limits"]
 
 
+def test_start_surfaces_recovery_for_obsolete_default_preset(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    workspace.mkdir()
+    (workspace / "config.toml").write_text(
+        "\n".join(
+            [
+                "schema_version = 1",
+                "",
+                "[workspace]",
+                'default_preset = "planning"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert cli.main(["start", "--target", str(tmp_path), "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["kind"] == "agentic-workspace/start-recovery/v1"
+    assert payload["status"] == "recovery-required"
+    assert payload["problem"]["obsolete_field"] == "workspace.default_preset"
+    assert payload["problem"]["replacement"] == "[modules] enabled = [...]"
+    assert payload["problem"]["config_valid"] is False
+    assert payload["automated_repair"]["safe"] is False
+    assert payload["next_safe_action"]["implementation_allowed"] is False
+    assert payload["recovery_packet"]["next_safe_command"] == "agentic-workspace config --target . --format json"
+
+
+def test_start_recovery_for_obsolete_default_preset_uses_configured_cli_invoke(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    workspace.mkdir()
+    (workspace / "config.toml").write_text(
+        "\n".join(
+            [
+                "schema_version = 1",
+                "",
+                "[workspace]",
+                'cli_invoke = "uv run aw-dev"',
+                'default_preset = "planning"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert cli.main(["start", "--target", str(tmp_path), "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["kind"] == "agentic-workspace/start-recovery/v1"
+    assert payload["recovery_packet"]["next_safe_command"] == "uv run aw-dev config --target . --format json"
+
+
 def test_proof_supports_exact_field_selectors_for_sufficiency(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -100,6 +100,83 @@ def test_implement_surfaces_memory_decision_packet_for_changed_paths(tmp_path: P
     assert packet["authority_boundary"]["agent_owns"]
 
 
+def test_implement_compact_omits_routine_stay_local_delegation_noise(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write(tmp_path / "docs" / "note.md", "# Note\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "docs/note.md",
+                "--task",
+                "Update a small doc note",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    context = _implement_context(payload)
+
+    assert "delegation_decision" not in context
+    assert "context.delegation_decision" not in payload["action_signals"]["advisory_detail"]["selectors"]
+    assert "context.delegation_decision" not in payload["drill_down"]["available_selectors"]
+
+
+def test_implement_compact_keeps_delegation_when_route_changes_next_action(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write(
+        tmp_path / ".agentic-workspace" / "config.local.toml",
+        "\n".join(
+            [
+                "schema_version = 1",
+                "",
+                "[runtime]",
+                "strong_planner_available = true",
+                "",
+                "[delegation]",
+                'mode = "manual"',
+            ]
+        ),
+    )
+    _write(tmp_path / "src" / "agentic_workspace" / "contracts" / "schemas" / "workspace_local_override.schema.json", "{}\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/contracts/schemas/workspace_local_override.schema.json",
+                "--task",
+                "Update delegation config schema",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    context = _implement_context(payload)
+
+    assert context["delegation_decision"]["recommended_route"] == "suggest-escalation"
+    assert context["delegation_decision"]["required_next_action"] == "prepare-handoff"
+    assert "context.delegation_decision" in payload["action_signals"]["advisory_detail"]["selectors"]
+    assert "context.delegation_decision" in payload["drill_down"]["available_selectors"]
+
+
 def test_implement_memory_decision_packet_reports_relevant_route_matches(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0


### PR DESCRIPTION
## Summary

Fixes the first grouped dogfooding runtime/proof issues:

- keeps `memory route --pending-command` as context only while explicit surfaces drive local command-construction guidance without task-prose matching
- makes `start --format json` return a compact recovery payload for obsolete `[workspace].default_preset` configs instead of hard failing or proceeding
- demotes routine stay-local delegation from compact implement output while preserving escalation/handoff routes
- adds a documented proof-command inventory to maintainer contract checks so stale conformance commands fail maintainer proof
- files follow-up #1660 for the command-option source-of-truth friction encountered during dogfooding

Fixes #1653.
Fixes #1623.
Fixes #1633.
Fixes #1624.

## Proof

- `uv run pytest packages/memory/tests/test_routing.py::test_route_memory_keeps_pending_command_context_separate_from_explicit_surfaces tests/test_workspace_cli.py::test_start_surfaces_recovery_for_obsolete_default_preset tests/test_workspace_cli.py::test_start_recovery_for_obsolete_default_preset_uses_configured_cli_invoke tests/test_workspace_implement_cli.py::test_implement_compact_omits_routine_stay_local_delegation_noise tests/test_workspace_implement_cli.py::test_implement_compact_keeps_delegation_when_route_changes_next_action tests/test_contract_tooling_surfaces.py -q`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_generated_command_packages.py`
