### PR TITLE
[codex] Guard external agent local path leaks

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/github-1680-local-path-leak-guard.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1680-local-path-leak-guard.plan.json
@@ -1,0 +1,388 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Guard external-agent local path leaks",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Advance #1680 live-behavior proof by addressing #1616: make external-agent local absolute scratch path leaks visible, classified, routed, and covered by replay-style regression tests.",
+    "hard_constraints": "Keep scope bounded to harness prompt/scoring, external evaluation evidence validation, tests, and lane evidence wording needed for #1616. Do not claim #1680 closure or completed live long-horizon proof without a clean allowed-model live run.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Patch harness local-path leak scoring and external-evidence validation, then run focused and workspace validation.",
+    "proof_expectations": [
+      "uv run pytest tests/test_external_agent_evaluation_lane.py tests/test_completion_cost_live_behavior_proof.py -q",
+      "uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate --format json",
+      "uv run python scripts/check/check_completion_cost_live_behavior_proof.py --format json"
+    ],
+    "touched_scope": [
+      "scripts/model_cli_harness/run_model_cli_harness.py",
+      "scripts/model_cli_harness/external_agent_evaluation_lane.py",
+      "tools/model-cli-harness/external-agent-evaluation/*.json",
+      "tests/test_external_agent_evaluation_lane.py",
+      ".agentic-workspace/planning/execplans/github-1680-local-path-leak-guard.plan.json"
+    ],
+    "completion_criteria": [
+      "Local absolute path leaks in final closeout text produce a distinct harness warning with owner/remediation metadata.",
+      "External-agent evidence validates that live local path leak records are classified and routed to #1616.",
+      "Regression tests replay the observed leak shape and prove repo-relative paths remain allowed.",
+      "#1680 remains honestly open unless live proof is clean."
+    ],
+    "continuation_owner": "planning",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Guard external-agent local path leaks."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Advance #1680 live-behavior proof by addressing #1616: make external-agent local absolute scratch path leaks visible, classified, routed, and covered by replay-style regression tests.",
+      "constraints": "Keep scope bounded to harness prompt/scoring, external evaluation evidence validation, tests, and lane evidence wording needed for #1616. Do not claim #1680 closure or completed live long-horizon proof without a clean allowed-model live run.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "github-1680-local-path-leak-guard",
+      "status": "completed",
+      "next_step": "Continue via planning.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "scripts/model_cli_harness/run_model_cli_harness.py",
+        "scripts/model_cli_harness/external_agent_evaluation_lane.py",
+        "tools/model-cli-harness/external-agent-evaluation/*.json",
+        "tests/test_external_agent_evaluation_lane.py",
+        ".agentic-workspace/planning/execplans/github-1680-local-path-leak-guard.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Keep working on #1680 until the lane can be honestly closed.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "planning"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "planning",
+    "activation trigger": "After this slice, rerun or refresh allowed-model live behavior proof and reconcile remaining #1680 closeout blockers."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via planning."
+  },
+  "intent_interpretation": {
+    "literal request": "Continue active #1680 lane work.",
+    "inferred intended outcome": "Address the routed live-behavior proof blocker #1616 without overstating #1680 closure.",
+    "chosen concrete what": "Make local absolute scratch path leaks distinct, validated, and regression-covered in the external-agent evaluation path.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the change satisfies #1616 acceptance while preserving repo-relative evidence in final answers."
+  },
+  "execution_bounds": {
+    "allowed paths": "Harness scoring, external-agent lane validator/reporting, external-agent evidence JSON, focused tests, and this execplan.",
+    "max changed files": "About 6 files; ask or split before touching unrelated AW runtime surfaces.",
+    "required validation commands": "uv run pytest tests/test_external_agent_evaluation_lane.py tests/test_completion_cost_live_behavior_proof.py -q; uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate --format json; uv run python scripts/check/check_completion_cost_live_behavior_proof.py --format json",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Implement #1616 local-path leak guard in model CLI harness scoring and external-agent lane validation.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Advance #1680 live-behavior proof by addressing #1616 local path leak remediation.",
+    "hard constraints": "Do not claim #1680 closure; keep scope to harness/evaluation/test evidence for local path leaks.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1680-local-path-leak-guard",
+    "status": "completed",
+    "scope": "Guard external-agent local absolute path leaks in final closeout scoring and evidence validation.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Patch harness scoring and external-agent validation, then run focused proof."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "scripts/model_cli_harness/run_model_cli_harness.py",
+    "scripts/model_cli_harness/external_agent_evaluation_lane.py",
+    "tools/model-cli-harness/external-agent-evaluation/scorecard-taxonomy.json",
+    "tools/model-cli-harness/external-agent-evaluation/live-results-2026-06-18.json",
+    "tests/test_external_agent_evaluation_lane.py",
+    ".agentic-workspace/planning/execplans/github-1680-local-path-leak-guard.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_external_agent_evaluation_lane.py tests/test_completion_cost_live_behavior_proof.py -q",
+    "uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate --format json",
+    "uv run python scripts/check/check_completion_cost_live_behavior_proof.py --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Guard external-agent local path leaks is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented #1616 local path leak guard for external-agent evaluation: distinct harness warning, specific failure id, routed live evidence packet, and replay-style regression tests.",
+    "scope touched": "model CLI harness scoring, external-agent lane validation/reporting evidence, live result/promotion evidence, focused tests, and this planning slice.",
+    "changed surfaces": "scripts/model_cli_harness/run_model_cli_harness.py; scripts/model_cli_harness/external_agent_evaluation_lane.py; tools/model-cli-harness/external-agent-evaluation/scorecard-taxonomy.json; tools/model-cli-harness/external-agent-evaluation/live-results-2026-06-18.json; tools/model-cli-harness/external-agent-evaluation/promotion-decisions.sample.json; tests/test_external_agent_evaluation_lane.py; tests/test_completion_cost_live_behavior_proof.py; planning closeout state.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from planning",
+    "next step": "promote the next bounded slice from planning"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed bounded to #1616 remediation. Repo-relative final paths remain allowed; local absolute paths now produce model_cli_local_path_leak with LOCAL_ABSOLUTE_PATH_LEAK, owner harness, remediation #1616. #1680 remains open because live proof is still unresolved and remaining lane closeout blockers persist.",
+    "proof status": "passed",
+    "intent served": "no; intent-status=partial keeps continuation explicit.",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "planning"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "make test-workspace: pass; make lint-workspace: pass; uv run pytest tests/test_external_agent_evaluation_lane.py tests/test_completion_cost_live_behavior_proof.py -q: 31 passed; uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate --format json: ok; uv run python scripts/check/check_completion_cost_live_behavior_proof.py --format json: evidence present, proof blocked with routed #1616 failures; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json: healthy; uv run pytest --collect-only -q tests packages: 1309 collected",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Guard external-agent local path leaks.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "planning"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1616 remediation evidence is implemented and validated; this is partial progress toward #1680, not parent closure.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "planning",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "planning",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to planning.",
+    "motivation worth preserving": "Future agents should continue from planning rather than rediscover this closeout residue.",
+    "canonical owner now": "planning",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "planning",
+    "proposed durable intent": "Future agents should continue from planning rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "planning"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status partial.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when planning activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "planning",
+          "owner": "planning",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-23: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "planning",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "continue-required",
+    "active_intent_satisfied": false,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "partial-progress",
+    "required_next_action": "create-follow-on-plan",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [
+          "done",
+          "implemented",
+          "complete",
+          "finished",
+          "all",
+          "full intent complete"
+        ],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "planning",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "no",
+      "reason": "planning"
+    },
+    "continuation": {
+      "owner_surface": "planning",
+      "created_or_required": true,
+      "reason": "planning"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Guard external-agent local path leaks.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: make test-workspace: pass; make lint-workspace: pass; uv run pytest tests/test_external_agent_evaluation_lane.py tests/test_completion_cost_live_behavior_proof.py -q: 31 passed; uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate --format json: ok; uv run python scripts/check/check_completion_cost_live_behavior_proof.py --format json: evidence present, proof blocked with routed #1616 failures; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json: healthy; uv run pytest --collect-only -q tests packages: 1309 collected\nChanged surfaces: scripts/model_cli_harness/run_model_cli_harness.py; scripts/model_cli_harness/external_agent_evaluation_lane.py; tools/model-cli-harness/external-agent-evaluation/scorecard-taxonomy.json; tools/model-cli-harness/external-agent-evaluation/live-results-2026-06-18.json; tools/model-cli-harness/external-agent-evaluation/promotion-decisions.sample.json; tests/test_external_agent_evaluation_lane.py; tests/test_completion_cost_live_behavior_proof.py; planning closeout state.\nDurable residue: planning (planning)\nMemory learning: route_to_planning\nFollow-up: planning\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
+  }
+}

--- a/scripts/model_cli_harness/external_agent_evaluation_lane.py
+++ b/scripts/model_cli_harness/external_agent_evaluation_lane.py
@@ -101,6 +101,29 @@ COMPLETION_COST_DRIVER_CLASSIFICATIONS = {
     "unsafe_closure",
     "unused_output",
 }
+LOCAL_PATH_LEAK_KIND = "agentic-workspace/external-agent-local-path-leak/v1"
+
+
+def _validate_local_path_leak_packet(
+    packet: Any,
+    *,
+    prefix: str,
+    errors: list[str],
+) -> None:
+    _require(isinstance(packet, dict), f"{prefix} local_path_leak must be an object", errors)
+    if not isinstance(packet, dict):
+        return
+    _require(packet.get("kind") == LOCAL_PATH_LEAK_KIND, f"{prefix} local_path_leak kind is invalid", errors)
+    _require(packet.get("status") == "detected", f"{prefix} local_path_leak status is invalid", errors)
+    _require(packet.get("warning_class") == "model_cli_local_path_leak", f"{prefix} local_path_leak warning_class is invalid", errors)
+    _require(packet.get("failure_id") == "LOCAL_ABSOLUTE_PATH_LEAK", f"{prefix} local_path_leak failure_id is invalid", errors)
+    _require(packet.get("owner_surface") == "harness", f"{prefix} local_path_leak owner_surface must be harness", errors)
+    _require(bool(str(packet.get("followup_ref") or "").strip()), f"{prefix} local_path_leak must route to a followup_ref", errors)
+    _require(
+        "repo-relative" in str(packet.get("allowed_path_rule") or ""),
+        f"{prefix} local_path_leak allowed_path_rule must preserve repo-relative evidence",
+        errors,
+    )
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -337,6 +360,12 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
             _require(failure_id in failure_ids, f"record {record.get('id')} references unknown failure id {failure_id}", errors)
         for owner in record.get("repair_surface_hints", []):
             _require(owner in owner_surfaces, f"record {record.get('id')} references unknown owner surface {owner}", errors)
+        if "LOCAL_ABSOLUTE_PATH_LEAK" in record.get("failure_ids", []):
+            _validate_local_path_leak_packet(
+                record.get("local_path_leak"),
+                prefix=f"record {record.get('id')}",
+                errors=errors,
+            )
         if "completion_cost_observations" in record:
             _validate_completion_cost_observations(
                 record.get("completion_cost_observations"),
@@ -381,6 +410,12 @@ def validate_pack(pack: dict[str, dict[str, Any]]) -> list[str]:
             )
         for failure_id in record.get("failure_ids", []):
             _require(failure_id in failure_ids, f"live run {record.get('id')} references unknown failure id {failure_id}", errors)
+        if "LOCAL_ABSOLUTE_PATH_LEAK" in record.get("failure_ids", []):
+            _validate_local_path_leak_packet(
+                record.get("local_path_leak"),
+                prefix=f"live run {record.get('id')}",
+                errors=errors,
+            )
         if "completion_cost_observations" in record:
             _validate_completion_cost_observations(
                 record.get("completion_cost_observations"),

--- a/scripts/model_cli_harness/run_model_cli_harness.py
+++ b/scripts/model_cli_harness/run_model_cli_harness.py
@@ -1798,9 +1798,15 @@ def _metadata_workflow_warnings(
             add("The agent reported a forbidden response phrase for this scenario.", evidence=forbidden)
     local_path_evidence = _local_absolute_path_evidence(_scored_agent_response_text(result))
     if local_path_evidence:
-        add(
-            "The agent exposed a local absolute path in the final response.",
-            evidence=local_path_evidence,
+        warnings.append(
+            {
+                "warning_class": "model_cli_local_path_leak",
+                "message": "The agent exposed a local absolute path in the final response.",
+                "evidence": local_path_evidence,
+                "owner_surface": "harness",
+                "failure_id": "LOCAL_ABSOLUTE_PATH_LEAK",
+                "remediation_ref": "#1616",
+            }
         )
     for pattern in _string_list(
         scenario.get("required_artifact_patterns"),
@@ -2821,7 +2827,7 @@ def _execution_warnings(*, result: dict[str, Any], repo_path: Path, mutation_sum
 
 
 def _warning_key(warning: dict[str, Any]) -> str:
-    return "|".join(str(warning.get(key, "")) for key in ("warning_class", "message", "evidence", "paths"))
+    return "|".join(str(warning.get(key, "")) for key in ("warning_class", "message", "evidence", "paths", "owner_surface", "failure_id"))
 
 
 def _finding_base_classes(warning_key: str) -> list[str]:
@@ -2836,6 +2842,8 @@ def _finding_base_classes(warning_key: str) -> list[str]:
         "model_cli_permission_denied",
     }:
         return ["environment_or_provider"]
+    if warning_class == "model_cli_local_path_leak":
+        return ["ownership_boundary", "harness_owned"]
     return ["first_seen"]
 
 
@@ -2914,8 +2922,11 @@ def _capability_routing_evaluation(
     local_path_leaks = [
         warning
         for warning in warnings
-        if warning.get("warning_class") == "model_cli_metadata_scoring_failure"
-        and "local absolute path" in str(warning.get("message", "")).lower()
+        if warning.get("warning_class") == "model_cli_local_path_leak"
+        or (
+            warning.get("warning_class") == "model_cli_metadata_scoring_failure"
+            and "local absolute path" in str(warning.get("message", "")).lower()
+        )
     ]
     if semantic_failures or required_command_misses:
         status = "ignored-or-misread"

--- a/tests/test_completion_cost_live_behavior_proof.py
+++ b/tests/test_completion_cost_live_behavior_proof.py
@@ -32,6 +32,7 @@ def test_live_behavior_proof_reports_checked_in_codex_spark_gate() -> None:
     assert payload["live_evaluation"]["run_count"] >= 4
     assert payload["live_evaluation"]["clean_run_count"] >= 3
     assert payload["live_evaluation"]["failure_counts"]["OWNERSHIP_BOUNDARY_LEAK"] == 1
+    assert payload["live_evaluation"]["failure_counts"]["LOCAL_ABSOLUTE_PATH_LEAK"] == 1
     assert payload["closure_boundary"]["may_complete_long_horizon_behavior_proof"] is False
     assert payload["closure_boundary"]["missing_live_failure_routes"] == []
     assert any("unresolved failures" in blocker for blocker in payload["closure_boundary"]["remaining_blockers"])
@@ -44,7 +45,7 @@ def test_live_behavior_proof_keeps_actionable_failure_route_visible() -> None:
     routes = payload["live_failure_routes"]
 
     assert routes
-    assert routes[0]["failure_ids"] == ["OWNERSHIP_BOUNDARY_LEAK"]
+    assert set(routes[0]["failure_ids"]) == {"OWNERSHIP_BOUNDARY_LEAK", "LOCAL_ABSOLUTE_PATH_LEAK"}
     assert routes[0]["followup_ref"] == "#1616"
     assert routes[0]["remediation_kind"] == "actionable-issue"
     assert routes[0]["closure_effect"] == "routed"

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -91,6 +91,7 @@ def test_external_agent_lane_scorecard_has_contract_ids_and_owner_surfaces() -> 
         "ARTIFACT_INSTALL_EVIDENCE_MISSING",
         "CLOSEOUT_RESIDUE_MISSING",
         "OWNERSHIP_BOUNDARY_LEAK",
+        "LOCAL_ABSOLUTE_PATH_LEAK",
         "HARNESS_SCENARIO_AMBIGUOUS",
     } <= failure_ids
     assert {"cli_output", "memory", "planning", "verification", "contracts", "harness", "no_change"} <= owner_surfaces
@@ -315,6 +316,17 @@ def test_external_agent_lane_rejects_promotions_without_actionable_remediation()
     assert any("promote-live-local-path-leak must route to an actionable remediation owner" in error for error in errors)
 
 
+def test_external_agent_lane_rejects_local_path_leak_without_owner_route() -> None:
+    module = _load_module()
+    pack = copy.deepcopy(module.load_pack(repo_root=REPO_ROOT))
+    live_run = next(item for item in pack["live_results"]["runs"] if item["id"] == "live-memory-consult-20260618T093207Z")
+    live_run.pop("local_path_leak", None)
+
+    errors = module.validate_pack(pack)
+
+    assert any("live-memory-consult-20260618T093207Z local_path_leak must be an object" in error for error in errors)
+
+
 def test_external_agent_lane_closure_report_is_ready_from_fixture_pack() -> None:
     module = _load_module()
     report = module.build_closure_report(module.load_pack(repo_root=REPO_ROOT))
@@ -333,8 +345,10 @@ def test_external_agent_lane_closure_report_is_ready_from_fixture_pack() -> None
     assert report["failure_counts"]["PROOF_MISSING_BEFORE_CLAIM"] >= 1
     assert report["failure_counts"]["PARTIAL_PROGRESS_CLAIMED_AS_FULL"] >= 1
     assert report["live_evaluation"]["failure_counts"]["OWNERSHIP_BOUNDARY_LEAK"] == 1
-    assert report["live_evaluation"]["promoted_failure_counts"]["OWNERSHIP_BOUNDARY_LEAK"] == 1
-    assert report["live_evaluation"]["actionable_remediation_failure_counts"]["OWNERSHIP_BOUNDARY_LEAK"] == 1
+    assert report["live_evaluation"]["failure_counts"]["LOCAL_ABSOLUTE_PATH_LEAK"] == 1
+    for failure_id in ("OWNERSHIP_BOUNDARY_LEAK", "LOCAL_ABSOLUTE_PATH_LEAK"):
+        assert report["live_evaluation"]["promoted_failure_counts"][failure_id] == 1
+        assert report["live_evaluation"]["actionable_remediation_failure_counts"][failure_id] == 1
     assert report["promotion_count"] >= 1
     loop = report["operating_loop_observability"]
     assert loop["kind"] == "agentic-workspace/external-agent-operating-loop-observability/v1"
@@ -371,6 +385,45 @@ def test_model_cli_harness_scores_source_checkout_aw_invocation_as_package_cli()
     executed = module._normalized_command_text("uv run python scripts/run_agentic_workspace.py start --target . --format json")
 
     assert module._command_requirement_satisfied(required="uv run agentic-workspace start", executed_command_text=executed)
+
+
+def test_model_cli_harness_scores_local_absolute_path_leak_with_owner(tmp_path: Path) -> None:
+    module = _load_harness_module()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    drive = "C:"
+    leaked_path = f"{drive}\\Users\\agent\\.agentic-workspace\\local\\scratch\\run.md"
+
+    warnings = module._metadata_workflow_warnings(
+        scenario={"id": "memory-consult-before-edit"},
+        result={
+            "status": "success",
+            "final_message": f"Updated README.md and wrote notes at {leaked_path}",
+        },
+        mutation_summary={"created": [], "modified": ["README.md"], "deleted": []},
+        repo_path=repo,
+    )
+
+    leak = next(warning for warning in warnings if warning["warning_class"] == "model_cli_local_path_leak")
+    assert leak["failure_id"] == "LOCAL_ABSOLUTE_PATH_LEAK"
+    assert leak["owner_surface"] == "harness"
+    assert leak["remediation_ref"] == "#1616"
+    assert leak["evidence"].startswith(f"{drive}\\Users\\agent")
+
+
+def test_model_cli_harness_allows_repo_relative_final_paths(tmp_path: Path) -> None:
+    module = _load_harness_module()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    warnings = module._metadata_workflow_warnings(
+        scenario={"id": "memory-consult-before-edit"},
+        result={"status": "success", "final_message": "Updated README.md and cited .agentic-workspace/planning/state.toml."},
+        mutation_summary={"created": [], "modified": ["README.md"], "deleted": []},
+        repo_path=repo,
+    )
+
+    assert not [warning for warning in warnings if warning["warning_class"] == "model_cli_local_path_leak"]
 
 
 def test_model_cli_harness_prepares_fixture_git_repo_for_diff_commands(tmp_path: Path) -> None:

--- a/tools/model-cli-harness/external-agent-evaluation/live-results-2026-06-18.json
+++ b/tools/model-cli-harness/external-agent-evaluation/live-results-2026-06-18.json
@@ -31,9 +31,18 @@
       "warning_classes": [
         "model_cli_fixture_mutation",
         "model_cli_command_execution_failed",
-        "model_cli_metadata_scoring_failure"
+        "model_cli_local_path_leak"
       ],
-      "failure_ids": ["OWNERSHIP_BOUNDARY_LEAK"],
+      "failure_ids": ["OWNERSHIP_BOUNDARY_LEAK", "LOCAL_ABSOLUTE_PATH_LEAK"],
+      "local_path_leak": {
+        "kind": "agentic-workspace/external-agent-local-path-leak/v1",
+        "status": "detected",
+        "warning_class": "model_cli_local_path_leak",
+        "failure_id": "LOCAL_ABSOLUTE_PATH_LEAK",
+        "owner_surface": "harness",
+        "followup_ref": "#1616",
+        "allowed_path_rule": "Final closeout text may cite repo-relative evidence paths, but must not expose local absolute harness or scratch paths."
+      },
       "summary": "Codex Spark reached the Memory route and completed the README edit, but issued a malformed patch command and leaked local absolute scratch paths in the final answer.",
       "promotion_status": "needs-promotion"
     },

--- a/tools/model-cli-harness/external-agent-evaluation/promotion-decisions.sample.json
+++ b/tools/model-cli-harness/external-agent-evaluation/promotion-decisions.sample.json
@@ -40,7 +40,7 @@
     },
     {
       "id": "promote-live-local-path-leak",
-      "failure_ids": ["OWNERSHIP_BOUNDARY_LEAK"],
+      "failure_ids": ["OWNERSHIP_BOUNDARY_LEAK", "LOCAL_ABSOLUTE_PATH_LEAK"],
       "evidence_record_ids": ["live-memory-consult-20260618T093207Z"],
       "threshold": "live Codex Spark run leaked local absolute scratch paths in final answer",
       "decision": "promote",

--- a/tools/model-cli-harness/external-agent-evaluation/scorecard-taxonomy.json
+++ b/tools/model-cli-harness/external-agent-evaluation/scorecard-taxonomy.json
@@ -160,6 +160,12 @@
       "claim_safety_impact": "partial_claim_only"
     },
     {
+      "id": "LOCAL_ABSOLUTE_PATH_LEAK",
+      "description": "The agent exposed a local absolute scratch path in final closeout text instead of repo-relative evidence.",
+      "owner_surface": "harness",
+      "claim_safety_impact": "partial_claim_only"
+    },
+    {
       "id": "LOCAL_MEMORY_ROUTE_MISSING",
       "description": "Local execution guidance should have been routed from structured command/surface facts before running a local command.",
       "owner_surface": "memory",


### PR DESCRIPTION
## What changed

- Adds a distinct `model_cli_local_path_leak` warning with `LOCAL_ABSOLUTE_PATH_LEAK`, owner `harness`, and remediation `#1616` when final closeout text exposes a local absolute path.
- Updates the external-agent lane pack so the live Codex Spark path-leak record carries a structured `local_path_leak` packet and routes both the broad ownership-boundary signal and the specific path-leak failure to #1616.
- Adds replay-style regression coverage for the observed leak shape and for allowing legitimate repo-relative paths.

## Why

#1680 live behavior proof remains blocked by the routed #1616 local scratch path leak. The prior evidence named the leak in prose, but the harness warning and lane validation did not make the path leak a first-class, owner-routed result.

## Validation

- `uv run pytest tests/test_external_agent_evaluation_lane.py tests/test_completion_cost_live_behavior_proof.py -q` -> 31 passed
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate --format json` -> ok
- `uv run python scripts/check/check_completion_cost_live_behavior_proof.py --format json` -> evidence present; proof remains blocked with routed #1616 failures
- `uv run python scripts/check/check_completion_cost_lane_evidence.py --format json` -> partial closure evidence; #1680 remains open
- `make test-workspace` -> pass
- `make lint-workspace` -> pass
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` -> healthy
- `uv run pytest --collect-only -q tests packages` -> 1309 collected

## Closure boundary

This PR addresses the #1616 remediation evidence path, but it does not close #1680. The lane still needs clean allowed-model live behavior proof and remaining closeout reconciliation before parent closure.
