### PR TITLE
[codex] Test compact installed-state drift signal

### DIFF
--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -20603,7 +20603,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         projected["cli_compatibility"] = cli_compatibility
     installed_state = payload.get("installed_state_compatibility", {})
     if isinstance(installed_state, dict) and installed_state.get("status") not in {None, "", "compatible"}:
-        projected["installed_state_compatibility"] = installed_state
+        projected["installed_state_compatibility"] = _compact_startup_installed_state_signal(installed_state)
     sibling_freshness = payload.get("sibling_repo_aw_freshness", {})
     if isinstance(sibling_freshness, dict) and sibling_freshness.get("status") not in {None, "", "not-referenced"}:
         projected["sibling_repo_aw_freshness"] = sibling_freshness
@@ -20722,6 +20722,37 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         agent_judgment="Agent owns work-shape choice unless hard_blockers names a gate.",
     )
     return projected
+
+
+def _compact_startup_installed_state_signal(installed_state: dict[str, Any]) -> dict[str, Any]:
+    executable = _as_dict(installed_state.get("executable"))
+    payload = _as_dict(installed_state.get("payload"))
+    generated_artifacts = _as_dict(installed_state.get("generated_artifacts"))
+    compact = {
+        "kind": installed_state.get("kind", "agentic-workspace/installed-state-compatibility/v1"),
+        "status": installed_state.get("status", ""),
+        "reason": installed_state.get("reason", ""),
+        "authority": installed_state.get("authority", "repo-state-authoritative"),
+        "executable": {
+            key: executable.get(key)
+            for key in ("compatibility_status", "classification", "failed_checks")
+            if executable.get(key) not in (None, "", [])
+        },
+        "payload": {
+            key: payload.get(key)
+            for key in ("status", "provenance_drift", "stale_generated_surfaces")
+            if payload.get(key) not in (None, "", [])
+        },
+        "generated_artifacts": {
+            key: generated_artifacts.get(key) for key in ("status", "stale_surfaces") if generated_artifacts.get(key) not in (None, "", [])
+        },
+        "selector": "installed_state_compatibility",
+        "detail_command": "agentic-workspace start --target . --select installed_state_compatibility --format json",
+        "detail_visibility": "full executable, payload provenance, generated-artifact, and adapter details stay behind selector",
+    }
+    if installed_state.get("next_action"):
+        compact["next_action"] = installed_state.get("next_action")
+    return compact
 
 
 def _attach_start_router_fields(payload: dict[str, Any]) -> None:
@@ -21429,6 +21460,8 @@ def _start_payload(
         changed_paths=changed_paths,
         task_text=task_text,
     )
+    if installed_state_compatibility["status"] != "compatible":
+        payload["installed_state_compatibility"] = installed_state_compatibility
     if parent_intent_status.get("status") != "guidance-only":
         payload["parent_intent_status"] = parent_intent_status
     if applicable_intent_status.get("status") != "guidance-only":
@@ -21695,8 +21728,6 @@ def _start_payload(
     cli_compatibility = startup_cli_compatibility
     if cli_compatibility["configured"]:
         payload["cli_compatibility"] = cli_compatibility
-    if installed_state_compatibility["status"] != "compatible":
-        payload["installed_state_compatibility"] = installed_state_compatibility
     sibling_freshness = _sibling_repo_aw_freshness_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)
     if sibling_freshness["status"] != "not-referenced":
         payload["sibling_repo_aw_freshness"] = sibling_freshness
@@ -22612,6 +22643,13 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             else len(available_selectors)
         )
         available_selectors.insert(insert_at, "acceptance")
+    advisory_selectors = [
+        "skill_routing",
+        "workflow_sufficiency",
+        "memory_decision_packet",
+    ]
+    if isinstance(installed_state, dict) and installed_state.get("status") not in {None, "", "compatible"}:
+        advisory_selectors.append("installed_state_compatibility")
     selected: dict[str, Any] = {
         "kind": payload["kind"],
         "target": ".",
@@ -22624,11 +22662,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             proof_required=bool(next_safe_action.get("proof_required")),
             proof_commands=startup_proof_commands,
             changed_signals=startup_changed_signals,
-            advisory_selectors=[
-                "skill_routing",
-                "workflow_sufficiency",
-                "memory_decision_packet",
-            ],
+            advisory_selectors=advisory_selectors,
             agent_judgment="Agent owns work-shape choice unless hard_blockers names a gate.",
         ),
         "next_safe_action": next_safe_action,

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -416,6 +416,59 @@ def test_start_default_routes_memory_and_installed_state_detail_behind_selectors
     assert payload["context"]["memory"]["status"] in {"recommended", "not_checked"}
 
 
+def test_start_default_compacts_noncompatible_installed_state_signal(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (tmp_path / ".agentic-workspace" / "payload-provenance.json").write_text(
+        json.dumps({"kind": "wrong-kind"}),
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Shape a workflow issue",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert "installed_state_compatibility" not in payload
+    assert "installed_state_compatibility=payload-upgrade-required" in payload["action_signals"]["changed_signals"]
+    assert "installed_state_compatibility" in payload["action_signals"]["advisory_detail"]["selectors"]
+    assert "installed_state_compatibility" in payload["drill_down"]["available_selectors"]
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Shape a workflow issue",
+                "--select",
+                "installed_state_compatibility",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    selected = json.loads(capsys.readouterr().out)
+    full = selected["values"]["installed_state_compatibility"]
+    assert full["status"] == "payload-upgrade-required"
+    assert full["payload"]["provenance"]["status"] == "invalid"
+    assert full["adapter_contracts"]
+
+
 def test_start_default_stays_under_tiny_output_budget_for_docs_task(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0


### PR DESCRIPTION
## Summary
- add a startup regression for non-compatible installed-state posture
- assert default `start --format json` keeps full `installed_state_compatibility` detail out of the ordinary payload
- expose the drift through `action_signals.changed_signals` and `action_signals.advisory_detail.selectors`
- prove full installed-state detail remains recoverable through `--select installed_state_compatibility`

## Validation
- `uv run pytest tests/test_workspace_cli.py::test_start_default_routes_memory_and_installed_state_detail_behind_selectors tests/test_workspace_cli.py::test_start_default_compacts_noncompatible_installed_state_signal tests/test_workspace_cli.py::test_start_select_surfaces_installed_state_compatibility -q`
- `uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_cli.py`
- `make test-workspace`
- `make lint-workspace`

## Stack
- Continues #1680 / #1695.
- Addresses the #1709 review concern that non-compatible installed-state startup posture needs a compact default signal plus selector recovery.
- Stacked on #1721 (`codex/pr-comment-delta-truncation`).