### PR TITLE
[codex] Action-shape summary closeout cautions

### DIFF
--- a/docs/maintainer/index.md
+++ b/docs/maintainer/index.md
@@ -15,6 +15,7 @@ This section is for source-checkout maintenance of this repository. It is not th
 - [Operational affordance design](operational-affordance-design.md): design review rubric for operational surfaces.
 - [Ordinary caution action-shape audit](ordinary-caution-action-shape-audit.md): disposition table for ordinary warning and gate classes.
 - [Planning continuation action-shape audit](planning-continuation-action-shape-audit.md): disposition table for active-owner and Planning continuation cautions.
+- [Summary/status/preflight action-shape audit](summary-status-preflight-action-shape-audit.md): disposition table for recovery and status-adjacent caution outputs.
 
 ## Boundary And Measurement
 

--- a/docs/maintainer/summary-status-preflight-action-shape-audit.md
+++ b/docs/maintainer/summary-status-preflight-action-shape-audit.md
@@ -1,0 +1,18 @@
+# Summary Status Preflight Action-Shape Audit
+
+## Purpose
+
+This note records the bounded #1761 review of summary, status-like, and preflight caution outputs after #1759.
+
+## Disposition
+
+| Caution class | Surface | Disposition | Action effect |
+| --- | --- | --- | --- |
+| Closeout trust inspection | `summary --select closeout_trust_inspection` and completion/status summary projections | action-shaped and selector-backed | `closeout_trust_inspection.action_effect` distinguishes required-before-claim closeout residue from advisory clear status and names the report command that resolves the condition. |
+| Planning surface health warnings | `summary` planning surface health | retained as status-like diagnostics | Warning classes already include concrete repair detail; future slices should move individual warnings behind action effects only when they change action or closure permission. |
+| Strict preflight token gate | strict preflight enforcement | retained as hard action gate | Token failures block guarded commands before execution; this is an action blocker, not a claim-only caution. |
+| Lifecycle/status setup warnings | `status` / `doctor` lifecycle summaries | leave for local/installed-state tranche | These warnings overlap #1762 and should be tightened with invocation and installed-state compatibility semantics instead of mixed into #1761. |
+
+## Follow-up Boundary
+
+This audit does not add a warning dashboard. Summary closeout trust is the changed emitted caution in this slice; future summary/status/preflight slices should keep the minimum contract visible: force, allowed action, blocked claim/action, claim boundary, and resolution selector or command.

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -21091,6 +21091,14 @@ def _completion_closeout_inspection_payload(
             "reason": "task-text semantics are agent-owned; AW does not infer completion/status posture from prompt keywords",
             "detail_command": command,
             "agent_owned_decision": "whether the user is asking for completion, status, or closeout judgment",
+            "action_effect": {
+                "force": "advisory",
+                "allowed_now": "continue-without-closeout-trust-inspection",
+                "blocked_until_reconciled": [],
+                "claim_boundary": "agent-owned-decision-whether-closeout-status-is-being-claimed",
+                "resolution_selector": "closeout_trust_inspection",
+                "resolution_command": command,
+            },
         }
     try:
         from repo_planning_bootstrap.installer import planning_report
@@ -21101,6 +21109,14 @@ def _completion_closeout_inspection_payload(
             "reason": "completion/status question requires closeout trust, but the planning module is not importable",
             "detail_command": command,
             "required_next_inspection": command,
+            "action_effect": {
+                "force": "required_before_claim",
+                "allowed_now": "inspect-or-restore-closeout-trust-before-status-claim",
+                "blocked_until_reconciled": ["claim-broad-work-complete", "claim-lane-closeable", "claim-issue-closure-safe"],
+                "claim_boundary": "do-not-answer-broad-completion-or-closeout-status-without-closeout-trust",
+                "resolution_selector": "closeout_trust_inspection",
+                "resolution_command": command,
+            },
         }
     planning_payload = planning_report(target=target_root)
     closeout = _report_closeout_trust_payload(
@@ -21113,6 +21129,20 @@ def _completion_closeout_inspection_payload(
     lower_trust_count = _as_int(closeout.get("lower_trust_closeout_count"))
     gate_blocking = bool(strict_gate.get("blocking"))
     needs_surface = trust != "normal" or lower_trust_count > 0 or gate_blocking
+    action_effect = {
+        "force": "required_before_claim" if needs_surface else "advisory",
+        "allowed_now": "inspect-closeout-trust-before-broad-status-claim" if needs_surface else "continue-closeout-status-answer",
+        "blocked_until_reconciled": ["claim-broad-work-complete", "claim-lane-closeable", "claim-issue-closure-safe"]
+        if needs_surface
+        else [],
+        "claim_boundary": (
+            "broad-completion-and-closeout-claims-blocked-until-closeout-trust-is-reconciled"
+            if needs_surface
+            else "closeout-trust-clear-does-not-replace-proof-and-acceptance-reconciliation"
+        ),
+        "resolution_selector": "closeout_trust_inspection",
+        "resolution_command": command,
+    }
     return {
         "status": "required" if needs_surface else "clear",
         "reason": "explicit closeout_trust inspection found residue to reconcile before claiming broad work is done"
@@ -21144,6 +21174,7 @@ def _completion_closeout_inspection_payload(
         },
         "required_next_inspection": command,
         "detail_command": command,
+        "action_effect": action_effect,
         "rule": "Do not answer done/complete/closeable for lane, epic, or broad work without reconciling this surface when agent judgment says the user is asking for closeout status.",
         "authority_boundary": _authority_boundary_payload(
             surface="closeout_trust_inspection",

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -512,6 +512,17 @@ def test_planning_continuation_action_shape_audit_records_dispositions() -> None
     assert "force, allowed action, blocked claim/action, claim boundary, and resolution selector or command" in text
 
 
+def test_summary_status_preflight_action_shape_audit_records_dispositions() -> None:
+    index = (WORKSPACE_ROOT / "docs" / "maintainer" / "index.md").read_text(encoding="utf-8")
+    text = (WORKSPACE_ROOT / "docs" / "maintainer" / "summary-status-preflight-action-shape-audit.md").read_text(encoding="utf-8")
+
+    assert "summary-status-preflight-action-shape-audit.md" in index
+    assert "Closeout trust inspection" in text
+    assert "Planning surface health warnings" in text
+    assert "Strict preflight token gate" in text
+    assert "force, allowed action, blocked claim/action, claim boundary, and resolution selector or command" in text
+
+
 def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     playbook = (WORKSPACE_ROOT / "docs" / "maintainer" / "contributor-playbook.md").read_text(encoding="utf-8")
     strategy = (WORKSPACE_ROOT / "docs" / "maintainer" / "testing-strategy.md").read_text(encoding="utf-8")

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -445,6 +445,15 @@ candidates = [
     closeout = payload["closeout_trust_inspection"]
     assert closeout["status"] == "required"
     assert closeout["trust"] == "lower-trust"
+    effect = closeout["action_effect"]
+    assert effect["force"] == "required_before_claim"
+    assert effect["allowed_now"] == "inspect-closeout-trust-before-broad-status-claim"
+    assert effect["blocked_until_reconciled"] == [
+        "claim-broad-work-complete",
+        "claim-lane-closeable",
+        "claim-issue-closure-safe",
+    ]
+    assert effect["resolution_selector"] == "closeout_trust_inspection"
     assert closeout["strict_closeout_gate"]["status"] == "blocked"
     assert closeout["intent_satisfaction"]["trust"] == "follow-up-required"
     protocol = closeout["closeout_protocol"]
@@ -457,6 +466,50 @@ candidates = [
     assert closeout["required_next_inspection"] == (
         f"agentic-workspace report --target {relative_target} --section closeout_trust --format json"
     )
+
+
+def test_workspace_summary_closeout_trust_inspection_clear_is_advisory(tmp_path: Path, capsys) -> None:
+    install_bootstrap(target=tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "summary",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Is the direct docs update closeable?",
+                "--select",
+                "closeout_trust_inspection",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    closeout = json.loads(capsys.readouterr().out)["values"]["closeout_trust_inspection"]
+    assert closeout["status"] == "clear"
+    assert closeout["action_effect"]["force"] == "advisory"
+    assert closeout["action_effect"]["allowed_now"] == "continue-closeout-status-answer"
+    assert closeout["action_effect"]["blocked_until_reconciled"] == []
+    assert closeout["action_effect"]["claim_boundary"] == "closeout-trust-clear-does-not-replace-proof-and-acceptance-reconciliation"
+    assert closeout["action_effect"]["resolution_selector"] == "closeout_trust_inspection"
 
 
 def test_workspace_summary_json_accepts_verbose_detail(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- add `action_effect` to `closeout_trust_inspection` summary output so required closeout residue blocks broad completion/closeability claims while clear status remains advisory
- cover required and advisory selector-routed closeout states in summary CLI tests
- record the #1761 summary/status/preflight caution disposition and defer lifecycle installed-state warnings to the #1762 tranche

Closes #1761

## Validation
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`

## Semver
- semver:minor