### PR TITLE
[codex] Make objective drift warnings action-shaped

### DIFF
--- a/docs/maintainer/operational-affordance-design.md
+++ b/docs/maintainer/operational-affordance-design.md
@@ -79,6 +79,18 @@ Every operational surface should answer these questions:
 - Does it expose raw files only after compact outputs point there?
 - Does it keep historical evidence from looking like live work?
 
+## Warning and Gate Posture
+
+Ordinary warnings and gates should be action-changing or selector-backed. A caution signal belongs in first-line output only when it changes at least one of these:
+
+- what action remains allowed now
+- what action or claim is blocked until reconciliation
+- what proof burden or closeout boundary changed
+- which owner surface or selector resolves the signal
+- whether skipping the signal lowers trust, blocks edits, or only blocks final claims
+
+When a caution is only background concern, route it behind a selector, review artifact, or maintainer diagnostic instead of making ordinary agents stop and reread. False-positive-prone signals should prefer typed posture over broad prose. For example, PR/review references should not become unknown issue-scope gates when the task is clearly PR-oriented, and objective-drift checks should classify explicit replacement or removal terms before warning that the retired term disappeared.
+
 ## Examples
 
 ### Startup

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -164,6 +164,12 @@ Cheap implementer context for a bounded changed-path scope.
 | `objective_drift.acceptance_closeout_rule` | string | no |  | Acceptance-specific closeout rule carried into objective-drift guidance. |  |  |
 | `objective_drift.missing_from_changed_surface` | array of string | yes |  | Requested terms that were not observed in changed files. |  |  |
 | `objective_drift.removed_or_retired_outcomes` | array of string | no |  | Reserved for explicit reconciliation evidence; AW does not infer removal or retirement from prompt keyword markers. |  |  |
+| `objective_drift.action_effect` | object | yes |  | Action-changing semantics for the objective-drift caution signal. |  |  |
+| `objective_drift.action_effect.force` | enum `"advisory"`, `"required_before_claim"` | yes |  | Whether this objective-drift signal is advisory or required before a completion claim. |  |  |
+| `objective_drift.action_effect.allowed_now` | string | yes |  | Action that remains allowed while the objective-drift signal is unresolved. |  |  |
+| `objective_drift.action_effect.blocked_until_reconciled` | array of string | yes |  | Claims or actions that the drift signal limits. |  |  |
+| `objective_drift.action_effect.claim_boundary` | string | yes |  | Completion claim boundary created by the objective-drift signal. |  |  |
+| `objective_drift.action_effect.resolution_selector` | string | yes |  | Selector or compact field that resolves or explains the signal. |  |  |
 | `objective_drift.rule` | string | no |  | Closeout rule agents should apply when drift is suspected. |  |  |
 | `objective_drift.recommended_next_action` | string | no |  | Small next step for resolving or dismissing the drift signal. |  |  |
 | `objective_drift.heuristic` | string | no |  | Brief explanation of the comparison method. |  |  |

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -566,7 +566,8 @@
         "kind",
         "status",
         "requested_outcomes",
-        "missing_from_changed_surface"
+        "missing_from_changed_surface",
+        "action_effect"
       ],
       "properties": {
         "kind": {
@@ -612,6 +613,48 @@
             "description": "Requested outcome the agent explicitly reconciled as removed or retired."
           },
           "description": "Reserved for explicit reconciliation evidence; AW does not infer removal or retirement from prompt keyword markers."
+        },
+        "action_effect": {
+          "type": "object",
+          "required": [
+            "force",
+            "allowed_now",
+            "blocked_until_reconciled",
+            "claim_boundary",
+            "resolution_selector"
+          ],
+          "properties": {
+            "force": {
+              "type": "string",
+              "enum": [
+                "advisory",
+                "required_before_claim"
+              ],
+              "description": "Whether this objective-drift signal is advisory or required before a completion claim."
+            },
+            "allowed_now": {
+              "type": "string",
+              "description": "Action that remains allowed while the objective-drift signal is unresolved."
+            },
+            "blocked_until_reconciled": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "One claim or action blocked until the missing outcome is reconciled."
+              },
+              "description": "Claims or actions that the drift signal limits."
+            },
+            "claim_boundary": {
+              "type": "string",
+              "description": "Completion claim boundary created by the objective-drift signal."
+            },
+            "resolution_selector": {
+              "type": "string",
+              "description": "Selector or compact field that resolves or explains the signal."
+            }
+          },
+          "additionalProperties": false,
+          "description": "Action-changing semantics for the objective-drift caution signal."
         },
         "rule": {
           "type": "string",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -25838,6 +25838,13 @@ def _read_changed_surface_text(*, target_root: Path, changed_paths: list[str], m
 def _objective_drift_payload(*, target_root: Path, changed_paths: list[str], task_text: str | None) -> dict[str, Any]:
     requested_outcomes = _extract_requested_outcomes(task_text)
     acceptance = _task_acceptance_payload(task_text=task_text, requested_outcomes=requested_outcomes)
+    action_effect_clear = {
+        "force": "advisory",
+        "allowed_now": "continue-implementation-and-reconcile-acceptance",
+        "blocked_until_reconciled": [],
+        "claim_boundary": "acceptance-reconciliation-required-before-completion-claim",
+        "resolution_selector": "context.objective_drift",
+    }
     if not task_text:
         return {
             "kind": "agentic-workspace/objective-drift/v1",
@@ -25846,6 +25853,10 @@ def _objective_drift_payload(*, target_root: Path, changed_paths: list[str], tas
             "requested_outcomes": [],
             "acceptance_item_count": 0,
             "missing_from_changed_surface": [],
+            "action_effect": {
+                **action_effect_clear,
+                "claim_boundary": "no-task-text-objective-comparison-unavailable",
+            },
         }
     if not requested_outcomes:
         return {
@@ -25856,6 +25867,7 @@ def _objective_drift_payload(*, target_root: Path, changed_paths: list[str], tas
             "acceptance_item_count": len(acceptance.get("items", [])),
             "acceptance_closeout_rule": acceptance.get("closeout_rule", ""),
             "missing_from_changed_surface": [],
+            "action_effect": action_effect_clear,
         }
     surface_text = _read_changed_surface_text(target_root=target_root, changed_paths=changed_paths)
     searchable = surface_text.lower()
@@ -25887,6 +25899,18 @@ def _objective_drift_payload(*, target_root: Path, changed_paths: list[str], tas
         if not _requested_outcome_present(searchable, item):
             missing.append(item)
     status = "warning" if missing and changed_paths else "clear"
+    action_effect = {
+        **action_effect_clear,
+        "force": "required_before_claim" if status == "warning" else "advisory",
+        "allowed_now": "continue-implementation-or-inspect-changed-surface",
+        "blocked_until_reconciled": ["claim-task-complete"] if status == "warning" else [],
+        "claim_boundary": (
+            "do-not-claim-complete-until-missing-outcomes-are-delivered-or-explicitly-out-of-scope"
+            if status == "warning"
+            else "acceptance-reconciliation-required-before-completion-claim"
+        ),
+        "resolution_selector": "context.objective_drift",
+    }
     return {
         "kind": "agentic-workspace/objective-drift/v1",
         "status": status,
@@ -25896,6 +25920,7 @@ def _objective_drift_payload(*, target_root: Path, changed_paths: list[str], tas
         "acceptance_item_count": len(acceptance.get("items", [])),
         "acceptance_closeout_rule": acceptance.get("closeout_rule", ""),
         "missing_from_changed_surface": missing,
+        "action_effect": action_effect,
         "rule": "Do not claim completion until each acceptance item and requested outcome is mapped to delivered behavior and proof, or explicitly marked out of scope.",
         "recommended_next_action": "Inspect changed files, exports, docs, and tests for the missing requested outcomes before closeout."
         if status == "warning"
@@ -29067,6 +29092,7 @@ def _tiny_objective_drift(value: Any) -> dict[str, Any]:
         "removed_or_retired_outcomes": value.get("removed_or_retired_outcomes", []),
         "replacement_checks": value.get("replacement_checks", []),
         "missing_from_changed_surface": value.get("missing_from_changed_surface", []),
+        "action_effect": value.get("action_effect", {}),
         "recommended_next_action": value.get("recommended_next_action", ""),
         "heuristic": value.get("heuristic", ""),
         "agent_owned_decisions": value.get("agent_owned_decisions", [])[:2] if isinstance(value.get("agent_owned_decisions"), list) else [],

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -480,6 +480,16 @@ def test_contributor_playbook_requires_operational_affordance_review() -> None:
     assert "weak agents can proceed without learning package internals" in text
 
 
+def test_operational_affordance_design_requires_action_changing_warnings() -> None:
+    text = (WORKSPACE_ROOT / "docs" / "maintainer" / "operational-affordance-design.md").read_text(encoding="utf-8")
+
+    assert "Warning and Gate Posture" in text
+    assert "Ordinary warnings and gates should be action-changing or selector-backed" in text
+    assert "what action or claim is blocked until reconciliation" in text
+    assert "PR/review references should not become unknown issue-scope gates" in text
+    assert "objective-drift checks should classify explicit replacement or removal terms" in text
+
+
 def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     playbook = (WORKSPACE_ROOT / "docs" / "maintainer" / "contributor-playbook.md").read_text(encoding="utf-8")
     strategy = (WORKSPACE_ROOT / "docs" / "maintainer" / "testing-strategy.md").read_text(encoding="utf-8")

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2427,6 +2427,10 @@ def test_implement_task_file_preserves_task_intent_for_acceptance_checks(tmp_pat
     assert context["acceptance_reconciliation"]["requested_outcomes"] == ["normalize_whitespace", "sentence_summary"]
     assert context["acceptance_reconciliation"]["acceptance_item_count"] >= 2
     assert context["objective_drift"]["missing_from_changed_surface"] == ["normalize_whitespace", "sentence_summary"]
+    assert context["objective_drift"]["action_effect"]["force"] == "required_before_claim"
+    assert context["objective_drift"]["action_effect"]["allowed_now"] == "continue-implementation-or-inspect-changed-surface"
+    assert context["objective_drift"]["action_effect"]["blocked_until_reconciled"] == ["claim-task-complete"]
+    assert context["objective_drift"]["action_effect"]["resolution_selector"] == "context.objective_drift"
     intent_proof = payload["proof"]["intent_proof"]
     assert intent_proof["status"] == "needs-agent-judgment"
     assert intent_proof["regression_only_risk"] == "possible"
@@ -2460,6 +2464,8 @@ def test_implement_objective_drift_understands_replacement_and_removal_terms(tmp
     assert "include_children=true" in drift["removed_or_retired_outcomes"]
     assert drift["replacement_checks"][0]["replacement"] == "embed=children"
     assert drift["replacement_checks"][0]["replacement_present"] is True
+    assert drift["action_effect"]["force"] == "advisory"
+    assert drift["action_effect"]["blocked_until_reconciled"] == []
 
 
 def test_implement_objective_drift_warns_when_replacement_target_is_absent(tmp_path: Path, capsys) -> None:
@@ -2488,6 +2494,7 @@ def test_implement_objective_drift_warns_when_replacement_target_is_absent(tmp_p
     assert "include_children=true" not in drift["missing_from_changed_surface"]
     assert "embed=children" in drift["missing_from_changed_surface"]
     assert drift["replacement_checks"][0]["replacement_present"] is False
+    assert drift["action_effect"]["claim_boundary"].startswith("do-not-claim-complete")
 
 
 def test_implement_objective_drift_handles_rename_and_ordinary_missing_terms(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## What changed

- Added an `action_effect` packet to objective-drift output so warnings state their force, allowed action, blocked claim, claim boundary, and resolution selector.
- Preserved the compact implementer context by carrying only the small action-effect object through the tiny projection.
- Documented the #1742 warning/gate posture rule in the existing operational-affordance design guide instead of adding a new surface.
- Added regression coverage for warning action effects, replacement/removal false-positive handling, and the durable warning/gate posture rule.

## Why

#1742 asks ordinary AW caution signals to be action-changing by design. Objective drift was a good concrete warning class to tighten because it can otherwise create false-positive hesitation when requested terms are intentionally replaced or removed.

## Validation

- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make maintainer-surfaces`
- `make schema-reference-docs`
- `git diff --check`