### PR TITLE
[codex] Record 1680 before-after closure evidence

### DIFF
--- a/.agentic-workspace/planning/closeout-evidence/github-1680-before-after-closure-evidence.closeout.json
+++ b/.agentic-workspace/planning/closeout-evidence/github-1680-before-after-closure-evidence.closeout.json
@@ -1,0 +1,53 @@
+{
+  "kind": "planning-closeout-evidence/v1",
+  "title": "Before/after closure evidence for #1680 completion-cost lane",
+  "plan_id": "github-1680-before-after-closure-evidence",
+  "created_at": "2026-06-23T15:40:00+00:00",
+  "source_plan": ".agentic-workspace/planning/execplans/github-1680-before-after-closure-evidence.plan.json",
+  "intended_archive": ".agentic-workspace/planning/execplans/archive/github-1680-before-after-closure-evidence.plan.json",
+  "retention": {
+    "state": "evidence-retained",
+    "reason": "retained evidence summarizes #1680 before/after and remaining-cost routing without replaying the full PR stack",
+    "canonical_evidence": "retained closeout evidence",
+    "ordinary_route": "uv run python scripts/check/check_completion_cost_lane_evidence.py --format json",
+    "trust_rule": "Use this record as the #1680 closeout-readiness input; it does not authorize parent closure by itself.",
+    "rule": "Retained closeout evidence preserves reportable closeout facts for lane-level continuation."
+  },
+  "active_milestone": {
+    "id": "github-1680-before-after-closure-evidence",
+    "status": "active",
+    "scope": "Record compact before/after evidence and remaining-cost routing for #1680.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "closure_check": {
+    "closeout scope": "lane-progress",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "parent_close_permission": "not-granted",
+    "before_after_evidence_status": "recorded",
+    "baseline_evidence": ".agentic-workspace/planning/closeout-evidence/github-1680-static-schema-cost-analysis.closeout.json; .agentic-workspace/planning/closeout-evidence/github-1680-json-corpus-cost-ranking.closeout.json; docs/reviews/aw-completion-cost-session-log-analysis-2026-06-23.md",
+    "behavior_evidence": "tools/model-cli-harness/external-agent-evaluation/result-records.sample.json; tools/model-cli-harness/external-agent-evaluation/live-results-2026-06-18.json",
+    "landed_reduction_evidence": "tools/model-cli-harness/external-agent-evaluation/surface-decisions.sample.json; scripts/check/check_completion_cost_lane_evidence.py",
+    "measured_improvement_count": "3",
+    "measured_improvements": "start.skills.catalog breakdown; implement.context.planning_safety_gate.candidate_pressure observed detail; implement.memory_decision_packet",
+    "child_issue_reconciliation_status": "partial",
+    "satisfied_pending_close_count": "5",
+    "satisfied_by_merged_prs_pending_issue_close": "#1692 via PR #1716/#1720; #1693 via PR #1718; #1694 via PR #1717; #1695 via PR #1709/#1710/#1711/#1712/#1719/#1720/#1722; #1696 via PR #1713/#1714/#1721",
+    "remaining_cost_source_count": "4",
+    "remaining_open_cost_sources": "#1697 workspace runtime editing; #1698 operator guidance; #1700-#1704 local checkpoint experiment; #1706 planning workflow friction",
+    "why this decision is honest": "Before/after evidence is now compact and checkable, but remaining child issues and cost sources are not fully reconciled and parent closure is not yet proven.",
+    "evidence carried forward": "scripts/check/check_completion_cost_lane_evidence.py reads this record and reports remaining blockers.",
+    "reopen trigger": "Reopen when child issue state or additional measurements change the parent closeout decision."
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Before/after evidence must distinguish measured reductions from unresolved cost owners and child issue state.",
+    "motivation worth preserving": "Future #1680 closeout should use this compact record instead of replaying the full PR stack.",
+    "canonical owner now": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "promotion trigger": "When all remaining open cost sources are either fixed, intentionally out of scope, or routed to non-blocking follow-up owners.",
+    "retention after promotion": "retain"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/github-1680-before-after-closure-evidence.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1680-before-after-closure-evidence.plan.json
@@ -1,0 +1,398 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Record #1680 before-after closure evidence",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Add retained before/after #1680 closeout evidence and checker integration without closing the parent issue.",
+    "hard_constraints": "Keep scope bounded to retained evidence, the #1680 lane evidence checker, focused tests, and the lane record. Do not claim #1680 closure.",
+    "agent_may_decide": "Exact JSON field names, focused assertion shape, lane wording, and validation breadth.",
+    "escalate_when": "A correct fix requires changing the #1680 lane acceptance boundary, closing child issues, or changing unrelated AW output contracts.",
+    "next_action": "Wire the retained before/after evidence into the checker, tests, and lane record; then validate and close out this plan.",
+    "proof_expectations": [
+      "uv run pytest tests/test_completion_cost_lane_evidence.py -q",
+      "uv run python scripts/check/check_completion_cost_lane_evidence.py --format json",
+      "make test-workspace",
+      "make lint-workspace",
+      "uv run python scripts/run_agentic_workspace.py summary --format json",
+      "uv run python scripts/run_agentic_workspace.py planning doctor --target . --format json"
+    ],
+    "touched_scope": [
+      ".agentic-workspace/planning/closeout-evidence/github-1680-before-after-closure-evidence.closeout.json",
+      "scripts/check/check_completion_cost_lane_evidence.py",
+      "tests/test_completion_cost_lane_evidence.py",
+      ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+      ".agentic-workspace/planning/execplans/github-1680-before-after-closure-evidence.plan.json"
+    ],
+    "completion_criteria": [
+      "Record #1680 before-after closure evidence is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Add retained before/after #1680 closeout evidence and checker integration without closing the parent issue."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Add retained before/after #1680 closeout evidence and checker integration without closing the parent issue.",
+      "constraints": "Keep scope bounded to retained evidence, the #1680 lane evidence checker, focused tests, and the lane record. Do not claim #1680 closure.",
+      "latitude": "Exact JSON field names, focused assertion shape, lane wording, and validation breadth.",
+      "escalation": "Escalate when a correct fix requires changing the #1680 lane acceptance boundary, closing child issues, or changing unrelated AW output contracts.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "github-1680-before-after-closure-evidence",
+      "status": "completed",
+      "next_step": "Continue via .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        ".agentic-workspace/planning/closeout-evidence/github-1680-before-after-closure-evidence.closeout.json",
+        "scripts/check/check_completion_cost_lane_evidence.py",
+        "tests/test_completion_cost_lane_evidence.py",
+        ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+        ".agentic-workspace/planning/execplans/github-1680-before-after-closure-evidence.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Reduce AW-induced completion cost for #1680 through measured, evidence-backed reductions and honest closure.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "activation trigger": "Child issue reconciliation and remaining-cost owner decisions before #1680 closeout."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json."
+  },
+  "intent_interpretation": {
+    "literal request": "Record #1680 before-after closure evidence",
+    "inferred intended outcome": "Add retained before/after #1680 closeout evidence and checker integration without closing the parent issue.",
+    "chosen concrete what": "Wire retained before/after evidence into the checker, tests, and lane record.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the checker reports before/after evidence as present while keeping parent close permission blocked."
+  },
+  "execution_bounds": {
+    "allowed paths": ".agentic-workspace/planning/closeout-evidence/github-1680-before-after-closure-evidence.closeout.json; scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; this execplan and closeout archive/state metadata.",
+    "max changed files": "Seven expected files before closeout archive/state updates.",
+    "required validation commands": "Focused pytest, lane evidence checker JSON, make test-workspace, make lint-workspace, summary, and planning doctor.",
+    "ask-before-refactor threshold": "Ask before broadening beyond retained evidence, the lane evidence checker, focused tests, lane record, or planning metadata.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Retained before/after closeout evidence must be checkable and must not authorize #1680 closure.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Add retained before/after #1680 closeout evidence and checker integration without closing the parent issue.",
+    "hard constraints": "Keep scope bounded to retained evidence, the #1680 lane evidence checker, focused tests, and the lane record. Do not claim #1680 closure.",
+    "agent may decide locally": "Exact JSON field names, focused assertion shape, lane wording, and validation breadth.",
+    "escalate when": "A correct fix requires changing the #1680 lane acceptance boundary, closing child issues, or changing unrelated AW output contracts."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1680-before-after-closure-evidence",
+    "status": "completed",
+    "scope": "Retain compact #1680 before/after closeout evidence and integrate it into the lane evidence checker without closing the parent issue.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Wire the retained before/after evidence into the checker, tests, and lane record; then validate and close out this plan."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    ".agentic-workspace/planning/closeout-evidence/github-1680-before-after-closure-evidence.closeout.json",
+    "scripts/check/check_completion_cost_lane_evidence.py",
+    "tests/test_completion_cost_lane_evidence.py",
+    ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    ".agentic-workspace/planning/execplans/github-1680-before-after-closure-evidence.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_completion_cost_lane_evidence.py -q",
+    "uv run python scripts/check/check_completion_cost_lane_evidence.py --format json",
+    "make test-workspace",
+    "make lint-workspace",
+    "uv run python scripts/run_agentic_workspace.py summary --format json",
+    "uv run python scripts/run_agentic_workspace.py planning doctor --target . --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Record #1680 before-after closure evidence is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added retained #1680 before/after closeout evidence and taught the lane evidence checker to report it as present while keeping parent closure blocked.",
+    "scope touched": "#1680 retained closeout evidence, lane evidence checker, focused tests, lane record, and planning metadata.",
+    "changed surfaces": ".agentic-workspace/planning/closeout-evidence/github-1680-before-after-closure-evidence.closeout.json; scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; planning closeout metadata.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope respected; checker reports before/after evidence present and parent close permission not granted; #1680 remains open for child issue reconciliation and remaining-cost owner decisions.",
+    "proof status": "passed",
+    "intent served": "yes for slice; parent remains open via .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_completion_cost_lane_evidence.py -q; uv run python scripts/check/check_completion_cost_lane_evidence.py --format json; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make test-workspace; make lint-workspace",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Add retained before/after #1680 closeout evidence and checker integration without closing the parent issue.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+  },
+  "execution_summary": {
+    "outcome delivered": "Compact before/after closure evidence is retained and checkable; parent #1680 closeout remains blocked honestly.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "proposed durable intent": "Future agents should continue from .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+          "owner": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-23: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "continue-required",
+    "active_intent_satisfied": false,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "partial-progress",
+    "required_next_action": "create-follow-on-plan",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1680",
+          "authorized": false,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [
+          "done",
+          "implemented",
+          "complete",
+          "finished",
+          "all",
+          "full intent complete",
+          "Closes #1680"
+        ],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "no",
+      "reason": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+    },
+    "continuation": {
+      "owner_surface": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json",
+      "created_or_required": true,
+      "reason": ".agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Add retained before/after #1680 closeout evidence and checker integration without closing the parent issue.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: uv run pytest tests/test_completion_cost_lane_evidence.py -q; uv run python scripts/check/check_completion_cost_lane_evidence.py --format json; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make test-workspace; make lint-workspace\nChanged surfaces: .agentic-workspace/planning/closeout-evidence/github-1680-before-after-closure-evidence.closeout.json; scripts/check/check_completion_cost_lane_evidence.py; tests/test_completion_cost_lane_evidence.py; .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json; planning closeout metadata.\nDurable residue: planning (.agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json)\nMemory learning: route_to_planning\nFollow-up: .agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
+  }
+}

--- a/.agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json
+++ b/.agentic-workspace/planning/lanes/github-1680-reduce-aw-induced-completion-cost.lane.json
@@ -93,20 +93,21 @@
       "scripts/check/check_completion_cost_json_corpus.py captures and ranks actual ordinary JSON outputs for start, summary, implement, and doctor samples.",
       "tools/model-cli-harness/external-agent-evaluation/result-records.sample.json records representative completion-cost observations for Codex GPT 5.3 Spark scenarios.",
       "tools/model-cli-harness/external-agent-evaluation/surface-decisions.sample.json records before/after cost signals and rollback conditions for landed reduction slices.",
+      ".agentic-workspace/planning/closeout-evidence/github-1680-before-after-closure-evidence.closeout.json records compact before/after evidence, child issue reconciliation, remaining cost sources, and the blocked parent close permission.",
       "scripts/check/check_completion_cost_lane_evidence.py aggregates the #1680 evidence loop and keeps parent closure blocked until remaining before/after evidence is explicit."
     ],
     "known_gaps": [
       "Representative behavior observations are present, but completed live long-horizon behavior proof remains open before #1680 can close.",
-      "Full before/after closure evidence and remaining-cost routing remain open before #1680 can close."
+      "Child issue reconciliation and remaining-cost owner decisions remain open before #1680 can close."
     ]
   },
-  "residual_lane_work": "Open: complete actual long-horizon behavior proof, aggregate before/after closure evidence, explicitly route remaining cost sources, reconcile completed child issues, and close #1680 only if the evidence proves representative bounded work is cheaper or cheaper to continue.",
+  "residual_lane_work": "Open: complete actual long-horizon behavior proof, reconcile completed child issues (#1692-#1696), decide whether #1697/#1698/#1700-#1706 remain blockers or routed follow-ups, and close #1680 only if evidence proves representative bounded work is cheaper or cheaper to continue without weakening proof, intent preservation, residue routing, reviewability, handoff, recovery, or honest closure.",
   "lane_to_epic_contribution": "Provides the checked-in Planning owner for GitHub #1680 and keeps child optimization issues tied to a strict evidence loop rather than isolated fixes.",
   "parent_close_permission": "not-evaluated",
   "closeout_state": {
     "status": "open",
-    "summary": "Static analysis, actual JSON corpus analysis, representative behavior observations, and first-tranche reduction signals have landed; parent closure remains blocked on completed long-horizon behavior proof, final before/after evidence, and remaining-cost routing.",
-    "residual_work": "Complete actual long-horizon behavior proof, run and preserve the #1680 lane evidence aggregation, decide which child issues are satisfied by merged reductions, and record explicit remaining cost owners before any parent closeout claim.",
+    "summary": "Static analysis, actual JSON corpus analysis, representative behavior observations, first-tranche reduction signals, and compact before/after closeout evidence have landed; parent closure remains blocked on completed long-horizon behavior proof, child issue reconciliation, and remaining-cost owner decisions.",
+    "residual_work": "Complete actual long-horizon behavior proof, reconcile completed child issues (#1692-#1696), decide whether #1697/#1698/#1700-#1706 remain blockers or routed follow-ups, and require explicit parent close permission before any #1680 closeout claim.",
     "next_owner": "long-horizon-behavior-proof"
   },
   "references": [

--- a/scripts/check/check_completion_cost_lane_evidence.py
+++ b/scripts/check/check_completion_cost_lane_evidence.py
@@ -15,6 +15,13 @@ STATIC_CLOSEOUT = REPO_ROOT / ".agentic-workspace" / "planning" / "closeout-evid
 CORPUS_CLOSEOUT = REPO_ROOT / ".agentic-workspace" / "planning" / "closeout-evidence" / "github-1680-json-corpus-cost-ranking.closeout.json"
 EXTERNAL_LANE_SCRIPT = REPO_ROOT / "scripts" / "model_cli_harness" / "external_agent_evaluation_lane.py"
 SURFACE_DECISIONS = REPO_ROOT / "tools" / "model-cli-harness" / "external-agent-evaluation" / "surface-decisions.sample.json"
+BEFORE_AFTER_CLOSEOUT = (
+    REPO_ROOT
+    / ".agentic-workspace"
+    / "planning"
+    / "closeout-evidence"
+    / "github-1680-before-after-closure-evidence.closeout.json"
+)
 
 
 def _repo_relative(path: Path) -> str:
@@ -77,6 +84,35 @@ def _surface_decision_summary(decisions_payload: dict[str, Any]) -> dict[str, An
     }
 
 
+def _before_after_closeout_summary(closeout: dict[str, Any] | None) -> dict[str, Any]:
+    if closeout is None:
+        return {
+            "status": "missing",
+            "evidence_ref": _repo_relative(BEFORE_AFTER_CLOSEOUT),
+            "rule": "Before/after signals exist for landed reductions, but retained closeout evidence is not present.",
+        }
+
+    closure_check = closeout.get("closure_check", {})
+    measured_count = int(str(closure_check.get("measured_improvement_count", "0") or "0"))
+    satisfied_count = int(str(closure_check.get("satisfied_pending_close_count", "0") or "0"))
+    remaining_count = int(str(closure_check.get("remaining_cost_source_count", "0") or "0"))
+    recorded = closure_check.get("before_after_evidence_status") == "recorded"
+
+    return {
+        "status": "present" if recorded else "partial",
+        "evidence_ref": _repo_relative(BEFORE_AFTER_CLOSEOUT),
+        "measured_improvement_count": measured_count,
+        "child_issue_reconciliation": {
+            "status": closure_check.get("child_issue_reconciliation_status", ""),
+            "satisfied_pending_close_count": satisfied_count,
+            "remaining_cost_source_count": remaining_count,
+        },
+        "parent_close_permission": closure_check.get("parent_close_permission", ""),
+        "closure_decision": closure_check.get("closure decision", ""),
+        "rule": "Retained before/after closeout evidence is present; parent closure still depends on explicit close permission and remaining-cost routing.",
+    }
+
+
 def build_lane_evidence_report() -> dict[str, Any]:
     lane = _load_json(LANE_PATH)
     external = _load_external_lane_module()
@@ -84,6 +120,8 @@ def build_lane_evidence_report() -> dict[str, Any]:
     static_closeout = _load_json(STATIC_CLOSEOUT)
     corpus_closeout = _load_json(CORPUS_CLOSEOUT)
     surface_summary = _surface_decision_summary(_load_json(SURFACE_DECISIONS))
+    before_after_closeout = _load_json(BEFORE_AFTER_CLOSEOUT) if BEFORE_AFTER_CLOSEOUT.exists() else None
+    before_after_summary = _before_after_closeout_summary(before_after_closeout)
 
     completion_cost = external_report["completion_cost_observability"]
     completed_slices = _completed_slice_ids(lane)
@@ -122,10 +160,7 @@ def build_lane_evidence_report() -> dict[str, Any]:
             "source": _repo_relative(SURFACE_DECISIONS),
             "summary": surface_summary,
         },
-        "before_after_closure_evidence": {
-            "status": "partial" if reductions_present and measurement_present else "missing",
-            "rule": "Before/after signals exist for landed reductions, but full lane closure still requires explicit remaining-cost routing and a final closure decision.",
-        },
+        "before_after_closure_evidence": before_after_summary,
     }
     blockers = []
     if not measurement_present:
@@ -138,6 +173,10 @@ def build_lane_evidence_report() -> dict[str, Any]:
         blockers.append("at least one landed reduction must have before/after evidence")
     if stages["before_after_closure_evidence"]["status"] != "present":
         blockers.append("full before/after closure evidence and remaining-cost routing are not complete")
+    elif stages["before_after_closure_evidence"]["parent_close_permission"] != "granted":
+        blockers.append("parent close permission is not granted")
+        if stages["before_after_closure_evidence"]["child_issue_reconciliation"]["remaining_cost_source_count"]:
+            blockers.append("remaining cost sources are not fully reconciled")
 
     return {
         "kind": "agentic-workspace/completion-cost-lane-evidence/v1",

--- a/tests/test_completion_cost_lane_evidence.py
+++ b/tests/test_completion_cost_lane_evidence.py
@@ -33,10 +33,18 @@ def test_completion_cost_lane_evidence_aggregates_required_stages() -> None:
     assert payload["stages"]["long_horizon_behavior_evidence"]["proof_status"] == "active"
     assert payload["stages"]["long_horizon_behavior_evidence"]["actual_long_horizon_proof_complete"] is False
     assert payload["stages"]["landed_reductions"]["status"] == "present"
-    assert payload["stages"]["before_after_closure_evidence"]["status"] == "partial"
+    before_after = payload["stages"]["before_after_closure_evidence"]
+    assert before_after["status"] == "present"
+    assert (
+        before_after["evidence_ref"]
+        == ".agentic-workspace/planning/closeout-evidence/github-1680-before-after-closure-evidence.closeout.json"
+    )
+    assert before_after["measured_improvement_count"] >= 3
+    assert before_after["child_issue_reconciliation"]["status"] == "partial"
+    assert before_after["child_issue_reconciliation"]["remaining_cost_source_count"] >= 1
     assert payload["closure_boundary"]["may_close_parent_issue"] is False
     assert any("actual long-horizon behavior proof" in blocker for blocker in payload["closure_boundary"]["remaining_blockers"])
-    assert any("full before/after closure evidence" in blocker for blocker in payload["closure_boundary"]["remaining_blockers"])
+    assert any("parent close permission is not granted" in blocker for blocker in payload["closure_boundary"]["remaining_blockers"])
 
 
 def test_completion_cost_lane_evidence_keeps_reduction_guardrails_visible() -> None:


### PR DESCRIPTION
## Summary

Records compact retained before/after closeout evidence for the #1680 completion-cost lane and wires it into the lane evidence checker.

The checker now reports before/after closure evidence as present while keeping parent #1680 closure blocked until child issue reconciliation and remaining-cost owner decisions are resolved.

## Validation

- `uv run pytest tests/test_completion_cost_lane_evidence.py -q`
- `uv run python scripts/check/check_completion_cost_lane_evidence.py --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `make test-workspace`
- `make lint-workspace`