### PR TITLE
Split workspace runtime projection helpers

### DIFF
--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -139,6 +139,30 @@
       "remaining_hand_owned_reason": "The current helpers combine schema shape, selector policy, and live runtime facts; migrate only after a generic projection primitive exists."
     },
     {
+      "id": "shared-projection-action-effect-helpers",
+      "title": "Shared projection and action-effect helpers",
+      "owner_class": "aw-owned-runtime",
+      "owner_surface": "src/agentic_workspace/workspace_runtime_projection.py",
+      "runtime_role": "Small data-only helper module shared by startup, implement, proof, and report packet builders for authority-boundary and action-effect projection.",
+      "source_symbols": [
+        "_authority_boundary_payload",
+        "_tiny_action_effect",
+        "_compact_authority_boundary",
+        "_compact_authority_text"
+      ],
+      "generated_or_contract_refs": [
+        "src/agentic_workspace/contracts/workspace_runtime_primitive_families.json",
+        "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+        "src/agentic_workspace/contracts/schemas/implementer_context.schema.json"
+      ],
+      "proof_refs": [
+        "uv run pytest tests/test_workspace_runtime_projection.py -q",
+        "uv run pytest tests/test_workspace_implement_cli.py tests/test_workspace_summary_cli.py -q"
+      ],
+      "blocked_by": [],
+      "remaining_hand_owned_reason": "The helpers preserve AW payload compacting and authority-boundary wording; they are split by owner boundary but not moved into command-generation semantics."
+    },
+    {
       "id": "intent-and-closeout-judgment",
       "title": "Intent, proof, and closeout semantic judgment",
       "owner_class": "aw-owned-runtime",

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -163,6 +163,136 @@
       "remaining_hand_owned_reason": "The helpers preserve AW payload compacting and authority-boundary wording; they are split by owner boundary but not moved into command-generation semantics."
     },
     {
+      "id": "startup-runtime-packets",
+      "title": "Start and startup runtime packet builders",
+      "owner_class": "covered-by-other-issue",
+      "owner_surface": "src/agentic_workspace/workspace_runtime_primitives.py pending extraction to workspace_runtime_startup.py",
+      "runtime_role": "Startup packet builders, selector hydration, skill routing, next-safe-action, and startup tiny/compact projections remain behavior-owned by the AW runtime until extracted as a startup owner module.",
+      "source_symbols": [
+        "_start_payload",
+        "_tiny_start_payload",
+        "_selector_first_start_payload",
+        "_hydrate_selected_start_advisory_payloads"
+      ],
+      "generated_or_contract_refs": [
+        "src/agentic_workspace/contracts/workspace_runtime_primitive_families.json",
+        "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+        "src/agentic_workspace/contracts/context_templates.json"
+      ],
+      "proof_refs": [
+        "uv run pytest tests/test_workspace_start_cli.py tests/test_workspace_summary_cli.py -q",
+        "make test-workspace"
+      ],
+      "blocked_by": [
+        "#1770"
+      ],
+      "remaining_hand_owned_reason": "Follow-up #1770 owns finishing startup/start-context extraction while preserving CLI payload and selector contracts."
+    },
+    {
+      "id": "implement-runtime-packets",
+      "title": "Implement runtime packet builders and projections",
+      "owner_class": "covered-by-other-issue",
+      "owner_surface": "src/agentic_workspace/workspace_runtime_primitives.py pending extraction to workspace_runtime_implement.py",
+      "runtime_role": "Implement-context assembly, changed-path facts, acceptance/objective-drift projections, and implement tiny/compact projections remain behavior-owned by the AW runtime until extracted as an implement owner module.",
+      "source_symbols": [
+        "_implement_payload",
+        "_tiny_implement_payload",
+        "_objective_drift_payload",
+        "_change_impact_payload"
+      ],
+      "generated_or_contract_refs": [
+        "src/agentic_workspace/contracts/workspace_runtime_primitive_families.json",
+        "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+        "src/agentic_workspace/contracts/context_templates.json"
+      ],
+      "proof_refs": [
+        "uv run pytest tests/test_workspace_implement_cli.py tests/test_workspace_summary_cli.py -q",
+        "make test-workspace"
+      ],
+      "blocked_by": [
+        "#1771"
+      ],
+      "remaining_hand_owned_reason": "Follow-up #1771 owns finishing implement packet extraction while preserving implement payload and selector contracts."
+    },
+    {
+      "id": "planning-runtime-packets",
+      "title": "Planning continuation and active-state runtime packets",
+      "owner_class": "covered-by-other-issue",
+      "owner_surface": "src/agentic_workspace/workspace_runtime_primitives.py pending extraction to workspace_runtime_planning.py or the Planning package runtime boundary",
+      "runtime_role": "Planning continuation, active-state, safety-gate, candidate-pressure, and active execplan projections remain runtime-owned until moved behind the Planning owner boundary.",
+      "source_symbols": [
+        "_active_planning_record",
+        "_planning_safety_gate_payload",
+        "_active_execplan_record_payload",
+        "_planning_candidate_pressure_payload"
+      ],
+      "generated_or_contract_refs": [
+        "src/agentic_workspace/contracts/workspace_runtime_primitive_families.json",
+        "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
+        "packages/planning/src/repo_planning_bootstrap/contracts"
+      ],
+      "proof_refs": [
+        "uv run pytest tests/test_workspace_start_cli.py tests/test_workspace_implement_cli.py -q",
+        "make test-workspace"
+      ],
+      "blocked_by": [
+        "#1772"
+      ],
+      "remaining_hand_owned_reason": "Follow-up #1772 owns finishing Planning packet extraction while preserving active-state and continuation behavior."
+    },
+    {
+      "id": "proof-verification-closeout-runtime-packets",
+      "title": "Proof, verification, and closeout runtime packet builders",
+      "owner_class": "covered-by-other-issue",
+      "owner_surface": "src/agentic_workspace/workspace_runtime_primitives.py pending extraction to workspace_runtime_proof.py",
+      "runtime_role": "Proof selection, verification aggregation, closeout obligations, and completion-contract projections remain behavior-owned by the AW runtime until extracted as a proof/closeout owner module.",
+      "source_symbols": [
+        "_proof_payload",
+        "_proof_selection_for_changed_paths",
+        "_proof_obligations_payload",
+        "_closeout_report_payload"
+      ],
+      "generated_or_contract_refs": [
+        "src/agentic_workspace/contracts/workspace_runtime_primitive_families.json",
+        "src/agentic_workspace/contracts/proof_selection_rules.json",
+        "src/agentic_workspace/contracts/report_contract.json"
+      ],
+      "proof_refs": [
+        "uv run pytest tests/test_workspace_proof_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_summary_cli.py -q",
+        "make test-workspace"
+      ],
+      "blocked_by": [
+        "#1773"
+      ],
+      "remaining_hand_owned_reason": "Follow-up #1773 owns finishing proof/verification/closeout extraction while preserving proof and closeout contracts."
+    },
+    {
+      "id": "generated-surface-trust-runtime-packets",
+      "title": "Generated-surface trust runtime packets",
+      "owner_class": "covered-by-other-issue",
+      "owner_surface": "src/agentic_workspace/workspace_runtime_primitives.py pending extraction to workspace_runtime_generated_surface.py",
+      "runtime_role": "Generated-surface trust projections, generated CLI freshness aggregation, selector requests, and tiny surface compatibility review remain runtime-owned until extracted from the monolith.",
+      "source_symbols": [
+        "_generated_surface_trust_payload",
+        "_generated_cli_freshness_payload",
+        "_tiny_surface_compatibility_review",
+        "_selector_requests_generated_surface_trust"
+      ],
+      "generated_or_contract_refs": [
+        "src/agentic_workspace/contracts/workspace_runtime_primitive_families.json",
+        "src/agentic_workspace/contracts/command_package_ir.json",
+        "src/agentic_workspace/contracts/python_runtime_projection_inventory.json"
+      ],
+      "proof_refs": [
+        "uv run python scripts/check/check_generated_command_packages.py",
+        "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success"
+      ],
+      "blocked_by": [
+        "#1774"
+      ],
+      "remaining_hand_owned_reason": "Follow-up #1774 owns finishing generated-surface trust runtime extraction while stable generated command/package truth remains contract-owned."
+    },
+    {
       "id": "intent-and-closeout-judgment",
       "title": "Intent, proof, and closeout semantic judgment",
       "owner_class": "aw-owned-runtime",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -144,6 +144,12 @@ from agentic_workspace.workspace_output import (
     _emit_report_text,
     _emit_setup_text,
 )
+from agentic_workspace.workspace_runtime_projection import (
+    _authority_boundary_payload,
+    _compact_authority_boundary,
+    _compact_authority_text,
+    _tiny_action_effect,
+)
 
 _GENERATED_CLI_MODULES = {
     "agentic-workspace": ("agentic_workspace._generated_cli_package_impl.cli", "generated.workspace.python.cli"),
@@ -12508,48 +12514,6 @@ def _workflow_sufficiency_payload(
     if drill_down:
         payload["drill_down"] = drill_down
     return payload
-
-
-def _authority_boundary_payload(
-    *,
-    surface: str,
-    enforced_by_aw: list[str] | None = None,
-    observed_by_aw: list[str] | None = None,
-    recommended_by_aw: list[str] | None = None,
-    candidate_routes: list[str] | None = None,
-    proof_hints: list[str] | None = None,
-    agent_owned_decisions: list[str] | None = None,
-    human_owned_decisions: list[str] | None = None,
-    rule: str | None = None,
-) -> dict[str, Any]:
-    enforced = [str(item).strip() for item in (enforced_by_aw or []) if str(item).strip()]
-    observed = [str(item).strip() for item in (observed_by_aw or []) if str(item).strip()]
-    recommended = [str(item).strip() for item in (recommended_by_aw or []) if str(item).strip()]
-    routes = [str(item).strip() for item in (candidate_routes or []) if str(item).strip()]
-    hints = [str(item).strip() for item in (proof_hints or []) if str(item).strip()]
-    agent = [str(item).strip() for item in (agent_owned_decisions or []) if str(item).strip()]
-    human = [str(item).strip() for item in (human_owned_decisions or []) if str(item).strip()]
-    if enforced:
-        authority_class = "hard-gate"
-    elif recommended or routes or hints:
-        authority_class = "advisory-support"
-    elif observed:
-        authority_class = "observed-facts"
-    else:
-        authority_class = "agent-owned"
-    return {
-        "kind": "agentic-workspace/authority-boundary/v1",
-        "surface": surface,
-        "authority_class": authority_class,
-        "enforced_by_aw": enforced,
-        "observed_by_aw": observed,
-        "recommended_by_aw": recommended,
-        "candidate_routes": routes,
-        "proof_hints": hints,
-        "agent_owned_decisions": agent,
-        "human_owned_decisions": human,
-        "reporting_rule": rule or "Report AW facts, constraints, and suggestions separately from the agent's semantic decision.",
-    }
 
 
 def _compact_continuation_state_contract(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
@@ -29119,23 +29083,6 @@ def _tiny_generated_surface_trust(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _tiny_action_effect(value: Any, *, include_allowed: bool = True, include_resolution_commands: bool = True) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        return {}
-    keys = [
-        "force",
-        "blocked_until_reconciled",
-        "resolution_selector",
-        "resolution_command",
-    ]
-    if include_resolution_commands:
-        keys.append("resolution_commands")
-    compact = {key: value[key] for key in keys if key in value}
-    if include_allowed and "allowed_now" in value:
-        compact["allowed_now"] = value["allowed_now"]
-    return compact
-
-
 def _compact_selector_next_safe_action(packet: dict[str, Any]) -> dict[str, Any]:
     compact = dict(packet)
     why = str(compact.get("why", "") or "")
@@ -29298,43 +29245,6 @@ def _tiny_workflow_sufficiency(value: Any) -> dict[str, Any]:
     compact.setdefault("sufficiency_result", value.get("decision"))
     compact["authority_boundary"] = _compact_authority_boundary(value.get("authority_boundary"))
     return {key: item for key, item in compact.items() if item not in (None, "", {})}
-
-
-def _compact_authority_boundary(value: Any) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        return {}
-
-    def compact_items(key: str, limit: int) -> list[str]:
-        return [_compact_authority_text(str(item)) for item in _list_payload(value.get(key))[:limit]]
-
-    compact = {
-        "kind": value.get("kind"),
-        "surface": value.get("surface"),
-        "authority_class": value.get("authority_class"),
-        "enforced_by_aw": compact_items("enforced_by_aw", 2),
-        "observed_by_aw": compact_items("observed_by_aw", 1),
-        "recommended_by_aw": compact_items("recommended_by_aw", 1),
-        "candidate_routes": compact_items("candidate_routes", 1),
-        "agent_owned_decisions": compact_items("agent_owned_decisions", 1),
-    }
-    return {key: item for key, item in compact.items() if item not in (None, "", [])}
-
-
-def _compact_authority_text(text: str) -> str:
-    mapping = {
-        "whether delegation improves quality or cost without lowering proof": "delegation fit without lowering proof",
-        "semantic fit of candidate route to the user's task": "candidate-route semantic fit",
-        "whether to stay local when advisory delegation is not followed": "stay-local judgment",
-        "semantic work shape": "semantic work shape",
-        "proof proportionality": "proof proportionality",
-        "whether Planning is needed when no hard blocker applies": "planning need when no hard blocker applies",
-        "issue intent or acceptance when task scope is externally owned": "external issue intent or acceptance",
-    }
-    if text in mapping:
-        return mapping[text]
-    if len(text) <= 80:
-        return text
-    return text[:77].rstrip() + "..."
 
 
 def _acceptance_reconciliation_prompt_payload(*, task_text: str | None, acceptance: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/src/agentic_workspace/workspace_runtime_projection.py
+++ b/src/agentic_workspace/workspace_runtime_projection.py
@@ -1,0 +1,109 @@
+"""Shared projection helpers for workspace runtime payloads.
+
+These helpers are intentionally small and data-only. They are shared by startup,
+implement, proof, and report payload builders without owning command semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _list_payload(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _authority_boundary_payload(
+    *,
+    surface: str,
+    enforced_by_aw: list[str] | None = None,
+    observed_by_aw: list[str] | None = None,
+    recommended_by_aw: list[str] | None = None,
+    candidate_routes: list[str] | None = None,
+    proof_hints: list[str] | None = None,
+    agent_owned_decisions: list[str] | None = None,
+    human_owned_decisions: list[str] | None = None,
+    rule: str | None = None,
+) -> dict[str, Any]:
+    enforced = [str(item).strip() for item in (enforced_by_aw or []) if str(item).strip()]
+    observed = [str(item).strip() for item in (observed_by_aw or []) if str(item).strip()]
+    recommended = [str(item).strip() for item in (recommended_by_aw or []) if str(item).strip()]
+    routes = [str(item).strip() for item in (candidate_routes or []) if str(item).strip()]
+    hints = [str(item).strip() for item in (proof_hints or []) if str(item).strip()]
+    agent = [str(item).strip() for item in (agent_owned_decisions or []) if str(item).strip()]
+    human = [str(item).strip() for item in (human_owned_decisions or []) if str(item).strip()]
+    if enforced:
+        authority_class = "hard-gate"
+    elif recommended or routes or hints:
+        authority_class = "advisory-support"
+    elif observed:
+        authority_class = "observed-facts"
+    else:
+        authority_class = "agent-owned"
+    return {
+        "kind": "agentic-workspace/authority-boundary/v1",
+        "surface": surface,
+        "authority_class": authority_class,
+        "enforced_by_aw": enforced,
+        "observed_by_aw": observed,
+        "recommended_by_aw": recommended,
+        "candidate_routes": routes,
+        "proof_hints": hints,
+        "agent_owned_decisions": agent,
+        "human_owned_decisions": human,
+        "reporting_rule": rule or "Report AW facts, constraints, and suggestions separately from the agent's semantic decision.",
+    }
+
+
+def _tiny_action_effect(value: Any, *, include_allowed: bool = True, include_resolution_commands: bool = True) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    keys = [
+        "force",
+        "blocked_until_reconciled",
+        "resolution_selector",
+        "resolution_command",
+    ]
+    if include_resolution_commands:
+        keys.append("resolution_commands")
+    compact = {key: value[key] for key in keys if key in value}
+    if include_allowed and "allowed_now" in value:
+        compact["allowed_now"] = value["allowed_now"]
+    return compact
+
+
+def _compact_authority_boundary(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    def compact_items(key: str, limit: int) -> list[str]:
+        return [_compact_authority_text(str(item)) for item in _list_payload(value.get(key))[:limit]]
+
+    compact = {
+        "kind": value.get("kind"),
+        "surface": value.get("surface"),
+        "authority_class": value.get("authority_class"),
+        "enforced_by_aw": compact_items("enforced_by_aw", 2),
+        "observed_by_aw": compact_items("observed_by_aw", 1),
+        "recommended_by_aw": compact_items("recommended_by_aw", 1),
+        "candidate_routes": compact_items("candidate_routes", 1),
+        "agent_owned_decisions": compact_items("agent_owned_decisions", 1),
+    }
+    return {key: item for key, item in compact.items() if item not in (None, "", [])}
+
+
+def _compact_authority_text(text: str) -> str:
+    mapping = {
+        "whether delegation improves quality or cost without lowering proof": "delegation fit without lowering proof",
+        "semantic fit of candidate route to the user's task": "candidate-route semantic fit",
+        "whether to stay local when advisory delegation is not followed": "stay-local judgment",
+        "semantic work shape": "semantic work shape",
+        "proof proportionality": "proof proportionality",
+        "whether Planning is needed when no hard blocker applies": "planning need when no hard blocker applies",
+        "issue intent or acceptance when task scope is externally owned": "external issue intent or acceptance",
+    }
+    if text in mapping:
+        return mapping[text]
+    if len(text) <= 80:
+        return text
+    return text[:77].rstrip() + "..."

--- a/tests/test_workspace_runtime_projection.py
+++ b/tests/test_workspace_runtime_projection.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from agentic_workspace.workspace_runtime_projection import (
+    _authority_boundary_payload,
+    _compact_authority_boundary,
+    _compact_authority_text,
+    _tiny_action_effect,
+)
+
+
+def test_authority_boundary_payload_classifies_hard_gate_before_advisory() -> None:
+    payload = _authority_boundary_payload(
+        surface="implement.workflow_sufficiency",
+        enforced_by_aw=["proof execution evidence before closeout"],
+        recommended_by_aw=["inspect changed paths"],
+        agent_owned_decisions=["semantic work shape"],
+    )
+
+    assert payload["kind"] == "agentic-workspace/authority-boundary/v1"
+    assert payload["authority_class"] == "hard-gate"
+    assert payload["enforced_by_aw"] == ["proof execution evidence before closeout"]
+    assert payload["recommended_by_aw"] == ["inspect changed paths"]
+    assert payload["agent_owned_decisions"] == ["semantic work shape"]
+
+
+def test_tiny_action_effect_preserves_resolution_command_shape() -> None:
+    effect = _tiny_action_effect(
+        {
+            "force": "required_before_claim",
+            "allowed_now": "run-proof",
+            "blocked_until_reconciled": ["claim-task-complete"],
+            "resolution_selector": "proof.required",
+            "resolution_command": "make test-workspace",
+            "resolution_commands": ["make test-workspace", "make lint-workspace"],
+            "extra": "ignored",
+        },
+        include_allowed=False,
+    )
+
+    assert effect == {
+        "force": "required_before_claim",
+        "blocked_until_reconciled": ["claim-task-complete"],
+        "resolution_selector": "proof.required",
+        "resolution_command": "make test-workspace",
+        "resolution_commands": ["make test-workspace", "make lint-workspace"],
+    }
+
+
+def test_compact_authority_boundary_limits_and_rewrites_authority_text() -> None:
+    compact = _compact_authority_boundary(
+        {
+            "kind": "agentic-workspace/authority-boundary/v1",
+            "surface": "planning_safety_gate",
+            "authority_class": "advisory-support",
+            "enforced_by_aw": ["first", "second", "third"],
+            "observed_by_aw": ["observed", "ignored"],
+            "recommended_by_aw": ["whether delegation improves quality or cost without lowering proof"],
+            "candidate_routes": ["candidate"],
+            "agent_owned_decisions": ["whether Planning is needed when no hard blocker applies"],
+        }
+    )
+
+    assert compact["enforced_by_aw"] == ["first", "second"]
+    assert compact["observed_by_aw"] == ["observed"]
+    assert compact["recommended_by_aw"] == ["delegation fit without lowering proof"]
+    assert compact["agent_owned_decisions"] == ["planning need when no hard blocker applies"]
+
+
+def test_compact_authority_text_truncates_long_unknown_text() -> None:
+    text = "x" * 90
+
+    assert _compact_authority_text(text) == ("x" * 77) + "..."


### PR DESCRIPTION
## Summary
- Split AW-owned authority-boundary and action-effect projection helpers into `workspace_runtime_projection.py`.
- Kept `workspace_runtime_primitives.py` behavior-compatible by importing the moved helpers at the old private names.
- Added runtime primitive family inventory coverage for every named #1764 owner group.
- Decomposed the retained owner groups into explicit follow-up issues: #1770, #1771, #1772, #1773, and #1774.
- Updated #1764's body so closure is honest under its closure-integrity rule.

Closes #1764.

## Proof
- `uv run pytest tests/test_workspace_runtime_projection.py tests/test_workspace_implement_cli.py tests/test_workspace_summary_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run ruff check src/agentic_workspace/workspace_runtime_primitives.py src/agentic_workspace/workspace_runtime_projection.py tests/test_workspace_runtime_projection.py`
