### PR TITLE
[codex] Add completion-cost observations to external-agent probes

### DIFF
--- a/scripts/model_cli_harness/external_agent_evaluation_lane.py
+++ b/scripts/model_cli_harness/external_agent_evaluation_lane.py
@@ -256,6 +256,7 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
         )
 
     observation_contract = pack["scenarios"].get("completion_cost_observation_contract")
+    minimum_observed_records = 1
     _require(isinstance(observation_contract, dict), "scenarios must define completion_cost_observation_contract", errors)
     if isinstance(observation_contract, dict):
         _require(
@@ -269,10 +270,16 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
             errors,
         )
         _require(
-            observation_contract.get("applies_to") == "all_probes",
-            "completion_cost_observation_contract must apply to all_probes",
+            observation_contract.get("applies_to") == "representative_evidence_records",
+            "completion_cost_observation_contract must apply to representative_evidence_records",
             errors,
         )
+        _require(
+            int(observation_contract.get("minimum_observed_records", 0) or 0) >= 1,
+            "completion_cost_observation_contract must define minimum_observed_records",
+            errors,
+        )
+        minimum_observed_records = int(observation_contract.get("minimum_observed_records", 0) or 0)
         required_fields = {str(item) for item in observation_contract.get("required_fields", [])}
         _require(
             COMPLETION_COST_REQUIRED_FIELDS.issubset(required_fields),
@@ -443,9 +450,12 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
 
     _require("PROOF_MISSING_BEFORE_CLAIM" in failure_ids_seen, "sample records must include proof claim-safety failure evidence", errors)
     _require("MEMORY_PULL_MISSING" in failure_ids_seen, "sample records must include Memory routing failure evidence", errors)
+    observed_record_count = sum(
+        1 for record in pack["results"].get("records", []) if isinstance(record.get("completion_cost_observations"), dict)
+    )
     _require(
-        any(isinstance(record.get("completion_cost_observations"), dict) for record in pack["results"].get("records", [])),
-        "sample records must include completion-cost observation evidence",
+        observed_record_count >= minimum_observed_records,
+        "sample records must include representative completion-cost observation evidence",
         errors,
     )
     return errors

--- a/scripts/model_cli_harness/external_agent_evaluation_lane.py
+++ b/scripts/model_cli_harness/external_agent_evaluation_lane.py
@@ -68,6 +68,39 @@ OPERATING_LOOP_REASON_CODES = {
     "memory_capture_required",
     "external_residue",
 }
+COMPLETION_COST_OBSERVATION_KIND = "agentic-workspace/external-agent-completion-cost-observations/v1"
+COMPLETION_COST_REQUIRED_FIELDS = {
+    "aw_command_count",
+    "proof_command_count",
+    "reread_events",
+    "proof_churn_events",
+    "over_planning_events",
+    "review_repair_loop_count",
+    "handoff_recovery_status",
+    "unsafe_closure_claims",
+    "aw_sections_used",
+    "cost_drivers",
+}
+COMPLETION_COST_NUMERIC_FIELDS = {
+    "aw_command_count",
+    "proof_command_count",
+    "reread_events",
+    "proof_churn_events",
+    "over_planning_events",
+    "review_repair_loop_count",
+    "unsafe_closure_claims",
+}
+COMPLETION_COST_HANDOFF_STATUSES = {"not_applicable", "success", "partial", "failed"}
+COMPLETION_COST_DRIVER_CLASSIFICATIONS = {
+    "startup_routing",
+    "memory_reread",
+    "proof_churn",
+    "planning_residue",
+    "review_repair",
+    "handoff_recovery",
+    "unsafe_closure",
+    "unused_output",
+}
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -145,6 +178,46 @@ def _validate_operating_loop_packet(
             _require(reason.get("owner") in OPERATING_LOOP_RESIDUE_OWNERS, f"{prefix} operating_loop reason owner is invalid", errors)
 
 
+def _validate_completion_cost_observations(
+    observations: Any,
+    *,
+    prefix: str,
+    scenario_id: str,
+    owner_surfaces: set[str],
+    errors: list[str],
+) -> None:
+    _require(isinstance(observations, dict), f"{prefix} completion_cost_observations must be an object", errors)
+    if not isinstance(observations, dict):
+        return
+    _require(observations.get("kind") == COMPLETION_COST_OBSERVATION_KIND, f"{prefix} completion_cost_observations kind is invalid", errors)
+    _require(observations.get("scenario_id") == scenario_id, f"{prefix} completion_cost_observations scenario_id must match record", errors)
+    missing_fields = COMPLETION_COST_REQUIRED_FIELDS.difference(observations)
+    _require(not missing_fields, f"{prefix} completion_cost_observations missing fields: {', '.join(sorted(missing_fields))}", errors)
+    for field in COMPLETION_COST_NUMERIC_FIELDS:
+        value = observations.get(field)
+        _require(isinstance(value, int) and value >= 0, f"{prefix} completion_cost_observations {field} must be a non-negative integer", errors)
+    _require(
+        observations.get("handoff_recovery_status") in COMPLETION_COST_HANDOFF_STATUSES,
+        f"{prefix} completion_cost_observations handoff_recovery_status is invalid",
+        errors,
+    )
+    sections = observations.get("aw_sections_used", [])
+    _require(isinstance(sections, list), f"{prefix} completion_cost_observations aw_sections_used must be a list", errors)
+    for section in (sections if isinstance(sections, list) else []):
+        _require(isinstance(section, str) and bool(section.strip()), f"{prefix} completion_cost_observations aw_sections_used entry is invalid", errors)
+    drivers = observations.get("cost_drivers", [])
+    _require(isinstance(drivers, list), f"{prefix} completion_cost_observations cost_drivers must be a list", errors)
+    for index, driver in enumerate(drivers if isinstance(drivers, list) else []):
+        driver_prefix = f"{prefix} completion_cost_observations cost_drivers[{index}]"
+        _require(isinstance(driver, dict), f"{driver_prefix} must be an object", errors)
+        if not isinstance(driver, dict):
+            continue
+        for field in ("source", "signal", "owner_surface", "classification"):
+            _require(bool(str(driver.get(field) or "").strip()), f"{driver_prefix} must include {field}", errors)
+        _require(driver.get("owner_surface") in owner_surfaces, f"{driver_prefix} owner_surface is invalid", errors)
+        _require(driver.get("classification") in COMPLETION_COST_DRIVER_CLASSIFICATIONS, f"{driver_prefix} classification is invalid", errors)
+
+
 def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
     errors: list[str] = []
     scorecard = pack["scorecard"]
@@ -179,6 +252,31 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
         _require(
             bool(str(boundary.get("agent_decision") or "").strip()),
             "scorecard authority_boundary must name agent_decision",
+            errors,
+        )
+
+    observation_contract = pack["scenarios"].get("completion_cost_observation_contract")
+    _require(isinstance(observation_contract, dict), "scenarios must define completion_cost_observation_contract", errors)
+    if isinstance(observation_contract, dict):
+        _require(
+            observation_contract.get("kind") == "agentic-workspace/external-agent-completion-cost-observation-contract/v1",
+            "completion_cost_observation_contract kind is invalid",
+            errors,
+        )
+        _require(
+            observation_contract.get("status") == "maintainer-evaluation-only",
+            "completion_cost_observation_contract status must be maintainer-evaluation-only",
+            errors,
+        )
+        _require(
+            observation_contract.get("applies_to") == "all_probes",
+            "completion_cost_observation_contract must apply to all_probes",
+            errors,
+        )
+        required_fields = {str(item) for item in observation_contract.get("required_fields", [])}
+        _require(
+            COMPLETION_COST_REQUIRED_FIELDS.issubset(required_fields),
+            "completion_cost_observation_contract is missing required fields",
             errors,
         )
 
@@ -232,6 +330,14 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
             _require(failure_id in failure_ids, f"record {record.get('id')} references unknown failure id {failure_id}", errors)
         for owner in record.get("repair_surface_hints", []):
             _require(owner in owner_surfaces, f"record {record.get('id')} references unknown owner surface {owner}", errors)
+        if "completion_cost_observations" in record:
+            _validate_completion_cost_observations(
+                record.get("completion_cost_observations"),
+                prefix=f"record {record.get('id')}",
+                scenario_id=scenario_id,
+                owner_surfaces=owner_surfaces,
+                errors=errors,
+            )
         decisions = record.get("decisions", {})
         if scenario_id in trace_required_scenarios:
             _require(
@@ -268,6 +374,14 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
             )
         for failure_id in record.get("failure_ids", []):
             _require(failure_id in failure_ids, f"live run {record.get('id')} references unknown failure id {failure_id}", errors)
+        if "completion_cost_observations" in record:
+            _validate_completion_cost_observations(
+                record.get("completion_cost_observations"),
+                prefix=f"live run {record.get('id')}",
+                scenario_id=str(record.get("scenario_id") or ""),
+                owner_surfaces=owner_surfaces,
+                errors=errors,
+            )
 
     allowed_fixture_statuses = {"active_regression_guard", "historical_calibration", "retired"}
     for fixture in pack["historical"].get("fixtures", []):
@@ -329,7 +443,41 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
 
     _require("PROOF_MISSING_BEFORE_CLAIM" in failure_ids_seen, "sample records must include proof claim-safety failure evidence", errors)
     _require("MEMORY_PULL_MISSING" in failure_ids_seen, "sample records must include Memory routing failure evidence", errors)
+    _require(
+        any(isinstance(record.get("completion_cost_observations"), dict) for record in pack["results"].get("records", [])),
+        "sample records must include completion-cost observation evidence",
+        errors,
+    )
     return errors
+
+
+def _completion_cost_observability(records: list[dict[str, Any]]) -> dict[str, Any]:
+    observed = [record["completion_cost_observations"] for record in records if isinstance(record.get("completion_cost_observations"), dict)]
+    totals = {field: sum(int(item.get(field, 0) or 0) for item in observed) for field in sorted(COMPLETION_COST_NUMERIC_FIELDS)}
+    driver_counts = Counter(
+        driver.get("classification")
+        for item in observed
+        for driver in item.get("cost_drivers", [])
+        if isinstance(driver, dict) and driver.get("classification")
+    )
+    owner_counts = Counter(
+        driver.get("owner_surface")
+        for item in observed
+        for driver in item.get("cost_drivers", [])
+        if isinstance(driver, dict) and driver.get("owner_surface")
+    )
+    section_counts = Counter(section for item in observed for section in item.get("aw_sections_used", []) if isinstance(section, str))
+    handoff_counts = Counter(item.get("handoff_recovery_status") for item in observed if item.get("handoff_recovery_status"))
+    return {
+        "kind": "agentic-workspace/external-agent-completion-cost-observability/v1",
+        "record_count": len(observed),
+        "scenario_ids": sorted({str(item.get("scenario_id")) for item in observed if item.get("scenario_id")}),
+        "totals": totals,
+        "driver_classification_counts": dict(sorted(driver_counts.items())),
+        "owner_surface_counts": dict(sorted(owner_counts.items())),
+        "aw_sections_used_counts": dict(sorted(section_counts.items())),
+        "handoff_recovery_status_counts": dict(sorted(handoff_counts.items())),
+    }
 
 
 def build_closure_report(pack: dict[str, dict[str, Any]]) -> dict[str, Any]:
@@ -367,6 +515,7 @@ def build_closure_report(pack: dict[str, dict[str, Any]]) -> dict[str, Any]:
     operating_loop_closeout_states = Counter(record["operating_loop"].get("closeout_state") for record in operating_loop_records)
     operating_loop_safe_claims = Counter(record["operating_loop"].get("safe_claim") for record in operating_loop_records)
     operating_loop_residue_owners = Counter(record["operating_loop"].get("residue_owner") for record in operating_loop_records)
+    completion_cost_observability = _completion_cost_observability([*records, *live_runs])
 
     operating_loop_observability = {
         "kind": "agentic-workspace/external-agent-operating-loop-observability/v1",
@@ -388,6 +537,8 @@ def build_closure_report(pack: dict[str, dict[str, Any]]) -> dict[str, Any]:
         "surface_simplification_decisions_exist": bool(pack["surfaces"]["decisions"]),
         "operational_trace_protocol_exists": (LANE_DIR / "operational-decision-trace.md").exists(),
         "operating_loop_observable": operating_loop_observability["record_count"] > 0,
+        "completion_cost_observation_contract_exists": isinstance(pack["scenarios"].get("completion_cost_observation_contract"), dict),
+        "completion_cost_observations_exist": completion_cost_observability["record_count"] > 0,
     }
     fixture_closure_state = "ready_for_fixture_closure" if all(acceptance.values()) else "continued_work"
     live_status = "not-run"
@@ -421,6 +572,7 @@ def build_closure_report(pack: dict[str, dict[str, Any]]) -> dict[str, Any]:
         "dismissal_count": len(dismissed),
         "surface_decision_counts": dict(sorted(surface_decisions.items())),
         "operating_loop_observability": operating_loop_observability,
+        "completion_cost_observability": completion_cost_observability,
         "acceptance": acceptance,
         "fixture_closure_state": fixture_closure_state,
         "closure_state": closure_state,

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -141,7 +141,9 @@ def test_external_agent_lane_scenarios_cover_issue_lane_requirements() -> None:
     assert any(probe.get("artifact_backed") for probe in probes)
     artifact_probe = next(probe for probe in probes if probe["id"] == "artifact-backed-host-startup")
     assert {"artifact_source", "artifact_checksum", "installed_entrypoint"} <= set(artifact_probe["artifact_evidence"]["required_fields"])
-    assert observation_contract["applies_to"] == "all_probes"
+    assert observation_contract["applies_to"] == "representative_evidence_records"
+    assert observation_contract["minimum_observed_records"] == 3
+    assert "representative observed records" in observation_contract["coverage_rule"]
     assert {
         "aw_command_count",
         "proof_command_count",
@@ -162,6 +164,7 @@ def test_external_agent_lane_completion_cost_observations_classify_representativ
         record["scenario_id"]: record["completion_cost_observations"] for record in records if "completion_cost_observations" in record
     }
 
+    assert len(observations) >= _read_json("scenario-probes.json")["completion_cost_observation_contract"]["minimum_observed_records"]
     assert observations["clean-host-startup"]["aw_command_count"] == 1
     assert observations["clean-host-startup"]["cost_drivers"][0]["classification"] == "startup_routing"
     assert observations["stale-memory-active-planning-handoff"]["reread_events"] >= 1

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -111,6 +111,7 @@ def test_external_agent_lane_rejects_missing_harness_authority_boundary() -> Non
 
 def test_external_agent_lane_scenarios_cover_issue_lane_requirements() -> None:
     probes = _read_json("scenario-probes.json")["probes"]
+    observation_contract = _read_json("scenario-probes.json")["completion_cost_observation_contract"]
     covered_dimensions = {dimension for probe in probes for dimension in probe["expected_dimensions"]}
     probe_ids = {probe["id"] for probe in probes}
 
@@ -140,6 +141,52 @@ def test_external_agent_lane_scenarios_cover_issue_lane_requirements() -> None:
     assert any(probe.get("artifact_backed") for probe in probes)
     artifact_probe = next(probe for probe in probes if probe["id"] == "artifact-backed-host-startup")
     assert {"artifact_source", "artifact_checksum", "installed_entrypoint"} <= set(artifact_probe["artifact_evidence"]["required_fields"])
+    assert observation_contract["applies_to"] == "all_probes"
+    assert {
+        "aw_command_count",
+        "proof_command_count",
+        "reread_events",
+        "proof_churn_events",
+        "over_planning_events",
+        "review_repair_loop_count",
+        "handoff_recovery_status",
+        "unsafe_closure_claims",
+        "aw_sections_used",
+        "cost_drivers",
+    } <= set(observation_contract["required_fields"])
+
+
+def test_external_agent_lane_completion_cost_observations_classify_representative_outcomes() -> None:
+    records = _read_json("result-records.sample.json")["records"]
+    observations = {
+        record["scenario_id"]: record["completion_cost_observations"] for record in records if "completion_cost_observations" in record
+    }
+
+    assert observations["clean-host-startup"]["aw_command_count"] == 1
+    assert observations["clean-host-startup"]["cost_drivers"][0]["classification"] == "startup_routing"
+    assert observations["stale-memory-active-planning-handoff"]["reread_events"] >= 1
+    assert {driver["classification"] for driver in observations["stale-memory-active-planning-handoff"]["cost_drivers"]} >= {
+        "memory_reread",
+        "review_repair",
+    }
+    assert observations["operational-decision-trace-required"]["unsafe_closure_claims"] == 1
+    assert {driver["classification"] for driver in observations["operational-decision-trace-required"]["cost_drivers"]} >= {
+        "proof_churn",
+        "unsafe_closure",
+    }
+
+
+def test_external_agent_lane_rejects_invalid_completion_cost_observation() -> None:
+    module = _load_module()
+    pack = copy.deepcopy(module.load_pack(repo_root=REPO_ROOT))
+    record = next(item for item in pack["results"]["records"] if item["scenario_id"] == "stale-memory-active-planning-handoff")
+    record["completion_cost_observations"]["reread_events"] = -1
+    record["completion_cost_observations"]["cost_drivers"][0]["classification"] = "expensive"
+
+    errors = module.validate_pack(pack)
+
+    assert any("reread_events must be a non-negative integer" in error for error in errors)
+    assert any("classification is invalid" in error for error in errors)
 
 
 def test_external_agent_lane_historical_fixtures_map_to_result_records() -> None:
@@ -242,6 +289,8 @@ def test_external_agent_lane_closure_report_is_ready_from_fixture_pack() -> None
     assert report["acceptance"]["scenario_probes_cover_major_phases"] is True
     assert report["acceptance"]["artifact_backed_path_defined"] is True
     assert report["acceptance"]["operating_loop_observable"] is True
+    assert report["acceptance"]["completion_cost_observation_contract_exists"] is True
+    assert report["acceptance"]["completion_cost_observations_exist"] is True
     assert report["failure_counts"]["PROOF_MISSING_BEFORE_CLAIM"] >= 1
     assert report["failure_counts"]["PARTIAL_PROGRESS_CLAIMED_AS_FULL"] >= 1
     assert report["live_evaluation"]["failure_counts"]["OWNERSHIP_BOUNDARY_LEAK"] == 1
@@ -253,6 +302,12 @@ def test_external_agent_lane_closure_report_is_ready_from_fixture_pack() -> None
     assert loop["record_count"] >= 1
     assert loop["safe_claim_counts"]["blocked"] >= 1
     assert loop["residue_owner_counts"]["issue"] >= 1
+    cost = report["completion_cost_observability"]
+    assert cost["kind"] == "agentic-workspace/external-agent-completion-cost-observability/v1"
+    assert cost["record_count"] >= 3
+    assert cost["driver_classification_counts"]["memory_reread"] >= 1
+    assert cost["driver_classification_counts"]["unsafe_closure"] >= 1
+    assert cost["totals"]["proof_command_count"] >= 2
 
 
 def test_operational_decision_trace_avoids_chain_of_thought_requirement() -> None:

--- a/tools/model-cli-harness/external-agent-evaluation/README.md
+++ b/tools/model-cli-harness/external-agent-evaluation/README.md
@@ -38,6 +38,8 @@ Scenarios that require an operational decision trace do not ask for private chai
 
 Trace-required result records must also include the normalized `agentic-workspace/operating-loop-decision/v1` packet. The older `decisions` object remains a compact human-readable trace, while `operating_loop` is the enum-backed evaluation evidence for Memory, Planning, Verification/proof, residue owner, and safe claim state.
 
+For #1680 completion-cost work, each probe can also emit `agentic-workspace/external-agent-completion-cost-observations/v1`. The observation packet is maintainer-evaluation evidence only, and records compact behavior-cost signals such as AW command count, proof command count, reread events, proof churn, over-planning, review/repair loops, handoff recovery status, unsafe closure claims, used AW output sections, and classified cost drivers.
+
 Run a real external-agent scenario only when maintainer evidence is needed. The Codex adapter defaults to GPT-5.3 Codex Spark:
 
 ```powershell
@@ -75,3 +77,4 @@ The lane is ready for parent closure only when the generated report can show:
 - surface simplification has evidence-backed decisions;
 - safe claim boundaries and closeout residue are represented.
 - partial slice progress is not reported as full parent-lane closure without explicit evidence.
+- completion-cost observations can distinguish static/schema suspicion from behavior-cost evidence.

--- a/tools/model-cli-harness/external-agent-evaluation/result-records.sample.json
+++ b/tools/model-cli-harness/external-agent-evaluation/result-records.sample.json
@@ -34,6 +34,27 @@
         "residue_owner": "none",
         "safe_claim": "full"
       },
+      "completion_cost_observations": {
+        "kind": "agentic-workspace/external-agent-completion-cost-observations/v1",
+        "scenario_id": "clean-host-startup",
+        "aw_command_count": 1,
+        "proof_command_count": 0,
+        "reread_events": 0,
+        "proof_churn_events": 0,
+        "over_planning_events": 0,
+        "review_repair_loop_count": 0,
+        "handoff_recovery_status": "not_applicable",
+        "unsafe_closure_claims": 0,
+        "aw_sections_used": ["next_safe_action", "action_signals"],
+        "cost_drivers": [
+          {
+            "source": "agentic-workspace start output",
+            "signal": "agent used routing fields directly and did not reread raw files",
+            "owner_surface": "cli_output",
+            "classification": "startup_routing"
+          }
+        ]
+      },
       "failure_ids": [],
       "repair_surface_hints": [],
       "evidence_refs": ["dry-run fixture: startup-orientation command rendering"]
@@ -105,6 +126,33 @@
         "verification": {"status": "not_applicable", "reason": "no proof route required by sample"},
         "residue_owner": "memory",
         "safe_claim": "partial"
+      },
+      "completion_cost_observations": {
+        "kind": "agentic-workspace/external-agent-completion-cost-observations/v1",
+        "scenario_id": "stale-memory-active-planning-handoff",
+        "aw_command_count": 2,
+        "proof_command_count": 0,
+        "reread_events": 2,
+        "proof_churn_events": 0,
+        "over_planning_events": 0,
+        "review_repair_loop_count": 1,
+        "handoff_recovery_status": "partial",
+        "unsafe_closure_claims": 0,
+        "aw_sections_used": ["memory_decision_packet", "next_safe_action"],
+        "cost_drivers": [
+          {
+            "source": "Memory route omitted or dismissed without evidence",
+            "signal": "agent reread setup context after missing route-specific Memory",
+            "owner_surface": "memory",
+            "classification": "memory_reread"
+          },
+          {
+            "source": "review repair turn",
+            "signal": "missing Memory decision created a follow-up repair loop",
+            "owner_surface": "cli_output",
+            "classification": "review_repair"
+          }
+        ]
       },
       "failure_ids": ["MEMORY_PULL_MISSING"],
       "repair_surface_hints": ["memory", "cli_output"],
@@ -205,6 +253,33 @@
             "code": "external_residue",
             "owner": "issue",
             "ref": "#1600"
+          }
+        ]
+      },
+      "completion_cost_observations": {
+        "kind": "agentic-workspace/external-agent-completion-cost-observations/v1",
+        "scenario_id": "operational-decision-trace-required",
+        "aw_command_count": 3,
+        "proof_command_count": 2,
+        "reread_events": 1,
+        "proof_churn_events": 1,
+        "over_planning_events": 1,
+        "review_repair_loop_count": 1,
+        "handoff_recovery_status": "failed",
+        "unsafe_closure_claims": 1,
+        "aw_sections_used": ["acceptance", "proof_required", "closeout_obligations", "operating_loop"],
+        "cost_drivers": [
+          {
+            "source": "slice-local proof treated as parent closure proof",
+            "signal": "agent needed repair to separate proof, partial progress, and remaining residue",
+            "owner_surface": "verification",
+            "classification": "proof_churn"
+          },
+          {
+            "source": "parent-lane residue not routed before closeout",
+            "signal": "unsafe closure claim caused review/repair loop",
+            "owner_surface": "planning",
+            "classification": "unsafe_closure"
           }
         ]
       },

--- a/tools/model-cli-harness/external-agent-evaluation/scenario-probes.json
+++ b/tools/model-cli-harness/external-agent-evaluation/scenario-probes.json
@@ -5,6 +5,35 @@
     "adapter": "codex",
     "model": "gpt-5.3-codex-spark"
   },
+  "completion_cost_observation_contract": {
+    "kind": "agentic-workspace/external-agent-completion-cost-observation-contract/v1",
+    "status": "maintainer-evaluation-only",
+    "applies_to": "all_probes",
+    "required_fields": [
+      "aw_command_count",
+      "proof_command_count",
+      "reread_events",
+      "proof_churn_events",
+      "over_planning_events",
+      "review_repair_loop_count",
+      "handoff_recovery_status",
+      "unsafe_closure_claims",
+      "aw_sections_used",
+      "cost_drivers"
+    ],
+    "cost_driver_fields": ["source", "signal", "owner_surface", "classification"],
+    "allowed_handoff_recovery_statuses": ["not_applicable", "success", "partial", "failed"],
+    "allowed_classifications": [
+      "startup_routing",
+      "memory_reread",
+      "proof_churn",
+      "planning_residue",
+      "review_repair",
+      "handoff_recovery",
+      "unsafe_closure",
+      "unused_output"
+    ]
+  },
   "suite_ref": "tools/model-cli-harness/suites/copilot-workflow-smoke.json",
   "probes": [
     {

--- a/tools/model-cli-harness/external-agent-evaluation/scenario-probes.json
+++ b/tools/model-cli-harness/external-agent-evaluation/scenario-probes.json
@@ -8,7 +8,9 @@
   "completion_cost_observation_contract": {
     "kind": "agentic-workspace/external-agent-completion-cost-observation-contract/v1",
     "status": "maintainer-evaluation-only",
-    "applies_to": "all_probes",
+    "applies_to": "representative_evidence_records",
+    "coverage_rule": "Every canonical probe may carry completion_cost_observations, but this fixture slice requires representative observed records rather than observations on every probe.",
+    "minimum_observed_records": 3,
     "required_fields": [
       "aw_command_count",
       "proof_command_count",


### PR DESCRIPTION
## Summary

Adds the next #1680 long-horizon behavior evidence slice on top of #1707.

This extends the #1602 external-agent evaluation pack with a maintainer-only completion-cost observation contract for all canonical scenario probes, plus representative sample observations for startup routing, stale Memory handoff/reread cost, proof churn, review repair loops, and unsafe closure claims.

The closure report now aggregates completion-cost observability so #1680 can compare static/schema suspects against behavior evidence before #1608 turns the evidence into ordinary-surface reductions.

This does not run live external-agent evaluations and does not close #1602 or #1680.

## Validation

- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate`
- `uv run pytest tests/test_external_agent_evaluation_lane.py -q`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py report --format json`
- `uv run pytest --collect-only -q tests packages`
- `make lint-workspace`
- `make test-workspace`
- `git diff --check`