### PR TITLE
Extract generated-surface runtime packets

### DIFF
--- a/generated/python/Dockerfile.conformance
+++ b/generated/python/Dockerfile.conformance
@@ -8,6 +8,9 @@ COPY src ./src
 COPY scripts ./scripts
 COPY packages ./packages
 COPY generated ./generated
+COPY .github/release-ownership.json ./.github/release-ownership.json
+COPY .agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json ./.agentic-workspace/planning/decompositions/python-generated-cli.decomposition.json
+COPY tests/test_workspace_packaging.py ./tests/test_workspace_packaging.py
 COPY pyproject.toml ./pyproject.toml
 
 ENV PYTHONPATH=/work:/work/src:/work/packages/planning/src:/work/packages/memory/src

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -269,9 +269,9 @@
     {
       "id": "generated-surface-trust-runtime-packets",
       "title": "Generated-surface trust runtime packets",
-      "owner_class": "covered-by-other-issue",
-      "owner_surface": "src/agentic_workspace/workspace_runtime_primitives.py pending extraction to workspace_runtime_generated_surface.py",
-      "runtime_role": "Generated-surface trust projections, generated CLI freshness aggregation, selector requests, and tiny surface compatibility review remain runtime-owned until extracted from the monolith.",
+      "owner_class": "aw-owned-runtime",
+      "owner_surface": "src/agentic_workspace/workspace_runtime_generated_surface.py",
+      "runtime_role": "Generated-surface trust projections, generated CLI freshness aggregation, selector requests, and tiny surface compatibility review are owned by the generated-surface runtime module.",
       "source_symbols": [
         "_generated_surface_trust_payload",
         "_generated_cli_freshness_payload",
@@ -287,10 +287,8 @@
         "uv run python scripts/check/check_generated_command_packages.py",
         "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success"
       ],
-      "blocked_by": [
-        "#1774"
-      ],
-      "remaining_hand_owned_reason": "Follow-up #1774 owns finishing generated-surface trust runtime extraction while stable generated command/package truth remains contract-owned."
+      "blocked_by": [],
+      "remaining_hand_owned_reason": "Generated-surface trust runtime extraction is complete for #1774; stable generated command/package truth remains contract-owned."
     },
     {
       "id": "intent-and-closeout-judgment",

--- a/src/agentic_workspace/workspace_runtime_generated_surface.py
+++ b/src/agentic_workspace/workspace_runtime_generated_surface.py
@@ -9,47 +9,223 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from agentic_workspace.config import DEFAULT_AGENT_INSTRUCTIONS_FILE
+from agentic_workspace.contract_tooling import authority_markers_manifest, proof_selection_rules_manifest
 
-def _runtime_attr(name: str) -> Any:
-    from agentic_workspace import workspace_runtime_primitives as runtime
-
-    return getattr(runtime, name)
-
-
-class _RuntimeValue:
-    def __init__(self, name: str) -> None:
-        self._name = name
-
-    def _value(self) -> Any:
-        return _runtime_attr(self._name)
-
-    def __getitem__(self, key: Any) -> Any:
-        return self._value()[key]
-
-    def get(self, *args: Any, **kwargs: Any) -> Any:
-        return self._value().get(*args, **kwargs)
-
-    def __iter__(self):
-        return iter(self._value())
-
-    def __bool__(self) -> bool:
-        return bool(self._value())
+_AUTHORITY_MARKERS = authority_markers_manifest()
+_PROOF_SELECTION_RULES = proof_selection_rules_manifest()
 
 
-def _as_dict(*args: Any, **kwargs: Any) -> Any:
-    return _runtime_attr("_as_dict")(*args, **kwargs)
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
 
 
-def _generated_surface_trust_path_payload(*args: Any, **kwargs: Any) -> Any:
-    return _runtime_attr("_generated_surface_trust_path_payload")(*args, **kwargs)
+def _list_payload(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
 
 
-def _list_payload(*args: Any, **kwargs: Any) -> Any:
-    return _runtime_attr("_list_payload")(*args, **kwargs)
+def _selector_tokens(select: str | None) -> list[str]:
+    if not select:
+        return []
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for raw in select.split(","):
+        token = raw.strip()
+        if not token or token in seen:
+            continue
+        tokens.append(token)
+        seen.add(token)
+    return tokens
 
 
-def _selector_tokens(*args: Any, **kwargs: Any) -> Any:
-    return _runtime_attr("_selector_tokens")(*args, **kwargs)
+def _normalize_changed_paths(paths: list[str]) -> list[str]:
+    normalized: list[str] = []
+    for path_text in paths:
+        stripped = str(path_text).strip()
+        if not stripped:
+            continue
+        path = Path(stripped)
+        try:
+            if path.is_absolute():
+                stripped = path.resolve().as_posix()
+            else:
+                stripped = path.as_posix()
+        except OSError:
+            stripped = path.as_posix()
+        while stripped.startswith("./"):
+            stripped = stripped[2:]
+        stripped = stripped.rstrip("/")
+        if stripped and stripped not in normalized:
+            normalized.append(stripped)
+    return normalized
+
+
+def _authority_marker_policy_by_id() -> dict[str, dict[str, Any]]:
+    return {
+        str(marker.get("id", "")): marker
+        for marker in _list_payload(_AUTHORITY_MARKERS.get("markers"))
+        if isinstance(marker, dict) and marker.get("id")
+    }
+
+
+def _authority_marker_canonical_source(*, marker: dict[str, Any], normalized: str) -> str:
+    canonical_source = str(marker.get("canonical_source", "")).strip()
+    if canonical_source:
+        return canonical_source
+    if normalized.startswith("src/agentic_workspace/contracts/schemas/"):
+        return "src/agentic_workspace/contracts/schemas"
+    if normalized.startswith("docs/reference/"):
+        return "src/agentic_workspace/contracts/schemas"
+    return ""
+
+
+def _authority_marker_payload(*, marker_id: str, normalized: str) -> dict[str, Any]:
+    marker = _authority_marker_policy_by_id()[marker_id]
+    return {
+        "path": normalized,
+        "authority": marker["authority"],
+        "canonical_source": _authority_marker_canonical_source(marker=marker, normalized=normalized),
+        "safe_to_edit": marker["safe_to_edit"],
+        "refresh_command": marker["refresh_command"],
+    }
+
+
+def _authority_marker_for_path(path_text: str, *, agent_instructions_file: str = DEFAULT_AGENT_INSTRUCTIONS_FILE) -> dict[str, Any]:
+    normalized_paths = _normalize_changed_paths([path_text])
+    normalized = normalized_paths[0] if normalized_paths else path_text
+    if normalized == agent_instructions_file:
+        return _authority_marker_payload(marker_id="root-agent-instructions", normalized=normalized)
+    if normalized.startswith(".agentic-workspace/planning/"):
+        return _authority_marker_payload(marker_id="planning-surface", normalized=normalized)
+    if normalized.startswith(".agentic-workspace/memory/"):
+        return _authority_marker_payload(marker_id="memory-surface", normalized=normalized)
+    if "/bootstrap/" in normalized or normalized.endswith("/bootstrap"):
+        return _authority_marker_payload(marker_id="package-bootstrap-payload", normalized=normalized)
+    if normalized.startswith("src/agentic_workspace/") or normalized.startswith("packages/"):
+        return _authority_marker_payload(marker_id="source", normalized=normalized)
+    if normalized.startswith(".agentic-workspace/"):
+        return _authority_marker_payload(marker_id="managed-workspace-surface", normalized=normalized)
+    return _authority_marker_payload(marker_id="repo-owned", normalized=normalized)
+
+
+def _cli_authority_classification_for_path(changed_path: str) -> dict[str, Any] | None:
+    for classification in _list_payload(_as_dict(_PROOF_SELECTION_RULES.get("cli_authority")).get("classifications")):
+        if not isinstance(classification, dict):
+            continue
+        exact_matches = set(classification.get("exact", []))
+        prefixes = tuple(classification.get("prefixes", []))
+        if changed_path in exact_matches or changed_path.startswith(prefixes):
+            return classification
+    return None
+
+
+def _generated_surface_validation_command(*, path: str, proof: dict[str, Any]) -> str:
+    commands = [str(command) for command in _list_payload(proof.get("required_commands")) if str(command).strip()]
+    if path.startswith("docs/reference/"):
+        return next((command for command in commands if "schema-reference-docs" in command), "make schema-reference-docs")
+    if path.startswith("generated/") or path.startswith("command_generation/"):
+        return next(
+            (command for command in commands if "check_generated_command_packages.py" in command),
+            "uv run python scripts/check/check_generated_command_packages.py",
+        )
+    return next(iter(commands), "")
+
+
+def _generated_surface_source_status(*, target_root: Path, canonical_source: str) -> str:
+    if not canonical_source:
+        return "unknown"
+    source_paths = [part.strip() for part in canonical_source.split("+") if part.strip()]
+    existing: list[str] = []
+    missing: list[str] = []
+    for source_path in source_paths:
+        if " " in source_path or not any(separator in source_path for separator in ("/", "\\")):
+            continue
+        if (target_root / source_path).exists():
+            existing.append(source_path)
+        else:
+            missing.append(source_path)
+    if missing:
+        return "missing"
+    if existing:
+        return "present"
+    return "not-checked"
+
+
+def _command_with_cli_invoke(*, command: str | None, cli_invoke: str) -> str | None:
+    if command is None:
+        return None
+    if command == "agentic-workspace" or command.startswith("agentic-workspace "):
+        return f"{cli_invoke}{command.removeprefix('agentic-workspace')}"
+    if command == "agentic-planning" or command.startswith("agentic-planning "):
+        mapped = command.replace("agentic-planning ", "agentic-workspace planning ", 1)
+        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke)
+    if command == "agentic-memory" or command.startswith("agentic-memory "):
+        mapped = command.replace("agentic-memory ", "agentic-workspace memory ", 1)
+        return _command_with_cli_invoke(command=mapped, cli_invoke=cli_invoke)
+    return command
+
+
+def _generated_surface_trust_path_payload(*, target_root: Path, path: str, proof: dict[str, Any], cli_invoke: str) -> dict[str, Any] | None:
+    def clean_text(value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    normalized = path.replace("\\", "/").strip("/")
+    classification = _cli_authority_classification_for_path(normalized)
+    authority_marker = _authority_marker_for_path(normalized, agent_instructions_file=DEFAULT_AGENT_INSTRUCTIONS_FILE)
+    is_schema_reference = normalized.startswith("docs/reference/")
+    is_generated = normalized.startswith("generated/") or is_schema_reference
+    if not is_generated and classification is None:
+        return None
+    role = str(classification.get("role", "generated-doc") if classification else "generated-doc" if is_schema_reference else "generated")
+    canonical_source = clean_text(classification.get("source_contract") if classification else authority_marker.get("canonical_source"))
+    refresh_command = clean_text(classification.get("regeneration_path") if classification else authority_marker.get("refresh_command"))
+    direct_edit_allowed = bool(classification.get("direct_edit_allowed", False)) if classification else False
+    direct_edit_policy = clean_text(classification.get("edit_policy") if classification else "")
+    if is_schema_reference:
+        canonical_source = "src/agentic_workspace/contracts/schemas"
+        refresh_command = "make render-schema-reference"
+        direct_edit_policy = "Do not hand-edit generated schema reference docs; edit the source schema and rerender."
+    if not direct_edit_policy:
+        direct_edit_policy = "Do not hand-edit generated surfaces when a canonical source or refresh command exists."
+    validation_command = _generated_surface_validation_command(path=normalized, proof=proof)
+    source_status = _generated_surface_source_status(target_root=target_root, canonical_source=canonical_source)
+    freshness_status = "validation-required"
+    if not refresh_command or source_status == "missing":
+        freshness_status = "missing-source-or-refresh-command"
+    refresh = _command_with_cli_invoke(command=refresh_command, cli_invoke=cli_invoke) if refresh_command else ""
+    validation = _command_with_cli_invoke(command=validation_command, cli_invoke=cli_invoke) if validation_command else ""
+    resolution_commands = list(dict.fromkeys(command for command in (refresh, validation) if command))
+    return {
+        "kind": "generated-surface-trust-item/v1",
+        "path": normalized,
+        "classification_id": str(classification.get("id", "")) if classification else "generated-reference-doc",
+        "role": role,
+        "canonical_source": canonical_source,
+        "canonical_source_status": source_status,
+        "freshness_status": freshness_status,
+        "freshness_checked_by_implement": False,
+        "refresh_command": refresh,
+        "validation_command": validation,
+        "direct_edit_allowed": direct_edit_allowed,
+        "direct_edit_policy": direct_edit_policy,
+        "action_effect": {
+            "force": "required_before_claim" if not direct_edit_allowed or freshness_status != "validated" else "advisory",
+            "allowed_now": "edit-canonical-source-refresh-and-validate-generated-surface",
+            "blocked_until_reconciled": ["claim-generated-surface-fresh", "claim-task-complete"]
+            if not direct_edit_allowed or freshness_status != "validated"
+            else [],
+            "claim_boundary": (
+                "do-not-claim-generated-output-fresh-until-refresh-and-validation-pass"
+                if refresh or validation
+                else "do-not-claim-generated-output-fresh-until-canonical-source-or-refresh-route-is-restored"
+            ),
+            "resolution_selector": "generated_surface_trust",
+            "resolution_command": resolution_commands[0] if resolution_commands else "",
+            "resolution_commands": resolution_commands,
+        },
+    }
 
 
 def _generated_surface_trust_payload(

--- a/src/agentic_workspace/workspace_runtime_generated_surface.py
+++ b/src/agentic_workspace/workspace_runtime_generated_surface.py
@@ -1,0 +1,189 @@
+"""Generated-surface trust runtime packet helpers.
+
+This module owns generated-surface trust projections extracted from
+``workspace_runtime_primitives`` while preserving the old private import names.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def _runtime_attr(name: str) -> Any:
+    from agentic_workspace import workspace_runtime_primitives as runtime
+
+    return getattr(runtime, name)
+
+
+class _RuntimeValue:
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def _value(self) -> Any:
+        return _runtime_attr(self._name)
+
+    def __getitem__(self, key: Any) -> Any:
+        return self._value()[key]
+
+    def get(self, *args: Any, **kwargs: Any) -> Any:
+        return self._value().get(*args, **kwargs)
+
+    def __iter__(self):
+        return iter(self._value())
+
+    def __bool__(self) -> bool:
+        return bool(self._value())
+
+
+def _as_dict(*args: Any, **kwargs: Any) -> Any:
+    return _runtime_attr("_as_dict")(*args, **kwargs)
+
+
+def _generated_surface_trust_path_payload(*args: Any, **kwargs: Any) -> Any:
+    return _runtime_attr("_generated_surface_trust_path_payload")(*args, **kwargs)
+
+
+def _list_payload(*args: Any, **kwargs: Any) -> Any:
+    return _runtime_attr("_list_payload")(*args, **kwargs)
+
+
+def _selector_tokens(*args: Any, **kwargs: Any) -> Any:
+    return _runtime_attr("_selector_tokens")(*args, **kwargs)
+
+
+def _generated_surface_trust_payload(
+    *, target_root: Path, changed_paths: list[str], proof: dict[str, Any], cli_invoke: str
+) -> dict[str, Any]:
+    items = [
+        item
+        for path in changed_paths
+        for item in [_generated_surface_trust_path_payload(target_root=target_root, path=path, proof=proof, cli_invoke=cli_invoke)]
+        if item is not None
+    ]
+    blocked_paths = [item["path"] for item in items if not item["direct_edit_allowed"]]
+    resolution_commands = list(
+        dict.fromkeys(
+            command
+            for item in items
+            for command in _list_payload(_as_dict(item.get("action_effect")).get("resolution_commands"))
+            if str(command).strip()
+        )
+    )
+    action_effect = {
+        "force": "required_before_claim" if items else "advisory",
+        "allowed_now": "continue-implementation-but-refresh-generated-surfaces-before-claim" if items else "continue-implementation",
+        "blocked_until_reconciled": ["claim-generated-surfaces-fresh", "claim-task-complete"] if items else [],
+        "claim_boundary": (
+            "generated-surface-freshness-must-be-reconciled-before-completion-claim" if items else "no-generated-surface-freshness-warning"
+        ),
+        "resolution_selector": "generated_surface_trust",
+        "resolution_commands": resolution_commands,
+    }
+    return {
+        "kind": "agentic-workspace/generated-surface-trust/v1",
+        "status": "present" if items else "not-applicable",
+        "changed_path_count": len(items),
+        "items": items,
+        "direct_edit_blocked_paths": blocked_paths,
+        "action_effect": action_effect,
+        "rule": (
+            "Generated surfaces are derived artifacts. Edit the canonical source first, refresh the generated output, "
+            "and run the validation command before trusting freshness."
+        ),
+        "detail_selector": "generated_surface_trust",
+    }
+
+
+def _selector_requests_generated_surface_trust(select: str | None) -> bool:
+    return any(token == "generated_surface_trust" or token.startswith("generated_surface_trust.") for token in _selector_tokens(select))
+
+
+def _generated_cli_freshness_payload(
+    *,
+    changed_paths: list[str],
+    selected_lanes: list[dict[str, Any]],
+    required_commands: list[str],
+) -> dict[str, Any] | None:
+    lane_ids = [str(lane.get("id", "")) for lane in selected_lanes if isinstance(lane, dict)]
+    relevant_lane_ids = [
+        lane_id
+        for lane_id in lane_ids
+        if lane_id in {"generated_command_packages", "cli_authority", "verification:generated_adapter_conformance"}
+    ]
+    related_commands = [
+        command
+        for command in required_commands
+        if "check_generated_command_packages.py" in command or "generate_command_packages.py" in command
+    ]
+    if not relevant_lane_ids and not related_commands:
+        return None
+    freshness_check = "uv run python scripts/generate/generate_command_packages.py --check"
+    refresh_command = "uv run python scripts/generate/generate_command_packages.py"
+    validation_command = next(
+        (command for command in related_commands if "check_generated_command_packages.py" in command),
+        "uv run python scripts/check/check_generated_command_packages.py",
+    )
+    obligation = "required" if related_commands else "advisory"
+    return {
+        "kind": "agentic-workspace/generated-cli-freshness/v1",
+        "status": obligation,
+        "triggered_by": changed_paths,
+        "selected_lanes": relevant_lane_ids,
+        "freshness_check_command": freshness_check,
+        "refresh_command": refresh_command,
+        "validation_command": validation_command,
+        "required_commands": related_commands,
+        "obligation": obligation,
+        "generated_target_parity": {
+            "kind": "agentic-workspace/generated-target-parity/v1",
+            "status": "required" if obligation == "required" else "advisory",
+            "target_families": ["python", "typescript"],
+            "freshness_evidence": [
+                "scripts/generate/generate_command_packages.py --check compares rendered outputs for all generated Python and TypeScript package targets without writing files",
+                "scripts/check/check_generated_command_packages.py performs static generated-package proof across Python and TypeScript surfaces",
+            ],
+            "stale_detection": {
+                "python": "generated/*/python/** outputs must match command-generation render output",
+                "typescript": "generated/*/typescript/** outputs must match command-generation render output",
+            },
+            "claim_rule": (
+                "Do not claim generated CLI freshness from Python-only proof; relevant generated CLI proof must name "
+                "both Python and TypeScript generated targets or record why one family is not applicable."
+            ),
+        },
+        "rule": (
+            "Generated CLI freshness is relevant only for generated command package surfaces. "
+            "Run the check path before trusting generated CLI output; refresh only when the check reports stale output."
+        ),
+    }
+
+
+def _tiny_surface_compatibility_review(changed_paths: list[str]) -> dict[str, Any]:
+    risky_paths = [
+        path
+        for path in changed_paths
+        if path
+        in {
+            "src/agentic_workspace/workspace_runtime_primitives.py",
+            "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+            "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+        }
+        or path.startswith("tests/test_workspace_start_preflight_cli.py")
+        or path.startswith("tests/test_workspace_implement_cli.py")
+        or path.startswith("tests/test_workspace_summary_cli.py")
+    ]
+    if not risky_paths:
+        return {"status": "not-applicable"}
+    return {
+        "kind": "agentic-workspace/tiny-surface-compatibility-review/v1",
+        "status": "required",
+        "changed_paths": risky_paths,
+        "rule": "New facts usually belong behind selector, verbose, or nested context unless they are essential to the tiny next action.",
+        "risk": "Tiny/default start, implement, preflight, and summary payloads are weak-agent startup contracts with size and shape budgets.",
+        "expected_proof": [
+            "focused tiny/default payload shape tests",
+            "size-budget assertions when existing tests define one",
+            "selector/full-surface assertion for any new diagnostic field",
+        ],
+    }

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -139,6 +139,12 @@ from agentic_workspace.workspace_output import (
     _emit_report_text,
     _emit_setup_text,
 )
+from agentic_workspace.workspace_runtime_generated_surface import (
+    _generated_cli_freshness_payload,  # noqa: F401 - compatibility re-export for runtime inventory
+    _generated_surface_trust_payload,  # noqa: F401 - compatibility re-export for runtime inventory
+    _selector_requests_generated_surface_trust,
+    _tiny_surface_compatibility_review,  # noqa: F401 - compatibility re-export for runtime inventory
+)
 from agentic_workspace.workspace_runtime_implement import (
     _change_impact_payload,  # noqa: F401 - compatibility re-export for runtime inventory
     _implement_payload,
@@ -25105,49 +25111,6 @@ def _generated_surface_trust_path_payload(*, target_root: Path, path: str, proof
     }
 
 
-def _generated_surface_trust_payload(
-    *, target_root: Path, changed_paths: list[str], proof: dict[str, Any], cli_invoke: str
-) -> dict[str, Any]:
-    items = [
-        item
-        for path in changed_paths
-        for item in [_generated_surface_trust_path_payload(target_root=target_root, path=path, proof=proof, cli_invoke=cli_invoke)]
-        if item is not None
-    ]
-    blocked_paths = [item["path"] for item in items if not item["direct_edit_allowed"]]
-    resolution_commands = list(
-        dict.fromkeys(
-            command
-            for item in items
-            for command in _list_payload(_as_dict(item.get("action_effect")).get("resolution_commands"))
-            if str(command).strip()
-        )
-    )
-    action_effect = {
-        "force": "required_before_claim" if items else "advisory",
-        "allowed_now": "continue-implementation-but-refresh-generated-surfaces-before-claim" if items else "continue-implementation",
-        "blocked_until_reconciled": ["claim-generated-surfaces-fresh", "claim-task-complete"] if items else [],
-        "claim_boundary": (
-            "generated-surface-freshness-must-be-reconciled-before-completion-claim" if items else "no-generated-surface-freshness-warning"
-        ),
-        "resolution_selector": "generated_surface_trust",
-        "resolution_commands": resolution_commands,
-    }
-    return {
-        "kind": "agentic-workspace/generated-surface-trust/v1",
-        "status": "present" if items else "not-applicable",
-        "changed_path_count": len(items),
-        "items": items,
-        "direct_edit_blocked_paths": blocked_paths,
-        "action_effect": action_effect,
-        "rule": (
-            "Generated surfaces are derived artifacts. Edit the canonical source first, refresh the generated output, "
-            "and run the validation command before trusting freshness."
-        ),
-        "detail_selector": "generated_surface_trust",
-    }
-
-
 def _task_contract_payload(
     *,
     changed_paths: list[str],
@@ -32875,10 +32838,6 @@ def _selector_requests_change_impact(select: str | None) -> bool:
     return any(token == "change_impact" or token.startswith("change_impact.") for token in _selector_tokens(select))
 
 
-def _selector_requests_generated_surface_trust(select: str | None) -> bool:
-    return any(token == "generated_surface_trust" or token.startswith("generated_surface_trust.") for token in _selector_tokens(select))
-
-
 def _selector_requests_task_contract(select: str | None) -> bool:
     return any(token == "task_contract" or token.startswith("task_contract.") for token in _selector_tokens(select))
 
@@ -36111,96 +36070,6 @@ def _transient_validation_retry_guidance(*, required_commands: list[str]) -> dic
         ],
         "rule": "Retry at most once for runtime/toolchain-looking failures; deterministic test assertions remain hard failures.",
         "closeout_note": "If the retry passes, report the first failure and successful bounded retry instead of pretending the first run passed.",
-    }
-
-
-def _generated_cli_freshness_payload(
-    *,
-    changed_paths: list[str],
-    selected_lanes: list[dict[str, Any]],
-    required_commands: list[str],
-) -> dict[str, Any] | None:
-    lane_ids = [str(lane.get("id", "")) for lane in selected_lanes if isinstance(lane, dict)]
-    relevant_lane_ids = [
-        lane_id
-        for lane_id in lane_ids
-        if lane_id in {"generated_command_packages", "cli_authority", "verification:generated_adapter_conformance"}
-    ]
-    related_commands = [
-        command
-        for command in required_commands
-        if "check_generated_command_packages.py" in command or "generate_command_packages.py" in command
-    ]
-    if not relevant_lane_ids and not related_commands:
-        return None
-    freshness_check = "uv run python scripts/generate/generate_command_packages.py --check"
-    refresh_command = "uv run python scripts/generate/generate_command_packages.py"
-    validation_command = next(
-        (command for command in related_commands if "check_generated_command_packages.py" in command),
-        "uv run python scripts/check/check_generated_command_packages.py",
-    )
-    obligation = "required" if related_commands else "advisory"
-    return {
-        "kind": "agentic-workspace/generated-cli-freshness/v1",
-        "status": obligation,
-        "triggered_by": changed_paths,
-        "selected_lanes": relevant_lane_ids,
-        "freshness_check_command": freshness_check,
-        "refresh_command": refresh_command,
-        "validation_command": validation_command,
-        "required_commands": related_commands,
-        "obligation": obligation,
-        "generated_target_parity": {
-            "kind": "agentic-workspace/generated-target-parity/v1",
-            "status": "required" if obligation == "required" else "advisory",
-            "target_families": ["python", "typescript"],
-            "freshness_evidence": [
-                "scripts/generate/generate_command_packages.py --check compares rendered outputs for all generated Python and TypeScript package targets without writing files",
-                "scripts/check/check_generated_command_packages.py performs static generated-package proof across Python and TypeScript surfaces",
-            ],
-            "stale_detection": {
-                "python": "generated/*/python/** outputs must match command-generation render output",
-                "typescript": "generated/*/typescript/** outputs must match command-generation render output",
-            },
-            "claim_rule": (
-                "Do not claim generated CLI freshness from Python-only proof; relevant generated CLI proof must name "
-                "both Python and TypeScript generated targets or record why one family is not applicable."
-            ),
-        },
-        "rule": (
-            "Generated CLI freshness is relevant only for generated command package surfaces. "
-            "Run the check path before trusting generated CLI output; refresh only when the check reports stale output."
-        ),
-    }
-
-
-def _tiny_surface_compatibility_review(changed_paths: list[str]) -> dict[str, Any]:
-    risky_paths = [
-        path
-        for path in changed_paths
-        if path
-        in {
-            "src/agentic_workspace/workspace_runtime_primitives.py",
-            "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
-            "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
-        }
-        or path.startswith("tests/test_workspace_start_preflight_cli.py")
-        or path.startswith("tests/test_workspace_implement_cli.py")
-        or path.startswith("tests/test_workspace_summary_cli.py")
-    ]
-    if not risky_paths:
-        return {"status": "not-applicable"}
-    return {
-        "kind": "agentic-workspace/tiny-surface-compatibility-review/v1",
-        "status": "required",
-        "changed_paths": risky_paths,
-        "rule": "New facts usually belong behind selector, verbose, or nested context unless they are essential to the tiny next action.",
-        "risk": "Tiny/default start, implement, preflight, and summary payloads are weak-agent startup contracts with size and shape budgets.",
-        "expected_proof": [
-            "focused tiny/default payload shape tests",
-            "size-budget assertions when existing tests define one",
-            "selector/full-surface assertion for any new diagnostic field",
-        ],
     }
 
 


### PR DESCRIPTION
## Summary
- Move generated-surface trust, generated CLI freshness, selector request, and tiny compatibility review helpers into `workspace_runtime_generated_surface.py`.
- Keep compatibility re-exports from `workspace_runtime_primitives.py` for existing private callers and inventory checks.
- Update the runtime primitive family inventory to mark generated-surface trust packets as owned by the new module.
- Fix the generated Python conformance Docker context so in-container generated-package proof sees release ownership and allowlisted compatibility files.

Stacked on #1778.
Closes #1774.

## Proof
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py src/agentic_workspace/workspace_runtime_generated_surface.py`
- `uv run pytest tests/test_workspace_implement_cli.py tests/test_workspace_proof_cli.py tests/test_workspace_summary_cli.py -q`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_generated_command_packages.py --require-node`
- `uv run python scripts/check/run_operation_conformance_tests.py --target python`
- `uv run python scripts/check/check_generated_command_packages.py --python-conformance`
- `uv run python scripts/check/check_generated_command_packages.py --python-docker-conformance --require-docker`
- `uv run python scripts/run_agentic_workspace.py implement --changed src/agentic_workspace/workspace_runtime_generated_surface.py --format json --select generated_surface_trust`