### PR TITLE
[codex] Document PR comment delta helper

### DIFF
--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -1,0 +1,42 @@
+# GitHub Helpers
+
+This directory holds read-only helpers for GitHub review and maintainer workflows.
+
+## PR Comment Delta Packet
+
+Use `pr_comment_delta.py` at the start of a review-response turn when a PR may have new comments, reviews, or inline review threads. The helper emits `agentic-workspace/pr-comment-delta/v1` so the next action can stay narrow:
+
+- inline review comments with a file path become focused code/doc changes;
+- PR title/body/closure comments stay metadata-only;
+- CI, label, draft, or mergeability comments route to PR checks or metadata first;
+- ambiguous comments route to clarification instead of broad local edits;
+- resolved or outdated threads become informational.
+
+Live read-only use:
+
+```powershell
+uv run python scripts/github/pr_comment_delta.py `
+  --repo rickardvh/agentic-workspace `
+  --pr 1713 `
+  --format json
+```
+
+Fresh-session or repeated-review use can suppress known comments with a baseline file:
+
+```json
+{
+  "seen_comment_urls": [
+    "https://github.com/rickardvh/agentic-workspace/pull/1713#discussion_r123"
+  ]
+}
+```
+
+```powershell
+uv run python scripts/github/pr_comment_delta.py `
+  --repo rickardvh/agentic-workspace `
+  --pr 1713 `
+  --baseline-json .agentic-workspace/local/pr-1713-comments.json `
+  --format json
+```
+
+The helper does not write to GitHub. Do not reply to comments, resolve review threads, or submit reviews from the packet unless the human explicitly approves that write.

--- a/tests/test_pr_comment_delta.py
+++ b/tests/test_pr_comment_delta.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "github" / "pr_comment_delta.py"
+README = REPO_ROOT / "scripts" / "github" / "README.md"
 
 
 def _load_module():
@@ -192,3 +193,12 @@ def test_pr_comment_delta_cli_reads_fixture(tmp_path: Path) -> None:
     assert packet["repository"] == "rickardvh/agentic-workspace"
     assert packet["pr_number"] == 1689
     assert packet["smallest_next_action"] == "Clarify ambiguous comments before editing or fetching broad patch context."
+
+
+def test_pr_comment_delta_readme_keeps_live_workflow_discoverable() -> None:
+    text = README.read_text(encoding="utf-8")
+
+    assert "agentic-workspace/pr-comment-delta/v1" in text
+    assert "uv run python scripts/github/pr_comment_delta.py" in text
+    assert "--baseline-json" in text
+    assert "does not write to GitHub" in text


### PR DESCRIPTION
## Summary

- add a maintainer-facing README for the read-only PR comment delta helper
- document live and baseline-filtered usage for review-response turns
- add a regression so the helper's packet kind, command, baseline flag, and write-safety rule stay discoverable

## Why

#1696 now has a helper, but without a small route surface future agents still have to rediscover the implementation before using it. This slice makes the #1680 review-response reduction cheaper to continue without changing GitHub write behavior.

## Validation

- `uv run pytest tests/test_pr_comment_delta.py -q`
- `make test-workspace`
- `make lint-workspace`
- `git diff --check`

#1680 remains open; this is one stacked reduction/discoverability slice, not lane closure.