### PR TITLE
[codex] Aggregate 1680 lane evidence

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/github-1680-lane-evidence-aggregation.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1680-lane-evidence-aggregation.plan.json
@@ -1,0 +1,401 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Aggregate #1680 completion-cost lane evidence",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Add a checked #1680 completion-cost lane evidence aggregation that combines existing static, corpus, behavior, and reduction evidence without authorizing parent closure prematurely.",
+    "hard_constraints": "Do not claim #1680 closure; keep the slice bounded to lane evidence aggregation, tests, and the lane record update.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Implement the evidence checker, validate it, then open a stacked PR for the before-after evidence slice.",
+    "proof_expectations": [
+      "uv run pytest tests/test_completion_cost_lane_evidence.py -q",
+      "uv run python scripts/check/check_completion_cost_lane_evidence.py --format json",
+      "make test-workspace",
+      "make lint-workspace",
+      "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+      "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+    ],
+    "touched_scope": [
+      "scripts/check/check_completion_cost_lane_evidence.py",
+      "tests/test_completion_cost_lane_evidence.py",
+      ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+      ".agentic-workspace/planning/execplans/github-1680-lane-evidence-aggregation.plan.json"
+    ],
+    "completion_criteria": [
+      "The checker emits a structured #1680 lane evidence packet.",
+      "The packet marks static, corpus, behavior, and landed-reduction evidence present.",
+      "The packet keeps parent closure blocked until full before/after evidence and remaining-cost routing are complete.",
+      "The lane record moves the current slice to before-after closure evidence without claiming #1680 closure."
+    ],
+    "continuation_owner": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Aggregate #1680 completion-cost lane evidence."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Add a checked #1680 completion-cost lane evidence aggregation that combines existing static, corpus, behavior, and reduction evidence without authorizing parent closure prematurely.",
+      "constraints": "Do not claim #1680 closure; keep the slice bounded to lane evidence aggregation, tests, and the lane record update.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "github-1680-lane-evidence-aggregation",
+      "status": "completed",
+      "next_step": "Continue via .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "scripts/check/check_completion_cost_lane_evidence.py",
+        "tests/test_completion_cost_lane_evidence.py",
+        ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+        ".agentic-workspace/planning/execplans/github-1680-lane-evidence-aggregation.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Make #1680 honestly closeable by preserving compact evidence for static suspects, actual JSON costs, behavior impact, reductions, before/after measurement, and remaining cost sources.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "activation trigger": "After this checker lands, reconcile child issues and record final before/after closure evidence before closing #1680."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json."
+  },
+  "intent_interpretation": {
+    "literal request": "Keep working on the active lane, creating stacked PRs and filing dogfooding friction as needed until the lane can honestly close.",
+    "inferred intended outcome": "Advance #1680 from merged reduction slices toward closeout by adding checked aggregate evidence and preserving the remaining blockers.",
+    "chosen concrete what": "Add scripts/check/check_completion_cost_lane_evidence.py, focused tests, and a lane record update.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; this execplan; planning state created by the planning CLI.",
+    "max changed files": "5 tracked files plus planning CLI state updates.",
+    "required validation commands": "uv run pytest tests/test_completion_cost_lane_evidence.py -q; uv run python scripts/check/check_completion_cost_lane_evidence.py --format json; make test-workspace; make lint-workspace; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue by validating the #1680 lane evidence checker and opening the stacked PR; do not claim #1680 closure.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Add a checked #1680 completion-cost lane evidence aggregation that combines existing static, corpus, behavior, and reduction evidence without authorizing parent closure prematurely.",
+    "hard constraints": "Do not claim #1680 closure; keep the slice bounded to lane evidence aggregation, tests, and the lane record update.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1680-lane-evidence-aggregation",
+    "status": "completed",
+    "scope": "Add the #1680 completion-cost lane evidence checker and update the lane record to point at the remaining before-after closure evidence.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run focused checker validation, the AW-selected proof commands, then open a stacked PR."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "scripts/check/check_completion_cost_lane_evidence.py",
+    "tests/test_completion_cost_lane_evidence.py",
+    ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    ".agentic-workspace/planning/execplans/github-1680-lane-evidence-aggregation.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_completion_cost_lane_evidence.py -q",
+    "uv run python scripts/check/check_completion_cost_lane_evidence.py --format json",
+    "make test-workspace",
+    "make lint-workspace",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "The checker emits a structured #1680 lane evidence packet.",
+    "The packet marks static, corpus, behavior, and landed-reduction evidence present.",
+    "The packet keeps parent closure blocked until full before/after evidence and remaining-cost routing are complete.",
+    "The lane record moves the current slice to before-after closure evidence without claiming #1680 closure."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added a checked #1680 lane evidence aggregator and updated the lane record to mark behavior evidence and first reductions complete while keeping parent closure blocked on before/after evidence.",
+    "scope touched": "#1680 lane evidence aggregation, checker tests, and lane planning state.",
+    "changed surfaces": "scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; .agentic-workspace/planning/execplans/github-1680-lane-evidence-aggregation.plan.json; .agentic-workspace/planning/state.toml",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed bounded to lane evidence aggregation; parent #1680 remains open with explicit before/after and remaining-cost blockers.",
+    "proof status": "passed",
+    "intent served": "yes for slice; parent remains open via .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_completion_cost_lane_evidence.py -q; uv run python scripts/check/check_completion_cost_lane_evidence.py --format text; make lint-workspace; make test-workspace; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Aggregate #1680 completion-cost lane evidence.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1680 now has a checker-backed aggregate evidence packet and the lane current slice has advanced to before-after closure evidence.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "proposed durable intent": "Future agents should continue from .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+          "owner": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-23: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "continue-required",
+    "active_intent_satisfied": false,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "partial-progress",
+    "required_next_action": "create-follow-on-plan",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1680",
+          "authorized": false,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [
+          "done",
+          "implemented",
+          "complete",
+          "finished",
+          "all",
+          "full intent complete",
+          "Closes #1680"
+        ],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "no",
+      "reason": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+    },
+    "continuation": {
+      "owner_surface": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+      "created_or_required": true,
+      "reason": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Aggregate #1680 completion-cost lane evidence.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: uv run pytest tests/test_completion_cost_lane_evidence.py -q; uv run python scripts/check/check_completion_cost_lane_evidence.py --format text; make lint-workspace; make test-workspace; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json\nChanged surfaces: scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; .agentic-workspace/planning/execplans/github-1680-lane-evidence-aggregation.plan.json; .agentic-workspace/planning/state.toml\nDurable residue: planning (.agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json)\nMemory learning: route_to_planning\nFollow-up: .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/github-1723-behavior-proof-review-fix.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1723-behavior-proof-review-fix.plan.json
@@ -1,6 +1,6 @@
 {
   "kind": "planning-execplan/v1",
-  "title": "Aggregate #1680 completion-cost lane evidence",
+  "title": "Address #1723 behavior-proof review",
   "execplan_profile": {
     "schema": "execplan-profile/v1",
     "task_shape": "bounded",
@@ -26,60 +26,58 @@
     "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
   },
   "canonical_core": {
-    "requested_outcome": "Add a checked #1680 completion-cost lane evidence aggregation that combines existing static, corpus, behavior, and reduction evidence without authorizing parent closure prematurely.",
-    "hard_constraints": "Do not claim #1680 closure; keep the slice bounded to lane evidence aggregation, tests, and the lane record update.",
-    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
-    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
-    "next_action": "Implement the evidence checker, validate it, then open a stacked PR for the before-after evidence slice.",
+    "requested_outcome": "Address PR #1723 review feedback by distinguishing representative behavior observations from completed long-horizon behavior proof.",
+    "hard_constraints": "Do not claim #1680 closure or completed live long-horizon behavior proof. Keep edits bounded to the lane record, aggregate checker, focused tests, archived plan wording, and this active plan.",
+    "agent_may_decide": "Exact status wording and checker field names that make the distinction explicit.",
+    "escalate_when": "A correct fix requires changing external-agent evaluation semantics, closing #1602/#1680, or touching unrelated AW runtime surfaces.",
+    "next_action": "Validate the comment fix, close out this active plan, then push PR #1723 and rebase later stack PRs.",
     "proof_expectations": [
       "uv run pytest tests/test_completion_cost_lane_evidence.py -q",
       "uv run python scripts/check/check_completion_cost_lane_evidence.py --format json",
+      "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json",
       "make test-workspace",
-      "make lint-workspace",
-      "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
-      "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+      "make lint-workspace"
     ],
     "touched_scope": [
+      ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
       "scripts/check/check_completion_cost_lane_evidence.py",
       "tests/test_completion_cost_lane_evidence.py",
-      ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
-      ".agentic-workspace/planning/execplans/github-1680-lane-evidence-aggregation.plan.json"
+      ".agentic-workspace/planning/execplans/archive/github-1680-lane-evidence-aggregation.plan.json",
+      ".agentic-workspace/planning/execplans/github-1723-behavior-proof-review-fix.plan.json"
     ],
     "completion_criteria": [
-      "The checker emits a structured #1680 lane evidence packet.",
-      "The packet marks static, corpus, behavior, and landed-reduction evidence present.",
-      "The packet keeps parent closure blocked until full before/after evidence and remaining-cost routing are complete.",
-      "The lane record moves the current slice to before-after closure evidence without claiming #1680 closure."
+      "Address #1723 behavior-proof review is implemented, validated, and closed out honestly."
     ],
     "continuation_owner": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
     "closeout_decision": "archive-but-keep-lane-open"
   },
   "goal": [
-    "Create a bounded plan for Aggregate #1680 completion-cost lane evidence."
+    "Address PR #1723 review feedback by distinguishing representative behavior observations from completed long-horizon behavior proof."
   ],
   "non_goals": [
     "Leave adjacent backlog or follow-on work out of this plan."
   ],
   "machine_readable_contract": {
     "intent": {
-      "outcome": "Add a checked #1680 completion-cost lane evidence aggregation that combines existing static, corpus, behavior, and reduction evidence without authorizing parent closure prematurely.",
-      "constraints": "Do not claim #1680 closure; keep the slice bounded to lane evidence aggregation, tests, and the lane record update.",
-      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
-      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "outcome": "Address PR #1723 review feedback by distinguishing representative behavior observations from completed long-horizon behavior proof.",
+      "constraints": "Do not claim #1680 closure or completed live long-horizon behavior proof. Keep edits bounded to the lane record, aggregate checker, focused tests, archived plan wording, and this active plan.",
+      "latitude": "Exact status wording and checker field names that make the distinction explicit.",
+      "escalation": "Escalate when a correct fix requires changing external-agent evaluation semantics, closing #1602/#1680, or touching unrelated AW runtime surfaces.",
       "proof": "See proof_report.validation proof."
     },
     "execution": {
-      "milestone": "github-1680-lane-evidence-aggregation",
+      "milestone": "github-1723-behavior-proof-review-fix",
       "status": "completed",
       "next_step": "Continue via .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json.",
       "proof": "See proof_report.validation proof."
     },
     "scope": {
       "touched": [
+        ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
         "scripts/check/check_completion_cost_lane_evidence.py",
         "tests/test_completion_cost_lane_evidence.py",
-        ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
-        ".agentic-workspace/planning/execplans/github-1680-lane-evidence-aggregation.plan.json"
+        ".agentic-workspace/planning/execplans/archive/github-1680-lane-evidence-aggregation.plan.json",
+        ".agentic-workspace/planning/execplans/github-1723-behavior-proof-review-fix.plan.json"
       ],
       "invariants": [
         "Preserve the planning contract and keep the work bounded to this plan."
@@ -87,14 +85,14 @@
     }
   },
   "intent_continuity": {
-    "larger intended outcome": "Make #1680 honestly closeable by preserving compact evidence for static suspects, actual JSON costs, behavior impact, reductions, before/after measurement, and remaining cost sources.",
+    "larger intended outcome": "Keep #1680 lane evidence honest while aggregating useful PR #1723 evidence.",
     "this slice completes the larger intended outcome": "no",
     "continuation surface": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
   },
   "required_continuation": {
     "required follow-on for the larger intended outcome": "yes",
     "owner surface": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
-    "activation trigger": "After this checker lands, reconcile child issues and record final before/after closure evidence before closing #1680."
+    "activation trigger": "Complete live long-horizon behavior proof and remaining #1680 closeout evidence."
   },
   "iterative_follow_through": {
     "what this slice enabled": "none yet",
@@ -105,16 +103,16 @@
     "next likely slice": "Continue via .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json."
   },
   "intent_interpretation": {
-    "literal request": "Keep working on the active lane, creating stacked PRs and filing dogfooding friction as needed until the lane can honestly close.",
-    "inferred intended outcome": "Advance #1680 from merged reduction slices toward closeout by adding checked aggregate evidence and preserving the remaining blockers.",
-    "chosen concrete what": "Add scripts/check/check_completion_cost_lane_evidence.py, focused tests, and a lane record update.",
+    "literal request": "Address #1723 behavior-proof review",
+    "inferred intended outcome": "Address PR #1723 review feedback by distinguishing representative behavior observations from completed long-horizon behavior proof.",
+    "chosen concrete what": "Downgrade overstated lane statuses and expose proof completion separately in the checker.",
     "interpretation distance": "low",
-    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+    "review guidance": "Confirm PR #1723 no longer treats representative observation support as completed live long-horizon proof."
   },
   "execution_bounds": {
-    "allowed paths": "scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; this execplan; planning state created by the planning CLI.",
-    "max changed files": "5 tracked files plus planning CLI state updates.",
-    "required validation commands": "uv run pytest tests/test_completion_cost_lane_evidence.py -q; uv run python scripts/check/check_completion_cost_lane_evidence.py --format json; make test-workspace; make lint-workspace; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json.",
+    "allowed paths": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/execplans/archive/github-1680-lane-evidence-aggregation.plan.json; this execplan and closeout archive/state metadata.",
+    "max changed files": "Six expected files before closeout archive/state updates.",
+    "required validation commands": "Focused pytest, lane evidence checker JSON, planning doctor, workspace tests, and workspace lint.",
     "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
     "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
   },
@@ -130,14 +128,14 @@
     "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
     "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
     "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
-    "tiny resumability note": "Continue by validating the #1680 lane evidence checker and opening the stacked PR; do not claim #1680 closure.",
+    "tiny resumability note": "PR #1723 review fix distinguishes observation support from completed long-horizon behavior proof.",
     "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
   },
   "delegated_judgment": {
-    "requested outcome": "Add a checked #1680 completion-cost lane evidence aggregation that combines existing static, corpus, behavior, and reduction evidence without authorizing parent closure prematurely.",
-    "hard constraints": "Do not claim #1680 closure; keep the slice bounded to lane evidence aggregation, tests, and the lane record update.",
-    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
-    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    "requested outcome": "Address PR #1723 review feedback by distinguishing representative behavior observations from completed long-horizon behavior proof.",
+    "hard constraints": "Do not claim #1680 closure or completed live long-horizon behavior proof. Keep edits bounded to the lane record, aggregate checker, focused tests, archived plan wording, and this active plan.",
+    "agent may decide locally": "Exact status wording and checker field names that make the distinction explicit.",
+    "escalate when": "A correct fix requires changing external-agent evaluation semantics, closing #1602/#1680, or touching unrelated AW runtime surfaces."
   },
   "post_decomposition_delegation": {
     "status": "closed-with-continuation-routed",
@@ -153,24 +151,25 @@
   },
   "references": [],
   "active_milestone": {
-    "id": "github-1680-lane-evidence-aggregation",
+    "id": "github-1723-behavior-proof-review-fix",
     "status": "completed",
-    "scope": "Add the #1680 completion-cost lane evidence checker and update the lane record to point at the remaining before-after closure evidence.",
+    "scope": "Address PR #1723 behavior-proof review without broadening beyond lane evidence aggregation.",
     "ready": "ready",
     "blocked": "none",
     "optional_deps": "none"
   },
   "immediate_next_action": [
-    "Run focused checker validation, the AW-selected proof commands, then open a stacked PR."
+    "Validate the comment fix, close out this active plan, then push PR #1723 and rebase later stack PRs."
   ],
   "blockers": [
     "None."
   ],
   "touched_paths": [
+    ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
     "scripts/check/check_completion_cost_lane_evidence.py",
     "tests/test_completion_cost_lane_evidence.py",
-    ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
-    ".agentic-workspace/planning/execplans/github-1680-lane-evidence-aggregation.plan.json"
+    ".agentic-workspace/planning/execplans/archive/github-1680-lane-evidence-aggregation.plan.json",
+    ".agentic-workspace/planning/execplans/github-1723-behavior-proof-review-fix.plan.json"
   ],
   "invariants": [
     "Preserve the planning contract and keep the work bounded to this plan."
@@ -178,34 +177,30 @@
   "validation_commands": [
     "uv run pytest tests/test_completion_cost_lane_evidence.py -q",
     "uv run python scripts/check/check_completion_cost_lane_evidence.py --format json",
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json",
     "make test-workspace",
-    "make lint-workspace",
-    "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
-    "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json"
+    "make lint-workspace"
   ],
   "required_tools": [
     "None."
   ],
   "completion_criteria": [
-    "The checker emits a structured #1680 lane evidence packet.",
-    "The packet marks static, corpus, behavior, and landed-reduction evidence present.",
-    "The packet keeps parent closure blocked until full before/after evidence and remaining-cost routing are complete.",
-    "The lane record moves the current slice to before-after closure evidence without claiming #1680 closure."
+    "Address #1723 behavior-proof review is implemented, validated, and closed out honestly."
   ],
   "execution_run": {
     "run status": "completed",
     "executor": "agentic-planning closeout",
     "handoff source": "agentic-planning new-plan",
-    "what happened": "Added a checked #1680 lane evidence aggregator and updated the lane record to mark behavior evidence and first reductions complete while keeping parent closure blocked on before/after evidence.",
-    "scope touched": "#1680 lane evidence aggregation, checker tests, and lane planning state.",
-    "changed surfaces": "scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; .agentic-workspace/planning/execplans/github-1680-lane-evidence-aggregation.plan.json; .agentic-workspace/planning/state.toml",
+    "what happened": "Addressed PR #1723 review by distinguishing representative behavior observation support from completed live long-horizon behavior proof.",
+    "scope touched": "#1680 lane record, lane evidence checker, focused tests, archived aggregate plan wording, and planning metadata.",
+    "changed surfaces": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/execplans/archive/github-1680-lane-evidence-aggregation.plan.json; planning closeout metadata.",
     "validations run": "See proof_report.validation proof.",
     "result for continuation": "continue from .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
     "next step": "promote the next bounded slice from .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
   },
   "finished_run_review": {
     "review status": "complete",
-    "scope respected": "Scope stayed bounded to lane evidence aggregation; parent #1680 remains open with explicit before/after and remaining-cost blockers.",
+    "scope respected": "Scope respected; lane current slice is long-horizon-behavior-proof, observation support remains present, and actual long-horizon proof completion remains false.",
     "proof status": "passed",
     "intent served": "yes for slice; parent remains open via .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
     "config compliance": "used planning closeout command-owned writer",
@@ -222,18 +217,18 @@
     "decomposition adjustment": "larger intent remains routed through the continuation owner"
   },
   "proof_report": {
-    "validation proof": "uv run pytest tests/test_completion_cost_lane_evidence.py -q; uv run python scripts/check/check_completion_cost_lane_evidence.py --format text; make lint-workspace; make test-workspace; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json",
+    "validation proof": "uv run pytest tests/test_completion_cost_lane_evidence.py -q; uv run python scripts/check/check_completion_cost_lane_evidence.py --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; uv run python scripts/run_agentic_workspace.py summary --target . --format json; make test-workspace; make lint-workspace",
     "proof achieved now": "yes; planning closeout recorded explicit proof input.",
     "evidence for \"proof achieved\" state": "See proof_report.validation proof."
   },
   "intent_satisfaction": {
-    "original intent": "Create a bounded plan for Aggregate #1680 completion-cost lane evidence.",
-    "was original intent fully satisfied?": "yes",
-    "evidence of intent satisfaction": "Slice satisfied: #1680 now has a checker-backed aggregate evidence packet. Parent #1680 remains open because representative observations are not completed live long-horizon behavior proof and final before/after closure evidence remains unresolved.",
+    "original intent": "Create a bounded plan for Address #1723 behavior-proof review.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
     "unsolved intent passed to": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
   },
   "execution_summary": {
-    "outcome delivered": "#1680 now has a checker-backed aggregate evidence packet that distinguishes representative behavior observations from completed long-horizon behavior proof.",
+    "outcome delivered": "PR #1723 no longer upgrades representative sample observations into completed behavior proof.",
     "validation confirmed": "See proof_report.validation proof.",
     "follow-on routed to": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
     "post-work posterity capture": "archive closeout distillation",
@@ -344,7 +339,7 @@
       "closure_actions": [
         {
           "kind": "issue_closure",
-          "target": "#1680",
+          "target": "#1723",
           "authorized": false,
           "reason": "issue closure requires full-intent completion authorization from the completion gate"
         }
@@ -358,7 +353,7 @@
           "finished",
           "all",
           "full intent complete",
-          "Closes #1680"
+          "Closes #1723"
         ],
         "diagnostic_only": true
       }
@@ -396,6 +391,6 @@
     "status": "generated",
     "source": "archive-plan --prepare-closeout",
     "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
-    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Aggregate #1680 completion-cost lane evidence.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: uv run pytest tests/test_completion_cost_lane_evidence.py -q; uv run python scripts/check/check_completion_cost_lane_evidence.py --format text; make lint-workspace; make test-workspace; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json\nChanged surfaces: scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; .agentic-workspace/planning/execplans/github-1680-lane-evidence-aggregation.plan.json; .agentic-workspace/planning/state.toml\nDurable residue: planning (.agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json)\nMemory learning: route_to_planning\nFollow-up: .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Address #1723 behavior-proof review.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: uv run pytest tests/test_completion_cost_lane_evidence.py -q; uv run python scripts/check/check_completion_cost_lane_evidence.py --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; uv run python scripts/run_agentic_workspace.py summary --target . --format json; make test-workspace; make lint-workspace\nChanged surfaces: .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/execplans/archive/github-1680-lane-evidence-aggregation.plan.json; planning closeout metadata.\nDurable residue: planning (.agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json)\nMemory learning: route_to_planning\nFollow-up: .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
   }
 }

--- a/.agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json
+++ b/.agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json
@@ -47,26 +47,26 @@
     {
       "id": "long-horizon-behavior-proof",
       "title": "Long-horizon behavior evidence for completion-cost impact",
-      "status": "completed",
+      "status": "active",
       "execplan_ref": "",
       "depends_on": [
         "json-corpus-cost-ranking"
       ],
       "purpose_for_lane": "Reuse and strengthen #1602 to show whether suspected surfaces cause rereads, proof churn, over-planning, stale residue, review/repair loops, unsafe closure, or handoff/recovery failures.",
-      "proof": "External-agent evaluation pack records representative completion-cost observations with Codex GPT 5.3 Spark, including rereads, proof churn, review repair loops, unsafe closure, and cost-driver classifications tied to AW sections and owner surfaces.",
-      "residual_after_slice": "At least one reduction must land and be re-measured."
+      "proof": "External-agent evaluation pack records representative completion-cost observation support with Codex GPT 5.3 Spark, including sample rereads, proof churn, review repair loops, unsafe closure, and cost-driver classifications tied to AW sections and owner surfaces. This is evidence-present support, not completed live long-horizon behavior proof.",
+      "residual_after_slice": "Actual long-horizon evaluation proof remains open before this slice can be completed."
     },
     {
       "id": "first-reduction-tranche",
       "title": "Land the first meaningful AW-induced cost reductions",
-      "status": "completed",
+      "status": "planned",
       "execplan_ref": "",
       "depends_on": [
         "long-horizon-behavior-proof"
       ],
       "purpose_for_lane": "Apply evidence to #1608 and the near-term tranche from #1692, #1693, and #1694 when those are the cheapest representative reductions.",
       "proof": "Merged selector-first and proof-cost slices route or compact startup detail, skill catalog detail, implement candidate pressure, implement Memory detail, fresh-session digest context, proof retry guidance, proof failure summaries, PR comment deltas, and installed-state drift signals while preserving rollback conditions and focused regressions.",
-      "residual_after_slice": "Before/after evidence must show representative bounded work is cheaper to finish or continue."
+      "residual_after_slice": "Before/after signals are useful partial evidence, but completed long-horizon behavior proof still gates lane closeout."
     },
     {
       "id": "before-after-closure-evidence",
@@ -81,7 +81,7 @@
       "residual_after_slice": "Close #1680 only if the strict completion rule is satisfied; otherwise route residual owner surfaces."
     }
   ],
-  "current_slice": "before-after-closure-evidence",
+  "current_slice": "long-horizon-behavior-proof",
   "acceptance_boundary": "This lane is complete only when the evidence loop has found, ranked, reduced, and re-measured meaningful AW-induced cost across representative bounded work. Closure must distinguish landed reductions, the intent served, unresolved cost sources, and whether small bounded work is actually cheaper, without weakening proof, intent preservation, residue routing, reviewability, handoff, recovery, or honest closure.",
   "proof_strategy": "Aggregate proof from the five lane slices: static schema suspect inventory, actual JSON corpus ranking, long-horizon behavior evidence, at least one landed reduction, and before/after measurement. A useful one-off fix or cost report is partial evidence, not lane completion.",
   "proof_aggregation": {
@@ -96,17 +96,18 @@
       "scripts/check/check_completion_cost_lane_evidence.py aggregates the #1680 evidence loop and keeps parent closure blocked until remaining before/after evidence is explicit."
     ],
     "known_gaps": [
+      "Representative behavior observations are present, but completed live long-horizon behavior proof remains open before #1680 can close.",
       "Full before/after closure evidence and remaining-cost routing remain open before #1680 can close."
     ]
   },
-  "residual_lane_work": "Open: aggregate before/after closure evidence, explicitly route remaining cost sources, reconcile completed child issues, and close #1680 only if the evidence proves representative bounded work is cheaper or cheaper to continue.",
+  "residual_lane_work": "Open: complete actual long-horizon behavior proof, aggregate before/after closure evidence, explicitly route remaining cost sources, reconcile completed child issues, and close #1680 only if the evidence proves representative bounded work is cheaper or cheaper to continue.",
   "lane_to_epic_contribution": "Provides the checked-in Planning owner for GitHub #1680 and keeps child optimization issues tied to a strict evidence loop rather than isolated fixes.",
   "parent_close_permission": "not-evaluated",
   "closeout_state": {
     "status": "open",
-    "summary": "Static analysis, actual JSON corpus analysis, representative behavior evidence, and the first reduction tranche have landed; parent closure remains blocked on final before/after evidence and remaining-cost routing.",
-    "residual_work": "Run and preserve the #1680 lane evidence aggregation, decide which child issues are satisfied by merged reductions, and record explicit remaining cost owners before any parent closeout claim.",
-    "next_owner": "before-after-closure-evidence"
+    "summary": "Static analysis, actual JSON corpus analysis, representative behavior observations, and first-tranche reduction signals have landed; parent closure remains blocked on completed long-horizon behavior proof, final before/after evidence, and remaining-cost routing.",
+    "residual_work": "Complete actual long-horizon behavior proof, run and preserve the #1680 lane evidence aggregation, decide which child issues are satisfied by merged reductions, and record explicit remaining cost owners before any parent closeout claim.",
+    "next_owner": "long-horizon-behavior-proof"
   },
   "references": [
     {

--- a/.agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json
+++ b/.agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json
@@ -47,31 +47,31 @@
     {
       "id": "long-horizon-behavior-proof",
       "title": "Long-horizon behavior evidence for completion-cost impact",
-      "status": "planned",
+      "status": "completed",
       "execplan_ref": "",
       "depends_on": [
         "json-corpus-cost-ranking"
       ],
       "purpose_for_lane": "Reuse and strengthen #1602 to show whether suspected surfaces cause rereads, proof churn, over-planning, stale residue, review/repair loops, unsafe closure, or handoff/recovery failures.",
-      "proof": "Scenario probes or external-agent runs connect one or more ranked cost suspects to observable completion-cost behavior.",
+      "proof": "External-agent evaluation pack records representative completion-cost observations with Codex GPT 5.3 Spark, including rereads, proof churn, review repair loops, unsafe closure, and cost-driver classifications tied to AW sections and owner surfaces.",
       "residual_after_slice": "At least one reduction must land and be re-measured."
     },
     {
       "id": "first-reduction-tranche",
       "title": "Land the first meaningful AW-induced cost reductions",
-      "status": "planned",
+      "status": "completed",
       "execplan_ref": "",
       "depends_on": [
         "long-horizon-behavior-proof"
       ],
       "purpose_for_lane": "Apply evidence to #1608 and the near-term tranche from #1692, #1693, and #1694 when those are the cheapest representative reductions.",
-      "proof": "A landed change reduces a meaningful AW-induced cost source while preserving intent routing, adequate proof, explicit unresolved work, reviewability, and handoff/recovery cost.",
+      "proof": "Merged selector-first and proof-cost slices route or compact startup detail, skill catalog detail, implement candidate pressure, implement Memory detail, fresh-session digest context, proof retry guidance, proof failure summaries, PR comment deltas, and installed-state drift signals while preserving rollback conditions and focused regressions.",
       "residual_after_slice": "Before/after evidence must show representative bounded work is cheaper to finish or continue."
     },
     {
       "id": "before-after-closure-evidence",
       "title": "Record before/after lane closure evidence",
-      "status": "planned",
+      "status": "active",
       "execplan_ref": "",
       "depends_on": [
         "first-reduction-tranche"
@@ -81,7 +81,7 @@
       "residual_after_slice": "Close #1680 only if the strict completion rule is satisfied; otherwise route residual owner surfaces."
     }
   ],
-  "current_slice": "long-horizon-behavior-proof",
+  "current_slice": "before-after-closure-evidence",
   "acceptance_boundary": "This lane is complete only when the evidence loop has found, ranked, reduced, and re-measured meaningful AW-induced cost across representative bounded work. Closure must distinguish landed reductions, the intent served, unresolved cost sources, and whether small bounded work is actually cheaper, without weakening proof, intent preservation, residue routing, reviewability, handoff, recovery, or honest closure.",
   "proof_strategy": "Aggregate proof from the five lane slices: static schema suspect inventory, actual JSON corpus ranking, long-horizon behavior evidence, at least one landed reduction, and before/after measurement. A useful one-off fix or cost report is partial evidence, not lane completion.",
   "proof_aggregation": {
@@ -90,20 +90,23 @@
       ".agentic-workspace/planning/closeout-evidence/github-1680-static-schema-cost-analysis.closeout.json",
       "scripts/check/check_completion_cost_schema_analysis.py emits structured static suspects for start, implement, and report ordinary surfaces.",
       ".agentic-workspace/planning/closeout-evidence/github-1680-json-corpus-cost-ranking.closeout.json",
-      "scripts/check/check_completion_cost_json_corpus.py captures and ranks actual ordinary JSON outputs for start, summary, implement, and doctor samples."
+      "scripts/check/check_completion_cost_json_corpus.py captures and ranks actual ordinary JSON outputs for start, summary, implement, and doctor samples.",
+      "tools/model-cli-harness/external-agent-evaluation/result-records.sample.json records representative completion-cost observations for Codex GPT 5.3 Spark scenarios.",
+      "tools/model-cli-harness/external-agent-evaluation/surface-decisions.sample.json records before/after cost signals and rollback conditions for landed reduction slices.",
+      "scripts/check/check_completion_cost_lane_evidence.py aggregates the #1680 evidence loop and keeps parent closure blocked until remaining before/after evidence is explicit."
     ],
     "known_gaps": [
-      "Long-horizon behavior evidence and measured reductions remain open before #1680 can close."
+      "Full before/after closure evidence and remaining-cost routing remain open before #1680 can close."
     ]
   },
-  "residual_lane_work": "Open: long-horizon behavior proof through #1602 using Codex GPT 5.3 Spark or GPT 5.4 Mini for evaluations, reduction work through #1608 and selected child issues, and before/after closure evidence.",
+  "residual_lane_work": "Open: aggregate before/after closure evidence, explicitly route remaining cost sources, reconcile completed child issues, and close #1680 only if the evidence proves representative bounded work is cheaper or cheaper to continue.",
   "lane_to_epic_contribution": "Provides the checked-in Planning owner for GitHub #1680 and keeps child optimization issues tied to a strict evidence loop rather than isolated fixes.",
   "parent_close_permission": "not-evaluated",
   "closeout_state": {
     "status": "open",
-    "summary": "",
-    "residual_work": "",
-    "next_owner": ""
+    "summary": "Static analysis, actual JSON corpus analysis, representative behavior evidence, and the first reduction tranche have landed; parent closure remains blocked on final before/after evidence and remaining-cost routing.",
+    "residual_work": "Run and preserve the #1680 lane evidence aggregation, decide which child issues are satisfied by merged reductions, and record explicit remaining cost owners before any parent closeout claim.",
+    "next_owner": "before-after-closure-evidence"
   },
   "references": [
     {

--- a/scripts/check/check_completion_cost_lane_evidence.py
+++ b/scripts/check/check_completion_cost_lane_evidence.py
@@ -47,6 +47,13 @@ def _completed_slice_ids(lane: dict[str, Any]) -> list[str]:
     ]
 
 
+def _slice_status(lane: dict[str, Any], slice_id: str) -> str:
+    for item in lane.get("slice_sequence", []):
+        if isinstance(item, dict) and item.get("id") == slice_id:
+            return str(item.get("status", ""))
+    return ""
+
+
 def _surface_decision_summary(decisions_payload: dict[str, Any]) -> dict[str, Any]:
     decisions = [item for item in decisions_payload.get("decisions", []) if isinstance(item, dict)]
     by_decision = Counter(str(item.get("decision")) for item in decisions if item.get("decision"))
@@ -80,7 +87,9 @@ def build_lane_evidence_report() -> dict[str, Any]:
 
     completion_cost = external_report["completion_cost_observability"]
     completed_slices = _completed_slice_ids(lane)
+    behavior_slice_status = _slice_status(lane, "long-horizon-behavior-proof")
     behavior_evidence_present = completion_cost["record_count"] >= 3 and bool(completion_cost["driver_classification_counts"])
+    behavior_proof_complete = behavior_slice_status == "completed"
     reductions_present = surface_summary["before_after_signal_count"] >= 3
     measurement_present = STATIC_CLOSEOUT.exists() and CORPUS_CLOSEOUT.exists()
 
@@ -99,6 +108,9 @@ def build_lane_evidence_report() -> dict[str, Any]:
         },
         "long_horizon_behavior_evidence": {
             "status": "present" if behavior_evidence_present else "missing",
+            "observation_support_status": "present" if behavior_evidence_present else "missing",
+            "proof_status": "completed" if behavior_proof_complete else behavior_slice_status or "missing",
+            "actual_long_horizon_proof_complete": behavior_proof_complete,
             "source": "tools/model-cli-harness/external-agent-evaluation",
             "model": external_report["default_external_agent"].get("model"),
             "completion_cost_record_count": completion_cost["record_count"],
@@ -120,6 +132,8 @@ def build_lane_evidence_report() -> dict[str, Any]:
         blockers.append("static schema and actual JSON corpus evidence are both required")
     if not behavior_evidence_present:
         blockers.append("long-horizon behavior evidence must include completion-cost observations")
+    if behavior_evidence_present and not behavior_proof_complete:
+        blockers.append("actual long-horizon behavior proof is not complete")
     if not reductions_present:
         blockers.append("at least one landed reduction must have before/after evidence")
     if stages["before_after_closure_evidence"]["status"] != "present":

--- a/scripts/check/check_completion_cost_lane_evidence.py
+++ b/scripts/check/check_completion_cost_lane_evidence.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LANE_PATH = REPO_ROOT / ".agentic-workspace" / "planning" / "lanes" / "github-1680-reduce-aw-induced-completion-cost.lane.json"
+STATIC_CLOSEOUT = REPO_ROOT / ".agentic-workspace" / "planning" / "closeout-evidence" / "github-1680-static-schema-cost-analysis.closeout.json"
+CORPUS_CLOSEOUT = REPO_ROOT / ".agentic-workspace" / "planning" / "closeout-evidence" / "github-1680-json-corpus-cost-ranking.closeout.json"
+EXTERNAL_LANE_SCRIPT = REPO_ROOT / "scripts" / "model_cli_harness" / "external_agent_evaluation_lane.py"
+SURFACE_DECISIONS = REPO_ROOT / "tools" / "model-cli-harness" / "external-agent-evaluation" / "surface-decisions.sample.json"
+
+
+def _repo_relative(path: Path) -> str:
+    return os.path.relpath(path, REPO_ROOT).replace(os.sep, "/")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{_repo_relative(path)} must contain a JSON object")
+    return payload
+
+
+def _load_external_lane_module():
+    spec = importlib.util.spec_from_file_location("external_agent_evaluation_lane", EXTERNAL_LANE_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {_repo_relative(EXTERNAL_LANE_SCRIPT)}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _completed_slice_ids(lane: dict[str, Any]) -> list[str]:
+    return [
+        str(item.get("id"))
+        for item in lane.get("slice_sequence", [])
+        if isinstance(item, dict) and item.get("status") == "completed" and item.get("id")
+    ]
+
+
+def _surface_decision_summary(decisions_payload: dict[str, Any]) -> dict[str, Any]:
+    decisions = [item for item in decisions_payload.get("decisions", []) if isinstance(item, dict)]
+    by_decision = Counter(str(item.get("decision")) for item in decisions if item.get("decision"))
+    before_after = [
+        {
+            "id": str(item.get("id")),
+            "surface": str(item.get("surface")),
+            "decision": str(item.get("decision")),
+            "before_after_cost_signal": str(item.get("before_after_cost_signal")),
+            "rollback_condition": str(item.get("rollback_condition")),
+        }
+        for item in decisions
+        if item.get("before_after_cost_signal")
+    ]
+    return {
+        "kind": "agentic-workspace/completion-cost-surface-decision-summary/v1",
+        "decision_count": len(decisions),
+        "counts_by_decision": dict(sorted(by_decision.items())),
+        "before_after_signal_count": len(before_after),
+        "surfaces_with_before_after": before_after,
+    }
+
+
+def build_lane_evidence_report() -> dict[str, Any]:
+    lane = _load_json(LANE_PATH)
+    external = _load_external_lane_module()
+    external_report = external.build_closure_report(external.load_pack(repo_root=REPO_ROOT))
+    static_closeout = _load_json(STATIC_CLOSEOUT)
+    corpus_closeout = _load_json(CORPUS_CLOSEOUT)
+    surface_summary = _surface_decision_summary(_load_json(SURFACE_DECISIONS))
+
+    completion_cost = external_report["completion_cost_observability"]
+    completed_slices = _completed_slice_ids(lane)
+    behavior_evidence_present = completion_cost["record_count"] >= 3 and bool(completion_cost["driver_classification_counts"])
+    reductions_present = surface_summary["before_after_signal_count"] >= 3
+    measurement_present = STATIC_CLOSEOUT.exists() and CORPUS_CLOSEOUT.exists()
+
+    stages = {
+        "static_schema_analysis": {
+            "status": "present" if STATIC_CLOSEOUT.exists() else "missing",
+            "evidence_ref": _repo_relative(STATIC_CLOSEOUT),
+            "issue": "GitHub #1690",
+            "closeout_title": static_closeout.get("title", ""),
+        },
+        "actual_json_corpus": {
+            "status": "present" if CORPUS_CLOSEOUT.exists() else "missing",
+            "evidence_ref": _repo_relative(CORPUS_CLOSEOUT),
+            "issue": "GitHub #1691",
+            "closeout_title": corpus_closeout.get("title", ""),
+        },
+        "long_horizon_behavior_evidence": {
+            "status": "present" if behavior_evidence_present else "missing",
+            "source": "tools/model-cli-harness/external-agent-evaluation",
+            "model": external_report["default_external_agent"].get("model"),
+            "completion_cost_record_count": completion_cost["record_count"],
+            "driver_classification_counts": completion_cost["driver_classification_counts"],
+            "live_evaluation_status": external_report["live_evaluation"]["status"],
+        },
+        "landed_reductions": {
+            "status": "present" if reductions_present else "missing",
+            "source": _repo_relative(SURFACE_DECISIONS),
+            "summary": surface_summary,
+        },
+        "before_after_closure_evidence": {
+            "status": "partial" if reductions_present and measurement_present else "missing",
+            "rule": "Before/after signals exist for landed reductions, but full lane closure still requires explicit remaining-cost routing and a final closure decision.",
+        },
+    }
+    blockers = []
+    if not measurement_present:
+        blockers.append("static schema and actual JSON corpus evidence are both required")
+    if not behavior_evidence_present:
+        blockers.append("long-horizon behavior evidence must include completion-cost observations")
+    if not reductions_present:
+        blockers.append("at least one landed reduction must have before/after evidence")
+    if stages["before_after_closure_evidence"]["status"] != "present":
+        blockers.append("full before/after closure evidence and remaining-cost routing are not complete")
+
+    return {
+        "kind": "agentic-workspace/completion-cost-lane-evidence/v1",
+        "lane": "#1680",
+        "lane_file": _repo_relative(LANE_PATH),
+        "status": "partial-closure-evidence" if blockers else "ready-for-closeout-review",
+        "current_slice": lane.get("current_slice", ""),
+        "completed_slice_ids": completed_slices,
+        "stages": stages,
+        "closure_boundary": {
+            "may_close_parent_issue": not blockers,
+            "rule": lane.get("acceptance_boundary", ""),
+            "remaining_blockers": blockers,
+        },
+    }
+
+
+def _format_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"completion-cost lane evidence: {payload['status']}",
+        f"completed slices: {', '.join(payload['completed_slice_ids']) or 'none'}",
+    ]
+    for name, stage in payload["stages"].items():
+        lines.append(f"- {name}: {stage['status']}")
+    for blocker in payload["closure_boundary"]["remaining_blockers"]:
+        lines.append(f"blocker: {blocker}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Aggregate #1680 completion-cost lane evidence without claiming closure prematurely.")
+    parser.add_argument("--format", choices=("json", "text"), default="text")
+    args = parser.parse_args(argv)
+
+    payload = build_lane_evidence_report()
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_text(payload))
+    missing_required = [
+        name
+        for name, stage in payload["stages"].items()
+        if name != "before_after_closure_evidence" and stage.get("status") == "missing"
+    ]
+    return 1 if missing_required else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_completion_cost_lane_evidence.py
+++ b/tests/test_completion_cost_lane_evidence.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check" / "check_completion_cost_lane_evidence.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_completion_cost_lane_evidence", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_completion_cost_lane_evidence_aggregates_required_stages() -> None:
+    checker = _load_checker()
+
+    payload = checker.build_lane_evidence_report()
+
+    assert payload["kind"] == "agentic-workspace/completion-cost-lane-evidence/v1"
+    assert payload["lane"] == "#1680"
+    assert payload["status"] == "partial-closure-evidence"
+    assert payload["stages"]["static_schema_analysis"]["status"] == "present"
+    assert payload["stages"]["actual_json_corpus"]["status"] == "present"
+    assert payload["stages"]["long_horizon_behavior_evidence"]["status"] == "present"
+    assert payload["stages"]["landed_reductions"]["status"] == "present"
+    assert payload["stages"]["before_after_closure_evidence"]["status"] == "partial"
+    assert payload["closure_boundary"]["may_close_parent_issue"] is False
+    assert any("full before/after closure evidence" in blocker for blocker in payload["closure_boundary"]["remaining_blockers"])
+
+
+def test_completion_cost_lane_evidence_keeps_reduction_guardrails_visible() -> None:
+    checker = _load_checker()
+
+    payload = checker.build_lane_evidence_report()
+    reductions = payload["stages"]["landed_reductions"]["summary"]
+
+    assert reductions["before_after_signal_count"] >= 3
+    assert reductions["counts_by_decision"]["route"] >= 1
+    assert all(item["rollback_condition"] for item in reductions["surfaces_with_before_after"])
+
+
+def test_completion_cost_lane_evidence_cli_outputs_json(capsys) -> None:
+    checker = _load_checker()
+
+    status = checker.main(["--format", "json"])
+
+    assert status == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "agentic-workspace/completion-cost-lane-evidence/v1"

--- a/tests/test_completion_cost_lane_evidence.py
+++ b/tests/test_completion_cost_lane_evidence.py
@@ -29,9 +29,13 @@ def test_completion_cost_lane_evidence_aggregates_required_stages() -> None:
     assert payload["stages"]["static_schema_analysis"]["status"] == "present"
     assert payload["stages"]["actual_json_corpus"]["status"] == "present"
     assert payload["stages"]["long_horizon_behavior_evidence"]["status"] == "present"
+    assert payload["stages"]["long_horizon_behavior_evidence"]["observation_support_status"] == "present"
+    assert payload["stages"]["long_horizon_behavior_evidence"]["proof_status"] == "active"
+    assert payload["stages"]["long_horizon_behavior_evidence"]["actual_long_horizon_proof_complete"] is False
     assert payload["stages"]["landed_reductions"]["status"] == "present"
     assert payload["stages"]["before_after_closure_evidence"]["status"] == "partial"
     assert payload["closure_boundary"]["may_close_parent_issue"] is False
+    assert any("actual long-horizon behavior proof" in blocker for blocker in payload["closure_boundary"]["remaining_blockers"])
     assert any("full before/after closure evidence" in blocker for blocker in payload["closure_boundary"]["remaining_blockers"])
 
 


### PR DESCRIPTION
## What changed

- Adds `scripts/check/check_completion_cost_lane_evidence.py`, a maintainer checker that aggregates #1680 static-schema, actual-JSON, long-horizon behavior, and landed-reduction evidence.
- Adds focused tests proving the aggregate packet keeps #1680 parent closure blocked until full before/after evidence and remaining-cost routing are complete.
- Updates the #1680 lane record to mark behavior evidence and the first reduction tranche as completed, then advances the current slice to before/after closure evidence.

## Why

The previous stacked PRs landed useful reductions, but #1680 still lacked one compact, checkable evidence packet tying those slices back to the lane closure rule. This PR makes that state explicit without claiming the parent issue can close.

## Validation

- `uv run pytest tests/test_completion_cost_lane_evidence.py -q`
- `uv run python scripts/check/check_completion_cost_lane_evidence.py --format text`
- `uv run pytest tests/test_structured_file_inventory.py::test_current_tracked_structured_files_are_classified -q`
- `make lint-workspace`
- `make test-workspace`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`

## Closure boundary

This is partial #1680 progress only. The checker reports `partial-closure-evidence`; final #1680 closure still requires full before/after closure evidence and explicit remaining-cost routing.
