### PR TITLE
Fix dogfooding completion-cost issues

### DIFF
--- a/docs/reviews/aw-induced-completion-cost-inventory-2026-06-22.md
+++ b/docs/reviews/aw-induced-completion-cost-inventory-2026-06-22.md
@@ -1,0 +1,23 @@
+# AW-Induced Completion Cost Inventory
+
+Date: 2026-06-22
+
+Scope: dogfooding issues #1680, #1684, #1686, and #1687.
+
+## Landed Reductions
+
+| Issue | Cost type | Owner surface | Before | After |
+| --- | --- | --- | --- | --- |
+| #1684 | repair churn, planning residue | Planning closeout | `planning closeout` could mutate proof and closeout fields before archive validation discovered an existing continuation conflict. | Closeout preflights structured continuation state before mutation and exits with a next safe action when archive-and-close is incompatible. |
+| #1686 | stale proof, validation time | Workspace proof selection | Host subsystem proof could require an executable inventory sweep for a retired/deleted test path. | Proof selection downgrades commands with absent path-like arguments to unavailable proof and keeps them out of required commands. |
+| #1687 | planning residue, intent repair | Planning promotion | External-intent candidates with generic outcome/reason text promoted into generic execplan intent. | Promotion preserves specific source outcomes and replaces known generic scaffold fallbacks with structured issue ref/title intent. |
+
+## Closure Boundary
+
+This closes the small dogfooding lane by removing three concrete sources of AW-induced completion cost while preserving safety gates:
+
+- proof remains required, but stale deleted-test sweeps are not treated as runnable required proof;
+- Planning closeout still blocks dishonest full closure, but does so before mutating records;
+- promoted plans still require agent review, but issue-specific intent is carried into the canonical record when available.
+
+Remaining broader completion-cost work should stay in external-agent evaluation and ordinary-loop noise issues rather than being claimed by this lane.

--- a/docs/reviews/aw-induced-completion-cost-inventory-2026-06-22.md
+++ b/docs/reviews/aw-induced-completion-cost-inventory-2026-06-22.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-22
 
-Scope: dogfooding issues #1680, #1684, #1686, and #1687.
+Scope: dogfooding slice for #1684, #1686, and #1687, contributing evidence and reductions under #1680.
 
 ## Landed Reductions
 
@@ -12,12 +12,12 @@ Scope: dogfooding issues #1680, #1684, #1686, and #1687.
 | #1686 | stale proof, validation time | Workspace proof selection | Host subsystem proof could require an executable inventory sweep for a retired/deleted test path. | Proof selection downgrades commands with absent path-like arguments to unavailable proof and keeps them out of required commands. |
 | #1687 | planning residue, intent repair | Planning promotion | External-intent candidates with generic outcome/reason text promoted into generic execplan intent. | Promotion preserves specific source outcomes and replaces known generic scaffold fallbacks with structured issue ref/title intent. |
 
-## Closure Boundary
+## Slice Boundary
 
-This closes the small dogfooding lane by removing three concrete sources of AW-induced completion cost while preserving safety gates:
+This slice removes three concrete sources of AW-induced completion cost while preserving safety gates:
 
 - proof remains required, but stale deleted-test sweeps are not treated as runnable required proof;
 - Planning closeout still blocks dishonest full closure, but does so before mutating records;
 - promoted plans still require agent review, but issue-specific intent is carried into the canonical record when available.
 
-Remaining broader completion-cost work should stay in external-agent evaluation and ordinary-loop noise issues rather than being claimed by this lane.
+#1680 remains open for broader completion-cost inventory, diagnosis, and reductions across ordinary-loop noise, proof/test cost, review/repair churn, planning residue, handoff friction, and recovery friction.

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -10536,12 +10536,17 @@ def promote_todo_item_to_execplan(
             or item.fields.get("promotion signal", "").strip()
         )
         done_when = item.fields.get("done when", "").strip() or item.fields.get("outcome", "").strip()
-        why_now = item.fields.get("why now", "").strip() or item.fields.get("reason", "").strip()
+        title = item.fields.get("title", "").strip() or _title_from_slug(slug)
+        why_now = (
+            item.fields.get("why now", "").strip()
+            or _promoted_item_identity_intent(title=title, item_id=item_id, source_fields=item.fields)
+            or item.fields.get("reason", "").strip()
+        )
         status = _normalize_status(item.fields.get("status", "planned"))
         if status == "planned":
             status = "in-progress"
         plan_record = _build_execplan_record_from_todo_item(
-            title=_title_from_slug(slug),
+            title=title,
             item_id=item_id,
             status=status,
             why_now=why_now,
@@ -10592,12 +10597,17 @@ def promote_todo_item_to_execplan(
         or item.fields.get("promotion signal", "").strip()
     )
     done_when = item.fields.get("done when", "").strip() or item.fields.get("outcome", "").strip()
-    why_now = item.fields.get("why now", "").strip() or item.fields.get("reason", "").strip()
+    title = item.fields.get("title", "").strip() or _title_from_slug(slug)
+    why_now = (
+        item.fields.get("why now", "").strip()
+        or _promoted_item_identity_intent(title=title, item_id=item_id, source_fields=item.fields)
+        or item.fields.get("reason", "").strip()
+    )
     status = _normalize_status(item.fields.get("status", "planned"))
     if status == "planned":
         status = "in-progress"
     plan_record = _build_execplan_record_from_todo_item(
-        title=_title_from_slug(slug),
+        title=title,
         item_id=item_id,
         status=status,
         why_now=why_now,
@@ -12765,6 +12775,36 @@ def _read_closeout_proof_file(*, target_root: Path, proof_file: str) -> tuple[st
     return proof, relative_path, ""
 
 
+def _closeout_continuation_conflict(
+    *,
+    record: dict[str, Any],
+    normalized_claim: str,
+    normalized_intent: str,
+    normalized_residue: str,
+    residue_owner: str | None,
+) -> dict[str, str] | None:
+    required_continuation = _record_section_dict(record, "required_continuation") or {}
+    intent_satisfaction = _record_section_dict(record, "intent_satisfaction") or {}
+    required_follow_on = str(required_continuation.get("required follow-on for the larger intended outcome", "")).strip().lower()
+    continuation_owner = str(required_continuation.get("owner surface", "")).strip()
+    unsolved_owner = str(intent_satisfaction.get("unsolved intent passed to", "")).strip()
+    live_unsolved_owner = unsolved_owner if unsolved_owner.lower() not in {"", "none", "n/a", "none yet"} else ""
+    owner = continuation_owner if continuation_owner.lower() not in {"", "none", "n/a"} else live_unsolved_owner
+    if required_follow_on != "yes" and not live_unsolved_owner:
+        return None
+    if normalized_intent != "satisfied":
+        return None
+    if normalized_residue not in {"none", "dismissed"} and (residue_owner or "").strip():
+        return None
+    if normalized_claim == "slice" and normalized_residue not in {"none", "dismissed"}:
+        return None
+    return {
+        "owner": owner or PLANNING_STATE_PATH.as_posix(),
+        "required_follow_on": required_follow_on or ("yes" if live_unsolved_owner else ""),
+        "unsolved_owner": live_unsolved_owner,
+    }
+
+
 def closeout_execplan(
     plan: str,
     *,
@@ -12819,6 +12859,38 @@ def closeout_execplan(
     record = _load_execplan_record(plan_path)
     if record is None:
         result.add("manual review", record_path, "planning closeout requires a canonical .plan.json record")
+        return result
+
+    continuation_conflict = _closeout_continuation_conflict(
+        record=record,
+        normalized_claim=normalized_claim,
+        normalized_intent=normalized_intent,
+        normalized_residue=normalized_residue,
+        residue_owner=residue_owner,
+    )
+    if continuation_conflict is not None:
+        owner = continuation_conflict["owner"]
+        result.warnings.append(
+            {
+                "warning_class": "closeout_continuation_preflight_blocked",
+                "path": record_path.relative_to(target_root).as_posix(),
+                "message": ("planning closeout cannot archive-and-close before resolving the existing structured continuation owner."),
+                "suggested_fix": (
+                    "Rerun closeout with --intent-status partial or deferred-with-owner and --residue planning "
+                    f"--residue-owner {owner!r}, or close the continuation before claiming full intent satisfaction."
+                ),
+            }
+        )
+        result.add(
+            "manual review",
+            record_path,
+            "closeout preflight found existing required_continuation or unsolved intent incompatible with archive-and-close",
+        )
+        result.add(
+            "next safe action",
+            record_path,
+            f"rerun planning closeout with --intent-status partial --residue planning --residue-owner {owner!r}",
+        )
         return result
 
     continuation_owner = residue_owner or ""
@@ -15353,13 +15425,13 @@ def _compact_todo_item_from_state(state: dict[str, Any] | None, item_id: str) ->
             if not isinstance(raw_items, list):
                 continue
             for raw in raw_items:
-                item = _todo_item_from_compact_record(raw, item_id)
+                item = _todo_item_from_compact_record(raw, item_id, source_bucket=f"roadmap.{bucket}")
                 if item is not None:
                     return item
     return None
 
 
-def _todo_item_from_compact_record(raw: Any, item_id: str) -> TodoItem | None:
+def _todo_item_from_compact_record(raw: Any, item_id: str, *, source_bucket: str = "") -> TodoItem | None:
     if not isinstance(raw, dict) or str(raw.get("id", "")) != item_id:
         return None
     fields: dict[str, str] = {}
@@ -15374,6 +15446,9 @@ def _todo_item_from_compact_record(raw: Any, item_id: str) -> TodoItem | None:
     if "surface" not in fields and "path" in fields:
         fields["surface"] = fields["path"]
         field_order.append("surface")
+    if source_bucket:
+        fields["source bucket"] = source_bucket
+        field_order.append("source bucket")
     return TodoItem(fields=fields, field_order=field_order, start=-1, end=-1)
 
 
@@ -15545,6 +15620,28 @@ def _normalize_status(status: str) -> str:
     if lowered in {"complete", "done", "completed", "closed"}:
         return "completed"
     return "planned"
+
+
+def _todo_identity_ref(source_fields: Mapping[str, Any] | None) -> str:
+    if not source_fields:
+        return ""
+    refs_value = source_fields.get("refs", "")
+    refs: list[str] = []
+    if isinstance(refs_value, list):
+        refs = [str(item).strip() for item in refs_value if str(item).strip()]
+    elif str(refs_value).strip():
+        refs = [part.strip() for part in re.split(r"[, ]+", str(refs_value)) if part.strip()]
+    return refs[0] if refs else str(source_fields.get("id") or "").strip()
+
+
+def _promoted_item_identity_intent(*, title: str, item_id: str, source_fields: Mapping[str, Any] | None) -> str:
+    if not source_fields or str(source_fields.get("source bucket", "")).strip() != "roadmap.candidates":
+        return ""
+    ref = _todo_identity_ref(source_fields) or item_id
+    title_text = title.strip() or _title_from_slug(item_id)
+    if ref and ref != item_id and title_text:
+        return f"Resolve {ref}: {title_text}."
+    return ""
 
 
 def _execplan_profile_record(*, task_shape: str) -> dict[str, Any]:

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -1644,6 +1644,7 @@ def test_planning_closeout_blocks_proxy_lane_archive_and_close(tmp_path: Path, c
         "activation trigger": "next lane slice",
     }
     installer_mod._write_execplan_record(record_path=record_path, record=record)
+    before = json.loads(record_path.read_text(encoding="utf-8"))
 
     assert (
         planning_cli.main(
@@ -1663,10 +1664,13 @@ def test_planning_closeout_blocks_proxy_lane_archive_and_close(tmp_path: Path, c
         == 0
     )
     payload = json.loads(capsys.readouterr().out)
+    after = json.loads(record_path.read_text(encoding="utf-8"))
 
-    assert any(warning["warning_class"] == "archive_larger_intent_proxy_closeout_blocked" for warning in payload["warnings"])
+    assert any(warning["warning_class"] == "closeout_continuation_preflight_blocked" for warning in payload["warnings"])
     assert any(action["kind"] == "manual review" for action in payload["actions"])
+    assert any(action["kind"] == "next safe action" and "--intent-status partial" in action["detail"] for action in payload["actions"])
     assert record_path.exists()
+    assert after == before
 
 
 def test_planning_closeout_records_explicit_proof_and_issue_residue(tmp_path: Path, capsys) -> None:

--- a/packages/planning/tests/test_promote.py
+++ b/packages/planning/tests/test_promote.py
@@ -1252,6 +1252,53 @@ candidates = [
     )
 
 
+def test_promote_to_plan_replaces_generic_external_intent_with_issue_specific_outcome(tmp_path: Path, capsys) -> None:
+    install_bootstrap(target=tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace/planning/state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "github-1687-specific-plan-intent", maturity = "candidate", status = "deferred", priority = "P1", refs = ["#1687"], title = "Promote external-intent candidates with issue-specific plan intent", outcome = "Route the upstream issue into a bounded Agentic Workspace slice before implementation.", reason = "Open prioritized upstream issue from refreshed external intent evidence.", promotion_signal = "Ready after issue review.", suggested_first_slice = "Implement the promotion-specific fallback." },
+]
+""",
+    )
+
+    assert (
+        planning_cli.main(
+            [
+                "promote-to-plan",
+                "github-1687-specific-plan-intent",
+                "--target",
+                str(tmp_path),
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    record = json.loads(
+        (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "github-1687-specific-plan-intent.plan.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert record["canonical_core"]["requested_outcome"] == (
+        "Resolve #1687: Promote external-intent candidates with issue-specific plan intent."
+    )
+    assert "Open prioritized upstream issue" not in record["canonical_core"]["requested_outcome"]
+    assert record["machine_readable_contract"]["intent"]["outcome"] == record["canonical_core"]["requested_outcome"]
+
+
 def test_planning_summary_continuation_view_prefers_fresh_execplan_over_stale_todo(tmp_path: Path) -> None:
     install_bootstrap(target=tmp_path)
     plan_path = tmp_path / ".agentic-workspace/planning/execplans/resume-lane.plan.json"

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -38253,6 +38253,71 @@ def _tiny_surface_compatibility_review(changed_paths: list[str]) -> dict[str, An
     }
 
 
+def _missing_repo_path_references_in_command(*, command: str, target_root: Path | None) -> list[str]:
+    if target_root is None:
+        return []
+    try:
+        tokens = shlex.split(command, posix=os.name != "nt")
+    except ValueError:
+        tokens = command.split()
+    missing: list[str] = []
+    path_suffixes = {
+        ".json",
+        ".md",
+        ".py",
+        ".toml",
+        ".ts",
+        ".tsx",
+        ".yml",
+        ".yaml",
+    }
+    option_values_to_ignore = {
+        "--config",
+        "--cwd",
+        "--format",
+        "--modules",
+        "--proof-file",
+        "--section",
+        "--select",
+        "--target",
+    }
+    skip_next = False
+    for token in tokens[1:]:
+        if skip_next:
+            skip_next = False
+            continue
+        candidate = token.strip().strip("'\"")
+        if not candidate or candidate.startswith("-"):
+            if candidate in option_values_to_ignore:
+                skip_next = True
+            continue
+        if candidate.startswith(("http://", "https://")) or "=" in candidate:
+            continue
+        path_like = "/" in candidate or "\\" in candidate or any(candidate.endswith(suffix) for suffix in path_suffixes)
+        if not path_like:
+            continue
+        if any(char in candidate for char in "*?[]{}()|^$"):
+            continue
+        path_candidate = candidate.split("::", 1)[0]
+        path = Path(path_candidate)
+        resolved = path if path.is_absolute() else target_root / path
+        try:
+            resolved.relative_to(target_root)
+        except ValueError:
+            continue
+        if not resolved.exists() and path_candidate not in missing:
+            missing.append(candidate)
+    return missing
+
+
+def _proof_command_is_search_sweep(command: str) -> bool:
+    try:
+        tokens = shlex.split(command, posix=os.name != "nt")
+    except ValueError:
+        tokens = command.split()
+    return any(Path(str(token).strip().strip("'\"")).name.lower() in {"rg", "grep", "git-grep"} for token in tokens[:3])
+
+
 def _proof_selection_for_changed_paths(
     *,
     changed_paths: list[str],
@@ -38591,6 +38656,21 @@ def _proof_selection_for_changed_paths(
                     proof_command_adjustments.append(adjustment)
             if adapted_command is None:
                 continue
+            missing_path_refs = (
+                _missing_repo_path_references_in_command(command=adapted_command, target_root=target_root)
+                if lane.get("subsystem") and _proof_command_is_search_sweep(adapted_command)
+                else []
+            )
+            if missing_path_refs:
+                unavailable_proof_commands.append(
+                    {
+                        "lane": str(lane.get("id", "")),
+                        "command": adapted_command,
+                        "reason": "selected proof command references path-like arguments absent from the target repo",
+                        "missing_paths": ", ".join(missing_path_refs),
+                    }
+                )
+                continue
             resolved_command = str(
                 _command_with_cli_invoke(
                     command=_proof_command_for_target(command=adapted_command, target_root=target_root), cli_invoke=cli_invoke
@@ -38653,6 +38733,7 @@ def _proof_selection_for_changed_paths(
             "lane": str(command.get("lane", "")),
             "reason": str(command.get("reason", "")),
             **({"replacement": command["replacement"]} if command.get("replacement") else {}),
+            **({"missing_paths": str(command["missing_paths"])} if command.get("missing_paths") else {}),
         }
         for command in unavailable_proof_commands
     ]

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -169,6 +169,73 @@ def test_implement_surfaces_operating_loop_with_proof_blocker(tmp_path: Path, ca
     assert packet["reasons"][0]["code"] == "proof_missing"
 
 
+def test_implement_does_not_require_stale_deleted_test_inventory_sweep(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write(
+        tmp_path / ".agentic-workspace" / "OWNERSHIP.toml",
+        """
+[[subsystems]]
+id = "model-cli-harness"
+paths = ["tools/model-cli-harness/**", "docs/maintainer/test-knowledge-inventory.md"]
+owns = ["model CLI harness"]
+proof = [
+  "uv run pytest --collect-only -q tests packages",
+  "rg -n \\"test_model_cli_harness.py\\" docs/maintainer/test-knowledge-inventory.md",
+]
+""",
+    )
+    _write(
+        tmp_path / "docs" / "maintainer" / "test-knowledge-inventory.md",
+        "# Test Knowledge Inventory\n\nRetired: tests/test_model_cli_harness.py\n",
+    )
+    _write(tmp_path / "tools" / "model-cli-harness" / "README.md", "# Harness\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "tools/model-cli-harness/README.md",
+                "--task",
+                "Update model CLI harness docs",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    required_commands = payload["proof"]["required_commands"]
+    assert "uv run pytest --collect-only -q tests packages" in required_commands
+    assert not any("test_model_cli_harness.py" in command for command in required_commands)
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "tools/model-cli-harness/README.md",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    proof_payload = json.loads(capsys.readouterr().out)
+    unavailable = proof_payload["unavailable_proof_commands"]
+    assert any(
+        command["lane"] == "subsystem:model-cli-harness" and "test_model_cli_harness.py" in command.get("missing_paths", "")
+        for command in unavailable
+    )
+
+
 def test_operating_loop_schema_rejects_unknown_enum_values() -> None:
     schema_path = Path("src/agentic_workspace/contracts/schemas/implementer_context.schema.json")
     schema = json.loads(schema_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Fixes three concrete dogfooding completion-cost issues and contributes reductions/evidence under the broader #1680 lane:

- preflight Planning closeout continuation conflicts before mutating execplan records
- preserve issue-specific intent when promoting external-intent roadmap candidates
- suppress stale deleted-test inventory sweep commands from required subsystem proof
- add a compact AW-induced completion-cost inventory/review artifact for this slice

Closes #1684.
Closes #1686.
Closes #1687.
Refs #1680.

## Validation

- `uv run pytest packages/planning/tests/test_archive.py::test_planning_closeout_blocks_proxy_lane_archive_and_close packages/planning/tests/test_promote.py::test_promote_to_plan_replaces_generic_external_intent_with_issue_specific_outcome tests/test_workspace_implement_cli.py::test_implement_does_not_require_stale_deleted_test_inventory_sweep -q`
- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`