### PR TITLE
[codex] Fix harness source checkout fixture deps

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/github-1727-harness-source-fixture-deps.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1727-harness-source-fixture-deps.plan.json
@@ -1,0 +1,378 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Fix harness source-checkout fixture dependencies",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Address #1727: make source-checkout model CLI harness runs generate AW fixture dependencies that resolve from the current checkout unless an explicit pinned dependency source is supplied.",
+    "hard_constraints": "Keep scope bounded to harness fixture dependency setup, regression tests, and plan closeout. Preserve explicit pinned release and local wheelhouse dependency behavior.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Patch fixture dependency source selection and run focused harness tests plus live dry-run preflight.",
+    "proof_expectations": [
+      "uv run pytest tests/test_external_agent_evaluation_lane.py -q",
+      "uv run python scripts/model_cli_harness/run_model_cli_harness.py --suite tools/model-cli-harness/suites/copilot-workflow-smoke.json --adapter codex --model gpt-5.4-mini --scenario memory-consult-before-edit --prompt-variant packaging-note --output-root .agentic-workspace/local/scratch/model-cli-harness-live-refresh --format json"
+    ],
+    "touched_scope": [
+      "scripts/model_cli_harness/run_model_cli_harness.py",
+      "tests/test_external_agent_evaluation_lane.py",
+      ".agentic-workspace/planning/execplans/github-1727-harness-source-fixture-deps.plan.json"
+    ],
+    "completion_criteria": [
+      "Generated AW fixture pyproject files use a current-checkout [tool.uv.sources] mapping for ordinary source-checkout dogfooding runs.",
+      "Pinned release and local wheelhouse dependency modes remain unchanged.",
+      "A dry-run harness result shows the generated codex AW fixture command is ready with a resolvable local source mapping."
+    ],
+    "continuation_owner": "planning",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Fix harness source-checkout fixture dependencies."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Address #1727: make source-checkout model CLI harness runs generate AW fixture dependencies that resolve from the current checkout unless an explicit pinned dependency source is supplied.",
+      "constraints": "Keep scope bounded to harness fixture dependency setup, regression tests, and plan closeout. Preserve explicit pinned release and local wheelhouse dependency behavior.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "github-1727-harness-source-fixture-deps",
+      "status": "completed",
+      "next_step": "Continue via planning.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "scripts/model_cli_harness/run_model_cli_harness.py",
+        "tests/test_external_agent_evaluation_lane.py",
+        ".agentic-workspace/planning/execplans/github-1727-harness-source-fixture-deps.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Keep working on #1680 until the lane can be honestly closed.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "planning"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "planning",
+    "activation trigger": "After this slice, rerun allowed-model live behavior proof and reconcile remaining #1680 blockers."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via planning."
+  },
+  "intent_interpretation": {
+    "literal request": "Continue active #1680 lane work.",
+    "inferred intended outcome": "Fix the #1727 fixture dependency friction discovered by the live gpt-5.4-mini evaluation so future live proof can measure model behavior rather than setup failure.",
+    "chosen concrete what": "Default source-checkout AW fixtures to the current checkout through tool.uv.sources unless explicit dependencies already define the source.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm codex source-checkout dry-runs generate a resolvable local dependency and codex-sbx pinned release behavior remains unchanged."
+  },
+  "execution_bounds": {
+    "allowed paths": "scripts/model_cli_harness/run_model_cli_harness.py, tests/test_external_agent_evaluation_lane.py, and this execplan.",
+    "max changed files": "3 files plus archived closeout.",
+    "required validation commands": "uv run pytest tests/test_external_agent_evaluation_lane.py -q; harness dry-run for codex memory-consult using gpt-5.4-mini.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Patch #1727 fixture dependency resolution in run_model_cli_harness.py and prove codex dry-run pyproject uses current checkout.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Address #1727 fixture dependency resolution for source-checkout model CLI harness runs.",
+    "hard constraints": "Preserve explicit pinned release and local wheelhouse dependency behavior.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1727-harness-source-fixture-deps",
+    "status": "completed",
+    "scope": "Source-checkout AW fixture dependency generation for model CLI harness runs.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Patch fixture dependency source selection and run focused proof."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "scripts/model_cli_harness/run_model_cli_harness.py",
+    "tests/test_external_agent_evaluation_lane.py",
+    ".agentic-workspace/planning/execplans/github-1727-harness-source-fixture-deps.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_external_agent_evaluation_lane.py -q",
+    "uv run python scripts/model_cli_harness/run_model_cli_harness.py --suite tools/model-cli-harness/suites/copilot-workflow-smoke.json --adapter codex --model gpt-5.4-mini --scenario memory-consult-before-edit --prompt-variant packaging-note --output-root .agentic-workspace/local/scratch/model-cli-harness-live-refresh --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Fix harness source-checkout fixture dependencies is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Fixed #1727 by making non-pinned source-checkout model CLI harness fixtures resolve agentic-workspace from the current checkout while preserving explicit fixture dependency and wheelhouse modes.",
+    "scope touched": "scripts/model_cli_harness/run_model_cli_harness.py; tests/test_external_agent_evaluation_lane.py",
+    "changed surfaces": "Harness fixture dependency source selection and external-agent lane regression coverage.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from planning",
+    "next step": "promote the next bounded slice from planning"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "The fix only supplies a local editable source when the adapter has not declared explicit fixture dependencies and no wheelhouse override is active, so codex-sbx release dependency coverage remains pinned.",
+    "proof status": "passed",
+    "intent served": "no; intent-status=partial keeps continuation explicit.",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "planning"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_external_agent_evaluation_lane.py -q => 29 passed; uv run python scripts/model_cli_harness/run_model_cli_harness.py --suite tools/model-cli-harness/suites/copilot-workflow-smoke.json --adapter codex --model gpt-5.4-mini --scenario memory-consult-before-edit --prompt-variant packaging-note --output-root .agentic-workspace/local/scratch/model-cli-harness-live-refresh --format json => dry-run ready and source-checkout fixture dependency resolved through current checkout; make test-workspace => [ok] workspace tests; make lint-workspace => [ok] workspace lint and prompt semantic markers; uv run python scripts/run_agentic_workspace.py summary --target . --format json => warning_count 0 with active plan present before closeout; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json => health healthy, warning_count 0; uv run pytest --collect-only -q tests packages => 1310 tests collected",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Fix harness source-checkout fixture dependencies.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "planning"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1727 is implemented and validated as a stacked #1680 slice; #1680 remains open for live behavior residue including #1616 path/ownership leakage.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "planning",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "planning",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to planning.",
+    "motivation worth preserving": "Future agents should continue from planning rather than rediscover this closeout residue.",
+    "canonical owner now": "planning",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "planning",
+    "proposed durable intent": "Future agents should continue from planning rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "planning"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status partial.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when planning activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "planning",
+          "owner": "planning",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-23: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "planning",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "continue-required",
+    "active_intent_satisfied": false,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "partial-progress",
+    "required_next_action": "create-follow-on-plan",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [
+          "done",
+          "implemented",
+          "complete",
+          "finished",
+          "all",
+          "full intent complete"
+        ],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "planning",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "no",
+      "reason": "planning"
+    },
+    "continuation": {
+      "owner_surface": "planning",
+      "created_or_required": true,
+      "reason": "planning"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Fix harness source-checkout fixture dependencies.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: uv run pytest tests/test_external_agent_evaluation_lane.py -q => 29 passed; uv run python scripts/model_cli_harness/run_model_cli_harness.py --suite tools/model-cli-harness/suites/copilot-workflow-smoke.json --adapter codex --model gpt-5.4-mini --scenario memory-consult-before-edit --prompt-variant packaging-note --output-root .agentic-workspace/local/scratch/model-cli-harness-live-refresh --format json => dry-run ready and source-checkout fixture dependency resolved through current checkout; make test-workspace => [ok] workspace tests; make lint-workspace => [ok] workspace lint and prompt semantic markers; uv run python scripts/run_agentic_workspace.py summary --target . --format json => warning_count 0 with active plan present before closeout; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json => health healthy, warning_count 0; uv run pytest --collect-only -q tests packages => 1310 tests collected\nChanged surfaces: Harness fixture dependency source selection and external-agent lane regression coverage.\nDurable residue: planning (planning)\nMemory learning: route_to_planning\nFollow-up: planning\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
+  }
+}

--- a/scripts/model_cli_harness/run_model_cli_harness.py
+++ b/scripts/model_cli_harness/run_model_cli_harness.py
@@ -361,6 +361,14 @@ def _adapter_fixture_dependencies(adapter: dict[str, Any]) -> list[str]:
     return ["agentic-workspace"]
 
 
+def _adapter_declares_fixture_dependency(adapter: dict[str, Any]) -> bool:
+    dependencies = adapter.get("fixture_dependencies")
+    if isinstance(dependencies, list) and all(isinstance(item, str) and item.strip() for item in dependencies):
+        return True
+    dependency = adapter.get("fixture_dependency")
+    return isinstance(dependency, str) and bool(dependency.strip())
+
+
 def _local_aw_version() -> str:
     return str(tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"])
 
@@ -554,6 +562,7 @@ def _prepare_source_checkout_invocation(
             "",
         ]
         if source_checkout_path:
+            source_checkout_path = source_checkout_path.replace("\\", "/")
             lines.extend(
                 [
                     "[tool.uv.sources]",
@@ -3149,6 +3158,9 @@ def run_suite(
     if not isinstance(scenarios, list):
         raise ValueError("suite.scenarios must be a list")
     local_aw_wheelhouse = _build_local_aw_wheelhouse(output_root) if aw_dependency_mode == "local-wheelhouse" else None
+    adapter_source_checkout_path = adapter.get("fixture_source_path") if isinstance(adapter.get("fixture_source_path"), str) else None
+    if adapter_source_checkout_path is None and local_aw_wheelhouse is None and not _adapter_declares_fixture_dependency(adapter):
+        adapter_source_checkout_path = REPO_ROOT.as_posix()
 
     selected = [item for item in scenarios if not scenario_filter or item.get("id") == scenario_filter]
     if scenario_filter and not selected:
@@ -3176,7 +3188,7 @@ def run_suite(
                 adapter=adapter,
                 dependency_specs=_adapter_fixture_dependencies(adapter),
                 local_aw_wheelhouse=local_aw_wheelhouse,
-                source_checkout_path=adapter.get("fixture_source_path") if isinstance(adapter.get("fixture_source_path"), str) else None,
+                source_checkout_path=adapter_source_checkout_path,
             )
             replacements = {
                 "repo": str(paths.repo_path),

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -464,6 +464,26 @@ def test_model_cli_harness_source_checkout_config_uses_local_schema(tmp_path: Pa
     assert 'cli_invoke = "uv run agentic-workspace"' in local_config
 
 
+def test_model_cli_harness_codex_source_checkout_fixture_uses_current_checkout(tmp_path: Path) -> None:
+    module = _load_harness_module()
+
+    payload = module.run_suite(
+        suite_path=REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json",
+        adapter_id="codex",
+        model="gpt-5.4-mini",
+        scenario_filter="memory-consult-before-edit",
+        prompt_variant="packaging-note",
+        execute=False,
+        output_root=tmp_path / "runs",
+        timeout_seconds=None,
+    )
+
+    pyproject_text = (Path(payload["results"][0]["repo_path"]) / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"agentic-workspace",' in pyproject_text
+    assert "[tool.uv.sources]" in pyproject_text
+    assert f'agentic-workspace = {{ path = "{REPO_ROOT.as_posix()}", editable = true }}' in pyproject_text
+
+
 def test_model_cli_harness_preflight_resolves_adapter_executable_candidates(tmp_path: Path) -> None:
     module = _load_harness_module()
     tool_dir = tmp_path / "tools"


### PR DESCRIPTION
## Summary

Fixes #1727 as the next #1680 lane slice.

The model CLI harness now wires ordinary source-checkout fixture runs to the current checkout through `tool.uv.sources` when an adapter has not declared an explicit fixture dependency and the local wheelhouse mode is not active. This keeps live source-checkout evaluation fixtures from resolving `agentic-workspace` as an unavailable public package while preserving pinned fixture dependency behavior for adapters such as `codex-sbx`.

## Root Cause

The copied fixture `pyproject.toml` declared `agentic-workspace` as a dependency but, for the ordinary `codex` adapter, did not provide a local source mapping. Live runs that followed fixture instructions with `uv run agentic-workspace ...` could fail during dependency resolution before the model behavior under evaluation was reached.

## Validation

- `uv run pytest tests/test_external_agent_evaluation_lane.py -q` -> 29 passed after rebase
- `uv run python scripts/model_cli_harness/run_model_cli_harness.py --suite tools/model-cli-harness/suites/copilot-workflow-smoke.json --adapter codex --model gpt-5.4-mini --scenario memory-consult-before-edit --prompt-variant packaging-note --output-root .agentic-workspace/local/scratch/model-cli-harness-live-refresh --format json` -> dry-run ready with source-checkout fixture dependency mapped to the current checkout
- `make test-workspace` -> pass
- `make lint-workspace` -> pass
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json` -> warning_count 0 after closeout
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` -> health healthy, warnings 0
- `uv run pytest --collect-only -q tests packages` -> 1310 tests collected