### PR TITLE
[codex] Compact startup skill catalog

### DIFF
--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -22150,10 +22150,13 @@ def _skill_catalog_summary_from_payload(skills_payload: dict[str, Any]) -> dict[
 def _compact_startup_skill_catalog_summary(skills_payload: dict[str, Any]) -> dict[str, Any]:
     skills = skills_payload.get("skills", [])
     warnings = skills_payload.get("warnings", [])
+    skills_valid = isinstance(skills, list)
+    warnings_valid = isinstance(warnings, list)
     return {
-        "available": True,
-        "total_count": len(skills) if isinstance(skills, list) else 0,
-        "warning_count": len(warnings) if isinstance(warnings, list) else 0,
+        "available": skills_valid,
+        "catalog_command_available": True,
+        "total_count": len(skills) if skills_valid else 0,
+        "warning_count": len(warnings) if warnings_valid else 0,
         "detail_visibility": "source and owner breakdowns stay behind catalog.command",
     }
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -22147,6 +22147,17 @@ def _skill_catalog_summary_from_payload(skills_payload: dict[str, Any]) -> dict[
     }
 
 
+def _compact_startup_skill_catalog_summary(skills_payload: dict[str, Any]) -> dict[str, Any]:
+    skills = skills_payload.get("skills", [])
+    warnings = skills_payload.get("warnings", [])
+    return {
+        "available": True,
+        "total_count": len(skills) if isinstance(skills, list) else 0,
+        "warning_count": len(warnings) if isinstance(warnings, list) else 0,
+        "detail_visibility": "source and owner breakdowns stay behind catalog.command",
+    }
+
+
 def _startup_skills_projection(
     *, payload: dict[str, Any], next_safe_action: dict[str, Any], target_root: Path | None, cli_invoke: str
 ) -> dict[str, Any]:
@@ -22183,7 +22194,7 @@ def _startup_skills_projection(
         "required": required,
         "recommended": recommended,
         "catalog": {
-            **_skill_catalog_summary_from_payload(skills_payload),
+            **_compact_startup_skill_catalog_summary(skills_payload),
             "command": catalog_command,
         },
     }

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -184,6 +184,7 @@ def test_external_agent_lane_surface_decisions_record_selector_first_start_reduc
 
     memory_decision = decisions["startup-memory-decision-packet-selector-only"]
     installed_state_decision = decisions["startup-installed-state-compatibility-selector-only"]
+    skill_catalog_decision = decisions["startup-skill-catalog-breakdown-command-only"]
 
     assert memory_decision["surface"] == "start.memory_decision_packet"
     assert memory_decision["decision"] == "route"
@@ -193,6 +194,13 @@ def test_external_agent_lane_surface_decisions_record_selector_first_start_reduc
     assert installed_state_decision["decision"] == "route"
     assert "sample-startup-codex-spark" in installed_state_decision["evidence_refs"]
     assert installed_state_decision["expected_cost_change"]
+    assert skill_catalog_decision["surface"] == "start.skills.catalog breakdown"
+    assert skill_catalog_decision["decision"] == "route"
+    assert "sample-startup-codex-spark" in skill_catalog_decision["evidence_refs"]
+    assert "before:" in skill_catalog_decision["before_after_cost_signal"]
+    assert "after:" in skill_catalog_decision["before_after_cost_signal"]
+    assert "package" in skill_catalog_decision["authority_boundary_guardrail"]
+    assert "required skill" in skill_catalog_decision["rollback_condition"]
 
 
 def test_external_agent_lane_rejects_invalid_completion_cost_observation() -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -326,6 +326,7 @@ def test_start_default_keeps_skill_catalog_breakdown_behind_command(tmp_path: Pa
 
     assert skills["kind"] == "agentic-workspace/startup-skills-projection/v1"
     assert catalog["available"] is True
+    assert catalog["catalog_command_available"] is True
     assert isinstance(catalog["total_count"], int)
     assert isinstance(catalog["warning_count"], int)
     assert "agentic-workspace skills" in catalog["command"]
@@ -333,6 +334,15 @@ def test_start_default_keeps_skill_catalog_breakdown_behind_command(tmp_path: Pa
     assert "counts_by_source_kind" not in catalog
     assert "counts_by_owner" not in catalog
     assert "sources" not in catalog
+
+
+def test_compact_skill_catalog_marks_malformed_payload_unavailable() -> None:
+    catalog = workspace_runtime_primitives._compact_startup_skill_catalog_summary({"skills": "bad", "warnings": "bad"})
+
+    assert catalog["available"] is False
+    assert catalog["catalog_command_available"] is True
+    assert catalog["total_count"] == 0
+    assert catalog["warning_count"] == 0
 
 
 def test_start_required_skill_projection_survives_compact_catalog(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -301,6 +301,69 @@ def test_start_default_routes_memory_and_installed_state_detail_behind_selectors
     assert payload["context"]["memory"]["status"] in {"recommended", "not_checked"}
 
 
+def test_start_default_keeps_skill_catalog_breakdown_behind_command(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Shape a workflow issue",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    skills = payload["skills"]
+    catalog = skills["catalog"]
+
+    assert skills["kind"] == "agentic-workspace/startup-skills-projection/v1"
+    assert catalog["available"] is True
+    assert isinstance(catalog["total_count"], int)
+    assert isinstance(catalog["warning_count"], int)
+    assert "agentic-workspace skills" in catalog["command"]
+    assert catalog["detail_visibility"] == "source and owner breakdowns stay behind catalog.command"
+    assert "counts_by_source_kind" not in catalog
+    assert "counts_by_owner" not in catalog
+    assert "sources" not in catalog
+
+
+def test_start_required_skill_projection_survives_compact_catalog(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #1680 lane",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    skills = payload["skills"]
+
+    assert skills["status"] == "recommended"
+    assert skills["required"][0]["id"] == "planning-reporting"
+    assert skills["required"][0]["reason"] == "required by next_safe_action.required_skill"
+    assert "catalog" in skills
+    assert "counts_by_owner" not in skills["catalog"]
+
+
 def test_start_select_surfaces_memory_decision_packet(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tools/model-cli-harness/external-agent-evaluation/README.md
+++ b/tools/model-cli-harness/external-agent-evaluation/README.md
@@ -40,7 +40,7 @@ Trace-required result records must also include the normalized `agentic-workspac
 
 For #1680 completion-cost work, each probe can also emit `agentic-workspace/external-agent-completion-cost-observations/v1`. The observation packet is maintainer-evaluation evidence only, and records compact behavior-cost signals such as AW command count, proof command count, reread events, proof churn, over-planning, review/repair loops, handoff recovery status, unsafe closure claims, used AW output sections, and classified cost drivers.
 
-Surface simplification decisions should be recorded in `surface-decisions.sample.json` before or alongside a default-output change. Each decision names the surface, owner, evidence records or scenarios, current role, posture decision, expected cost change, and rollback condition. Selector-routed detail must remain recoverable by explicit `--select` or report-section drill-down, and the compact default must still expose hard blockers, proof obligations, closure/residue blockers, and action signals.
+Surface simplification decisions should be recorded in `surface-decisions.sample.json` before or alongside a default-output change. Each decision names the surface, owner, evidence records or scenarios, observed confusion or bypass evidence, current role, posture decision, before/after cost signal, expected cost change, authority-boundary guardrail, and rollback condition. Selector-routed detail must remain recoverable by explicit `--select` or report-section drill-down, and the compact default must still expose hard blockers, proof obligations, closure/residue blockers, and action signals.
 
 Run a real external-agent scenario only when maintainer evidence is needed. The Codex adapter defaults to GPT-5.3 Codex Spark:
 

--- a/tools/model-cli-harness/external-agent-evaluation/surface-decisions.sample.json
+++ b/tools/model-cli-harness/external-agent-evaluation/surface-decisions.sample.json
@@ -51,6 +51,19 @@
       "decision": "route",
       "expected_cost_change": "fewer default bytes while preserving install/payload compatibility evidence by selector",
       "rollback_condition": "agents fail to discover payload or artifact compatibility problems during startup recovery"
+    },
+    {
+      "id": "startup-skill-catalog-breakdown-command-only",
+      "surface": "start.skills.catalog breakdown",
+      "owner": "cli_output",
+      "evidence_refs": ["clean-host-startup", "sample-startup-codex-spark"],
+      "observed_evidence": "default startup exposes source and owner skill breakdown even when the actionable required/recommended skill projection is compact",
+      "current_role": "catalogue",
+      "decision": "route",
+      "before_after_cost_signal": "before: catalog repeats source, owner, and source list detail in default startup; after: default keeps counts and catalog.command while full breakdown stays recoverable through the skills command",
+      "expected_cost_change": "fewer default bytes while preserving required skill projection and task-specific catalog search",
+      "authority_boundary_guardrail": "catalog.command must preserve package-owned skill metadata and must not present generated or host-local catalogues as package authority",
+      "rollback_condition": "agents miss a required skill because required/recommended projections no longer name it"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Compacts the default `start --format json` skill catalog projection to availability, total/warning counts, detail visibility, and the recovery `catalog.command`.
- Keeps required/recommended skill projections visible so task-specific skill routing still appears in default startup output.
- Records the #1608 surface-simplification comment requirements with observed evidence, before/after cost signal, expected cost change, authority-boundary guardrail, and rollback condition.

## Validation

- `uv run pytest tests/test_workspace_cli.py::test_start_default_keeps_skill_catalog_breakdown_behind_command tests/test_workspace_cli.py::test_start_required_skill_projection_survives_compact_catalog tests/test_external_agent_evaluation_lane.py::test_external_agent_lane_surface_decisions_record_selector_first_start_reduction -q`
- Live dogfood: `uv run python scripts/run_agentic_workspace.py start --task "Dogfood compact startup skill catalog" --format json`
- `uv run pytest tests/test_workspace_cli.py tests/test_external_agent_evaluation_lane.py -q`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py report --format json`
- `make lint-workspace`
- `uv run pytest --collect-only -q tests packages`
- `make test-workspace`
- `git diff --check`

## Notes

This is stacked on #1709. The runtime source edit is an inventory-backed change to the AW startup projection primitive: it changes only the default output projection shape and leaves full skill catalog detail recoverable through `catalog.command`. The host-agnostic agent-judgment principle is preserved because the change does not infer routing from prose, filenames, executable names, or host-specific issue taxonomy.