### PR TITLE
[codex] Route startup detail behind selectors

### DIFF
--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -22460,7 +22460,6 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             agent_judgment="Agent owns work-shape choice unless hard_blockers names a gate.",
         ),
         "next_safe_action": next_safe_action,
-        "memory_decision_packet": payload.get("memory_decision_packet", {}),
         "skills": _startup_skills_projection(
             payload=payload,
             next_safe_action=next_safe_action,
@@ -22512,8 +22511,6 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         "warning-drift",
     }:
         selected["cli_compatibility"] = cli_compatibility
-    if isinstance(installed_state, dict) and installed_state.get("status") not in {None, "", "compatible"}:
-        selected["installed_state_compatibility"] = installed_state
     if isinstance(sibling_freshness, dict) and sibling_freshness.get("status") not in {None, "", "not-referenced"}:
         selected["sibling_repo_aw_freshness"] = sibling_freshness
     durable_intent = payload.get("durable_intent", {})

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -179,6 +179,22 @@ def test_external_agent_lane_completion_cost_observations_classify_representativ
     }
 
 
+def test_external_agent_lane_surface_decisions_record_selector_first_start_reduction() -> None:
+    decisions = {decision["id"]: decision for decision in _read_json("surface-decisions.sample.json")["decisions"]}
+
+    memory_decision = decisions["startup-memory-decision-packet-selector-only"]
+    installed_state_decision = decisions["startup-installed-state-compatibility-selector-only"]
+
+    assert memory_decision["surface"] == "start.memory_decision_packet"
+    assert memory_decision["decision"] == "route"
+    assert "sample-memory-routing-regression" in memory_decision["evidence_refs"]
+    assert memory_decision["rollback_condition"]
+    assert installed_state_decision["surface"] == "start.installed_state_compatibility"
+    assert installed_state_decision["decision"] == "route"
+    assert "sample-startup-codex-spark" in installed_state_decision["evidence_refs"]
+    assert installed_state_decision["expected_cost_change"]
+
+
 def test_external_agent_lane_rejects_invalid_completion_cost_observation() -> None:
     module = _load_module()
     pack = copy.deepcopy(module.load_pack(repo_root=REPO_ROOT))

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -273,7 +273,7 @@ def test_start_exposes_workflow_sufficiency_and_continuation_selectors(tmp_path:
     ]
 
 
-def test_start_surfaces_memory_decision_packet(tmp_path: Path, capsys) -> None:
+def test_start_default_routes_memory_and_installed_state_detail_behind_selectors(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
     capsys.readouterr()
@@ -293,7 +293,37 @@ def test_start_surfaces_memory_decision_packet(tmp_path: Path, capsys) -> None:
         == 0
     )
     payload = json.loads(capsys.readouterr().out)
-    packet = payload["memory_decision_packet"]
+
+    assert "memory_decision_packet" not in payload
+    assert "installed_state_compatibility" not in payload
+    assert "memory_decision_packet" in payload["action_signals"]["advisory_detail"]["selectors"]
+    assert "memory_decision_packet" in payload["drill_down"]["available_selectors"]
+    assert payload["context"]["memory"]["status"] in {"recommended", "not_checked"}
+
+
+def test_start_select_surfaces_memory_decision_packet(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Shape a workflow issue",
+                "--select",
+                "memory_decision_packet",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    packet = payload["values"]["memory_decision_packet"]
 
     assert packet["kind"] == "agentic-workspace/memory-decision-packet/v1"
     assert packet["stage"] == "startup"
@@ -302,6 +332,36 @@ def test_start_surfaces_memory_decision_packet(tmp_path: Path, capsys) -> None:
     assert "--stage startup" in packet["pull"]["recommended_command"]
     assert packet["authority_boundary"]["agent_owns"]
     assert "No keyword-triggered Memory requirement." in packet["limits"]
+
+
+def test_start_select_surfaces_installed_state_compatibility(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Inspect installed state",
+                "--select",
+                "installed_state_compatibility",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    compatibility = payload["values"]["installed_state_compatibility"]
+
+    assert compatibility["kind"] == "agentic-workspace/installed-state-compatibility/v1"
+    assert compatibility["authority"] == "repo-state-authoritative"
+    assert compatibility["executable"]["classification"]
+    assert compatibility["payload"]["status"]
 
 
 def test_start_surfaces_recovery_for_obsolete_default_preset(tmp_path: Path, capsys) -> None:

--- a/tools/model-cli-harness/external-agent-evaluation/README.md
+++ b/tools/model-cli-harness/external-agent-evaluation/README.md
@@ -40,6 +40,8 @@ Trace-required result records must also include the normalized `agentic-workspac
 
 For #1680 completion-cost work, each probe can also emit `agentic-workspace/external-agent-completion-cost-observations/v1`. The observation packet is maintainer-evaluation evidence only, and records compact behavior-cost signals such as AW command count, proof command count, reread events, proof churn, over-planning, review/repair loops, handoff recovery status, unsafe closure claims, used AW output sections, and classified cost drivers.
 
+Surface simplification decisions should be recorded in `surface-decisions.sample.json` before or alongside a default-output change. Each decision names the surface, owner, evidence records or scenarios, current role, posture decision, expected cost change, and rollback condition. Selector-routed detail must remain recoverable by explicit `--select` or report-section drill-down, and the compact default must still expose hard blockers, proof obligations, closure/residue blockers, and action signals.
+
 Run a real external-agent scenario only when maintainer evidence is needed. The Codex adapter defaults to GPT-5.3 Codex Spark:
 
 ```powershell

--- a/tools/model-cli-harness/external-agent-evaluation/surface-decisions.sample.json
+++ b/tools/model-cli-harness/external-agent-evaluation/surface-decisions.sample.json
@@ -31,6 +31,26 @@
       "decision": "generate",
       "expected_cost_change": "less drift",
       "rollback_condition": "generated output hides package/host authority"
+    },
+    {
+      "id": "startup-memory-decision-packet-selector-only",
+      "surface": "start.memory_decision_packet",
+      "owner": "cli_output",
+      "evidence_refs": ["sample-memory-routing-regression", "stale-memory-active-planning-handoff"],
+      "current_role": "authority detail",
+      "decision": "route",
+      "expected_cost_change": "fewer default bytes and fewer rereads of Memory detail when no matched route exists",
+      "rollback_condition": "agents miss a required Memory pull/capture decision because selectors or action signals no longer surface it"
+    },
+    {
+      "id": "startup-installed-state-compatibility-selector-only",
+      "surface": "start.installed_state_compatibility",
+      "owner": "cli_output",
+      "evidence_refs": ["artifact-backed-host-startup", "sample-startup-codex-spark"],
+      "current_role": "compatibility diagnostic",
+      "decision": "route",
+      "expected_cost_change": "fewer default bytes while preserving install/payload compatibility evidence by selector",
+      "rollback_condition": "agents fail to discover payload or artifact compatibility problems during startup recovery"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Continues #1680 with the first concrete #1608/#1695 ordinary-output reduction on top of #1708.

Default `start --format json` no longer emits the full `memory_decision_packet` or non-compatible `installed_state_compatibility` payloads. The compact default still exposes action signals, changed signals, context memory status, and drill-down selectors; explicit `--select memory_decision_packet,installed_state_compatibility` still returns the full packets.

The external-agent evaluation pack now records the repeatable surface-simplification process and two evidence-backed route decisions with rollback conditions for these startup fields.

This is a bounded reduction slice. It does not close #1608, #1695, or #1680.

## Validation

- `uv run pytest tests/test_workspace_cli.py::test_start_default_routes_memory_and_installed_state_detail_behind_selectors tests/test_workspace_cli.py::test_start_select_surfaces_memory_decision_packet tests/test_workspace_cli.py::test_start_select_surfaces_installed_state_compatibility tests/test_external_agent_evaluation_lane.py::test_external_agent_lane_surface_decisions_record_selector_first_start_reduction -q`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate`
- `uv run python scripts/run_agentic_workspace.py start --task "Dogfood selector-first default start output" --format json`
- `uv run python scripts/run_agentic_workspace.py start --task "Dogfood selector-first default start output" --select memory_decision_packet,installed_state_compatibility --format json`
- `uv run pytest tests/test_workspace_cli.py tests/test_external_agent_evaluation_lane.py -q`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py report --format json`
- `make lint-workspace`
- `uv run pytest --collect-only -q tests packages`
- `make test-workspace`
- `git diff --check`