### PR TITLE
Surface pre-test evidence guardrail

### DIFF
--- a/.agentic-workspace/verification/test-strategy-dispositions.json
+++ b/.agentic-workspace/verification/test-strategy-dispositions.json
@@ -1,0 +1,17 @@
+{
+  "kind": "agentic-workspace/test-strategy-dispositions/v1",
+  "items": [
+    {
+      "id": "issue-1786-pre-test-evidence-guardrail-cli-surfaces",
+      "disposition": "standalone-durable-contract-proof",
+      "changed_test_paths": [
+        "tests/test_workspace_cli.py",
+        "tests/test_workspace_implement_cli.py"
+      ],
+      "reason": "The change adds focused CLI contract coverage for the startup guardrail and implement tiny-output routing; the evidence belongs with package-local runtime behavior rather than a broad regression matrix.",
+      "proof_owner": "package-local-behavior",
+      "replacement_or_follow_up_evidence": [],
+      "reviewer_requested_coverage": true
+    }
+  ]
+}

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -181,6 +181,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `next_safe_action.source_fields` | array of enum `"immediate_next_allowed_action"`, `"workflow_sufficiency"`, `"skill_routing"`, `"memory_consult"`, `"planning_safety_gate"`, `"proof"`, `"closeout_trust_inspection"`, `"continuation_state"` | yes |  | Startup fields used to derive the packet. |  |  |
 | `skills` | object | no |  | Compact startup projection over skill routing, required skill, recommendations, and catalog drill-down. |  |  |
 | `context` | object | no |  | Supporting startup context for the primary next-safe-action decision, including compatibility projections for detail fields. |  |  |
+| `context.pre_test_evidence_guardrail` | object | no |  | Selector-first location for the optional non-blocking pre-test evidence-owner advisory; mirrors the root field when startup exposes the guardrail in context detail. |  |  |
 | `parent_intent_status` | object | no |  | Parent/original-intent status preserving larger intent across bounded startup and implementation slices. |  |  |
 | `applicable_intent_status` | object | no |  | Applicable-intent evidence, conflicts, missing authority, and manual-verification obligations for startup closeout safety. |  |  |
 | `planning_safety_gate` | object | no |  | Planning ownership guard for broad, high-assurance, decomposed, or scope-widened work. |  |  |

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -14,6 +14,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `kind` | const `"startup-context/v1"` | yes |  | Discriminator for the startup context payload shape. |  |  |
 | `target` | string | yes |  | Resolved target repository for the startup decision. |  |  |
 | `action_signals` | object | no |  | Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment. |  |  |
+| `pre_test_evidence_guardrail` | object | no |  | Optional non-blocking pre-test evidence-owner advisory surfaced when configured assurance signals or changed test paths indicate test-shape decisions. |  |  |
 | `task_posture_packet` | ref `#/$defs/task_posture_packet` | no |  | Optional dynamic instruction packet emitted when task facts, config posture, workflow obligations, or module contributions change startup routing. |  |  |
 | `task_posture_packet.kind` | const `"agentic-workspace/task-posture-packet/v1"` | yes |  | Discriminator for dynamic task posture. |  |  |
 | `task_posture_packet.operating_posture` | object | yes |  | Resolved optimization, artifact, initiative, assurance, and delegation posture for this task. |  |  |

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -22,6 +22,11 @@
       "description": "Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment.",
       "additionalProperties": true
     },
+    "pre_test_evidence_guardrail": {
+      "type": "object",
+      "description": "Optional non-blocking pre-test evidence-owner advisory surfaced when configured assurance signals or changed test paths indicate test-shape decisions.",
+      "additionalProperties": true
+    },
     "task_posture_packet": {
       "$ref": "#/$defs/task_posture_packet",
       "description": "Optional dynamic instruction packet emitted when task facts, config posture, workflow obligations, or module contributions change startup routing."

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -309,6 +309,13 @@
     "context": {
       "type": "object",
       "description": "Supporting startup context for the primary next-safe-action decision, including compatibility projections for detail fields.",
+      "properties": {
+        "pre_test_evidence_guardrail": {
+          "type": "object",
+          "description": "Selector-first location for the optional non-blocking pre-test evidence-owner advisory; mirrors the root field when startup exposes the guardrail in context detail.",
+          "additionalProperties": true
+        }
+      },
       "additionalProperties": true
     },
     "parent_intent_status": {

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -337,6 +337,18 @@
       "checked_in_justification": "Compact agent-recorded evidence labels preserve proof/review handoff decisions that would otherwise be lossy in chat or PR prose."
     },
     {
+      "pattern": ".agentic-workspace/verification/test-strategy-dispositions.json",
+      "format": "json",
+      "owner": "verification",
+      "status": "typed-validator-backed",
+      "schema_or_validator": "agentic_workspace.workspace_runtime_primitives._load_test_strategy_dispositions",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Optional compact disposition records explain ordinary test evidence ownership, durability, and follow-up proof decisions without storing raw review transcripts.",
+      "storage_class": "non-reconstructable-decision",
+      "checked_in_justification": "Compact agent-recorded test strategy dispositions preserve evidence-owner decisions that would otherwise be lossy in chat or PR prose."
+    },
+    {
       "pattern": ".agentic-workspace/memory/UPGRADE-SOURCE.toml",
       "format": "toml",
       "owner": "memory-payload",

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -576,6 +576,7 @@
           "_load_proof_route_hints",
           "_make_targets_without_negative_routes",
           "_missing_repo_path_references_in_command",
+          "_pre_test_evidence_guardrail_payload",
           "_proof_adequacy_payload",
           "_proof_command_for_target",
           "_proof_command_is_search_sweep",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -21045,6 +21045,7 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "intent_satisfaction_matrix",
         "issue_reference_intent",
         "workflow_sufficiency",
+        "pre_test_evidence_guardrail",
         "task_posture_packet",
         "next_safe_action",
         "health",
@@ -21475,6 +21476,15 @@ def _start_tiny_payload_fast(
             cli_invoke=config.cli_invoke,
         ),
     }
+    pre_test_guardrail = _pre_test_evidence_guardrail_payload(
+        target_root=target_root,
+        changed_paths=changed_paths,
+        task_text=task_text,
+        config=config,
+        compact=True,
+    )
+    if pre_test_guardrail.get("status") == "advisory":
+        payload["pre_test_evidence_guardrail"] = pre_test_guardrail
     payload["memory_decision_packet"] = _memory_decision_packet_payload(
         stage="startup",
         cli_invoke=config.cli_invoke,
@@ -26080,6 +26090,178 @@ _TEST_STRATEGY_DISPOSITION_VALUES = {
     "temporary-with-follow-up-consolidation",
 }
 
+_PRE_TEST_EVIDENCE_REQUIREMENT_IDS = {"test_evidence_change_decision"}
+_PRE_TEST_EVIDENCE_PROOF_PROFILES = {"test_evidence_change"}
+_PRE_TEST_EVIDENCE_REQUIRED_LABELS = {"verification_proof_decision_review"}
+
+
+def _is_python_test_path_for_guardrail(path: str) -> bool:
+    candidate = Path(path)
+    normalized = candidate.as_posix()
+    return candidate.suffix == ".py" and candidate.name.startswith("test_") and (normalized.startswith("tests/") or "/tests/" in normalized)
+
+
+def _pre_test_evidence_requirement(requirement: dict[str, Any]) -> bool:
+    requirement_id = str(requirement.get("id", "")).strip()
+    proof_profile = str(requirement.get("proof_profile") or "").strip()
+    required_evidence = {str(item).strip() for item in _list_payload(requirement.get("required_evidence")) if str(item).strip()}
+    if requirement_id in _PRE_TEST_EVIDENCE_REQUIREMENT_IDS:
+        return True
+    if proof_profile in _PRE_TEST_EVIDENCE_PROOF_PROFILES:
+        return True
+    return bool(required_evidence & _PRE_TEST_EVIDENCE_REQUIRED_LABELS)
+
+
+def _pre_test_evidence_requirement_matches(
+    *, config: WorkspaceConfig | None, changed_paths: list[str] | None, task_text: str | None
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    relevant = [item for item in _assurance_requirement_payloads(config) if _pre_test_evidence_requirement(item)]
+    matched: list[dict[str, Any]] = []
+    for requirement in relevant:
+        applies, applies_because, _activation_facts = _assurance_requirement_match(
+            requirement=requirement,
+            changed_paths=changed_paths,
+            task_text=task_text,
+            planning_facts={},
+        )
+        if not applies:
+            continue
+        requirement_id = str(requirement.get("id", "")).strip()
+        matched.append(
+            {
+                "requirement_id": requirement_id,
+                "source": f"assurance.requirements.{requirement_id}",
+                "matches": applies_because,
+                "authority_refs": _list_payload(requirement.get("authority_refs")),
+                "required_evidence": _list_payload(requirement.get("required_evidence")),
+                "proof_profile": requirement.get("proof_profile"),
+            }
+        )
+    return relevant, matched
+
+
+def _verification_evidence_strategy_payload(verification: dict[str, Any] | None) -> dict[str, Any]:
+    verification_payload = _as_dict(verification)
+    return _as_dict(verification_payload.get("evidence_strategy"))
+
+
+def _pre_test_evidence_guardrail_payload(
+    *,
+    target_root: Path | None = None,
+    changed_paths: list[str] | None = None,
+    task_text: str | None,
+    config: WorkspaceConfig | None = None,
+    verification: dict[str, Any] | None = None,
+    compact: bool = False,
+) -> dict[str, Any]:
+    normalized_paths = _normalize_changed_paths(changed_paths or [])
+    changed_test_paths = [path for path in normalized_paths if _is_python_test_path_for_guardrail(path)]
+    if config is None and target_root is not None:
+        try:
+            config = _load_workspace_config(target_root=target_root)
+        except WorkspaceUsageError:
+            config = None
+    configured_requirements, matched_requirements = _pre_test_evidence_requirement_matches(
+        config=config,
+        changed_paths=normalized_paths,
+        task_text=task_text,
+    )
+    trigger_sources = [f"changed test path {path}" for path in changed_test_paths]
+    for matched in matched_requirements:
+        for reason in _list_payload(matched.get("matches")):
+            trigger_sources.append(f"{matched.get('source')}: {reason}")
+    trigger_sources = _dedupe([str(item) for item in trigger_sources if str(item).strip()])
+    if not trigger_sources:
+        return {
+            "kind": "agentic-workspace/pre-test-evidence-guardrail/v1",
+            "status": "not-applicable",
+            "changed_test_paths": changed_test_paths,
+            "configured_requirement_count": len(configured_requirements),
+            "blocking": False,
+        }
+
+    verification_payload = _as_dict(verification)
+    if not verification_payload and target_root is not None:
+        try:
+            assurance_requirements = _assurance_requirements_report_payload(
+                config=config,
+                target_root=target_root,
+                active_planning_record=None,
+                task_text=task_text,
+                changed_paths=normalized_paths,
+            )
+            verification_payload = _verification_report_payload(
+                target_root=target_root,
+                changed_paths=normalized_paths,
+                task_text=task_text,
+                assurance_requirements=assurance_requirements,
+            )
+        except WorkspaceUsageError:
+            verification_payload = {}
+    evidence_strategy = _verification_evidence_strategy_payload(verification_payload)
+    proof_governance = _as_dict(evidence_strategy.get("proof_governance"))
+    regression_sprawl = _as_dict(evidence_strategy.get("regression_sprawl"))
+    evidence_owner_options = [str(item) for item in _list_payload(proof_governance.get("proof_owner_options")) if str(item).strip()]
+    proof_decision_options = [str(item) for item in _list_payload(proof_governance.get("available_decisions")) if str(item).strip()]
+    decision_questions = [str(item) for item in _list_payload(proof_governance.get("pre_test_decision_questions")) if str(item).strip()]
+    sprawl_questions = [str(item) for item in _list_payload(regression_sprawl.get("review_questions")) if str(item).strip()]
+    payload = {
+        "kind": "agentic-workspace/pre-test-evidence-guardrail/v1",
+        "status": "advisory",
+        "blocking": False,
+        "trigger_sources": trigger_sources,
+        "activation_sources": matched_requirements,
+        "changed_test_paths": changed_test_paths,
+        "decision_prompt": (
+            "Before adding or expanding ordinary regression tests, choose the evidence owner and the narrowest proof surface."
+        ),
+        "evidence_owner_options": evidence_owner_options,
+        "proof_decision_options": proof_decision_options,
+        "pre_test_decision_questions": decision_questions,
+        "regression_sprawl_review_questions": sprawl_questions,
+        "detail_selectors": ["test_strategy_check", "verification"],
+        "source_boundary": {
+            "activation": "configured assurance requirement markers/paths or explicit changed test paths",
+            "options": "verification.evidence_strategy.proof_governance",
+            "review_questions": "verification.evidence_strategy.regression_sprawl",
+            "no_universal_task_keyword_policy": True,
+        },
+        "authority_boundary": _authority_boundary_payload(
+            surface="pre_test_evidence_guardrail",
+            observed_by_aw=trigger_sources[:5],
+            recommended_by_aw=["choose the proof owner before adding ordinary regression-test evidence"],
+            proof_hints=[
+                "verification.evidence_strategy.proof_governance",
+                "verification.evidence_strategy.regression_sprawl",
+                "assurance.requirements.*.applies_to_task_markers",
+            ],
+            agent_owned_decisions=[
+                "whether new executable proof is needed",
+                "which owner should hold the evidence",
+                "what narrow proof surface answers the trust question",
+            ],
+            rule="AW surfaces configured evidence-owner choices early; it does not decide the host repo's testing strategy.",
+        ),
+    }
+    if not compact:
+        return payload
+    return {
+        key: payload[key]
+        for key in (
+            "kind",
+            "status",
+            "blocking",
+            "trigger_sources",
+            "changed_test_paths",
+            "decision_prompt",
+            "evidence_owner_options",
+            "proof_decision_options",
+            "pre_test_decision_questions",
+            "detail_selectors",
+            "source_boundary",
+        )
+    }
+
 
 def _load_test_strategy_dispositions(target_root: Path) -> dict[str, Any]:
     path = target_root / TEST_STRATEGY_DISPOSITIONS_RELATIVE_PATH
@@ -26152,12 +26334,25 @@ def _load_test_strategy_dispositions(target_root: Path) -> dict[str, Any]:
 def _test_strategy_check_payload(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, verification: dict[str, Any]
 ) -> dict[str, Any]:
-    test_paths = [
-        path
-        for path in changed_paths
-        if Path(path).name.startswith("test_") and Path(path).suffix == ".py" and ("tests/" in path or path.startswith("tests/"))
-    ]
+    test_paths = [path for path in changed_paths if _is_python_test_path_for_guardrail(path)]
+    pre_test_guardrail = _pre_test_evidence_guardrail_payload(
+        target_root=target_root,
+        changed_paths=changed_paths,
+        task_text=task_text,
+        verification=verification,
+    )
     if not test_paths:
+        if pre_test_guardrail.get("status") == "advisory":
+            return {
+                "kind": "agentic-workspace/test-strategy-check/v1",
+                "status": "advisory",
+                "changed_test_paths": [],
+                "pre_test_evidence_guardrail": pre_test_guardrail,
+                "evidence_owner_options": pre_test_guardrail.get("evidence_owner_options", []),
+                "proof_decision_options": pre_test_guardrail.get("proof_decision_options", []),
+                "pre_test_decision_questions": pre_test_guardrail.get("pre_test_decision_questions", []),
+                "blocking": False,
+            }
         return {"kind": "agentic-workspace/test-strategy-check/v1", "status": "not-applicable", "changed_test_paths": []}
     disposition_record = _load_test_strategy_dispositions(target_root)
     disposition_items = [item for item in _list_payload(disposition_record.get("items")) if isinstance(item, dict)]
@@ -26234,6 +26429,11 @@ def _test_strategy_check_payload(
         "unknown_materiality_count": unknown_materiality_count,
         "files": files,
         "reviewer_requested_coverage": reviewer_requested,
+        "pre_test_evidence_guardrail": pre_test_guardrail,
+        "evidence_owner_options": pre_test_guardrail.get("evidence_owner_options", []),
+        "proof_decision_options": pre_test_guardrail.get("proof_decision_options", []),
+        "pre_test_decision_questions": pre_test_guardrail.get("pre_test_decision_questions", []),
+        "regression_sprawl_review_questions": pre_test_guardrail.get("regression_sprawl_review_questions", []),
         "verification_evidence_surfaces": {
             "evidence_strategy_status": evidence_strategy.get("status", "unavailable"),
             "proof_governance_status": proof_governance.get("status", "unavailable"),

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -671,6 +671,9 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     reuse_pressure = payload.get("reuse_pressure", {})
     if isinstance(reuse_pressure, dict):
         reuse_pressure = dict(reuse_pressure)
+    test_strategy_check = payload.get("test_strategy_check", {})
+    test_strategy_check = test_strategy_check if isinstance(test_strategy_check, dict) else {}
+    test_strategy_applicable = str(test_strategy_check.get("status") or "").strip() not in {"", "not-applicable"}
     workflow_sufficiency = _tiny_workflow_sufficiency(payload.get("workflow_sufficiency"))
     context_reuse_pressure = {
         "status": reuse_pressure.get("status") if isinstance(reuse_pressure, dict) else None,
@@ -687,9 +690,10 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "architecture_principles",
         "requirement_grounding",
         "plan_delegation_packet",
-        "test_strategy_check",
         "routine_work_context",
     ]
+    if test_strategy_applicable:
+        advisory_selectors.insert(-1, "test_strategy_check")
     if delegation_attention:
         advisory_selectors.insert(2, "context.delegation_decision")
     detail_commands = {
@@ -943,18 +947,15 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "detail_selector": "plan_delegation_packet",
             },
             "test_strategy_check": {
-                "status": payload.get("test_strategy_check", {}).get("status", "not-applicable")
-                if isinstance(payload.get("test_strategy_check"), dict)
-                else "not-applicable",
-                "changed_test_paths": payload.get("test_strategy_check", {}).get("changed_test_paths", [])
-                if isinstance(payload.get("test_strategy_check"), dict)
-                else [],
-                "hotspot_file_count": payload.get("test_strategy_check", {}).get("hotspot_file_count", 0)
-                if isinstance(payload.get("test_strategy_check"), dict)
-                else 0,
-                "scenario_matrix_candidate_count": payload.get("test_strategy_check", {}).get("scenario_matrix_candidate_count", 0)
-                if isinstance(payload.get("test_strategy_check"), dict)
-                else 0,
+                "status": test_strategy_check.get("status", "not-applicable"),
+                "changed_test_paths": test_strategy_check.get("changed_test_paths", []),
+                "hotspot_file_count": test_strategy_check.get("hotspot_file_count", 0),
+                "scenario_matrix_candidate_count": test_strategy_check.get("scenario_matrix_candidate_count", 0),
+                "pre_test_guardrail_status": _as_dict(test_strategy_check.get("pre_test_evidence_guardrail")).get(
+                    "status", "not-applicable"
+                ),
+                "evidence_owner_options": test_strategy_check.get("evidence_owner_options", [])[:8],
+                "pre_test_decision_questions": test_strategy_check.get("pre_test_decision_questions", [])[:3],
                 "detail_selector": "test_strategy_check",
             },
         },
@@ -1009,6 +1010,12 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
     if not delegation_attention:
         remove_available_selector("context.delegation_decision")
+    if not test_strategy_applicable:
+        tiny_context_for_test_strategy = projected.get("context", {})
+        if isinstance(tiny_context_for_test_strategy, dict):
+            tiny_context_for_test_strategy.pop("test_strategy_check", None)
+        remove_available_selector("context.test_strategy_check")
+        remove_available_selector("test_strategy_check")
     if isinstance(payload.get("generated_surface_trust"), dict) and payload["generated_surface_trust"].get("status") == "present":
         tiny_context = projected.get("context", {})
         if isinstance(tiny_context, dict):

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -69,6 +69,7 @@ from agentic_workspace.workspace_runtime_core import (
     _operating_posture_payload,
     _package_boundary_payload,
     _parent_intent_status_payload,
+    _pre_test_evidence_guardrail_payload,
     _prep_only_handoff_payload,
     _raw_active_planning_record_for_closeout,
     _read_only_response_posture_payload,
@@ -235,6 +236,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         },
         "repo_posture": _compact_repo_posture_projection(payload.get("repo_posture", {})),
         "delegation_decision": _compact_start_delegation_decision(payload.get("delegation_decision", {})),
+        **({"pre_test_evidence_guardrail": payload["pre_test_evidence_guardrail"]} if "pre_test_evidence_guardrail" in payload else {}),
         "skill_routing": {
             "status": skill_routing.get("status", "unknown") if isinstance(skill_routing, dict) else "unknown",
             "rule": "Use listed skills only when directly relevant; otherwise proceed from the next action.",
@@ -409,7 +411,11 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         read_only_allowed=bool(projected["next_safe_action"].get("read_only_allowed")),
         proof_required=bool(projected["next_safe_action"].get("proof_required")),
         proof_commands=_tiny_required_proof_commands(payload.get("proof", {})) if isinstance(payload.get("proof"), dict) else [],
-        advisory_selectors=["skill_routing", "workflow_sufficiency"],
+        advisory_selectors=[
+            "skill_routing",
+            "workflow_sufficiency",
+            *(["pre_test_evidence_guardrail"] if "pre_test_evidence_guardrail" in payload else []),
+        ],
         agent_judgment="Agent owns work-shape choice unless hard_blockers names a gate.",
     )
     return projected
@@ -609,6 +615,15 @@ def _start_payload(
             cli_invoke=config.cli_invoke,
         ),
     }
+    pre_test_guardrail = _pre_test_evidence_guardrail_payload(
+        target_root=target_root,
+        changed_paths=changed_paths,
+        task_text=task_text,
+        config=config,
+        compact=True,
+    )
+    if pre_test_guardrail.get("status") == "advisory":
+        payload["pre_test_evidence_guardrail"] = pre_test_guardrail
     payload["memory_decision_packet"] = _memory_decision_packet_payload(
         stage="startup",
         cli_invoke=config.cli_invoke,
@@ -1176,6 +1191,9 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             )
             if key in payload["applicable_intent_status"]
         }
+    pre_test_guardrail = payload.get("pre_test_evidence_guardrail", {})
+    if isinstance(pre_test_guardrail, dict) and pre_test_guardrail.get("status") == "advisory":
+        context["pre_test_evidence_guardrail"] = pre_test_guardrail
     uv_guidance = payload.get("uv_cache_guidance", {})
     if not (isinstance(uv_guidance, dict) and uv_guidance.get("status") == "available"):
         cli_invocation = payload.get("cli_invocation", {})
@@ -1243,6 +1261,8 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     sibling_freshness = payload.get("sibling_repo_aw_freshness", {})
     if isinstance(sibling_freshness, dict) and sibling_freshness.get("status") == "attention":
         startup_changed_signals.append("sibling_repo_aw_freshness=attention")
+    if isinstance(pre_test_guardrail, dict) and pre_test_guardrail.get("status") == "advisory":
+        startup_changed_signals.append("pre_test_evidence=advisory")
     startup_proof = payload.get("proof", {})
     startup_proof_commands = _tiny_required_proof_commands(startup_proof) if isinstance(startup_proof, dict) else []
     available_selectors = _available_selectors_for_payload(payload)
@@ -1262,6 +1282,8 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         advisory_selectors.append("installed_state_compatibility")
     if isinstance(local_checkpoint, dict) and local_checkpoint.get("status") in {"present", "stale", "unreadable"}:
         advisory_selectors.append("local_chat_checkpoint")
+    if isinstance(pre_test_guardrail, dict) and pre_test_guardrail.get("status") == "advisory":
+        advisory_selectors.append("pre_test_evidence_guardrail")
     selected: dict[str, Any] = {
         "kind": payload["kind"],
         "target": ".",
@@ -1354,6 +1376,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         "vague_outcome_orientation",
         "intent_acknowledgement",
         "lane_shaping_gate",
+        "pre_test_evidence_guardrail",
     ):
         if optional_key in payload:
             context[optional_key] = payload[optional_key]

--- a/tests/test_schema_reference_docs.py
+++ b/tests/test_schema_reference_docs.py
@@ -152,6 +152,8 @@ def test_schema_reference_curated_descriptions_cover_high_value_schemas() -> Non
 
     assert "minimum safe context for entering or resuming work" in startup
     assert "Ordered surfaces and commands an agent should use" in startup
+    assert "`context.pre_test_evidence_guardrail`" in startup
+    assert "Selector-first location for the optional non-blocking pre-test evidence-owner advisory" in startup
     assert "Combined workspace report payload for installed modules" in report
     assert "Recommended next action derived from report health" in report
     assert "Manifest for a checked-in agent aid" in aid

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -416,6 +416,70 @@ def test_start_default_routes_memory_and_installed_state_detail_behind_selectors
     assert payload["context"]["memory"]["status"] in {"recommended", "not_checked"}
 
 
+def test_start_surfaces_configured_pre_test_guardrail_without_universal_bug_keyword(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance.requirements.test_evidence_change_decision]
+level = "high"
+applies_to_paths = ["tests/**"]
+applies_to_task_markers = ["regression test"]
+required_evidence = ["verification_proof_decision_review"]
+proof_profile = "test_evidence_change"
+force = "required-before-closeout"
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Fix the runtime issue by adding a regression test",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    guardrail = payload["context"]["pre_test_evidence_guardrail"]
+    assert guardrail["status"] == "advisory"
+    assert guardrail["blocking"] is False
+    assert guardrail["source_boundary"]["no_universal_task_keyword_policy"] is True
+    assert any("task marker matched regression test" in source for source in guardrail["trigger_sources"])
+    assert "package-local-behavior" in guardrail["evidence_owner_options"]
+    assert "convert-to-conformance" in guardrail["proof_decision_options"]
+    assert any("trust question" in question for question in guardrail["pre_test_decision_questions"])
+    assert "pre_test_evidence_guardrail" in payload["action_signals"]["advisory_detail"]["selectors"]
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Fix a bug in the README",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    quiet_payload = json.loads(capsys.readouterr().out)
+    assert "pre_test_evidence_guardrail" not in quiet_payload["context"]
+    assert "pre_test_evidence_guardrail" not in quiet_payload["action_signals"]["advisory_detail"]["selectors"]
+
+
 def test_start_default_compacts_noncompatible_installed_state_signal(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -4426,8 +4426,44 @@ def test_runtime_warning_eta(): assert True
     assert check["reviewer_requested_coverage"] is True
     assert check["disposition_required_before_closeout"] is True
     assert check["verification_evidence_surfaces"]["proof_decision_status"]
+    assert check["pre_test_evidence_guardrail"]["status"] == "advisory"
+    assert check["pre_test_evidence_guardrail"]["blocking"] is False
+    assert check["pre_test_evidence_guardrail"]["source_boundary"]["no_universal_task_keyword_policy"] is True
+    assert "package-local-behavior" in check["evidence_owner_options"]
+    assert "convert-to-conformance" in check["proof_decision_options"]
+    assert any("trust question" in question for question in check["pre_test_decision_questions"])
+    assert any("scenario matrix" in question for question in check["regression_sprawl_review_questions"])
     assert "standalone-durable-contract-proof" in check["record_disposition_options"]
     assert check["files"][0]["parametrized_test_count"] == 1
+
+
+def test_implement_tiny_omits_not_applicable_test_strategy_advisory(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "runtime.py", "def runtime_value():\n    return 1\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/runtime.py",
+                "--task",
+                "Adjust runtime behavior",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert "test_strategy_check" not in payload["action_signals"]["advisory_detail"]["selectors"]
+    assert "test_strategy_check" not in payload["drill_down"]["available_selectors"]
+    assert "context.test_strategy_check" not in payload["drill_down"]["available_selectors"]
+    assert "test_strategy_check" not in payload["context"]
 
 
 def test_test_strategy_check_reads_recorded_disposition(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Surface a compact, non-blocking pre-test evidence guardrail from configured test-evidence assurance markers or changed test paths, without adding a universal bug/regression keyword policy.
- Promote Verification proof-owner choices and pre-test questions into `test_strategy_check`, and stop advertising that selector in tiny implement output when it is not applicable.
- Update the startup schema/reference docs, shared-core boundary inventory, and record the focused test-evidence disposition for this PR.

Fixes #1786

## Validation
- `uv run pytest tests/test_workspace_cli.py::test_start_surfaces_configured_pre_test_guardrail_without_universal_bug_keyword tests/test_workspace_implement_cli.py::test_implement_surfaces_test_strategy_check_for_hotspot_tests tests/test_workspace_implement_cli.py::test_implement_tiny_omits_not_applicable_test_strategy_advisory -q`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make schema-reference-docs`
- `make maintainer-surfaces`
- `make test-workspace`
- `make lint-workspace`