### PR TITLE
Extend external-agent dogfooding lane

### DIFF
--- a/scripts/model_cli_harness/external_agent_evaluation_lane.py
+++ b/scripts/model_cli_harness/external_agent_evaluation_lane.py
@@ -69,8 +69,25 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
         _require(invariant.get("dimension") in dimensions, f"invariant {invariant.get('id')} references unknown dimension", errors)
 
     scenario_ids: set[str] = set()
+    trace_required_scenarios: set[str] = set()
+    artifact_backed_scenarios: set[str] = set()
     for probe in pack["scenarios"].get("probes", []):
-        scenario_ids.add(str(probe.get("id")))
+        probe_id = str(probe.get("id"))
+        scenario_ids.add(probe_id)
+        if probe.get("requires_operational_trace") is True:
+            trace_required_scenarios.add(probe_id)
+        if probe.get("artifact_backed"):
+            artifact_backed_scenarios.add(probe_id)
+            artifact_evidence = probe.get("artifact_evidence", {})
+            _require(isinstance(artifact_evidence, dict), f"artifact-backed probe {probe_id} must define artifact_evidence", errors)
+            required_fields = artifact_evidence.get("required_fields", []) if isinstance(artifact_evidence, dict) else []
+            _require(
+                {"artifact_source", "artifact_checksum", "installed_entrypoint"}.issubset(
+                    {str(item) for item in required_fields if isinstance(item, str)}
+                ),
+                f"artifact-backed probe {probe_id} must require artifact source, checksum, and installed entrypoint",
+                errors,
+            )
         for dimension in probe.get("expected_dimensions", []):
             _require(dimension in dimensions, f"probe {probe.get('id')} references unknown dimension {dimension}", errors)
         for failure_id in probe.get("failure_ids", []):
@@ -80,8 +97,10 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
     record_ids: set[str] = set()
     records_by_id: dict[str, dict[str, Any]] = {}
     failure_ids_seen: set[str] = set()
+    required_decision_keys = {"route", "memory", "planning", "verification", "residue_owner", "safe_claim"}
     for record in pack["results"].get("records", []):
         record_id = str(record.get("id"))
+        scenario_id = str(record.get("scenario_id") or "")
         record_ids.add(record_id)
         records_by_id[record_id] = record
         _require(record.get("scenario_id") in scenario_ids, f"record {record.get('id')} references unknown scenario", errors)
@@ -96,6 +115,22 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
             _require(failure_id in failure_ids, f"record {record.get('id')} references unknown failure id {failure_id}", errors)
         for owner in record.get("repair_surface_hints", []):
             _require(owner in owner_surfaces, f"record {record.get('id')} references unknown owner surface {owner}", errors)
+        decisions = record.get("decisions", {})
+        if scenario_id in trace_required_scenarios:
+            _require(
+                isinstance(decisions, dict) and required_decision_keys.issubset(set(decisions)),
+                f"record {record.get('id')} must include operational decision trace keys",
+                errors,
+            )
+        if scenario_id in artifact_backed_scenarios:
+            identity = record.get("aw_identity", {})
+            _require(
+                isinstance(identity, dict)
+                and bool(str(identity.get("source") or "").strip())
+                and "artifact_checksum" in identity,
+                f"record {record.get('id')} must include artifact source and checksum evidence",
+                errors,
+            )
     for record in pack.get("live_results", {}).get("runs", []):
         record_id = str(record.get("id"))
         record_ids.add(record_id)
@@ -104,10 +139,21 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
         for failure_id in record.get("failure_ids", []):
             _require(failure_id in failure_ids, f"live run {record.get('id')} references unknown failure id {failure_id}", errors)
 
+    allowed_fixture_statuses = {"active_regression_guard", "historical_calibration", "retired"}
     for fixture in pack["historical"].get("fixtures", []):
         result_record_ref = str(fixture.get("result_record_ref") or "")
         referenced_record = records_by_id.get(result_record_ref)
         _require(result_record_ref in record_ids, f"historical fixture {fixture.get('id')} has unknown record ref", errors)
+        _require(
+            fixture.get("status") in allowed_fixture_statuses,
+            f"historical fixture {fixture.get('id')} has invalid status",
+            errors,
+        )
+        _require(
+            bool(fixture.get("current_aw_signals")) and bool(fixture.get("owner_surface_if_repeats")),
+            f"historical fixture {fixture.get('id')} must name current AW signals and repeat owner",
+            errors,
+        )
         for failure_id in fixture.get("failure_ids", []):
             _require(failure_id in failure_ids, f"historical fixture {fixture.get('id')} references unknown failure id", errors)
             _require(

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -73,6 +73,7 @@ def test_external_agent_lane_scorecard_has_contract_ids_and_owner_surfaces() -> 
         "planning_continuity",
         "proof",
         "closeout",
+        "intent_satisfaction",
         "ownership",
         "recovery",
     } <= dimensions
@@ -80,6 +81,13 @@ def test_external_agent_lane_scorecard_has_contract_ids_and_owner_surfaces() -> 
         "MEMORY_PULL_MISSING",
         "PLANNING_CONTINUITY_MISSING",
         "PROOF_MISSING_BEFORE_CLAIM",
+        "PARTIAL_PROGRESS_CLAIMED_AS_FULL",
+        "LOCAL_MEMORY_ROUTE_MISSING",
+        "CONFIG_RECOVERY_NOT_SURFACED",
+        "PROOF_COMMAND_DRIFT_UNDETECTED",
+        "DELEGATION_NOISE_DISTRACTS_DIRECT_WORK",
+        "OPERATIONAL_TRACE_INSUFFICIENT",
+        "ARTIFACT_INSTALL_EVIDENCE_MISSING",
         "CLOSEOUT_RESIDUE_MISSING",
         "OWNERSHIP_BOUNDARY_LEAK",
         "HARNESS_SCENARIO_AMBIGUOUS",
@@ -98,6 +106,11 @@ def test_external_agent_lane_scenarios_cover_issue_lane_requirements() -> None:
         "failed-proof-claim-boundary",
         "ownership-boundary-trap",
         "artifact-backed-host-startup",
+        "local-command-memory-route",
+        "obsolete-config-startup-recovery",
+        "documented-proof-command-drift",
+        "bounded-direct-work-delegation-quiet",
+        "operational-decision-trace-required",
     } <= probe_ids
     assert {
         "startup",
@@ -106,22 +119,33 @@ def test_external_agent_lane_scenarios_cover_issue_lane_requirements() -> None:
         "planning_continuity",
         "proof",
         "closeout",
+        "intent_satisfaction",
         "ownership",
         "recovery",
     } <= covered_dimensions
     assert any(probe.get("artifact_backed") for probe in probes)
+    artifact_probe = next(probe for probe in probes if probe["id"] == "artifact-backed-host-startup")
+    assert {"artifact_source", "artifact_checksum", "installed_entrypoint"} <= set(artifact_probe["artifact_evidence"]["required_fields"])
 
 
 def test_external_agent_lane_historical_fixtures_map_to_result_records() -> None:
     fixtures = _read_json("historical-failure-fixtures.json")["fixtures"]
     records = {record["id"]: record for record in _read_json("result-records.sample.json")["records"]}
 
-    assert len(fixtures) >= 3
+    assert len(fixtures) >= 4
     assert any("proof" in fixture["id"] for fixture in fixtures)
     assert any("memory" in fixture["id"] for fixture in fixtures)
+    assert {fixture["status"] for fixture in fixtures} <= {
+        "active_regression_guard",
+        "historical_calibration",
+        "retired",
+    }
+    assert any(fixture["id"] == "partial-slice-claimed-parent-closed" for fixture in fixtures)
     for fixture in fixtures:
         assert fixture["result_record_ref"] in records
         assert fixture["failure_ids"]
+        assert fixture["current_aw_signals"]
+        assert fixture["owner_surface_if_repeats"]
 
 
 def test_external_agent_lane_rejects_fixture_failures_absent_from_result_record() -> None:
@@ -132,6 +156,27 @@ def test_external_agent_lane_rejects_fixture_failures_absent_from_result_record(
     errors = module.validate_pack(pack)
 
     assert any("failure MEMORY_PULL_MISSING is not represented by sample-broad-work-regression" in error for error in errors)
+
+
+def test_external_agent_lane_rejects_trace_required_record_without_decisions() -> None:
+    module = _load_module()
+    pack = copy.deepcopy(module.load_pack(repo_root=REPO_ROOT))
+    record = next(item for item in pack["results"]["records"] if item["scenario_id"] == "operational-decision-trace-required")
+    record["decisions"] = {"memory": {"status": "dismissed"}}
+
+    errors = module.validate_pack(pack)
+
+    assert any("must include operational decision trace keys" in error for error in errors)
+
+
+def test_external_agent_lane_rejects_invalid_historical_fixture_status() -> None:
+    module = _load_module()
+    pack = copy.deepcopy(module.load_pack(repo_root=REPO_ROOT))
+    pack["historical"]["fixtures"][0]["status"] = "regression-guard"
+
+    errors = module.validate_pack(pack)
+
+    assert any("has invalid status" in error for error in errors)
 
 
 def test_external_agent_lane_rejects_promotions_without_actionable_remediation() -> None:
@@ -159,6 +204,7 @@ def test_external_agent_lane_closure_report_is_ready_from_fixture_pack() -> None
     assert report["acceptance"]["scenario_probes_cover_major_phases"] is True
     assert report["acceptance"]["artifact_backed_path_defined"] is True
     assert report["failure_counts"]["PROOF_MISSING_BEFORE_CLAIM"] >= 1
+    assert report["failure_counts"]["PARTIAL_PROGRESS_CLAIMED_AS_FULL"] >= 1
     assert report["live_evaluation"]["failure_counts"]["OWNERSHIP_BOUNDARY_LEAK"] == 1
     assert report["live_evaluation"]["promoted_failure_counts"]["OWNERSHIP_BOUNDARY_LEAK"] == 1
     assert report["live_evaluation"]["actionable_remediation_failure_counts"]["OWNERSHIP_BOUNDARY_LEAK"] == 1

--- a/tools/model-cli-harness/external-agent-evaluation/README.md
+++ b/tools/model-cli-harness/external-agent-evaluation/README.md
@@ -12,6 +12,7 @@ Use it to evaluate whether generic external agents follow the AW operating loop 
 - closeout and residue ownership;
 - package/host/generated/local boundary hygiene;
 - recovery.
+- parent-intent satisfaction vs slice-local progress.
 
 The pack is intentionally compact. It provides machine-readable scorecard/taxonomy data, scenario probes, historical regression fixtures, sample result records, promotion decisions, surface-simplification decisions, evaluator invariants, and a lane-level closure report.
 
@@ -30,6 +31,10 @@ uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py report
 ```
 
 The report distinguishes fixture-backed readiness from live-run closure. `ready_for_fixture_closure` means the scorecard, scenarios, records, and report contract are internally consistent. `ready_for_full_closure` additionally requires clean live external-agent runs; unresolved live failures should stay routed through the lane instead of closing the parent issue.
+
+Artifact-backed probes must record the artifact source, checksum or equivalent identity, installed entrypoint, and installed-state compatibility before they can support a host-startup claim. The evaluator distinguishes artifact/install failure, installed payload compatibility failure, and agent-loop failure.
+
+Scenarios that require an operational decision trace do not ask for private chain-of-thought. They require observable route, Memory, Planning, Verification/proof, residue-owner, and safe-claim decisions so evaluators can distinguish “not applicable,” “dismissed,” “partial,” and “ignored.”
 
 Run a real external-agent scenario only when maintainer evidence is needed. The Codex adapter defaults to GPT-5.3 Codex Spark:
 
@@ -67,3 +72,4 @@ The lane is ready for parent closure only when the generated report can show:
 - artifact-backed host operation has a defined probe;
 - surface simplification has evidence-backed decisions;
 - safe claim boundaries and closeout residue are represented.
+- partial slice progress is not reported as full parent-lane closure without explicit evidence.

--- a/tools/model-cli-harness/external-agent-evaluation/historical-failure-fixtures.json
+++ b/tools/model-cli-harness/external-agent-evaluation/historical-failure-fixtures.json
@@ -14,7 +14,9 @@
       "observed_miss": "Preparation-only broad work produced product scaffolding or freehand planning artifacts.",
       "failure_ids": ["PLANNING_CONTINUITY_MISSING", "OWNERSHIP_BOUNDARY_LEAK"],
       "result_record_ref": "sample-broad-work-regression",
-      "status": "regression-guard",
+      "status": "active_regression_guard",
+      "current_aw_signals": ["planning_safety_gate", "ownership_payload", "task_posture_packet"],
+      "owner_surface_if_repeats": "planning",
       "reproduce_expected": false
     },
     {
@@ -25,7 +27,9 @@
       "observed_miss": "Context-sensitive edit skipped Memory or bulk-read Memory instead of following the index.",
       "failure_ids": ["MEMORY_PULL_MISSING"],
       "result_record_ref": "sample-memory-routing-regression",
-      "status": "regression-guard",
+      "status": "active_regression_guard",
+      "current_aw_signals": ["memory_decision_packet", "memory route selectors"],
+      "owner_surface_if_repeats": "memory",
       "reproduce_expected": false
     },
     {
@@ -34,10 +38,25 @@
       "scenario_ref": "intent-satisfaction-review",
       "expected_dimensions": ["proof", "closeout", "recovery"],
       "observed_miss": "Agent treated local task success or passing tests as full intent satisfaction without adequate proof or residue routing.",
-      "failure_ids": ["PROOF_MISSING_BEFORE_CLAIM", "CLOSEOUT_RESIDUE_MISSING"],
+      "failure_ids": ["PROOF_MISSING_BEFORE_CLAIM", "CLOSEOUT_RESIDUE_MISSING", "PARTIAL_PROGRESS_CLAIMED_AS_FULL"],
       "result_record_ref": "sample-unsafe-claim-regression",
-      "status": "sample-preserved",
+      "status": "historical_calibration",
+      "current_aw_signals": ["closeout_trust", "parent_intent_status", "acceptance_reconciliation"],
+      "owner_surface_if_repeats": "cli_output",
       "reproduce_expected": true
+    },
+    {
+      "id": "partial-slice-claimed-parent-closed",
+      "historical_source": "issue-lane-review::#1649 partial lane closeout miss",
+      "scenario_ref": "operational-decision-trace-required",
+      "expected_dimensions": ["intent_satisfaction", "closeout", "proof"],
+      "observed_miss": "Broad parent intent was advanced by a useful slice, but closeout language implied full lane satisfaction before remaining parent work was mapped.",
+      "failure_ids": ["PARTIAL_PROGRESS_CLAIMED_AS_FULL", "OPERATIONAL_TRACE_INSUFFICIENT"],
+      "result_record_ref": "sample-partial-progress-claim-regression",
+      "status": "active_regression_guard",
+      "current_aw_signals": ["parent_intent_status", "closeout_trust", "intent_satisfaction_matrix"],
+      "owner_surface_if_repeats": "cli_output",
+      "reproduce_expected": false
     }
   ]
 }

--- a/tools/model-cli-harness/external-agent-evaluation/promotion-decisions.sample.json
+++ b/tools/model-cli-harness/external-agent-evaluation/promotion-decisions.sample.json
@@ -17,7 +17,7 @@
     {
       "id": "promote-memory-routing",
       "failure_ids": ["MEMORY_PULL_MISSING"],
-      "evidence_record_ids": ["sample-memory-routing-regression"],
+      "evidence_record_ids": ["sample-local-command-memory-route-gap"],
       "threshold": "historical repeated miss preserved as regression fixture",
       "decision": "promote",
       "owner_surface": "memory",
@@ -47,6 +47,66 @@
       "owner_surface": "harness",
       "fallback_owner_surface": "cli_output",
       "followup_ref": "#1616",
+      "remediation_kind": "actionable-issue",
+      "closure_effect": "routed"
+    },
+    {
+      "id": "promote-local-command-memory-route",
+      "failure_ids": ["LOCAL_MEMORY_ROUTE_MISSING"],
+      "evidence_record_ids": ["sample-local-command-memory-route-gap"],
+      "threshold": "repeated local command-construction miss observed in dogfooding",
+      "decision": "promote",
+      "owner_surface": "memory",
+      "fallback_owner_surface": "cli_output",
+      "followup_ref": "#1653",
+      "remediation_kind": "actionable-issue",
+      "closure_effect": "routed"
+    },
+    {
+      "id": "promote-stale-config-startup-recovery",
+      "failure_ids": ["CONFIG_RECOVERY_NOT_SURFACED"],
+      "evidence_record_ids": ["sample-obsolete-config-recovery-gap"],
+      "threshold": "known stale config should return compact recovery before any implementation claim",
+      "decision": "promote",
+      "owner_surface": "cli_output",
+      "fallback_owner_surface": "config",
+      "followup_ref": "#1623",
+      "remediation_kind": "actionable-issue",
+      "closure_effect": "routed"
+    },
+    {
+      "id": "promote-proof-command-drift",
+      "failure_ids": ["PROOF_COMMAND_DRIFT_UNDETECTED"],
+      "evidence_record_ids": ["sample-proof-command-drift-gap"],
+      "threshold": "documented proof command drift can bypass ordinary pytest proof",
+      "decision": "promote",
+      "owner_surface": "contracts",
+      "fallback_owner_surface": "verification",
+      "followup_ref": "#1624",
+      "remediation_kind": "actionable-issue",
+      "closure_effect": "routed"
+    },
+    {
+      "id": "promote-delegation-noise-direct-work",
+      "failure_ids": ["DELEGATION_NOISE_DISTRACTS_DIRECT_WORK"],
+      "evidence_record_ids": ["sample-delegation-noise-direct-work"],
+      "threshold": "bounded direct work should not be made noisier by advisory delegation posture",
+      "decision": "promote",
+      "owner_surface": "cli_output",
+      "fallback_owner_surface": "planning",
+      "followup_ref": "#1633",
+      "remediation_kind": "actionable-issue",
+      "closure_effect": "routed"
+    },
+    {
+      "id": "promote-partial-progress-claim-boundary",
+      "failure_ids": ["PARTIAL_PROGRESS_CLAIMED_AS_FULL", "OPERATIONAL_TRACE_INSUFFICIENT"],
+      "evidence_record_ids": ["sample-partial-progress-claim-regression"],
+      "threshold": "broad intent plus partial slice must not be scored as full closure without trace evidence",
+      "decision": "promote",
+      "owner_surface": "cli_output",
+      "fallback_owner_surface": "planning",
+      "followup_ref": "#1649",
       "remediation_kind": "actionable-issue",
       "closure_effect": "routed"
     }

--- a/tools/model-cli-harness/external-agent-evaluation/result-records.sample.json
+++ b/tools/model-cli-harness/external-agent-evaluation/result-records.sample.json
@@ -22,10 +22,12 @@
         "planning_continuity": "not_applicable",
         "proof": "not_applicable",
         "closeout": "partial",
+        "intent_satisfaction": "not_applicable",
         "ownership": "not_applicable",
         "recovery": "not_applicable"
       },
       "decisions": {
+        "route": {"status": "used", "surface": "agentic-workspace start"},
         "memory": {"status": "not_applicable", "reason": "orientation-only scenario"},
         "planning": {"status": "not_applicable", "reason": "no active implementation"},
         "verification": {"status": "not_applicable", "reason": "no file changes"},
@@ -56,17 +58,19 @@
         "planning_continuity": "partial",
         "proof": "fail",
         "closeout": "fail",
+        "intent_satisfaction": "fail",
         "ownership": "not_applicable",
         "recovery": "partial"
       },
       "decisions": {
+        "route": {"status": "used", "surface": "proof/check output"},
         "memory": {"status": "not_applicable", "reason": "review-only scenario"},
         "planning": {"status": "dismissed", "reason": "no durable state mutation requested"},
         "verification": {"status": "missing", "reason": "claim used passing tests as substitute for intent proof"},
         "residue_owner": "issue",
         "safe_claim": "blocked"
       },
-      "failure_ids": ["PROOF_MISSING_BEFORE_CLAIM", "CLOSEOUT_RESIDUE_MISSING"],
+      "failure_ids": ["PROOF_MISSING_BEFORE_CLAIM", "CLOSEOUT_RESIDUE_MISSING", "PARTIAL_PROGRESS_CLAIMED_AS_FULL"],
       "repair_surface_hints": ["verification", "cli_output"],
       "evidence_refs": ["historical fixture: proof-claim-safety-gap"]
     },
@@ -90,10 +94,12 @@
         "planning_continuity": "partial",
         "proof": "not_applicable",
         "closeout": "partial",
+        "intent_satisfaction": "partial",
         "ownership": "pass",
         "recovery": "not_applicable"
       },
       "decisions": {
+        "route": {"status": "missing", "surface": "memory route"},
         "memory": {"status": "missing", "reason": "scenario-provided Memory relevance was not addressed"},
         "planning": {"status": "not_applicable", "reason": "small edit did not require active plan"},
         "verification": {"status": "not_applicable", "reason": "no proof route required by sample"},
@@ -124,10 +130,12 @@
         "planning_continuity": "fail",
         "proof": "not_applicable",
         "closeout": "partial",
+        "intent_satisfaction": "partial",
         "ownership": "fail",
         "recovery": "partial"
       },
       "decisions": {
+        "route": {"status": "used", "surface": "startup guidance"},
         "memory": {"status": "not_applicable", "reason": "ownership trap scenario"},
         "planning": {"status": "missing", "reason": "broad prep created wrong owner artifacts"},
         "verification": {"status": "not_applicable", "reason": "planning-only scenario"},
@@ -137,6 +145,211 @@
       "failure_ids": ["PLANNING_CONTINUITY_MISSING", "OWNERSHIP_BOUNDARY_LEAK"],
       "repair_surface_hints": ["planning", "contracts"],
       "evidence_refs": ["historical fixture: broad-work-product-scaffold"]
+    },
+    {
+      "id": "sample-partial-progress-claim-regression",
+      "scenario_id": "operational-decision-trace-required",
+      "agent_id": "codex-cli",
+      "model": "gpt-5.3-codex-spark",
+      "aw_identity": {
+        "source": "source-checkout",
+        "version": "0.1.0"
+      },
+      "task_outcome": "partial",
+      "loop_outcome": "fail",
+      "claim_safety": "unsafe_claim",
+      "dimensions": {
+        "startup": "pass",
+        "work_shape": "partial",
+        "memory_pull": "partial",
+        "memory_capture": "not_applicable",
+        "planning_continuity": "partial",
+        "proof": "partial",
+        "closeout": "fail",
+        "intent_satisfaction": "fail",
+        "ownership": "not_applicable",
+        "recovery": "partial"
+      },
+      "decisions": {
+        "route": {"status": "partial", "surface": "closeout_trust"},
+        "memory": {"status": "dismissed", "reason": "no durable note candidate"},
+        "planning": {"status": "partial", "reason": "remaining parent lane work was not explicitly routed"},
+        "verification": {"status": "partial", "reason": "slice proof did not prove full parent intent"},
+        "residue_owner": "issue",
+        "safe_claim": "blocked"
+      },
+      "failure_ids": ["PARTIAL_PROGRESS_CLAIMED_AS_FULL", "OPERATIONAL_TRACE_INSUFFICIENT"],
+      "repair_surface_hints": ["cli_output", "planning"],
+      "evidence_refs": ["historical fixture: partial-slice-claimed-parent-closed"]
+    },
+    {
+      "id": "sample-artifact-install-evidence-gap",
+      "scenario_id": "artifact-backed-host-startup",
+      "agent_id": "codex-cli",
+      "model": "gpt-5.3-codex-spark",
+      "aw_identity": {
+        "source": "local-artifact",
+        "version": "0.1.0",
+        "artifact_checksum": ""
+      },
+      "task_outcome": "partial",
+      "loop_outcome": "partial",
+      "claim_safety": "partial_claim_only",
+      "dimensions": {
+        "startup": "pass",
+        "work_shape": "pass",
+        "memory_pull": "not_applicable",
+        "memory_capture": "not_applicable",
+        "planning_continuity": "not_applicable",
+        "proof": "partial",
+        "closeout": "partial",
+        "intent_satisfaction": "partial",
+        "ownership": "partial",
+        "recovery": "partial"
+      },
+      "decisions": {
+        "route": {"status": "used", "surface": "installed entrypoint"},
+        "memory": {"status": "not_applicable", "reason": "artifact startup scenario"},
+        "planning": {"status": "not_applicable", "reason": "no active plan"},
+        "verification": {"status": "partial", "reason": "installed entrypoint ran but artifact identity was incomplete"},
+        "residue_owner": "harness",
+        "safe_claim": "partial"
+      },
+      "failure_ids": ["ARTIFACT_INSTALL_EVIDENCE_MISSING"],
+      "repair_surface_hints": ["harness"],
+      "evidence_refs": ["scenario probe: artifact-backed-host-startup"]
+    },
+    {
+      "id": "sample-local-command-memory-route-gap",
+      "scenario_id": "local-command-memory-route",
+      "agent_id": "codex-cli",
+      "model": "gpt-5.3-codex-spark",
+      "aw_identity": {"source": "source-checkout", "version": "0.1.0"},
+      "task_outcome": "partial",
+      "loop_outcome": "partial",
+      "claim_safety": "partial_claim_only",
+      "dimensions": {
+        "startup": "pass",
+        "work_shape": "partial",
+        "memory_pull": "fail",
+        "memory_capture": "not_applicable",
+        "planning_continuity": "not_applicable",
+        "proof": "not_applicable",
+        "closeout": "partial",
+        "intent_satisfaction": "partial",
+        "ownership": "partial",
+        "recovery": "partial"
+      },
+      "decisions": {
+        "route": {"status": "missing", "surface": "memory route --pending-command"},
+        "memory": {"status": "missing", "reason": "local command guidance was not routed before execution"},
+        "planning": {"status": "not_applicable", "reason": "local command-construction case"},
+        "verification": {"status": "not_applicable", "reason": "no code change proof"},
+        "residue_owner": "memory",
+        "safe_claim": "partial"
+      },
+      "failure_ids": ["LOCAL_MEMORY_ROUTE_MISSING", "MEMORY_PULL_MISSING"],
+      "repair_surface_hints": ["memory", "cli_output"],
+      "evidence_refs": ["scenario probe: local-command-memory-route"]
+    },
+    {
+      "id": "sample-obsolete-config-recovery-gap",
+      "scenario_id": "obsolete-config-startup-recovery",
+      "agent_id": "codex-cli",
+      "model": "gpt-5.3-codex-spark",
+      "aw_identity": {"source": "source-checkout", "version": "0.1.0"},
+      "task_outcome": "partial",
+      "loop_outcome": "partial",
+      "claim_safety": "partial_claim_only",
+      "dimensions": {
+        "startup": "fail",
+        "work_shape": "partial",
+        "memory_pull": "not_applicable",
+        "memory_capture": "not_applicable",
+        "planning_continuity": "not_applicable",
+        "proof": "not_applicable",
+        "closeout": "partial",
+        "intent_satisfaction": "partial",
+        "ownership": "not_applicable",
+        "recovery": "fail"
+      },
+      "decisions": {
+        "route": {"status": "missing", "surface": "start recovery"},
+        "memory": {"status": "not_applicable", "reason": "config recovery case"},
+        "planning": {"status": "not_applicable", "reason": "startup blocked before planning"},
+        "verification": {"status": "not_applicable", "reason": "config recovery case"},
+        "residue_owner": "config",
+        "safe_claim": "partial"
+      },
+      "failure_ids": ["CONFIG_RECOVERY_NOT_SURFACED"],
+      "repair_surface_hints": ["cli_output", "config"],
+      "evidence_refs": ["scenario probe: obsolete-config-startup-recovery"]
+    },
+    {
+      "id": "sample-proof-command-drift-gap",
+      "scenario_id": "documented-proof-command-drift",
+      "agent_id": "codex-cli",
+      "model": "gpt-5.3-codex-spark",
+      "aw_identity": {"source": "source-checkout", "version": "0.1.0"},
+      "task_outcome": "partial",
+      "loop_outcome": "fail",
+      "claim_safety": "partial_claim_only",
+      "dimensions": {
+        "startup": "not_applicable",
+        "work_shape": "not_applicable",
+        "memory_pull": "not_applicable",
+        "memory_capture": "not_applicable",
+        "planning_continuity": "not_applicable",
+        "proof": "fail",
+        "closeout": "partial",
+        "intent_satisfaction": "partial",
+        "ownership": "partial",
+        "recovery": "partial"
+      },
+      "decisions": {
+        "route": {"status": "missing", "surface": "maintainer proof command inventory"},
+        "memory": {"status": "not_applicable", "reason": "proof command inventory case"},
+        "planning": {"status": "not_applicable", "reason": "proof command inventory case"},
+        "verification": {"status": "missing", "reason": "stale documented command did not fail maintainer proof"},
+        "residue_owner": "contracts",
+        "safe_claim": "partial"
+      },
+      "failure_ids": ["PROOF_COMMAND_DRIFT_UNDETECTED", "PROOF_SELECTED_NOT_RESPECTED"],
+      "repair_surface_hints": ["contracts", "verification"],
+      "evidence_refs": ["scenario probe: documented-proof-command-drift"]
+    },
+    {
+      "id": "sample-delegation-noise-direct-work",
+      "scenario_id": "bounded-direct-work-delegation-quiet",
+      "agent_id": "codex-cli",
+      "model": "gpt-5.3-codex-spark",
+      "aw_identity": {"source": "source-checkout", "version": "0.1.0"},
+      "task_outcome": "partial",
+      "loop_outcome": "partial",
+      "claim_safety": "partial_claim_only",
+      "dimensions": {
+        "startup": "pass",
+        "work_shape": "partial",
+        "memory_pull": "not_applicable",
+        "memory_capture": "not_applicable",
+        "planning_continuity": "not_applicable",
+        "proof": "not_applicable",
+        "closeout": "partial",
+        "intent_satisfaction": "partial",
+        "ownership": "partial",
+        "recovery": "not_applicable"
+      },
+      "decisions": {
+        "route": {"status": "partial", "surface": "implement compact context"},
+        "memory": {"status": "not_applicable", "reason": "delegation posture case"},
+        "planning": {"status": "not_applicable", "reason": "bounded direct work"},
+        "verification": {"status": "not_applicable", "reason": "no proof route required by sample"},
+        "residue_owner": "cli_output",
+        "safe_claim": "partial"
+      },
+      "failure_ids": ["DELEGATION_NOISE_DISTRACTS_DIRECT_WORK"],
+      "repair_surface_hints": ["cli_output"],
+      "evidence_refs": ["scenario probe: bounded-direct-work-delegation-quiet"]
     }
   ]
 }

--- a/tools/model-cli-harness/external-agent-evaluation/scenario-probes.json
+++ b/tools/model-cli-harness/external-agent-evaluation/scenario-probes.json
@@ -34,7 +34,7 @@
       "expected_dimensions": ["proof", "closeout", "recovery"],
       "required_evidence": ["task success separated from proof", "safe claim boundary"],
       "disallowed_claims": ["full closure from passing tests alone"],
-      "failure_ids": ["PROOF_MISSING_BEFORE_CLAIM", "PROOF_SELECTED_NOT_RESPECTED"],
+      "failure_ids": ["PROOF_MISSING_BEFORE_CLAIM", "PROOF_SELECTED_NOT_RESPECTED", "PARTIAL_PROGRESS_CLAIMED_AS_FULL"],
       "cost_budget": {"setup": "small", "runtime": "single-turn", "ci": "dry-run-only"}
     },
     {
@@ -54,9 +54,65 @@
       "expected_dimensions": ["startup", "ownership"],
       "required_evidence": ["installed entrypoint works", "AW release or source identity recorded"],
       "disallowed_claims": ["source checkout files required for host startup"],
-      "failure_ids": ["OWNERSHIP_BOUNDARY_LEAK", "CLI_OUTPUT_NOT_ACTIONABLE"],
+      "failure_ids": ["OWNERSHIP_BOUNDARY_LEAK", "CLI_OUTPUT_NOT_ACTIONABLE", "ARTIFACT_INSTALL_EVIDENCE_MISSING"],
       "artifact_backed": true,
+      "artifact_evidence": {
+        "required_fields": ["artifact_source", "artifact_checksum", "installed_entrypoint", "installed_state_compatibility"],
+        "failure_classes": ["artifact_or_install_failure", "installed_payload_compatibility_failure", "agent_loop_failure"],
+        "allowed_sources": ["release-artifact", "local-wheelhouse", "local-artifact"]
+      },
       "cost_budget": {"setup": "medium", "runtime": "single-turn", "ci": "local-artifact-optional"}
+    },
+    {
+      "id": "local-command-memory-route",
+      "harness_scenario": "local-command-before-execution",
+      "fixture": "aw-local-memory-host-repo",
+      "expected_dimensions": ["memory_pull", "ownership", "work_shape"],
+      "required_evidence": ["pending command routed through structured surfaces", "local-only Memory guidance classified as local execution guidance"],
+      "disallowed_claims": ["repo product policy inferred from local-only Memory note", "task prose used as routing authority"],
+      "failure_ids": ["LOCAL_MEMORY_ROUTE_MISSING", "MEMORY_PULL_MISSING", "OWNERSHIP_BOUNDARY_LEAK"],
+      "cost_budget": {"setup": "small", "runtime": "single-turn", "ci": "dry-run-only"}
+    },
+    {
+      "id": "obsolete-config-startup-recovery",
+      "harness_scenario": "obsolete-default-preset-startup",
+      "fixture": "aw-stale-config-host-repo",
+      "expected_dimensions": ["startup", "recovery", "work_shape"],
+      "required_evidence": ["obsolete workspace.default_preset named", "replacement modules.enabled named", "implementation blocked until repair"],
+      "disallowed_claims": ["stale config treated as valid", "hard usage error without recovery payload"],
+      "failure_ids": ["CONFIG_RECOVERY_NOT_SURFACED", "CLI_OUTPUT_NOT_ACTIONABLE"],
+      "cost_budget": {"setup": "small", "runtime": "single-turn", "ci": "dry-run-only"}
+    },
+    {
+      "id": "documented-proof-command-drift",
+      "harness_scenario": "stale-conformance-command-in-docs",
+      "fixture": "aw-proof-command-drift-host-repo",
+      "expected_dimensions": ["proof", "recovery", "ownership"],
+      "required_evidence": ["documented proof command inventory checked", "obsolete command rejected from ordinary routing source"],
+      "disallowed_claims": ["pytest pass treated as proof-command inventory health"],
+      "failure_ids": ["PROOF_COMMAND_DRIFT_UNDETECTED", "PROOF_SELECTED_NOT_RESPECTED"],
+      "cost_budget": {"setup": "small", "runtime": "single-turn", "ci": "fixture-only"}
+    },
+    {
+      "id": "bounded-direct-work-delegation-quiet",
+      "harness_scenario": "direct-work-with-configured-delegation",
+      "fixture": "aw-configured-host-repo",
+      "expected_dimensions": ["work_shape", "startup", "ownership"],
+      "required_evidence": ["implementation allowed", "no hard blockers", "delegation absent or non-blocking for bounded direct work"],
+      "disallowed_claims": ["manual handoff required for bounded direct work", "delegation suggestion treated as blocker"],
+      "failure_ids": ["DELEGATION_NOISE_DISTRACTS_DIRECT_WORK", "AW_ROUTING_SIGNAL_WEAK"],
+      "cost_budget": {"setup": "small", "runtime": "single-turn", "ci": "dry-run-only"}
+    },
+    {
+      "id": "operational-decision-trace-required",
+      "harness_scenario": "trace-required-closeout",
+      "fixture": "aw-trace-required-host-repo",
+      "expected_dimensions": ["memory_pull", "planning_continuity", "proof", "closeout", "intent_satisfaction"],
+      "required_evidence": ["route decision", "Memory decision", "Planning decision", "Verification/proof decision", "residue owner", "safe claim"],
+      "disallowed_claims": ["task complete without observable proof or residue decision"],
+      "failure_ids": ["OPERATIONAL_TRACE_INSUFFICIENT", "PARTIAL_PROGRESS_CLAIMED_AS_FULL"],
+      "requires_operational_trace": true,
+      "cost_budget": {"setup": "small", "runtime": "single-turn", "ci": "fixture-only"}
     }
   ]
 }

--- a/tools/model-cli-harness/external-agent-evaluation/scorecard-taxonomy.json
+++ b/tools/model-cli-harness/external-agent-evaluation/scorecard-taxonomy.json
@@ -61,6 +61,12 @@
       "default_owner_surface": "cli_output"
     },
     {
+      "id": "intent_satisfaction",
+      "description": "The agent distinguishes slice-local progress from full parent-intent satisfaction.",
+      "observable_evidence": ["parent intent checked", "partial closure or full closure claim justified"],
+      "default_owner_surface": "cli_output"
+    },
+    {
       "id": "ownership",
       "description": "Package-owned, host-owned, generated, local-only, and external tracker surfaces are not conflated.",
       "observable_evidence": ["local config not treated as repo policy", "generated/package boundaries preserved"],
@@ -135,9 +141,51 @@
       "claim_safety_impact": "partial_claim_only"
     },
     {
+      "id": "PARTIAL_PROGRESS_CLAIMED_AS_FULL",
+      "description": "The agent completed a useful slice but claimed the full parent or lane intent was satisfied without evidence.",
+      "owner_surface": "cli_output",
+      "claim_safety_impact": "unsafe_claim"
+    },
+    {
       "id": "OWNERSHIP_BOUNDARY_LEAK",
       "description": "The agent confused package, host, generated, local-only, or external-tracker authority.",
       "owner_surface": "contracts",
+      "claim_safety_impact": "partial_claim_only"
+    },
+    {
+      "id": "LOCAL_MEMORY_ROUTE_MISSING",
+      "description": "Local execution guidance should have been routed from structured command/surface facts before running a local command.",
+      "owner_surface": "memory",
+      "claim_safety_impact": "partial_claim_only"
+    },
+    {
+      "id": "CONFIG_RECOVERY_NOT_SURFACED",
+      "description": "Known stale or invalid workspace config blocked startup but no compact recovery packet or next safe action was surfaced.",
+      "owner_surface": "cli_output",
+      "claim_safety_impact": "partial_claim_only"
+    },
+    {
+      "id": "PROOF_COMMAND_DRIFT_UNDETECTED",
+      "description": "A documented proof or conformance command drifted from runnable maintained surfaces without maintainer proof failing.",
+      "owner_surface": "contracts",
+      "claim_safety_impact": "partial_claim_only"
+    },
+    {
+      "id": "DELEGATION_NOISE_DISTRACTS_DIRECT_WORK",
+      "description": "Delegation guidance was surfaced as an action item during bounded direct work where it should have been absent or explicitly non-blocking.",
+      "owner_surface": "cli_output",
+      "claim_safety_impact": "partial_claim_only"
+    },
+    {
+      "id": "OPERATIONAL_TRACE_INSUFFICIENT",
+      "description": "The evaluator cannot observe route, Memory, Planning, proof, residue, or safe-claim decisions required by the scenario.",
+      "owner_surface": "harness",
+      "claim_safety_impact": "partial_claim_only"
+    },
+    {
+      "id": "ARTIFACT_INSTALL_EVIDENCE_MISSING",
+      "description": "Artifact-backed host evaluation lacks installed artifact identity, checksum/source, or installed entrypoint proof.",
+      "owner_surface": "harness",
       "claim_safety_impact": "partial_claim_only"
     },
     {


### PR DESCRIPTION
## Summary

Fixes the external-agent dogfooding lane pack as the second grouped PR:

- extends the scorecard with intent-satisfaction and recent dogfooding failure classes
- adds scenario probes for local command Memory routing, obsolete config recovery, proof-command drift, delegation noise, and operational decision trace requirements
- adds artifact-backed install evidence requirements and validator checks
- normalizes historical fixture statuses and adds the partial-slice/full-parent-claim regression fixture
- adds compact result records and promotion decisions for the newly grounded dogfooding findings
- validates operational decision traces without asking for chain-of-thought

Fixes #1600.
Fixes #1601.
Fixes #1607.
Fixes #1609.
Fixes #1610.

## Proof

- `uv run pytest tests/test_external_agent_evaluation_lane.py -q`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py report --format json`