### PR TITLE
Generalize evidence path classification

### DIFF
--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -149,11 +149,12 @@ Cheap implementer context for a bounded changed-path scope.
 | `applicable_intent_status.kind` | const `"agentic-workspace/applicable-intent-status/v1"` | yes |  | Discriminator for the applicable-intent status packet. |  |  |
 | `applicable_intent_status.status` | string | yes |  | Whether applicable-intent evidence is present, guidance-only, or requires attention. |  |  |
 | `reuse_pressure` | object | yes |  | Changed-path reuse and abstraction-pressure facts that help the agent decide whether to reuse, accept duplication, or route extraction follow-up. |  |  |
+| `optimization_posture` | object | no |  | Compact configured optimisation posture summary for changed implementation paths, with detailed per-path reasoning kept behind change_impact. |  |  |
 | `assurance_requirements` | object | yes |  | Repo-declared assurance requirements matched to the task or changed paths, with evidence status and claim-boundary facts; task-marker matches cite explicit config while semantic acceptance remains agent/human owned. |  |  |
 | `verification` | object | yes |  | Matched repo-native verification protocols and bounded evidence status for the task or changed paths; task-marker matches are configured protocol evidence, not AW-owned intent classification. |  |  |
 | `requirement_grounding` | object | no |  | Requirement refs, applicability, interpretation, design effects, verification refs, known gaps, and closeout claim boundaries for the changed paths. |  |  |
 | `plan_delegation_packet` | object | no |  | Delegation-ready plan packet or guided tightening projection for active-plan work. |  |  |
-| `test_strategy_check` | object | no |  | Advisory ordinary-test sustainability projection, including recorded disposition state when changed tests are present. |  |  |
+| `test_strategy_check` | object | no |  | Advisory evidence/test sustainability projection, including recorded disposition state when declared changed evidence paths are present. |  |  |
 | `routine_work_context` | object | yes |  | Assembled routine router projection grouping existing owner surfaces into authority, active work, evidence/proof, durable knowledge, and promotion/residue; configured or learned Memory matches remain owner-surface evidence, not AW-owned semantic classification. |  |  |
 | `objective_drift` | object | yes |  | Heuristic warning when changed files do not mention explicit requested outcomes. |  |  |
 | `objective_drift.kind` | const `"agentic-workspace/objective-drift/v1"` | yes |  | Discriminator for the lightweight objective-drift heuristic. |  |  |

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -14,7 +14,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `kind` | const `"startup-context/v1"` | yes |  | Discriminator for the startup context payload shape. |  |  |
 | `target` | string | yes |  | Resolved target repository for the startup decision. |  |  |
 | `action_signals` | object | no |  | Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment. |  |  |
-| `pre_test_evidence_guardrail` | object | no |  | Optional non-blocking pre-test evidence-owner advisory surfaced when configured assurance signals or changed test paths indicate test-shape decisions. |  |  |
+| `pre_test_evidence_guardrail` | object | no |  | Optional non-blocking pre-test evidence-owner advisory surfaced when configured assurance signals or declared changed evidence/test paths indicate proof-shape decisions. |  |  |
 | `task_posture_packet` | ref `#/$defs/task_posture_packet` | no |  | Optional dynamic instruction packet emitted when task facts, config posture, workflow obligations, or module contributions change startup routing. |  |  |
 | `task_posture_packet.kind` | const `"agentic-workspace/task-posture-packet/v1"` | yes |  | Discriminator for dynamic task posture. |  |  |
 | `task_posture_packet.operating_posture` | object | yes |  | Resolved optimization, artifact, initiative, assurance, and delegation posture for this task. |  |  |

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -208,6 +208,11 @@
       "description": "Changed-path reuse and abstraction-pressure facts that help the agent decide whether to reuse, accept duplication, or route extraction follow-up.",
       "additionalProperties": true
     },
+    "optimization_posture": {
+      "type": "object",
+      "description": "Compact configured optimisation posture summary for changed implementation paths, with detailed per-path reasoning kept behind change_impact.",
+      "additionalProperties": true
+    },
     "assurance_requirements": {
       "type": "object",
       "description": "Repo-declared assurance requirements matched to the task or changed paths, with evidence status and claim-boundary facts; task-marker matches cite explicit config while semantic acceptance remains agent/human owned.",
@@ -230,7 +235,7 @@
     },
     "test_strategy_check": {
       "type": "object",
-      "description": "Advisory ordinary-test sustainability projection, including recorded disposition state when changed tests are present.",
+      "description": "Advisory evidence/test sustainability projection, including recorded disposition state when declared changed evidence paths are present.",
       "additionalProperties": true
     },
     "routine_work_context": {

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -24,7 +24,7 @@
     },
     "pre_test_evidence_guardrail": {
       "type": "object",
-      "description": "Optional non-blocking pre-test evidence-owner advisory surfaced when configured assurance signals or changed test paths indicate test-shape decisions.",
+      "description": "Optional non-blocking pre-test evidence-owner advisory surfaced when configured assurance signals or declared changed evidence/test paths indicate proof-shape decisions.",
       "additionalProperties": true
     },
     "task_posture_packet": {

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -26113,6 +26113,82 @@ def _pre_test_evidence_requirement(requirement: dict[str, Any]) -> bool:
     return bool(required_evidence & _PRE_TEST_EVIDENCE_REQUIRED_LABELS)
 
 
+def _verification_protocol_is_test_evidence(protocol: dict[str, Any]) -> bool:
+    protocol_id = str(protocol.get("id", "")).strip()
+    proof_profiles = {str(item).strip() for item in _list_payload(protocol.get("proof_profiles")) if str(item).strip()}
+    expected_evidence = {str(item).strip() for item in _list_payload(protocol.get("expected_evidence")) if str(item).strip()}
+    if protocol_id == "test_evidence_decision":
+        return True
+    if proof_profiles & _PRE_TEST_EVIDENCE_PROOF_PROFILES:
+        return True
+    return bool(expected_evidence & _PRE_TEST_EVIDENCE_REQUIRED_LABELS)
+
+
+def _test_evidence_path_classifications(
+    *, changed_paths: list[str], config: WorkspaceConfig | None, verification: dict[str, Any] | None
+) -> list[dict[str, Any]]:
+    classifications: list[dict[str, Any]] = []
+    normalized_paths = _normalize_changed_paths(changed_paths)
+    for requirement in _assurance_requirement_payloads(config):
+        if not _pre_test_evidence_requirement(requirement):
+            continue
+        requirement_id = str(requirement.get("id", "")).strip()
+        for pattern in [str(item).strip() for item in _list_payload(requirement.get("applies_to_paths")) if str(item).strip()]:
+            for path in normalized_paths:
+                if not _path_matches_subsystem_pattern(path=path, pattern=pattern):
+                    continue
+                classifications.append(
+                    {
+                        "path": path,
+                        "source": f"assurance.requirements.{requirement_id}",
+                        "matched_by": "assurance.applies_to_paths",
+                        "pattern": pattern,
+                        "authority_refs": _list_payload(requirement.get("authority_refs")),
+                    }
+                )
+    verification_payload = _as_dict(verification)
+    for protocol in _list_payload(verification_payload.get("configured_protocols")):
+        if not isinstance(protocol, dict) or not _verification_protocol_is_test_evidence(protocol):
+            continue
+        protocol_id = str(protocol.get("id", "")).strip()
+        for pattern in [str(item).strip() for item in _list_payload(protocol.get("applies_to_paths")) if str(item).strip()]:
+            for path in normalized_paths:
+                if not _path_matches_subsystem_pattern(path=path, pattern=pattern):
+                    continue
+                classifications.append(
+                    {
+                        "path": path,
+                        "source": f"verification.protocols.{protocol_id}",
+                        "matched_by": "verification.applies_to_paths",
+                        "pattern": pattern,
+                        "authority_refs": _list_payload(protocol.get("authority_refs")),
+                    }
+                )
+    classified_paths = {str(item.get("path")) for item in classifications}
+    for path in normalized_paths:
+        if path in classified_paths or not _is_python_test_path_for_guardrail(path):
+            continue
+        classifications.append(
+            {
+                "path": path,
+                "source": "compatibility.python-test-path",
+                "matched_by": "compatibility-fallback",
+                "pattern": "tests/**/test_*.py",
+                "authority_refs": [],
+                "compatibility": True,
+            }
+        )
+    deduped: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in classifications:
+        key = (str(item.get("path")), str(item.get("source")), str(item.get("pattern")))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped
+
+
 def _pre_test_evidence_requirement_matches(
     *, config: WorkspaceConfig | None, changed_paths: list[str] | None, task_text: str | None
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -26156,18 +26232,25 @@ def _pre_test_evidence_guardrail_payload(
     compact: bool = False,
 ) -> dict[str, Any]:
     normalized_paths = _normalize_changed_paths(changed_paths or [])
-    changed_test_paths = [path for path in normalized_paths if _is_python_test_path_for_guardrail(path)]
     if config is None and target_root is not None:
         try:
             config = _load_workspace_config(target_root=target_root)
         except WorkspaceUsageError:
             config = None
+    path_classifications = _test_evidence_path_classifications(
+        changed_paths=normalized_paths,
+        config=config,
+        verification=verification,
+    )
+    changed_test_paths = _dedupe([str(item.get("path")) for item in path_classifications if str(item.get("path", "")).strip()])
     configured_requirements, matched_requirements = _pre_test_evidence_requirement_matches(
         config=config,
         changed_paths=normalized_paths,
         task_text=task_text,
     )
-    trigger_sources = [f"changed test path {path}" for path in changed_test_paths]
+    trigger_sources = [
+        f"{item.get('source')}: changed evidence path {item.get('path')} matched {item.get('pattern')}" for item in path_classifications
+    ]
     for matched in matched_requirements:
         for reason in _list_payload(matched.get("matches")):
             trigger_sources.append(f"{matched.get('source')}: {reason}")
@@ -26177,6 +26260,7 @@ def _pre_test_evidence_guardrail_payload(
             "kind": "agentic-workspace/pre-test-evidence-guardrail/v1",
             "status": "not-applicable",
             "changed_test_paths": changed_test_paths,
+            "evidence_path_classifications": path_classifications,
             "configured_requirement_count": len(configured_requirements),
             "blocking": False,
         }
@@ -26213,6 +26297,7 @@ def _pre_test_evidence_guardrail_payload(
         "trigger_sources": trigger_sources,
         "activation_sources": matched_requirements,
         "changed_test_paths": changed_test_paths,
+        "evidence_path_classifications": path_classifications,
         "decision_prompt": (
             "Before adding or expanding ordinary regression tests, choose the evidence owner and the narrowest proof surface."
         ),
@@ -26222,10 +26307,14 @@ def _pre_test_evidence_guardrail_payload(
         "regression_sprawl_review_questions": sprawl_questions,
         "detail_selectors": ["test_strategy_check", "verification"],
         "source_boundary": {
-            "activation": "configured assurance requirement markers/paths or explicit changed test paths",
+            "activation": (
+                "declared assurance/Verification evidence path facts first; Python test filename conventions are a bounded "
+                "compatibility fallback, not package-wide policy"
+            ),
             "options": "verification.evidence_strategy.proof_governance",
             "review_questions": "verification.evidence_strategy.regression_sprawl",
             "no_universal_task_keyword_policy": True,
+            "no_universal_filename_policy": True,
         },
         "authority_boundary": _authority_boundary_payload(
             surface="pre_test_evidence_guardrail",
@@ -26254,6 +26343,7 @@ def _pre_test_evidence_guardrail_payload(
             "blocking",
             "trigger_sources",
             "changed_test_paths",
+            "evidence_path_classifications",
             "decision_prompt",
             "evidence_owner_options",
             "proof_decision_options",
@@ -26335,13 +26425,13 @@ def _load_test_strategy_dispositions(target_root: Path) -> dict[str, Any]:
 def _test_strategy_check_payload(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, verification: dict[str, Any]
 ) -> dict[str, Any]:
-    test_paths = [path for path in changed_paths if _is_python_test_path_for_guardrail(path)]
     pre_test_guardrail = _pre_test_evidence_guardrail_payload(
         target_root=target_root,
         changed_paths=changed_paths,
         task_text=task_text,
         verification=verification,
     )
+    test_paths = _list_payload(pre_test_guardrail.get("changed_test_paths"))
     if not test_paths:
         if pre_test_guardrail.get("status") == "advisory":
             return {

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -26096,12 +26096,6 @@ _PRE_TEST_EVIDENCE_PROOF_PROFILES = {"test_evidence_change"}
 _PRE_TEST_EVIDENCE_REQUIRED_LABELS = {"verification_proof_decision_review"}
 
 
-def _is_python_test_path_for_guardrail(path: str) -> bool:
-    candidate = Path(path)
-    normalized = candidate.as_posix()
-    return candidate.suffix == ".py" and candidate.name.startswith("test_") and (normalized.startswith("tests/") or "/tests/" in normalized)
-
-
 def _pre_test_evidence_requirement(requirement: dict[str, Any]) -> bool:
     requirement_id = str(requirement.get("id", "")).strip()
     proof_profile = str(requirement.get("proof_profile") or "").strip()
@@ -26164,20 +26158,6 @@ def _test_evidence_path_classifications(
                         "authority_refs": _list_payload(protocol.get("authority_refs")),
                     }
                 )
-    classified_paths = {str(item.get("path")) for item in classifications}
-    for path in normalized_paths:
-        if path in classified_paths or not _is_python_test_path_for_guardrail(path):
-            continue
-        classifications.append(
-            {
-                "path": path,
-                "source": "compatibility.python-test-path",
-                "matched_by": "compatibility-fallback",
-                "pattern": "tests/**/test_*.py",
-                "authority_refs": [],
-                "compatibility": True,
-            }
-        )
     deduped: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
     for item in classifications:
@@ -26307,10 +26287,7 @@ def _pre_test_evidence_guardrail_payload(
         "regression_sprawl_review_questions": sprawl_questions,
         "detail_selectors": ["test_strategy_check", "verification"],
         "source_boundary": {
-            "activation": (
-                "declared assurance/Verification evidence path facts first; Python test filename conventions are a bounded "
-                "compatibility fallback, not package-wide policy"
-            ),
+            "activation": ("declared assurance/Verification evidence path facts; AW does not infer host test conventions from filenames"),
             "options": "verification.evidence_strategy.proof_governance",
             "review_questions": "verification.evidence_strategy.regression_sprawl",
             "no_universal_task_keyword_policy": True,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -26089,12 +26089,6 @@ def _test_strategy_check_payload(
                 if _path_matches_subsystem_pattern(path=path, pattern=pattern) and path not in test_paths:
                     test_paths.append(path)
     if not test_paths:
-        test_paths = [
-            path
-            for path in normalized_paths
-            if Path(path).name.startswith("test_") and Path(path).suffix == ".py" and ("tests/" in path or path.startswith("tests/"))
-        ]
-    if not test_paths:
         return {"kind": "agentic-workspace/test-strategy-check/v1", "status": "not-applicable", "changed_test_paths": []}
     disposition_record = _load_test_strategy_dispositions(target_root)
     disposition_items = [item for item in _list_payload(disposition_record.get("items")) if isinstance(item, dict)]

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -26079,11 +26079,21 @@ def _load_test_strategy_dispositions(target_root: Path) -> dict[str, Any]:
 def _test_strategy_check_payload(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, verification: dict[str, Any]
 ) -> dict[str, Any]:
-    test_paths = [
-        path
-        for path in changed_paths
-        if Path(path).name.startswith("test_") and Path(path).suffix == ".py" and ("tests/" in path or path.startswith("tests/"))
-    ]
+    normalized_paths = _normalize_changed_paths(changed_paths)
+    test_paths: list[str] = []
+    for protocol in _list_payload(verification.get("configured_protocols")):
+        if not isinstance(protocol, dict) or str(protocol.get("id", "")).strip() != "test_evidence_decision":
+            continue
+        for pattern in [str(item).strip() for item in _list_payload(protocol.get("applies_to_paths")) if str(item).strip()]:
+            for path in normalized_paths:
+                if _path_matches_subsystem_pattern(path=path, pattern=pattern) and path not in test_paths:
+                    test_paths.append(path)
+    if not test_paths:
+        test_paths = [
+            path
+            for path in normalized_paths
+            if Path(path).name.startswith("test_") and Path(path).suffix == ".py" and ("tests/" in path or path.startswith("tests/"))
+        ]
     if not test_paths:
         return {"kind": "agentic-workspace/test-strategy-check/v1", "status": "not-applicable", "changed_test_paths": []}
     disposition_record = _load_test_strategy_dispositions(target_root)

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -4606,9 +4606,30 @@ candidates = []
     assert packet["recommended_route"] == "validation-delegate"
 
 
+def _write_python_test_evidence_config(tmp_path: Path) -> None:
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[workspace]
+cli_invoke = "uv run python scripts/run_agentic_workspace.py"
+
+[assurance.requirements.test_evidence_change_decision]
+level = "high"
+applies_to_paths = ["tests/**"]
+required_evidence = ["verification_proof_decision_review"]
+proof_profile = "test_evidence_change"
+review_owner = "maintainer"
+force = "required-before-closeout"
+""",
+    )
+
+
 def test_implement_surfaces_test_strategy_check_for_hotspot_tests(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
+    _write_python_test_evidence_config(tmp_path)
     _write(
         tmp_path / "tests" / "test_runtime.py",
         """
@@ -4661,6 +4682,10 @@ def test_runtime_warning_eta(): assert True
     assert check["pre_test_evidence_guardrail"]["status"] == "advisory"
     assert check["pre_test_evidence_guardrail"]["blocking"] is False
     assert check["pre_test_evidence_guardrail"]["source_boundary"]["no_universal_task_keyword_policy"] is True
+    assert check["pre_test_evidence_guardrail"]["source_boundary"]["no_universal_filename_policy"] is True
+    assert check["pre_test_evidence_guardrail"]["evidence_path_classifications"][0]["source"] == (
+        "assurance.requirements.test_evidence_change_decision"
+    )
     assert "package-local-behavior" in check["evidence_owner_options"]
     assert "convert-to-conformance" in check["proof_decision_options"]
     assert any("trust question" in question for question in check["pre_test_decision_questions"])
@@ -4761,6 +4786,7 @@ def test_implement_tiny_omits_not_applicable_test_strategy_advisory(tmp_path: Pa
 def test_test_strategy_check_reads_recorded_disposition(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
+    _write_python_test_evidence_config(tmp_path)
     _write(tmp_path / "tests" / "test_runtime.py", "def test_runtime_case():\n    assert True\n")
     _write_json(
         tmp_path / ".agentic-workspace" / "verification" / "test-strategy-dispositions.json",
@@ -4812,6 +4838,7 @@ def test_test_strategy_check_distinguishes_non_material_retained_test_edit(tmp_p
     subprocess.run(["git", "config", "user.email", "agent@example.test"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.name", "Agent"], cwd=tmp_path, check=True)
     _write_empty_planning_state(tmp_path)
+    _write_python_test_evidence_config(tmp_path)
     _write(tmp_path / "tests" / "test_runtime.py", "def test_runtime_case():\n    assert True\n")
     subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-m", "baseline"], cwd=tmp_path, check=True, capture_output=True, text=True)
@@ -4849,6 +4876,7 @@ def test_test_strategy_check_marks_added_test_as_material(tmp_path: Path, capsys
     subprocess.run(["git", "config", "user.email", "agent@example.test"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.name", "Agent"], cwd=tmp_path, check=True)
     _write_empty_planning_state(tmp_path)
+    _write_python_test_evidence_config(tmp_path)
     subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-m", "baseline"], cwd=tmp_path, check=True, capture_output=True, text=True)
     _write(tmp_path / "tests" / "test_runtime.py", "def test_runtime_case():\n    assert True\n")
@@ -4884,6 +4912,7 @@ def test_test_strategy_check_marks_deleted_test_as_material(tmp_path: Path, caps
     subprocess.run(["git", "config", "user.email", "agent@example.test"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.name", "Agent"], cwd=tmp_path, check=True)
     _write_empty_planning_state(tmp_path)
+    _write_python_test_evidence_config(tmp_path)
     _write(tmp_path / "tests" / "test_runtime.py", "def test_runtime_case():\n    assert True\n")
     subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-m", "baseline"], cwd=tmp_path, check=True, capture_output=True, text=True)
@@ -4917,6 +4946,7 @@ def test_test_strategy_check_marks_count_change_as_material(tmp_path: Path, caps
     subprocess.run(["git", "config", "user.email", "agent@example.test"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.name", "Agent"], cwd=tmp_path, check=True)
     _write_empty_planning_state(tmp_path)
+    _write_python_test_evidence_config(tmp_path)
     _write(tmp_path / "tests" / "test_runtime.py", "def test_runtime_case():\n    assert True\n")
     subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-m", "baseline"], cwd=tmp_path, check=True, capture_output=True, text=True)
@@ -4953,6 +4983,7 @@ def test_test_strategy_check_marks_renamed_test_as_material(tmp_path: Path, caps
     subprocess.run(["git", "config", "user.email", "agent@example.test"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.name", "Agent"], cwd=tmp_path, check=True)
     _write_empty_planning_state(tmp_path)
+    _write_python_test_evidence_config(tmp_path)
     _write(tmp_path / "tests" / "test_runtime.py", "def test_runtime_case():\n    assert True\n")
     subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-m", "baseline"], cwd=tmp_path, check=True, capture_output=True, text=True)
@@ -4983,6 +5014,7 @@ def test_test_strategy_check_marks_renamed_test_as_material(tmp_path: Path, caps
 def test_test_strategy_check_requires_temporary_follow_up_evidence(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
+    _write_python_test_evidence_config(tmp_path)
     _write(tmp_path / "tests" / "test_runtime.py", "def test_runtime_case():\n    assert True\n")
     _write_json(
         tmp_path / ".agentic-workspace" / "verification" / "test-strategy-dispositions.json",
@@ -5026,6 +5058,7 @@ def test_test_strategy_check_requires_temporary_follow_up_evidence(tmp_path: Pat
 def test_proof_surfaces_test_strategy_check_for_closeout_visibility(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
+    _write_python_test_evidence_config(tmp_path)
     _write(tmp_path / "tests" / "test_runtime.py", "def test_runtime_contract():\n    assert True\n")
 
     assert (

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -4669,6 +4669,66 @@ def test_runtime_warning_eta(): assert True
     assert check["files"][0]["parametrized_test_count"] == 1
 
 
+def test_implement_classifies_declared_non_python_evidence_path(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[workspace]
+cli_invoke = "uv run python scripts/run_agentic_workspace.py"
+
+[assurance.requirements.frontend_evidence_change]
+level = "high"
+applies_to_paths = ["web/specs/*.spec.ts"]
+required_evidence = ["verification_proof_decision_review"]
+proof_profile = "test_evidence_change"
+review_owner = "maintainer"
+force = "required-before-closeout"
+""",
+    )
+    _write(tmp_path / "web" / "specs" / "checkout.spec.ts", "test('checkout flow', () => expect(true).toBe(true));\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "web/specs/checkout.spec.ts",
+                "--task",
+                "Adjust frontend evidence",
+                "--select",
+                "test_strategy_check",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    check = json.loads(capsys.readouterr().out)["values"]["test_strategy_check"]
+    assert check["status"] == "advisory"
+    assert check["changed_test_paths"] == ["web/specs/checkout.spec.ts"]
+    guardrail = check["pre_test_evidence_guardrail"]
+    assert guardrail["status"] == "advisory"
+    assert guardrail["source_boundary"]["no_universal_filename_policy"] is True
+    assert guardrail["evidence_path_classifications"] == [
+        {
+            "path": "web/specs/checkout.spec.ts",
+            "source": "assurance.requirements.frontend_evidence_change",
+            "matched_by": "assurance.applies_to_paths",
+            "pattern": "web/specs/*.spec.ts",
+            "authority_refs": [],
+        }
+    ]
+    assert check["files"][0]["path"] == "web/specs/checkout.spec.ts"
+    assert check["files"][0]["test_function_count"] == 0
+
+
 def test_implement_tiny_omits_not_applicable_test_strategy_advisory(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)


### PR DESCRIPTION
Closes #1790

## Summary
- replace the Python-only changed-test-path classifier with declared evidence path classification from assurance requirements and Verification protocols
- remove the unconditional Python filename fallback so AW does not infer host test conventions from `tests/**/test_*.py`
- route both `pre_test_evidence_guardrail` and `test_strategy_check` through declared evidence/test path facts
- add a non-Python TypeScript evidence-path regression proving declared assurance paths activate the guardrail/check without Python filename conventions
- update existing Python-path fixtures to declare `tests/**` evidence ownership explicitly
- update schema/reference text to describe declared evidence/test paths and add the missing `optimization_posture` implementer schema field exposed by the merged runtime posture work

## Proof
- `uv run pytest tests/test_workspace_implement_cli.py -q -k "test_strategy_check or declared_non_python or tiny_omits_not_applicable"`
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run pytest tests/test_schema_reference_docs.py tests/test_workspace_implement_cli.py -q -k "schema_reference or test_strategy_check or declared_non_python or tiny_omits_not_applicable"`
- `uv run pytest tests/test_workspace_implement_cli.py tests/test_workspace_cli.py -q`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make render-schema-reference`
- `make schema-reference-docs`
- `make maintainer-surfaces`
- `make lint-workspace`
- `make test-workspace`
- `git diff --check`
- `rg -n 'compatibility\.python-test-path|compatibility-fallback|_is_python_test_path_for_guardrail|bounded compatibility fallback|Python test filename|Path\(path\)\.name\.startswith' src tests docs .agentic-workspace -g '*.py' -g '*.json' -g '*.md' -g '*.toml'` (no matches)
- `uv run python scripts/run_agentic_workspace.py implement --changed src/agentic_workspace/workspace_runtime_core.py --changed src/agentic_workspace/workspace_runtime_primitives.py --changed tests/test_workspace_implement_cli.py --task "Remove #1790 Python test-path compatibility fallback" --format json --select proof,assurance_requirements,verification,change_impact`
- `uv run python scripts/run_agentic_workspace.py report --target . --section closeout_trust --format json`
- `uv run python scripts/run_agentic_workspace.py report --target . --section verification --format json`
- `uv run python scripts/run_agentic_workspace.py implement --changed src/agentic_workspace/workspace_runtime_core.py --changed src/agentic_workspace/workspace_runtime_primitives.py --changed tests/test_workspace_implement_cli.py --select requirement_grounding,context.delegation_decision,context.plan_delegation_packet --format json`