### PR TITLE
[codex] Add ordinary output budget guards

### DIFF
--- a/docs/reviews/aw-ordinary-output-budget-guards-2026-06-23.md
+++ b/docs/reviews/aw-ordinary-output-budget-guards-2026-06-23.md
@@ -1,0 +1,40 @@
+# AW ordinary output budget guards
+
+Date: 2026-06-23
+
+Related issues: #1680, #1695
+
+## Context
+
+Recent #1680 dogfooding showed that ordinary `start` and `implement` payloads can become a token sink when diagnostic packets are emitted by default. The first guardrail should make output-size drift visible before changing more behavior.
+
+## Initial Tiny Budgets
+
+Representative ordinary cases now have explicit JSON payload budgets:
+
+- `start` docs-only first-contact task: under 10 KB.
+- `implement` docs-only task: under 15 KB.
+- `implement` simple code-change task: under 15 KB.
+
+These are not final product budgets. They are regression guards sized to current compact payloads so later reductions can tighten them without losing blockers, proof, or closeout state.
+
+## Selector-Only Detail Areas
+
+This slice locks three non-essential detail areas behind selectors for ordinary `implement` defaults:
+
+- `change_impact`
+- `routine_work_context`
+- `generated_surface_trust`
+
+It also keeps `start` default detail for `memory_decision_packet`, `installed_state_compatibility`, and `planning_safety_gate` out of the ordinary payload while preserving action signals and next safe action. For the representative docs-only start case, the asserted drill-down details are `memory_decision_packet`, `routine_work_context`, and `workflow_sufficiency`; other startup diagnostics remain absent from the default payload unless relevant.
+
+## Dogfood Cases
+
+The guard tests cover both requested #1695 dogfood shapes:
+
+- docs-only correction: `README.md` / "Fix one docs typo";
+- code-change task: `src/app.py` / "Fix one code path".
+
+## Guardrail
+
+Budget assertions are not permission to hide hard blockers, proof obligations, or closure/residue blockers. If a future reduction needs to remove default fields, it must keep those facts either in the tiny action/proof path or behind exact selectors.

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -357,6 +357,37 @@ def test_start_default_routes_memory_and_installed_state_detail_behind_selectors
     assert payload["context"]["memory"]["status"] in {"recommended", "not_checked"}
 
 
+def test_start_default_stays_under_tiny_output_budget_for_docs_task(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Fix one docs typo",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    _assert_json_payload_under(payload, 10_000, label="start tiny docs-task payload", sort_keys=False)
+    assert payload["next_safe_action"]["next_safe_action"] == "choose-smallest-workflow-shape"
+    assert "memory_decision_packet" not in payload
+    assert "installed_state_compatibility" not in payload
+    assert "planning_safety_gate" not in payload
+    assert "memory_decision_packet" in payload["drill_down"]["available_selectors"]
+    assert "routine_work_context" in payload["drill_down"]["available_selectors"]
+    assert "workflow_sufficiency" in payload["drill_down"]["available_selectors"]
+
+
 def test_start_default_keeps_skill_catalog_breakdown_behind_command(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1819,6 +1819,82 @@ blocking_claims = ["claim-work-complete"]
             assert selector in payload["drill_down"]["available_selectors"], field
 
 
+def test_implement_default_stays_under_tiny_output_budget_for_docs_task(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "README.md", "hello\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "README.md",
+                "--task",
+                "Fix one docs typo",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    _assert_json_payload_under(payload, 15_000, label="implement tiny docs-task payload", sort_keys=False)
+    assert payload["kind"] == "implementer-context-tiny/v1"
+    assert payload["next"]["action"]
+    assert payload["proof"]["required_commands"]
+    assert payload["proof"]["proof_obligations"]["required_proof"]["status"] == "required"
+    assert payload["operating_loop"]["closeout_state"] == "blocked_missing_proof"
+    assert payload["operating_loop"]["verification"]["state"] == "proof_missing"
+    assert "change_impact" not in payload
+    assert "routine_work_context" not in payload
+    assert "generated_surface_trust" not in payload
+    assert "change_impact" in payload["drill_down"]["available_selectors"]
+    assert "routine_work_context" in payload["drill_down"]["available_selectors"]
+    assert "generated_surface_trust" in payload["drill_down"]["available_selectors"]
+
+
+def test_implement_default_stays_under_tiny_output_budget_for_code_task(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "app.py", "print('hello')\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/app.py",
+                "--task",
+                "Fix one code path",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    _assert_json_payload_under(payload, 15_000, label="implement tiny code-task payload", sort_keys=False)
+    assert payload["kind"] == "implementer-context-tiny/v1"
+    assert payload["next"]["action"]
+    assert payload["proof"]["proof_obligations"]["required_proof"]["status"] == "required"
+    assert payload["proof"]["proof_obligations"]["required_proof"]["manual_verification_required"] is True
+    assert payload["operating_loop"]["closeout_state"] == "blocked_missing_proof"
+    assert payload["operating_loop"]["verification"]["state"] == "proof_missing"
+    assert "change_impact" not in payload
+    assert "routine_work_context" not in payload
+    assert "generated_surface_trust" not in payload
+    assert "change_impact" in payload["drill_down"]["available_selectors"]
+    assert "routine_work_context" in payload["drill_down"]["available_selectors"]
+    assert "generated_surface_trust" in payload["drill_down"]["available_selectors"]
+
+
 def test_implement_tiny_profile_defers_reuse_pressure_scan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)


### PR DESCRIPTION
## Summary

- add explicit tiny/default JSON payload budget guards for representative `start` and `implement` ordinary tasks
- assert non-essential implement detail remains selector-backed while proof and closeout blockers stay visible
- document initial #1695 budgets and the docs/code dogfood cases

## Proof

- `uv run pytest tests/test_workspace_cli.py::test_start_default_stays_under_tiny_output_budget_for_docs_task tests/test_workspace_implement_cli.py::test_implement_default_stays_under_tiny_output_budget_for_docs_task tests/test_workspace_implement_cli.py::test_implement_default_stays_under_tiny_output_budget_for_code_task -q`
- `uv run ruff check tests/test_workspace_cli.py tests/test_workspace_implement_cli.py`
- `make lint-workspace`
- `make maintainer-surfaces`
- `make test-workspace`

## Notes

Closes part of #1695. Continues #1680.