### PR TITLE
[codex] Compact implement memory decision packet

### DIFF
--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -14097,6 +14097,41 @@ def _memory_decision_packet_payload(
     }
 
 
+def _compact_memory_decision_packet(packet: Any) -> dict[str, Any]:
+    full = _as_dict(packet)
+    pull = _as_dict(full.get("pull"))
+    capture = _as_dict(full.get("capture"))
+    candidate_routes = _list_payload(pull.get("candidate_routes"))
+    relevant_routes = [
+        item for item in candidate_routes if isinstance(item, dict) and str(item.get("match_source") or "").strip() != "routing-baseline"
+    ]
+    compact_pull: dict[str, Any] = {
+        "status": pull.get("status"),
+        "recommended_command": pull.get("recommended_command"),
+        "route_count": len(candidate_routes),
+        "relevant_route_count": len(relevant_routes),
+        "read_budget": pull.get("read_budget"),
+        "agent_decision_required": pull.get("agent_decision_required"),
+    }
+    if relevant_routes:
+        compact_pull["candidate_routes"] = relevant_routes
+    compact_capture: dict[str, Any] = {
+        "status": capture.get("status"),
+        "recommended_commands": capture.get("recommended_commands", []),
+        "candidate_owner_surface_count": len(_list_payload(capture.get("candidate_owner_surfaces"))),
+        "agent_decision_required": capture.get("agent_decision_required"),
+    }
+    return {
+        "kind": full.get("kind"),
+        "stage": full.get("stage"),
+        "force": full.get("force"),
+        "why_visible": "Explicit agent-owned Memory pull/capture decision.",
+        "pull": {key: value for key, value in compact_pull.items() if value is not None},
+        "capture": {key: value for key, value in compact_capture.items() if value is not None},
+        "detail_visibility": "full authority, limits, owner, and candidate detail stay behind verbose implement context",
+    }
+
+
 def _memory_consult_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
     memory_consult = payload.get("memory_consult", {})
     return memory_consult if isinstance(memory_consult, dict) else {}
@@ -27926,7 +27961,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             if isinstance(payload.get("task_posture_packet"), dict)
             else {}
         ),
-        "memory_decision_packet": payload.get("memory_decision_packet", {}),
+        "memory_decision_packet": _compact_memory_decision_packet(payload.get("memory_decision_packet", {})),
         "operating_loop": payload.get("operating_loop", {}),
         "context": {
             "workflow_sufficiency": workflow_sufficiency,

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -186,6 +186,7 @@ def test_external_agent_lane_surface_decisions_record_selector_first_start_reduc
     installed_state_decision = decisions["startup-installed-state-compatibility-selector-only"]
     skill_catalog_decision = decisions["startup-skill-catalog-breakdown-command-only"]
     candidate_pressure_decision = decisions["implement-observed-candidate-pressure-summary"]
+    memory_packet_decision = decisions["implement-memory-decision-packet-compact-default"]
 
     assert memory_decision["surface"] == "start.memory_decision_packet"
     assert memory_decision["decision"] == "route"
@@ -207,6 +208,11 @@ def test_external_agent_lane_surface_decisions_record_selector_first_start_reduc
     assert "before:" in candidate_pressure_decision["before_after_cost_signal"]
     assert "after:" in candidate_pressure_decision["before_after_cost_signal"]
     assert "hard blockers" in candidate_pressure_decision["authority_boundary_guardrail"]
+    assert memory_packet_decision["surface"] == "implement.memory_decision_packet"
+    assert memory_packet_decision["decision"] == "route"
+    assert "before:" in memory_packet_decision["before_after_cost_signal"]
+    assert "after:" in memory_packet_decision["before_after_cost_signal"]
+    assert "pull/capture status" in memory_packet_decision["authority_boundary_guardrail"]
 
 
 def test_external_agent_lane_rejects_invalid_completion_cost_observation() -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -129,10 +129,38 @@ def test_implement_surfaces_memory_decision_packet_for_changed_paths(tmp_path: P
     assert packet["pull"]["status"] == "checked_none"
     assert "--stage implement" in packet["pull"]["recommended_command"]
     assert "docs/package/knowledge-routing.md" in packet["pull"]["recommended_command"]
-    assert "repo_memory" in packet["capture"]["candidate_owner_surfaces"]
-    assert "local_memory" in packet["capture"]["candidate_owner_surfaces"]
-    assert "planning" in packet["capture"]["candidate_owner_surfaces"]
-    assert packet["authority_boundary"]["agent_owns"]
+    assert packet["pull"]["route_count"] >= 1
+    assert packet["pull"]["relevant_route_count"] == 0
+    assert packet["capture"]["candidate_owner_surface_count"] >= 3
+    assert "candidate_owner_surfaces" not in packet["capture"]
+    assert "authority_boundary" not in packet
+    assert "limits" not in packet
+    assert packet["detail_visibility"] == ("full authority, limits, owner, and candidate detail stay behind verbose implement context")
+    assert len(json.dumps(packet, separators=(",", ":")).encode()) < 900
+
+    capsys.readouterr()
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "docs/package/knowledge-routing.md",
+                "--task",
+                "Improve Memory routing guidance",
+                "--verbose",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    verbose_packet = json.loads(capsys.readouterr().out)["memory_decision_packet"]
+    assert "repo_memory" in verbose_packet["capture"]["candidate_owner_surfaces"]
+    assert "local_memory" in verbose_packet["capture"]["candidate_owner_surfaces"]
+    assert "planning" in verbose_packet["capture"]["candidate_owner_surfaces"]
+    assert verbose_packet["authority_boundary"]["agent_owns"]
 
 
 def test_implement_surfaces_operating_loop_with_proof_blocker(tmp_path: Path, capsys) -> None:

--- a/tools/model-cli-harness/external-agent-evaluation/surface-decisions.sample.json
+++ b/tools/model-cli-harness/external-agent-evaluation/surface-decisions.sample.json
@@ -77,6 +77,19 @@
       "expected_cost_change": "fewer default bytes and fewer rereads of unrelated roadmap candidates during bounded implement turns",
       "authority_boundary_guardrail": "default counts must not turn unrelated planning candidates into hard blockers; full candidate evidence remains available from verbose implement context",
       "rollback_condition": "agents miss candidate-lane promotion requirements or cannot audit why candidate pressure changed"
+    },
+    {
+      "id": "implement-memory-decision-packet-compact-default",
+      "surface": "implement.memory_decision_packet",
+      "owner": "cli_output",
+      "evidence_refs": ["sample-memory-routing-regression", "sample-startup-codex-spark"],
+      "observed_evidence": "bounded implement turns repeated Memory authority, limits, and owner-surface lists even when the required decision was pull/capture status plus commands",
+      "current_role": "authority detail",
+      "decision": "route",
+      "before_after_cost_signal": "before: docs-only implement memory_decision_packet emitted 1831 bytes; after: it emits 860 bytes while preserving pull/capture statuses and commands",
+      "expected_cost_change": "fewer default bytes while preserving the explicit agent-owned Memory decision before claim",
+      "authority_boundary_guardrail": "default compacting must not hide pull/capture status, route commands, relevant candidate routes, or the agent-owned decision boundary; full authority detail remains available in verbose implement context",
+      "rollback_condition": "agents skip required Memory pull/capture decisions or cannot recover full authority and owner-surface detail"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a compact default projection for `implement.memory_decision_packet`.
- Keeps the explicit agent-owned Memory pull/capture decision visible: force, statuses, route/capture commands, route counts, and relevant candidate routes.
- Moves repeated authority boundary text, limits, and full owner-surface lists behind verbose implement context.
- Records the surface decision with before/after evidence and rollback guardrails.

## Evidence

Live dogfood on this branch:

- Docs-only implement memory packet: 1,831 bytes before to 866 bytes after; full docs-only output is 20,143 bytes.
- Code-change implement memory packet: 954 bytes after while keeping pull/capture statuses and commands.

## Validation

- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_surfaces_memory_decision_packet_for_changed_paths tests/test_workspace_implement_cli.py::test_implement_memory_decision_packet_reports_relevant_route_matches tests/test_external_agent_evaluation_lane.py::test_external_agent_lane_surface_decisions_record_selector_first_start_reduction -q`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py report --format json`
- `uv run pytest tests/test_workspace_implement_cli.py tests/test_external_agent_evaluation_lane.py -q`
- live dogfood: docs-only and code-change `implement --format json`
- `make lint-workspace`
- `uv run pytest --collect-only -q tests packages`
- `make test-workspace`
- `git diff --check`

## Notes

This is stacked on #1711. The runtime source edit is an inventory-backed projection change in `workspace_runtime_primitives.py`; it changes the default tiny `implement` output shape only. Host-agnostic agent judgment is preserved: the packet still exposes facts and commands while leaving relevance, capture, and closeout judgment to the agent.