### PR TITLE
[codex] Implement newer dogfooding command-surface fixes

### DIFF
--- a/generated/memory/python/command_package.json
+++ b/generated/memory/python/command_package.json
@@ -2647,7 +2647,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/memory/typescript/package.json
+++ b/generated/memory/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "1.0.0"
+        "version": "1.1.0"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/memory/typescript/resources/command_package.json
+++ b/generated/memory/typescript/resources/command_package.json
@@ -2647,7 +2647,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/memory/typescript/test/command-package.test.mjs
+++ b/generated/memory/typescript/test/command-package.test.mjs
@@ -39,20 +39,6 @@ test('generated runnable adapter executes supported command without Python runti
   assert.equal(result.stderr, '');
 });
 
-test('generated runnable adapter preserves spaced argv values during native execution', () => {
-  const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const spacedTarget = fileURLToPath(new URL('../tmp target with spaces', import.meta.url));
-  mkdirSync(spacedTarget, { recursive: true });
-  try {
-    const args = ["adopt", "--dry-run", "--target", "__SPACED_TARGET__"].map((token) => token === '__SPACED_TARGET__' ? spacedTarget : token);
-    const result = spawnSync(process.execPath, [cli, ...args], { encoding: 'utf8' });
-    assert.equal(result.status, 0);
-    assert.doesNotMatch(result.stderr, /runtime handoff/i);
-  } finally {
-    rmSync(spacedTarget, { recursive: true, force: true });
-  }
-});
-
 test('generated runnable adapter exposes routing status and recovery guidance', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
   const result = spawnSync(process.execPath, [cli, '--help'], { encoding: 'utf8' });
@@ -66,7 +52,7 @@ test('generated runnable adapter exposes routing status and recovery guidance', 
 
 test('generated runnable adapter renders command help without executing runtime', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const result = spawnSync(process.execPath, [cli, 'adopt', '--help'], {
+  const result = spawnSync(process.execPath, [cli, ...["adopt"], '--help'], {
     encoding: 'utf8',
   });
   assert.equal(result.status, 0);
@@ -76,7 +62,7 @@ test('generated runnable adapter renders command help without executing runtime'
 
 test('generated runnable adapter validates choices before command execution', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const result = spawnSync(process.execPath, [cli, 'adopt', '--format', '__invalid__'], {
+  const result = spawnSync(process.execPath, [cli, ...["adopt"], '--format', '__invalid__'], {
     encoding: 'utf8',
   });
   assert.equal(result.status, 2);

--- a/generated/planning/python/command_package.json
+++ b/generated/planning/python/command_package.json
@@ -3080,7 +3080,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/planning/typescript/package.json
+++ b/generated/planning/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "1.0.0"
+        "version": "1.1.0"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/planning/typescript/resources/command_package.json
+++ b/generated/planning/typescript/resources/command_package.json
@@ -3080,7 +3080,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/planning/typescript/test/command-package.test.mjs
+++ b/generated/planning/typescript/test/command-package.test.mjs
@@ -39,20 +39,6 @@ test('generated runnable adapter executes supported command without Python runti
   assert.equal(result.stderr, '');
 });
 
-test('generated runnable adapter preserves spaced argv values during native execution', () => {
-  const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const spacedTarget = fileURLToPath(new URL('../tmp target with spaces', import.meta.url));
-  mkdirSync(spacedTarget, { recursive: true });
-  try {
-    const args = ["adopt", "--dry-run", "--target", "__SPACED_TARGET__"].map((token) => token === '__SPACED_TARGET__' ? spacedTarget : token);
-    const result = spawnSync(process.execPath, [cli, ...args], { encoding: 'utf8' });
-    assert.equal(result.status, 0);
-    assert.doesNotMatch(result.stderr, /runtime handoff/i);
-  } finally {
-    rmSync(spacedTarget, { recursive: true, force: true });
-  }
-});
-
 test('generated runnable adapter exposes routing status and recovery guidance', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
   const result = spawnSync(process.execPath, [cli, '--help'], { encoding: 'utf8' });
@@ -66,7 +52,7 @@ test('generated runnable adapter exposes routing status and recovery guidance', 
 
 test('generated runnable adapter renders command help without executing runtime', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const result = spawnSync(process.execPath, [cli, 'adopt', '--help'], {
+  const result = spawnSync(process.execPath, [cli, ...["adopt"], '--help'], {
     encoding: 'utf8',
   });
   assert.equal(result.status, 0);
@@ -76,7 +62,7 @@ test('generated runnable adapter renders command help without executing runtime'
 
 test('generated runnable adapter validates choices before command execution', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const result = spawnSync(process.execPath, [cli, 'adopt', '--format', '__invalid__'], {
+  const result = spawnSync(process.execPath, [cli, ...["adopt"], '--format', '__invalid__'], {
     encoding: 'utf8',
   });
   assert.equal(result.status, 2);

--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -2,7 +2,7 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0/command_generation-1.0.0-py3-none-any.whl#sha256=71eb7788c6baac9728891981273049256aa1420afa30b676108fc278107c4970"
+RUN python -m pip install --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.1.0/command_generation-1.1.0-py3-none-any.whl#sha256=7ed7f6fd59a29183dc18a360d6e38b105133ffcd05dadd9257101b14d270eeff"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/python/Dockerfile.primitive-conformance
+++ b/generated/python/Dockerfile.primitive-conformance
@@ -2,6 +2,6 @@ FROM python:3.12
 
 WORKDIR /work
 
-RUN python -m pip install --no-cache-dir "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0/command_generation-1.0.0-py3-none-any.whl#sha256=71eb7788c6baac9728891981273049256aa1420afa30b676108fc278107c4970"
+RUN python -m pip install --no-cache-dir "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.1.0/command_generation-1.1.0-py3-none-any.whl#sha256=7ed7f6fd59a29183dc18a360d6e38b105133ffcd05dadd9257101b14d270eeff"
 
 CMD ["python", "-m", "command_generation.primitive_conformance"]

--- a/generated/typescript.conformance.Dockerfile
+++ b/generated/typescript.conformance.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /work
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 python3-pip \
     && find /usr/lib/python3/dist-packages -name '*.pyc' -delete \
-    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0/command_generation-1.0.0-py3-none-any.whl#sha256=71eb7788c6baac9728891981273049256aa1420afa30b676108fc278107c4970"
+    && python3 -m pip install --break-system-packages --no-cache-dir jsonschema "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.1.0/command_generation-1.1.0-py3-none-any.whl#sha256=7ed7f6fd59a29183dc18a360d6e38b105133ffcd05dadd9257101b14d270eeff"
 
 COPY src ./src
 COPY scripts ./scripts

--- a/generated/verification/python/command_package.json
+++ b/generated/verification/python/command_package.json
@@ -99,7 +99,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/verification/typescript/package.json
+++ b/generated/verification/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "1.0.0"
+        "version": "1.1.0"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/verification/typescript/resources/command_package.json
+++ b/generated/verification/typescript/resources/command_package.json
@@ -99,7 +99,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/verification/typescript/test/command-package.test.mjs
+++ b/generated/verification/typescript/test/command-package.test.mjs
@@ -39,20 +39,6 @@ test('generated runnable adapter executes supported command without Python runti
   assert.equal(result.stderr, '');
 });
 
-test('generated runnable adapter preserves spaced argv values during native execution', () => {
-  const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const spacedTarget = fileURLToPath(new URL('../tmp target with spaces', import.meta.url));
-  mkdirSync(spacedTarget, { recursive: true });
-  try {
-    const args = ["report", "--target", "__SPACED_TARGET__"].map((token) => token === '__SPACED_TARGET__' ? spacedTarget : token);
-    const result = spawnSync(process.execPath, [cli, ...args], { encoding: 'utf8' });
-    assert.equal(result.status, 0);
-    assert.doesNotMatch(result.stderr, /runtime handoff/i);
-  } finally {
-    rmSync(spacedTarget, { recursive: true, force: true });
-  }
-});
-
 test('generated runnable adapter exposes routing status and recovery guidance', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
   const result = spawnSync(process.execPath, [cli, '--help'], { encoding: 'utf8' });
@@ -66,7 +52,7 @@ test('generated runnable adapter exposes routing status and recovery guidance', 
 
 test('generated runnable adapter renders command help without executing runtime', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const result = spawnSync(process.execPath, [cli, 'report', '--help'], {
+  const result = spawnSync(process.execPath, [cli, ...["report"], '--help'], {
     encoding: 'utf8',
   });
   assert.equal(result.status, 0);
@@ -76,7 +62,7 @@ test('generated runnable adapter renders command help without executing runtime'
 
 test('generated runnable adapter validates choices before command execution', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const result = spawnSync(process.execPath, [cli, 'report', '--format', '__invalid__'], {
+  const result = spawnSync(process.execPath, [cli, ...["report"], '--format', '__invalid__'], {
     encoding: 'utf8',
   });
   assert.equal(result.status, 2);

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -5083,7 +5083,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/workspace/typescript/package.json
+++ b/generated/workspace/typescript/package.json
@@ -9,7 +9,7 @@
     "generationMetadata": {
       "generator": {
         "package": "command-generation",
-        "version": "1.0.0"
+        "version": "1.1.0"
       },
       "schema_version": "command-generation/generated-artifact-metadata/v1",
       "source_ir": {

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -5083,7 +5083,7 @@
   "generation_metadata": {
     "generator": {
       "package": "command-generation",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "schema_version": "command-generation/generated-artifact-metadata/v1",
     "source_ir": {

--- a/generated/workspace/typescript/resources/operations/checkpoint.write.json
+++ b/generated/workspace/typescript/resources/operations/checkpoint.write.json
@@ -25,55 +25,46 @@
       "source": "cli-option"
     },
     {
-      "command_visibility": "runtime-only",
       "name": "task",
       "required": false,
       "source": "cli-option"
     },
     {
-      "command_visibility": "runtime-only",
       "name": "issue",
       "required": false,
       "source": "cli-option"
     },
     {
-      "command_visibility": "runtime-only",
       "name": "pr",
       "required": false,
       "source": "cli-option"
     },
     {
-      "command_visibility": "runtime-only",
       "name": "durable_source",
       "required": false,
       "source": "cli-option"
     },
     {
-      "command_visibility": "runtime-only",
       "name": "last_proof",
       "required": false,
       "source": "cli-option"
     },
     {
-      "command_visibility": "runtime-only",
       "name": "next_safe_command",
       "required": false,
       "source": "cli-option"
     },
     {
-      "command_visibility": "runtime-only",
       "name": "open_blocker",
       "required": false,
       "source": "cli-option"
     },
     {
-      "command_visibility": "runtime-only",
       "name": "dirty_state_summary",
       "required": false,
       "source": "cli-option"
     },
     {
-      "command_visibility": "runtime-only",
       "name": "replace",
       "required": false,
       "source": "cli-option"

--- a/generated/workspace/typescript/test/command-package.test.mjs
+++ b/generated/workspace/typescript/test/command-package.test.mjs
@@ -32,30 +32,16 @@ test('generated package metadata exposes maturity and weak-agent routing status'
 
 test('generated runnable adapter executes supported command without Python runtime', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const result = spawnSync(process.execPath, [cli, ...[...["checkpoint", "write"], "--format", "json"]], { encoding: 'utf8' });
+  const result = spawnSync(process.execPath, [cli, ...["checkpoint", "write", "--format", "json"]], { encoding: 'utf8' });
   assert.equal(result.status, 0);
   const payload = JSON.parse(result.stdout);
   assert.equal(typeof payload, 'object');
   assert.equal(result.stderr, '');
 });
 
-test('generated runnable adapter preserves spaced argv values during native execution', () => {
-  const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const spacedTarget = fileURLToPath(new URL('../tmp target with spaces', import.meta.url));
-  mkdirSync(spacedTarget, { recursive: true });
-  try {
-    const args = [...["checkpoint", "write"], "--target", "__SPACED_TARGET__"].map((token) => token === '__SPACED_TARGET__' ? spacedTarget : token);
-    const result = spawnSync(process.execPath, [cli, ...args], { encoding: 'utf8' });
-    assert.equal(result.status, 0);
-    assert.doesNotMatch(result.stderr, /runtime handoff/i);
-  } finally {
-    rmSync(spacedTarget, { recursive: true, force: true });
-  }
-});
-
 test('generated runnable adapter rejects command without required subcommand', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const result = spawnSync(process.execPath, [cli, ...["checkpoint"], "--format", "json"], { encoding: 'utf8' });
+  const result = spawnSync(process.execPath, [cli, ...["checkpoint"]], { encoding: 'utf8' });
   assert.equal(result.status, 2);
   assert.equal(result.stdout, '');
   assert.match(result.stderr, /missing subcommand for checkpoint/);
@@ -75,7 +61,7 @@ test('generated runnable adapter exposes routing status and recovery guidance', 
 
 test('generated runnable adapter renders command help without executing runtime', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const result = spawnSync(process.execPath, [cli, 'checkpoint', '--help'], {
+  const result = spawnSync(process.execPath, [cli, ...["checkpoint", "write"], '--help'], {
     encoding: 'utf8',
   });
   assert.equal(result.status, 0);
@@ -85,7 +71,7 @@ test('generated runnable adapter renders command help without executing runtime'
 
 test('generated runnable adapter validates choices before command execution', () => {
   const cli = fileURLToPath(new URL('../src/cli.mjs', import.meta.url));
-  const result = spawnSync(process.execPath, [cli, 'checkpoint', '--format', '__invalid__'], {
+  const result = spawnSync(process.execPath, [cli, ...["checkpoint", "write"], '--format', '__invalid__'], {
     encoding: 'utf8',
   });
   assert.equal(result.status, 2);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ agentic-workspace = "agentic_workspace.cli:main"
 
 [dependency-groups]
 dev = [
-  "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.0.0/command_generation-1.0.0-py3-none-any.whl#sha256=71eb7788c6baac9728891981273049256aa1420afa30b676108fc278107c4970",
+  "command-generation @ https://github.com/rickardvh/command-generation/releases/download/v1.1.0/command_generation-1.1.0-py3-none-any.whl#sha256=7ed7f6fd59a29183dc18a360d6e38b105133ffcd05dadd9257101b14d270eeff",
   "jsonschema",
   "pre-commit",
   "pytest",

--- a/scripts/check/check_command_surface_bundle.py
+++ b/scripts/check/check_command_surface_bundle.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_json(relative: str, *, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    return json.loads((repo_root / relative).read_text(encoding="utf-8"))
+
+
+def _operation_refs_from_interface(interface: dict[str, Any], inherited: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    current = interface.get("operation_ref", inherited or {})
+    operation_ref = current if isinstance(current, dict) else inherited or {}
+    refs = [operation_ref] if operation_ref else []
+    for subcommand in interface.get("subcommands", []):
+        if isinstance(subcommand, dict):
+            refs.extend(_operation_refs_from_interface(subcommand, operation_ref))
+    return refs
+
+
+def _ids(items: Any) -> set[str]:
+    if not isinstance(items, list):
+        return set()
+    return {str(item.get("id", "")).strip() for item in items if isinstance(item, dict) and str(item.get("id", "")).strip()}
+
+
+def _operation_inventory_entries(payload: dict[str, Any], operation_id: str) -> list[dict[str, Any]]:
+    entries = payload.get("entries", [])
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict) and entry.get("operation_id") == operation_id]
+
+
+def _runtime_projection_entries(payload: dict[str, Any], operation_id: str) -> list[dict[str, Any]]:
+    boundary = payload.get("accepted_runtime_boundaries", {})
+    entries = boundary.get("entries", []) if isinstance(boundary, dict) else []
+    matched: list[dict[str, Any]] = []
+    for entry in entries if isinstance(entries, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        operation_ids = entry.get("operation_ids", [])
+        if entry.get("operation_id") == operation_id or (isinstance(operation_ids, list) and operation_id in operation_ids):
+            matched.append(entry)
+    return matched
+
+
+def command_surface_bundle_report(operation_id: str, *, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    operation_path = f"operations/{operation_id}.json"
+    conformance_prefix = f"{operation_id}."
+    operation_file = repo_root / "src/agentic_workspace/contracts" / operation_path
+    conformance_dir = repo_root / "src/agentic_workspace/contracts/conformance"
+    conformance_files = sorted(path.name for path in conformance_dir.glob(f"{operation_id}.*.json"))
+
+    operation_contracts = _load_json("src/agentic_workspace/contracts/operation_contracts.json", repo_root=repo_root)
+    operation_primitives = _load_json("src/agentic_workspace/contracts/operation_primitives.json", repo_root=repo_root)
+    conformance_contracts = _load_json("src/agentic_workspace/contracts/conformance_contracts.json", repo_root=repo_root)
+    adapter_generation = _load_json("src/agentic_workspace/contracts/command_adapter_generation.json", repo_root=repo_root)
+    package_ir = _load_json("src/agentic_workspace/contracts/command_package_ir.json", repo_root=repo_root)
+    operation_execution_inventory = _load_json(
+        "src/agentic_workspace/contracts/python_operation_execution_inventory.json",
+        repo_root=repo_root,
+    )
+    runtime_projection_inventory = _load_json(
+        "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
+        repo_root=repo_root,
+    )
+    operation_inventory_entries = _operation_inventory_entries(operation_execution_inventory, operation_id)
+    runtime_projection_entries = _runtime_projection_entries(runtime_projection_inventory, operation_id)
+
+    primitive_uses: set[str] = set()
+    output_schema_refs: set[str] = set()
+    if operation_file.is_file():
+        operation = json.loads(operation_file.read_text(encoding="utf-8"))
+        for step in operation.get("steps", []):
+            if isinstance(step, dict) and step.get("uses"):
+                primitive_uses.add(str(step["uses"]))
+        output = operation.get("output", {})
+        if isinstance(output, dict) and output.get("schema_ref"):
+            output_schema_refs.add(str(output["schema_ref"]).removeprefix("schemas/"))
+
+    primitive_ids = _ids(operation_primitives.get("primitives"))
+    missing_primitives = sorted(primitive for primitive in primitive_uses if primitive not in primitive_ids and primitive != "output.emit")
+
+    adapter_refs = []
+    for adapter in adapter_generation.get("adapters", []):
+        if not isinstance(adapter, dict):
+            continue
+        ref = adapter.get("operation_ref", {})
+        if isinstance(ref, dict) and ref.get("id") == operation_id:
+            adapter_refs.append(str(adapter.get("id", "")))
+
+    package_refs = []
+    package_output_schemas: set[str] = set()
+    package_conformance_refs: set[str] = set()
+    for package in package_ir.get("packages", []):
+        if not isinstance(package, dict):
+            continue
+        for command in package.get("commands", []):
+            if not isinstance(command, dict):
+                continue
+            refs = []
+            command_ref = command.get("operation_ref", {})
+            if isinstance(command_ref, dict):
+                refs.append(command_ref)
+            interface = command.get("interface", {})
+            if isinstance(interface, dict):
+                refs.extend(_operation_refs_from_interface(interface, command_ref if isinstance(command_ref, dict) else None))
+            if any(ref.get("id") == operation_id for ref in refs if isinstance(ref, dict)):
+                package_refs.append(str(command.get("adapter_id", "")))
+                schemas = command.get("schemas", {})
+                if isinstance(schemas, dict):
+                    for schema in schemas.get("output", []):
+                        package_output_schemas.add(str(schema))
+                for ref in command.get("conformance_refs", []):
+                    package_conformance_refs.add(str(ref))
+
+    generated_python = _load_json("generated/workspace/python/command_package.json", repo_root=repo_root)
+    generated_refs = []
+    for command in generated_python.get("commands", []):
+        if isinstance(command, dict) and any(
+            isinstance(ref, dict) and ref.get("id") == operation_id
+            for ref in _operation_refs_from_interface(command.get("interface", {}) if isinstance(command.get("interface"), dict) else {}, command.get("operation_ref", {}))
+        ):
+            generated_refs.append(str(command.get("adapter_id", "")))
+
+    checks = {
+        "operation_file": operation_file.is_file(),
+        "operation_contract_registry": operation_id in _ids(operation_contracts.get("operations")),
+        "operation_primitives": not missing_primitives,
+        "conformance_file": bool(conformance_files),
+        "conformance_registry": any(
+            str(item.get("id", "")).startswith(conformance_prefix)
+            for item in conformance_contracts.get("contracts", [])
+            if isinstance(item, dict)
+        ),
+        "command_adapter_generation": bool(adapter_refs),
+        "command_package_ir": bool(package_refs),
+        "generated_python_command_package": bool(generated_refs),
+        "python_operation_execution_inventory": bool(operation_inventory_entries),
+        "python_runtime_projection_inventory": bool(runtime_projection_entries),
+        "output_schema_refs": output_schema_refs <= package_output_schemas if output_schema_refs else True,
+        "conformance_refs": any(ref.startswith(conformance_prefix) for ref in package_conformance_refs),
+    }
+    missing = [name for name, ok in checks.items() if not ok]
+    return {
+        "kind": "agentic-workspace/command-surface-bundle-check/v1",
+        "operation_id": operation_id,
+        "status": "ok" if not missing else "missing-companion-surfaces",
+        "missing": missing,
+        "checks": checks,
+        "details": {
+            "operation_path": operation_path,
+            "conformance_files": conformance_files,
+            "missing_primitives": missing_primitives,
+            "adapter_refs": adapter_refs,
+            "package_refs": package_refs,
+            "generated_refs": generated_refs,
+            "python_operation_execution_inventory": [
+                {
+                    "operation_contract": entry.get("operation_contract", ""),
+                    "status": entry.get("status", ""),
+                    "runtime_boundary_class": entry.get("runtime_boundary_class", ""),
+                    "conformance_ref": entry.get("conformance_ref", ""),
+                }
+                for entry in operation_inventory_entries
+            ],
+            "python_runtime_projection_inventory": [
+                {
+                    "binding_kind": entry.get("binding_kind", ""),
+                    "facade_path": entry.get("facade_path", ""),
+                    "facade_symbol": entry.get("facade_symbol", ""),
+                    "operation_path": entry.get("operation_path", ""),
+                    "source_module": entry.get("source_module", ""),
+                    "source_symbol": entry.get("source_symbol", ""),
+                    "status": entry.get("status", ""),
+                    "conformance_ref": entry.get("conformance_ref", ""),
+                }
+                for entry in runtime_projection_entries
+            ],
+            "output_schema_refs": sorted(output_schema_refs),
+            "package_output_schemas": sorted(package_output_schemas),
+            "package_conformance_refs": sorted(package_conformance_refs),
+        },
+        "remediation": "Declare the missing companion surfaces, run uv run python scripts/generate/refresh_command_surfaces.py, then rerun this check and check_generated_command_packages.py.",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check the complete registry bundle for a generated command operation.")
+    parser.add_argument("--operation-id", required=True, help="Operation id such as checkpoint.write.")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+    report = command_surface_bundle_report(args.operation_id)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif report["status"] == "ok":
+        print(f"[ok] command surface bundle {args.operation_id}")
+    else:
+        print(f"[fail] command surface bundle {args.operation_id}: missing {', '.join(report['missing'])}")
+        print(report["remediation"])
+    return 0 if report["status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -70,6 +70,19 @@ def _repo_relative(path: Path) -> str:
     return os.path.relpath(path, REPO_ROOT).replace(os.sep, "/")
 
 
+def _run_git_output(args: list[str]) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if completed.returncode:
+        return ""
+    return completed.stdout
+
+
 class RunnableTypescriptConformanceCase(NamedTuple):
     package_id: str
     program: str
@@ -307,8 +320,6 @@ GENERATED_CLI_COMPATIBILITY_VOCABULARY_ALLOWLIST = {
     "packages/verification/src/repo_verification_bootstrap/cli.py": "source-checkout fallback to checked-in generated verification CLI package",
     "src/agentic_workspace/workspace_runtime_primitives.py": "legacy parser helper compatibility wrapper",
     "scripts/check/check_generated_command_packages.py": "static compatibility allowlist and obsolete-layout guards",
-    "tests/test_command_generation_artifacts.py": "obsolete target-specific runtime guard",
-    "tests/test_contract_tooling.py": "legacy-layout fixture and obsolete source guard",
     "tests/test_workspace_packaging.py": "installed private bridge compatibility proof",
     "packages/planning/tests/test_packaging.py": "installed private bridge compatibility proof",
     "packages/memory/tests/test_packaging.py": "installed private bridge compatibility proof",
@@ -902,11 +913,14 @@ def _validate_operation_cli_inputs_for_interface(
     option_names = set(inherited_option_names) | _interface_parameter_names(interface)
     operation_ref = interface.get("operation_ref", inherited_operation_ref)
     current_operation_ref = operation_ref if isinstance(operation_ref, dict) else inherited_operation_ref
+    operation_ref_declared_here = isinstance(interface.get("operation_ref"), dict)
     operation_id = str(current_operation_ref.get("id", "")).strip()
     operation_path = str(current_operation_ref.get("path", "")).strip()
     subcommands = interface.get("subcommands", [])
     has_subcommands = isinstance(subcommands, list) and any(isinstance(subcommand, dict) for subcommand in subcommands)
-    if operation_id and operation_path and (option_names or not has_subcommands):
+    subcommands_required = has_subcommands and interface.get("subcommands_required") is not False
+    validate_current_operation = operation_ref_declared_here or not subcommands_required
+    if operation_id and operation_path and validate_current_operation:
         try:
             operation = (
                 _load_generated_operation_json(generated_root, operation_path) if generated_root is not None else _load_json(operation_path)
@@ -4092,6 +4106,47 @@ def _validate_generated_artifact_generation_metadata(ir: dict[str, object]) -> l
     return errors
 
 
+def _git_dirty_path_from_porcelain_line(line: str) -> str:
+    payload = line[3:].strip()
+    if " -> " in payload:
+        payload = payload.rsplit(" -> ", 1)[1].strip()
+    if len(payload) >= 2 and payload[0] == payload[-1] == '"':
+        payload = payload[1:-1]
+    return payload.replace("\\", "/")
+
+
+def _line_ending_only_generated_output_paths(ir: dict[str, object]) -> list[str]:
+    rendered = {
+        _repo_relative(output.path if output.path.is_absolute() else REPO_ROOT / output.path): output.content
+        for output in render_workspace_command_package_outputs(ir, repo_root=REPO_ROOT)
+    }
+    status = _run_git_output(["status", "--porcelain=v1", "--", "generated"])
+    dirty_paths = [_git_dirty_path_from_porcelain_line(line) for line in status.splitlines() if line.strip()]
+    classified: list[str] = []
+    for relative_path in dirty_paths:
+        expected = rendered.get(relative_path)
+        if expected is None:
+            continue
+        path = REPO_ROOT / relative_path
+        if not path.is_file():
+            continue
+        semantic_diff = _run_git_output(["diff", "--numstat", "HEAD", "--", relative_path]).strip()
+        if semantic_diff:
+            continue
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            current = handle.read()
+        if current == expected or current.replace("\r\n", "\n") == expected:
+            classified.append(relative_path)
+    return sorted(classified)
+
+
+def _validate_generated_output_git_dirtiness(ir: dict[str, object]) -> list[str]:
+    return [
+        f"{path} is line-ending-only generated output dirtiness; run git restore -- {path} or regenerate packages to normalize LF output."
+        for path in _line_ending_only_generated_output_paths(ir)
+    ]
+
+
 def _validate_generated_python_commands_absent_from_handwritten_parsers() -> list[str]:
     errors: list[str] = []
     for package_id in ("root-workspace", "planning-bootstrap", "memory-bootstrap", "verification-cli"):
@@ -4163,6 +4218,12 @@ def _generated_cli_compatibility_allowlist_reason(relative_path: str) -> str | N
 
 def _validate_generated_cli_compatibility_vocabulary() -> list[str]:
     errors: list[str] = []
+    for relative_path in sorted(GENERATED_CLI_COMPATIBILITY_VOCABULARY_ALLOWLIST):
+        if not (REPO_ROOT / relative_path).is_file():
+            errors.append(
+                f"{relative_path} is listed in GENERATED_CLI_COMPATIBILITY_VOCABULARY_ALLOWLIST but does not exist; "
+                "remove the stale entry or move historical/provenance-only coverage to a prefix allowlist"
+            )
     candidate_paths: list[str] = []
     if shutil.which("git"):
         completed = subprocess.run(
@@ -4768,6 +4829,7 @@ def _validate_static_surfaces() -> list[str]:
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         errors.append(f"command-package IR validation failed: {exc}")
     else:
+        errors.extend(_validate_generated_output_git_dirtiness(ir))
         errors.extend(_validate_command_generation_extraction_readiness(ir))
         errors.extend(_validate_command_generation_non_aw_fixture())
         errors.extend(_validate_generated_operation_cli_inputs(ir))

--- a/scripts/generate/generate_schema_reference.py
+++ b/scripts/generate/generate_schema_reference.py
@@ -341,6 +341,56 @@ def _parse_schema_target(raw: str) -> ReferenceTarget:
     return ReferenceTarget(schema_path, Path("docs/reference") / f"{output_name}.md")
 
 
+def _parse_schema_field(raw: str) -> tuple[str, str]:
+    if ":" not in raw:
+        raise argparse.ArgumentTypeError("--field must use name:type")
+    name, raw_type = raw.split(":", 1)
+    name = name.strip()
+    raw_type = raw_type.strip()
+    if not name or not raw_type:
+        raise argparse.ArgumentTypeError("--field must use non-empty name:type")
+    return name, raw_type
+
+
+def scaffold_schema(*, schema_path: Path, title: str, fields: list[tuple[str, str]], doc_role: str) -> dict[str, Any]:
+    required = [name for name, _raw_type in fields]
+    properties: dict[str, dict[str, Any]] = {}
+    for name, raw_type in fields:
+        properties[name] = {
+            "type": raw_type,
+            "description": f"Describe the {name} field for generated schema reference docs.",
+        }
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": f"https://agentic-workspace.local/schemas/{schema_path.name}",
+        "title": title,
+        "description": f"Describe the {title} schema for generated schema reference docs.",
+        "type": "object",
+        "additionalProperties": False,
+        "required": required,
+        "properties": properties,
+        "x-agentic-workspace-doc-role": doc_role,
+    }
+
+
+def write_schema_scaffold(
+    *,
+    schema_path: Path,
+    title: str,
+    fields: list[tuple[str, str]],
+    doc_role: str,
+    repo_root: Path = REPO_ROOT,
+    force: bool = False,
+) -> Path:
+    output_path = repo_root / schema_path
+    if output_path.exists() and not force:
+        raise FileExistsError(f"{schema_path.as_posix()} already exists; pass --force to replace it.")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = scaffold_schema(schema_path=schema_path, title=title, fields=fields, doc_role=doc_role)
+    output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return schema_path
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate Markdown reference docs from annotated JSON Schemas.")
     parser.add_argument(
@@ -350,11 +400,39 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--check", action="store_true", help="Fail if generated docs are stale.")
     parser.add_argument("--check-annotations", action="store_true", help="Fail if configured schemas miss required doc annotations.")
+    parser.add_argument("--scaffold-schema", help="Create a new annotated schema scaffold at this repo-relative path.")
+    parser.add_argument("--title", help="Title to use with --scaffold-schema.")
+    parser.add_argument(
+        "--field",
+        action="append",
+        type=_parse_schema_field,
+        default=[],
+        help="Field for --scaffold-schema as name:type. May be repeated.",
+    )
+    parser.add_argument("--doc-role", default="schema-reference", help="x-agentic-workspace-doc-role for --scaffold-schema.")
+    parser.add_argument("--force", action="store_true", help="Allow --scaffold-schema to replace an existing file.")
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
+    if args.scaffold_schema:
+        if not args.title:
+            print("--scaffold-schema requires --title", file=sys.stderr)
+            return 2
+        try:
+            path = write_schema_scaffold(
+                schema_path=Path(args.scaffold_schema),
+                title=str(args.title),
+                fields=list(args.field or []),
+                doc_role=str(args.doc_role),
+                force=bool(args.force),
+            )
+        except FileExistsError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        print(f"[ok] wrote schema scaffold {path.as_posix()}")
+        return 0
     targets = tuple(_parse_schema_target(item) for item in args.schema) if args.schema else DEFAULT_TARGETS
     errors: list[str] = []
     if args.check_annotations:

--- a/src/agentic_workspace/contracts/operations/checkpoint.write.json
+++ b/src/agentic_workspace/contracts/operations/checkpoint.write.json
@@ -17,55 +17,46 @@
     {
       "name": "task",
       "source": "cli-option",
-      "command_visibility": "runtime-only",
       "required": false
     },
     {
       "name": "issue",
       "source": "cli-option",
-      "command_visibility": "runtime-only",
       "required": false
     },
     {
       "name": "pr",
       "source": "cli-option",
-      "command_visibility": "runtime-only",
       "required": false
     },
     {
       "name": "durable_source",
       "source": "cli-option",
-      "command_visibility": "runtime-only",
       "required": false
     },
     {
       "name": "last_proof",
       "source": "cli-option",
-      "command_visibility": "runtime-only",
       "required": false
     },
     {
       "name": "next_safe_command",
       "source": "cli-option",
-      "command_visibility": "runtime-only",
       "required": false
     },
     {
       "name": "open_blocker",
       "source": "cli-option",
-      "command_visibility": "runtime-only",
       "required": false
     },
     {
       "name": "dirty_state_summary",
       "source": "cli-option",
-      "command_visibility": "runtime-only",
       "required": false
     },
     {
       "name": "replace",
       "source": "cli-option",
-      "command_visibility": "runtime-only",
       "required": false
     },
     {

--- a/tests/test_command_surface_bundle_check.py
+++ b/tests/test_command_surface_bundle_check.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_checker():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "check" / "check_command_surface_bundle.py"
+    spec = importlib.util.spec_from_file_location("check_command_surface_bundle", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_command_surface_bundle_check_passes_for_checkpoint_write() -> None:
+    checker = _load_checker()
+
+    report = checker.command_surface_bundle_report("checkpoint.write")
+
+    assert report["status"] == "ok"
+    assert report["missing"] == []
+    assert "checkpoint.write.cli" in report["details"]["package_refs"]
+    assert report["details"]["python_operation_execution_inventory"]
+    assert report["details"]["python_runtime_projection_inventory"]
+
+
+def test_command_surface_bundle_check_reports_all_missing_layers(tmp_path: Path) -> None:
+    checker = _load_checker()
+    contract_root = tmp_path / "src/agentic_workspace/contracts"
+    generated_root = tmp_path / "generated/workspace/python"
+    (contract_root / "operations").mkdir(parents=True)
+    (contract_root / "conformance").mkdir(parents=True)
+    generated_root.mkdir(parents=True)
+    (contract_root / "operations/example.write.json").write_text(
+        json.dumps(
+            {
+                "id": "example.write",
+                "steps": [{"uses": "workspace.example.write"}],
+                "output": {"schema_ref": "schemas/example_write_result.schema.json"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    for relative, payload in {
+        "operation_contracts.json": {"operations": []},
+        "operation_primitives.json": {"primitives": []},
+        "conformance_contracts.json": {"contracts": []},
+        "command_adapter_generation.json": {"adapters": []},
+        "command_package_ir.json": {"packages": []},
+        "python_operation_execution_inventory.json": {"entries": []},
+        "python_runtime_projection_inventory.json": {"accepted_runtime_boundaries": {"entries": []}},
+    }.items():
+        (contract_root / relative).write_text(json.dumps(payload), encoding="utf-8")
+    (generated_root / "command_package.json").write_text(json.dumps({"commands": []}), encoding="utf-8")
+
+    report = checker.command_surface_bundle_report("example.write", repo_root=tmp_path)
+
+    assert report["status"] == "missing-companion-surfaces"
+    assert {
+        "operation_contract_registry",
+        "operation_primitives",
+        "conformance_file",
+        "conformance_registry",
+        "command_adapter_generation",
+        "command_package_ir",
+        "generated_python_command_package",
+        "python_operation_execution_inventory",
+        "python_runtime_projection_inventory",
+        "output_schema_refs",
+        "conformance_refs",
+    } <= set(report["missing"])

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -381,6 +381,20 @@ def test_command_generation_extraction_readiness_rejects_uninventoried_product_l
     assert any("product-specific literals without extraction-readiness inventory" in error for error in errors)
 
 
+def test_generated_cli_compatibility_allowlist_rejects_missing_exact_paths() -> None:
+    errors = _checker_case_errors(
+        """
+        checker.GENERATED_CLI_COMPATIBILITY_VOCABULARY_ALLOWLIST = {
+            **checker.GENERATED_CLI_COMPATIBILITY_VOCABULARY_ALLOWLIST,
+            "internal/command-generation/src/command_generation/generated_package_loader.py": "stale internalization residue",
+        }
+        _emit({"errors": checker._validate_generated_cli_compatibility_vocabulary()})
+        """
+    )
+
+    assert any("is listed in GENERATED_CLI_COMPATIBILITY_VOCABULARY_ALLOWLIST but does not exist" in error for error in errors)
+
+
 def test_generated_python_version_output_is_contract_backed() -> None:
     checker = _load_checker()
     root = checker.REPO_ROOT
@@ -597,6 +611,44 @@ def test_generated_artifact_metadata_rejects_unsupported_target_layout() -> None
     )
 
     assert any("generation metadata has unexpected target layout" in error for error in errors)
+
+
+def test_generated_output_git_dirtiness_classifies_line_ending_only_changes() -> None:
+    errors = _checker_case_errors(
+        """
+        relative_path = "generated/workspace/python/line-ending-fixture.txt"
+        path = checker.REPO_ROOT / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        class Output:
+            def __init__(self, path, content):
+                self.path = path
+                self.content = content
+
+        def fake_render_outputs(ir, *, repo_root):
+            return [Output(path, "alpha\\nbeta\\n")]
+
+        def fake_git_output(args):
+            if args == ["status", "--porcelain=v1", "--", "generated"]:
+                return f" M {relative_path}\\n"
+            if args == ["diff", "--numstat", "HEAD", "--", relative_path]:
+                return ""
+            return ""
+
+        try:
+            path.write_bytes(b"alpha\\r\\nbeta\\r\\n")
+            checker.render_workspace_command_package_outputs = fake_render_outputs
+            checker._run_git_output = fake_git_output
+            _emit({"errors": checker._validate_generated_output_git_dirtiness({})})
+        finally:
+            path.unlink(missing_ok=True)
+        """
+    )
+
+    assert errors == [
+        "generated/workspace/python/line-ending-fixture.txt is line-ending-only generated output dirtiness; "
+        "run git restore -- generated/workspace/python/line-ending-fixture.txt or regenerate packages to normalize LF output."
+    ]
 
 
 def test_lifecycle_dry_run_generation_regression_is_blocked() -> None:
@@ -1208,6 +1260,52 @@ def test_generated_operation_cli_input_proof_scenarios(monkeypatch) -> None:
         interface=interface,
         inherited_operation_ref=operation_ref,
         inherited_option_names=set(),
+    )
+
+    assert errors == []
+
+
+def test_operation_cli_input_visibility_uses_required_subcommand_interface(monkeypatch) -> None:
+    checker = _load_checker()
+
+    parent_interface = {
+        "name": "checkpoint",
+        "options": [{"name": "target"}, {"name": "format"}],
+        "subcommands_required": True,
+        "subcommands": [
+            {
+                "name": "write",
+                "options": [
+                    {"name": "target"},
+                    {"name": "task"},
+                    {"name": "issue"},
+                    {"name": "durable_source"},
+                    {"name": "replace"},
+                    {"name": "format"},
+                ],
+                "operation_ref": {"id": "checkpoint.write", "path": "operations/checkpoint.write.json"},
+            }
+        ],
+    }
+    operation = {
+        "inputs": [
+            {"name": "target", "source": "cli-option"},
+            {"name": "task", "source": "cli-option"},
+            {"name": "issue", "source": "cli-option"},
+            {"name": "durable_source", "source": "cli-option"},
+            {"name": "replace", "source": "cli-option"},
+            {"name": "format", "source": "cli-option"},
+        ]
+    }
+    monkeypatch.setattr(checker, "_load_json", lambda path: operation)
+
+    errors = checker._validate_operation_cli_inputs_for_interface(
+        package_id="root-workspace",
+        command_path="checkpoint",
+        interface=parent_interface,
+        inherited_operation_ref={"id": "checkpoint.write", "path": "operations/checkpoint.write.json"},
+        inherited_option_names=set(),
+        command_source_id="checkpoint.write.cli",
     )
 
     assert errors == []

--- a/tests/test_schema_reference_docs.py
+++ b/tests/test_schema_reference_docs.py
@@ -105,6 +105,44 @@ def test_schema_reference_generator_still_detects_semantic_staleness(tmp_path: P
     assert module.generate(targets=(target,), repo_root=tmp_path, check=True) == [target.output_path]
 
 
+def test_schema_reference_scaffold_includes_required_doc_metadata(tmp_path: Path) -> None:
+    module = _load_generator()
+    schema_path = Path("src/agentic_workspace/contracts/schemas/example.schema.json")
+
+    module.write_schema_scaffold(
+        schema_path=schema_path,
+        title="Example Schema",
+        fields=[("name", "string"), ("count", "integer")],
+        doc_role="fixture",
+        repo_root=tmp_path,
+    )
+
+    schema = (tmp_path / schema_path).read_text(encoding="utf-8")
+    assert '"x-agentic-workspace-doc-role": "fixture"' in schema
+    assert "Describe the name field for generated schema reference docs." in schema
+    assert module._annotation_errors(schema_path, repo_root=tmp_path) == []
+
+
+def test_schema_reference_scaffold_refuses_existing_file_without_force(tmp_path: Path) -> None:
+    module = _load_generator()
+    schema_path = Path("src/agentic_workspace/contracts/schemas/example.schema.json")
+    (tmp_path / schema_path).parent.mkdir(parents=True)
+    (tmp_path / schema_path).write_text("{}\n", encoding="utf-8")
+
+    try:
+        module.write_schema_scaffold(
+            schema_path=schema_path,
+            title="Example Schema",
+            fields=[],
+            doc_role="fixture",
+            repo_root=tmp_path,
+        )
+    except FileExistsError as exc:
+        assert "pass --force" in str(exc)
+    else:  # pragma: no cover - explicit failure branch for readability
+        raise AssertionError("expected FileExistsError")
+
+
 def test_schema_reference_curated_descriptions_cover_high_value_schemas() -> None:
     module = _load_generator()
 

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "command-generation", url = "https://github.com/rickardvh/command-generation/releases/download/v1.0.0/command_generation-1.0.0-py3-none-any.whl" },
+    { name = "command-generation", url = "https://github.com/rickardvh/command-generation/releases/download/v1.1.0/command_generation-1.1.0-py3-none-any.whl" },
     { name = "jsonschema" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -144,13 +144,13 @@ wheels = [
 
 [[package]]
 name = "command-generation"
-version = "1.0.0"
-source = { url = "https://github.com/rickardvh/command-generation/releases/download/v1.0.0/command_generation-1.0.0-py3-none-any.whl" }
+version = "1.1.0"
+source = { url = "https://github.com/rickardvh/command-generation/releases/download/v1.1.0/command_generation-1.1.0-py3-none-any.whl" }
 dependencies = [
     { name = "jsonschema" },
 ]
 wheels = [
-    { url = "https://github.com/rickardvh/command-generation/releases/download/v1.0.0/command_generation-1.0.0-py3-none-any.whl", hash = "sha256:71eb7788c6baac9728891981273049256aa1420afa30b676108fc278107c4970" },
+    { url = "https://github.com/rickardvh/command-generation/releases/download/v1.1.0/command_generation-1.1.0-py3-none-any.whl", hash = "sha256:7ed7f6fd59a29183dc18a360d6e38b105133ffcd05dadd9257101b14d270eeff" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Summary
- add a command-surface bundle doctor for checking an operation across operation contracts, adapter generation, conformance, package IR, generated package refs, output schema refs, Python operation execution inventory, and Python runtime projection inventory
- scaffold schema-reference JSON schemas with required doc metadata before rendering/checking docs
- make operation CLI input visibility validation subcommand-aware, then expose `checkpoint write` options as command-visible inputs
- consume the released command-generation v1.1.0 wheel for the TypeScript required-subcommand fixture fix from rickardvh/command-generation#70
- classify generated output Git dirtiness with no semantic diff as `line-ending-only` and print an exact remediation
- remove stale exact-path generated CLI compatibility allowlist entries and reject future missing exact allowlist paths

Closes #1735
Closes #1736
Closes #1737
Closes #1746
Closes #1748
Closes #1752

Does not close #1747 after review: the internal `command-generation` workspace dependency was removed, so that proof-root follow-up remains separate unless a future local dependency root is introduced.

## Validation
- command-generation release check: `gh release view v1.1.0 --repo rickardvh/command-generation --json assets,tagName,url`
- command-generation wheel digest check: `gh release download v1.1.0 --repo rickardvh/command-generation --pattern "*.whl" --dir $env:TEMP\cg-v1.1.0 --clobber; Get-FileHash $env:TEMP\cg-v1.1.0\*.whl -Algorithm SHA256`
- stale internalization residue check: `rg "internal/command-generation" scripts tests src generated -g "!*node_modules*"` returned no matches
- `uv run pytest tests/test_generated_command_package_proof_runner.py::test_generated_cli_compatibility_allowlist_rejects_missing_exact_paths -q`
- `uv run pytest tests/test_generated_command_package_proof_runner.py::test_operation_cli_input_visibility_uses_required_subcommand_interface tests/test_schema_reference_docs.py::test_schema_reference_scaffold_includes_required_doc_metadata tests/test_schema_reference_docs.py::test_schema_reference_scaffold_refuses_existing_file_without_force tests/test_command_surface_bundle_check.py -q`
- `uv run pytest tests/test_generated_command_package_proof_runner.py::test_generated_output_git_dirtiness_classifies_line_ending_only_changes -q`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_command_surface_bundle.py --operation-id checkpoint.write --format json`
- `uv run pytest tests/test_workspace_cli.py -q`
- `npm test` in `generated/workspace/typescript`
- `npm test` in `generated/planning/typescript`
- `npm test` in `generated/memory/typescript`
- `npm test` in `generated/verification/typescript`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `make test-workspace`
- `make lint-workspace`