### PR TITLE
[codex] Surface PR comment delta truncation

### DIFF
--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -40,3 +40,5 @@ uv run python scripts/github/pr_comment_delta.py `
 ```
 
 The helper does not write to GitHub. Do not reply to comments, resolve review threads, or submit reviews from the packet unless the human explicitly approves that write.
+
+Live GitHub reads include `pagination.truncated`, `pagination.truncated_surfaces`, and GraphQL page limits. When `pagination.truncated` is `true`, treat the packet as incomplete and fetch complete paginated comments before deciding there are no actionable review obligations.

--- a/scripts/github/pr_comment_delta.py
+++ b/scripts/github/pr_comment_delta.py
@@ -16,6 +16,10 @@ from pathlib import Path
 from typing import Any
 
 PACKET_KIND = "agentic-workspace/pr-comment-delta/v1"
+ISSUE_COMMENT_LIMIT = 100
+REVIEW_LIMIT = 100
+REVIEW_THREAD_LIMIT = 100
+THREAD_COMMENT_LIMIT = 20
 CATEGORIES = (
     "actionable_code_doc_body_change",
     "pr_metadata_body_only_change",
@@ -75,6 +79,10 @@ def _normalize_graphql(payload: dict[str, Any]) -> dict[str, Any]:
         pr = {}
 
     comments: list[dict[str, Any]] = []
+    truncated_surfaces: list[str] = []
+    page_info = _page_info(pr.get("comments"))
+    if page_info.get("hasNextPage") is True:
+        truncated_surfaces.append("comments")
     for node in pr.get("comments", {}).get("nodes", []) or []:
         if not isinstance(node, dict):
             continue
@@ -89,6 +97,9 @@ def _normalize_graphql(payload: dict[str, Any]) -> dict[str, Any]:
                 "author": node.get("author"),
             }
         )
+    page_info = _page_info(pr.get("reviews"))
+    if page_info.get("hasNextPage") is True:
+        truncated_surfaces.append("reviews")
     for review in pr.get("reviews", {}).get("nodes", []) or []:
         if not isinstance(review, dict):
             continue
@@ -103,9 +114,15 @@ def _normalize_graphql(payload: dict[str, Any]) -> dict[str, Any]:
                 "review_state": review.get("state"),
             }
         )
-    for thread in pr.get("reviewThreads", {}).get("nodes", []) or []:
+    page_info = _page_info(pr.get("reviewThreads"))
+    if page_info.get("hasNextPage") is True:
+        truncated_surfaces.append("reviewThreads")
+    for index, thread in enumerate(pr.get("reviewThreads", {}).get("nodes", []) or []):
         if not isinstance(thread, dict):
             continue
+        page_info = _page_info(thread.get("comments"))
+        if page_info.get("hasNextPage") is True:
+            truncated_surfaces.append(f"reviewThreads[{index}].comments")
         for comment in thread.get("comments", {}).get("nodes", []) or []:
             if not isinstance(comment, dict):
                 continue
@@ -131,7 +148,25 @@ def _normalize_graphql(payload: dict[str, Any]) -> dict[str, Any]:
         "pr_number": payload.get("pr_number") or payload.get("number"),
         "pr_url": pr.get("url") or payload.get("pr_url"),
         "comments": comments if comments else payload.get("comments", []),
+        "pagination": {
+            "truncated": bool(truncated_surfaces),
+            "truncated_surfaces": truncated_surfaces,
+            "limits": {
+                "comments_first": ISSUE_COMMENT_LIMIT,
+                "reviews_first": REVIEW_LIMIT,
+                "review_threads_first": REVIEW_THREAD_LIMIT,
+                "thread_comments_first": THREAD_COMMENT_LIMIT,
+            },
+            "rule": "When truncated is true, do not treat this packet as a complete review-comment delta.",
+        },
     }
+
+
+def _page_info(connection: Any) -> dict[str, Any]:
+    if not isinstance(connection, dict):
+        return {}
+    page_info = connection.get("pageInfo")
+    return page_info if isinstance(page_info, dict) else {}
 
 
 def _baseline_seen_urls(path: Path | None) -> set[str]:
@@ -234,6 +269,7 @@ def build_packet(payload: dict[str, Any], *, since: datetime | None = None, seen
     counts = {category: 0 for category in CATEGORIES}
     for item in items:
         counts[item["category"]] += 1
+    pagination = _as_pagination(normalized.get("pagination"))
     return {
         "kind": PACKET_KIND,
         "repository": normalized.get("repository") or "",
@@ -248,7 +284,8 @@ def build_packet(payload: dict[str, Any], *, since: datetime | None = None, seen
         "new_comment_count": len(items),
         "category_counts": counts,
         "items": items,
-        "smallest_next_action": _smallest_next_action(counts),
+        "pagination": pagination,
+        "smallest_next_action": _smallest_next_action(counts, pagination=pagination),
         "write_safety": {
             "github_writes_performed": False,
             "rule": "Do not reply, resolve, or submit reviews from this packet without explicit user approval.",
@@ -256,7 +293,30 @@ def build_packet(payload: dict[str, Any], *, since: datetime | None = None, seen
     }
 
 
-def _smallest_next_action(counts: dict[str, int]) -> str:
+def _as_pagination(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {
+            "truncated": False,
+            "truncated_surfaces": [],
+            "limits": {
+                "comments_first": ISSUE_COMMENT_LIMIT,
+                "reviews_first": REVIEW_LIMIT,
+                "review_threads_first": REVIEW_THREAD_LIMIT,
+                "thread_comments_first": THREAD_COMMENT_LIMIT,
+            },
+            "rule": "When truncated is true, do not treat this packet as a complete review-comment delta.",
+        }
+    return {
+        "truncated": bool(raw.get("truncated")),
+        "truncated_surfaces": [str(item) for item in raw.get("truncated_surfaces", []) if str(item)],
+        "limits": raw.get("limits") if isinstance(raw.get("limits"), dict) else {},
+        "rule": str(raw.get("rule") or "When truncated is true, do not treat this packet as a complete review-comment delta."),
+    }
+
+
+def _smallest_next_action(counts: dict[str, int], *, pagination: dict[str, Any] | None = None) -> str:
+    if pagination and pagination.get("truncated"):
+        return "Fetch complete paginated PR comments before treating this packet as complete."
     if counts["ambiguous_needs_human"]:
         return "Clarify ambiguous comments before editing or fetching broad patch context."
     if counts["actionable_code_doc_body_change"]:
@@ -277,13 +337,21 @@ query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
       url
-      comments(first: 100) { nodes { databaseId url body createdAt updatedAt author { login } } }
-      reviews(first: 100) { nodes { databaseId url body state submittedAt author { login } } }
+      comments(first: 100) {
+        nodes { databaseId url body createdAt updatedAt author { login } }
+        pageInfo { hasNextPage endCursor }
+      }
+      reviews(first: 100) {
+        nodes { databaseId url body state submittedAt author { login } }
+        pageInfo { hasNextPage endCursor }
+      }
       reviewThreads(first: 100) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           isResolved
           isOutdated
           comments(first: 20) {
+            pageInfo { hasNextPage endCursor }
             nodes {
               databaseId
               url

--- a/tests/test_pr_comment_delta.py
+++ b/tests/test_pr_comment_delta.py
@@ -131,11 +131,13 @@ def test_pr_comment_delta_normalizes_graphql_review_threads() -> None:
                     "comments": {"nodes": []},
                     "reviews": {"nodes": []},
                     "reviewThreads": {
+                        "pageInfo": {"hasNextPage": False},
                         "nodes": [
                             {
                                 "isResolved": False,
                                 "isOutdated": False,
                                 "comments": {
+                                    "pageInfo": {"hasNextPage": False},
                                     "nodes": [
                                         {
                                             "databaseId": 99,
@@ -147,10 +149,10 @@ def test_pr_comment_delta_normalizes_graphql_review_threads() -> None:
                                             "author": {"login": "reviewer"},
                                             "replyTo": None,
                                         }
-                                    ]
+                                    ],
                                 },
                             }
-                        ]
+                        ],
                     },
                 }
             }
@@ -165,6 +167,69 @@ def test_pr_comment_delta_normalizes_graphql_review_threads() -> None:
     assert item["category"] == "actionable_code_doc_body_change"
     assert item["path"] == "src/app.py"
     assert item["line"] == 12
+
+
+def test_pr_comment_delta_reports_graphql_truncation_boundaries() -> None:
+    module = _load_module()
+    payload = {
+        "repository": "rickardvh/agentic-workspace",
+        "pr_number": 43,
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "url": "https://github.com/rickardvh/agentic-workspace/pull/43",
+                    "comments": {
+                        "pageInfo": {"hasNextPage": True, "endCursor": "issue-cursor"},
+                        "nodes": [],
+                    },
+                    "reviews": {
+                        "pageInfo": {"hasNextPage": False},
+                        "nodes": [],
+                    },
+                    "reviewThreads": {
+                        "pageInfo": {"hasNextPage": True, "endCursor": "thread-cursor"},
+                        "nodes": [
+                            {
+                                "isResolved": False,
+                                "isOutdated": False,
+                                "comments": {
+                                    "pageInfo": {"hasNextPage": True, "endCursor": "comment-cursor"},
+                                    "nodes": [
+                                        {
+                                            "databaseId": 100,
+                                            "url": "https://example.test/pr#thread",
+                                            "body": "Please update this branch.",
+                                            "createdAt": "2026-06-23T11:00:00Z",
+                                            "path": "src/app.py",
+                                            "line": 12,
+                                            "author": {"login": "reviewer"},
+                                            "replyTo": None,
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                    },
+                }
+            }
+        },
+    }
+
+    packet = module.build_packet(payload)
+
+    assert packet["pagination"]["truncated"] is True
+    assert packet["pagination"]["truncated_surfaces"] == [
+        "comments",
+        "reviewThreads",
+        "reviewThreads[0].comments",
+    ]
+    assert packet["pagination"]["limits"] == {
+        "comments_first": 100,
+        "reviews_first": 100,
+        "review_threads_first": 100,
+        "thread_comments_first": 20,
+    }
+    assert packet["smallest_next_action"] == "Fetch complete paginated PR comments before treating this packet as complete."
 
 
 def test_pr_comment_delta_cli_reads_fixture(tmp_path: Path) -> None:
@@ -201,4 +266,5 @@ def test_pr_comment_delta_readme_keeps_live_workflow_discoverable() -> None:
     assert "agentic-workspace/pr-comment-delta/v1" in text
     assert "uv run python scripts/github/pr_comment_delta.py" in text
     assert "--baseline-json" in text
+    assert "pagination.truncated" in text
     assert "does not write to GitHub" in text


### PR DESCRIPTION
## Summary
- add explicit `pagination` metadata to `pr_comment_delta.py` packets, including GraphQL limits and truncated surfaces
- make truncation override `smallest_next_action` so agents do not treat an incomplete live fetch as complete
- request `pageInfo` for issue comments, reviews, review threads, and per-thread comments in the live GraphQL query
- document the truncation boundary in the GitHub helper README

## Validation
- `uv run pytest tests/test_pr_comment_delta.py -q`
- `uv run ruff check scripts/github/pr_comment_delta.py tests/test_pr_comment_delta.py`
- `make test-workspace`
- `make lint-workspace`

## Stack
- Continues #1680 / #1696.
- Addresses the #1713 review concern about silent live-fetch truncation by surfacing completeness metadata rather than silently emitting a confident no-delta packet.
- Stacked on #1720 (`codex/compact-clear-planning-gate`).