### PR TITLE
[codex] Repair harness local path leak exports

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/github-1616-harness-path-leak-repair.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-1616-harness-path-leak-repair.plan.json
@@ -1,0 +1,392 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Repair harness local path leaks",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Repair #1616 prompt-resistant local path leaks by keeping raw scoring attribution while sanitizing the exported model CLI harness final closeout text.",
+    "hard_constraints": "Keep scope bounded to harness final-message repair, focused tests, and planning closeout; do not suppress LOCAL_ABSOLUTE_PATH_LEAK warnings or rewrite historical live-result records.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Add final-message local path repair after raw scoring and prove warnings still route to #1616.",
+    "proof_expectations": [
+      "uv run pytest tests/test_external_agent_evaluation_lane.py -q",
+      "uv run python scripts/model_cli_harness/run_model_cli_harness.py --suite tools/model-cli-harness/suites/copilot-workflow-smoke.json --adapter codex --model gpt-5.4-mini --scenario memory-consult-before-edit --prompt-variant packaging-note --output-root .agentic-workspace/local/scratch/model-cli-harness-path-leak-repair --format json"
+    ],
+    "touched_scope": [
+      "scripts/model_cli_harness/run_model_cli_harness.py",
+      "tests/test_external_agent_evaluation_lane.py",
+      ".agentic-workspace/planning/execplans/github-1616-harness-path-leak-repair.plan.json"
+    ],
+    "completion_criteria": [
+      "Raw local path leaks still produce LOCAL_ABSOLUTE_PATH_LEAK warnings routed to #1616.",
+      "The exported final_message/session artifact replaces copied-repo absolute paths with repo-relative paths and replaces harness-local artifact paths with role labels.",
+      "Focused tests and an allowed-model dry-run pass."
+    ],
+    "continuation_owner": "#1616 and checked-in live evaluation evidence",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Repair harness local path leaks."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Repair #1616 prompt-resistant local path leaks by keeping raw scoring attribution while sanitizing the exported model CLI harness final closeout text.",
+      "constraints": "Keep scope bounded to harness final-message repair, focused tests, and planning closeout; do not suppress LOCAL_ABSOLUTE_PATH_LEAK warnings or rewrite historical live-result records.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "github-1616-harness-path-leak-repair",
+      "status": "completed",
+      "next_step": "Continue via #1616 and checked-in live evaluation evidence.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "scripts/model_cli_harness/run_model_cli_harness.py",
+        "tests/test_external_agent_evaluation_lane.py",
+        ".agentic-workspace/planning/execplans/github-1616-harness-path-leak-repair.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "#1680 live behavior proof can run without published local scratch paths while preserving owner-routed evidence for any model leak.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "#1616 and checked-in live evaluation evidence"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "#1616 and checked-in live evaluation evidence",
+    "activation trigger": "After this repair lands, refresh allowed-model live evidence and decide whether remaining failures are clean, accepted, or still routed."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via #1616 and checked-in live evaluation evidence."
+  },
+  "intent_interpretation": {
+    "literal request": "Continue #1680 and remediate the prompt-resistant #1616 local path leak.",
+    "inferred intended outcome": "Prevent exported harness final closeout text from leaking local absolute paths while preserving scoring attribution.",
+    "chosen concrete what": "Add a final-message repair packet that runs after raw warning collection.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "scripts/model_cli_harness/run_model_cli_harness.py; tests/test_external_agent_evaluation_lane.py; .agentic-workspace/planning/execplans/github-1616-harness-path-leak-repair.plan.json",
+    "max changed files": "4 including archived closeout if this slice closes.",
+    "required validation commands": "uv run pytest tests/test_external_agent_evaluation_lane.py -q; allowed-model harness dry-run for memory-consult-before-edit; required AW proof after implement --changed.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, #1616 issue text, final-message scoring/repair helpers, and focused harness tests.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Score raw final_message for LOCAL_ABSOLUTE_PATH_LEAK, then repair exported final_message/session.md without erasing the warning.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Repair #1616 prompt-resistant local path leaks by keeping raw scoring attribution while sanitizing the exported model CLI harness final closeout text.",
+    "hard constraints": "Keep scope bounded to harness final-message repair, focused tests, and planning closeout; do not suppress LOCAL_ABSOLUTE_PATH_LEAK warnings or rewrite historical live-result records.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-1616-harness-path-leak-repair",
+    "status": "completed",
+    "scope": "Harness final-message repair after raw scoring for #1616.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Add final-message local path repair after raw scoring and prove warnings still route to #1616."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "scripts/model_cli_harness/run_model_cli_harness.py",
+    "tests/test_external_agent_evaluation_lane.py",
+    ".agentic-workspace/planning/execplans/github-1616-harness-path-leak-repair.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_external_agent_evaluation_lane.py -q",
+    "uv run python scripts/model_cli_harness/run_model_cli_harness.py --suite tools/model-cli-harness/suites/copilot-workflow-smoke.json --adapter codex --model gpt-5.4-mini --scenario memory-consult-before-edit --prompt-variant packaging-note --output-root .agentic-workspace/local/scratch/model-cli-harness-path-leak-repair --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Raw local path leaks still produce LOCAL_ABSOLUTE_PATH_LEAK warnings routed to #1616.",
+    "The exported final_message/session artifact replaces copied-repo absolute paths with repo-relative paths and replaces harness-local artifact paths with role labels.",
+    "Focused tests and an allowed-model dry-run pass."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added final-message local path repair after raw harness scoring so raw local-path leaks still warn and route to #1616, while exported final_message/session.md text is sanitized.",
+    "scope touched": "Model CLI harness final-message export path repair and external-agent evaluation regression coverage.",
+    "changed surfaces": "scripts/model_cli_harness/run_model_cli_harness.py; tests/test_external_agent_evaluation_lane.py; planning closeout archive",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from #1616 and checked-in live evaluation evidence",
+    "next step": "promote the next bounded slice from #1616 and checked-in live evaluation evidence"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "No new actionable comments on open PR #1729; direct GraphQL and pr_comment_delta both showed no comments/reviews/threads. This slice partially satisfies #1616 by preventing exported final-message path leaks and preserving raw warning attribution; parent lane and checked-in live evidence remain open.",
+    "proof status": "passed",
+    "intent served": "no; intent-status=partial keeps continuation explicit.",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "#1616 and checked-in live evaluation evidence"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "PR comment delta for #1729: new_comment_count=0, truncated=false; no actionable comments. Focused regression: uv run pytest tests/test_external_agent_evaluation_lane.py -q -> 31 passed. Required proof: make test-workspace -> [ok] workspace tests (218.04s); make lint-workspace -> [ok] workspace lint and prompt semantic markers; summary -> warning_count=0, active execplan=1 before closeout; planning doctor -> health=healthy, warnings_count=0, needs_review_count=0; collect-only -> 1312 tests collected. Live allowed-model dry run and execute completed earlier with gpt-5.4-mini; execute had no local path leak warning and final_message used repo-relative README.md.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Repair harness local path leaks.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "#1616 and checked-in live evaluation evidence"
+  },
+  "execution_summary": {
+    "outcome delivered": "Prompt-resistant local absolute paths in exported harness final messages are repaired to repo-relative or role-labelled placeholders after scoring.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "#1616 and checked-in live evaluation evidence",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "#1616 and checked-in live evaluation evidence",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed issue residue to #1616 and checked-in live evaluation evidence.",
+    "motivation worth preserving": "Future agents should continue from #1616 and checked-in live evaluation evidence rather than rediscover this closeout residue.",
+    "canonical owner now": "#1616 and checked-in live evaluation evidence",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "#1616 and checked-in live evaluation evidence",
+    "proposed durable intent": "Future agents should continue from #1616 and checked-in live evaluation evidence rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "#1616 and checked-in live evaluation evidence"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status partial.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when #1616 and checked-in live evaluation evidence activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      {
+        "summary": "Closeout routed issue residue to #1616 and checked-in live evaluation evidence.",
+        "owner": "#1616 and checked-in live evaluation evidence",
+        "source": "durable_residue"
+      }
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      {
+        "summary": "Closeout routed issue residue to #1616 and checked-in live evaluation evidence.",
+        "owner": "#1616 and checked-in live evaluation evidence",
+        "source": "durable_residue"
+      }
+    ],
+    "signals dismissed": [],
+    "next owner": "see routed signal owner"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "#1616 and checked-in live evaluation evidence",
+          "owner": "#1616 and checked-in live evaluation evidence",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-23: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "#1616 and checked-in live evaluation evidence",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "continue-required",
+    "active_intent_satisfied": false,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "partial-progress",
+    "required_next_action": "create-follow-on-plan",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [
+          "done",
+          "implemented",
+          "complete",
+          "finished",
+          "all",
+          "full intent complete"
+        ],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "#1616 and checked-in live evaluation evidence",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "no",
+      "reason": "#1616 and checked-in live evaluation evidence"
+    },
+    "continuation": {
+      "owner_surface": "#1616 and checked-in live evaluation evidence",
+      "created_or_required": true,
+      "reason": "#1616 and checked-in live evaluation evidence"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Repair harness local path leaks.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: PR comment delta for #1729: new_comment_count=0, truncated=false; no actionable comments. Focused regression: uv run pytest tests/test_external_agent_evaluation_lane.py -q -> 31 passed. Required proof: make test-workspace -> [ok] workspace tests (218.04s); make lint-workspace -> [ok] workspace lint and prompt semantic markers; summary -> warning_count=0, active execplan=1 before closeout; planning doctor -> health=healthy, warnings_count=0, needs_review_count=0; collect-only -> 1312 tests collected. Live allowed-model dry run and execute completed earlier with gpt-5.4-mini; execute had no local path leak warning and final_message used repo-relative README.md.\nChanged surfaces: scripts/model_cli_harness/run_model_cli_harness.py; tests/test_external_agent_evaluation_lane.py; planning closeout archive\nDurable residue: planning (#1616 and checked-in live evaluation evidence)\nMemory learning: route_to_planning\nFollow-up: #1616 and checked-in live evaluation evidence\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
+  }
+}

--- a/scripts/model_cli_harness/run_model_cli_harness.py
+++ b/scripts/model_cli_harness/run_model_cli_harness.py
@@ -1510,6 +1510,72 @@ def _full_response_text(result: dict[str, Any]) -> str:
     return "\n".join(parts)
 
 
+_LOCAL_ABSOLUTE_PATH_PATTERNS = (
+    re.compile(r"\b[A-Za-z]:[\\/][^\s)`>\"']+"),
+    re.compile(r"\b/(?:Users|home|tmp|var/tmp|private/tmp)/[^\s)`>\"']+"),
+)
+
+
+def _path_from_local_evidence(evidence: str) -> Path | None:
+    candidate = evidence.strip().rstrip(".,;:")
+    if not candidate:
+        return None
+    try:
+        return Path(candidate)
+    except (OSError, ValueError):
+        return None
+
+
+def _repair_local_absolute_paths_in_text(*, text: str, repo_path: Path, run_root: Path) -> dict[str, Any]:
+    repairs: list[dict[str, str]] = []
+
+    def replacement(match: re.Match[str]) -> str:
+        evidence = match.group(0)
+        path = _path_from_local_evidence(evidence)
+        if path is None:
+            return "<local path>"
+        replacement_text = "<local path>"
+        repair_kind = "local_path_redacted"
+        if _is_relative_to(path, repo_path):
+            replacement_text = path.resolve().relative_to(repo_path.resolve()).as_posix()
+            repair_kind = "repo_relative"
+        elif _is_relative_to(path, run_root):
+            replacement_text = "<harness artifact>"
+            repair_kind = "harness_artifact_role"
+        repairs.append({"kind": repair_kind, "replacement": replacement_text})
+        return replacement_text
+
+    repaired = text
+    for pattern in _LOCAL_ABSOLUTE_PATH_PATTERNS:
+        repaired = pattern.sub(replacement, repaired)
+    return {
+        "kind": "agentic-workspace/model-cli-final-message-local-path-repair/v1",
+        "status": "repaired" if repairs and repaired != text else "not-needed",
+        "repair_count": len(repairs),
+        "repairs": repairs,
+        "rule": "Raw model text remains the scoring source; exported final_message text must not expose local absolute paths.",
+        "text": repaired,
+    }
+
+
+def _repair_result_final_message_local_paths(*, result: dict[str, Any], repo_path: Path, run_root: Path, share_path: Path) -> dict[str, Any]:
+    final_message = result.get("final_message")
+    if not isinstance(final_message, str) or not final_message:
+        return {
+            "kind": "agentic-workspace/model-cli-final-message-local-path-repair/v1",
+            "status": "not-needed",
+            "repair_count": 0,
+            "repairs": [],
+            "rule": "Raw model text remains the scoring source; exported final_message text must not expose local absolute paths.",
+        }
+    repair = _repair_local_absolute_paths_in_text(text=final_message, repo_path=repo_path, run_root=run_root)
+    repaired_text = str(repair.pop("text"))
+    if repair["status"] == "repaired":
+        result["final_message"] = repaired_text
+        share_path.write_text(repaired_text, encoding="utf-8")
+    return repair
+
+
 def _last_copilot_transcript_answer(text: str) -> str:
     matches = list(re.finditer(r"^### .+ Copilot\s*$", text, flags=re.MULTILINE))
     if not matches:
@@ -1847,11 +1913,7 @@ def _metadata_workflow_warnings(
 def _local_absolute_path_evidence(text: str) -> str:
     if not text:
         return ""
-    patterns = (
-        re.compile(r"\b[A-Za-z]:[\\/][^\s)`>\"']+"),
-        re.compile(r"\b/(?:Users|home|tmp|var/tmp|private/tmp)/[^\s)`>\"']+"),
-    )
-    for pattern in patterns:
+    for pattern in _LOCAL_ABSOLUTE_PATH_PATTERNS:
         match = pattern.search(text)
         if match:
             evidence = match.group(0)
@@ -3348,6 +3410,12 @@ def run_suite(
                         result=result,
                         metrics=invocation["proportionality_metrics"],
                     )
+                )
+                invocation["final_message_repair"] = _repair_result_final_message_local_paths(
+                    result=result,
+                    repo_path=paths.repo_path,
+                    run_root=paths.run_root,
+                    share_path=paths.share_path,
                 )
                 if postmortem_feedback:
                     if adapter.get("postmortem_feedback_supported") is False:

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -433,6 +433,40 @@ def test_model_cli_harness_scores_local_absolute_path_leak_with_owner(tmp_path: 
     assert leak["evidence"].startswith(f"{drive}\\Users\\agent")
 
 
+def test_model_cli_harness_repairs_exported_final_message_without_suppressing_warning(tmp_path: Path) -> None:
+    module = _load_harness_module()
+    repo = tmp_path / "repo"
+    run_root = tmp_path / "run"
+    repo.mkdir()
+    run_root.mkdir()
+    readme = repo / "README.md"
+    readme.write_text("notes\n", encoding="utf-8")
+    share_path = run_root / "session.md"
+    raw_message = f"Changed [README.md]({readme.as_posix()}) and see {run_root.as_posix()}/session.md"
+    result = {"status": "success", "final_message": raw_message}
+
+    warnings = module._metadata_workflow_warnings(
+        scenario={"id": "memory-consult-before-edit"},
+        result=result,
+        mutation_summary={"created": [], "modified": ["README.md"], "deleted": []},
+        repo_path=repo,
+    )
+    repair = module._repair_result_final_message_local_paths(
+        result=result,
+        repo_path=repo,
+        run_root=run_root,
+        share_path=share_path,
+    )
+
+    leak = next(warning for warning in warnings if warning["warning_class"] == "model_cli_local_path_leak")
+    assert leak["failure_id"] == "LOCAL_ABSOLUTE_PATH_LEAK"
+    assert repair["status"] == "repaired"
+    assert {item["kind"] for item in repair["repairs"]} == {"repo_relative", "harness_artifact_role"}
+    assert result["final_message"] == "Changed [README.md](README.md) and see <harness artifact>"
+    assert share_path.read_text(encoding="utf-8") == result["final_message"]
+    assert str(tmp_path).replace("\\", "/") not in result["final_message"]
+
+
 def test_model_cli_harness_allows_repo_relative_final_paths(tmp_path: Path) -> None:
     module = _load_harness_module()
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Summary

- repair exported model CLI harness final messages after raw warning collection so local absolute paths do not leak into `final_message` or `session.md`
- keep raw scoring attribution intact, so `LOCAL_ABSOLUTE_PATH_LEAK` still routes to #1616 when a model emits a local path
- add regression coverage for prompt-resistant repo-local and harness-artifact path leaks
- archive the bounded #1616 repair plan with residue left on #1616 and checked-in live evaluation evidence

## Proof

- `uv run pytest tests/test_external_agent_evaluation_lane.py -q` -> 31 passed
- `make test-workspace` -> `[ok] workspace tests (218.04s)`
- `make lint-workspace` -> workspace lint and prompt semantic markers passed
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json` -> warning_count=0 after closeout; active_count=0
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` -> health=healthy; warnings_count=0; needs_review_count=0
- `uv run pytest --collect-only -q tests packages` -> 1312 tests collected
- live allowed-model execute with `gpt-5.4-mini` completed earlier with no local path leak warning and a repo-relative final message

## Comment check

- `gh pr view 1729` and direct GraphQL showed no comments, reviews, or review threads
- `uv run python scripts/github/pr_comment_delta.py --repo rickardvh/agentic-workspace --pr 1729 --format json` -> `new_comment_count: 0`, `truncated: false`

## Boundary

This is stacked on #1729. It partially satisfies #1616 by repairing exported harness final-message/session artifacts without suppressing raw leak detection. It does not close #1616 or #1680; checked-in live evaluation evidence still needs refresh after the stack lands.
