### PR TITLE
Treat task path mentions as conceptual

### DIFF
--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -37,6 +37,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `task_posture_packet.provenance` | array of object | yes |  | Config, obligation, module, or command sources used to assemble this packet. |  |  |
 | `task_posture_packet.dynamic_instruction_projection` | object | yes |  | Compact dynamic AGENTS.md-style projection assembled for this task instead of static prose expansion. |  |  |
 | `task_posture_packet.posture_adherence` | object | yes |  | Closeout/report visibility for whether the selected posture was followed or requires explanation. |  |  |
+| `task_path_references` | object | no |  | Observed named repo paths from task text. These references are conceptual by default and do not create changed-path routing authority; explicit --changed paths remain the path-scoped workflow input. |  |  |
 | `memory_decision_packet` | ref `#/$defs/memory_decision_packet` | no |  | Command-backed Memory pull/capture decision packet that keeps semantic judgment with the agent. |  |  |
 | `memory_decision_packet.kind` | const `"agentic-workspace/memory-decision-packet/v1"` | yes |  | Discriminator for the Memory decision packet. |  |  |
 | `memory_decision_packet.stage` | string | yes |  | Workflow stage that produced the packet. |  |  |

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -37,7 +37,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `task_posture_packet.provenance` | array of object | yes |  | Config, obligation, module, or command sources used to assemble this packet. |  |  |
 | `task_posture_packet.dynamic_instruction_projection` | object | yes |  | Compact dynamic AGENTS.md-style projection assembled for this task instead of static prose expansion. |  |  |
 | `task_posture_packet.posture_adherence` | object | yes |  | Closeout/report visibility for whether the selected posture was followed or requires explanation. |  |  |
-| `task_path_references` | object | no |  | Observed named repo paths from task text. These references are conceptual by default and do not create changed-path routing authority; explicit --changed paths remain the path-scoped workflow input. |  |  |
+| `task_path_references` | object | no |  | Observed named repo paths from task text, classified as conceptual-reference or path-scoped-work. Conceptual references do not create changed-path routing authority; explicit path-work intent or --changed paths can route path-scoped workflow. |  |  |
 | `memory_decision_packet` | ref `#/$defs/memory_decision_packet` | no |  | Command-backed Memory pull/capture decision packet that keeps semantic judgment with the agent. |  |  |
 | `memory_decision_packet.kind` | const `"agentic-workspace/memory-decision-packet/v1"` | yes |  | Discriminator for the Memory decision packet. |  |  |
 | `memory_decision_packet.stage` | string | yes |  | Workflow stage that produced the packet. |  |  |

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -31,6 +31,11 @@
       "$ref": "#/$defs/task_posture_packet",
       "description": "Optional dynamic instruction packet emitted when task facts, config posture, workflow obligations, or module contributions change startup routing."
     },
+    "task_path_references": {
+      "type": "object",
+      "description": "Observed named repo paths from task text. These references are conceptual by default and do not create changed-path routing authority; explicit --changed paths remain the path-scoped workflow input.",
+      "additionalProperties": true
+    },
     "memory_decision_packet": {
       "$ref": "#/$defs/memory_decision_packet",
       "description": "Command-backed Memory pull/capture decision packet that keeps semantic judgment with the agent."

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -33,7 +33,7 @@
     },
     "task_path_references": {
       "type": "object",
-      "description": "Observed named repo paths from task text. These references are conceptual by default and do not create changed-path routing authority; explicit --changed paths remain the path-scoped workflow input.",
+      "description": "Observed named repo paths from task text, classified as conceptual-reference or path-scoped-work. Conceptual references do not create changed-path routing authority; explicit path-work intent or --changed paths can route path-scoped workflow.",
       "additionalProperties": true
     },
     "memory_decision_packet": {

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -491,6 +491,7 @@
           "_task_intent_carry_forward_payload",
           "_task_intent_evidence_payload",
           "_task_mentioned_existing_paths",
+          "_task_path_reference_payload",
           "_task_posture_packet_changes_routing",
           "_task_posture_packet_payload",
           "_task_posture_packet_relevant",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -21527,6 +21527,9 @@ def _start_tiny_payload_fast(
     if read_only_response["status"] == "read-only-reporting":
         payload["read_only_response"] = read_only_response
     task_mentioned_paths = _task_mentioned_existing_paths(task_text=task_text, target_root=target_root)
+    task_path_references = _task_path_reference_payload(task_text=task_text, detected_paths=task_mentioned_paths)
+    if task_path_references["status"] == "present":
+        payload["task_path_references"] = task_path_references
     vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
     if vague_orientation["applies_to_current_task"]:
         payload["vague_outcome_orientation"] = vague_orientation
@@ -21638,28 +21641,7 @@ def _start_tiny_payload_fast(
             "open_execplan_only_when": startup_template["open_execplan_only_when"],
             "question_to_user": question,
         }
-    if not active_planning_present and task_mentioned_paths and (not changed_paths) and (not _is_config_posture_task(task_text)):
-        implement_command = str(task_intent.get("implement_changed_command", "")) if isinstance(task_intent, dict) else ""
-        if implement_command:
-            implement_command = implement_command.replace("<paths>", " ".join(task_mentioned_paths))
-        else:
-            implement_command = _command_with_cli_invoke(
-                command=f"agentic-workspace implement --changed {' '.join(task_mentioned_paths)} --format json",
-                cli_invoke=config.cli_invoke,
-            )
-        payload["immediate_next_allowed_action"] = {
-            "action": "inspect-known-task-paths",
-            "summary": "The task text names existing repo paths. Run the implement surface for those paths before broader startup or raw workspace reads.",
-            "command": implement_command,
-            "run": implement_command,
-            "risk": "read-only changed-path routing",
-            "required_inputs": ["target repo", "named path(s)"],
-            "next_proof": "use the proof.required_commands from implement output",
-            "read_first": [implement_command],
-            "open_execplan_only_when": startup_template["open_execplan_only_when"],
-            "detected_paths": task_mentioned_paths,
-        }
-    elif not active_planning_present and _is_prep_only_handoff_task(task_text):
+    if not active_planning_present and _is_prep_only_handoff_task(task_text):
         prep_only = _prep_only_handoff_payload(config=config)
         payload["prep_only_handoff"] = prep_only
         payload["immediate_next_allowed_action"] = {
@@ -23063,6 +23045,31 @@ def _task_mentioned_existing_paths(*, task_text: str | None, target_root: Path) 
         seen.add(key)
         found.append(normalized)
     return found[:6]
+
+
+def _task_path_reference_payload(*, task_text: str | None, detected_paths: list[str]) -> dict[str, Any]:
+    paths = _normalize_changed_paths(detected_paths)
+    if not paths:
+        return {
+            "kind": "agentic-workspace/task-path-references/v1",
+            "status": "absent",
+            "path_reference_kind": "none",
+            "detected_paths": [],
+        }
+    return {
+        "kind": "agentic-workspace/task-path-references/v1",
+        "status": "present",
+        "path_reference_kind": "conceptual-reference",
+        "detected_paths": paths,
+        "path_scoped_paths": [],
+        "agent_decision_required": True,
+        "rule": "Named repo paths in task text are observed facts, not changed-path routing authority. Use explicit --changed paths when path-scoped workflow is known.",
+        "limits": [
+            "Conceptual references to workflow/config/docs do not force implement --changed.",
+            "AW does not infer path-scoped work from prompt keywords, filenames, or prose markers.",
+            "Explicit --changed arguments remain authoritative changed-path routing.",
+        ],
+    }
 
 
 _TASK_INTENT_INLINE_COMMAND_MAX_CHARS = 1200

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -21641,7 +21641,36 @@ def _start_tiny_payload_fast(
             "open_execplan_only_when": startup_template["open_execplan_only_when"],
             "question_to_user": question,
         }
-    if not active_planning_present and _is_prep_only_handoff_task(task_text):
+    if (
+        not active_planning_present
+        and task_path_references.get("path_reference_kind") == "path-scoped-work"
+        and (not changed_paths)
+        and (not _is_config_posture_task(task_text))
+    ):
+        path_scoped_paths = _list_payload(task_path_references.get("path_scoped_paths")) or task_mentioned_paths
+        implement_command = str(task_intent.get("implement_changed_command", "")) if isinstance(task_intent, dict) else ""
+        if implement_command:
+            implement_command = implement_command.replace("<paths>", " ".join(path_scoped_paths))
+        else:
+            implement_command = _command_with_cli_invoke(
+                command=f"agentic-workspace implement --changed {' '.join(path_scoped_paths)} --format json",
+                cli_invoke=config.cli_invoke,
+            )
+        payload["immediate_next_allowed_action"] = {
+            "action": "inspect-known-task-paths",
+            "summary": "The task text explicitly asks for work on existing repo paths. Run the implement surface for those paths before broader startup or raw workspace reads.",
+            "command": implement_command,
+            "run": implement_command,
+            "risk": "read-only changed-path routing",
+            "required_inputs": ["target repo", "named path(s)"],
+            "next_proof": "use the proof.required_commands from implement output",
+            "read_first": [implement_command],
+            "open_execplan_only_when": startup_template["open_execplan_only_when"],
+            "detected_paths": path_scoped_paths,
+            "path_reference_kind": task_path_references.get("path_reference_kind"),
+            "matched_action_terms": _list_payload(task_path_references.get("matched_action_terms")),
+        }
+    elif not active_planning_present and _is_prep_only_handoff_task(task_text):
         prep_only = _prep_only_handoff_payload(config=config)
         payload["prep_only_handoff"] = prep_only
         payload["immediate_next_allowed_action"] = {
@@ -23047,6 +23076,27 @@ def _task_mentioned_existing_paths(*, task_text: str | None, target_root: Path) 
     return found[:6]
 
 
+_PATH_SCOPED_ACTION_TERMS = (
+    "change",
+    "edit",
+    "explain",
+    "fix",
+    "implement",
+    "inspect",
+    "modify",
+    "review",
+    "update",
+    "validate",
+)
+
+
+def _task_path_action_terms_for_window(text: str) -> list[str]:
+    lowered = text.lower()
+    return [
+        term for term in _PATH_SCOPED_ACTION_TERMS if re.search(rf"(?<![a-z0-9_-]){re.escape(term)}(?:ing|ed|s)?(?![a-z0-9_-])", lowered)
+    ]
+
+
 def _task_path_reference_payload(*, task_text: str | None, detected_paths: list[str]) -> dict[str, Any]:
     paths = _normalize_changed_paths(detected_paths)
     if not paths:
@@ -23056,17 +23106,35 @@ def _task_path_reference_payload(*, task_text: str | None, detected_paths: list[
             "path_reference_kind": "none",
             "detected_paths": [],
         }
+    text = str(task_text or "")
+    lowered = text.lower()
+    scoped_paths: list[str] = []
+    matched_action_terms: list[str] = []
+    for path in paths:
+        path_index = lowered.find(path.lower())
+        if path_index < 0:
+            continue
+        window = text[max(0, path_index - 80) : min(len(text), path_index + len(path) + 80)]
+        action_terms = _task_path_action_terms_for_window(window)
+        if not action_terms:
+            continue
+        scoped_paths.append(path)
+        for term in action_terms:
+            if term not in matched_action_terms:
+                matched_action_terms.append(term)
+    path_reference_kind = "path-scoped-work" if scoped_paths else "conceptual-reference"
     return {
         "kind": "agentic-workspace/task-path-references/v1",
         "status": "present",
-        "path_reference_kind": "conceptual-reference",
+        "path_reference_kind": path_reference_kind,
         "detected_paths": paths,
-        "path_scoped_paths": [],
+        "path_scoped_paths": scoped_paths,
+        "matched_action_terms": matched_action_terms,
         "agent_decision_required": True,
-        "rule": "Named repo paths in task text are observed facts, not changed-path routing authority. Use explicit --changed paths when path-scoped workflow is known.",
+        "rule": "Named repo paths in task text are observed facts. Explicit path-work verbs near those paths may route changed-path inspection; otherwise references stay conceptual.",
         "limits": [
             "Conceptual references to workflow/config/docs do not force implement --changed.",
-            "AW does not infer path-scoped work from prompt keywords, filenames, or prose markers.",
+            "AW does not infer path-scoped work from filenames or prose markers alone.",
             "Explicit --changed arguments remain authoritative changed-path routing.",
         ],
     }

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -21557,7 +21557,36 @@ def _start_tiny_payload_fast(
             "open_execplan_only_when": startup_template["open_execplan_only_when"],
             "question_to_user": question,
         }
-    if not active_planning_present and _is_prep_only_handoff_task(task_text):
+    if (
+        not active_planning_present
+        and task_path_references.get("path_reference_kind") == "path-scoped-work"
+        and (not changed_paths)
+        and (not _is_config_posture_task(task_text))
+    ):
+        path_scoped_paths = _list_payload(task_path_references.get("path_scoped_paths")) or task_mentioned_paths
+        implement_command = str(task_intent.get("implement_changed_command", "")) if isinstance(task_intent, dict) else ""
+        if implement_command:
+            implement_command = implement_command.replace("<paths>", " ".join(path_scoped_paths))
+        else:
+            implement_command = _command_with_cli_invoke(
+                command=f"agentic-workspace implement --changed {' '.join(path_scoped_paths)} --format json",
+                cli_invoke=config.cli_invoke,
+            )
+        payload["immediate_next_allowed_action"] = {
+            "action": "inspect-known-task-paths",
+            "summary": "The task text explicitly asks for work on existing repo paths. Run the implement surface for those paths before broader startup or raw workspace reads.",
+            "command": implement_command,
+            "run": implement_command,
+            "risk": "read-only changed-path routing",
+            "required_inputs": ["target repo", "named path(s)"],
+            "next_proof": "use the proof.required_commands from implement output",
+            "read_first": [implement_command],
+            "open_execplan_only_when": startup_template["open_execplan_only_when"],
+            "detected_paths": path_scoped_paths,
+            "path_reference_kind": task_path_references.get("path_reference_kind"),
+            "matched_action_terms": _list_payload(task_path_references.get("matched_action_terms")),
+        }
+    elif not active_planning_present and _is_prep_only_handoff_task(task_text):
         prep_only = _prep_only_handoff_payload(config=config)
         payload["prep_only_handoff"] = prep_only
         payload["immediate_next_allowed_action"] = {
@@ -22963,6 +22992,27 @@ def _task_mentioned_existing_paths(*, task_text: str | None, target_root: Path) 
     return found[:6]
 
 
+_PATH_SCOPED_ACTION_TERMS = (
+    "change",
+    "edit",
+    "explain",
+    "fix",
+    "implement",
+    "inspect",
+    "modify",
+    "review",
+    "update",
+    "validate",
+)
+
+
+def _task_path_action_terms_for_window(text: str) -> list[str]:
+    lowered = text.lower()
+    return [
+        term for term in _PATH_SCOPED_ACTION_TERMS if re.search(rf"(?<![a-z0-9_-]){re.escape(term)}(?:ing|ed|s)?(?![a-z0-9_-])", lowered)
+    ]
+
+
 def _task_path_reference_payload(*, task_text: str | None, detected_paths: list[str]) -> dict[str, Any]:
     paths = _normalize_changed_paths(detected_paths)
     if not paths:
@@ -22972,17 +23022,35 @@ def _task_path_reference_payload(*, task_text: str | None, detected_paths: list[
             "path_reference_kind": "none",
             "detected_paths": [],
         }
+    text = str(task_text or "")
+    lowered = text.lower()
+    scoped_paths: list[str] = []
+    matched_action_terms: list[str] = []
+    for path in paths:
+        path_index = lowered.find(path.lower())
+        if path_index < 0:
+            continue
+        window = text[max(0, path_index - 80) : min(len(text), path_index + len(path) + 80)]
+        action_terms = _task_path_action_terms_for_window(window)
+        if not action_terms:
+            continue
+        scoped_paths.append(path)
+        for term in action_terms:
+            if term not in matched_action_terms:
+                matched_action_terms.append(term)
+    path_reference_kind = "path-scoped-work" if scoped_paths else "conceptual-reference"
     return {
         "kind": "agentic-workspace/task-path-references/v1",
         "status": "present",
-        "path_reference_kind": "conceptual-reference",
+        "path_reference_kind": path_reference_kind,
         "detected_paths": paths,
-        "path_scoped_paths": [],
+        "path_scoped_paths": scoped_paths,
+        "matched_action_terms": matched_action_terms,
         "agent_decision_required": True,
-        "rule": "Named repo paths in task text are observed facts, not changed-path routing authority. Use explicit --changed paths when path-scoped workflow is known.",
+        "rule": "Named repo paths in task text are observed facts. Explicit path-work verbs near those paths may route changed-path inspection; otherwise references stay conceptual.",
         "limits": [
             "Conceptual references to workflow/config/docs do not force implement --changed.",
-            "AW does not infer path-scoped work from prompt keywords, filenames, or prose markers.",
+            "AW does not infer path-scoped work from filenames or prose markers alone.",
             "Explicit --changed arguments remain authoritative changed-path routing.",
         ],
     }

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -21443,6 +21443,9 @@ def _start_tiny_payload_fast(
     if read_only_response["status"] == "read-only-reporting":
         payload["read_only_response"] = read_only_response
     task_mentioned_paths = _task_mentioned_existing_paths(task_text=task_text, target_root=target_root)
+    task_path_references = _task_path_reference_payload(task_text=task_text, detected_paths=task_mentioned_paths)
+    if task_path_references["status"] == "present":
+        payload["task_path_references"] = task_path_references
     vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
     if vague_orientation["applies_to_current_task"]:
         payload["vague_outcome_orientation"] = vague_orientation
@@ -21554,28 +21557,7 @@ def _start_tiny_payload_fast(
             "open_execplan_only_when": startup_template["open_execplan_only_when"],
             "question_to_user": question,
         }
-    if not active_planning_present and task_mentioned_paths and (not changed_paths) and (not _is_config_posture_task(task_text)):
-        implement_command = str(task_intent.get("implement_changed_command", "")) if isinstance(task_intent, dict) else ""
-        if implement_command:
-            implement_command = implement_command.replace("<paths>", " ".join(task_mentioned_paths))
-        else:
-            implement_command = _command_with_cli_invoke(
-                command=f"agentic-workspace implement --changed {' '.join(task_mentioned_paths)} --format json",
-                cli_invoke=config.cli_invoke,
-            )
-        payload["immediate_next_allowed_action"] = {
-            "action": "inspect-known-task-paths",
-            "summary": "The task text names existing repo paths. Run the implement surface for those paths before broader startup or raw workspace reads.",
-            "command": implement_command,
-            "run": implement_command,
-            "risk": "read-only changed-path routing",
-            "required_inputs": ["target repo", "named path(s)"],
-            "next_proof": "use the proof.required_commands from implement output",
-            "read_first": [implement_command],
-            "open_execplan_only_when": startup_template["open_execplan_only_when"],
-            "detected_paths": task_mentioned_paths,
-        }
-    elif not active_planning_present and _is_prep_only_handoff_task(task_text):
+    if not active_planning_present and _is_prep_only_handoff_task(task_text):
         prep_only = _prep_only_handoff_payload(config=config)
         payload["prep_only_handoff"] = prep_only
         payload["immediate_next_allowed_action"] = {
@@ -22979,6 +22961,31 @@ def _task_mentioned_existing_paths(*, task_text: str | None, target_root: Path) 
         seen.add(key)
         found.append(normalized)
     return found[:6]
+
+
+def _task_path_reference_payload(*, task_text: str | None, detected_paths: list[str]) -> dict[str, Any]:
+    paths = _normalize_changed_paths(detected_paths)
+    if not paths:
+        return {
+            "kind": "agentic-workspace/task-path-references/v1",
+            "status": "absent",
+            "path_reference_kind": "none",
+            "detected_paths": [],
+        }
+    return {
+        "kind": "agentic-workspace/task-path-references/v1",
+        "status": "present",
+        "path_reference_kind": "conceptual-reference",
+        "detected_paths": paths,
+        "path_scoped_paths": [],
+        "agent_decision_required": True,
+        "rule": "Named repo paths in task text are observed facts, not changed-path routing authority. Use explicit --changed paths when path-scoped workflow is known.",
+        "limits": [
+            "Conceptual references to workflow/config/docs do not force implement --changed.",
+            "AW does not infer path-scoped work from prompt keywords, filenames, or prose markers.",
+            "Explicit --changed arguments remain authoritative changed-path routing.",
+        ],
+    }
 
 
 _TASK_INTENT_INLINE_COMMAND_MAX_CHARS = 1200

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -807,7 +807,36 @@ def _start_payload(
             "open_execplan_only_when": startup_template["open_execplan_only_when"],
             "question_to_user": question,
         }
-    if not active_planning_present and _is_prep_only_handoff_task(task_text):
+    if (
+        not active_planning_present
+        and task_path_references.get("path_reference_kind") == "path-scoped-work"
+        and (not changed_paths)
+        and (not _is_config_posture_task(task_text))
+    ):
+        path_scoped_paths = _list_payload(task_path_references.get("path_scoped_paths")) or task_mentioned_paths
+        implement_command = str(task_intent.get("implement_changed_command", "")) if isinstance(task_intent, dict) else ""
+        if implement_command:
+            implement_command = implement_command.replace("<paths>", " ".join(path_scoped_paths))
+        else:
+            implement_command = _command_with_cli_invoke(
+                command=f"agentic-workspace implement --changed {' '.join(path_scoped_paths)} --format json",
+                cli_invoke=config.cli_invoke,
+            )
+        payload["immediate_next_allowed_action"] = {
+            "action": "inspect-known-task-paths",
+            "summary": "The task text explicitly asks for work on existing repo paths. Run the implement surface for those paths before broader startup or raw workspace reads.",
+            "command": implement_command,
+            "run": implement_command,
+            "risk": "read-only changed-path routing",
+            "required_inputs": ["target repo", "named path(s)"],
+            "next_proof": "use the proof.required_commands from implement output",
+            "read_first": [implement_command],
+            "open_execplan_only_when": startup_template["open_execplan_only_when"],
+            "detected_paths": path_scoped_paths,
+            "path_reference_kind": task_path_references.get("path_reference_kind"),
+            "matched_action_terms": _list_payload(task_path_references.get("matched_action_terms")),
+        }
+    elif not active_planning_present and _is_prep_only_handoff_task(task_text):
         prep_only = _prep_only_handoff_payload(config=config)
         planning_command = prep_only["first_command"]
         summary_command = prep_only["after_write"]

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -87,6 +87,7 @@ from agentic_workspace.workspace_runtime_core import (
     _task_intent_carry_forward_payload,
     _task_intent_evidence_payload,
     _task_mentioned_existing_paths,
+    _task_path_reference_payload,
     _task_posture_packet_changes_routing,
     _task_posture_packet_payload,
     _task_posture_packet_relevant,
@@ -236,6 +237,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         },
         "repo_posture": _compact_repo_posture_projection(payload.get("repo_posture", {})),
         "delegation_decision": _compact_start_delegation_decision(payload.get("delegation_decision", {})),
+        **({"task_path_references": payload["task_path_references"]} if isinstance(payload.get("task_path_references"), dict) else {}),
         **({"pre_test_evidence_guardrail": payload["pre_test_evidence_guardrail"]} if "pre_test_evidence_guardrail" in payload else {}),
         "skill_routing": {
             "status": skill_routing.get("status", "unknown") if isinstance(skill_routing, dict) else "unknown",
@@ -655,6 +657,9 @@ def _start_payload(
     if read_only_response["status"] == "read-only-reporting":
         payload["read_only_response"] = read_only_response
     task_mentioned_paths = _task_mentioned_existing_paths(task_text=task_text, target_root=target_root)
+    task_path_references = _task_path_reference_payload(task_text=task_text, detected_paths=task_mentioned_paths)
+    if task_path_references["status"] == "present":
+        payload["task_path_references"] = task_path_references
     vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
     if vague_orientation["applies_to_current_task"]:
         payload["vague_outcome_orientation"] = vague_orientation
@@ -802,28 +807,7 @@ def _start_payload(
             "open_execplan_only_when": startup_template["open_execplan_only_when"],
             "question_to_user": question,
         }
-    if not active_planning_present and task_mentioned_paths and (not changed_paths) and (not _is_config_posture_task(task_text)):
-        implement_command = str(task_intent.get("implement_changed_command", "")) if isinstance(task_intent, dict) else ""
-        if implement_command:
-            implement_command = implement_command.replace("<paths>", " ".join(task_mentioned_paths))
-        else:
-            implement_command = _command_with_cli_invoke(
-                command=f"agentic-workspace implement --changed {' '.join(task_mentioned_paths)} --format json",
-                cli_invoke=config.cli_invoke,
-            )
-        payload["immediate_next_allowed_action"] = {
-            "action": "inspect-known-task-paths",
-            "summary": "The task text names existing repo paths. Run the implement surface for those paths before broader startup or raw workspace reads.",
-            "command": implement_command,
-            "run": implement_command,
-            "risk": "read-only changed-path routing",
-            "required_inputs": ["target repo", "named path(s)"],
-            "next_proof": "use the proof.required_commands from implement output",
-            "read_first": [implement_command],
-            "open_execplan_only_when": startup_template["open_execplan_only_when"],
-            "detected_paths": task_mentioned_paths,
-        }
-    elif not active_planning_present and _is_prep_only_handoff_task(task_text):
+    if not active_planning_present and _is_prep_only_handoff_task(task_text):
         prep_only = _prep_only_handoff_payload(config=config)
         planning_command = prep_only["first_command"]
         summary_command = prep_only["after_write"]
@@ -1194,6 +1178,9 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     pre_test_guardrail = payload.get("pre_test_evidence_guardrail", {})
     if isinstance(pre_test_guardrail, dict) and pre_test_guardrail.get("status") == "advisory":
         context["pre_test_evidence_guardrail"] = pre_test_guardrail
+    task_path_references = payload.get("task_path_references", {})
+    if isinstance(task_path_references, dict) and task_path_references.get("status") == "present":
+        context["task_path_references"] = task_path_references
     uv_guidance = payload.get("uv_cache_guidance", {})
     if not (isinstance(uv_guidance, dict) and uv_guidance.get("status") == "available"):
         cli_invocation = payload.get("cli_invocation", {})

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -656,6 +656,65 @@ def test_start_default_stays_under_tiny_output_budget_for_docs_task(tmp_path: Pa
     assert "workflow_sufficiency" in payload["drill_down"]["available_selectors"]
 
 
+def test_start_treats_named_path_question_as_conceptual_reference(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Are you actively applying the dogfooding instructions in AGENTS.md?",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["next_safe_action"]["next_safe_action"] == "choose-smallest-workflow-shape"
+    assert payload["context"]["primary_action"]["command"] is None
+    path_refs = payload["context"]["task_path_references"]
+    assert path_refs["path_reference_kind"] == "conceptual-reference"
+    assert path_refs["detected_paths"] == ["AGENTS.md"]
+    assert path_refs["path_scoped_paths"] == []
+    assert path_refs["agent_decision_required"] is True
+    assert "implement --changed AGENTS.md" not in json.dumps(payload)
+
+
+def test_start_explicit_changed_path_still_uses_changed_path_startup(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "AGENTS.md",
+                "--task",
+                "Review AGENTS.md",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["next_safe_action"]["next_safe_action"] == "select-changed-path-proof"
+    assert payload["context"]["primary_action"]["command"].endswith("proof --changed AGENTS.md --format json")
+    assert payload["context"]["primary_action"]["read_first"] == [payload["context"]["primary_action"]["command"]]
+
+
 def test_local_chat_checkpoint_write_creates_valid_local_record_and_startup_packet(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -687,6 +687,36 @@ def test_start_treats_named_path_question_as_conceptual_reference(tmp_path: Path
     assert "implement --changed AGENTS.md" not in json.dumps(payload)
 
 
+def test_start_path_scoped_task_text_uses_known_path_inspection(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Review AGENTS.md",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["next_safe_action"]["next_safe_action"] == "inspect-known-task-paths"
+    assert payload["context"]["primary_action"]["command"].endswith('implement --changed AGENTS.md --task "Review AGENTS.md" --format json')
+    assert payload["context"]["primary_action"]["read_first"] == [payload["context"]["primary_action"]["command"]]
+    path_refs = payload["context"]["task_path_references"]
+    assert path_refs["path_reference_kind"] == "path-scoped-work"
+    assert path_refs["path_scoped_paths"] == ["AGENTS.md"]
+    assert path_refs["matched_action_terms"] == ["review"]
+
+
 def test_start_explicit_changed_path_still_uses_changed_path_startup(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
@@ -712,7 +742,6 @@ def test_start_explicit_changed_path_still_uses_changed_path_startup(tmp_path: P
 
     assert payload["next_safe_action"]["next_safe_action"] == "select-changed-path-proof"
     assert payload["context"]["primary_action"]["command"].endswith("proof --changed AGENTS.md --format json")
-    assert payload["context"]["primary_action"]["read_first"] == [payload["context"]["primary_action"]["command"]]
 
 
 def test_local_chat_checkpoint_write_creates_valid_local_record_and_startup_packet(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
Closes #1788

## Summary
- keep `task_path_references` so named repo paths are visible as observed task facts
- treat conceptual/self-assessment path mentions, such as asking about `AGENTS.md`, as `conceptual-reference` without forcing `implement --changed`
- preserve path-scoped startup routing when task text names an existing path and uses explicit path-work intent such as review, inspect, explain, edit, change, validate, or implement
- keep explicit `--changed` paths as the authoritative changed-path startup/proof route
- update the startup context schema/reference and runtime primitive-family inventory
- add focused startup tests for conceptual `AGENTS.md`, path-scoped `Review AGENTS.md` without `--changed`, and explicit `--changed AGENTS.md`

## Why
The old route treated any existing path in task text as enough to recommend changed-path inspection. That over-escalated simple workflow/self-assessment questions like “are you applying AGENTS.md?”. The corrected behavior distinguishes conceptual references from explicit path-scoped work without using filenames or prose markers alone as authority.

## Proof
- `uv run pytest tests/test_workspace_cli.py -q -k "named_path_question or path_scoped_task_text or explicit_changed_path_still_uses_changed_path_startup or tiny_output_budget"`
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make render-schema-reference`
- `make schema-reference-docs`
- `make maintainer-surfaces`
- `make lint-workspace`
- `make test-workspace`
- `git diff --check`
- `uv run python scripts/run_agentic_workspace.py implement --changed src/agentic_workspace/workspace_runtime_core.py --changed src/agentic_workspace/workspace_runtime_primitives.py --changed src/agentic_workspace/workspace_runtime_startup.py --changed src/agentic_workspace/contracts/schemas/startup_context.schema.json --changed src/agentic_workspace/contracts/workspace_runtime_primitive_families.json --changed docs/reference/startup-context.md --changed tests/test_workspace_cli.py --task "Address PR #1798 review: preserve explicit path-scoped task routing" --format json --select proof,change_impact`
- `uv run python scripts/run_agentic_workspace.py report --target . --section closeout_trust --format json`
- `uv run python scripts/run_agentic_workspace.py report --target . --section verification --format json`
- `uv run python scripts/run_agentic_workspace.py implement --changed src/agentic_workspace/workspace_runtime_core.py --changed src/agentic_workspace/workspace_runtime_primitives.py --changed src/agentic_workspace/workspace_runtime_startup.py --changed src/agentic_workspace/contracts/schemas/startup_context.schema.json --changed src/agentic_workspace/contracts/workspace_runtime_primitive_families.json --changed docs/reference/startup-context.md --changed tests/test_workspace_cli.py --select requirement_grounding,context.delegation_decision,context.plan_delegation_packet --format json`