### PR TITLE
[codex] Action-shape installed-state cautions

### DIFF
--- a/docs/maintainer/index.md
+++ b/docs/maintainer/index.md
@@ -13,6 +13,7 @@ This section is for source-checkout maintenance of this repository. It is not th
 - [Generated command check inventory](generated-command-check-inventory.md): checked split between AW-owned generated-command proof and command-generation-owned generic target baselines.
 - [Installed-contract design checklist](installed-contract-design-checklist.md): review bar for collaboration-sensitive installed surfaces.
 - [Operational affordance design](operational-affordance-design.md): design review rubric for operational surfaces.
+- [Local installed-state action-shape audit](local-installed-state-action-shape-audit.md): disposition table for local and installed-state compatibility cautions.
 - [Ordinary caution action-shape audit](ordinary-caution-action-shape-audit.md): disposition table for ordinary warning and gate classes.
 - [Planning continuation action-shape audit](planning-continuation-action-shape-audit.md): disposition table for active-owner and Planning continuation cautions.
 - [Summary/status/preflight action-shape audit](summary-status-preflight-action-shape-audit.md): disposition table for recovery and status-adjacent caution outputs.

--- a/docs/maintainer/local-installed-state-action-shape-audit.md
+++ b/docs/maintainer/local-installed-state-action-shape-audit.md
@@ -1,0 +1,19 @@
+# Local Installed-State Action-Shape Audit
+
+## Purpose
+
+This note records the bounded #1762 review of local state and installed-state compatibility cautions after #1759.
+
+## Disposition
+
+| Caution class | Surface | Disposition | Action effect |
+| --- | --- | --- | --- |
+| Installed-state compatibility | `start --select installed_state_compatibility` and report installed-state sections | action-shaped and selector-backed | `installed_state_compatibility.action_effect` distinguishes execution-blocking CLI drift from claim-only payload freshness drift and clean advisory compatibility. |
+| Invoked CLI identity | `invoked_cli_identity` selectors | retained as evidence | The identity packet remains an input to compatibility decisions; it should not independently block work without the compatibility packet. |
+| Payload provenance drift | installed-state compatibility payload | claim blocker | Missing, invalid, stale, or older payload provenance blocks installed-state freshness claims until the upgrade dry-run/sync check is run, while bounded work may continue with the repo-local invocation. |
+| Stale installed selector risk | AGENTS adapter and CLI compatibility remediation | retained as hard safety rule | Agents must keep using the effective repo-local invocation; stale bare commands remain actionable through compatibility remediation rather than generic warnings. |
+| Adapter/generated-surface trust facts | generated-surface trust and installed-state packets | covered by stronger packets | Generated freshness stays behind `generated_surface_trust` when changed paths are generated; installed-state only carries repo payload freshness and adapter compatibility boundaries. |
+
+## Follow-up Boundary
+
+This audit does not replace install, update, or doctor lifecycle models. Future local-state slices should keep the minimum contract visible: force, allowed action, blocked claim/action, claim boundary, and resolution selector or command.

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -84,6 +84,13 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `installed_state_compatibility.generated_artifacts` | object | yes |  | Generated artifact freshness classification. |  |  |
 | `installed_state_compatibility.adapter_contracts` | array of object | no |  | Entry-surface adapter contracts covered by this model. |  |  |
 | `installed_state_compatibility.next_action` | string \| null | no |  | Suggested command when drift requires or recommends action. |  |  |
+| `installed_state_compatibility.action_effect` | object | no |  | Action and claim effect for the installed-state compatibility condition. |  |  |
+| `installed_state_compatibility.action_effect.force` | enum `"advisory"`, `"required_before_claim"`, `"required_before_execution"` | yes |  | Whether this installed-state condition blocks execution, blocks only claims, or is advisory. |  |  |
+| `installed_state_compatibility.action_effect.allowed_now` | string | yes |  | Action still allowed before reconciling this installed-state condition. |  |  |
+| `installed_state_compatibility.action_effect.blocked_until_reconciled` | array of string | yes |  | Actions or claims blocked until the condition is resolved. |  |  |
+| `installed_state_compatibility.action_effect.claim_boundary` | string | yes |  | Claim limit created by this local or installed-state condition. |  |  |
+| `installed_state_compatibility.action_effect.resolution_selector` | string | yes |  | Selector that exposes the resolving diagnostic. |  |  |
+| `installed_state_compatibility.action_effect.resolution_command` | string | yes |  | Command to run when reconciliation is required or desired. |  |  |
 | `installed_state_compatibility.rule` | string | no |  | Policy rule for applying this packet. |  |  |
 | `sibling_repo_aw_freshness` | ref `#/$defs/sibling_repo_aw_freshness` | no |  | Cross-repo AW freshness posture for sibling repositories referenced by the current task. |  |  |
 | `sibling_repo_aw_freshness.kind` | const `"agentic-workspace/sibling-repo-aw-freshness/v1"` | yes |  | Discriminator identifying the payload or record shape. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -59,6 +59,13 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `installed_state_compatibility.generated_artifacts` | object | yes |  | Generated artifact freshness classification. |  |  |
 | `installed_state_compatibility.adapter_contracts` | array of object | no |  | Entry-surface adapter contracts covered by this model. |  |  |
 | `installed_state_compatibility.next_action` | string \| null | no |  | Suggested command when drift requires or recommends action. |  |  |
+| `installed_state_compatibility.action_effect` | object | no |  | Action and claim effect for the installed-state compatibility condition. |  |  |
+| `installed_state_compatibility.action_effect.force` | enum `"advisory"`, `"required_before_claim"`, `"required_before_execution"` | yes |  | Whether this installed-state condition blocks execution, blocks only claims, or is advisory. |  |  |
+| `installed_state_compatibility.action_effect.allowed_now` | string | yes |  | Action still allowed before reconciling this installed-state condition. |  |  |
+| `installed_state_compatibility.action_effect.blocked_until_reconciled` | array of string | yes |  | Actions or claims blocked until the condition is resolved. |  |  |
+| `installed_state_compatibility.action_effect.claim_boundary` | string | yes |  | Claim limit created by this local or installed-state condition. |  |  |
+| `installed_state_compatibility.action_effect.resolution_selector` | string | yes |  | Selector that exposes the resolving diagnostic. |  |  |
+| `installed_state_compatibility.action_effect.resolution_command` | string | yes |  | Command to run when reconciliation is required or desired. |  |  |
 | `installed_state_compatibility.rule` | string | no |  | Policy rule for applying this packet. |  |  |
 | `selected_modules` | array of string | yes |  | Modules selected for this report invocation. |  |  |
 | `installed_modules` | array of string | yes |  | Installed Agentic Workspace modules detected in the target repository. |  |  |

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -778,6 +778,50 @@
           "type": [ "string", "null" ],
           "description": "Suggested command when drift requires or recommends action."
         },
+        "action_effect": {
+          "type": "object",
+          "required": [
+            "force",
+            "allowed_now",
+            "blocked_until_reconciled",
+            "claim_boundary",
+            "resolution_selector",
+            "resolution_command"
+          ],
+          "properties": {
+            "force": {
+              "enum": [
+                "advisory",
+                "required_before_claim",
+                "required_before_execution"
+              ],
+              "description": "Whether this installed-state condition blocks execution, blocks only claims, or is advisory."
+            },
+            "allowed_now": {
+              "type": "string",
+              "description": "Action still allowed before reconciling this installed-state condition."
+            },
+            "blocked_until_reconciled": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Actions or claims blocked until the condition is resolved."
+            },
+            "claim_boundary": {
+              "type": "string",
+              "description": "Claim limit created by this local or installed-state condition."
+            },
+            "resolution_selector": {
+              "type": "string",
+              "description": "Selector that exposes the resolving diagnostic."
+            },
+            "resolution_command": {
+              "type": "string",
+              "description": "Command to run when reconciliation is required or desired."
+            }
+          },
+          "additionalProperties": false,
+          "description": "Action and claim effect for the installed-state compatibility condition."
+        },
         "rule": {
           "type": "string",
           "description": "Policy rule for applying this packet."

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -1268,6 +1268,50 @@
           "type": [ "string", "null" ],
           "description": "Suggested command when drift requires or recommends action."
         },
+        "action_effect": {
+          "type": "object",
+          "required": [
+            "force",
+            "allowed_now",
+            "blocked_until_reconciled",
+            "claim_boundary",
+            "resolution_selector",
+            "resolution_command"
+          ],
+          "properties": {
+            "force": {
+              "enum": [
+                "advisory",
+                "required_before_claim",
+                "required_before_execution"
+              ],
+              "description": "Whether this installed-state condition blocks execution, blocks only claims, or is advisory."
+            },
+            "allowed_now": {
+              "type": "string",
+              "description": "Action still allowed before reconciling this installed-state condition."
+            },
+            "blocked_until_reconciled": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Actions or claims blocked until the condition is resolved."
+            },
+            "claim_boundary": {
+              "type": "string",
+              "description": "Claim limit created by this local or installed-state condition."
+            },
+            "resolution_selector": {
+              "type": "string",
+              "description": "Selector that exposes the resolving diagnostic."
+            },
+            "resolution_command": {
+              "type": "string",
+              "description": "Command to run when reconciliation is required or desired."
+            }
+          },
+          "additionalProperties": false,
+          "description": "Action and claim effect for the installed-state compatibility condition."
+        },
         "rule": {
           "type": "string",
           "description": "Policy rule for applying this packet."

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -728,6 +728,45 @@ def _cli_compatibility_remediation(
     }
 
 
+def _installed_state_action_effect(*, status: str, next_action: str | None, config: WorkspaceConfig) -> dict[str, Any]:
+    resolution_command = next_action or config.cli_invoke
+    if status == "blocking-drift":
+        return {
+            "force": "required_before_execution",
+            "allowed_now": "switch-to-compatible-invocation-before-running-workspace-actions",
+            "blocked_until_reconciled": ["run-workspace-action", "claim-installed-state-compatible"],
+            "claim_boundary": "do-not-trust-workspace-action-output-until-the-effective-cli-invocation-is-compatible",
+            "resolution_selector": "installed_state_compatibility",
+            "resolution_command": resolution_command,
+        }
+    if status == "payload-upgrade-required":
+        return {
+            "force": "required_before_claim",
+            "allowed_now": "continue-bounded-work-with-repo-local-invocation",
+            "blocked_until_reconciled": ["claim-installed-state-fresh", "claim-payload-synced", "claim-generated-surfaces-current"],
+            "claim_boundary": "do-not-claim-local-installed-state-or-generated-payload-freshness-before-running-the-sync-check",
+            "resolution_selector": "installed_state_compatibility",
+            "resolution_command": resolution_command,
+        }
+    if status == "upgrade-recommended":
+        return {
+            "force": "advisory",
+            "allowed_now": "continue-bounded-work-with-compatible-claim-limits",
+            "blocked_until_reconciled": [],
+            "claim_boundary": "advisory-cli-drift-does-not-block-ordinary-work-but-limits-strong-compatibility-claims",
+            "resolution_selector": "installed_state_compatibility",
+            "resolution_command": resolution_command,
+        }
+    return {
+        "force": "advisory",
+        "allowed_now": "continue-ordinary-work",
+        "blocked_until_reconciled": [],
+        "claim_boundary": "installed-state-compatible-does-not-replace-task-proof-or-acceptance-reconciliation",
+        "resolution_selector": "installed_state_compatibility",
+        "resolution_command": resolution_command,
+    }
+
+
 def _installed_state_compatibility_payload(
     *,
     config: WorkspaceConfig,
@@ -805,6 +844,7 @@ def _installed_state_compatibility_payload(
         executable_class = "upgrade-recommended"
     generated_status = "stale" if stale_generated_surfaces else "compatible"
     payload_status = "sync-required" if stale_generated_surfaces or payload_provenance_drift != "none" else "observed-compatible"
+    action_effect = _installed_state_action_effect(status=status, next_action=next_action, config=config)
     payload: dict[str, Any] = {
         "kind": "agentic-workspace/installed-state-compatibility/v1",
         "status": status,
@@ -856,6 +896,7 @@ def _installed_state_compatibility_payload(
             },
         ],
         "next_action": next_action,
+        "action_effect": action_effect,
         "rule": (
             "Every entry surface should classify executable, payload, generated-artifact, and adapter posture through this "
             "repo-state-authoritative packet instead of separate CLI- or MCP-specific sync rules."
@@ -879,6 +920,7 @@ def _installed_state_compatibility_payload(
             "generated_artifacts": payload["generated_artifacts"],
             "adapter_contracts": payload["adapter_contracts"],
             "next_action": payload["next_action"],
+            "action_effect": payload["action_effect"],
         }
         if compact_payload["next_action"] is None:
             compact_payload.pop("next_action")

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -752,7 +752,7 @@ def _installed_state_action_effect(*, status: str, next_action: str | None, conf
         return {
             "force": "advisory",
             "allowed_now": "continue-bounded-work-with-compatible-claim-limits",
-            "blocked_until_reconciled": [],
+            "blocked_until_reconciled": ["claim-installed-state-current", "claim-cli-fully-current"],
             "claim_boundary": "advisory-cli-drift-does-not-block-ordinary-work-but-limits-strong-compatibility-claims",
             "resolution_selector": "installed_state_compatibility",
             "resolution_command": resolution_command,

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -523,6 +523,18 @@ def test_summary_status_preflight_action_shape_audit_records_dispositions() -> N
     assert "force, allowed action, blocked claim/action, claim boundary, and resolution selector or command" in text
 
 
+def test_local_installed_state_action_shape_audit_records_dispositions() -> None:
+    index = (WORKSPACE_ROOT / "docs" / "maintainer" / "index.md").read_text(encoding="utf-8")
+    text = (WORKSPACE_ROOT / "docs" / "maintainer" / "local-installed-state-action-shape-audit.md").read_text(encoding="utf-8")
+
+    assert "local-installed-state-action-shape-audit.md" in index
+    assert "Installed-state compatibility" in text
+    assert "Invoked CLI identity" in text
+    assert "Payload provenance drift" in text
+    assert "Stale installed selector risk" in text
+    assert "force, allowed action, blocked claim/action, claim boundary, and resolution selector or command" in text
+
+
 def test_testing_strategy_guides_against_one_off_regression_sprawl() -> None:
     playbook = (WORKSPACE_ROOT / "docs" / "maintainer" / "contributor-playbook.md").read_text(encoding="utf-8")
     strategy = (WORKSPACE_ROOT / "docs" / "maintainer" / "testing-strategy.md").read_text(encoding="utf-8")

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -520,6 +520,47 @@ def test_start_select_installed_state_blocking_drift_blocks_execution(tmp_path: 
     )
 
 
+def test_start_select_installed_state_advisory_drift_limits_currentness_claims(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "config.toml").write_text(
+        'schema_version = 1\n\n[cli_compatibility]\nenforcement = "advisory"\nexact_version = "999.0.0"\n',
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Inspect installed state",
+                "--select",
+                "installed_state_compatibility",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    compatibility = json.loads(capsys.readouterr().out)["values"]["installed_state_compatibility"]
+
+    assert compatibility["status"] == "upgrade-recommended"
+    assert compatibility["action_effect"]["force"] == "advisory"
+    assert compatibility["action_effect"]["allowed_now"] == "continue-bounded-work-with-compatible-claim-limits"
+    assert compatibility["action_effect"]["blocked_until_reconciled"] == [
+        "claim-installed-state-current",
+        "claim-cli-fully-current",
+    ]
+    assert (
+        compatibility["action_effect"]["claim_boundary"]
+        == "advisory-cli-drift-does-not-block-ordinary-work-but-limits-strong-compatibility-claims"
+    )
+
+
 def test_start_default_stays_under_tiny_output_budget_for_docs_task(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -466,7 +466,58 @@ def test_start_default_compacts_noncompatible_installed_state_signal(tmp_path: P
     full = selected["values"]["installed_state_compatibility"]
     assert full["status"] == "payload-upgrade-required"
     assert full["payload"]["provenance"]["status"] == "invalid"
+    assert full["action_effect"]["force"] == "required_before_claim"
+    assert full["action_effect"]["allowed_now"] == "continue-bounded-work-with-repo-local-invocation"
+    assert full["action_effect"]["blocked_until_reconciled"] == [
+        "claim-installed-state-fresh",
+        "claim-payload-synced",
+        "claim-generated-surfaces-current",
+    ]
+    assert full["action_effect"]["resolution_selector"] == "installed_state_compatibility"
+    assert "agentic-workspace upgrade" in full["action_effect"]["resolution_command"]
     assert full["adapter_contracts"]
+
+
+def test_start_select_installed_state_blocking_drift_blocks_execution(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "config.toml").write_text(
+        'schema_version = 1\n\n[cli_compatibility]\nenforcement = "blocking"\nexact_version = "999.0.0"\n',
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Inspect installed state",
+                "--select",
+                "installed_state_compatibility",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    compatibility = json.loads(capsys.readouterr().out)["values"]["installed_state_compatibility"]
+
+    assert compatibility["status"] == "blocking-drift"
+    assert compatibility["executable"]["classification"] == "executable-too-old-or-wrong-version"
+    assert compatibility["action_effect"]["force"] == "required_before_execution"
+    assert compatibility["action_effect"]["allowed_now"] == "switch-to-compatible-invocation-before-running-workspace-actions"
+    assert compatibility["action_effect"]["blocked_until_reconciled"] == [
+        "run-workspace-action",
+        "claim-installed-state-compatible",
+    ]
+    assert (
+        compatibility["action_effect"]["claim_boundary"]
+        == "do-not-trust-workspace-action-output-until-the-effective-cli-invocation-is-compatible"
+    )
 
 
 def test_start_default_stays_under_tiny_output_budget_for_docs_task(tmp_path: Path, capsys) -> None:
@@ -969,6 +1020,14 @@ def test_start_select_surfaces_installed_state_compatibility(tmp_path: Path, cap
     assert compatibility["authority"] == "repo-state-authoritative"
     assert compatibility["executable"]["classification"]
     assert compatibility["payload"]["status"]
+    assert compatibility["status"] == "compatible"
+    assert compatibility["action_effect"]["force"] == "advisory"
+    assert compatibility["action_effect"]["allowed_now"] == "continue-ordinary-work"
+    assert compatibility["action_effect"]["blocked_until_reconciled"] == []
+    assert (
+        compatibility["action_effect"]["claim_boundary"]
+        == "installed-state-compatible-does-not-replace-task-proof-or-acceptance-reconciliation"
+    )
 
 
 def test_start_surfaces_recovery_for_obsolete_default_preset(tmp_path: Path, capsys) -> None:

--- a/tests/workspace_cli_support.py
+++ b/tests/workspace_cli_support.py
@@ -127,6 +127,8 @@ def _assert_installed_state_compatibility(payload: dict[str, object], *, status:
     assert compatibility["executable"]["classification"]
     assert compatibility["payload"]["status"]
     assert compatibility["generated_artifacts"]["status"]
+    assert compatibility["action_effect"]["force"] in {"advisory", "required_before_claim", "required_before_execution"}
+    assert compatibility["action_effect"]["resolution_selector"] == "installed_state_compatibility"
     return compatibility
 
 


### PR DESCRIPTION
## Summary
- add `installed_state_compatibility.action_effect` so local/installed-state cautions distinguish execution blockers, claim-only payload freshness blockers, advisory drift, and clean compatibility
- cover blocking CLI drift, invalid payload provenance, and clean selector-routed startup cases
- document the #1762 local/installed-state caution audit and regenerate schema reference docs

Closes #1762

## Validation
- `uv run pytest tests/test_workspace_cli.py::test_start_default_compacts_noncompatible_installed_state_signal tests/test_workspace_cli.py::test_start_select_installed_state_blocking_drift_blocks_execution tests/test_workspace_cli.py::test_start_select_surfaces_installed_state_compatibility tests/test_maintainer_surfaces.py::test_local_installed_state_action_shape_audit_records_dispositions`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make maintainer-surfaces`
- `make schema-reference-docs`

## Semver
- semver:minor