### PR TITLE
[codex] Compact implement candidate pressure

### DIFF
--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -22295,7 +22295,7 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
             pressure_summary.pop("route_options", None)
             if not pressure_summary.get("candidate_ids"):
                 pressure_summary.pop("candidate_ids", None)
-            pressure_summary["detail_visibility"] = "relevance and advisory backlog stay behind drill_down.detail_command"
+            pressure_summary["detail_visibility"] = "relevance and advisory backlog stay behind verbose implement context"
         compact["candidate_pressure"] = pressure_summary
     issue_scope_evidence = gate.get("issue_scope_evidence")
     if isinstance(issue_scope_evidence, dict) and issue_scope_evidence.get("status") in {"unknown", "partial"}:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -22270,7 +22270,7 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         compact["repair_route"] = repair_route
     candidate_pressure = gate.get("candidate_pressure")
     if isinstance(candidate_pressure, dict) and candidate_pressure.get("status") in {"promotion-required", "observed"}:
-        compact["candidate_pressure"] = {
+        pressure_summary = {
             key: candidate_pressure.get(key)
             for key in (
                 "kind",
@@ -22283,14 +22283,20 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
                 "stale_or_closed_roadmap_candidate_count",
                 "matched_decomposition_candidate_count",
                 "candidate_ids",
-                "relevance",
-                "advisory_backlog",
                 "reasons",
                 "required_before_implementation",
                 "route_options",
             )
             if key in candidate_pressure
         }
+        if candidate_pressure.get("status") == "observed":
+            pressure_summary.pop("reasons", None)
+            pressure_summary.pop("required_before_implementation", None)
+            pressure_summary.pop("route_options", None)
+            if not pressure_summary.get("candidate_ids"):
+                pressure_summary.pop("candidate_ids", None)
+            pressure_summary["detail_visibility"] = "relevance and advisory backlog stay behind drill_down.detail_command"
+        compact["candidate_pressure"] = pressure_summary
     issue_scope_evidence = gate.get("issue_scope_evidence")
     if isinstance(issue_scope_evidence, dict) and issue_scope_evidence.get("status") in {"unknown", "partial"}:
         compact["issue_scope_evidence"] = {

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -185,6 +185,7 @@ def test_external_agent_lane_surface_decisions_record_selector_first_start_reduc
     memory_decision = decisions["startup-memory-decision-packet-selector-only"]
     installed_state_decision = decisions["startup-installed-state-compatibility-selector-only"]
     skill_catalog_decision = decisions["startup-skill-catalog-breakdown-command-only"]
+    candidate_pressure_decision = decisions["implement-observed-candidate-pressure-summary"]
 
     assert memory_decision["surface"] == "start.memory_decision_packet"
     assert memory_decision["decision"] == "route"
@@ -201,6 +202,11 @@ def test_external_agent_lane_surface_decisions_record_selector_first_start_reduc
     assert "after:" in skill_catalog_decision["before_after_cost_signal"]
     assert "package" in skill_catalog_decision["authority_boundary_guardrail"]
     assert "required skill" in skill_catalog_decision["rollback_condition"]
+    assert candidate_pressure_decision["surface"] == "implement.context.planning_safety_gate.candidate_pressure observed detail"
+    assert candidate_pressure_decision["decision"] == "route"
+    assert "before:" in candidate_pressure_decision["before_after_cost_signal"]
+    assert "after:" in candidate_pressure_decision["before_after_cost_signal"]
+    assert "hard blockers" in candidate_pressure_decision["authority_boundary_guardrail"]
 
 
 def test_external_agent_lane_rejects_invalid_completion_cost_observation() -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2941,8 +2941,34 @@ candidates = [
     assert gate["implementation_allowed"] is True
     pressure = gate["candidate_pressure"]
     assert pressure["status"] == "observed"
-    assert pressure["candidate_ids"] == []
-    assert pressure["advisory_backlog"]["unmatched_candidate_ids"] == [
+    assert "candidate_ids" not in pressure
+    assert "relevance" not in pressure
+    assert "advisory_backlog" not in pressure
+    assert pressure["unmatched_roadmap_candidate_count"] == 2
+    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind drill_down.detail_command"
+    assert len(json.dumps(pressure, separators=(",", ":")).encode()) < 400
+
+    capsys.readouterr()
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_primitives.py",
+                "--task",
+                "Implement #1556 #1559 #1560 requirement grounded delegation support",
+                "--verbose",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    verbose_payload = json.loads(capsys.readouterr().out)
+    verbose_pressure = verbose_payload["planning_safety_gate"]["candidate_pressure"]
+    assert verbose_pressure["advisory_backlog"]["unmatched_candidate_ids"] == [
         "github-1522-packaging-tests",
         "github-1523-generated-proof-tests",
     ]
@@ -2988,9 +3014,9 @@ candidates = [
 
     pressure = json.loads(capsys.readouterr().out)["context"]["planning_safety_gate"]["candidate_pressure"]
     assert pressure["status"] == "observed"
-    assert pressure["candidate_ids"] == []
-    assert pressure["relevance"]["roadmap"][0]["evidence"] == []
-    assert "weak_lexical_hints" in pressure["relevance"]["roadmap"][0]
+    assert "candidate_ids" not in pressure
+    assert "relevance" not in pressure
+    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind drill_down.detail_command"
 
 
 def test_implement_keeps_generic_ci_refresh_terms_as_weak_hints(tmp_path: Path, capsys) -> None:
@@ -3033,9 +3059,10 @@ candidates = [
 
     pressure = json.loads(capsys.readouterr().out)["context"]["planning_safety_gate"]["candidate_pressure"]
     assert pressure["status"] == "observed"
-    assert pressure["candidate_ids"] == []
     assert pressure["matched_roadmap_candidate_count"] == 0
-    assert all(item["evidence"] == [] for item in pressure["relevance"]["roadmap"])
+    assert "candidate_ids" not in pressure
+    assert "relevance" not in pressure
+    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind drill_down.detail_command"
 
 
 def test_implement_ignores_closed_external_intent_candidate_pressure(tmp_path: Path, capsys) -> None:
@@ -3091,7 +3118,8 @@ candidates = [
     pressure = json.loads(capsys.readouterr().out)["context"]["planning_safety_gate"]["candidate_pressure"]
     assert pressure["status"] == "observed"
     assert pressure["stale_or_closed_roadmap_candidate_count"] == 2
-    assert pressure["advisory_backlog"]["stale_or_closed_candidate_ids"] == ["github-1201-old", "github-1202-old"]
+    assert "advisory_backlog" not in pressure
+    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind drill_down.detail_command"
 
 
 def test_start_surfaces_lane_shaping_prompt_for_broad_unshaped_work(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2945,7 +2945,7 @@ candidates = [
     assert "relevance" not in pressure
     assert "advisory_backlog" not in pressure
     assert pressure["unmatched_roadmap_candidate_count"] == 2
-    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind drill_down.detail_command"
+    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind verbose implement context"
     assert len(json.dumps(pressure, separators=(",", ":")).encode()) < 400
 
     capsys.readouterr()
@@ -3016,7 +3016,7 @@ candidates = [
     assert pressure["status"] == "observed"
     assert "candidate_ids" not in pressure
     assert "relevance" not in pressure
-    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind drill_down.detail_command"
+    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind verbose implement context"
 
 
 def test_implement_keeps_generic_ci_refresh_terms_as_weak_hints(tmp_path: Path, capsys) -> None:
@@ -3062,7 +3062,7 @@ candidates = [
     assert pressure["matched_roadmap_candidate_count"] == 0
     assert "candidate_ids" not in pressure
     assert "relevance" not in pressure
-    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind drill_down.detail_command"
+    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind verbose implement context"
 
 
 def test_implement_ignores_closed_external_intent_candidate_pressure(tmp_path: Path, capsys) -> None:
@@ -3119,7 +3119,7 @@ candidates = [
     assert pressure["status"] == "observed"
     assert pressure["stale_or_closed_roadmap_candidate_count"] == 2
     assert "advisory_backlog" not in pressure
-    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind drill_down.detail_command"
+    assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind verbose implement context"
 
 
 def test_start_surfaces_lane_shaping_prompt_for_broad_unshaped_work(tmp_path: Path, capsys) -> None:

--- a/tools/model-cli-harness/external-agent-evaluation/surface-decisions.sample.json
+++ b/tools/model-cli-harness/external-agent-evaluation/surface-decisions.sample.json
@@ -64,6 +64,19 @@
       "expected_cost_change": "fewer default bytes while preserving required skill projection and task-specific catalog search",
       "authority_boundary_guardrail": "catalog.command must preserve package-owned skill metadata and must not present generated or host-local catalogues as package authority",
       "rollback_condition": "agents miss a required skill because required/recommended projections no longer name it"
+    },
+    {
+      "id": "implement-observed-candidate-pressure-summary",
+      "surface": "implement.context.planning_safety_gate.candidate_pressure observed detail",
+      "owner": "cli_output",
+      "evidence_refs": ["clean-host-startup", "sample-startup-codex-spark"],
+      "observed_evidence": "docs-only implement dogfood exposed unmatched roadmap relevance and advisory backlog detail even when candidate pressure was observed and non-blocking",
+      "current_role": "advisory residue",
+      "decision": "route",
+      "before_after_cost_signal": "before: docs-only implement emitted 26527 bytes with a 5681-byte planning_safety_gate; after: it emits 21456 bytes with a 2549-byte planning_safety_gate and keeps full detail behind drill_down.detail_command",
+      "expected_cost_change": "fewer default bytes and fewer rereads of unrelated roadmap candidates during bounded implement turns",
+      "authority_boundary_guardrail": "default counts must not turn unrelated planning candidates into hard blockers; full candidate evidence remains available from verbose implement context",
+      "rollback_condition": "agents miss candidate-lane promotion requirements or cannot audit why candidate pressure changed"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Compacts non-blocking observed `implement.context.planning_safety_gate.candidate_pressure` to counts plus `detail_visibility`.
- Keeps promotion-required candidate pressure actionable by retaining candidate ids, reasons, required-before-implementation, and route options.
- Records the surface decision with before/after dogfood evidence and an authority-boundary guardrail.

## Evidence

Live dogfood on this branch:

- Docs-only implement: 26,527 bytes before to 21,456 bytes after; planning_safety_gate 5,681 bytes before to 2,549 bytes after.
- Code-change implement: candidate_pressure remains a 404-byte count summary with full detail recoverable through `drill_down.detail_command` / verbose implement context.

## Validation

- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_blocks_epic_work_with_multiple_roadmap_candidates tests/test_workspace_implement_cli.py::test_implement_keeps_unrelated_roadmap_candidates_advisory tests/test_workspace_implement_cli.py::test_implement_keeps_generic_github_issue_filing_terms_as_weak_hints tests/test_workspace_implement_cli.py::test_implement_keeps_generic_ci_refresh_terms_as_weak_hints tests/test_workspace_implement_cli.py::test_implement_ignores_closed_external_intent_candidate_pressure tests/test_external_agent_evaluation_lane.py::test_external_agent_lane_surface_decisions_record_selector_first_start_reduction -q`
- `uv run pytest tests/test_workspace_implement_cli.py tests/test_external_agent_evaluation_lane.py -q`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py report --format json`
- live dogfood: docs-only and code-change `implement --format json`
- `make lint-workspace`
- `uv run pytest --collect-only -q tests packages`
- `make test-workspace`
- `git diff --check`

## Notes

This is stacked on #1710. The runtime source edit is an inventory-backed projection change in `workspace_runtime_primitives.py`; it changes default tiny output shape only. Host-agnostic agent judgment is preserved: the change does not infer routing from prose, filenames, executable names, or issue taxonomy, and it keeps non-blocking candidate pressure advisory rather than converting it into package-owned policy.