### PR TITLE
[codex] Sharpen local checkpoint resume packets

### DIFF
--- a/docs/reference/local-chat-checkpoint.md
+++ b/docs/reference/local-chat-checkpoint.md
@@ -11,7 +11,7 @@ Ignored local-only continuity checkpoint used to rehydrate a chat after compacti
 | Field | Type | Required | Default | Description | Examples | Annotations |
 | --- | --- | --- | --- | --- | --- | --- |
 | (root) | object | yes |  | Ignored local-only continuity checkpoint used to rehydrate a chat after compaction or resume without treating local notes as closure evidence. |  | x-agentic-workspace-doc-role: "schema-reference" |
-| `kind` | const `"agentic-workspace/local-chat-checkpoint/v1"` | yes |  | Stable checkpoint record discriminator. |  |  |
+| `kind` | const `"agentic-workspace/local-chat-checkpoint/v2"` | yes |  | Stable checkpoint record discriminator. |  |  |
 | `created_at` | string | yes |  | ISO-like UTC timestamp for the first checkpoint write. |  |  |
 | `updated_at` | string | yes |  | ISO-like UTC timestamp for the most recent checkpoint write. |  |  |
 | `task` | string | yes |  | Short current task summary suitable for startup projection. |  |  |
@@ -24,6 +24,66 @@ Ignored local-only continuity checkpoint used to rehydrate a chat after compacti
 | `open_blockers` | array of string | yes |  | Unresolved blockers to re-check after resume. |  |  |
 | `dirty_state_summary` | string | yes |  | Short summary of local dirty state at checkpoint write time. |  |  |
 | `next_safe_command` | string | yes |  | Next safe command to run after resume. |  |  |
+| `volatile_observations` | object | yes |  | Stale-prone local or remote observations captured with provenance and observation time. |  |  |
+| `volatile_observations.repo_root` | ref `#/$defs/observation` | yes |  | Repository root path observed when the checkpoint was written. |  |  |
+| `volatile_observations.repo_root.value` |  | yes |  | Observed value. |  |  |
+| `volatile_observations.repo_root.source` | string | yes |  | Source of the observed value. |  |  |
+| `volatile_observations.repo_root.observed_at` | string | yes |  | Timestamp when the value was observed. |  |  |
+| `volatile_observations.remote_origin_url` | ref `#/$defs/observation` | yes |  | Origin remote URL observed when available. |  |  |
+| `volatile_observations.remote_origin_url.value` |  | yes |  | Observed value. |  |  |
+| `volatile_observations.remote_origin_url.source` | string | yes |  | Source of the observed value. |  |  |
+| `volatile_observations.remote_origin_url.observed_at` | string | yes |  | Timestamp when the value was observed. |  |  |
+| `volatile_observations.branch` | ref `#/$defs/observation` | yes |  | Git branch observed when the checkpoint was written. |  |  |
+| `volatile_observations.branch.value` |  | yes |  | Observed value. |  |  |
+| `volatile_observations.branch.source` | string | yes |  | Source of the observed value. |  |  |
+| `volatile_observations.branch.observed_at` | string | yes |  | Timestamp when the value was observed. |  |  |
+| `volatile_observations.head_commit` | ref `#/$defs/observation` | yes |  | Local HEAD commit observed when the checkpoint was written. |  |  |
+| `volatile_observations.head_commit.value` |  | yes |  | Observed value. |  |  |
+| `volatile_observations.head_commit.source` | string | yes |  | Source of the observed value. |  |  |
+| `volatile_observations.head_commit.observed_at` | string | yes |  | Timestamp when the value was observed. |  |  |
+| `volatile_observations.upstream_commit` | ref `#/$defs/observation` | yes |  | Upstream commit observed when available; compare with local HEAD on resume. |  |  |
+| `volatile_observations.upstream_commit.value` |  | yes |  | Observed value. |  |  |
+| `volatile_observations.upstream_commit.source` | string | yes |  | Source of the observed value. |  |  |
+| `volatile_observations.upstream_commit.observed_at` | string | yes |  | Timestamp when the value was observed. |  |  |
+| `volatile_observations.current_pr` | ref `#/$defs/observation` | no |  | Pull request number or URL observed when known. |  |  |
+| `volatile_observations.current_pr.value` |  | yes |  | Observed value. |  |  |
+| `volatile_observations.current_pr.source` | string | yes |  | Source of the observed value. |  |  |
+| `volatile_observations.current_pr.observed_at` | string | yes |  | Timestamp when the value was observed. |  |  |
+| `volatile_observations.current_issue_refs` | ref `#/$defs/observation` | yes |  | Issue references associated with the checkpoint task. |  |  |
+| `volatile_observations.current_issue_refs.value` |  | yes |  | Observed value. |  |  |
+| `volatile_observations.current_issue_refs.source` | string | yes |  | Source of the observed value. |  |  |
+| `volatile_observations.current_issue_refs.observed_at` | string | yes |  | Timestamp when the value was observed. |  |  |
+| `volatile_observations.dirty_state_summary` | ref `#/$defs/observation` | yes |  | Local dirty-state summary observed or preserved at checkpoint write. |  |  |
+| `volatile_observations.dirty_state_summary.value` |  | yes |  | Observed value. |  |  |
+| `volatile_observations.dirty_state_summary.source` | string | yes |  | Source of the observed value. |  |  |
+| `volatile_observations.dirty_state_summary.observed_at` | string | yes |  | Timestamp when the value was observed. |  |  |
+| `volatile_observations.remote_comments` | ref `#/$defs/observation` | yes |  | Marker that remote PR/issue comments were not fetched by checkpoint write. |  |  |
+| `volatile_observations.remote_comments.value` |  | yes |  | Observed value. |  |  |
+| `volatile_observations.remote_comments.source` | string | yes |  | Source of the observed value. |  |  |
+| `volatile_observations.remote_comments.observed_at` | string | yes |  | Timestamp when the value was observed. |  |  |
+| `volatile_observations.ci_state` | ref `#/$defs/observation` | yes |  | Marker that CI state was not fetched by checkpoint write. |  |  |
+| `volatile_observations.ci_state.value` |  | yes |  | Observed value. |  |  |
+| `volatile_observations.ci_state.source` | string | yes |  | Source of the observed value. |  |  |
+| `volatile_observations.ci_state.observed_at` | string | yes |  | Timestamp when the value was observed. |  |  |
+| `volatile_observations.dependency_state` | ref `#/$defs/observation` | yes |  | Marker that dependency release/availability state was not fetched by checkpoint write. |  |  |
+| `volatile_observations.dependency_state.value` |  | yes |  | Observed value. |  |  |
+| `volatile_observations.dependency_state.source` | string | yes |  | Source of the observed value. |  |  |
+| `volatile_observations.dependency_state.observed_at` | string | yes |  | Timestamp when the value was observed. |  |  |
+| `local_notes` | object | yes |  | Advisory local notes copied from the checkpoint write inputs. |  |  |
+| `local_notes.task` | string | yes |  | Advisory task summary recorded for resume orientation. |  |  |
+| `local_notes.next_safe_command` | string | yes |  | Advisory next command from the checkpoint writer. |  |  |
+| `local_notes.open_blockers` | array of string | yes |  | Local blocker notes to re-check after resume. |  |  |
+| `local_notes.source` | string | yes |  | Where these local notes came from. |  |  |
+| `local_notes.observed_at` | string | yes |  | Timestamp when these local notes were observed. |  |  |
+| `proof_state` | object | yes |  | Proof history plus explicit invalidation conditions; not current completion evidence. |  |  |
+| `proof_state.status` | enum `"historical-local-summary"`, `"no-proof-recorded"` | yes |  | Whether proof history was recorded in this local checkpoint. |  |  |
+| `proof_state.last_proof` | array of string | yes |  | Recently run proof commands or summaries recorded as history. |  |  |
+| `proof_state.source` | string | yes |  | Where the proof history came from. |  |  |
+| `proof_state.observed_at` | string | yes |  | Timestamp when the proof history was recorded. |  |  |
+| `proof_state.valid_until_change` | array of string | yes |  | Change classes that invalidate treating recorded proof as current. |  |  |
+| `proof_state.stale_if` | array of string | yes |  | Concrete stale conditions that require proof re-check. |  |  |
+| `proof_state.rule` | string | yes |  | Rule preventing checkpoint proof history from becoming completion evidence. |  |  |
+| `resume_checklist` | array of object | yes |  | Action-shaped checklist for the next agent before trusting checkpoint state. |  |  |
 | `limits` | object | yes |  | Invariant flags that make the local-only and non-evidence limits explicit. |  |  |
 | `limits.local_only` | const `true` | yes |  | Checkpoint is only for the local workspace. |  |  |
 | `limits.gitignored` | const `true` | yes |  | Checkpoint must remain in an ignored local path. |  |  |

--- a/docs/reference/local-chat-checkpoints.md
+++ b/docs/reference/local-chat-checkpoints.md
@@ -2,7 +2,7 @@
 
 Local chat checkpoints are ignored, machine-local continuity hints stored at `.agentic-workspace/local/chat-checkpoint.json`.
 
-They use `kind: agentic-workspace/local-chat-checkpoint/v1` and are intentionally not durable AW evidence. A checkpoint may record the current task, branch, PR or issue refs, short dirty-state notes, the last proof command names, blockers, and the next safe command. It must point to durable sources such as issues, PRs, checked-in Planning, Memory, docs, reviews, or proof receipts instead of copying raw transcript or policy text.
+They use `kind: agentic-workspace/local-chat-checkpoint/v2` and are intentionally not durable AW evidence. A checkpoint may record the current task, repo root, remote URL, branch, PR or issue refs, local HEAD, upstream HEAD, short dirty-state notes, the last proof command names, blockers, and the next safe command. It must point to durable sources such as issues, PRs, checked-in Planning, Memory, docs, reviews, or proof receipts instead of copying raw transcript or policy text. Older `agentic-workspace/local-chat-checkpoint/v1` records are legacy local hints and should be treated as stale until rewritten.
 
 The required resume rule is: treat older chat as advisory and re-read `durable_sources` before making claims.
 
@@ -17,7 +17,7 @@ Example:
 
 ```json
 {
-  "kind": "agentic-workspace/local-chat-checkpoint/v1",
+  "kind": "agentic-workspace/local-chat-checkpoint/v2",
   "created_at": "2026-06-23T10:00:00+00:00",
   "updated_at": "2026-06-23T10:05:00+00:00",
   "task": "Implement #1680 first tranche",
@@ -30,6 +30,58 @@ Example:
   "open_blockers": [],
   "dirty_state_summary": "No uncommitted durable state beyond the current slice.",
   "next_safe_command": "uv run python scripts/run_agentic_workspace.py start --target . --format json",
+  "volatile_observations": {
+    "repo_root": {
+      "value": "<repo-root>",
+      "source": "resolved target root at checkpoint write",
+      "observed_at": "2026-06-23T10:05:00+00:00"
+    },
+    "remote_origin_url": {
+      "value": "git@github.com:rickardvh/agentic-workspace.git",
+      "source": "git config remote.origin.url at checkpoint write",
+      "observed_at": "2026-06-23T10:05:00+00:00"
+    },
+    "branch": {
+      "value": "codex/example",
+      "source": "git branch at checkpoint write",
+      "observed_at": "2026-06-23T10:05:00+00:00"
+    },
+    "head_commit": {
+      "value": "0123456789abcdef0123456789abcdef01234567",
+      "source": "git rev-parse HEAD at checkpoint write",
+      "observed_at": "2026-06-23T10:05:00+00:00"
+    },
+    "upstream_commit": {
+      "value": "0123456789abcdef0123456789abcdef01234567",
+      "source": "git rev-parse --verify @{upstream} at checkpoint write",
+      "observed_at": "2026-06-23T10:05:00+00:00"
+    },
+    "current_issue_refs": {
+      "value": ["#1680"],
+      "source": "checkpoint write input",
+      "observed_at": "2026-06-23T10:05:00+00:00"
+    },
+    "dirty_state_summary": {
+      "value": "No uncommitted durable state beyond the current slice.",
+      "source": "checkpoint write input or preserved local checkpoint value",
+      "observed_at": "2026-06-23T10:05:00+00:00"
+    },
+    "remote_comments": {
+      "value": {"status": "not-checked-by-local-checkpoint-writer"},
+      "source": "checkpoint write does not fetch PR or issue comments",
+      "observed_at": "2026-06-23T10:05:00+00:00"
+    },
+    "ci_state": {
+      "value": {"status": "not-checked-by-local-checkpoint-writer"},
+      "source": "checkpoint write does not inspect CI state",
+      "observed_at": "2026-06-23T10:05:00+00:00"
+    },
+    "dependency_state": {
+      "value": {"status": "not-checked-by-local-checkpoint-writer"},
+      "source": "checkpoint write does not inspect dependency releases or availability",
+      "observed_at": "2026-06-23T10:05:00+00:00"
+    }
+  },
   "limits": {
     "local_only": true,
     "gitignored": true,

--- a/src/agentic_workspace/contracts/schemas/local_chat_checkpoint.schema.json
+++ b/src/agentic_workspace/contracts/schemas/local_chat_checkpoint.schema.json
@@ -18,11 +18,15 @@
     "open_blockers",
     "dirty_state_summary",
     "next_safe_command",
+    "volatile_observations",
+    "local_notes",
+    "proof_state",
+    "resume_checklist",
     "limits"
   ],
   "properties": {
     "kind": {
-      "const": "agentic-workspace/local-chat-checkpoint/v1",
+      "const": "agentic-workspace/local-chat-checkpoint/v2",
       "description": "Stable checkpoint record discriminator."
     },
     "created_at": {
@@ -67,7 +71,7 @@
     },
     "resume_rule": {
       "type": "string",
-      "pattern": "advisory|durable_sources|durable sources|Re-read|re-read",
+      "pattern": "advisory|durable_sources|durable sources|fresh local/remote truth|Re-read|re-read",
       "description": "Human-readable rule reminding agents that local checkpoints are advisory and durable sources remain authoritative."
     },
     "last_proof": {
@@ -97,6 +101,184 @@
       "type": "string",
       "maxLength": 500,
       "description": "Next safe command to run after resume."
+    },
+    "volatile_observations": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Stale-prone local or remote observations captured with provenance and observation time.",
+      "required": [
+        "repo_root",
+        "remote_origin_url",
+        "branch",
+        "head_commit",
+        "upstream_commit",
+        "current_issue_refs",
+        "dirty_state_summary",
+        "remote_comments",
+        "ci_state",
+        "dependency_state"
+      ],
+      "properties": {
+        "repo_root": {
+          "$ref": "#/$defs/observation",
+          "description": "Repository root path observed when the checkpoint was written."
+        },
+        "remote_origin_url": {
+          "$ref": "#/$defs/observation",
+          "description": "Origin remote URL observed when available."
+        },
+        "branch": {
+          "$ref": "#/$defs/observation",
+          "description": "Git branch observed when the checkpoint was written."
+        },
+        "head_commit": {
+          "$ref": "#/$defs/observation",
+          "description": "Local HEAD commit observed when the checkpoint was written."
+        },
+        "upstream_commit": {
+          "$ref": "#/$defs/observation",
+          "description": "Upstream commit observed when available; compare with local HEAD on resume."
+        },
+        "current_pr": {
+          "$ref": "#/$defs/observation",
+          "description": "Pull request number or URL observed when known."
+        },
+        "current_issue_refs": {
+          "$ref": "#/$defs/observation",
+          "description": "Issue references associated with the checkpoint task."
+        },
+        "dirty_state_summary": {
+          "$ref": "#/$defs/observation",
+          "description": "Local dirty-state summary observed or preserved at checkpoint write."
+        },
+        "remote_comments": {
+          "$ref": "#/$defs/observation",
+          "description": "Marker that remote PR/issue comments were not fetched by checkpoint write."
+        },
+        "ci_state": {
+          "$ref": "#/$defs/observation",
+          "description": "Marker that CI state was not fetched by checkpoint write."
+        },
+        "dependency_state": {
+          "$ref": "#/$defs/observation",
+          "description": "Marker that dependency release/availability state was not fetched by checkpoint write."
+        }
+      }
+    },
+    "local_notes": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Advisory local notes copied from the checkpoint write inputs.",
+      "required": ["task", "next_safe_command", "open_blockers", "source", "observed_at"],
+      "properties": {
+        "task": {
+          "type": "string",
+          "maxLength": 500,
+          "description": "Advisory task summary recorded for resume orientation."
+        },
+        "next_safe_command": {
+          "type": "string",
+          "maxLength": 500,
+          "description": "Advisory next command from the checkpoint writer."
+        },
+        "open_blockers": {
+          "type": "array",
+          "description": "Local blocker notes to re-check after resume.",
+          "items": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "One local blocker note."
+          }
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where these local notes came from."
+        },
+        "observed_at": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Timestamp when these local notes were observed."
+        }
+      }
+    },
+    "proof_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Proof history plus explicit invalidation conditions; not current completion evidence.",
+      "required": ["status", "last_proof", "source", "observed_at", "valid_until_change", "stale_if", "rule"],
+      "properties": {
+        "status": {
+          "enum": ["historical-local-summary", "no-proof-recorded"],
+          "description": "Whether proof history was recorded in this local checkpoint."
+        },
+        "last_proof": {
+          "type": "array",
+          "description": "Recently run proof commands or summaries recorded as history.",
+          "items": {
+            "type": "string",
+            "maxLength": 500,
+            "description": "One historical proof command or summary."
+          }
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where the proof history came from."
+        },
+        "observed_at": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Timestamp when the proof history was recorded."
+        },
+        "valid_until_change": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Change classes that invalidate treating recorded proof as current.",
+          "items": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "One proof invalidation change class."
+          }
+        },
+        "stale_if": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Concrete stale conditions that require proof re-check.",
+          "items": {
+            "type": "string",
+            "maxLength": 250,
+            "description": "One stale condition."
+          }
+        },
+        "rule": {
+          "type": "string",
+          "pattern": "not treat|current completion evidence|re-run|re-evaluate",
+          "description": "Rule preventing checkpoint proof history from becoming completion evidence."
+        }
+      }
+    },
+    "resume_checklist": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Action-shaped checklist for the next agent before trusting checkpoint state.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["action", "why"],
+        "properties": {
+          "action": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 250
+          },
+          "why": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 300
+          }
+        }
+      }
     },
     "limits": {
       "type": "object",
@@ -134,6 +316,29 @@
         "durable_decisions_require_durable_source": {
           "const": true,
           "description": "Durable decisions must be backed by durable sources outside this checkpoint."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "observation": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "A stale-prone observation with source and observation time.",
+      "required": ["value", "source", "observed_at"],
+      "properties": {
+        "value": {
+          "description": "Observed value."
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Source of the observed value."
+        },
+        "observed_at": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Timestamp when the value was observed."
         }
       }
     }

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -214,7 +214,7 @@ WORKSPACE_HANDOFF_SURFACES = tuple((Path(relative) for relative in _WORKSPACE_SU
 MODULE_UPGRADE_SOURCE_PATHS = {
     module_name: Path(relative) for module_name, relative in _WORKSPACE_SURFACES_MANIFEST["module_upgrade_source_paths"].items()
 }
-LOCAL_CHAT_CHECKPOINT_KIND = "agentic-workspace/local-chat-checkpoint/v1"
+LOCAL_CHAT_CHECKPOINT_KIND = "agentic-workspace/local-chat-checkpoint/v2"
 LOCAL_CHAT_CHECKPOINT_PATH = Path(".agentic-workspace") / "local" / "chat-checkpoint.json"
 
 
@@ -22574,6 +22574,10 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                 "durable_sources",
                 "resume_rule",
                 "next_safe_command",
+                "volatile_observations",
+                "local_notes",
+                "proof_state",
+                "resume_checklist",
                 "detail_command",
                 "authority",
             )
@@ -25476,6 +25480,69 @@ def _compact_checkpoint_refs(values: list[Any], *, limit: int = 3) -> list[str]:
     return refs
 
 
+def _checkpoint_observation(*, value: Any, source: str, observed_at: str) -> dict[str, Any]:
+    return {
+        "value": value,
+        "source": source,
+        "observed_at": observed_at,
+    }
+
+
+def _checkpoint_git_value(*, target_root: Path, args: list[str]) -> str:
+    if _git_metadata_dir(target_root=target_root) is None:
+        return ""
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(target_root), *args],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout.strip()
+
+
+def _checkpoint_git_snapshot(*, target_root: Path) -> dict[str, str]:
+    return {
+        "repo_root": target_root.resolve().as_posix(),
+        "remote_origin_url": _checkpoint_git_value(
+            target_root=target_root,
+            args=["config", "--get", "remote.origin.url"],
+        ),
+        "head_commit": _checkpoint_git_value(target_root=target_root, args=["rev-parse", "HEAD"]),
+        "upstream_commit": _checkpoint_git_value(
+            target_root=target_root,
+            args=["rev-parse", "--verify", "@{upstream}"],
+        ),
+    }
+
+
+def _checkpoint_resume_checklist() -> list[dict[str, str]]:
+    return [
+        {
+            "action": "fetch latest PR comments and issue comments",
+            "why": "review and issue state are volatile and may have changed after this checkpoint",
+        },
+        {
+            "action": "inspect git status and compare local HEAD with PR head",
+            "why": "local dirty state, branch, and pushed commits are stale-prone observations",
+        },
+        {
+            "action": "verify dependency pins, release URLs, and digests before relying on them",
+            "why": "dependency availability and release state can change outside this local checkpoint",
+        },
+        {
+            "action": "re-run or re-evaluate proof after any later commit, generated output change, dependency bump, or new review comment",
+            "why": "checkpoint proof summaries are history, not current completion evidence",
+        },
+    ]
+
+
 def _local_chat_checkpoint_projection(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
     path = _local_chat_checkpoint_path(target_root)
     relative_path = LOCAL_CHAT_CHECKPOINT_PATH.as_posix()
@@ -25529,8 +25596,12 @@ def _local_chat_checkpoint_projection(*, target_root: Path, cli_invoke: str) -> 
         "next_safe_command": str(checkpoint.get("next_safe_command", "")).strip(),
         "last_proof_count": len(_list_payload(checkpoint.get("last_proof"))),
         "open_blocker_count": len(_list_payload(checkpoint.get("open_blockers"))),
+        "volatile_observations": _as_dict(checkpoint.get("volatile_observations")),
+        "local_notes": _as_dict(checkpoint.get("local_notes")),
+        "proof_state": _as_dict(checkpoint.get("proof_state")),
+        "resume_checklist": _list_payload(checkpoint.get("resume_checklist"))[:5],
         "limits": _as_dict(checkpoint.get("limits")),
-        "rule": "Local checkpoints are ignored, advisory continuity hints; durable sources remain authoritative.",
+        "rule": "Local checkpoints are advisory continuity hints; fresh local/remote truth and durable sources remain authoritative.",
     }
 
 
@@ -25571,22 +25642,114 @@ def _local_chat_checkpoint_record(
     if not durable_source_values:
         warnings.append("no-durable-source: checkpoint is local only and cannot support closure claims without durable sources")
     branch_posture = _branch_workflow_posture_payload(target_root=target_root)
+    branch = str(branch_posture.get("current_branch") or existing.get("branch", "")).strip()
+    current_pr = pr if pr not in {None, ""} else existing.get("current_pr")
+    current_issue_refs = kept_list("current_issue_refs", issue_refs)
+    last_proof_values = kept_list("last_proof", last_proof)
+    open_blocker_values = kept_list("open_blockers", open_blockers)
+    dirty_state = (dirty_state_summary if dirty_state_summary is not None else str(existing.get("dirty_state_summary", ""))).strip()
+    next_command = next_safe_command if next_safe_command is not None else str(existing.get("next_safe_command", "")).strip()
+    task_text = (task if task is not None else str(existing.get("task", ""))).strip()
+    git_snapshot = _checkpoint_git_snapshot(target_root=target_root)
+    volatile_observations: dict[str, Any] = {
+        "repo_root": _checkpoint_observation(
+            value=git_snapshot["repo_root"],
+            source="resolved target root at checkpoint write",
+            observed_at=now,
+        ),
+        "remote_origin_url": _checkpoint_observation(
+            value=git_snapshot["remote_origin_url"],
+            source="git config remote.origin.url at checkpoint write",
+            observed_at=now,
+        ),
+        "branch": _checkpoint_observation(value=branch, source="git branch at checkpoint write", observed_at=now),
+        "head_commit": _checkpoint_observation(
+            value=git_snapshot["head_commit"],
+            source="git rev-parse HEAD at checkpoint write",
+            observed_at=now,
+        ),
+        "upstream_commit": _checkpoint_observation(
+            value=git_snapshot["upstream_commit"],
+            source="git rev-parse --verify @{upstream} at checkpoint write",
+            observed_at=now,
+        ),
+        "current_issue_refs": _checkpoint_observation(
+            value=current_issue_refs,
+            source="checkpoint write input",
+            observed_at=now,
+        ),
+        "dirty_state_summary": _checkpoint_observation(
+            value=dirty_state,
+            source="checkpoint write input or preserved local checkpoint value",
+            observed_at=now,
+        ),
+        "remote_comments": _checkpoint_observation(
+            value={"status": "not-checked-by-local-checkpoint-writer"},
+            source="checkpoint write does not fetch PR or issue comments",
+            observed_at=now,
+        ),
+        "ci_state": _checkpoint_observation(
+            value={"status": "not-checked-by-local-checkpoint-writer"},
+            source="checkpoint write does not inspect CI state",
+            observed_at=now,
+        ),
+        "dependency_state": _checkpoint_observation(
+            value={"status": "not-checked-by-local-checkpoint-writer"},
+            source="checkpoint write does not inspect dependency releases or availability",
+            observed_at=now,
+        ),
+    }
+    if current_pr not in {None, ""}:
+        volatile_observations["current_pr"] = _checkpoint_observation(
+            value=current_pr,
+            source="checkpoint write input or preserved local checkpoint value",
+            observed_at=now,
+        )
+    local_notes = {
+        "task": task_text,
+        "next_safe_command": next_command,
+        "open_blockers": open_blocker_values,
+        "source": "local checkpoint write input; advisory only",
+        "observed_at": now,
+    }
+    proof_state = {
+        "status": "historical-local-summary" if last_proof_values else "no-proof-recorded",
+        "last_proof": last_proof_values,
+        "source": "checkpoint write input; not current proof",
+        "observed_at": now,
+        "valid_until_change": [
+            "later commits",
+            "generated output changes",
+            "dependency bumps",
+            "new review or issue comments",
+            "local dirty state changes",
+        ],
+        "stale_if": [
+            "HEAD changed after observed_at",
+            "PR or issue comments changed after observed_at",
+            "dependency release or digest state changed after observed_at",
+            "required proof selection changed after observed_at",
+        ],
+        "rule": "Do not treat checkpoint proof history as current completion evidence; re-run or re-evaluate proof after fresh truth checks.",
+    }
     record: dict[str, Any] = {
         "kind": LOCAL_CHAT_CHECKPOINT_KIND,
         "created_at": str(existing.get("created_at") or now),
         "updated_at": now,
-        "task": (task if task is not None else str(existing.get("task", ""))).strip(),
-        "branch": str(branch_posture.get("current_branch") or existing.get("branch", "")).strip(),
-        "current_pr": pr if pr not in {None, ""} else existing.get("current_pr"),
-        "current_issue_refs": kept_list("current_issue_refs", issue_refs),
+        "task": task_text,
+        "branch": branch,
+        "current_pr": current_pr,
+        "current_issue_refs": current_issue_refs,
         "durable_sources": durable_source_values,
-        "resume_rule": "Treat chat before this checkpoint as advisory. Re-read durable_sources before making claims.",
-        "last_proof": kept_list("last_proof", last_proof),
-        "open_blockers": kept_list("open_blockers", open_blockers),
-        "dirty_state_summary": (
-            dirty_state_summary if dirty_state_summary is not None else str(existing.get("dirty_state_summary", ""))
-        ).strip(),
-        "next_safe_command": (next_safe_command if next_safe_command is not None else str(existing.get("next_safe_command", "")).strip()),
+        "resume_rule": "Treat chat before this checkpoint as advisory. Re-read durable_sources and recheck fresh local/remote truth before making claims.",
+        "last_proof": last_proof_values,
+        "open_blockers": open_blocker_values,
+        "dirty_state_summary": dirty_state,
+        "next_safe_command": next_command,
+        "volatile_observations": volatile_observations,
+        "local_notes": local_notes,
+        "proof_state": proof_state,
+        "resume_checklist": _checkpoint_resume_checklist(),
         "limits": {
             "local_only": True,
             "gitignored": True,
@@ -25646,7 +25809,7 @@ def _write_local_chat_checkpoint(
         "current_issue_refs": record.get("current_issue_refs", []),
         "warnings": warnings,
         "resume_rule": record["resume_rule"],
-        "rule": "This command writes only ignored local continuity state; durable claims still require durable AW sources.",
+        "rule": "This command writes only ignored local continuity state; durable claims still require durable AW sources and fresh local/remote truth checks.",
     }
 
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -546,9 +546,29 @@ def test_local_chat_checkpoint_write_creates_valid_local_record_and_startup_pack
     schema = json.loads(Path("src/agentic_workspace/contracts/schemas/local_chat_checkpoint.schema.json").read_text(encoding="utf-8"))
     errors = sorted(Draft202012Validator(schema).iter_errors(checkpoint), key=lambda error: list(error.path))
     assert [error.message for error in errors] == []
-    assert checkpoint["kind"] == "agentic-workspace/local-chat-checkpoint/v1"
+    assert checkpoint["kind"] == "agentic-workspace/local-chat-checkpoint/v2"
     assert checkpoint["limits"]["not_closure_evidence"] is True
     assert "durable_sources" in checkpoint["resume_rule"]
+    assert "fresh local/remote truth" in checkpoint["resume_rule"]
+    assert checkpoint["volatile_observations"]["repo_root"]["value"] == tmp_path.resolve().as_posix()
+    assert checkpoint["volatile_observations"]["branch"]["source"] == "git branch at checkpoint write"
+    assert checkpoint["volatile_observations"]["head_commit"]["source"] == "git rev-parse HEAD at checkpoint write"
+    assert checkpoint["volatile_observations"]["head_commit"]["observed_at"] == checkpoint["updated_at"]
+    assert checkpoint["volatile_observations"]["current_pr"]["value"] == "1705"
+    assert checkpoint["volatile_observations"]["current_pr"]["observed_at"] == checkpoint["updated_at"]
+    assert checkpoint["volatile_observations"]["remote_comments"]["value"]["status"] == "not-checked-by-local-checkpoint-writer"
+    assert checkpoint["volatile_observations"]["ci_state"]["value"]["status"] == "not-checked-by-local-checkpoint-writer"
+    assert checkpoint["volatile_observations"]["dependency_state"]["value"]["status"] == "not-checked-by-local-checkpoint-writer"
+    assert checkpoint["local_notes"]["task"] == "Implement #1700 checkpoint slice"
+    assert checkpoint["local_notes"]["source"] == "local checkpoint write input; advisory only"
+    assert checkpoint["proof_state"]["status"] == "historical-local-summary"
+    assert checkpoint["proof_state"]["last_proof"] == ["uv run pytest tests/test_workspace_cli.py"]
+    assert "new review or issue comments" in checkpoint["proof_state"]["valid_until_change"]
+    assert any("PR or issue comments changed" in item for item in checkpoint["proof_state"]["stale_if"])
+    assert "current completion evidence" in checkpoint["proof_state"]["rule"]
+    resume_actions = [item["action"] for item in checkpoint["resume_checklist"]]
+    assert "fetch latest PR comments and issue comments" in resume_actions
+    assert "inspect git status and compare local HEAD with PR head" in resume_actions
 
     assert (
         cli.main(
@@ -569,6 +589,10 @@ def test_local_chat_checkpoint_write_creates_valid_local_record_and_startup_pack
     assert packet["status"] == "present"
     assert packet["durable_source_count"] == 1
     assert packet["durable_sources"] == ["docs/reference/local-chat-checkpoints.md"]
+    assert packet["volatile_observations"]["head_commit"]["observed_at"] == checkpoint["updated_at"]
+    assert packet["volatile_observations"]["current_pr"]["observed_at"] == checkpoint["updated_at"]
+    assert packet["proof_state"]["status"] == "historical-local-summary"
+    assert any(item["action"].startswith("re-run or re-evaluate proof") for item in packet["resume_checklist"])
     assert "local_chat_checkpoint" in startup["drill_down"]["available_selectors"]
     assert "local_chat_checkpoint=present" in startup["action_signals"]["changed_signals"]
 
@@ -659,6 +683,16 @@ def test_local_chat_checkpoint_startup_reports_absent_stale_and_unreadable(tmp_p
     stale = json.loads(capsys.readouterr().out)["values"]["local_chat_checkpoint"]
     assert stale["status"] == "stale"
     assert stale["durable_sources"] == ["docs/source.md"]
+
+    checkpoint_path.write_text(
+        json.dumps({"kind": "agentic-workspace/local-chat-checkpoint/v1", "durable_sources": ["docs/source.md"]}),
+        encoding="utf-8",
+    )
+    assert cli.main(["start", "--target", str(tmp_path), "--select", "local_chat_checkpoint", "--format", "json"]) == 0
+    stale_v1 = json.loads(capsys.readouterr().out)["values"]["local_chat_checkpoint"]
+    assert stale_v1["status"] == "stale"
+    assert stale_v1["checkpoint_kind"] == "agentic-workspace/local-chat-checkpoint/v1"
+    assert stale_v1["durable_sources"] == ["docs/source.md"]
 
     checkpoint_path.write_text("{not json", encoding="utf-8")
     assert cli.main(["start", "--target", str(tmp_path), "--select", "local_chat_checkpoint", "--format", "json"]) == 0


### PR DESCRIPTION
## Summary
- bump local chat checkpoint records to `agentic-workspace/local-chat-checkpoint/v2`, so old v1 local records project as stale instead of present
- sharpen checkpoint records with provenance-separated resume buckets: durable sources, volatile observations, local notes, proof state, and an action-shaped resume checklist
- add orientation anchors for repo root, origin remote, branch, local HEAD, upstream HEAD, PR/issue refs, and dirty state, each with source/observed_at metadata
- explicitly mark remote comments, CI state, and dependency state as `not-checked-by-local-checkpoint-writer`
- project the sharper packet through startup context while preserving the non-authoritative checkpoint boundary
- update the checkpoint JSON schema, rendered schema reference, and checkpoint CLI regression coverage

Closes #1753

## Validation
- `uv run pytest tests/test_workspace_cli.py::test_local_chat_checkpoint_write_creates_valid_local_record_and_startup_packet tests/test_workspace_cli.py::test_local_chat_checkpoint_write_preserves_and_replaces_values tests/test_workspace_cli.py::test_local_chat_checkpoint_startup_reports_absent_stale_and_unreadable -q`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make render-schema-reference`
- `make schema-reference-docs`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`

## Runtime Boundary
- Edit reason: existing `workspace.local-chat-checkpoint.write` primitive improvement.
- Owner: AW workspace runtime, because checkpoint merge/write/projection semantics are local-only, ignored-state continuity policy and not generic command-generation behavior.
- Boundary preserved: checkpoints remain advisory and cannot serve as closure or proof evidence.