### PR TITLE
Guard against non-enum keyword routing

### DIFF
--- a/docs/maintainer/non-enum-keyword-routing-audit.json
+++ b/docs/maintainer/non-enum-keyword-routing-audit.json
@@ -1,0 +1,168 @@
+{
+  "kind": "agentic-workspace/non-enum-keyword-routing-audit/v1",
+  "purpose": "Classify local string tables that are structurally used in substring-style decisions so they cannot silently become package-owned keyword routing policy.",
+  "rule": "Substring marker tables are allowed only when they remain advisory diagnostics/search or documented checker fixtures. Repo-specific routing must come from explicit labels, structured state, or learned metadata.",
+  "entries": [
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_planned_task_posture_residue",
+      "variable": "posture_markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table identifies planning-posture residue for review and does not choose a workflow owner."
+    },
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_review_artifact_has_resolved_findings",
+      "variable": "resolved_markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table checks review-artifact wording for stale-residue diagnostics and does not route task ownership."
+    },
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_compact_repair_plan_profile",
+      "variable": "repair_terms",
+      "classification": "advisory-diagnostic",
+      "authority": "The table describes repair-shaped diagnostic hints; the agent still owns work-shape judgment."
+    },
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_capability_posture_for_implementation",
+      "variable": "judgment_terms",
+      "classification": "advisory-diagnostic",
+      "authority": "The table contributes capability-posture hints, not a package-owned delegation route."
+    },
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_capability_posture_for_implementation",
+      "variable": "mechanical_terms",
+      "classification": "advisory-diagnostic",
+      "authority": "The table contributes capability-posture hints, not a package-owned delegation route."
+    },
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_manual_external_relay_payload",
+      "variable": "code_local_terms",
+      "classification": "advisory-diagnostic",
+      "authority": "The table suppresses noisy relay suggestions for code-local diagnostics; it does not force a route."
+    },
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_manual_external_relay_payload",
+      "variable": "domain_terms",
+      "classification": "advisory-diagnostic",
+      "authority": "The table supports relay-suggestion diagnostics; it does not make the delegation decision."
+    },
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_knowledge_gates_payload",
+      "variable": "knowledge_markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table surfaces possible knowledge-gate pressure for agent review and does not enforce routing."
+    },
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_task_posture_packet_relevant",
+      "variable": "markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table gates visibility of an advisory task-posture packet; it does not decide task ownership."
+    },
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_ownership_diagnostics",
+      "variable": "active_state_markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table flags possible adapter drift for review and does not select a routing owner."
+    },
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_ownership_diagnostics",
+      "variable": "config_active_markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table flags possible config drift for review and does not select a routing owner."
+    },
+    {
+      "path": "src/agentic_workspace/workspace_runtime_primitives.py",
+      "function": "_ownership_diagnostics",
+      "variable": "policy_knobs",
+      "classification": "advisory-diagnostic",
+      "authority": "The table identifies policy-looking config fields for drift diagnostics."
+    },
+    {
+      "path": "packages/planning/src/repo_planning_bootstrap/installer.py",
+      "function": "_finished_run_config_signal",
+      "variable": "lower_trust_markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table evaluates finished-run config-signal trust for closeout diagnostics."
+    },
+    {
+      "path": "packages/planning/src/repo_planning_bootstrap/installer.py",
+      "function": "_finished_run_config_signal",
+      "variable": "positive_markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table evaluates finished-run config-signal trust for closeout diagnostics."
+    },
+    {
+      "path": "packages/planning/scripts/check/check_planning_surfaces.py",
+      "function": "_looks_like_freehand_planning_artifact",
+      "variable": "plan_markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table identifies possible freehand planning artifacts for checker review."
+    },
+    {
+      "path": "packages/planning/scripts/check/check_planning_surfaces.py",
+      "function": "_check_promotion_linkage",
+      "variable": "signal_hints",
+      "classification": "advisory-diagnostic",
+      "authority": "The table validates planning promotion-linkage documentation hints in a checker."
+    },
+    {
+      "path": "packages/planning/scripts/check/check_planning_surfaces.py",
+      "function": "_check_startup_policy",
+      "variable": "required_agents_fragments",
+      "classification": "advisory-diagnostic",
+      "authority": "The table validates required startup-policy documentation fragments in a checker."
+    },
+    {
+      "path": "packages/planning/scripts/check/check_planning_surfaces.py",
+      "function": "_check_startup_policy",
+      "variable": "required_contributor_fragments",
+      "classification": "advisory-diagnostic",
+      "authority": "The table validates required startup-policy documentation fragments in a checker."
+    },
+    {
+      "path": "packages/planning/scripts/check/check_planning_surfaces.py",
+      "function": "_check_startup_policy",
+      "variable": "required_readme_fragments",
+      "classification": "advisory-diagnostic",
+      "authority": "The table validates required startup-policy documentation fragments in a checker."
+    },
+    {
+      "path": "packages/planning/scripts/check/check_planning_surfaces.py",
+      "function": "_check_docs_surface_roles",
+      "variable": "required_fragments",
+      "classification": "advisory-diagnostic",
+      "authority": "The table validates required documentation fragments in a checker."
+    },
+    {
+      "path": "packages/memory/src/repo_memory_bootstrap/installer.py",
+      "function": "_looks_like_improvement_pressure",
+      "variable": "phrase_markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table surfaces possible improvement pressure for routing review and does not write Memory or choose an owner."
+    },
+    {
+      "path": "packages/memory/src/repo_memory_bootstrap/installer.py",
+      "function": "_looks_like_active_current_memory_claim",
+      "variable": "inactive_markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table identifies stale current-memory prose claims for diagnostic review."
+    },
+    {
+      "path": "packages/memory/scripts/check/check_memory_freshness.py",
+      "function": "_delegates_durable_context",
+      "variable": "delegation_markers",
+      "classification": "advisory-diagnostic",
+      "authority": "The table flags Memory freshness issues for review and does not route task ownership."
+    }
+  ]
+}

--- a/docs/reviews/generic-cg-control-operations-plan-2026-06-21.md
+++ b/docs/reviews/generic-cg-control-operations-plan-2026-06-21.md
@@ -1,0 +1,62 @@
+# Generic CG Control Operations Plan
+
+Date: 2026-06-21
+
+Issues: #1659, #1649, #1655
+
+## Boundary
+
+Command-generation should own generic renderers, primitive machinery, conformance runners, and host-neutral operation control/dataflow. Agentic Workspace should own product-specific operation contracts, runtime primitive implementations, integration seams, proof routing, and generated output ownership.
+
+This plan does not move AW semantics into CG. It identifies the next generic shapes needed before more accepted runtime boundaries can be removed.
+
+## Current CG Support
+
+Existing CG support already covers the simple cases:
+
+- `runtime_handler`
+- `function_call`
+- `conditional_function_call`
+- `generated_target_root_resolve`
+- `runtime_emit`
+- `sectioned_payload_select`
+- `json_resource_load`
+- `json_output_with_source_fallback`
+- `payload.assemble`
+- `output.emit`
+
+This explains why the simple front-door/wrapper family was exhausted by earlier work. The remaining #1649 boundaries need host-neutral projection/view mechanics, not more AW-specific adapters.
+
+## Candidate Generic Shapes
+
+| Candidate | CG owns | Host owns | AW pressure example | Host-neutral fixture requirement |
+| --- | --- | --- | --- | --- |
+| `record.project` or `payload.project` | Dot-path projection from declared input payloads; missing-path reporting. | Which payload exists and which selectors matter. | `_select_workspace_operation_fields` after AW constructs a config payload. | A synthetic package projects fields from a generic inventory payload. |
+| `view.render` | Rendering JSON/text from a declared view spec. | View spec contents, labels, ordering, and domain meaning. | `_emit_workspace_operation_output` text cases for selected/compact/tiny packets. | A synthetic package renders a product-neutral status payload. |
+| `output.emit` view extension | Format dispatch and serialization using host-provided view specs. | Semantic payload construction and view policy. | Workspace config/defaults/prompt/system-intent output paths. | A synthetic command emits JSON and text from one host-neutral operation. |
+| `control.switch` | Branch over declared enum/status values. | Enum definitions and semantic consequences. | Summary/report section routing after AW declares section ids. | A synthetic operation switches over neutral mode labels. |
+| `transaction.envelope` | Plan/apply/dry-run scaffolding and provenance hook slots. | Mutation safety, conflict policy, and provider/domain semantics. | Lifecycle mutation adapters in #1656, not #1655 first slice. | A synthetic filesystem plan with host-owned safety hook. |
+
+## Forbidden Shortcuts
+
+- No arbitrary expressions.
+- No embedded Python or JavaScript.
+- No unbounded loops.
+- No AW command names, filenames, issue ids, or policy language in CG primitive definitions or CG tests.
+- No runtime imports of `command_generation` into generated AW packages.
+
+## Next Implementation Slice
+
+The first useful CG implementation should be `record.project` or a small `view.render` primitive, because it directly targets #1655 without touching mutation/provider semantics.
+
+Acceptance for that CG slice:
+
+- One host-neutral synthetic fixture in CG.
+- One AW pressure mapping in this repo.
+- Generated runtimes remain self-contained.
+- AW consumes the primitive only through declared IR metadata and regenerated artifacts.
+- The accepted runtime boundary count drops only after the generated operation consumes the new source of truth.
+
+## Current Decision
+
+No CG code change is made in this AW PR because the current branch can enforce the non-enum keyword routing guardrail and record the exact #1655/#1659 disposition without requiring a partially designed CG primitive. The next implementation PR should start in `command-generation` if it attempts to retire `_emit_workspace_operation_output` or `_select_workspace_operation_fields`.

--- a/docs/reviews/workspace-report-context-runtime-disposition-2026-06-21.md
+++ b/docs/reviews/workspace-report-context-runtime-disposition-2026-06-21.md
@@ -1,0 +1,68 @@
+# Workspace Report and Context Runtime Disposition
+
+Date: 2026-06-21
+
+Issues: #1655, #1649, #1659
+
+## Purpose
+
+This review narrows the workspace report/context/output part of the runtime-boundary decomposition lane. It uses the current exact-symbol inventory instead of recounting from source code by hand.
+
+Source command:
+
+```powershell
+uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json
+```
+
+Current baseline:
+
+- 75 accepted runtime symbols.
+- 19 workspace package runtime boundaries.
+- 1 accepted output-emission symbol: `agentic_workspace.workspace_runtime_primitives._emit_workspace_operation_output`.
+- The high-confidence #1655 symbols `_emit_workspace_operation_output` and `_select_workspace_operation_fields` are still accepted hand-owned boundaries.
+
+## Disposition Table
+
+| Symbol | Current audit classification | Proposed next owner | Semantic owner after split | Exact proof/update required | Remaining hand-owned rationale |
+| --- | --- | --- | --- | --- | --- |
+| `_emit_workspace_operation_output` | `generic-cg-control` | split | AW owns prompt/system-intent/config/defaults text policy until it is declared as view metadata. CG can own JSON emission and generic selected/tiny/compact answer rendering. | Add a host-neutral output/view primitive or declarative view spec in CG, consume it from AW IR, regenerate, then remove the accepted boundary entry. | Current generated code already handles JSON and several generic packet shapes, but falls back to AW for prompt, system-intent, config, defaults, and text emission policy. |
+| `_select_workspace_operation_fields` | `generic-cg-control` | split | AW owns config payload construction and tiny/compact config view policy until those views are declared. CG can own selector projection once the payload exists. | Add declared view policy for config tiny/compact/select or a generic projection operation that consumes host-provided payload and view metadata; regenerate and remove boundary entry. | It currently mixes payload construction from `WorkspaceConfig` with projection/view shaping. |
+| `_run_report_combined_adapter` | `declarative-policy` | split | AW owns report section payload semantics; CG may own section dispatch and selector routing. | Declare section routing/view metadata and prove report CLI parity before moving. | Current function assembles multiple AW semantic report packets and live module state. |
+| `_run_summary_report_adapter` | `declarative-policy` | split | AW/Planning owns closeout, active state, residue, and intent-satisfaction semantics; CG may own selected output and section projection. | Add section/view metadata and focused summary CLI tests. | Summary is an operating-loop semantic surface, not only a renderer. |
+| `_run_lifecycle_report_adapter` | `declarative-policy` | split | AW owns module lifecycle/readiness interpretation; CG may own generic report envelope and output projection. | Add lifecycle report view metadata and prove module status parity. | It reads live module reports and readiness facts. |
+| `_load_workspace_operation_config` | `declarative-policy` | declared AW policy plus semantic primitive | AW owns config layering and compatibility semantics; CG may own generic load-step wiring. | Separate config load primitive from view projection and keep config semantics inventoried. | Config layering is product policy, not generic data loading. |
+| `_render_workspace_operation_prompt` | `declarative-policy` | declared AW policy plus semantic primitive | AW owns prompt/adopt/uninstall/upgrade semantics; CG may own generic template dispatch when prompt policy is declared. | Declare prompt template routing and prove prompt command parity. | Prompt output is package workflow policy. |
+| `_resolve_workspace_operation_selection` | `declarative-policy` | declared AW policy plus semantic primitive | AW owns module selection/default semantics; CG may own argument-to-selection step wiring. | Declare selection enum/default policy or keep as exact semantic primitive. | Selection affects installed modules and command safety. |
+| `_run_start_context_adapter` | `mixed-policy-plus-kernel` | AW semantic primitive | AW owns next-safe-action, issue grounding, memory packet, proof posture, and startup judgment. | Only split after named smaller semantic payload functions exist with parity tests. | Startup is the main AW operating-loop judgment surface. |
+| `_run_implement_context_adapter` | `mixed-policy-plus-kernel` | AW semantic primitive with possible projection split | AW owns changed-path interpretation, proof selection, memory/capture pressure, and workflow sufficiency. | Split only projection/output after semantic payload remains named and exact. | Implementation context affects action safety. |
+| `_run_setup_guidance_adapter` | `mixed-policy-plus-kernel` | AW semantic primitive with possible projection split | AW owns setup guidance semantics; CG may own generic output projection later. | Add setup guidance view metadata and focused tests. | Setup guidance is repo/product interpretation rather than pure rendering. |
+
+## #1659 CG Support Needed
+
+The current CG/AW support already includes `function_call`, `conditional_function_call`, `runtime_emit`, generated local overrides, `sectioned_payload_select`, and `json_output_with_source_fallback`. That is enough for simple wrappers but not enough to honestly retire the two #1655 high-confidence workspace symbols.
+
+The smallest generic additions worth considering are:
+
+- `record.project` or `payload.project` over declared dot-path selectors.
+- `view.render` over host-owned view specs for tiny/compact/text forms.
+- `output.emit` extension that can use declared view renderers without importing host runtime code.
+
+Each primitive needs a host-neutral CG fixture and an AW pressure example. CG must not contain AW command names, issue terms, filenames, or policy language.
+
+## Implementation Decision
+
+No runtime boundary is removed by this review alone. The useful implementation in this slice is the #1663 guardrail: new keyword/string-table routing policy cannot silently enter the runtime while #1659/#1655 design work proceeds.
+
+Closing #1655 from this document alone would be premature. A later implementation PR should either:
+
+1. add the missing generic CG projection/view primitive and consume it from AW IR, or
+2. prove that an existing CG primitive can retire `_emit_workspace_operation_output` or `_select_workspace_operation_fields` without hiding AW semantics.
+
+## Proof
+
+Required checks for this artifact:
+
+```powershell
+uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success
+uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json
+```

--- a/scripts/check/check_contract_tooling_surfaces.py
+++ b/scripts/check/check_contract_tooling_surfaces.py
@@ -2334,6 +2334,129 @@ def _validate_documented_proof_command_inventory(
     return errors
 
 
+KEYWORD_ROUTING_AUDIT_ALLOWED_CLASSIFICATIONS = {
+    "enum-vocabulary",
+    "structured-field-projection",
+    "advisory-diagnostic",
+    "advisory-search",
+    "test-fixture-schema",
+    "documented-command-set",
+}
+
+
+def _keyword_routing_scan_excluded(path: Path) -> bool:
+    return any(part == "__pycache__" or part.startswith(".uv-cache") for part in path.parts)
+
+
+def _name_occurs(node: ast.AST, name: str) -> bool:
+    return any(isinstance(child, ast.Name) and child.id == name for child in ast.walk(node))
+
+
+def _string_table_drives_substring_decision(*, node: ast.FunctionDef, variable: str) -> bool:
+    for child in ast.walk(node):
+        if not isinstance(child, ast.GeneratorExp):
+            continue
+        for generator in child.generators:
+            if not isinstance(generator.iter, ast.Name) or generator.iter.id != variable:
+                continue
+            target_name = generator.target.id if isinstance(generator.target, ast.Name) else ""
+            if not target_name:
+                continue
+            for expression in ast.walk(child.elt):
+                if not isinstance(expression, ast.Compare) or not _name_occurs(expression, target_name):
+                    continue
+                if any(isinstance(operator, (ast.In, ast.NotIn)) for operator in expression.ops):
+                    return True
+    return False
+
+
+def _keyword_routing_candidate_keys(*, repo_root: Path) -> set[str]:
+    candidates: set[str] = set()
+    for root in (repo_root / "src", repo_root / "packages"):
+        if not root.exists():
+            continue
+        for path in root.rglob("*.py"):
+            if _keyword_routing_scan_excluded(path):
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (OSError, SyntaxError, UnicodeDecodeError):
+                continue
+
+            class CandidateVisitor(ast.NodeVisitor):
+                def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+                    assignments: dict[str, int] = {}
+                    for child in ast.walk(node):
+                        if not isinstance(child, ast.Assign) or not isinstance(child.value, (ast.Set, ast.List, ast.Tuple)):
+                            continue
+                        literal_count = sum(
+                            1 for element in child.value.elts if isinstance(element, ast.Constant) and isinstance(element.value, str)
+                        )
+                        if literal_count < 3 or not child.targets:
+                            continue
+                        target = child.targets[0]
+                        variable = getattr(target, "id", getattr(target, "attr", ""))
+                        if variable:
+                            assignments[variable] = literal_count
+                    for variable in sorted(assignments):
+                        if not _string_table_drives_substring_decision(node=node, variable=variable):
+                            continue
+                        relative = path.relative_to(repo_root).as_posix()
+                        candidates.add(f"{relative}|{node.name}|{variable}")
+                    self.generic_visit(node)
+
+            CandidateVisitor().visit(tree)
+    return candidates
+
+
+def _validate_non_enum_keyword_routing_audit(
+    *,
+    repo_root: Path = REPO_ROOT,
+    audit_path: Path | None = None,
+) -> list[str]:
+    path = audit_path or repo_root / "docs" / "maintainer" / "non-enum-keyword-routing-audit.json"
+    errors: list[str] = []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return [f"{path.relative_to(repo_root).as_posix()} could not be read: {exc}"]
+    except json.JSONDecodeError as exc:
+        return [f"{path.relative_to(repo_root).as_posix()} is invalid JSON: {exc}"]
+    if payload.get("kind") != "agentic-workspace/non-enum-keyword-routing-audit/v1":
+        errors.append("non-enum-keyword-routing-audit kind drifted")
+    entries = payload.get("entries", [])
+    if not isinstance(entries, list):
+        return errors + ["non-enum-keyword-routing-audit entries must be a list"]
+    observed = _keyword_routing_candidate_keys(repo_root=repo_root)
+    classified: dict[str, dict[str, object]] = {}
+    for raw_entry in entries:
+        if not isinstance(raw_entry, dict):
+            errors.append("non-enum-keyword-routing-audit entries must be objects")
+            continue
+        key = "|".join(
+            str(raw_entry.get(field, "")).strip()
+            for field in ("path", "function", "variable")
+        )
+        if key in classified:
+            errors.append(f"non-enum-keyword-routing-audit duplicates entry: {key}")
+        classified[key] = raw_entry
+        classification = str(raw_entry.get("classification") or "").strip()
+        if classification == "disallowed-package-policy":
+            errors.append(f"{key} is classified as disallowed-package-policy; remove the keyword table or demote it to non-authoritative evidence")
+        elif classification not in KEYWORD_ROUTING_AUDIT_ALLOWED_CLASSIFICATIONS:
+            allowed = ", ".join(sorted([*KEYWORD_ROUTING_AUDIT_ALLOWED_CLASSIFICATIONS, "disallowed-package-policy"]))
+            errors.append(f"{key} has unknown classification {classification!r}; expected one of: {allowed}")
+        if not str(raw_entry.get("authority") or "").strip():
+            errors.append(f"{key} must explain why the string table is not package-owned routing authority")
+    missing = sorted(observed - set(classified))
+    extra = sorted(set(classified) - observed)
+    for key in missing:
+        errors.append(f"non-enum-keyword-routing-audit missing structural candidate: {key}")
+    for key in extra:
+        errors.append(f"non-enum-keyword-routing-audit contains stale candidate: {key}")
+    return errors
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     checks: list[tuple[str, list[str]]] = [
@@ -2348,6 +2471,7 @@ def main(argv: list[str] | None = None) -> int:
         ("review artifacts startup hygiene", _validate_review_artifacts_not_startup_inputs()),
         ("product-managed enclave", _validate_product_managed_enclave()),
         ("documented proof command inventory", _validate_documented_proof_command_inventory()),
+        ("non-enum keyword routing audit", _validate_non_enum_keyword_routing_audit()),
         ("compact answer sample", _validate(_sample_compact_answer(), "compact_contract_answer.schema.json")),
         ("workspace report sample", _validate(_sample_report_payload(), "workspace_report.schema.json")),
         ("workspace config sample", _validate(_sample_workspace_config_payload(), "workspace_config.schema.json")),

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -684,6 +684,30 @@
       "checked_in_justification": "Canonical checked-in structured input used by package behavior, validation, packaging, or repo policy."
     },
     {
+      "pattern": "docs/maintainer/proof-command-inventory.json",
+      "format": "json",
+      "owner": "workspace-maintainer-checks",
+      "status": "typed-validator-backed",
+      "schema_or_validator": "scripts/check/check_contract_tooling_surfaces.py::_validate_documented_proof_command_inventory",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Maintainer audit of documented proof commands so obsolete command guidance cannot remain in ordinary routing docs.",
+      "storage_class": "diagnostic-fixture",
+      "checked_in_justification": "Maintainer-reviewed dogfooding evidence used to prioritize product work; not package runtime authority."
+    },
+    {
+      "pattern": "docs/maintainer/non-enum-keyword-routing-audit.json",
+      "format": "json",
+      "owner": "workspace-maintainer-checks",
+      "status": "typed-validator-backed",
+      "schema_or_validator": "scripts/check/check_contract_tooling_surfaces.py::_validate_non_enum_keyword_routing_audit",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Maintainer audit of route-shaped string tables so package runtime code cannot silently add non-enum keyword routing policy.",
+      "storage_class": "diagnostic-fixture",
+      "checked_in_justification": "Maintainer-reviewed dogfooding evidence used to prioritize product work; not package runtime authority."
+    },
+    {
       "pattern": "packages/memory/**/manifest.toml",
       "format": "toml",
       "owner": "memory",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -25408,17 +25408,12 @@ def _reuse_pressure_memory_signals(
 
 
 def _reuse_pressure_memory_match_reason(*, changed_paths: list[str], note_path: str, note: dict[str, Any]) -> str | None:
-    keywords = {"abstraction", "boundary", "duplicate", "duplication", "extraction", "helper", "pattern", "reuse"}
-    haystack_values: list[str] = [note_path]
-    for key in ("surfaces", "subsystems", "routes_from", "stale_when", "memory_role", "promotion_target", "improvement_note"):
-        value = note.get(key)
-        if isinstance(value, str):
-            haystack_values.append(value)
-        elif isinstance(value, list):
-            haystack_values.extend(str(item) for item in value)
-    haystack = " ".join(haystack_values).lower()
-    if any(keyword in haystack for keyword in keywords):
-        return "memory metadata mentions reuse, duplication, abstraction, extraction, boundary, helper, or pattern"
+    structured_role = str(note.get("memory_role") or "").strip()
+    if structured_role in {"improvement_signal", "invariant", "runbook"}:
+        return f"memory metadata role {structured_role!r} may carry reusable workflow evidence"
+    promotion_target = str(note.get("promotion_target") or "").strip()
+    if promotion_target:
+        return "memory metadata declares a promotion target"
     route_patterns = [item for item in note.get("routes_from", []) if isinstance(item, str)]
     stale_patterns = [item for item in note.get("stale_when", []) if isinstance(item, str)]
     for changed_path in changed_paths:
@@ -28503,12 +28498,10 @@ def _active_plan_delegation_requirement(
     normalized_task = " ".join((task_text or "").lower().split())
     capability = execution_posture.get("capability_posture", {}) if isinstance(execution_posture, dict) else {}
     work_shape, proof_burden = _capability_structural_hints(capability)
-    trigger_terms = ("decomposed", "decomposition", "delegate", "delegation", "mechanical", "lane", "epic", "high-assurance")
-    active_plan_continuation = _task_appears_to_continue_active_plan(
+    active_plan_continuation = _task_explicitly_references_active_plan(
         active_surface=active_surface,
         record=record,
         normalized_task=normalized_task,
-        trigger_terms=trigger_terms,
     )
     if not active_plan_continuation:
         return {"required": False, "status": "delegation-decision-not-needed-for-direct-task", "path": active_surface}
@@ -28535,12 +28528,7 @@ def _active_plan_delegation_requirement(
                 "state and cannot prove the current session made or reviewed the decision."
             ),
         }
-    required = (
-        status in {"pending", "required", "available", "suitable"}
-        or work_shape in {"lane", "epic"}
-        or proof_burden == "high"
-        or any((term in normalized_task for term in trigger_terms))
-    )
+    required = status in {"pending", "required", "available", "suitable"} or work_shape in {"lane", "epic"} or proof_burden == "high"
     if not required:
         return {"required": False, "status": "delegation-decision-not-needed", "path": active_surface}
     planning_revision = _planning_revision_payload(target_root=target_root)
@@ -28569,28 +28557,9 @@ def _delegation_decision_has_command_provenance(delegation: dict[str, Any]) -> b
     return decision_command in {"agentic-planning delegation-decision", "agentic-workspace planning delegation-decision"}
 
 
-def _task_appears_to_continue_active_plan(
-    *, active_surface: str, record: dict[str, Any], normalized_task: str, trigger_terms: tuple[str, ...]
-) -> bool:
+def _task_explicitly_references_active_plan(*, active_surface: str, record: dict[str, Any], normalized_task: str) -> bool:
     if not normalized_task:
         return False
-    continuation_terms = (
-        "continue",
-        "resume",
-        "advance",
-        "finish",
-        "complete",
-        "implement",
-        "implementation",
-        "closeout",
-        "close out",
-        "run proof",
-        "validate",
-    )
-    if not any((term in normalized_task for term in continuation_terms)):
-        return False
-    if any((term in normalized_task for term in trigger_terms)):
-        return True
     identifiers: list[str] = [Path(active_surface).stem.replace(".plan", "")]
     for key in ("id", "title"):
         value = record.get(key)

--- a/tests/test_contract_tooling_surfaces.py
+++ b/tests/test_contract_tooling_surfaces.py
@@ -73,3 +73,76 @@ def test_documented_proof_command_inventory_accepts_runnable_source_ref(tmp_path
     )
 
     assert module._validate_documented_proof_command_inventory(repo_root=tmp_path, inventory_path=inventory) == []
+
+
+def test_non_enum_keyword_routing_audit_rejects_unclassified_candidate(tmp_path: Path) -> None:
+    module = _load_module()
+    source = tmp_path / "src" / "sample.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "\n".join(
+            [
+                "def neutral_helper_name(value):",
+                '    local_markers = ("alpha", "beta", "gamma")',
+                "    return any(marker in value for marker in local_markers)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    audit = tmp_path / "docs" / "maintainer" / "non-enum-keyword-routing-audit.json"
+    audit.parent.mkdir(parents=True)
+    audit.write_text(
+        json.dumps(
+            {
+                "kind": "agentic-workspace/non-enum-keyword-routing-audit/v1",
+                "entries": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    errors = module._validate_non_enum_keyword_routing_audit(repo_root=tmp_path, audit_path=audit)
+
+    assert errors == ["non-enum-keyword-routing-audit missing structural candidate: src/sample.py|neutral_helper_name|local_markers"]
+
+
+def test_non_enum_keyword_routing_audit_rejects_disallowed_policy(tmp_path: Path) -> None:
+    module = _load_module()
+    source = tmp_path / "src" / "sample.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "\n".join(
+            [
+                "def neutral_helper_name(value):",
+                '    local_markers = ("alpha", "beta", "gamma")',
+                "    return any(marker in value for marker in local_markers)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    audit = tmp_path / "docs" / "maintainer" / "non-enum-keyword-routing-audit.json"
+    audit.parent.mkdir(parents=True)
+    audit.write_text(
+        json.dumps(
+            {
+                "kind": "agentic-workspace/non-enum-keyword-routing-audit/v1",
+                "entries": [
+                    {
+                        "path": "src/sample.py",
+                        "function": "neutral_helper_name",
+                        "variable": "local_markers",
+                        "classification": "disallowed-package-policy",
+                        "authority": "sample",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    errors = module._validate_non_enum_keyword_routing_audit(repo_root=tmp_path, audit_path=audit)
+
+    assert errors == [
+        "src/sample.py|neutral_helper_name|local_markers is classified as disallowed-package-policy; "
+        "remove the keyword table or demote it to non-authoritative evidence"
+    ]

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1931,6 +1931,60 @@ candidates = []
     assert payload["kind"] == "implementer-context-tiny/v1"
 
 
+def test_implement_generic_continuation_task_does_not_link_active_plan(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "active-plan.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "id": "active-plan",
+            "title": "Active Plan",
+            "post_decomposition_delegation": {"status": "required"},
+        },
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "active-plan", title = "Active Plan", status = "active", surface = ".agentic-workspace/planning/execplans/active-plan.plan.json" },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write(tmp_path / "README.md", "hello\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "README.md",
+                "--task",
+                "continue resume finish follow up",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    reliance = payload["context"]["planning_safety_gate"]["active_plan_reliance"]
+    assert reliance["permission_claim"] == "direct-work-not-active-plan-continuation"
+    assert reliance["requirement_status"] == "delegation-decision-not-needed-for-direct-task"
+    assert payload["context"]["planning_safety_gate"]["delegation_decision_required"] is False
+
+
 def test_implement_accumulates_repeated_changed_flags(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
@@ -4615,18 +4669,12 @@ def test_implement_suppresses_manual_external_relay_for_code_local_changed_paths
     )
 
     payload = json.loads(capsys.readouterr().out)
-    decision = _implement_context(payload)["delegation_decision"]
-    assert decision["recommended_route"] == "stay-local"
-    assert decision["required_next_action"] == "continue-local"
-    assert decision["effort_guidance"]["orchestrator"] == "medium"
-    assert decision["effort_guidance"]["implementer"] == "medium"
-    assert decision["effort_guidance"]["validator"] == "high"
-    assert decision["effort_guidance"]["cost_posture"] == "quality-first"
-    assert "target" not in decision["effort_guidance"]
-    assert "manual_external_relay" not in decision
-    assert "config_effect" not in decision
-    assert "manual_prompt" not in decision
-    assert "handoff_command" not in decision
+    context = _implement_context(payload)
+    assert "delegation_decision" not in context
+    payload_text = json.dumps(payload)
+    assert "manual_external_relay" not in payload_text
+    assert "manual_prompt" not in payload_text
+    assert "handoff_command" not in payload_text
 
 
 def test_implement_supports_selector_drilldown(tmp_path: Path, capsys) -> None:
@@ -5089,7 +5137,7 @@ def test_implement_selector_reports_available_fields_for_missing_selector(tmp_pa
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["missing"] == ["does_not_exist"]
-    assert "context.delegation_decision" in payload["available_selectors"]
+    assert "context.delegation_decision" not in payload["available_selectors"]
     assert "next" in payload["available_selectors"]
     assert "context.scope" in payload["available_selectors"]
     assert "proof" in payload["available_selectors"]


### PR DESCRIPTION
## Summary

Closes the concrete high-priority guardrail issue and advances the runtime-boundary lane:

- adds a maintained non-enum keyword routing audit and wires it into contract tooling proof
- rejects new unclassified route/owner/proof/workflow-shaped string tables in runtime paths
- removes two prose-triggered decisions from runtime behavior: reuse-pressure Memory matching and active-plan delegation pressure
- records the #1655 workspace report/context/output disposition table from the current 75-symbol baseline
- records the #1659 generic CG control-operation plan and why the next real boundary move needs host-neutral projection/view support
- files rickardvh/command-generation#67 for the CG primitive work needed before AW can honestly retire `_emit_workspace_operation_output` or `_select_workspace_operation_fields`

Fixes #1663.
Advances #1659.
Advances #1655.
Advances #1649.

## Honest closure boundary

This PR should close #1663 only.

It should not close #1649, #1655, or #1659. Those remain open because the accepted runtime-boundary count is still 75 and no workspace output/projection boundary has been retired yet. The next implementation step is command-generation#67, followed by an AW consumption PR that removes at least one accepted runtime-boundary entry only after generated operations consume the new generic source of truth.

## Proof

- `uv run pytest tests/test_contract_tooling_surfaces.py tests/test_workspace_implement_cli.py::test_implement_compact_omits_routine_stay_local_delegation_noise tests/test_workspace_implement_cli.py::test_implement_compact_keeps_delegation_when_route_changes_next_action -q`
- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_suppresses_manual_external_relay_for_code_local_changed_paths tests/test_workspace_implement_cli.py::test_implement_selector_reports_available_fields_for_missing_selector tests/test_structured_file_inventory.py::test_current_tracked_structured_files_are_classified -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json`
