### PR TITLE
[codex] Action-shape planning continuation cautions

### DIFF
--- a/docs/maintainer/index.md
+++ b/docs/maintainer/index.md
@@ -14,6 +14,7 @@ This section is for source-checkout maintenance of this repository. It is not th
 - [Installed-contract design checklist](installed-contract-design-checklist.md): review bar for collaboration-sensitive installed surfaces.
 - [Operational affordance design](operational-affordance-design.md): design review rubric for operational surfaces.
 - [Ordinary caution action-shape audit](ordinary-caution-action-shape-audit.md): disposition table for ordinary warning and gate classes.
+- [Planning continuation action-shape audit](planning-continuation-action-shape-audit.md): disposition table for active-owner and Planning continuation cautions.
 
 ## Boundary And Measurement
 

--- a/docs/maintainer/planning-continuation-action-shape-audit.md
+++ b/docs/maintainer/planning-continuation-action-shape-audit.md
@@ -1,0 +1,19 @@
+# Planning Continuation Action-Shape Audit
+
+## Purpose
+
+This note records the bounded #1760 review of active-owner and Planning continuation caution outputs after #1759.
+
+## Disposition
+
+| Caution class | Ordinary surface | Disposition | Action effect |
+| --- | --- | --- | --- |
+| Active plan reliance | `start` / `summary` / `implement` planning safety gate | action-shaped and allowed when active Planning state changes edit or claim boundaries | `active_plan_reliance.action_effect` distinguishes edit-blocking active-plan continuation from claim-blocking review/closeout posture and advisory direct-work non-reliance. |
+| Active delegation decision | `implement` planning safety gate | required-before-edit when active-plan continuation needs a recorded keep-local/delegation decision | Blocks active-plan-owned edits and completion claims until the planning delegation-decision command records provenance. |
+| Direct work with unrelated active plan | `implement` compact planning safety gate | advisory when task wording does not rely on active Planning continuation | Allows direct work, blocks only claims that the direct work advanced or completed the active plan. |
+| Active parent lane owner | `implement` planning safety gate | remains edit-blocking through existing lane-owner requirement packet | Missing or invalid lane owner artifacts still block implementation before active parent-lane slice work proceeds. |
+| Planning revision | `summary --select planning_revision` and planning safety gate detail | selector-backed freshness evidence | Revision identifiers remain resolution guards for Planning mutation commands rather than a first-line ordinary warning. |
+
+## Follow-up Boundary
+
+This audit does not replace Planning ownership semantics. Future slices should continue one caution family at a time and keep the minimum contract visible: force, allowed action, blocked claim/action, claim boundary, and resolution selector or command.

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -29782,42 +29782,77 @@ def _active_plan_reliance_payload(
 ) -> dict[str, Any]:
     revision_id = str(planning_revision.get("revision_id", "") or "")
     requirement_status = str(active_delegation_requirement.get("status", "") or "unknown")
+    active_execplan = str(active_summary.get("active_execplan") or active_delegation_requirement.get("path") or "").strip()
     if not active_planning_present:
         status = "no-active-plan"
         permission_claim = "direct-work-no-active-plan"
         integrity = "not-applicable"
         reliance = "not-needed"
+        force = "advisory"
+        allowed_now = "continue-direct-work"
+        blocked_until_reconciled: list[str] = []
+        claim_boundary = "no-active-planning-continuation-claim-boundary"
+        resolution_command = ""
     elif active_delegation_requirement.get("required"):
         status = "blocked"
         permission_claim = "blocked-until-active-plan-decision-recorded"
         integrity = "missing-or-untrusted"
         reliance = "do-not-continue-active-plan"
+        force = "required_before_edit"
+        allowed_now = "record-active-plan-decision-before-editing"
+        blocked_until_reconciled = ["edit-active-plan-owned-work", "claim-active-plan-continuation", "claim-task-complete"]
+        claim_boundary = "do-not-edit-or-claim-active-plan-continuation-until-delegation-decision-is-recorded"
+        resolution_command = str(active_delegation_requirement.get("command") or "")
     elif requirement_status == "delegation-decision-recorded":
         status = "command-written-state-observed"
         permission_claim = "review-before-continuing-active-plan"
         integrity = "command-written-state"
         reliance = "allowed-after-review-of-current-revision"
+        force = "required_before_claim"
+        allowed_now = "continue-after-reviewing-current-active-plan-revision"
+        blocked_until_reconciled = ["claim-active-plan-complete", "claim-task-complete"]
+        claim_boundary = "active-plan-completion-claims-require-current-revision-review-and-closeout"
+        resolution_command = _command_with_cli_invoke(command="agentic-workspace summary --target . --format json", cli_invoke=cli_invoke)
     elif requirement_status == "delegation-decision-not-needed-for-direct-task":
         status = "not-needed-for-current-task"
         permission_claim = "direct-work-not-active-plan-continuation"
         integrity = "not-applicable-to-current-task"
         reliance = "active-plan-gate-not-relied-on"
+        force = "advisory"
+        allowed_now = "continue-direct-work-without-active-plan-reliance"
+        blocked_until_reconciled = ["claim-active-plan-progress", "claim-active-plan-complete"]
+        claim_boundary = "do-not-claim-active-plan-progress-from-this-direct-work"
+        resolution_command = ""
     else:
         status = "active-plan-present"
         permission_claim = "continue-active-plan-after-normal-review"
         integrity = "not-required-by-current-facts"
         reliance = "allowed-after-current-state-review"
+        force = "required_before_claim"
+        allowed_now = "continue-after-reviewing-active-planning-state"
+        blocked_until_reconciled = ["claim-active-plan-complete", "claim-task-complete"]
+        claim_boundary = "active-plan-completion-claims-require-current-state-review-and-closeout"
+        resolution_command = _command_with_cli_invoke(command="agentic-workspace summary --target . --format json", cli_invoke=cli_invoke)
     payload = {
         "kind": "agentic-workspace/active-plan-reliance/v1",
         "status": status,
         "permission_claim": permission_claim,
         "integrity": integrity,
+        "active_execplan": active_execplan,
         "freshness": {
             "revision_id": revision_id,
             "source": "planning_revision",
         },
         "reliance": reliance,
         "requirement_status": requirement_status,
+        "action_effect": {
+            "force": force,
+            "allowed_now": allowed_now,
+            "blocked_until_reconciled": blocked_until_reconciled,
+            "claim_boundary": claim_boundary,
+            "resolution_selector": "planning_safety_gate.active_plan_reliance",
+            "resolution_command": resolution_command,
+        },
     }
     if active_planning_present:
         payload["authority_evidence"] = _active_plan_freshness_evidence(

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -501,6 +501,17 @@ def test_ordinary_caution_action_shape_audit_records_dispositions() -> None:
     assert "force, allowed action, blocked claim/action, claim boundary, and resolution selector or command" in text
 
 
+def test_planning_continuation_action_shape_audit_records_dispositions() -> None:
+    index = (WORKSPACE_ROOT / "docs" / "maintainer" / "index.md").read_text(encoding="utf-8")
+    text = (WORKSPACE_ROOT / "docs" / "maintainer" / "planning-continuation-action-shape-audit.md").read_text(encoding="utf-8")
+
+    assert "planning-continuation-action-shape-audit.md" in index
+    assert "Active plan reliance" in text
+    assert "Active delegation decision" in text
+    assert "Direct work with unrelated active plan" in text
+    assert "force, allowed action, blocked claim/action, claim boundary, and resolution selector or command" in text
+
+
 def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     playbook = (WORKSPACE_ROOT / "docs" / "maintainer" / "contributor-playbook.md").read_text(encoding="utf-8")
     strategy = (WORKSPACE_ROOT / "docs" / "maintainer" / "testing-strategy.md").read_text(encoding="utf-8")

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2322,7 +2322,82 @@ candidates = []
     reliance = payload["context"]["planning_safety_gate"]["active_plan_reliance"]
     assert reliance["permission_claim"] == "direct-work-not-active-plan-continuation"
     assert reliance["requirement_status"] == "delegation-decision-not-needed-for-direct-task"
+    assert reliance["action_effect"]["force"] == "advisory"
+    assert reliance["action_effect"]["allowed_now"] == "continue-direct-work-without-active-plan-reliance"
+    assert reliance["action_effect"]["blocked_until_reconciled"] == [
+        "claim-active-plan-progress",
+        "claim-active-plan-complete",
+    ]
+    assert reliance["action_effect"]["claim_boundary"] == "do-not-claim-active-plan-progress-from-this-direct-work"
+    assert reliance["action_effect"]["resolution_selector"] == "planning_safety_gate.active_plan_reliance"
     assert payload["context"]["planning_safety_gate"]["delegation_decision_required"] is False
+
+
+def test_implement_active_plan_continuation_blocks_edits_until_decision_recorded(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "active-plan.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "id": "active-plan",
+            "title": "Active Plan",
+            "post_decomposition_delegation": {"status": "required"},
+        },
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "active-plan", title = "Active Plan", status = "active", surface = ".agentic-workspace/planning/execplans/active-plan.plan.json" },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write(tmp_path / "README.md", "hello\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "README.md",
+                "--task",
+                "Continue active plan",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    gate = payload["context"]["planning_safety_gate"]
+    reliance = gate["active_plan_reliance"]
+    assert gate["status"] == "blocked"
+    assert gate["implementation_allowed"] is False
+    assert gate["delegation_decision_required"] is True
+    assert reliance["status"] == "blocked"
+    assert reliance["permission_claim"] == "blocked-until-active-plan-decision-recorded"
+    assert reliance["active_execplan"] == ".agentic-workspace/planning/execplans/active-plan.plan.json"
+    assert reliance["action_effect"]["force"] == "required_before_edit"
+    assert reliance["action_effect"]["allowed_now"] == "record-active-plan-decision-before-editing"
+    assert reliance["action_effect"]["blocked_until_reconciled"] == [
+        "edit-active-plan-owned-work",
+        "claim-active-plan-continuation",
+        "claim-task-complete",
+    ]
+    assert reliance["action_effect"]["resolution_selector"] == "planning_safety_gate.active_plan_reliance"
+    assert "planning delegation-decision" in reliance["action_effect"]["resolution_command"]
 
 
 def test_implement_accumulates_repeated_changed_flags(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- add action_effect semantics to active_plan_reliance so Planning continuation cautions distinguish edit blockers, claim blockers, and advisory direct-work non-reliance
- cover required active-plan continuation and advisory unrelated-active-plan cases in implement tests
- add a maintainer audit note for active-owner and Planning continuation caution dispositions

## Why
This continues the post-#1759 warning/gate action-shaping work for #1760. Active Planning state can protect real continuation ownership, but the emitted caution needs to say what remains allowed, what is blocked, and which selector or command resolves it.

Closes #1760

## Validation
- uv run pytest tests/test_workspace_implement_cli.py::test_implement_generic_continuation_task_does_not_link_active_plan tests/test_workspace_implement_cli.py::test_implement_active_plan_continuation_blocks_edits_until_decision_recorded tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics tests/test_maintainer_surfaces.py::test_planning_continuation_action_shape_audit_records_dispositions
- make test-workspace
- make lint-workspace
- make maintainer-surfaces

Semver: minor, because this adds fields to an emitted CLI contract.
