### PR TITLE
Improve generated option drift diagnostics

### DIFF
--- a/generated/memory/typescript/src/hostPrimitiveSupport.mjs
+++ b/generated/memory/typescript/src/hostPrimitiveSupport.mjs
@@ -708,7 +708,10 @@ export function executeHostPrimitive(primitive, values, args, operationId) {
   if (primitive === 'workspace.output.emit') return emitOutput(values, args);
   if (primitive === 'workspace.defaults.load') return loadJsonResource('_contracts/payload.json');
   if (primitive === 'workspace.defaults.select') return workspaceDefaultsSelect(values.defaults_payload, values);
-  if (primitive === 'workspace.config.load') return workspaceConfig(values);
+  if (primitive === 'workspace.config.load') {
+    const config = workspaceConfig(values);
+    return args?.include_payload ? { config, result: config } : config;
+  }
   if (primitive === 'output.fields.select') return selectFields(values.config, values);
   if (primitive === 'workspace.config.emit') return emitOutput({ ...values, result: values.result ?? values.config }, args);
   return domainPrimitive(primitive, values, args, operationId);

--- a/generated/planning/typescript/src/hostPrimitiveSupport.mjs
+++ b/generated/planning/typescript/src/hostPrimitiveSupport.mjs
@@ -708,7 +708,10 @@ export function executeHostPrimitive(primitive, values, args, operationId) {
   if (primitive === 'workspace.output.emit') return emitOutput(values, args);
   if (primitive === 'workspace.defaults.load') return loadJsonResource('_contracts/payload.json');
   if (primitive === 'workspace.defaults.select') return workspaceDefaultsSelect(values.defaults_payload, values);
-  if (primitive === 'workspace.config.load') return workspaceConfig(values);
+  if (primitive === 'workspace.config.load') {
+    const config = workspaceConfig(values);
+    return args?.include_payload ? { config, result: config } : config;
+  }
   if (primitive === 'output.fields.select') return selectFields(values.config, values);
   if (primitive === 'workspace.config.emit') return emitOutput({ ...values, result: values.result ?? values.config }, args);
   return domainPrimitive(primitive, values, args, operationId);

--- a/generated/verification/typescript/src/hostPrimitiveSupport.mjs
+++ b/generated/verification/typescript/src/hostPrimitiveSupport.mjs
@@ -708,7 +708,10 @@ export function executeHostPrimitive(primitive, values, args, operationId) {
   if (primitive === 'workspace.output.emit') return emitOutput(values, args);
   if (primitive === 'workspace.defaults.load') return loadJsonResource('_contracts/payload.json');
   if (primitive === 'workspace.defaults.select') return workspaceDefaultsSelect(values.defaults_payload, values);
-  if (primitive === 'workspace.config.load') return workspaceConfig(values);
+  if (primitive === 'workspace.config.load') {
+    const config = workspaceConfig(values);
+    return args?.include_payload ? { config, result: config } : config;
+  }
   if (primitive === 'output.fields.select') return selectFields(values.config, values);
   if (primitive === 'workspace.config.emit') return emitOutput({ ...values, result: values.result ?? values.config }, args);
   return domainPrimitive(primitive, values, args, operationId);

--- a/generated/workspace/typescript/src/hostPrimitiveSupport.mjs
+++ b/generated/workspace/typescript/src/hostPrimitiveSupport.mjs
@@ -708,7 +708,10 @@ export function executeHostPrimitive(primitive, values, args, operationId) {
   if (primitive === 'workspace.output.emit') return emitOutput(values, args);
   if (primitive === 'workspace.defaults.load') return loadJsonResource('_contracts/payload.json');
   if (primitive === 'workspace.defaults.select') return workspaceDefaultsSelect(values.defaults_payload, values);
-  if (primitive === 'workspace.config.load') return workspaceConfig(values);
+  if (primitive === 'workspace.config.load') {
+    const config = workspaceConfig(values);
+    return args?.include_payload ? { config, result: config } : config;
+  }
   if (primitive === 'output.fields.select') return selectFields(values.config, values);
   if (primitive === 'workspace.config.emit') return emitOutput({ ...values, result: values.result ?? values.config }, args);
   return domainPrimitive(primitive, values, args, operationId);

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -837,6 +837,54 @@ def _operation_input_matches_interface(input_name: str, parameter_names: set[str
     return f"{input_name}s" in parameter_names
 
 
+def _generated_command_option_owners(commands: list[object]) -> dict[str, list[str]]:
+    owners: dict[str, list[str]] = {}
+
+    def collect(interface: dict[str, object], owner: str) -> None:
+        for option_name in _interface_parameter_names(interface):
+            owners.setdefault(option_name, []).append(owner)
+        subcommands = interface.get("subcommands", [])
+        if not isinstance(subcommands, list):
+            return
+        for subcommand in subcommands:
+            if not isinstance(subcommand, dict):
+                continue
+            subcommand_name = str(subcommand.get("name", "")).strip() or "<unnamed>"
+            collect(subcommand, f"{owner} {subcommand_name}")
+
+    for command in commands:
+        if not isinstance(command, dict) or command.get("status") != "generated":
+            continue
+        interface = command.get("interface", {})
+        if not isinstance(interface, dict):
+            continue
+        raw_command = command.get("command", {})
+        command_name = str(interface.get("name") or (raw_command.get("name") if isinstance(raw_command, dict) else "") or "<unnamed>")
+        adapter_id = str(command.get("adapter_id", "")).strip()
+        owner = adapter_id or command_name
+        collect(interface, owner)
+    return {name: sorted(set(name_owners)) for name, name_owners in owners.items()}
+
+
+def _relative_posix(path: Path) -> str:
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _command_interface_source_hint(
+    *, package_id: str, command_source_id: str, nested_interface_path: tuple[str, ...] = ()
+) -> str:
+    hint = (
+        "src/agentic_workspace/contracts/command_package_ir.json "
+        f"$.packages[id={package_id}].commands[adapter_id={command_source_id}].interface"
+    )
+    for subcommand_name in nested_interface_path:
+        hint += f".subcommands[name={subcommand_name}]"
+    return f"{hint}.options"
+
+
 def _validate_operation_cli_inputs_for_interface(
     *,
     package_id: str,
@@ -844,6 +892,10 @@ def _validate_operation_cli_inputs_for_interface(
     interface: dict[str, object],
     inherited_operation_ref: dict[str, object],
     inherited_option_names: set[str],
+    command_source_id: str = "",
+    operation_contract_root: str = "",
+    sibling_option_owners: dict[str, list[str]] | None = None,
+    nested_interface_path: tuple[str, ...] = (),
     generated_root: Path | None = None,
 ) -> list[str]:
     errors: list[str] = []
@@ -869,11 +921,36 @@ def _validate_operation_cli_inputs_for_interface(
                         continue
                     input_name = str(input_record.get("name", "")).strip()
                     if input_name and not _operation_input_matches_interface(input_name, option_names):
+                        source_id = command_source_id or command_path
+                        source_hint = _command_interface_source_hint(
+                            package_id=package_id,
+                            command_source_id=source_id,
+                            nested_interface_path=nested_interface_path,
+                        )
+                        operation_source = operation_path
+                        if operation_contract_root:
+                            operation_source = f"{operation_contract_root.rstrip('/')}/{operation_path}"
+                        generated_artifact = ""
+                        if generated_root is not None:
+                            generated_artifact = _relative_posix(generated_root / "command_package.json")
+                        sibling_owners = [
+                            owner
+                            for owner in (sibling_option_owners or {}).get(input_name, [])
+                            if owner != source_id and not owner.startswith(f"{source_id} ")
+                        ]
+                        sibling_hint = ""
+                        if sibling_owners:
+                            sibling_hint = (
+                                f"; option {input_name!r} appears on sibling command interface(s) {sibling_owners!r}, "
+                                f"but expected command id is {source_id!r}"
+                            )
                         errors.append(
                             f"{package_id} {command_path} operation {operation_id} declares cli-option input "
                             f"{input_name!r} but generated command options are {sorted(option_names)!r}; "
-                            "add the option to the command interface or mark the input command_visibility='runtime-only' "
-                            "or command_visibility='non-command-visible'"
+                            f"source interface: {source_hint}; source operation: {operation_source}; "
+                            f"generated artifact: {generated_artifact or '<unknown>'}{sibling_hint}; "
+                            "add the option to the source command interface before regenerating, or mark the input "
+                            "command_visibility='runtime-only' or command_visibility='non-command-visible'"
                         )
     if isinstance(subcommands, list):
         for subcommand in subcommands:
@@ -887,6 +964,10 @@ def _validate_operation_cli_inputs_for_interface(
                     interface=subcommand,
                     inherited_operation_ref=current_operation_ref,
                     inherited_option_names=option_names,
+                    command_source_id=command_source_id,
+                    operation_contract_root=operation_contract_root,
+                    sibling_option_owners=sibling_option_owners,
+                    nested_interface_path=(*nested_interface_path, subcommand_name),
                     generated_root=generated_root,
                 )
             )
@@ -899,6 +980,7 @@ def _validate_generated_operation_cli_inputs(ir: dict[str, object]) -> list[str]
         if not isinstance(package, dict):
             continue
         package_id = str(package.get("id", "")).strip() or "<unknown-package>"
+        operation_contract_root = str(package.get("operation_contract_root", "")).strip()
         python_targets = [
             target
             for target in package.get("targets", [])
@@ -911,7 +993,10 @@ def _validate_generated_operation_cli_inputs(ir: dict[str, object]) -> list[str]
             except (OSError, json.JSONDecodeError) as exc:
                 errors.append(f"{package_id} generated Python command package cannot be loaded for CLI input proof: {exc}")
                 continue
-            for command in command_package.get("commands", []):
+            commands = command_package.get("commands", [])
+            command_records = commands if isinstance(commands, list) else []
+            command_option_owners = _generated_command_option_owners(command_records)
+            for command in command_records:
                 if not isinstance(command, dict) or command.get("status") != "generated":
                     continue
                 interface = command.get("interface", {})
@@ -929,6 +1014,9 @@ def _validate_generated_operation_cli_inputs(ir: dict[str, object]) -> list[str]
                         interface=interface,
                         inherited_operation_ref=operation_ref,
                         inherited_option_names=set(),
+                        command_source_id=str(command.get("adapter_id", "")).strip(),
+                        operation_contract_root=operation_contract_root,
+                        sibling_option_owners=command_option_owners,
                         generated_root=generated_root,
                     )
                 )

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -933,16 +933,15 @@ def _validate_operation_cli_inputs_for_interface(
                         generated_artifact = ""
                         if generated_root is not None:
                             generated_artifact = _relative_posix(generated_root / "command_package.json")
+                        current_interface_owner = " ".join((source_id, *nested_interface_path)).strip()
                         sibling_owners = [
-                            owner
-                            for owner in (sibling_option_owners or {}).get(input_name, [])
-                            if owner != source_id and not owner.startswith(f"{source_id} ")
+                            owner for owner in (sibling_option_owners or {}).get(input_name, []) if owner != current_interface_owner
                         ]
                         sibling_hint = ""
                         if sibling_owners:
                             sibling_hint = (
                                 f"; option {input_name!r} appears on sibling command interface(s) {sibling_owners!r}, "
-                                f"but expected command id is {source_id!r}"
+                                f"but expected command interface is {current_interface_owner!r}"
                             )
                         errors.append(
                             f"{package_id} {command_path} operation {operation_id} declares cli-option input "

--- a/src/agentic_workspace/contracts/typescript_primitive_support.mjs
+++ b/src/agentic_workspace/contracts/typescript_primitive_support.mjs
@@ -702,7 +702,10 @@ export function executeHostPrimitive(primitive, values, args, operationId) {
   if (primitive === 'workspace.output.emit') return emitOutput(values, args);
   if (primitive === 'workspace.defaults.load') return loadJsonResource('_contracts/payload.json');
   if (primitive === 'workspace.defaults.select') return workspaceDefaultsSelect(values.defaults_payload, values);
-  if (primitive === 'workspace.config.load') return workspaceConfig(values);
+  if (primitive === 'workspace.config.load') {
+    const config = workspaceConfig(values);
+    return args?.include_payload ? { config, result: config } : config;
+  }
   if (primitive === 'output.fields.select') return selectFields(values.config, values);
   if (primitive === 'workspace.config.emit') return emitOutput({ ...values, result: values.result ?? values.config }, args);
   return domainPrimitive(primitive, values, args, operationId);

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -1103,11 +1103,48 @@ def test_generated_operation_cli_input_proof_scenarios(monkeypatch) -> None:
         interface=route_command["interface"],
         inherited_operation_ref=route_command["operation_ref"],
         inherited_option_names=set(),
+        command_source_id="memory.route-report.cli",
+        operation_contract_root="packages/memory/src/repo_memory_bootstrap/contracts",
+        sibling_option_owners=checker._generated_command_option_owners(command_package["commands"]),
         generated_root=generated_root,
     )
 
     assert any(
         "memory-bootstrap route-report operation memory.route-report.report declares cli-option input 'verbose'" in error
+        for error in errors
+    )
+    assert any(
+        "source interface: src/agentic_workspace/contracts/command_package_ir.json "
+        "$.packages[id=memory-bootstrap].commands[adapter_id=memory.route-report.cli].interface.options" in error
+        for error in errors
+    )
+    assert any(
+        "source operation: packages/memory/src/repo_memory_bootstrap/contracts/operations/memory.route-report.report.json" in error
+        for error in errors
+    )
+    assert any("generated artifact: generated/memory/python/command_package.json" in error for error in errors)
+
+    route_command = copy.deepcopy(next(command for command in command_package["commands"] if command["adapter_id"] == "memory.route.cli"))
+    route_command["interface"]["options"] = [
+        option for option in route_command["interface"]["options"] if option.get("name") != "pending_command"
+    ]
+    wrong_neighbor_option_owners = {"pending_command": ["memory.capture-note.cli"]}
+
+    errors = checker._validate_operation_cli_inputs_for_interface(
+        package_id="memory-bootstrap",
+        command_path="route",
+        interface=route_command["interface"],
+        inherited_operation_ref=route_command["operation_ref"],
+        inherited_option_names=set(),
+        command_source_id="memory.route.cli",
+        operation_contract_root="packages/memory/src/repo_memory_bootstrap/contracts",
+        sibling_option_owners=wrong_neighbor_option_owners,
+        generated_root=generated_root,
+    )
+
+    assert any(
+        "option 'pending_command' appears on sibling command interface(s) ['memory.capture-note.cli'], "
+        "but expected command id is 'memory.route.cli'" in error
         for error in errors
     )
 

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -1144,7 +1144,51 @@ def test_generated_operation_cli_input_proof_scenarios(monkeypatch) -> None:
 
     assert any(
         "option 'pending_command' appears on sibling command interface(s) ['memory.capture-note.cli'], "
-        "but expected command id is 'memory.route.cli'" in error
+        "but expected command interface is 'memory.route.cli'" in error
+        for error in errors
+    )
+
+    nested_operation = {
+        "inputs": [
+            {"name": "format", "source": "cli-option"},
+            {"name": "misplaced", "source": "cli-option"},
+        ]
+    }
+    monkeypatch.setattr(checker, "_load_json", lambda path: nested_operation)
+    nested_interface = {
+        "name": "parent",
+        "options": [{"name": "format"}],
+        "subcommands": [
+            {
+                "name": "expected",
+                "options": [],
+                "operation_ref": {"id": "example.expected", "path": "operations/example.expected.json"},
+            },
+            {
+                "name": "wrong",
+                "options": [{"name": "misplaced"}],
+                "operation_ref": {"id": "example.wrong", "path": "operations/example.wrong.json"},
+            },
+        ],
+    }
+    nested_option_owners = checker._generated_command_option_owners(
+        [{"status": "generated", "adapter_id": "example.parent.cli", "interface": nested_interface}]
+    )
+
+    errors = checker._validate_operation_cli_inputs_for_interface(
+        package_id="example-package",
+        command_path="parent",
+        interface=nested_interface,
+        inherited_operation_ref={"id": "example.parent", "path": "operations/example.parent.json"},
+        inherited_option_names=set(),
+        command_source_id="example.parent.cli",
+        operation_contract_root="packages/example/contracts",
+        sibling_option_owners=nested_option_owners,
+    )
+
+    assert any(
+        "option 'misplaced' appears on sibling command interface(s) ['example.parent.cli wrong'], "
+        "but expected command interface is 'example.parent.cli expected'" in error
         for error in errors
     )
 


### PR DESCRIPTION
## What changed

- Improves generated command option drift diagnostics in `check_generated_command_packages.py`.
- Missing CLI-option errors now name the source command interface in `command_package_ir.json`, the source operation contract path, the generated artifact, and the expected adapter id.
- Adds a sibling-command hint when the missing option appears on another generated command interface.
- Fixes the AW-owned TypeScript primitive support for `workspace.config.load` multi-output calls so the selected TypeScript conformance case stays green, then regenerates TypeScript host primitive support copies.

Closes #1660.

## Validation

- `uv run pytest tests/test_generated_command_package_proof_runner.py::test_generated_operation_cli_input_proof_scenarios -q`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `make lint-workspace`
- `make test-workspace`
