### PR TITLE
Route remaining assumption findings to authority surfaces

### DIFF
--- a/.agentic-workspace/agent-aids/scripts/github-issue-body/manifest.json
+++ b/.agentic-workspace/agent-aids/scripts/github-issue-body/manifest.json
@@ -27,6 +27,12 @@
       "uv run python .agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py --input-json .agentic-workspace/agent-aids/scripts/github-issue-body/examples/direction-request.json --format json"
     ]
   },
+  "authority_boundary": {
+    "runtime_authority": "none",
+    "fact_owner": "external-intent-evidence",
+    "promote_behavior_relevant_facts_to": ".agentic-workspace/local/cache/external-intent-evidence.json or .agentic-workspace/planning/external-intent-evidence.json",
+    "agent_decision": "The agent interprets issue intent; the aid only renders this repo's GitHub issue body from structured input."
+  },
   "promotion": {
     "target_kind": "command",
     "target": "agentic-workspace issue-body",

--- a/.agentic-workspace/docs/agent-aids-storage.md
+++ b/.agentic-workspace/docs/agent-aids-storage.md
@@ -42,6 +42,8 @@ Use this for repo-shared aids that are still proving value. Suggested subfolders
 
 Checked-in candidate aids are reviewable repo state. Put each aid in its own directory under the relevant subfolder and add `manifest.json` beside the aid files. The manifest kind is `agentic-workspace/agent-aid/v1`; it records type, status, scope, portability, owner, why it exists, when to use it, entrypoint, safety, validation, promotion, and retirement criteria.
 
+Use `authority_boundary` when an aid is provider-specific, tracker-specific, or close to workflow routing. Advisory aids should declare `runtime_authority: none` or `advisory-only` and name the owner surface for behavior-relevant facts, such as external-intent evidence, Planning state, Memory, docs contracts, or host config. This makes the aid's boundary explicit without making the aid a package-owned policy source.
+
 Run `python scripts/check/check_agent_aids.py` or `make agent-aids` to validate checked-in aid manifests and ensure aid files are covered by nearby metadata.
 
 Run `agentic-workspace report --target . --section agent_aids --format json` to list checked-in and local-only aids without scanning the repo. Run `agentic-workspace skills --target . --task "<task>" --format json` when the question is task-specific aid or skill recommendation.

--- a/docs/maintainer/non-enum-keyword-routing-audit.json
+++ b/docs/maintainer/non-enum-keyword-routing-audit.json
@@ -1,168 +1,214 @@
 {
   "kind": "agentic-workspace/non-enum-keyword-routing-audit/v1",
   "purpose": "Classify local string tables that are structurally used in substring-style decisions so they cannot silently become package-owned keyword routing policy.",
-  "rule": "Substring marker tables are allowed only when they remain advisory diagnostics/search or documented checker fixtures. Repo-specific routing must come from explicit labels, structured state, or learned metadata.",
+  "rule": "Substring marker tables are allowed only when decision_authority is advisory-only, checker-only, enum-owned, or structured-owned. Repo-specific routing must come from explicit labels, structured state, or learned metadata.",
   "entries": [
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_planned_task_posture_residue",
       "variable": "posture_markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table identifies planning-posture residue for review and does not choose a workflow owner."
+      "authority": "The table identifies planning-posture residue for review and does not choose a workflow owner.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_review_artifact_has_resolved_findings",
       "variable": "resolved_markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table checks review-artifact wording for stale-residue diagnostics and does not route task ownership."
+      "authority": "The table checks review-artifact wording for stale-residue diagnostics and does not route task ownership.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_compact_repair_plan_profile",
       "variable": "repair_terms",
       "classification": "advisory-diagnostic",
-      "authority": "The table describes repair-shaped diagnostic hints; the agent still owns work-shape judgment."
+      "authority": "The table describes repair-shaped diagnostic hints; the agent still owns work-shape judgment.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_capability_posture_for_implementation",
       "variable": "judgment_terms",
       "classification": "advisory-diagnostic",
-      "authority": "The table contributes capability-posture hints, not a package-owned delegation route."
+      "authority": "The table contributes capability-posture hints, not a package-owned delegation route.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_capability_posture_for_implementation",
       "variable": "mechanical_terms",
       "classification": "advisory-diagnostic",
-      "authority": "The table contributes capability-posture hints, not a package-owned delegation route."
+      "authority": "The table contributes capability-posture hints, not a package-owned delegation route.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_manual_external_relay_payload",
       "variable": "code_local_terms",
       "classification": "advisory-diagnostic",
-      "authority": "The table suppresses noisy relay suggestions for code-local diagnostics; it does not force a route."
+      "authority": "The table suppresses noisy relay suggestions for code-local diagnostics; it does not force a route.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_manual_external_relay_payload",
       "variable": "domain_terms",
       "classification": "advisory-diagnostic",
-      "authority": "The table supports relay-suggestion diagnostics; it does not make the delegation decision."
+      "authority": "The table supports relay-suggestion diagnostics; it does not make the delegation decision.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_knowledge_gates_payload",
       "variable": "knowledge_markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table surfaces possible knowledge-gate pressure for agent review and does not enforce routing."
+      "authority": "The table surfaces possible knowledge-gate pressure for agent review and does not enforce routing.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_task_posture_packet_relevant",
       "variable": "markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table gates visibility of an advisory task-posture packet; it does not decide task ownership."
+      "authority": "The table gates visibility of an advisory task-posture packet; it does not decide task ownership.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_ownership_diagnostics",
       "variable": "active_state_markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table flags possible adapter drift for review and does not select a routing owner."
+      "authority": "The table flags possible adapter drift for review and does not select a routing owner.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_ownership_diagnostics",
       "variable": "config_active_markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table flags possible config drift for review and does not select a routing owner."
+      "authority": "The table flags possible config drift for review and does not select a routing owner.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "src/agentic_workspace/workspace_runtime_primitives.py",
       "function": "_ownership_diagnostics",
       "variable": "policy_knobs",
       "classification": "advisory-diagnostic",
-      "authority": "The table identifies policy-looking config fields for drift diagnostics."
+      "authority": "The table identifies policy-looking config fields for drift diagnostics.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "packages/planning/src/repo_planning_bootstrap/installer.py",
       "function": "_finished_run_config_signal",
       "variable": "lower_trust_markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table evaluates finished-run config-signal trust for closeout diagnostics."
+      "authority": "The table evaluates finished-run config-signal trust for closeout diagnostics.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "packages/planning/src/repo_planning_bootstrap/installer.py",
       "function": "_finished_run_config_signal",
       "variable": "positive_markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table evaluates finished-run config-signal trust for closeout diagnostics."
+      "authority": "The table evaluates finished-run config-signal trust for closeout diagnostics.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "packages/planning/scripts/check/check_planning_surfaces.py",
       "function": "_looks_like_freehand_planning_artifact",
       "variable": "plan_markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table identifies possible freehand planning artifacts for checker review."
+      "authority": "The table identifies possible freehand planning artifacts for checker review.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "packages/planning/scripts/check/check_planning_surfaces.py",
       "function": "_check_promotion_linkage",
       "variable": "signal_hints",
       "classification": "advisory-diagnostic",
-      "authority": "The table validates planning promotion-linkage documentation hints in a checker."
+      "authority": "The table validates planning promotion-linkage documentation hints in a checker.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "packages/planning/scripts/check/check_planning_surfaces.py",
       "function": "_check_startup_policy",
       "variable": "required_agents_fragments",
       "classification": "advisory-diagnostic",
-      "authority": "The table validates required startup-policy documentation fragments in a checker."
+      "authority": "The table validates required startup-policy documentation fragments in a checker.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "packages/planning/scripts/check/check_planning_surfaces.py",
       "function": "_check_startup_policy",
       "variable": "required_contributor_fragments",
       "classification": "advisory-diagnostic",
-      "authority": "The table validates required startup-policy documentation fragments in a checker."
+      "authority": "The table validates required startup-policy documentation fragments in a checker.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "packages/planning/scripts/check/check_planning_surfaces.py",
       "function": "_check_startup_policy",
       "variable": "required_readme_fragments",
       "classification": "advisory-diagnostic",
-      "authority": "The table validates required startup-policy documentation fragments in a checker."
+      "authority": "The table validates required startup-policy documentation fragments in a checker.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "packages/planning/scripts/check/check_planning_surfaces.py",
       "function": "_check_docs_surface_roles",
       "variable": "required_fragments",
       "classification": "advisory-diagnostic",
-      "authority": "The table validates required documentation fragments in a checker."
+      "authority": "The table validates required documentation fragments in a checker.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "packages/memory/src/repo_memory_bootstrap/installer.py",
       "function": "_looks_like_improvement_pressure",
       "variable": "phrase_markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table surfaces possible improvement pressure for routing review and does not write Memory or choose an owner."
+      "authority": "The table surfaces possible improvement pressure for routing review and does not write Memory or choose an owner.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "packages/memory/src/repo_memory_bootstrap/installer.py",
       "function": "_looks_like_active_current_memory_claim",
       "variable": "inactive_markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table identifies stale current-memory prose claims for diagnostic review."
+      "authority": "The table identifies stale current-memory prose claims for diagnostic review.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     },
     {
       "path": "packages/memory/scripts/check/check_memory_freshness.py",
       "function": "_delegates_durable_context",
       "variable": "delegation_markers",
       "classification": "advisory-diagnostic",
-      "authority": "The table flags Memory freshness issues for review and does not route task ownership."
+      "authority": "The table flags Memory freshness issues for review and does not route task ownership.",
+      "decision_authority": "advisory-only",
+      "agent_judgment_boundary": "The table may surface evidence or diagnostics; the agent decides semantic task fit, owner, proof sufficiency, and action."
     }
   ]
 }

--- a/docs/reference/agent-aid-manifest.md
+++ b/docs/reference/agent-aid-manifest.md
@@ -34,6 +34,11 @@ Manifest for a checked-in agent aid such as a script, runbook, prompt, template,
 | `validation` | object | yes |  | How this aid is validated, or why validation is absent. |  |  |
 | `validation.commands` | array of string | no |  | Commands associated with this check, proof, or workflow step. |  |  |
 | `validation.absent_reason` | string | no |  | Reason validation commands are intentionally absent. |  |  |
+| `authority_boundary` | object | no |  | Boundary that prevents advisory aids from becoming hidden workflow or package authority. |  |  |
+| `authority_boundary.runtime_authority` | enum `"none"`, `"advisory-only"`, `"canonical"` | yes |  | Whether this aid can act as package runtime authority. |  |  |
+| `authority_boundary.fact_owner` | enum `"agent-aid"`, `"external-intent-evidence"`, `"planning-state"`, `"memory"`, `"docs-contract"`, `"host-config"` | yes |  | Canonical owner for behavior-relevant facts related to the aid. |  |  |
+| `authority_boundary.promote_behavior_relevant_facts_to` | string | no |  | Target surface for behavior-relevant facts if the aid reveals reusable package behavior. |  |  |
+| `authority_boundary.agent_decision` | string | yes |  | Decision that remains owned by the agent. |  |  |
 | `promotion` | object | yes |  | Promotion path if the aid should become more canonical or package-owned. |  |  |
 | `promotion.target_kind` | enum `"command"`, `"check"`, `"skill"`, `"runbook"`, `"prompt"`, `"template"`, `"module-component"`, `"docs-contract"` | yes |  | Kind of destination this entry may promote or point to. |  |  |
 | `promotion.target` | string | yes |  | Destination file, surface, package, or record referenced by this entry. |  |  |

--- a/docs/reviews/remaining-assumption-authority-migrations-2026-06-22.md
+++ b/docs/reviews/remaining-assumption-authority-migrations-2026-06-22.md
@@ -1,0 +1,28 @@
+# Remaining Assumption Authority Migrations
+
+Date: 2026-06-22
+
+Issues: #1673, #1675, #1677, #1678
+
+## Result
+
+- `docs/maintainer/non-enum-keyword-routing-audit.json` now carries enum-backed `decision_authority` for each string-table row.
+- `scripts/check/check_contract_tooling_surfaces.py` rejects any `decision-affecting-package-policy` row, forcing migration to structured authority before the audit can pass.
+- `.agentic-workspace/agent-aids/scripts/github-issue-body/manifest.json` now records an `authority_boundary` with `runtime_authority: none` and `fact_owner: external-intent-evidence`.
+- `scripts/check/check_agent_aids.py` rejects GitHub-specific advisory aids that route behavior-relevant facts anywhere other than external-intent evidence.
+- `tools/model-cli-harness/external-agent-evaluation/scorecard-taxonomy.json` now records that harness output is maintainer-evaluation evidence, not runtime authority.
+- `scripts/model_cli_harness/external_agent_evaluation_lane.py` validates that the harness authority boundary remains present.
+
+## Boundary
+
+The deleted package-owned assumptions inventory is not restored. These findings now live in their actual owner surfaces:
+
+- string-table risk: maintainer audit plus contract-tooling validator;
+- GitHub issue-body helper: checked-in agent-aid manifest plus external-intent evidence contract;
+- model CLI harness: external-agent evaluation lane pack plus validator.
+
+Agent judgment remains responsible for applying these facts. The package may surface diagnostics, normalized external intent, or harness evidence, but it does not route work from arbitrary prose markers, GitHub template phrasing, or provider CLI assumptions.
+
+## Follow-Up Rule
+
+Future assumption findings should either be removed, moved into their owning contract/config/state/Memory surface, or recorded as review-only evidence. Do not recreate a maintained package-owned assumptions ledger.

--- a/docs/reviews/remaining-assumption-authority-migrations-2026-06-22.md
+++ b/docs/reviews/remaining-assumption-authority-migrations-2026-06-22.md
@@ -23,6 +23,70 @@ The deleted package-owned assumptions inventory is not restored. These findings 
 
 Agent judgment remains responsible for applying these facts. The package may surface diagnostics, normalized external intent, or harness evidence, but it does not route work from arbitrary prose markers, GitHub template phrasing, or provider CLI assumptions.
 
+## GitHub Issue-Body Handoff
+
+The GitHub issue-body aid remains a renderer. Its structured input can carry issue-shaping text, but behavior-relevant facts used by AW runtime surfaces must be promoted into provider-neutral external-intent evidence before they influence routing or scope.
+
+Renderer-owned input example:
+
+```json
+{
+  "kind": "agentic-workspace/issue-body-request/v1",
+  "template": "direction",
+  "title": "Inventory current built-in assumptions",
+  "fields": {
+    "problem_intent": {
+      "kind": "markdown",
+      "value": "AW should stop relying on built-in repo/provider assumptions that are not owned by a declared contract, config, state, Memory, or review surface."
+    },
+    "intended_outcome": {
+      "kind": "markdown",
+      "value": "The current assumptions are inventoried and each finding is routed to its owning surface instead of becoming package policy."
+    },
+    "acceptance": {
+      "kind": "markdown",
+      "value": "No package-owned assumptions ledger is recreated; remaining findings name their owner surfaces and authority boundaries."
+    }
+  },
+  "source_refs": [
+    {
+      "kind": "github_issue",
+      "id": "#1675"
+    }
+  ]
+}
+```
+
+Behavior-relevant promoted fact shape:
+
+```json
+{
+  "kind": "planning-external-intent-evidence/v1",
+  "items": [
+    {
+      "system": "github",
+      "id": "#1675",
+      "title": "Inventory current built-in assumptions",
+      "status": "open",
+      "kind": "issue",
+      "planning_residue_expected": "Route durable findings to their owning contract, config, state, Memory, docs, or review surface; do not recreate a package-owned assumptions ledger.",
+      "negative_invariants": [
+        "Do not treat GitHub issue template prose as runtime authority.",
+        "Do not route work from provider-specific strings unless provider-neutral external-intent evidence owns the fact."
+      ],
+      "url": "https://github.com/rickardvh/agentic-workspace/issues/1675",
+      "source_repository": "rickardvh/agentic-workspace"
+    }
+  ]
+}
+```
+
+This handoff is deliberately one-way: the aid renders a GitHub issue body, while external-intent evidence owns the normalized facts that runtime planning and summary surfaces may consume.
+
+## Non-Consumption Proof
+
+The ordinary package runtime does not read `.agentic-workspace/agent-aids/scripts/github-issue-body/` to make routing decisions. Runtime paths that need issue-backed intent read `.agentic-workspace/local/cache/external-intent-evidence.json` or `.agentic-workspace/planning/external-intent-evidence.json`; agent-aid discovery reads manifests as candidate tools and documentation only. Repository search for `github-issue-body` is limited to the aid files, manifest/schema checks, structured-file inventory, docs, and tests, not runtime decision logic.
+
 ## Follow-Up Rule
 
 Future assumption findings should either be removed, moved into their owning contract/config/state/Memory surface, or recorded as review-only evidence. Do not recreate a maintained package-owned assumptions ledger.

--- a/scripts/check/check_agent_aids.py
+++ b/scripts/check/check_agent_aids.py
@@ -204,6 +204,17 @@ def _safety_policy_findings(path: str, payload: dict[str, Any], *, root: Path, t
                     ),
                 )
             )
+    boundary = payload.get("authority_boundary")
+    if isinstance(boundary, dict):
+        runtime_authority = boundary.get("runtime_authority")
+        if payload.get("proof_role") != "canonical-proof" and runtime_authority == "canonical":
+            findings.append(Finding(path=path, message="advisory or candidate aids cannot declare canonical runtime authority"))
+        if (
+            str(payload.get("id") or "").startswith("github-")
+            and boundary.get("fact_owner") != "external-intent-evidence"
+            and payload.get("proof_role") != "canonical-proof"
+        ):
+            findings.append(Finding(path=path, message="GitHub-specific advisory aids must route behavior-relevant facts to external-intent evidence"))
     promotion = payload.get("promotion")
     if isinstance(promotion, dict):
         if payload.get("status") == "promoted" and promotion.get("retention_after_promotion") == "delete":

--- a/scripts/check/check_contract_tooling_surfaces.py
+++ b/scripts/check/check_contract_tooling_surfaces.py
@@ -2342,6 +2342,13 @@ KEYWORD_ROUTING_AUDIT_ALLOWED_CLASSIFICATIONS = {
     "test-fixture-schema",
     "documented-command-set",
 }
+KEYWORD_ROUTING_AUDIT_ALLOWED_DECISION_AUTHORITIES = {
+    "advisory-only",
+    "checker-only",
+    "enum-owned",
+    "structured-owned",
+    "decision-affecting-package-policy",
+}
 
 def _keyword_routing_scan_excluded(path: Path) -> bool:
     return any(part == "__pycache__" or part.startswith(".uv-cache") for part in path.parts)
@@ -2447,6 +2454,14 @@ def _validate_non_enum_keyword_routing_audit(
             errors.append(f"{key} has unknown classification {classification!r}; expected one of: {allowed}")
         if not str(raw_entry.get("authority") or "").strip():
             errors.append(f"{key} must explain why the string table is not package-owned routing authority")
+        decision_authority = str(raw_entry.get("decision_authority") or "").strip()
+        if decision_authority not in KEYWORD_ROUTING_AUDIT_ALLOWED_DECISION_AUTHORITIES:
+            allowed = ", ".join(sorted(KEYWORD_ROUTING_AUDIT_ALLOWED_DECISION_AUTHORITIES))
+            errors.append(f"{key} has unknown decision_authority {decision_authority!r}; expected one of: {allowed}")
+        elif decision_authority == "decision-affecting-package-policy":
+            errors.append(f"{key} is decision-affecting package policy; migrate it to structured authority before accepting the audit")
+        if not str(raw_entry.get("agent_judgment_boundary") or "").strip():
+            errors.append(f"{key} must name the agent judgment boundary")
     missing = sorted(observed - set(classified))
     extra = sorted(set(classified) - observed)
     for key in missing:

--- a/scripts/model_cli_harness/external_agent_evaluation_lane.py
+++ b/scripts/model_cli_harness/external_agent_evaluation_lane.py
@@ -64,6 +64,30 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
     _require(scorecard.get("kind") == "agentic-workspace/external-agent-scorecard/v1", "scorecard kind is invalid", errors)
     _require(len(dimensions) >= 8, "scorecard must define the major AW loop dimensions", errors)
     _require(len(failure_ids) >= 10, "scorecard must define stable failure ids", errors)
+    boundary = scorecard.get("authority_boundary")
+    _require(isinstance(boundary, dict), "scorecard must define authority_boundary", errors)
+    if isinstance(boundary, dict):
+        _require(
+            boundary.get("harness_role") == "maintainer-evaluation-evidence",
+            "scorecard authority_boundary.harness_role must be maintainer-evaluation-evidence",
+            errors,
+        )
+        _require(boundary.get("runtime_authority") == "none", "scorecard authority_boundary.runtime_authority must be none", errors)
+        _require(
+            boundary.get("portable_contract_status") in {"not-declared", "declared"},
+            "scorecard authority_boundary.portable_contract_status is invalid",
+            errors,
+        )
+        _require(
+            bool(str(boundary.get("promotion_rule") or "").strip()),
+            "scorecard authority_boundary must name promotion_rule",
+            errors,
+        )
+        _require(
+            bool(str(boundary.get("agent_decision") or "").strip()),
+            "scorecard authority_boundary must name agent_decision",
+            errors,
+        )
 
     for invariant in pack["invariants"].get("invariants", []):
         _require(invariant.get("dimension") in dimensions, f"invariant {invariant.get('id')} references unknown dimension", errors)

--- a/src/agentic_workspace/contracts/schemas/agent_aid_manifest.schema.json
+++ b/src/agentic_workspace/contracts/schemas/agent_aid_manifest.schema.json
@@ -189,6 +189,49 @@
       "additionalProperties": false,
       "description": "How this aid is validated, or why validation is absent."
     },
+    "authority_boundary": {
+      "type": "object",
+      "required": [
+        "runtime_authority",
+        "fact_owner",
+        "agent_decision"
+      ],
+      "properties": {
+        "runtime_authority": {
+          "type": "string",
+          "enum": [
+            "none",
+            "advisory-only",
+            "canonical"
+          ],
+          "description": "Whether this aid can act as package runtime authority."
+        },
+        "fact_owner": {
+          "type": "string",
+          "enum": [
+            "agent-aid",
+            "external-intent-evidence",
+            "planning-state",
+            "memory",
+            "docs-contract",
+            "host-config"
+          ],
+          "description": "Canonical owner for behavior-relevant facts related to the aid."
+        },
+        "promote_behavior_relevant_facts_to": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Target surface for behavior-relevant facts if the aid reveals reusable package behavior."
+        },
+        "agent_decision": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Decision that remains owned by the agent."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Boundary that prevents advisory aids from becoming hidden workflow or package authority."
+    },
     "promotion": {
       "type": "object",
       "required": [

--- a/tests/test_agent_aids.py
+++ b/tests/test_agent_aids.py
@@ -219,6 +219,30 @@ def test_candidate_agent_aid_cannot_claim_canonical_proof_role(tmp_path: Path) -
     assert any("only promoted aids may declare proof_role='canonical-proof'" in finding.message for finding in findings)
 
 
+def test_github_specific_advisory_aid_routes_facts_to_external_intent(tmp_path: Path) -> None:
+    _prepare_schema(tmp_path)
+    manifest = ".agentic-workspace/agent-aids/scripts/github-issue-body/manifest.json"
+    entrypoint = ".agentic-workspace/agent-aids/scripts/github-issue-body/new_github_issue_body.py"
+    payload = _valid_manifest(
+        id="github-issue-body",
+        entrypoint=entrypoint,
+        authority_boundary={
+            "runtime_authority": "none",
+            "fact_owner": "agent-aid",
+            "agent_decision": "Agent interprets issue intent.",
+        },
+    )
+    _write(tmp_path / manifest, json.dumps(payload))
+    _write(tmp_path / entrypoint, "print('ok')\n")
+
+    findings = check_agent_aids.agent_aid_findings([manifest, entrypoint], root=tmp_path)
+
+    assert any(
+        "GitHub-specific advisory aids must route behavior-relevant facts to external-intent evidence" in finding.message
+        for finding in findings
+    )
+
+
 def test_agent_aid_manifest_requires_promotion_target_kind(tmp_path: Path) -> None:
     _prepare_schema(tmp_path)
     manifest = ".agentic-workspace/agent-aids/scripts/workspace-validation/manifest.json"

--- a/tests/test_contract_tooling_surfaces.py
+++ b/tests/test_contract_tooling_surfaces.py
@@ -132,7 +132,9 @@ def test_non_enum_keyword_routing_audit_rejects_disallowed_policy(tmp_path: Path
                         "function": "neutral_helper_name",
                         "variable": "local_markers",
                         "classification": "disallowed-package-policy",
+                        "decision_authority": "advisory-only",
                         "authority": "sample",
+                        "agent_judgment_boundary": "Agent decides.",
                     }
                 ],
             }
@@ -145,4 +147,48 @@ def test_non_enum_keyword_routing_audit_rejects_disallowed_policy(tmp_path: Path
     assert errors == [
         "src/sample.py|neutral_helper_name|local_markers is classified as disallowed-package-policy; "
         "remove the keyword table or demote it to non-authoritative evidence"
+    ]
+
+
+def test_non_enum_keyword_routing_audit_rejects_decision_affecting_package_policy(tmp_path: Path) -> None:
+    module = _load_module()
+    source = tmp_path / "src" / "sample.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "\n".join(
+            [
+                "def neutral_helper_name(value):",
+                '    local_markers = ("alpha", "beta", "gamma")',
+                "    return any(marker in value for marker in local_markers)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    audit = tmp_path / "docs" / "maintainer" / "non-enum-keyword-routing-audit.json"
+    audit.parent.mkdir(parents=True)
+    audit.write_text(
+        json.dumps(
+            {
+                "kind": "agentic-workspace/non-enum-keyword-routing-audit/v1",
+                "entries": [
+                    {
+                        "path": "src/sample.py",
+                        "function": "neutral_helper_name",
+                        "variable": "local_markers",
+                        "classification": "advisory-diagnostic",
+                        "decision_authority": "decision-affecting-package-policy",
+                        "authority": "sample",
+                        "agent_judgment_boundary": "Agent decides.",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    errors = module._validate_non_enum_keyword_routing_audit(repo_root=tmp_path, audit_path=audit)
+
+    assert errors == [
+        "src/sample.py|neutral_helper_name|local_markers is decision-affecting package policy; "
+        "migrate it to structured authority before accepting the audit"
     ]

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -60,6 +60,7 @@ def test_external_agent_lane_pack_validates() -> None:
 
 def test_external_agent_lane_scorecard_has_contract_ids_and_owner_surfaces() -> None:
     scorecard = _read_json("scorecard-taxonomy.json")
+    boundary = scorecard["authority_boundary"]
 
     dimensions = {item["id"] for item in scorecard["dimensions"]}
     failure_ids = {item["id"] for item in scorecard["failure_taxonomy"]}
@@ -93,6 +94,19 @@ def test_external_agent_lane_scorecard_has_contract_ids_and_owner_surfaces() -> 
         "HARNESS_SCENARIO_AMBIGUOUS",
     } <= failure_ids
     assert {"cli_output", "memory", "planning", "verification", "contracts", "harness", "no_change"} <= owner_surfaces
+    assert boundary["harness_role"] == "maintainer-evaluation-evidence"
+    assert boundary["runtime_authority"] == "none"
+    assert boundary["portable_contract_status"] == "not-declared"
+
+
+def test_external_agent_lane_rejects_missing_harness_authority_boundary() -> None:
+    module = _load_module()
+    pack = copy.deepcopy(module.load_pack(repo_root=REPO_ROOT))
+    pack["scorecard"].pop("authority_boundary", None)
+
+    errors = module.validate_pack(pack)
+
+    assert "scorecard must define authority_boundary" in errors
 
 
 def test_external_agent_lane_scenarios_cover_issue_lane_requirements() -> None:

--- a/tools/model-cli-harness/external-agent-evaluation/scorecard-taxonomy.json
+++ b/tools/model-cli-harness/external-agent-evaluation/scorecard-taxonomy.json
@@ -1,6 +1,13 @@
 {
   "kind": "agentic-workspace/external-agent-scorecard/v1",
   "lane": "#1600",
+  "authority_boundary": {
+    "harness_role": "maintainer-evaluation-evidence",
+    "runtime_authority": "none",
+    "portable_contract_status": "not-declared",
+    "promotion_rule": "Harness findings may become package behavior only after an explicit provider-neutral contract or owner surface is declared.",
+    "agent_decision": "The agent interprets harness findings as evidence and decides whether they indicate product ambiguity, model/provider limits, fixture gaps, or no change."
+  },
   "result_values": ["pass", "partial", "fail", "not_applicable"],
   "claim_safety_values": ["safe_full_claim", "partial_claim_only", "unsafe_claim", "not_applicable"],
   "owner_surfaces": [


### PR DESCRIPTION
## Summary

Closes #1673.
Closes #1675.
Closes #1677.
Closes #1678.

- add enum-backed `decision_authority` and `agent_judgment_boundary` to the non-enum keyword-routing audit
- make contract tooling reject any audit row marked as decision-affecting package policy
- add `authority_boundary` to agent-aid manifests and route the GitHub issue-body aid's behavior-relevant facts to external-intent evidence
- make agent-aid checks reject GitHub-specific advisory aids that do not route facts to external-intent evidence
- add an explicit maintainer-evaluation authority boundary to the model CLI external-agent scorecard and validate it
- add a review artifact recording the direct owner surfaces and confirming the deleted assumptions inventory was not restored

## Boundary

This PR does not recreate `docs/maintainer/package-owned-assumptions-inventory.json` or `report --section assumption_migration`. The remaining lane findings are represented in their actual authority homes: maintainer audit + checker, agent-aid manifest + external-intent evidence contract, and model CLI evaluation pack + validator.

Agent judgment remains responsible for applying these facts. AW can surface diagnostics, normalized external intent, or harness evidence; it does not route work from arbitrary prose markers, GitHub template phrasing, or provider CLI assumptions.

## Validation

- `uv run pytest tests/test_contract_tooling_surfaces.py::test_non_enum_keyword_routing_audit_rejects_unclassified_candidate tests/test_contract_tooling_surfaces.py::test_non_enum_keyword_routing_audit_rejects_disallowed_policy tests/test_contract_tooling_surfaces.py::test_non_enum_keyword_routing_audit_rejects_decision_affecting_package_policy tests/test_agent_aids.py::test_valid_agent_aid_manifest_passes tests/test_agent_aids.py::test_github_specific_advisory_aid_routes_facts_to_external_intent tests/test_external_agent_evaluation_lane.py::test_external_agent_lane_pack_validates tests/test_external_agent_evaluation_lane.py::test_external_agent_lane_scorecard_has_contract_ids_and_owner_surfaces tests/test_external_agent_evaluation_lane.py::test_external_agent_lane_rejects_missing_harness_authority_boundary -q`
- `uv run pytest tests/test_contract_tooling_surfaces.py tests/test_agent_aids.py tests/test_external_agent_evaluation_lane.py -q`
- `uv run python scripts/check/check_agent_aids.py --quiet-success`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `make lint-workspace`
- `make test-workspace`
- `uv run pytest --collect-only -q tests packages`
- `rg -n "test_model_cli_harness.py" docs/maintainer/test-knowledge-inventory.md`
- `make schema-reference-docs`

## Dogfooding

- Ran `uv run python scripts/run_agentic_workspace.py implement --changed ... --task "Implement remaining package-owned assumptions lane issues #1673 #1675 #1677 #1678 through direct authority surfaces" --format json`; AW surfaced the host-agnostic agent-judgment principle and selected the proof listed above.
- Memory routing found only architecture index notes; the result belongs in docs/contracts/checks, not a Memory note.