### PR TITLE
[codex] Compact clear planning gate output

### DIFF
--- a/docs/reviews/aw-clear-planning-gate-compression-2026-06-23.md
+++ b/docs/reviews/aw-clear-planning-gate-compression-2026-06-23.md
@@ -1,0 +1,37 @@
+# AW clear planning gate compression
+
+Date: 2026-06-23
+
+Related issues: #1680, #1695
+
+## Context
+
+After the initial ordinary-output budget guards, representative `implement` payload contributors showed `context.planning_safety_gate` as the largest docs-only default section. In clear direct-work cases, much of that gate duplicated `context.guidance` or selector-backed detail.
+
+## Change
+
+Tiny/default `implement` output now keeps clear/satisfied planning gates to an action-critical summary:
+
+- status and gate result;
+- workflow sufficiency;
+- required next action;
+- implementation/delegation booleans;
+- compact changed-path facts.
+
+Verbose and selector-backed implement output still expose richer planning safety detail. Attention or blocking gates retain richer default evidence so hard blockers, external issue gates, proof boundaries, and closure risks stay visible.
+
+## Dogfood Measurement
+
+Representative payload sizes from the local fixture:
+
+- docs-only `implement README.md`: about 13.7 KB before, 11.9 KB after;
+- simple code `implement src/app.py`: about 12.8 KB before, 11.1 KB after.
+
+The budget guards were tightened to:
+
+- docs-only implement: under 13 KB;
+- code-task implement: under 12 KB.
+
+## Guardrail
+
+This reduction applies only to clear/satisfied planning gates. Non-clear planning safety gates still need enough default evidence for agents to see blockers without guessing or doing selector drill-down first.

--- a/docs/reviews/aw-fresh-session-digest-dogfood-2026-06-23.md
+++ b/docs/reviews/aw-fresh-session-digest-dogfood-2026-06-23.md
@@ -23,7 +23,7 @@ uv run python scripts/run_agentic_workspace.py summary `
 - `issue_refs`: contains `#1680`
 - `current_branch_or_state`: reports the current git branch/state
 - `closure_boundary.may_claim_parent_closure`: `false`
-- `source_artifacts`: points to cached external intent evidence and compact review artifacts
+- `source_artifacts`: points to cached external intent evidence, relevant changed paths, and issue refs when available
 - `detail_commands.refresh_issue_evidence`: keeps issue refresh explicit instead of embedding issue bodies
 
 ## Boundary

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -22043,6 +22043,17 @@ def _fresh_session_digest_payload(
     active_execplan = str(planning_record.get("path") or planning_record.get("source") or "").strip()
     if active_execplan:
         active_refs.append(active_execplan)
+    source_artifacts = []
+    issue_source_path = str(issue_scope.get("source_path") or "").strip()
+    if issue_source_path:
+        source_artifacts.append(issue_source_path)
+    if active_execplan:
+        source_artifacts.append(active_execplan)
+    for changed_path in normalized_changed[:5]:
+        if changed_path not in source_artifacts:
+            source_artifacts.append(changed_path)
+    if issue_refs:
+        source_artifacts.append("GitHub issue refs listed in issue_refs")
     facts = [
         f"task_refs={','.join(issue_refs)}" if issue_refs else "task_refs=none",
         f"branch={branch_posture.get('current_branch', '') or branch_posture.get('status', 'unknown')}",
@@ -22091,11 +22102,7 @@ def _fresh_session_digest_payload(
             command='agentic-workspace start --target . --task "<next task>" --format json',
             cli_invoke=cli_invoke,
         ),
-        "source_artifacts": [
-            ".agentic-workspace/local/cache/external-intent-evidence.json",
-            "docs/reviews/aw-completion-cost-session-log-analysis-2026-06-23.md",
-            "GitHub issue refs listed in issue_refs",
-        ],
+        "source_artifacts": source_artifacts,
         "detail_commands": {
             "refresh_issue_evidence": _command_with_cli_invoke(
                 command="agentic-workspace external-intent refresh-github --target . --state all --format json",
@@ -28331,6 +28338,44 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
         compact_gate = _selector_first_planning_safety_gate(planning_safety_gate)
         compact_gate.pop("planning_revision", None)
         compact_gate.pop("work_shape_guidance", None)
+        if compact_gate.get("status") in {"clear", "satisfied"}:
+            active_plan_reliance = _as_dict(compact_gate.get("active_plan_reliance"))
+            keep_active_plan_reliance = active_plan_reliance.get("permission_claim") != "direct-work-no-active-plan"
+            candidate_pressure = _as_dict(compact_gate.get("candidate_pressure"))
+            issue_scope_evidence = _as_dict(compact_gate.get("issue_scope_evidence"))
+            changed_path_facts = _as_dict(compact_gate.get("changed_path_facts"))
+            compact_changed_path_facts = {
+                key: changed_path_facts.get(key)
+                for key in (
+                    "dirty_shape",
+                    "surface_roots",
+                    "surface_root_count",
+                    "scope_growth_detected",
+                    "scope_growth_reasons",
+                )
+                if key in changed_path_facts
+            }
+            compact_gate = {
+                key: compact_gate.get(key)
+                for key in (
+                    "kind",
+                    "status",
+                    "gate_result",
+                    "workflow_sufficient",
+                    "required_next_action",
+                    "implementation_allowed",
+                    "delegation_decision_required",
+                )
+                if key in compact_gate
+            }
+            if compact_changed_path_facts:
+                compact_gate["changed_path_facts"] = compact_changed_path_facts
+            if candidate_pressure.get("status") == "observed":
+                compact_gate["candidate_pressure"] = candidate_pressure
+                if issue_scope_evidence:
+                    compact_gate["issue_scope_evidence"] = issue_scope_evidence
+            if keep_active_plan_reliance:
+                compact_gate["active_plan_reliance"] = active_plan_reliance
         if (
             compact_gate.get("status") in {"clear", "satisfied"}
             and _as_dict(compact_gate.get("candidate_pressure")).get("status") != "observed"

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -285,10 +285,69 @@ def test_summary_fresh_session_digest_is_selector_backed(tmp_path: Path, capsys)
     assert digest["issue_evidence"]["status"] == "available"
     assert digest["issue_evidence"]["items"][0]["title"] == "[Workspace]: Reduce AW-induced completion cost"
     assert digest["changed_paths"] == ["docs/reviews/example.md"]
+    assert digest["source_artifacts"] == [
+        ".agentic-workspace/local/cache/external-intent-evidence.json",
+        "docs/reviews/example.md",
+        "GitHub issue refs listed in issue_refs",
+    ]
     assert digest["closure_boundary"]["may_claim_parent_closure"] is False
     assert "cannot close issues" in digest["closure_boundary"]["rule"]
     assert digest["safe_next_command"].endswith('start --target . --task "<next task>" --format json')
     assert "refresh_issue_evidence" in digest["detail_commands"]
+
+
+def test_summary_fresh_session_digest_omits_unrelated_lane_artifacts(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    evidence_path = tmp_path / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json"
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "id": "#42",
+                        "system": "github",
+                        "status": "open",
+                        "kind": "issue",
+                        "title": "Unrelated docs task",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "summary",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #42 docs lane",
+                "--changed",
+                "docs/notes/unrelated.md",
+                "--select",
+                "fresh_session_digest",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload_text = capsys.readouterr().out
+    digest = json.loads(payload_text)["values"]["fresh_session_digest"]
+
+    assert digest["issue_refs"] == ["#42"]
+    assert digest["source_artifacts"] == [
+        ".agentic-workspace/local/cache/external-intent-evidence.json",
+        "docs/notes/unrelated.md",
+        "GitHub issue refs listed in issue_refs",
+    ]
+    assert "#1680" not in payload_text
+    assert "aw-completion-cost-session-log-analysis-2026-06-23.md" not in payload_text
 
 
 def test_start_exposes_workflow_sufficiency_and_continuation_selectors(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -1842,13 +1842,20 @@ def test_implement_default_stays_under_tiny_output_budget_for_docs_task(tmp_path
     )
     payload = json.loads(capsys.readouterr().out)
 
-    _assert_json_payload_under(payload, 15_000, label="implement tiny docs-task payload", sort_keys=False)
+    _assert_json_payload_under(payload, 13_000, label="implement tiny docs-task payload", sort_keys=False)
     assert payload["kind"] == "implementer-context-tiny/v1"
     assert payload["next"]["action"]
     assert payload["proof"]["required_commands"]
     assert payload["proof"]["proof_obligations"]["required_proof"]["status"] == "required"
     assert payload["operating_loop"]["closeout_state"] == "blocked_missing_proof"
     assert payload["operating_loop"]["verification"]["state"] == "proof_missing"
+    planning_gate = payload["context"]["planning_safety_gate"]
+    assert planning_gate["status"] == "clear"
+    assert planning_gate["required_next_action"] == "continue-direct"
+    assert planning_gate["changed_path_facts"]["surface_roots"] == ["README.md"]
+    assert "reason" not in planning_gate
+    assert "promotion_command" not in planning_gate
+    assert "active_plan_reliance" not in planning_gate
     assert "change_impact" not in payload
     assert "routine_work_context" not in payload
     assert "generated_surface_trust" not in payload
@@ -1880,13 +1887,20 @@ def test_implement_default_stays_under_tiny_output_budget_for_code_task(tmp_path
     )
     payload = json.loads(capsys.readouterr().out)
 
-    _assert_json_payload_under(payload, 15_000, label="implement tiny code-task payload", sort_keys=False)
+    _assert_json_payload_under(payload, 12_000, label="implement tiny code-task payload", sort_keys=False)
     assert payload["kind"] == "implementer-context-tiny/v1"
     assert payload["next"]["action"]
     assert payload["proof"]["proof_obligations"]["required_proof"]["status"] == "required"
     assert payload["proof"]["proof_obligations"]["required_proof"]["manual_verification_required"] is True
     assert payload["operating_loop"]["closeout_state"] == "blocked_missing_proof"
     assert payload["operating_loop"]["verification"]["state"] == "proof_missing"
+    planning_gate = payload["context"]["planning_safety_gate"]
+    assert planning_gate["status"] == "clear"
+    assert planning_gate["required_next_action"] == "continue-direct"
+    assert planning_gate["changed_path_facts"]["surface_roots"] == ["src"]
+    assert "reason" not in planning_gate
+    assert "promotion_command" not in planning_gate
+    assert "active_plan_reliance" not in planning_gate
     assert "change_impact" not in payload
     assert "routine_work_context" not in payload
     assert "generated_surface_trust" not in payload


### PR DESCRIPTION
## Summary
- compact clear/satisfied implement planning safety gates to action-critical fields while preserving observed candidate pressure and non-default active-plan reliance
- tighten tiny implement output budget regressions for docs and code tasks
- address the fresh-session digest review comment by deriving `source_artifacts` from issue evidence, active planning state, and changed paths instead of hard-coding the #1680 review artifact
- add a dogfood review note for the clear planning-gate reduction

## Validation
- `uv run pytest tests/test_workspace_cli.py::test_summary_fresh_session_digest_is_selector_backed tests/test_workspace_cli.py::test_summary_fresh_session_digest_omits_unrelated_lane_artifacts tests/test_workspace_implement_cli.py::test_implement_default_stays_under_tiny_output_budget_for_docs_task tests/test_workspace_implement_cli.py::test_implement_default_stays_under_tiny_output_budget_for_code_task tests/test_workspace_implement_cli.py::test_implement_generic_continuation_task_does_not_link_active_plan -q`
- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_keeps_generic_ci_refresh_terms_as_weak_hints tests/test_workspace_implement_cli.py::test_implement_ignores_closed_external_intent_candidate_pressure tests/test_workspace_implement_cli.py::test_implement_keeps_unrelated_roadmap_candidates_advisory tests/test_workspace_implement_cli.py::test_implement_keeps_generic_github_issue_filing_terms_as_weak_hints tests/test_workspace_implement_cli.py::test_implement_default_stays_under_tiny_output_budget_for_docs_task tests/test_workspace_implement_cli.py::test_implement_default_stays_under_tiny_output_budget_for_code_task tests/test_workspace_cli.py::test_summary_fresh_session_digest_is_selector_backed tests/test_workspace_cli.py::test_summary_fresh_session_digest_omits_unrelated_lane_artifacts -q`
- `uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_cli.py tests/test_workspace_implement_cli.py`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`

## Stack
- Continues #1680 / #1695.
- Stacked on #1719 (`codex/ordinary-output-budget-guards`).