### PR TITLE
[codex] Add PR comment delta packet helper

### DIFF
--- a/scripts/github/pr_comment_delta.py
+++ b/scripts/github/pr_comment_delta.py
@@ -1,0 +1,357 @@
+"""Build a compact PR comment/review delta packet.
+
+The helper is read-only. It can consume a saved GraphQL/normalized fixture for
+tests and dogfooding, or fetch a PR's comments and review threads through
+``gh api graphql`` for live use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+PACKET_KIND = "agentic-workspace/pr-comment-delta/v1"
+CATEGORIES = (
+    "actionable_code_doc_body_change",
+    "pr_metadata_body_only_change",
+    "ci_label_only_issue",
+    "informational_no_local_change",
+    "ambiguous_needs_human",
+)
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise SystemExit(f"invalid --since timestamp: {value}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _timestamp_value(item: dict[str, Any]) -> datetime | None:
+    for key in ("created_at", "createdAt", "submitted_at", "submittedAt", "updated_at", "updatedAt"):
+        parsed = _parse_timestamp(str(item.get(key) or ""))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _excerpt(body: str, limit: int = 220) -> str:
+    collapsed = " ".join(body.split())
+    if len(collapsed) <= limit:
+        return collapsed
+    return f"{collapsed[: limit - 1]}..."
+
+
+def _author_login(raw: Any) -> str:
+    if isinstance(raw, dict):
+        return _text(raw.get("login"))
+    return _text(raw)
+
+
+def _normalize_graphql(payload: dict[str, Any]) -> dict[str, Any]:
+    pr = payload.get("pull_request") if isinstance(payload.get("pull_request"), dict) else None
+    if pr is None:
+        pr = payload.get("data", {}).get("repository", {}).get("pullRequest", {})
+    if not isinstance(pr, dict):
+        pr = {}
+
+    comments: list[dict[str, Any]] = []
+    for node in pr.get("comments", {}).get("nodes", []) or []:
+        if not isinstance(node, dict):
+            continue
+        comments.append(
+            {
+                "kind": "issue_comment",
+                "database_id": node.get("databaseId"),
+                "url": node.get("url"),
+                "body": node.get("body"),
+                "created_at": node.get("createdAt"),
+                "updated_at": node.get("updatedAt"),
+                "author": node.get("author"),
+            }
+        )
+    for review in pr.get("reviews", {}).get("nodes", []) or []:
+        if not isinstance(review, dict):
+            continue
+        comments.append(
+            {
+                "kind": "review",
+                "database_id": review.get("databaseId"),
+                "url": review.get("url"),
+                "body": review.get("body"),
+                "created_at": review.get("submittedAt"),
+                "author": review.get("author"),
+                "review_state": review.get("state"),
+            }
+        )
+    for thread in pr.get("reviewThreads", {}).get("nodes", []) or []:
+        if not isinstance(thread, dict):
+            continue
+        for comment in thread.get("comments", {}).get("nodes", []) or []:
+            if not isinstance(comment, dict):
+                continue
+            comments.append(
+                {
+                    "kind": "review_thread_comment",
+                    "database_id": comment.get("databaseId"),
+                    "url": comment.get("url"),
+                    "body": comment.get("body"),
+                    "created_at": comment.get("createdAt"),
+                    "updated_at": comment.get("updatedAt"),
+                    "author": comment.get("author"),
+                    "path": comment.get("path"),
+                    "line": comment.get("line") or comment.get("originalLine"),
+                    "diff_hunk": comment.get("diffHunk"),
+                    "is_resolved": thread.get("isResolved"),
+                    "is_outdated": thread.get("isOutdated"),
+                    "reply_to_database_id": (comment.get("replyTo") or {}).get("databaseId"),
+                }
+            )
+    return {
+        "repository": payload.get("repository") or payload.get("repo"),
+        "pr_number": payload.get("pr_number") or payload.get("number"),
+        "pr_url": pr.get("url") or payload.get("pr_url"),
+        "comments": comments if comments else payload.get("comments", []),
+    }
+
+
+def _baseline_seen_urls(path: Path | None) -> set[str]:
+    if path is None:
+        return set()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    urls = payload.get("seen_comment_urls", []) if isinstance(payload, dict) else []
+    return {_text(item) for item in urls if _text(item)}
+
+
+def _classify(item: dict[str, Any]) -> tuple[str, str, str]:
+    body = _text(item.get("body"))
+    lower = body.lower()
+    path = _text(item.get("path"))
+    if item.get("is_resolved") is True or item.get("is_outdated") is True:
+        return (
+            "informational_no_local_change",
+            "review thread is resolved or outdated",
+            "No local proof unless the thread is reopened.",
+        )
+    if path:
+        return (
+            "actionable_code_doc_body_change",
+            "inline review comment anchors to a changed file",
+            f"Inspect {path}; run focused tests or `agentic-workspace proof --changed {path} --format json`.",
+        )
+    if any(token in lower for token in ("pr body", "pull request body", "description", "title", "close #", "closes #", "closing #")):
+        return (
+            "pr_metadata_body_only_change",
+            "comment appears to target PR title/body/closure metadata",
+            "Update PR metadata/body only; no source proof unless the body is generated from checked-in files.",
+        )
+    if any(token in lower for token in ("ci", "check", "workflow", "label", "draft", "mergeable")):
+        return (
+            "ci_label_only_issue",
+            "comment appears to target CI, labels, draft state, or mergeability",
+            "Inspect PR checks/metadata; run local proof only if CI points to a reproducible failure.",
+        )
+    if "?" in body or any(token in lower for token in ("unclear", "which", "maybe", "could you", "can you")):
+        return (
+            "ambiguous_needs_human",
+            "comment asks a question or leaves scope ambiguous",
+            "Ask or draft a response before editing; no local proof yet.",
+        )
+    if any(token in lower for token in ("approve", "approved", "thanks", "nit:", "fyi", "note:")):
+        return (
+            "informational_no_local_change",
+            "comment is approval, FYI, or low-action note",
+            "No local proof required.",
+        )
+    return (
+        "ambiguous_needs_human",
+        "comment is not anchored and does not clearly identify a local change",
+        "Classify manually before fetching patch context or editing.",
+    )
+
+
+def _item_identity(item: dict[str, Any]) -> str:
+    for key in ("url", "database_id", "databaseId", "id"):
+        value = _text(item.get(key))
+        if value:
+            return value
+    return _excerpt(_text(item.get("body")), limit=80)
+
+
+def build_packet(payload: dict[str, Any], *, since: datetime | None = None, seen_urls: set[str] | None = None) -> dict[str, Any]:
+    normalized = _normalize_graphql(payload)
+    seen_urls = seen_urls or set()
+    items: list[dict[str, Any]] = []
+    skipped_old = 0
+    skipped_seen = 0
+    for raw in normalized.get("comments", []) or []:
+        if not isinstance(raw, dict):
+            continue
+        created = _timestamp_value(raw)
+        if since is not None and created is not None and created <= since:
+            skipped_old += 1
+            continue
+        url = _text(raw.get("url"))
+        if url and url in seen_urls:
+            skipped_seen += 1
+            continue
+        category, reason, proof_hint = _classify(raw)
+        item = {
+            "id": _item_identity(raw),
+            "kind": _text(raw.get("kind") or "comment"),
+            "category": category,
+            "reason": reason,
+            "proof_hint": proof_hint,
+            "url": url,
+            "author": _author_login(raw.get("author")),
+            "created_at": created.isoformat().replace("+00:00", "Z") if created else "",
+            "body_excerpt": _excerpt(_text(raw.get("body"))),
+        }
+        for key in ("path", "line", "is_resolved", "is_outdated"):
+            if key in raw and raw.get(key) not in (None, ""):
+                item[key] = raw.get(key)
+        items.append(item)
+
+    counts = {category: 0 for category in CATEGORIES}
+    for item in items:
+        counts[item["category"]] += 1
+    return {
+        "kind": PACKET_KIND,
+        "repository": normalized.get("repository") or "",
+        "pr_number": normalized.get("pr_number") or "",
+        "pr_url": normalized.get("pr_url") or "",
+        "baseline": {
+            "since": since.isoformat().replace("+00:00", "Z") if since else "",
+            "seen_comment_url_count": len(seen_urls),
+            "skipped_old_count": skipped_old,
+            "skipped_seen_count": skipped_seen,
+        },
+        "new_comment_count": len(items),
+        "category_counts": counts,
+        "items": items,
+        "smallest_next_action": _smallest_next_action(counts),
+        "write_safety": {
+            "github_writes_performed": False,
+            "rule": "Do not reply, resolve, or submit reviews from this packet without explicit user approval.",
+        },
+    }
+
+
+def _smallest_next_action(counts: dict[str, int]) -> str:
+    if counts["ambiguous_needs_human"]:
+        return "Clarify ambiguous comments before editing or fetching broad patch context."
+    if counts["actionable_code_doc_body_change"]:
+        return "Inspect only anchored files and run focused proof for those paths."
+    if counts["pr_metadata_body_only_change"]:
+        return "Update PR metadata/body; avoid source edits unless generated metadata is checked in."
+    if counts["ci_label_only_issue"]:
+        return "Inspect checks or labels before local source proof."
+    if counts["informational_no_local_change"]:
+        return "No local change required."
+    return "No new PR comment delta."
+
+
+def _fetch_with_gh(*, repo: str, pr_number: int) -> dict[str, Any]:
+    owner, name = repo.split("/", 1)
+    query = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      url
+      comments(first: 100) { nodes { databaseId url body createdAt updatedAt author { login } } }
+      reviews(first: 100) { nodes { databaseId url body state submittedAt author { login } } }
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          isOutdated
+          comments(first: 20) {
+            nodes {
+              databaseId
+              url
+              body
+              createdAt
+              updatedAt
+              path
+              line
+              originalLine
+              diffHunk
+              author { login }
+              replyTo { databaseId }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-F",
+            f"number={pr_number}",
+            "-f",
+            f"query={query}",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(result.stderr.strip() or "gh api graphql failed")
+    payload = json.loads(result.stdout)
+    payload["repository"] = repo
+    payload["pr_number"] = pr_number
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--fixture", type=Path, help="Read normalized or GraphQL-like PR comment JSON from a file.")
+    source.add_argument("--repo", help="GitHub repository in owner/name form; requires --pr.")
+    parser.add_argument("--pr", type=int, help="Pull request number when fetching through gh.")
+    parser.add_argument("--since", help="Only include comments created after this ISO timestamp.")
+    parser.add_argument("--baseline-json", type=Path, help="JSON with seen_comment_urls to suppress already-seen comments.")
+    parser.add_argument("--format", choices=("json",), default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.repo and args.pr is None:
+        raise SystemExit("--repo requires --pr")
+    payload = json.loads(args.fixture.read_text(encoding="utf-8")) if args.fixture else _fetch_with_gh(repo=args.repo, pr_number=args.pr)
+    packet = build_packet(payload, since=_parse_timestamp(args.since), seen_urls=_baseline_seen_urls(args.baseline_json))
+    print(json.dumps(packet, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_pr_comment_delta.py
+++ b/tests/test_pr_comment_delta.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "github" / "pr_comment_delta.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("pr_comment_delta", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture() -> dict:
+    return {
+        "repository": "rickardvh/agentic-workspace",
+        "pr_number": 1689,
+        "pr_url": "https://github.com/rickardvh/agentic-workspace/pull/1689",
+        "comments": [
+            {
+                "kind": "issue_comment",
+                "database_id": 1,
+                "url": "https://example.test/pr#old",
+                "body": "Old note",
+                "created_at": "2026-06-22T10:00:00Z",
+                "author": {"login": "maintainer"},
+            },
+            {
+                "kind": "issue_comment",
+                "database_id": 2,
+                "url": "https://example.test/pr#closure",
+                "body": "Please stop closing #1680 in the PR body and reframe this as a slice.",
+                "created_at": "2026-06-23T10:00:00Z",
+                "author": {"login": "maintainer"},
+            },
+            {
+                "kind": "review_thread_comment",
+                "database_id": 3,
+                "url": "https://example.test/pr#code",
+                "body": "This assertion should cover the empty state.",
+                "created_at": "2026-06-23T10:01:00Z",
+                "author": {"login": "reviewer"},
+                "path": "tests/test_widget.py",
+                "line": 42,
+                "is_resolved": False,
+                "is_outdated": False,
+            },
+            {
+                "kind": "issue_comment",
+                "database_id": 4,
+                "url": "https://example.test/pr#ci",
+                "body": "The CI check is failing on Windows.",
+                "created_at": "2026-06-23T10:02:00Z",
+                "author": {"login": "reviewer"},
+            },
+            {
+                "kind": "issue_comment",
+                "database_id": 5,
+                "url": "https://example.test/pr#question",
+                "body": "Which behavior should win here?",
+                "created_at": "2026-06-23T10:03:00Z",
+                "author": {"login": "reviewer"},
+            },
+            {
+                "kind": "review_thread_comment",
+                "database_id": 6,
+                "url": "https://example.test/pr#resolved",
+                "body": "Resolved nit.",
+                "created_at": "2026-06-23T10:04:00Z",
+                "author": {"login": "reviewer"},
+                "path": "README.md",
+                "is_resolved": True,
+            },
+        ],
+    }
+
+
+def test_pr_comment_delta_classifies_new_review_response_scope() -> None:
+    module = _load_module()
+    packet = module.build_packet(_fixture(), since=module._parse_timestamp("2026-06-23T09:59:00Z"))
+
+    assert packet["kind"] == "agentic-workspace/pr-comment-delta/v1"
+    assert packet["new_comment_count"] == 5
+    assert packet["category_counts"]["pr_metadata_body_only_change"] == 1
+    assert packet["category_counts"]["actionable_code_doc_body_change"] == 1
+    assert packet["category_counts"]["ci_label_only_issue"] == 1
+    assert packet["category_counts"]["ambiguous_needs_human"] == 1
+    assert packet["category_counts"]["informational_no_local_change"] == 1
+    closure = next(item for item in packet["items"] if item["url"].endswith("#closure"))
+    assert closure["category"] == "pr_metadata_body_only_change"
+    assert "no source proof" in closure["proof_hint"].lower()
+    anchored = next(item for item in packet["items"] if item["url"].endswith("#code"))
+    assert anchored["path"] == "tests/test_widget.py"
+    assert "focused tests" in anchored["proof_hint"]
+
+
+def test_pr_comment_delta_filters_seen_comment_urls(tmp_path: Path) -> None:
+    module = _load_module()
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"seen_comment_urls": ["https://example.test/pr#ci"]}), encoding="utf-8")
+
+    packet = module.build_packet(
+        _fixture(),
+        since=module._parse_timestamp("2026-06-23T09:59:00Z"),
+        seen_urls=module._baseline_seen_urls(baseline),
+    )
+
+    assert packet["baseline"]["skipped_seen_count"] == 1
+    assert all(not item["url"].endswith("#ci") for item in packet["items"])
+
+
+def test_pr_comment_delta_normalizes_graphql_review_threads() -> None:
+    module = _load_module()
+    payload = {
+        "repository": "rickardvh/agentic-workspace",
+        "pr_number": 42,
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "url": "https://github.com/rickardvh/agentic-workspace/pull/42",
+                    "comments": {"nodes": []},
+                    "reviews": {"nodes": []},
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "isResolved": False,
+                                "isOutdated": False,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "databaseId": 99,
+                                            "url": "https://example.test/pr#thread",
+                                            "body": "Please update this branch.",
+                                            "createdAt": "2026-06-23T11:00:00Z",
+                                            "path": "src/app.py",
+                                            "line": 12,
+                                            "author": {"login": "reviewer"},
+                                            "replyTo": None,
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    },
+                }
+            }
+        },
+    }
+
+    packet = module.build_packet(payload)
+
+    assert packet["new_comment_count"] == 1
+    item = packet["items"][0]
+    assert item["kind"] == "review_thread_comment"
+    assert item["category"] == "actionable_code_doc_body_change"
+    assert item["path"] == "src/app.py"
+    assert item["line"] == 12
+
+
+def test_pr_comment_delta_cli_reads_fixture(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "comments.json"
+    fixture_path.write_text(json.dumps(_fixture()), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--fixture",
+            str(fixture_path),
+            "--since",
+            "2026-06-23T09:59:00Z",
+            "--format",
+            "json",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    packet = json.loads(result.stdout)
+    assert packet["repository"] == "rickardvh/agentic-workspace"
+    assert packet["pr_number"] == 1689
+    assert packet["smallest_next_action"] == "Clarify ambiguous comments before editing or fetching broad patch context."


### PR DESCRIPTION
## Summary

- Adds `scripts/github/pr_comment_delta.py`, a read-only helper that builds `agentic-workspace/pr-comment-delta/v1` packets from either a fixture or live `gh api graphql` PR data.
- Classifies new comments/reviews into #1696's requested buckets: actionable code/doc/body change, PR metadata/body-only change, CI/label-only issue, informational/no local change, and ambiguous needs human.
- Supports supplied baselines via `--since` and `--baseline-json` seen URLs.
- Uses thread-aware GraphQL `reviewThreads` data when fetching live PR comments and preserves comment URLs/anchors for audit.

## Dogfood

- Fixture covers the #1689-style closure-boundary comment: “stop closing #1680 in the PR body and reframe this as a slice,” classified as PR metadata/body-only with no source proof.
- Live read-only dogfood on #1712 returned a compact no-comment delta packet and performed no GitHub writes.

## Validation

- `uv run pytest tests/test_pr_comment_delta.py -q`
- `uv run python scripts/github/pr_comment_delta.py --repo rickardvh/agentic-workspace --pr 1712 --format json`
- `make lint-workspace`
- `make test-workspace`
- `git diff --cached --check`

## Notes

This is stacked on #1712. It is a bounded first #1696 slice: a standalone read-only helper rather than a broad AW runtime integration. The packet suggests the smallest next action/proof scope and explicitly forbids automatic GitHub writes.