### PR TITLE
[codex] Action-shape ordinary caution outputs

### DIFF
--- a/docs/maintainer/index.md
+++ b/docs/maintainer/index.md
@@ -13,6 +13,7 @@ This section is for source-checkout maintenance of this repository. It is not th
 - [Generated command check inventory](generated-command-check-inventory.md): checked split between AW-owned generated-command proof and command-generation-owned generic target baselines.
 - [Installed-contract design checklist](installed-contract-design-checklist.md): review bar for collaboration-sensitive installed surfaces.
 - [Operational affordance design](operational-affordance-design.md): design review rubric for operational surfaces.
+- [Ordinary caution action-shape audit](ordinary-caution-action-shape-audit.md): disposition table for ordinary warning and gate classes.
 
 ## Boundary And Measurement
 

--- a/docs/maintainer/ordinary-caution-action-shape-audit.md
+++ b/docs/maintainer/ordinary-caution-action-shape-audit.md
@@ -1,0 +1,19 @@
+# Ordinary Caution Action-Shape Audit
+
+## Purpose
+
+This audit records the ordinary caution classes reviewed after #1755 so warning and gate work stays tied to concrete action effects instead of broad caution prose.
+
+## Disposition
+
+| Caution class | Ordinary surface | Disposition | Action effect |
+| --- | --- | --- | --- |
+| Objective drift | `implement` context | action-shaped and allowed in ordinary output | `objective_drift.action_effect` names allowed work, blocked completion claim, claim boundary, and selector. |
+| External issue intent | `start` / `implement` issue-reference intent | action-shaped and allowed in ordinary output when task text names issue refs | `issue_reference_intent.action_effect` allows read/review or bounded slice work, blocks issue-scope and task-complete claims until refresh, and names the refresh command. |
+| Knowledge gates | task posture packet | already action-shaped; retain in ordinary output only when matched gates affect design, edits, proof, or claims | Gate records name `force`, `next_allowed_action`, `forbidden_actions`, `required_actions`, `record_resolution_to`, and closeout boundaries. |
+| Generated surface trust | `implement` generated-surface trust selector and compact context | action-shaped and selector-backed | `generated_surface_trust.action_effect` blocks generated-freshness and task-complete claims until refresh/validation, while allowing implementation to continue through the canonical source. |
+| Required proof | proof obligations | action-shaped and allowed in ordinary output when proof is selected | `required_proof.action_effect` allows implementation, blocks task-complete claims, and points to `proof.proof_obligations.required_proof`. |
+
+## Follow-up Boundary
+
+This audit does not claim every warning class is finished. Future slices should prefer one caution family at a time and preserve the same minimum contract: force, allowed action, blocked claim/action, claim boundary, and resolution selector or command.

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -21937,6 +21937,21 @@ def _hydrate_selected_start_advisory_payloads(
             task_text=task_text,
             execution_posture=execution_posture,
         )
+    if _selector_requests(select, "issue_reference_intent"):
+        gate = payload.get("planning_safety_gate")
+        if not isinstance(gate, dict):
+            execution_posture = _execution_posture_payload(config=config, changed_paths=[], task_text=task_text, target_root=target_root)
+            gate = _planning_safety_gate_payload(
+                target_root=target_root,
+                config=config,
+                changed_paths=[],
+                task_text=task_text,
+                execution_posture=execution_posture,
+            )
+        if _list_payload(gate.get("issue_refs")):
+            payload["issue_reference_intent"] = _issue_reference_intent_payload(
+                issue_scope_evidence=gate.get("issue_scope_evidence", {}), cli_invoke=config.cli_invoke
+            )
     if _selector_requests(select, "local_chat_checkpoint"):
         payload["local_chat_checkpoint"] = _local_chat_checkpoint_projection(target_root=target_root, cli_invoke=config.cli_invoke)
     if _selector_requests(select, "installed_state_compatibility"):
@@ -23991,6 +24006,18 @@ def _issue_reference_intent_payload(*, issue_scope_evidence: dict[str, Any], cli
         )
     details_needed = evidence_status in {"unknown", "partial"}
     provider_hint = "github" if "refresh-github" in refresh_command else "external-intent"
+    action_effect = {
+        "force": "required_before_claim" if details_needed else "advisory",
+        "allowed_now": "read-review-and-state-bounded-slice" if details_needed else "continue-with-cached-issue-intent",
+        "blocked_until_reconciled": ["claim-external-issue-scope-confirmed", "claim-task-complete"] if details_needed else [],
+        "claim_boundary": (
+            "do-not-claim-issue-scope-or-task-completion-until-external-intent-is-refreshed"
+            if details_needed
+            else "cached-issue-intent-available-agent-still-owns-semantic-scope"
+        ),
+        "resolution_selector": "context.issue_reference_intent",
+        "resolution_command": refresh_command if details_needed else "",
+    }
     return {
         "kind": "agentic-workspace/issue-reference-intent/v1",
         "status": "details-needed" if details_needed else "evidence-available",
@@ -24004,6 +24031,7 @@ def _issue_reference_intent_payload(*, issue_scope_evidence: dict[str, Any], cli
         "required_next_action": "refresh-external-issue-intent" if details_needed else "use-cached-issue-intent",
         "intent_state": "issue-details-need-fetching" if details_needed else "issue-details-available",
         "not_intent_ambiguity": details_needed,
+        "action_effect": action_effect,
         "reason": (
             "The task names external issue ref(s); fetch issue details before treating the issue body as confirmed scope."
             if details_needed
@@ -26918,6 +26946,9 @@ def _generated_surface_trust_path_payload(*, target_root: Path, path: str, proof
     freshness_status = "validation-required"
     if not refresh_command or source_status == "missing":
         freshness_status = "missing-source-or-refresh-command"
+    refresh = _command_with_cli_invoke(command=refresh_command, cli_invoke=cli_invoke) if refresh_command else ""
+    validation = _command_with_cli_invoke(command=validation_command, cli_invoke=cli_invoke) if validation_command else ""
+    resolution_commands = list(dict.fromkeys(command for command in (refresh, validation) if command))
     return {
         "kind": "generated-surface-trust-item/v1",
         "path": normalized,
@@ -26927,10 +26958,25 @@ def _generated_surface_trust_path_payload(*, target_root: Path, path: str, proof
         "canonical_source_status": source_status,
         "freshness_status": freshness_status,
         "freshness_checked_by_implement": False,
-        "refresh_command": _command_with_cli_invoke(command=refresh_command, cli_invoke=cli_invoke) if refresh_command else "",
-        "validation_command": _command_with_cli_invoke(command=validation_command, cli_invoke=cli_invoke) if validation_command else "",
+        "refresh_command": refresh,
+        "validation_command": validation,
         "direct_edit_allowed": direct_edit_allowed,
         "direct_edit_policy": direct_edit_policy,
+        "action_effect": {
+            "force": "required_before_claim" if not direct_edit_allowed or freshness_status != "validated" else "advisory",
+            "allowed_now": "edit-canonical-source-refresh-and-validate-generated-surface",
+            "blocked_until_reconciled": ["claim-generated-surface-fresh", "claim-task-complete"]
+            if not direct_edit_allowed or freshness_status != "validated"
+            else [],
+            "claim_boundary": (
+                "do-not-claim-generated-output-fresh-until-refresh-and-validation-pass"
+                if refresh or validation
+                else "do-not-claim-generated-output-fresh-until-canonical-source-or-refresh-route-is-restored"
+            ),
+            "resolution_selector": "generated_surface_trust",
+            "resolution_command": resolution_commands[0] if resolution_commands else "",
+            "resolution_commands": resolution_commands,
+        },
     }
 
 
@@ -26943,12 +26989,32 @@ def _generated_surface_trust_payload(
         for item in [_generated_surface_trust_path_payload(target_root=target_root, path=path, proof=proof, cli_invoke=cli_invoke)]
         if item is not None
     ]
+    blocked_paths = [item["path"] for item in items if not item["direct_edit_allowed"]]
+    resolution_commands = list(
+        dict.fromkeys(
+            command
+            for item in items
+            for command in _list_payload(_as_dict(item.get("action_effect")).get("resolution_commands"))
+            if str(command).strip()
+        )
+    )
+    action_effect = {
+        "force": "required_before_claim" if items else "advisory",
+        "allowed_now": "continue-implementation-but-refresh-generated-surfaces-before-claim" if items else "continue-implementation",
+        "blocked_until_reconciled": ["claim-generated-surfaces-fresh", "claim-task-complete"] if items else [],
+        "claim_boundary": (
+            "generated-surface-freshness-must-be-reconciled-before-completion-claim" if items else "no-generated-surface-freshness-warning"
+        ),
+        "resolution_selector": "generated_surface_trust",
+        "resolution_commands": resolution_commands,
+    }
     return {
         "kind": "agentic-workspace/generated-surface-trust/v1",
         "status": "present" if items else "not-applicable",
         "changed_path_count": len(items),
         "items": items,
-        "direct_edit_blocked_paths": [item["path"] for item in items if not item["direct_edit_allowed"]],
+        "direct_edit_blocked_paths": blocked_paths,
+        "action_effect": action_effect,
         "rule": (
             "Generated surfaces are derived artifacts. Edit the canonical source first, refresh the generated output, "
             "and run the validation command before trusting freshness."
@@ -28706,6 +28772,11 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "changed_path_count": payload.get("generated_surface_trust", {}).get("changed_path_count", 0)
                 if isinstance(payload.get("generated_surface_trust"), dict)
                 else 0,
+                "action_effect": _tiny_action_effect(
+                    payload.get("generated_surface_trust", {}).get("action_effect", {}), include_allowed=False
+                )
+                if isinstance(payload.get("generated_surface_trust"), dict)
+                else {},
                 "detail_selector": "generated_surface_trust",
             },
             "architecture_principles": _architecture_principles_payload(
@@ -28963,18 +29034,33 @@ def _tiny_generated_surface_trust(value: dict[str, Any]) -> dict[str, Any]:
                 "path": item.get("path"),
                 "canonical_source": item.get("canonical_source"),
                 "freshness_status": item.get("freshness_status"),
-                "refresh_command": item.get("refresh_command"),
-                "validation_command": item.get("validation_command"),
                 "direct_edit_allowed": item.get("direct_edit_allowed"),
-                "direct_edit_policy": "Do not hand-edit generated output; edit the canonical source, refresh, then validate.",
             }
         )
     return {
         "status": value.get("status", "present"),
         "changed_path_count": value.get("changed_path_count", len(items)),
         "items": items,
+        "action_effect": _tiny_action_effect(value.get("action_effect", {}), include_allowed=False),
         "detail_selector": "generated_surface_trust",
     }
+
+
+def _tiny_action_effect(value: Any, *, include_allowed: bool = True, include_resolution_commands: bool = True) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    keys = [
+        "force",
+        "blocked_until_reconciled",
+        "resolution_selector",
+        "resolution_command",
+    ]
+    if include_resolution_commands:
+        keys.append("resolution_commands")
+    compact = {key: value[key] for key in keys if key in value}
+    if include_allowed and "allowed_now" in value:
+        compact["allowed_now"] = value["allowed_now"]
+    return compact
 
 
 def _compact_selector_next_safe_action(packet: dict[str, Any]) -> dict[str, Any]:
@@ -39059,6 +39145,7 @@ def _proof_obligations_payload(
                 "rule": "Authority describes why AW surfaced the command; the agent still owns proof sufficiency.",
             }
         )
+    proof_required = bool(required_commands or manual_required)
     return {
         "kind": "agentic-workspace/proof-obligations/v1",
         "status": "required-proof-selected" if required_commands else "manual-proof-required" if manual_required else "no-required-proof",
@@ -39070,6 +39157,18 @@ def _proof_obligations_payload(
             "manual_verification_required": manual_required,
             "manual_verification_status": manual_status,
             "source_field": "required_commands",
+            "action_effect": {
+                "force": "required_before_claim" if proof_required else "advisory",
+                "allowed_now": "continue-implementation-and-run-required-proof" if proof_required else "continue-implementation",
+                "blocked_until_reconciled": ["claim-task-complete"] if proof_required else [],
+                "claim_boundary": (
+                    "completion-claims-blocked-until-required-proof-passes-or-manual-verification-is-recorded"
+                    if proof_required
+                    else "no-required-proof-selected"
+                ),
+                "resolution_selector": "proof.proof_obligations.required_proof",
+                "resolution_commands": required_commands,
+            },
             "rule": (
                 "These commands, or required manual verification when commands are unavailable, are the proof gate for completion claims."
             ),
@@ -39194,6 +39293,9 @@ def _tiny_proof_obligations_payload(value: dict[str, Any], *, required_commands:
             "status": required.get("status", "unknown"),
             "commands": visible_required_commands,
             "manual_verification_required": bool(required.get("manual_verification_required", False)),
+            "action_effect": _tiny_action_effect(
+                required.get("action_effect", {}), include_allowed=False, include_resolution_commands=False
+            ),
         },
         "recommended_confidence_checks": {
             "status": recommended.get("status", "unknown"),

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -490,6 +490,17 @@ def test_operational_affordance_design_requires_action_changing_warnings() -> No
     assert "objective-drift checks should classify explicit replacement or removal terms" in text
 
 
+def test_ordinary_caution_action_shape_audit_records_dispositions() -> None:
+    index = (WORKSPACE_ROOT / "docs" / "maintainer" / "index.md").read_text(encoding="utf-8")
+    text = (WORKSPACE_ROOT / "docs" / "maintainer" / "ordinary-caution-action-shape-audit.md").read_text(encoding="utf-8")
+
+    assert "ordinary-caution-action-shape-audit.md" in index
+    assert "External issue intent" in text
+    assert "Generated surface trust" in text
+    assert "Required proof" in text
+    assert "force, allowed action, blocked claim/action, claim boundary, and resolution selector or command" in text
+
+
 def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     playbook = (WORKSPACE_ROOT / "docs" / "maintainer" / "contributor-playbook.md").read_text(encoding="utf-8")
     strategy = (WORKSPACE_ROOT / "docs" / "maintainer" / "testing-strategy.md").read_text(encoding="utf-8")

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -751,6 +751,62 @@ def test_start_issue_reference_wording_keeps_issue_scope_warning(tmp_path: Path,
     payload = json.loads(capsys.readouterr().out)
     assert payload["next_safe_action"]["next_safe_action"] == "refresh-external-issue-intent"
     assert payload["context"]["issue_reference_intent"]["issue_refs"] == ["#103"]
+    effect = payload["context"]["issue_reference_intent"]["action_effect"]
+    assert effect["force"] == "required_before_claim"
+    assert effect["allowed_now"] == "read-review-and-state-bounded-slice"
+    assert effect["blocked_until_reconciled"] == ["claim-external-issue-scope-confirmed", "claim-task-complete"]
+    assert effect["resolution_selector"] == "context.issue_reference_intent"
+    assert "external-intent refresh-github" in effect["resolution_command"]
+
+
+def test_start_cached_issue_reference_intent_is_advisory(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    evidence_path = tmp_path / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json"
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "id": "#103",
+                        "system": "github",
+                        "status": "open",
+                        "kind": "issue",
+                        "title": "Cached issue-backed intent",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Implement issue #103",
+                "--select",
+                "issue_reference_intent",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    intent = payload["values"]["issue_reference_intent"]
+    assert intent["status"] == "evidence-available"
+    effect = intent["action_effect"]
+    assert effect["force"] == "advisory"
+    assert effect["allowed_now"] == "continue-with-cached-issue-intent"
+    assert effect["blocked_until_reconciled"] == []
+    assert effect["resolution_selector"] == "context.issue_reference_intent"
+    assert effect["resolution_command"] == ""
 
 
 def test_start_ambiguous_numeric_ref_stays_advisory_without_blocking_read_work(tmp_path: Path, capsys) -> None:
@@ -775,6 +831,7 @@ def test_start_ambiguous_numeric_ref_stays_advisory_without_blocking_read_work(t
     payload = json.loads(capsys.readouterr().out)
     assert payload["next_safe_action"]["read_only_allowed"] is True
     assert payload["context"]["issue_reference_intent"]["status"] == "details-needed"
+    assert payload["context"]["issue_reference_intent"]["action_effect"]["force"] == "required_before_claim"
     assert payload["context"]["planning"]["planning_safety_gate"]["workflow_sufficient"] is True
 
 

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -551,6 +551,25 @@ def test_implement_command_returns_bounded_context_and_boundary_warnings(tmp_pat
     assert trust["items"][0]["refresh_command"] == "uv run python scripts/generate/generate_command_packages.py"
     assert trust["items"][0]["validation_command"] == "uv run python scripts/check/check_generated_command_packages.py"
     assert trust["items"][0]["direct_edit_allowed"] is False
+    assert trust["items"][0]["action_effect"]["force"] == "required_before_claim"
+    assert trust["items"][0]["action_effect"]["allowed_now"] == "edit-canonical-source-refresh-and-validate-generated-surface"
+    assert trust["items"][0]["action_effect"]["blocked_until_reconciled"] == [
+        "claim-generated-surface-fresh",
+        "claim-task-complete",
+    ]
+    assert trust["items"][0]["action_effect"]["resolution_selector"] == "generated_surface_trust"
+    assert trust["items"][0]["action_effect"]["resolution_command"] == "uv run python scripts/generate/generate_command_packages.py"
+    assert trust["items"][0]["action_effect"]["resolution_commands"] == [
+        "uv run python scripts/generate/generate_command_packages.py",
+        "uv run python scripts/check/check_generated_command_packages.py",
+    ]
+    assert trust["action_effect"]["force"] == "required_before_claim"
+    assert trust["action_effect"]["blocked_until_reconciled"] == ["claim-generated-surfaces-fresh", "claim-task-complete"]
+    assert trust["action_effect"]["resolution_selector"] == "generated_surface_trust"
+    assert trust["action_effect"]["resolution_commands"] == [
+        "uv run python scripts/generate/generate_command_packages.py",
+        "uv run python scripts/check/check_generated_command_packages.py",
+    ]
     assert "Do not hand-edit generated/workspace/python/cli.py" in trust["items"][0]["direct_edit_policy"]
     assert payload["orientation"]["status"] == "changed-path-context"
     assert "preflight" in payload["orientation"]["preflight_command"]
@@ -1506,6 +1525,10 @@ def test_implement_selector_surfaces_generated_surface_trust(tmp_path: Path, cap
     assert item["validation_command"] == "uv run python scripts/check/check_generated_command_packages.py"
     assert item["direct_edit_allowed"] is False
     assert "Do not hand-edit generated command package outputs" in item["direct_edit_policy"]
+    assert item["action_effect"]["force"] == "required_before_claim"
+    assert item["action_effect"]["resolution_command"] == "uv run python scripts/check/check_generated_command_packages.py"
+    assert item["action_effect"]["resolution_commands"] == ["uv run python scripts/check/check_generated_command_packages.py"]
+    assert trust["action_effect"]["resolution_commands"] == ["uv run python scripts/check/check_generated_command_packages.py"]
 
 
 def test_implement_readme_change_omits_generated_cli_freshness(tmp_path: Path, capsys) -> None:
@@ -1534,6 +1557,7 @@ def test_implement_readme_change_omits_generated_cli_freshness(tmp_path: Path, c
     assert "generated_cli_freshness" not in payload["proof"]
     assert all("generated_cli_freshness" not in signal for signal in payload["action_signals"]["changed_signals"])
     assert payload["context"]["generated_surface_trust"]["status"] == "not-applicable"
+    assert payload["context"]["generated_surface_trust"]["action_effect"]["force"] == "advisory"
 
 
 def test_implement_selector_surfaces_task_contract_view(tmp_path: Path, capsys) -> None:
@@ -2000,6 +2024,9 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert "Python-only proof" in payload["proof"]["generated_cli_freshness"]["generated_target_parity"]["claim_rule"]
     obligations = payload["proof"]["proof_obligations"]
     assert obligations["required_proof"]["commands"] == payload["proof"]["required_commands"]
+    assert obligations["required_proof"]["action_effect"]["force"] == "required_before_claim"
+    assert obligations["required_proof"]["action_effect"]["blocked_until_reconciled"] == ["claim-task-complete"]
+    assert obligations["required_proof"]["action_effect"]["resolution_selector"] == "proof.proof_obligations.required_proof"
     assert obligations["recommended_confidence_checks"]["status"] == "available"
     assert "do not replace or relax required proof" in obligations["recommended_confidence_checks"]["rule"]
     assert "Completion claims remain blocked" in obligations["completion_claim_rule"]
@@ -2011,8 +2038,10 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert context["generated_surface_trust"] == {
         "status": "present",
         "changed_path_count": 1,
+        "action_effect": trust["action_effect"],
         "detail_selector": "generated_surface_trust",
     }
+    assert context["generated_surface_trust"]["action_effect"]["force"] == "required_before_claim"
     assert payload["proof"]["acceptance_guidance"]["status"] == "present"
     guidance = context["guidance"]
     assert guidance["rule"].startswith("AW exposes facts")


### PR DESCRIPTION
## Summary
- add action_effect contracts for external issue intent, generated surface trust, and required proof warnings
- preserve those action gates in tiny/compact implement projections without breaking payload budgets
- keep cached external-intent evidence selector-routed with advisory action posture
- add a maintainer audit table for ordinary caution classes and their action-shaped disposition

## Why
This continues the post-#1755 tranche by turning ordinary caution output from broad warning prose into concrete allowed work, blocked claims, claim boundaries, and resolution selectors/commands.

Closes #1756
Closes #1757
Closes #1758

## Validation
- uv run pytest tests/test_workspace_cli.py::test_start_issue_reference_wording_keeps_issue_scope_warning tests/test_workspace_cli.py::test_start_cached_issue_reference_intent_is_advisory tests/test_workspace_cli.py::test_start_ambiguous_numeric_ref_stays_advisory_without_blocking_read_work tests/test_workspace_implement_cli.py::test_implement_selector_surfaces_generated_surface_trust tests/test_workspace_implement_cli.py::test_implement_readme_change_omits_generated_cli_freshness tests/test_workspace_implement_cli.py::test_implement_command_returns_bounded_context_and_boundary_warnings tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_maintainer_surfaces.py::test_ordinary_caution_action_shape_audit_records_dispositions
- make test-workspace
- make lint-workspace
- make maintainer-surfaces

Semver: minor, because this adds output contract fields to CLI payloads.
