### PR TITLE
Complete configuration-driven instruction surfacing lane

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -592,6 +592,11 @@ def report_router_payload(
             cli_invoke=cli_invoke,
             target_arg=target_arg,
         ),
+        "selective_surfacing_evaluation": _command_with_cli_invoke(
+            "agentic-workspace report --target ./repo --section selective_surfacing_evaluation --format json",
+            cli_invoke=cli_invoke,
+            target_arg=target_arg,
+        ),
         "feature_tier": _command_with_cli_invoke(
             "agentic-workspace modules --target ./repo --format json", cli_invoke=cli_invoke, target_arg=target_arg
         ),
@@ -656,6 +661,7 @@ def report_router_payload(
         "effective_authority": _report_router_effective_authority(payload.get("effective_authority", {})),
         "execution_shape": _report_router_execution_shape(payload.get("execution_shape", {})),
         "configuration_projection": payload.get("configuration_projection", {}),
+        "selective_surfacing_evaluation": _report_router_selective_surfacing_evaluation(payload.get("selective_surfacing_evaluation", {})),
         "durable_intent": payload.get("durable_intent", {}),
         "improvement_intake": _report_router_improvement_intake(payload.get("improvement_intake", {})),
         "external_work_reconciliation": _report_router_external_work_reconciliation(payload.get("external_work_reconciliation", {})),
@@ -726,6 +732,7 @@ def report_router_payload(
                 "context.warning_summary",
                 "context.execution_shape",
                 "context.configuration_projection",
+                "context.selective_surfacing_evaluation",
                 "context.improvement_intake",
                 "context.external_work_reconciliation",
                 "context.closeout_report",
@@ -784,9 +791,10 @@ def _compact_report_section_hints(hints: list[dict[str, Any]]) -> list[dict[str,
         "operating_posture": 5,
         "external_work_reconciliation": 6,
         "configuration_projection": 7,
-        "module_reports": 8,
-        "successful_completion_cost": 9,
-        "findings": 10,
+        "selective_surfacing_evaluation": 8,
+        "module_reports": 9,
+        "successful_completion_cost": 10,
+        "findings": 11,
     }
     ordered = sorted(
         hints,
@@ -898,6 +906,29 @@ def _report_router_config_effect_audit(value: Any) -> dict[str, Any]:
         "agent_dependent_field_count": len(agent_dependent),
         "warning_count": len(warnings),
         "detail_section": "config_effect_audit",
+    }
+
+
+def _report_router_selective_surfacing_evaluation(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"status": "unavailable"}
+    checks = value.get("checks", [])
+    if not isinstance(checks, list):
+        checks = []
+    failing = value.get("failing_checks", [])
+    if not isinstance(failing, list):
+        failing = []
+    metrics = value.get("metrics", {})
+    if not isinstance(metrics, dict):
+        metrics = {}
+    return {
+        "kind": value.get("kind", "agentic-workspace/selective-surfacing-evaluation/v1"),
+        "status": value.get("status", "unknown"),
+        "check_count": len(checks),
+        "failing_check_count": len(failing),
+        "scenario_count": value.get("scenario_count", 0),
+        "metrics": {key: metrics[key] for key in ("projection_row_count", "compact_json_size", "compact_selector_count") if key in metrics},
+        "detail_section": "selective_surfacing_evaluation",
     }
 
 
@@ -1197,6 +1228,7 @@ def report_section_hints(
         "config_enforcement": "config fields classified by actual enforcement strength and operational routes",
         "config_effect_audit": "audit of actual config force, affected outputs, and agent-dependent settings",
         "configuration_projection": "config-to-runtime projection coverage, suppression rules, owner exceptions, and verification probes",
+        "selective_surfacing_evaluation": "cheap contract checks for positive config surfacing, non-applicable suppression, and compact-output bounds",
         "registry": "module registry and lifecycle metadata",
     }
     findings = [finding for finding in payload.get("findings", []) if isinstance(finding, dict)]
@@ -1239,6 +1271,7 @@ def report_section_hints(
         "config_enforcement": "inspect when deciding whether a config field is hard, operational, advisory, or local-only",
         "config_effect_audit": "inspect when verifying whether settings have concrete behavior or only advise agents",
         "configuration_projection": "inspect when verifying configured behavior has ordinary-path projection or stays suppressed",
+        "selective_surfacing_evaluation": "inspect when proving config surfacing is executable, bounded, and not only documented",
         "registry": "deep detail; inspect only when module metadata or lifecycle registration matters",
     }
     if current_status in {"absent", "direct-or-no-active-plan"}:

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -587,6 +587,11 @@ def report_router_payload(
             cli_invoke=cli_invoke,
             target_arg=target_arg,
         ),
+        "configuration_projection": _command_with_cli_invoke(
+            "agentic-workspace report --target ./repo --section configuration_projection --format json",
+            cli_invoke=cli_invoke,
+            target_arg=target_arg,
+        ),
         "feature_tier": _command_with_cli_invoke(
             "agentic-workspace modules --target ./repo --format json", cli_invoke=cli_invoke, target_arg=target_arg
         ),
@@ -650,6 +655,7 @@ def report_router_payload(
         "section_hints": compact_section_hints,
         "effective_authority": _report_router_effective_authority(payload.get("effective_authority", {})),
         "execution_shape": _report_router_execution_shape(payload.get("execution_shape", {})),
+        "configuration_projection": payload.get("configuration_projection", {}),
         "durable_intent": payload.get("durable_intent", {}),
         "improvement_intake": _report_router_improvement_intake(payload.get("improvement_intake", {})),
         "external_work_reconciliation": _report_router_external_work_reconciliation(payload.get("external_work_reconciliation", {})),
@@ -719,6 +725,7 @@ def report_router_payload(
                 "context.routine_work_context",
                 "context.warning_summary",
                 "context.execution_shape",
+                "context.configuration_projection",
                 "context.improvement_intake",
                 "context.external_work_reconciliation",
                 "context.closeout_report",
@@ -776,9 +783,10 @@ def _compact_report_section_hints(hints: list[dict[str, Any]]) -> list[dict[str,
         "applicable_intent": 4,
         "operating_posture": 5,
         "external_work_reconciliation": 6,
-        "module_reports": 7,
-        "successful_completion_cost": 8,
-        "findings": 9,
+        "configuration_projection": 7,
+        "module_reports": 8,
+        "successful_completion_cost": 9,
+        "findings": 10,
     }
     ordered = sorted(
         hints,
@@ -1188,6 +1196,7 @@ def report_section_hints(
         "config": "resolved workspace config and local posture",
         "config_enforcement": "config fields classified by actual enforcement strength and operational routes",
         "config_effect_audit": "audit of actual config force, affected outputs, and agent-dependent settings",
+        "configuration_projection": "config-to-runtime projection coverage, suppression rules, owner exceptions, and verification probes",
         "registry": "module registry and lifecycle metadata",
     }
     findings = [finding for finding in payload.get("findings", []) if isinstance(finding, dict)]
@@ -1229,6 +1238,7 @@ def report_section_hints(
         "config": "deep detail; inspect only when resolved config, posture, or obligations matter",
         "config_enforcement": "inspect when deciding whether a config field is hard, operational, advisory, or local-only",
         "config_effect_audit": "inspect when verifying whether settings have concrete behavior or only advise agents",
+        "configuration_projection": "inspect when verifying configured behavior has ordinary-path projection or stays suppressed",
         "registry": "deep detail; inspect only when module metadata or lifecycle registration matters",
     }
     if current_status in {"absent", "direct-or-no-active-plan"}:

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -8415,6 +8415,7 @@ def _run_report_command(
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
         "configuration_projection": _configuration_projection_payload(config=config),
+        "selective_surfacing_evaluation": _configuration_projection_payload(config=config)["selective_surfacing_evaluation"],
         "branch_workflow_posture": branch_workflow_posture,
         "local_memory": local_memory,
         "memory_consult": memory_consult,
@@ -12123,6 +12124,7 @@ def _run_report_router_command(
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
         "configuration_projection": _compact_configuration_projection_payload(_configuration_projection_payload(config=config)),
+        "selective_surfacing_evaluation": _configuration_projection_payload(config=config)["selective_surfacing_evaluation"],
         "memory_consult": memory_consult,
         "reuse_pressure": _reuse_pressure_payload(target_root=target_root, cli_invoke=config.cli_invoke, compact=True),
         "execution_shape": _report_router_execution_shape_fast(config=config),
@@ -28942,30 +28944,38 @@ def _configuration_projection_payload(*, config: WorkspaceConfig) -> dict[str, A
         commands = [str(item) for item in _list_payload(effect.get("concrete_commands")) if str(item).strip()]
         payload_fields = [str(item) for item in _list_payload(effect.get("payload_fields")) if str(item).strip()]
         owner_boundary = "human-owned" if scope == "repo-config" else "local-human-owned" if scope == "local-config" else "package-owned"
-        if dependency == "not-applicable":
-            status = "unprojected"
-        elif commands and payload_fields:
-            status = "active"
-        else:
-            status = "latent"
+        status = "unprojected" if dependency == "not-applicable" else "active" if commands and payload_fields else "latent"
         projection_facts.append(
-            {
-                "field": field,
-                "scope": scope,
-                "effect_type": str(effect.get("effect_type", "")),
-                "projection_status": status,
-                "ordinary_path_routes": commands,
-                "payload_fields": payload_fields,
-                "applicability_signal": _configuration_projection_applicability(field),
-                "suppression_rule": _configuration_projection_suppression(field),
-                "owner_boundary": owner_boundary,
-                "authority_exception": _configuration_projection_authority_exception(
+            _configuration_projection_row(
+                row_id=f"config:{field}",
+                source="workspace-config",
+                source_surface=".agentic-workspace/config.toml",
+                owner=owner_boundary,
+                field=field,
+                configured_concern=field,
+                status=status,
+                ordinary_path_routes=commands,
+                payload_fields=payload_fields,
+                trigger=_configuration_projection_applicability(field),
+                suppression_rule=_configuration_projection_suppression(field),
+                proof_or_test_coverage=["tests/test_workspace_config_cli.py", "tests/test_workspace_cli.py"],
+                effect_type=str(effect.get("effect_type", "")),
+                scope=scope,
+                authority_exception=_configuration_projection_authority_exception(
                     field=field, owner_boundary=owner_boundary, dependency=dependency
                 ),
-            }
+            )
         )
+    projection_facts.extend(_ambient_configuration_projection_rows(config=config))
 
-    status_counts: dict[str, int] = {"active": 0, "latent": 0, "stale": 0, "unprojected": 0}
+    status_counts: dict[str, int] = {
+        "active": 0,
+        "selector-backed": 0,
+        "latent": 0,
+        "stale": 0,
+        "unprojected": 0,
+        "owner-exempt": 0,
+    }
     for fact in projection_facts:
         projection_status = str(fact.get("projection_status", "unprojected"))
         status_counts[projection_status] = status_counts.get(projection_status, 0) + 1
@@ -29017,7 +29027,7 @@ def _configuration_projection_payload(*, config: WorkspaceConfig) -> dict[str, A
             "covers": ["ownership exceptions"],
         },
     ]
-    return {
+    payload = {
         "kind": "agentic-workspace/configuration-projection/v1",
         "status": "present",
         "purpose": "Machine-consumable coverage of which configured facts can affect ordinary startup, implementation, proof, report, and closeout routing.",
@@ -29049,9 +29059,195 @@ def _configuration_projection_payload(*, config: WorkspaceConfig) -> dict[str, A
             cli_invoke=config.cli_invoke,
         ),
     }
+    payload["selective_surfacing_evaluation"] = _selective_surfacing_evaluation_payload(
+        projection_payload=payload,
+        compact_projection=_compact_configuration_projection_payload(payload),
+        cli_invoke=config.cli_invoke,
+    )
+    return payload
+
+
+def _configuration_projection_row(
+    *,
+    row_id: str,
+    source: str,
+    source_surface: str,
+    owner: str,
+    field: str,
+    configured_concern: str,
+    status: str,
+    ordinary_path_routes: list[str],
+    payload_fields: list[str],
+    trigger: str,
+    suppression_rule: str,
+    proof_or_test_coverage: list[str],
+    scope: str = "",
+    effect_type: str = "",
+    authority_exception: str = "",
+) -> dict[str, Any]:
+    return {
+        "id": row_id,
+        "source": source,
+        "source_surface": source_surface,
+        "owner": owner,
+        "field": field,
+        "configured_concern": configured_concern,
+        "scope": scope,
+        "effect_type": effect_type,
+        "projection_status": status,
+        "status": status,
+        "ordinary_path_routes": ordinary_path_routes,
+        "payload_fields": payload_fields,
+        "trigger": trigger,
+        "applicability_signal": trigger,
+        "suppression_rule": suppression_rule,
+        "proof_or_test_coverage": proof_or_test_coverage,
+        "owner_boundary": owner,
+        "authority_exception": authority_exception
+        or "AW reports the route and owner; the agent owns semantic applicability unless a hard gate is explicit.",
+    }
+
+
+def _ambient_configuration_projection_rows(*, config: WorkspaceConfig) -> list[dict[str, Any]]:
+    target_root = config.target_root or Path(".")
+    rows: list[dict[str, Any]] = []
+    ownership_path = target_root / ".agentic-workspace" / "OWNERSHIP.toml"
+    ownership_exists = ownership_path.is_file()
+    rows.append(
+        _configuration_projection_row(
+            row_id="ownership:authority-ledger",
+            source="ownership",
+            source_surface=".agentic-workspace/OWNERSHIP.toml",
+            owner="human-owned",
+            field="ownership.authority_surfaces",
+            configured_concern="ownership, authority, audience, managed-surface, and subsystem routing",
+            status="selector-backed" if ownership_exists else "latent",
+            ordinary_path_routes=[
+                "agentic-workspace ownership --target ./repo --format json",
+                "agentic-workspace implement --target ./repo --changed <paths> --select change_impact --format json",
+            ],
+            payload_fields=["ownership", "change_impact.paths[].owner", "change_impact.paths[].optimization_posture"],
+            trigger="changed path intersects an authority surface, module root, managed surface, or subsystem path",
+            suppression_rule="ordinary report keeps ownership detail behind ownership/change_impact selectors unless a path boundary affects the next action",
+            proof_or_test_coverage=[
+                "tests/test_workspace_implement_cli.py::test_implement_change_impact_routes_optimization_posture_by_audience_boundary"
+            ],
+        )
+    )
+    system_intent_path = target_root / ".agentic-workspace" / "system-intent" / "intent.toml"
+    system_intent_sources = [str(item) for item in config.system_intent.sources if str(item).strip()]
+    rows.append(
+        _configuration_projection_row(
+            row_id="system-intent:durable-intent",
+            source="system-intent",
+            source_surface=".agentic-workspace/system-intent/intent.toml",
+            owner="human-owned",
+            field="system_intent.sources",
+            configured_concern="durable system and architecture intent",
+            status="selector-backed" if system_intent_path.is_file() or system_intent_sources else "latent",
+            ordinary_path_routes=[
+                "agentic-workspace system-intent --target ./repo --format json",
+                "agentic-workspace report --target ./repo --section durable_intent --format json",
+                "agentic-workspace implement --target ./repo --changed <paths> --select architecture_principles --format json",
+            ],
+            payload_fields=["durable_intent", "applicable_intent", "architecture_principles"],
+            trigger="task text or changed paths intersect durable system intent, subsystem intent, or architecture principle globs",
+            suppression_rule="surface compact applicable-intent or architecture-principle status only when work intersects durable intent; keep full intent behind selectors",
+            proof_or_test_coverage=["tests/test_workspace_implement_cli.py", "tests/test_workspace_intent_cli.py"],
+        )
+    )
+    verification_enabled = "verification" in set(config.enabled_modules)
+    verification_manifest = target_root / ".agentic-workspace" / "verification" / "manifest.toml"
+    verification_status = "selector-backed" if verification_manifest.is_file() else "stale" if verification_enabled else "latent"
+    rows.append(
+        _configuration_projection_row(
+            row_id="verification:manifest",
+            source="verification",
+            source_surface=".agentic-workspace/verification/manifest.toml",
+            owner="human-owned",
+            field="verification.manifest",
+            configured_concern="Verification protocol activation, proof routes, and known gaps",
+            status=verification_status,
+            ordinary_path_routes=[
+                "agentic-workspace report --target ./repo --section verification --format json",
+                "agentic-workspace proof --target ./repo --changed <paths> --format json",
+            ],
+            payload_fields=["verification", "proof.verification_enrichment", "assurance_requirements.verification"],
+            trigger="Verification module is enabled and a manifest protocol matches task markers, changed paths, or proof routes",
+            suppression_rule="do not surface inactive Verification protocol detail in ordinary output; report missing enabled manifest as stale coverage, not a hard blocker by default",
+            proof_or_test_coverage=[
+                "tests/test_workspace_implement_cli.py::test_implement_verification_task_marker_reports_configured_protocol_authority"
+            ],
+        )
+    )
+    memory_index = target_root / ".agentic-workspace" / "memory" / "repo" / "index.md"
+    rows.append(
+        _configuration_projection_row(
+            row_id="memory:routing-metadata",
+            source="memory",
+            source_surface=".agentic-workspace/memory/repo/index.md",
+            owner="memory-owned",
+            field="memory.routing_metadata",
+            configured_concern="Memory route hints, read budgets, and anti-rediscovery metadata",
+            status="selector-backed" if memory_index.is_file() else "latent",
+            ordinary_path_routes=[
+                "agentic-workspace memory route --target ./repo --stage implement --files <paths> --format json",
+                "agentic-workspace implement --target ./repo --changed <paths> --format json",
+            ],
+            payload_fields=["memory_consult", "memory_decision_packet"],
+            trigger="task or changed paths match Memory manifest/index routing metadata",
+            suppression_rule="ordinary paths show read-first and route counts; candidate owner detail stays behind Memory selectors",
+            proof_or_test_coverage=[
+                "tests/test_workspace_implement_cli.py::test_implement_surfaces_memory_decision_packet_for_changed_paths"
+            ],
+        )
+    )
+    active_plan = _active_planning_record_for_report_section(target_root=target_root)
+    active_plan_present = bool(active_plan) and str(active_plan.get("status", "")).lower() != "absent"
+    rows.append(
+        _configuration_projection_row(
+            row_id="planning:active-state-obligations",
+            source="planning",
+            source_surface=".agentic-workspace/planning/state.toml",
+            owner="planning-owned",
+            field="planning.active_state",
+            configured_concern="active Planning intent, proof expectations, blockers, and closeout obligations",
+            status="active" if active_plan_present else "latent",
+            ordinary_path_routes=[
+                "agentic-workspace summary --format json",
+                "agentic-workspace implement --target ./repo --changed <paths> --format json",
+                "agentic-workspace report --target ./repo --section completion_contract --format json",
+            ],
+            payload_fields=["summary.execution_readiness", "implement.planning_safety_gate", "completion_contract"],
+            trigger="active TODO item or execplan exists, or broad lane work needs shared intent custody",
+            suppression_rule="do not require Planning for narrow direct work; surface active obligations when present or when broad work claims lane progress",
+            proof_or_test_coverage=["tests/test_workspace_implement_cli.py", "tests/test_workspace_summary_cli.py"],
+        )
+    )
+    rows.append(
+        _configuration_projection_row(
+            row_id="local-memory:disabled-default",
+            source="local-config",
+            source_surface=".agentic-workspace/config.local.toml [local_memory]",
+            owner="local-human-owned",
+            field="local_memory.enabled",
+            configured_concern="optional local-only memory posture",
+            status="latent" if not config.local_override.local_memory_enabled else "selector-backed",
+            ordinary_path_routes=["agentic-workspace report --target ./repo --section local_memory --format json"],
+            payload_fields=["local_memory"],
+            trigger="local_memory.enabled is true in local config",
+            suppression_rule="disabled or local-only memory stays out of shared authority and ordinary repo closeout",
+            proof_or_test_coverage=["tests/test_workspace_config_cli.py"],
+            authority_exception="local-only advisory; cannot become shared Planning, Memory, proof, or closeout authority",
+        )
+    )
+    return rows
 
 
 def _compact_configuration_projection_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    evaluation = payload.get("selective_surfacing_evaluation", {})
+    checks = _list_payload(evaluation.get("checks")) if isinstance(evaluation, dict) else []
+    failing = [item for item in checks if isinstance(item, dict) and item.get("result") == "fail"]
     return {
         "kind": payload["kind"],
         "status": payload["status"],
@@ -29060,7 +29256,105 @@ def _compact_configuration_projection_payload(payload: dict[str, Any]) -> dict[s
         "owner_boundary_exception_count": len(payload["owner_boundary_exceptions"]),
         "verification_probe_count": len(payload["verification"]["positive_surfacing"])
         + len(payload["verification"]["non_applicable_suppression"]),
+        "evaluation": {
+            "status": evaluation.get("status", "not-run") if isinstance(evaluation, dict) else "not-run",
+            "check_count": len(checks),
+            "failing_check_count": len(failing),
+            "detail_section": "selective_surfacing_evaluation",
+        },
         "detail_command": payload["detail_command"],
+    }
+
+
+def _selective_surfacing_evaluation_payload(
+    *, projection_payload: dict[str, Any], compact_projection: dict[str, Any], cli_invoke: str
+) -> dict[str, Any]:
+    facts = [dict(item) for item in _list_payload(projection_payload.get("facts")) if isinstance(item, dict)]
+    statuses = {str(item.get("projection_status") or item.get("status") or "") for item in facts}
+    compact_json_size = len(json.dumps(compact_projection, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    compact_has_fact_detail = "facts" in compact_projection or "owner_boundary_exceptions" in compact_projection
+    required_fields = ("source_surface", "owner", "ordinary_path_routes", "trigger", "suppression_rule", "projection_status")
+    missing_required_guidance = [
+        str(item.get("id") or item.get("field") or "")
+        for item in facts
+        if any(key not in item or item.get(key) in (None, "", []) for key in required_fields)
+    ]
+    scenario_ids = {
+        "positive-config-surfacing": "active" in statuses,
+        "selector-backed-owner-memory-intent": "selector-backed" in statuses,
+        "latent-suppression": "latent" in statuses,
+        "stale-or-unprojected-gap": bool(statuses & {"stale", "unprojected"}),
+        "ordinary-output-noise": not compact_has_fact_detail,
+    }
+    required_scenarios = ("positive-config-surfacing", "latent-suppression", "ordinary-output-noise")
+    checks = [
+        {
+            "id": "required-guidance-present",
+            "result": "fail" if missing_required_guidance else "pass",
+            "fails_when": "any projection row lacks source_surface, owner, ordinary_path_routes, trigger, suppression_rule, or projection_status",
+            "evidence": missing_required_guidance[:5],
+            "finding_route": "issue follow-up when a source family lacks route/status fields",
+        },
+        {
+            "id": "positive-and-suppression-scenarios-present",
+            "result": "pass" if all(scenario_ids[item] for item in required_scenarios) else "fail",
+            "fails_when": "representative active positive-surfacing or latent/ordinary-output suppression scenarios are missing",
+            "evidence": scenario_ids,
+            "finding_route": "Planning continuation or narrow issue for the missing scenario class",
+        },
+        {
+            "id": "irrelevant-guidance-suppressed-from-compact-output",
+            "result": "fail" if compact_has_fact_detail else "pass",
+            "fails_when": "compact ordinary projection contains full facts or owner-boundary exception prose",
+            "evidence": {"compact_has_fact_detail": compact_has_fact_detail},
+            "finding_route": "direct fix to router/compact projection shape",
+        },
+        {
+            "id": "compact-output-size-bounded",
+            "result": "pass" if compact_json_size <= 1400 else "fail",
+            "fails_when": "compact configuration_projection summary exceeds 1400 JSON bytes",
+            "evidence": {"compact_json_size": compact_json_size, "max_json_size": 1400},
+            "finding_route": "surface-value guardrail issue or direct compact-shape fix",
+        },
+    ]
+    failing = [item for item in checks if item["result"] == "fail"]
+    return {
+        "kind": "agentic-workspace/selective-surfacing-evaluation/v1",
+        "status": "pass" if not failing else "fail",
+        "purpose": "Cheap contract checks for whether configured guidance surfaces when needed and stays hidden when irrelevant.",
+        "scenario_count": len(scenario_ids),
+        "scenarios": [
+            {
+                "id": scenario_id,
+                "covered": covered,
+                "role": (
+                    "positive surfacing"
+                    if scenario_id.startswith("positive")
+                    else "selector-backed surfacing"
+                    if scenario_id.startswith("selector")
+                    else "non-applicable suppression"
+                    if scenario_id in {"latent-suppression", "ordinary-output-noise"}
+                    else "gap visibility"
+                ),
+            }
+            for scenario_id, covered in scenario_ids.items()
+        ],
+        "checks": checks,
+        "failing_checks": failing,
+        "metrics": {
+            "projection_row_count": len(facts),
+            "compact_json_size": compact_json_size,
+            "compact_selector_count": 1,
+            "status_counts": projection_payload.get("projection_status_counts", {}),
+        },
+        "finding_routing": {
+            "rule": "Route failed checks to the narrowest owner: direct fix for compact shape, issue for product behavior, Memory only for durable anti-rediscovery lessons.",
+            "memory_allowed_when": "the same evaluation failure recurs and the lesson is durable across tasks",
+        },
+        "detail_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section selective_surfacing_evaluation --format json",
+            cli_invoke=cli_invoke,
+        ),
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -8388,6 +8388,7 @@ def _run_report_command(
         cli_compatibility=_cli_compatibility_payload(config=config),
         summary=_summarise_reports(target_root=target_root, reports=module_reports, descriptors=descriptors, command_name="report"),
     )
+    configuration_projection = _configuration_projection_payload(config=config)
     payload = {
         "kind": "workspace-report/v1",
         "schema": _reporting_schema_payload(),
@@ -8414,8 +8415,8 @@ def _run_report_command(
         "maintainer_mode": _maintainer_mode_payload(config=config, target_root=target_root),
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
-        "configuration_projection": _configuration_projection_payload(config=config),
-        "selective_surfacing_evaluation": _configuration_projection_payload(config=config)["selective_surfacing_evaluation"],
+        "configuration_projection": configuration_projection,
+        "selective_surfacing_evaluation": configuration_projection["selective_surfacing_evaluation"],
         "branch_workflow_posture": branch_workflow_posture,
         "local_memory": local_memory,
         "memory_consult": memory_consult,
@@ -12101,6 +12102,7 @@ def _run_report_router_command(
             "command": next_command,
             "run": next_command,
         }
+    configuration_projection = _configuration_projection_payload(config=config)
     router_source = {
         "kind": "workspace-report/v1",
         "schema": _reporting_schema_payload(),
@@ -12123,8 +12125,8 @@ def _run_report_router_command(
         "report_profile": _report_profile_payload(cli_invoke=config.cli_invoke),
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
-        "configuration_projection": _compact_configuration_projection_payload(_configuration_projection_payload(config=config)),
-        "selective_surfacing_evaluation": _configuration_projection_payload(config=config)["selective_surfacing_evaluation"],
+        "configuration_projection": _compact_configuration_projection_payload(configuration_projection),
+        "selective_surfacing_evaluation": configuration_projection["selective_surfacing_evaluation"],
         "memory_consult": memory_consult,
         "reuse_pressure": _reuse_pressure_payload(target_root=target_root, cli_invoke=config.cli_invoke, compact=True),
         "execution_shape": _report_router_execution_shape_fast(config=config),

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -8414,6 +8414,7 @@ def _run_report_command(
         "maintainer_mode": _maintainer_mode_payload(config=config, target_root=target_root),
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
+        "configuration_projection": _configuration_projection_payload(config=config),
         "branch_workflow_posture": branch_workflow_posture,
         "local_memory": local_memory,
         "memory_consult": memory_consult,
@@ -12121,6 +12122,7 @@ def _run_report_router_command(
         "report_profile": _report_profile_payload(cli_invoke=config.cli_invoke),
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
+        "configuration_projection": _compact_configuration_projection_payload(_configuration_projection_payload(config=config)),
         "memory_consult": memory_consult,
         "reuse_pressure": _reuse_pressure_payload(target_root=target_root, cli_invoke=config.cli_invoke, compact=True),
         "execution_shape": _report_router_execution_shape_fast(config=config),
@@ -28928,6 +28930,182 @@ def _config_effect_audit_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
     }
 
 
+def _configuration_projection_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
+    effect_audit = _config_effect_audit_payload(config=config)
+    field_effects = [dict(item) for item in _list_payload(effect_audit.get("field_effects")) if isinstance(item, dict)]
+
+    projection_facts: list[dict[str, Any]] = []
+    for effect in field_effects:
+        field = str(effect.get("field", ""))
+        scope = str(effect.get("scope", ""))
+        dependency = str(effect.get("agent_dependency", ""))
+        commands = [str(item) for item in _list_payload(effect.get("concrete_commands")) if str(item).strip()]
+        payload_fields = [str(item) for item in _list_payload(effect.get("payload_fields")) if str(item).strip()]
+        owner_boundary = "human-owned" if scope == "repo-config" else "local-human-owned" if scope == "local-config" else "package-owned"
+        if dependency == "not-applicable":
+            status = "unprojected"
+        elif commands and payload_fields:
+            status = "active"
+        else:
+            status = "latent"
+        projection_facts.append(
+            {
+                "field": field,
+                "scope": scope,
+                "effect_type": str(effect.get("effect_type", "")),
+                "projection_status": status,
+                "ordinary_path_routes": commands,
+                "payload_fields": payload_fields,
+                "applicability_signal": _configuration_projection_applicability(field),
+                "suppression_rule": _configuration_projection_suppression(field),
+                "owner_boundary": owner_boundary,
+                "authority_exception": _configuration_projection_authority_exception(
+                    field=field, owner_boundary=owner_boundary, dependency=dependency
+                ),
+            }
+        )
+
+    status_counts: dict[str, int] = {"active": 0, "latent": 0, "stale": 0, "unprojected": 0}
+    for fact in projection_facts:
+        projection_status = str(fact.get("projection_status", "unprojected"))
+        status_counts[projection_status] = status_counts.get(projection_status, 0) + 1
+
+    positive_probes = [
+        {
+            "id": "startup-config-task-routes-to-config",
+            "command": _command_with_cli_invoke(
+                command='agentic-workspace start --target ./repo --task "inspect configured posture" --format json',
+                cli_invoke=config.cli_invoke,
+            ),
+            "expect": "next_safe_action.action=inspect-effective-config",
+            "covers": ["workspace posture", "config-posture-routing"],
+        },
+        {
+            "id": "implementation-routes-proof-and-posture",
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace implement --target ./repo --changed <paths> --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+            "expect": "proof, authority, and task_posture_packet reflect applicable config",
+            "covers": ["proof", "ownership", "closeout"],
+        },
+        {
+            "id": "report-section-inspects-projection",
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section configuration_projection --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+            "expect": "projection_status_counts and facts are present",
+            "covers": ["machine-consumable coverage"],
+        },
+    ]
+    suppression_probes = [
+        {
+            "id": "ordinary-report-keeps-detail-sectioned",
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --format json", cli_invoke=config.cli_invoke
+            ),
+            "expect": "router names configuration_projection in section hints without expanding every fact",
+            "covers": ["non-applicable suppression", "compact-output"],
+        },
+        {
+            "id": "local-posture-stays-local",
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace config --target ./repo --format json", cli_invoke=config.cli_invoke
+            ),
+            "expect": "local runtime/delegation posture is advisory and not shared repo authority",
+            "covers": ["ownership exceptions"],
+        },
+    ]
+    return {
+        "kind": "agentic-workspace/configuration-projection/v1",
+        "status": "present",
+        "purpose": "Machine-consumable coverage of which configured facts can affect ordinary startup, implementation, proof, report, and closeout routing.",
+        "rule": "Configured facts must have an ordinary-path route, applicability signal, suppression rule, owner boundary, and verification probe before being treated as active runtime guidance.",
+        "projection_status_counts": status_counts,
+        "facts": projection_facts,
+        "unprojected_fields": [fact for fact in projection_facts if fact.get("projection_status") == "unprojected"],
+        "owner_boundary_exceptions": [
+            {
+                "owner_boundary": "human-owned",
+                "rule": "Repo config declares policy and posture; AW may validate and project it, but the agent still owns semantic fit unless a hard gate is explicit.",
+            },
+            {
+                "owner_boundary": "local-human-owned",
+                "rule": "Local config may shape handoff and runtime guidance on this machine, but must not become shared repo authority or close issues by itself.",
+            },
+            {
+                "owner_boundary": "agent-owned",
+                "rule": "Config may recommend work shape, proof proportionality, or delegation, but cannot remove agent judgment where output labels authority_class=agent-owned or advisory-support.",
+            },
+        ],
+        "verification": {
+            "positive_surfacing": positive_probes,
+            "non_applicable_suppression": suppression_probes,
+            "contract_check": "Tests should assert both an applicable field surfacing path and an irrelevant/detail-heavy path staying sectioned.",
+        },
+        "detail_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section configuration_projection --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+    }
+
+
+def _compact_configuration_projection_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "kind": payload["kind"],
+        "status": payload["status"],
+        "projection_status_counts": payload["projection_status_counts"],
+        "unprojected_field_count": len(payload["unprojected_fields"]),
+        "owner_boundary_exception_count": len(payload["owner_boundary_exceptions"]),
+        "verification_probe_count": len(payload["verification"]["positive_surfacing"])
+        + len(payload["verification"]["non_applicable_suppression"]),
+        "detail_command": payload["detail_command"],
+    }
+
+
+def _configuration_projection_applicability(field: str) -> str:
+    if field.startswith("workflow_obligations"):
+        return "task text, changed paths, or active Planning scope matches obligation scope_tags"
+    if field.startswith("assurance"):
+        return "changed paths, active Planning assurance fields, or selected proof profile require assurance routing"
+    if field.startswith("runtime|handoff|safety|delegation_targets"):
+        return "delegation or runtime posture is relevant to the current task shape and safety allows handoff"
+    if field.startswith("local_memory"):
+        return "local memory is enabled and a memory-backed route is requested"
+    if field.startswith("system_intent"):
+        return "task, changed paths, or subsystem config intersects durable system intent"
+    if field.startswith("update.modules"):
+        return "status, doctor, or upgrade inspects installed module freshness"
+    if field.startswith("workspace.maintainer_mode"):
+        return "maintainer mode is enabled or dogfooding/reporting posture is requested"
+    return "configured field is requested directly or the ordinary route names its payload field"
+
+
+def _configuration_projection_suppression(field: str) -> str:
+    if field.startswith("workflow_obligations"):
+        return "hide obligation detail when no current scope tag matches; keep configured list behind config/report selectors"
+    if field.startswith("assurance"):
+        return "hide proof profile detail until proof selection, assurance report, or closeout trust needs it"
+    if field.startswith("runtime|handoff|safety|delegation_targets"):
+        return "hide target detail unless delegation posture changes the next action or config detail is requested"
+    if field.startswith("local_memory"):
+        return "hide local memory detail when disabled or when shared repo authority is being reported"
+    if field.startswith("system_intent"):
+        return "surface only compact applicable-intent facts unless system-intent detail is requested"
+    return "keep detailed field data behind config/report selectors unless it changes the ordinary next action"
+
+
+def _configuration_projection_authority_exception(*, field: str, owner_boundary: str, dependency: str) -> str:
+    if owner_boundary == "local-human-owned":
+        return "local-only advisory; cannot create shared repo obligations, proof gates, or closeout claims"
+    if dependency in {"medium", "high"}:
+        return "advisory or diagnostic projection; agent owns semantic applicability unless another payload reports a hard gate"
+    if field.startswith("assurance") or field.startswith("workflow_obligations"):
+        return "may create closeout or proof pressure only through the named proof, obligation, or closeout payload"
+    return "tool-owned validation may affect output, but human-owned config remains the source authority"
+
+
 def _scope_tags_for_current_work(
     *, active_planning_record: dict[str, Any] | None, task_text: str | None = None, changed_paths: list[str] | None = None
 ) -> tuple[list[str], list[str]]:
@@ -38441,6 +38619,7 @@ def _config_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
         "warnings": list(config.warnings),
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
+        "configuration_projection": _configuration_projection_payload(config=config),
         "workspace": {
             "enabled_modules": list(config.enabled_modules),
             "module_enablement_source": "repo-config" if config.exists else "product-default",
@@ -38541,6 +38720,7 @@ def _compact_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "warning_count": len(payload["config_effect_audit"]["claimed_vs_actual_warnings"]),
             "detail_command": payload["config_effect_audit"]["detail_command"],
         },
+        "configuration_projection": _compact_configuration_projection_payload(payload["configuration_projection"]),
         "workspace": {
             "enabled_modules": workspace["enabled_modules"],
             "agent_instructions_file": workspace["agent_instructions_file"],

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -8341,6 +8341,7 @@ def _run_report_command(
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
         "configuration_projection": _configuration_projection_payload(config=config),
+        "selective_surfacing_evaluation": _configuration_projection_payload(config=config)["selective_surfacing_evaluation"],
         "branch_workflow_posture": branch_workflow_posture,
         "local_memory": local_memory,
         "memory_consult": memory_consult,
@@ -12049,6 +12050,7 @@ def _run_report_router_command(
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
         "configuration_projection": _compact_configuration_projection_payload(_configuration_projection_payload(config=config)),
+        "selective_surfacing_evaluation": _configuration_projection_payload(config=config)["selective_surfacing_evaluation"],
         "memory_consult": memory_consult,
         "reuse_pressure": _reuse_pressure_payload(target_root=target_root, cli_invoke=config.cli_invoke, compact=True),
         "execution_shape": _report_router_execution_shape_fast(config=config),
@@ -28605,30 +28607,38 @@ def _configuration_projection_payload(*, config: WorkspaceConfig) -> dict[str, A
         commands = [str(item) for item in _list_payload(effect.get("concrete_commands")) if str(item).strip()]
         payload_fields = [str(item) for item in _list_payload(effect.get("payload_fields")) if str(item).strip()]
         owner_boundary = "human-owned" if scope == "repo-config" else "local-human-owned" if scope == "local-config" else "package-owned"
-        if dependency == "not-applicable":
-            status = "unprojected"
-        elif commands and payload_fields:
-            status = "active"
-        else:
-            status = "latent"
+        status = "unprojected" if dependency == "not-applicable" else "active" if commands and payload_fields else "latent"
         projection_facts.append(
-            {
-                "field": field,
-                "scope": scope,
-                "effect_type": str(effect.get("effect_type", "")),
-                "projection_status": status,
-                "ordinary_path_routes": commands,
-                "payload_fields": payload_fields,
-                "applicability_signal": _configuration_projection_applicability(field),
-                "suppression_rule": _configuration_projection_suppression(field),
-                "owner_boundary": owner_boundary,
-                "authority_exception": _configuration_projection_authority_exception(
+            _configuration_projection_row(
+                row_id=f"config:{field}",
+                source="workspace-config",
+                source_surface=".agentic-workspace/config.toml",
+                owner=owner_boundary,
+                field=field,
+                configured_concern=field,
+                status=status,
+                ordinary_path_routes=commands,
+                payload_fields=payload_fields,
+                trigger=_configuration_projection_applicability(field),
+                suppression_rule=_configuration_projection_suppression(field),
+                proof_or_test_coverage=["tests/test_workspace_config_cli.py", "tests/test_workspace_cli.py"],
+                effect_type=str(effect.get("effect_type", "")),
+                scope=scope,
+                authority_exception=_configuration_projection_authority_exception(
                     field=field, owner_boundary=owner_boundary, dependency=dependency
                 ),
-            }
+            )
         )
+    projection_facts.extend(_ambient_configuration_projection_rows(config=config))
 
-    status_counts: dict[str, int] = {"active": 0, "latent": 0, "stale": 0, "unprojected": 0}
+    status_counts: dict[str, int] = {
+        "active": 0,
+        "selector-backed": 0,
+        "latent": 0,
+        "stale": 0,
+        "unprojected": 0,
+        "owner-exempt": 0,
+    }
     for fact in projection_facts:
         projection_status = str(fact.get("projection_status", "unprojected"))
         status_counts[projection_status] = status_counts.get(projection_status, 0) + 1
@@ -28680,7 +28690,7 @@ def _configuration_projection_payload(*, config: WorkspaceConfig) -> dict[str, A
             "covers": ["ownership exceptions"],
         },
     ]
-    return {
+    payload = {
         "kind": "agentic-workspace/configuration-projection/v1",
         "status": "present",
         "purpose": "Machine-consumable coverage of which configured facts can affect ordinary startup, implementation, proof, report, and closeout routing.",
@@ -28712,9 +28722,195 @@ def _configuration_projection_payload(*, config: WorkspaceConfig) -> dict[str, A
             cli_invoke=config.cli_invoke,
         ),
     }
+    payload["selective_surfacing_evaluation"] = _selective_surfacing_evaluation_payload(
+        projection_payload=payload,
+        compact_projection=_compact_configuration_projection_payload(payload),
+        cli_invoke=config.cli_invoke,
+    )
+    return payload
+
+
+def _configuration_projection_row(
+    *,
+    row_id: str,
+    source: str,
+    source_surface: str,
+    owner: str,
+    field: str,
+    configured_concern: str,
+    status: str,
+    ordinary_path_routes: list[str],
+    payload_fields: list[str],
+    trigger: str,
+    suppression_rule: str,
+    proof_or_test_coverage: list[str],
+    scope: str = "",
+    effect_type: str = "",
+    authority_exception: str = "",
+) -> dict[str, Any]:
+    return {
+        "id": row_id,
+        "source": source,
+        "source_surface": source_surface,
+        "owner": owner,
+        "field": field,
+        "configured_concern": configured_concern,
+        "scope": scope,
+        "effect_type": effect_type,
+        "projection_status": status,
+        "status": status,
+        "ordinary_path_routes": ordinary_path_routes,
+        "payload_fields": payload_fields,
+        "trigger": trigger,
+        "applicability_signal": trigger,
+        "suppression_rule": suppression_rule,
+        "proof_or_test_coverage": proof_or_test_coverage,
+        "owner_boundary": owner,
+        "authority_exception": authority_exception
+        or "AW reports the route and owner; the agent owns semantic applicability unless a hard gate is explicit.",
+    }
+
+
+def _ambient_configuration_projection_rows(*, config: WorkspaceConfig) -> list[dict[str, Any]]:
+    target_root = config.target_root or Path(".")
+    rows: list[dict[str, Any]] = []
+    ownership_path = target_root / ".agentic-workspace" / "OWNERSHIP.toml"
+    ownership_exists = ownership_path.is_file()
+    rows.append(
+        _configuration_projection_row(
+            row_id="ownership:authority-ledger",
+            source="ownership",
+            source_surface=".agentic-workspace/OWNERSHIP.toml",
+            owner="human-owned",
+            field="ownership.authority_surfaces",
+            configured_concern="ownership, authority, audience, managed-surface, and subsystem routing",
+            status="selector-backed" if ownership_exists else "latent",
+            ordinary_path_routes=[
+                "agentic-workspace ownership --target ./repo --format json",
+                "agentic-workspace implement --target ./repo --changed <paths> --select change_impact --format json",
+            ],
+            payload_fields=["ownership", "change_impact.paths[].owner", "change_impact.paths[].optimization_posture"],
+            trigger="changed path intersects an authority surface, module root, managed surface, or subsystem path",
+            suppression_rule="ordinary report keeps ownership detail behind ownership/change_impact selectors unless a path boundary affects the next action",
+            proof_or_test_coverage=[
+                "tests/test_workspace_implement_cli.py::test_implement_change_impact_routes_optimization_posture_by_audience_boundary"
+            ],
+        )
+    )
+    system_intent_path = target_root / ".agentic-workspace" / "system-intent" / "intent.toml"
+    system_intent_sources = [str(item) for item in config.system_intent.sources if str(item).strip()]
+    rows.append(
+        _configuration_projection_row(
+            row_id="system-intent:durable-intent",
+            source="system-intent",
+            source_surface=".agentic-workspace/system-intent/intent.toml",
+            owner="human-owned",
+            field="system_intent.sources",
+            configured_concern="durable system and architecture intent",
+            status="selector-backed" if system_intent_path.is_file() or system_intent_sources else "latent",
+            ordinary_path_routes=[
+                "agentic-workspace system-intent --target ./repo --format json",
+                "agentic-workspace report --target ./repo --section durable_intent --format json",
+                "agentic-workspace implement --target ./repo --changed <paths> --select architecture_principles --format json",
+            ],
+            payload_fields=["durable_intent", "applicable_intent", "architecture_principles"],
+            trigger="task text or changed paths intersect durable system intent, subsystem intent, or architecture principle globs",
+            suppression_rule="surface compact applicable-intent or architecture-principle status only when work intersects durable intent; keep full intent behind selectors",
+            proof_or_test_coverage=["tests/test_workspace_implement_cli.py", "tests/test_workspace_intent_cli.py"],
+        )
+    )
+    verification_enabled = "verification" in set(config.enabled_modules)
+    verification_manifest = target_root / ".agentic-workspace" / "verification" / "manifest.toml"
+    verification_status = "selector-backed" if verification_manifest.is_file() else "stale" if verification_enabled else "latent"
+    rows.append(
+        _configuration_projection_row(
+            row_id="verification:manifest",
+            source="verification",
+            source_surface=".agentic-workspace/verification/manifest.toml",
+            owner="human-owned",
+            field="verification.manifest",
+            configured_concern="Verification protocol activation, proof routes, and known gaps",
+            status=verification_status,
+            ordinary_path_routes=[
+                "agentic-workspace report --target ./repo --section verification --format json",
+                "agentic-workspace proof --target ./repo --changed <paths> --format json",
+            ],
+            payload_fields=["verification", "proof.verification_enrichment", "assurance_requirements.verification"],
+            trigger="Verification module is enabled and a manifest protocol matches task markers, changed paths, or proof routes",
+            suppression_rule="do not surface inactive Verification protocol detail in ordinary output; report missing enabled manifest as stale coverage, not a hard blocker by default",
+            proof_or_test_coverage=[
+                "tests/test_workspace_implement_cli.py::test_implement_verification_task_marker_reports_configured_protocol_authority"
+            ],
+        )
+    )
+    memory_index = target_root / ".agentic-workspace" / "memory" / "repo" / "index.md"
+    rows.append(
+        _configuration_projection_row(
+            row_id="memory:routing-metadata",
+            source="memory",
+            source_surface=".agentic-workspace/memory/repo/index.md",
+            owner="memory-owned",
+            field="memory.routing_metadata",
+            configured_concern="Memory route hints, read budgets, and anti-rediscovery metadata",
+            status="selector-backed" if memory_index.is_file() else "latent",
+            ordinary_path_routes=[
+                "agentic-workspace memory route --target ./repo --stage implement --files <paths> --format json",
+                "agentic-workspace implement --target ./repo --changed <paths> --format json",
+            ],
+            payload_fields=["memory_consult", "memory_decision_packet"],
+            trigger="task or changed paths match Memory manifest/index routing metadata",
+            suppression_rule="ordinary paths show read-first and route counts; candidate owner detail stays behind Memory selectors",
+            proof_or_test_coverage=[
+                "tests/test_workspace_implement_cli.py::test_implement_surfaces_memory_decision_packet_for_changed_paths"
+            ],
+        )
+    )
+    active_plan = _active_planning_record_for_report_section(target_root=target_root)
+    active_plan_present = bool(active_plan) and str(active_plan.get("status", "")).lower() != "absent"
+    rows.append(
+        _configuration_projection_row(
+            row_id="planning:active-state-obligations",
+            source="planning",
+            source_surface=".agentic-workspace/planning/state.toml",
+            owner="planning-owned",
+            field="planning.active_state",
+            configured_concern="active Planning intent, proof expectations, blockers, and closeout obligations",
+            status="active" if active_plan_present else "latent",
+            ordinary_path_routes=[
+                "agentic-workspace summary --format json",
+                "agentic-workspace implement --target ./repo --changed <paths> --format json",
+                "agentic-workspace report --target ./repo --section completion_contract --format json",
+            ],
+            payload_fields=["summary.execution_readiness", "implement.planning_safety_gate", "completion_contract"],
+            trigger="active TODO item or execplan exists, or broad lane work needs shared intent custody",
+            suppression_rule="do not require Planning for narrow direct work; surface active obligations when present or when broad work claims lane progress",
+            proof_or_test_coverage=["tests/test_workspace_implement_cli.py", "tests/test_workspace_summary_cli.py"],
+        )
+    )
+    rows.append(
+        _configuration_projection_row(
+            row_id="local-memory:disabled-default",
+            source="local-config",
+            source_surface=".agentic-workspace/config.local.toml [local_memory]",
+            owner="local-human-owned",
+            field="local_memory.enabled",
+            configured_concern="optional local-only memory posture",
+            status="latent" if not config.local_override.local_memory_enabled else "selector-backed",
+            ordinary_path_routes=["agentic-workspace report --target ./repo --section local_memory --format json"],
+            payload_fields=["local_memory"],
+            trigger="local_memory.enabled is true in local config",
+            suppression_rule="disabled or local-only memory stays out of shared authority and ordinary repo closeout",
+            proof_or_test_coverage=["tests/test_workspace_config_cli.py"],
+            authority_exception="local-only advisory; cannot become shared Planning, Memory, proof, or closeout authority",
+        )
+    )
+    return rows
 
 
 def _compact_configuration_projection_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    evaluation = payload.get("selective_surfacing_evaluation", {})
+    checks = _list_payload(evaluation.get("checks")) if isinstance(evaluation, dict) else []
+    failing = [item for item in checks if isinstance(item, dict) and item.get("result") == "fail"]
     return {
         "kind": payload["kind"],
         "status": payload["status"],
@@ -28723,7 +28919,105 @@ def _compact_configuration_projection_payload(payload: dict[str, Any]) -> dict[s
         "owner_boundary_exception_count": len(payload["owner_boundary_exceptions"]),
         "verification_probe_count": len(payload["verification"]["positive_surfacing"])
         + len(payload["verification"]["non_applicable_suppression"]),
+        "evaluation": {
+            "status": evaluation.get("status", "not-run") if isinstance(evaluation, dict) else "not-run",
+            "check_count": len(checks),
+            "failing_check_count": len(failing),
+            "detail_section": "selective_surfacing_evaluation",
+        },
         "detail_command": payload["detail_command"],
+    }
+
+
+def _selective_surfacing_evaluation_payload(
+    *, projection_payload: dict[str, Any], compact_projection: dict[str, Any], cli_invoke: str
+) -> dict[str, Any]:
+    facts = [dict(item) for item in _list_payload(projection_payload.get("facts")) if isinstance(item, dict)]
+    statuses = {str(item.get("projection_status") or item.get("status") or "") for item in facts}
+    compact_json_size = len(json.dumps(compact_projection, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    compact_has_fact_detail = "facts" in compact_projection or "owner_boundary_exceptions" in compact_projection
+    required_fields = ("source_surface", "owner", "ordinary_path_routes", "trigger", "suppression_rule", "projection_status")
+    missing_required_guidance = [
+        str(item.get("id") or item.get("field") or "")
+        for item in facts
+        if any(key not in item or item.get(key) in (None, "", []) for key in required_fields)
+    ]
+    scenario_ids = {
+        "positive-config-surfacing": "active" in statuses,
+        "selector-backed-owner-memory-intent": "selector-backed" in statuses,
+        "latent-suppression": "latent" in statuses,
+        "stale-or-unprojected-gap": bool(statuses & {"stale", "unprojected"}),
+        "ordinary-output-noise": not compact_has_fact_detail,
+    }
+    required_scenarios = ("positive-config-surfacing", "latent-suppression", "ordinary-output-noise")
+    checks = [
+        {
+            "id": "required-guidance-present",
+            "result": "fail" if missing_required_guidance else "pass",
+            "fails_when": "any projection row lacks source_surface, owner, ordinary_path_routes, trigger, suppression_rule, or projection_status",
+            "evidence": missing_required_guidance[:5],
+            "finding_route": "issue follow-up when a source family lacks route/status fields",
+        },
+        {
+            "id": "positive-and-suppression-scenarios-present",
+            "result": "pass" if all(scenario_ids[item] for item in required_scenarios) else "fail",
+            "fails_when": "representative active positive-surfacing or latent/ordinary-output suppression scenarios are missing",
+            "evidence": scenario_ids,
+            "finding_route": "Planning continuation or narrow issue for the missing scenario class",
+        },
+        {
+            "id": "irrelevant-guidance-suppressed-from-compact-output",
+            "result": "fail" if compact_has_fact_detail else "pass",
+            "fails_when": "compact ordinary projection contains full facts or owner-boundary exception prose",
+            "evidence": {"compact_has_fact_detail": compact_has_fact_detail},
+            "finding_route": "direct fix to router/compact projection shape",
+        },
+        {
+            "id": "compact-output-size-bounded",
+            "result": "pass" if compact_json_size <= 1400 else "fail",
+            "fails_when": "compact configuration_projection summary exceeds 1400 JSON bytes",
+            "evidence": {"compact_json_size": compact_json_size, "max_json_size": 1400},
+            "finding_route": "surface-value guardrail issue or direct compact-shape fix",
+        },
+    ]
+    failing = [item for item in checks if item["result"] == "fail"]
+    return {
+        "kind": "agentic-workspace/selective-surfacing-evaluation/v1",
+        "status": "pass" if not failing else "fail",
+        "purpose": "Cheap contract checks for whether configured guidance surfaces when needed and stays hidden when irrelevant.",
+        "scenario_count": len(scenario_ids),
+        "scenarios": [
+            {
+                "id": scenario_id,
+                "covered": covered,
+                "role": (
+                    "positive surfacing"
+                    if scenario_id.startswith("positive")
+                    else "selector-backed surfacing"
+                    if scenario_id.startswith("selector")
+                    else "non-applicable suppression"
+                    if scenario_id in {"latent-suppression", "ordinary-output-noise"}
+                    else "gap visibility"
+                ),
+            }
+            for scenario_id, covered in scenario_ids.items()
+        ],
+        "checks": checks,
+        "failing_checks": failing,
+        "metrics": {
+            "projection_row_count": len(facts),
+            "compact_json_size": compact_json_size,
+            "compact_selector_count": 1,
+            "status_counts": projection_payload.get("projection_status_counts", {}),
+        },
+        "finding_routing": {
+            "rule": "Route failed checks to the narrowest owner: direct fix for compact shape, issue for product behavior, Memory only for durable anti-rediscovery lessons.",
+            "memory_allowed_when": "the same evaluation failure recurs and the lesson is durable across tasks",
+        },
+        "detail_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section selective_surfacing_evaluation --format json",
+            cli_invoke=cli_invoke,
+        ),
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -8340,6 +8340,7 @@ def _run_report_command(
         "maintainer_mode": _maintainer_mode_payload(config=config, target_root=target_root),
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
+        "configuration_projection": _configuration_projection_payload(config=config),
         "branch_workflow_posture": branch_workflow_posture,
         "local_memory": local_memory,
         "memory_consult": memory_consult,
@@ -12047,6 +12048,7 @@ def _run_report_router_command(
         "report_profile": _report_profile_payload(cli_invoke=config.cli_invoke),
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
+        "configuration_projection": _compact_configuration_projection_payload(_configuration_projection_payload(config=config)),
         "memory_consult": memory_consult,
         "reuse_pressure": _reuse_pressure_payload(target_root=target_root, cli_invoke=config.cli_invoke, compact=True),
         "execution_shape": _report_router_execution_shape_fast(config=config),
@@ -28591,6 +28593,182 @@ def _config_effect_audit_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
     }
 
 
+def _configuration_projection_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
+    effect_audit = _config_effect_audit_payload(config=config)
+    field_effects = [dict(item) for item in _list_payload(effect_audit.get("field_effects")) if isinstance(item, dict)]
+
+    projection_facts: list[dict[str, Any]] = []
+    for effect in field_effects:
+        field = str(effect.get("field", ""))
+        scope = str(effect.get("scope", ""))
+        dependency = str(effect.get("agent_dependency", ""))
+        commands = [str(item) for item in _list_payload(effect.get("concrete_commands")) if str(item).strip()]
+        payload_fields = [str(item) for item in _list_payload(effect.get("payload_fields")) if str(item).strip()]
+        owner_boundary = "human-owned" if scope == "repo-config" else "local-human-owned" if scope == "local-config" else "package-owned"
+        if dependency == "not-applicable":
+            status = "unprojected"
+        elif commands and payload_fields:
+            status = "active"
+        else:
+            status = "latent"
+        projection_facts.append(
+            {
+                "field": field,
+                "scope": scope,
+                "effect_type": str(effect.get("effect_type", "")),
+                "projection_status": status,
+                "ordinary_path_routes": commands,
+                "payload_fields": payload_fields,
+                "applicability_signal": _configuration_projection_applicability(field),
+                "suppression_rule": _configuration_projection_suppression(field),
+                "owner_boundary": owner_boundary,
+                "authority_exception": _configuration_projection_authority_exception(
+                    field=field, owner_boundary=owner_boundary, dependency=dependency
+                ),
+            }
+        )
+
+    status_counts: dict[str, int] = {"active": 0, "latent": 0, "stale": 0, "unprojected": 0}
+    for fact in projection_facts:
+        projection_status = str(fact.get("projection_status", "unprojected"))
+        status_counts[projection_status] = status_counts.get(projection_status, 0) + 1
+
+    positive_probes = [
+        {
+            "id": "startup-config-task-routes-to-config",
+            "command": _command_with_cli_invoke(
+                command='agentic-workspace start --target ./repo --task "inspect configured posture" --format json',
+                cli_invoke=config.cli_invoke,
+            ),
+            "expect": "next_safe_action.action=inspect-effective-config",
+            "covers": ["workspace posture", "config-posture-routing"],
+        },
+        {
+            "id": "implementation-routes-proof-and-posture",
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace implement --target ./repo --changed <paths> --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+            "expect": "proof, authority, and task_posture_packet reflect applicable config",
+            "covers": ["proof", "ownership", "closeout"],
+        },
+        {
+            "id": "report-section-inspects-projection",
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section configuration_projection --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+            "expect": "projection_status_counts and facts are present",
+            "covers": ["machine-consumable coverage"],
+        },
+    ]
+    suppression_probes = [
+        {
+            "id": "ordinary-report-keeps-detail-sectioned",
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --format json", cli_invoke=config.cli_invoke
+            ),
+            "expect": "router names configuration_projection in section hints without expanding every fact",
+            "covers": ["non-applicable suppression", "compact-output"],
+        },
+        {
+            "id": "local-posture-stays-local",
+            "command": _command_with_cli_invoke(
+                command="agentic-workspace config --target ./repo --format json", cli_invoke=config.cli_invoke
+            ),
+            "expect": "local runtime/delegation posture is advisory and not shared repo authority",
+            "covers": ["ownership exceptions"],
+        },
+    ]
+    return {
+        "kind": "agentic-workspace/configuration-projection/v1",
+        "status": "present",
+        "purpose": "Machine-consumable coverage of which configured facts can affect ordinary startup, implementation, proof, report, and closeout routing.",
+        "rule": "Configured facts must have an ordinary-path route, applicability signal, suppression rule, owner boundary, and verification probe before being treated as active runtime guidance.",
+        "projection_status_counts": status_counts,
+        "facts": projection_facts,
+        "unprojected_fields": [fact for fact in projection_facts if fact.get("projection_status") == "unprojected"],
+        "owner_boundary_exceptions": [
+            {
+                "owner_boundary": "human-owned",
+                "rule": "Repo config declares policy and posture; AW may validate and project it, but the agent still owns semantic fit unless a hard gate is explicit.",
+            },
+            {
+                "owner_boundary": "local-human-owned",
+                "rule": "Local config may shape handoff and runtime guidance on this machine, but must not become shared repo authority or close issues by itself.",
+            },
+            {
+                "owner_boundary": "agent-owned",
+                "rule": "Config may recommend work shape, proof proportionality, or delegation, but cannot remove agent judgment where output labels authority_class=agent-owned or advisory-support.",
+            },
+        ],
+        "verification": {
+            "positive_surfacing": positive_probes,
+            "non_applicable_suppression": suppression_probes,
+            "contract_check": "Tests should assert both an applicable field surfacing path and an irrelevant/detail-heavy path staying sectioned.",
+        },
+        "detail_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section configuration_projection --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+    }
+
+
+def _compact_configuration_projection_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "kind": payload["kind"],
+        "status": payload["status"],
+        "projection_status_counts": payload["projection_status_counts"],
+        "unprojected_field_count": len(payload["unprojected_fields"]),
+        "owner_boundary_exception_count": len(payload["owner_boundary_exceptions"]),
+        "verification_probe_count": len(payload["verification"]["positive_surfacing"])
+        + len(payload["verification"]["non_applicable_suppression"]),
+        "detail_command": payload["detail_command"],
+    }
+
+
+def _configuration_projection_applicability(field: str) -> str:
+    if field.startswith("workflow_obligations"):
+        return "task text, changed paths, or active Planning scope matches obligation scope_tags"
+    if field.startswith("assurance"):
+        return "changed paths, active Planning assurance fields, or selected proof profile require assurance routing"
+    if field.startswith("runtime|handoff|safety|delegation_targets"):
+        return "delegation or runtime posture is relevant to the current task shape and safety allows handoff"
+    if field.startswith("local_memory"):
+        return "local memory is enabled and a memory-backed route is requested"
+    if field.startswith("system_intent"):
+        return "task, changed paths, or subsystem config intersects durable system intent"
+    if field.startswith("update.modules"):
+        return "status, doctor, or upgrade inspects installed module freshness"
+    if field.startswith("workspace.maintainer_mode"):
+        return "maintainer mode is enabled or dogfooding/reporting posture is requested"
+    return "configured field is requested directly or the ordinary route names its payload field"
+
+
+def _configuration_projection_suppression(field: str) -> str:
+    if field.startswith("workflow_obligations"):
+        return "hide obligation detail when no current scope tag matches; keep configured list behind config/report selectors"
+    if field.startswith("assurance"):
+        return "hide proof profile detail until proof selection, assurance report, or closeout trust needs it"
+    if field.startswith("runtime|handoff|safety|delegation_targets"):
+        return "hide target detail unless delegation posture changes the next action or config detail is requested"
+    if field.startswith("local_memory"):
+        return "hide local memory detail when disabled or when shared repo authority is being reported"
+    if field.startswith("system_intent"):
+        return "surface only compact applicable-intent facts unless system-intent detail is requested"
+    return "keep detailed field data behind config/report selectors unless it changes the ordinary next action"
+
+
+def _configuration_projection_authority_exception(*, field: str, owner_boundary: str, dependency: str) -> str:
+    if owner_boundary == "local-human-owned":
+        return "local-only advisory; cannot create shared repo obligations, proof gates, or closeout claims"
+    if dependency in {"medium", "high"}:
+        return "advisory or diagnostic projection; agent owns semantic applicability unless another payload reports a hard gate"
+    if field.startswith("assurance") or field.startswith("workflow_obligations"):
+        return "may create closeout or proof pressure only through the named proof, obligation, or closeout payload"
+    return "tool-owned validation may affect output, but human-owned config remains the source authority"
+
+
 def _scope_tags_for_current_work(
     *, active_planning_record: dict[str, Any] | None, task_text: str | None = None, changed_paths: list[str] | None = None
 ) -> tuple[list[str], list[str]]:
@@ -38104,6 +38282,7 @@ def _config_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
         "warnings": list(config.warnings),
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
+        "configuration_projection": _configuration_projection_payload(config=config),
         "workspace": {
             "enabled_modules": list(config.enabled_modules),
             "module_enablement_source": "repo-config" if config.exists else "product-default",
@@ -38204,6 +38383,7 @@ def _compact_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "warning_count": len(payload["config_effect_audit"]["claimed_vs_actual_warnings"]),
             "detail_command": payload["config_effect_audit"]["detail_command"],
         },
+        "configuration_projection": _compact_configuration_projection_payload(payload["configuration_projection"]),
         "workspace": {
             "enabled_modules": workspace["enabled_modules"],
             "agent_instructions_file": workspace["agent_instructions_file"],

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -8314,6 +8314,7 @@ def _run_report_command(
         cli_compatibility=_cli_compatibility_payload(config=config),
         summary=_summarise_reports(target_root=target_root, reports=module_reports, descriptors=descriptors, command_name="report"),
     )
+    configuration_projection = _configuration_projection_payload(config=config)
     payload = {
         "kind": "workspace-report/v1",
         "schema": _reporting_schema_payload(),
@@ -8340,8 +8341,8 @@ def _run_report_command(
         "maintainer_mode": _maintainer_mode_payload(config=config, target_root=target_root),
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
-        "configuration_projection": _configuration_projection_payload(config=config),
-        "selective_surfacing_evaluation": _configuration_projection_payload(config=config)["selective_surfacing_evaluation"],
+        "configuration_projection": configuration_projection,
+        "selective_surfacing_evaluation": configuration_projection["selective_surfacing_evaluation"],
         "branch_workflow_posture": branch_workflow_posture,
         "local_memory": local_memory,
         "memory_consult": memory_consult,
@@ -12027,6 +12028,7 @@ def _run_report_router_command(
             "command": next_command,
             "run": next_command,
         }
+    configuration_projection = _configuration_projection_payload(config=config)
     router_source = {
         "kind": "workspace-report/v1",
         "schema": _reporting_schema_payload(),
@@ -12049,8 +12051,8 @@ def _run_report_router_command(
         "report_profile": _report_profile_payload(cli_invoke=config.cli_invoke),
         "config_enforcement": _config_enforcement_payload(config=config),
         "config_effect_audit": _config_effect_audit_payload(config=config),
-        "configuration_projection": _compact_configuration_projection_payload(_configuration_projection_payload(config=config)),
-        "selective_surfacing_evaluation": _configuration_projection_payload(config=config)["selective_surfacing_evaluation"],
+        "configuration_projection": _compact_configuration_projection_payload(configuration_projection),
+        "selective_surfacing_evaluation": configuration_projection["selective_surfacing_evaluation"],
         "memory_consult": memory_consult,
         "reuse_pressure": _reuse_pressure_payload(target_root=target_root, cli_invoke=config.cli_invoke, compact=True),
         "execution_shape": _report_router_execution_shape_fast(config=config),

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1326,6 +1326,32 @@ def test_report_sections_expose_authority_and_compliance_boundaries(tmp_path: Pa
     assert strengths["schema_validity"] == "strong"
 
 
+def test_report_exposes_configuration_projection_without_expanding_config_detail(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    assert cli.main(["report", "--target", str(tmp_path), "--format", "json"]) == 0
+
+    router = json.loads(capsys.readouterr().out)
+    projection = router["context"]["configuration_projection"]
+    assert projection["projection_status_counts"]["active"] >= 1
+    assert projection["unprojected_field_count"] == 0
+    assert projection["verification_probe_count"] >= 2
+    assert "facts" not in projection
+    hint = next(item for item in router["drill_down"]["section_hints"] if item["section"] == "configuration_projection")
+    assert "projection coverage" in hint["purpose_summary"]
+    assert hint["volume"] == "normal"
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "configuration_projection", "--format", "json"]) == 0
+
+    selected = json.loads(capsys.readouterr().out)
+    assert selected["selector"] == {"section": "configuration_projection"}
+    answer = selected["answer"]
+    assert answer["kind"] == "agentic-workspace/configuration-projection/v1"
+    assert answer["unprojected_fields"] == []
+    assert any(item["owner_boundary"] == "local-human-owned" for item in answer["facts"])
+    assert answer["verification"]["non_applicable_suppression"][0]["id"] == "ordinary-report-keeps-detail-sectioned"
+
+
 def test_improvement_intake_includes_repair_recurrence_subtype(capsys) -> None:
     assert cli.main(["defaults", "--verbose", "--section", "improvement_intake", "--format", "json"]) == 0
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1336,10 +1336,19 @@ def test_report_exposes_configuration_projection_without_expanding_config_detail
     assert projection["projection_status_counts"]["active"] >= 1
     assert projection["unprojected_field_count"] == 0
     assert projection["verification_probe_count"] >= 2
+    assert projection["evaluation"]["status"] == "pass"
+    assert projection["evaluation"]["detail_section"] == "selective_surfacing_evaluation"
     assert "facts" not in projection
+    assert "owner_boundary_exceptions" not in projection
+    evaluation = router["context"]["selective_surfacing_evaluation"]
+    assert evaluation["status"] == "pass"
+    assert evaluation["failing_check_count"] == 0
+    assert evaluation["metrics"]["compact_selector_count"] == 1
     hint = next(item for item in router["drill_down"]["section_hints"] if item["section"] == "configuration_projection")
     assert "projection coverage" in hint["purpose_summary"]
     assert hint["volume"] == "normal"
+    eval_hint = next(item for item in router["drill_down"]["section_hints"] if item["section"] == "selective_surfacing_evaluation")
+    assert "cheap contract checks" in eval_hint["purpose_summary"]
 
     assert cli.main(["report", "--target", str(tmp_path), "--section", "configuration_projection", "--format", "json"]) == 0
 
@@ -1350,6 +1359,42 @@ def test_report_exposes_configuration_projection_without_expanding_config_detail
     assert answer["unprojected_fields"] == []
     assert any(item["owner_boundary"] == "local-human-owned" for item in answer["facts"])
     assert answer["verification"]["non_applicable_suppression"][0]["id"] == "ordinary-report-keeps-detail-sectioned"
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "selective_surfacing_evaluation", "--format", "json"]) == 0
+
+    selected_eval = json.loads(capsys.readouterr().out)
+    assert selected_eval["selector"] == {"section": "selective_surfacing_evaluation"}
+    assert selected_eval["answer"]["kind"] == "agentic-workspace/selective-surfacing-evaluation/v1"
+    assert selected_eval["answer"]["status"] == "pass"
+    assert selected_eval["answer"]["metrics"]["compact_json_size"] <= 1400
+
+
+def test_selective_surfacing_evaluation_fails_on_missing_guidance_or_compact_noise(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    config = cli._load_workspace_config(target_root=tmp_path)
+    projection = cli._configuration_projection_payload(config=config)
+    compact = cli._compact_configuration_projection_payload(projection)
+
+    noisy_compact = {**compact, "facts": projection["facts"]}
+    noisy_evaluation = cli._selective_surfacing_evaluation_payload(
+        projection_payload=projection,
+        compact_projection=noisy_compact,
+        cli_invoke=config.cli_invoke,
+    )
+    noisy_checks = {check["id"]: check for check in noisy_evaluation["checks"]}
+    assert noisy_checks["irrelevant-guidance-suppressed-from-compact-output"]["result"] == "fail"
+    assert noisy_evaluation["status"] == "fail"
+
+    broken_projection = {**projection, "facts": [{"id": "broken:row", "projection_status": "active"}]}
+    missing_evaluation = cli._selective_surfacing_evaluation_payload(
+        projection_payload=broken_projection,
+        compact_projection=compact,
+        cli_invoke=config.cli_invoke,
+    )
+    missing_checks = {check["id"]: check for check in missing_evaluation["checks"]}
+    assert missing_checks["required-guidance-present"]["result"] == "fail"
+    assert missing_checks["required-guidance-present"]["evidence"] == ["broken:row"]
+    assert missing_evaluation["finding_routing"]["rule"].startswith("Route failed checks")
 
 
 def test_improvement_intake_includes_repair_recurrence_subtype(capsys) -> None:

--- a/tests/test_workspace_config_cli.py
+++ b/tests/test_workspace_config_cli.py
@@ -48,6 +48,24 @@ def test_config_command_reports_effective_defaults_without_repo_file(tmp_path: P
     assert payload["config_effect_audit"]["detail_command"].endswith(
         "agentic-workspace report --target ./repo --section config_effect_audit --format json"
     )
+    projection = payload["configuration_projection"]
+    assert projection["kind"] == "agentic-workspace/configuration-projection/v1"
+    assert projection["projection_status_counts"]["active"] >= 1
+    assert projection["projection_status_counts"]["unprojected"] == 0
+    assert projection["unprojected_fields"] == []
+    obligation_projection = next(field for field in projection["facts"] if field["field"] == "workflow_obligations.<name>.*")
+    assert obligation_projection["projection_status"] == "active"
+    assert "scope_tags" in obligation_projection["applicability_signal"]
+    assert "hide obligation detail" in obligation_projection["suppression_rule"]
+    assert obligation_projection["owner_boundary"] == "human-owned"
+    local_projection = next(field for field in projection["facts"] if field["field"] == "runtime|handoff|safety|delegation_targets")
+    assert local_projection["owner_boundary"] == "local-human-owned"
+    assert "cannot create shared repo obligations" in local_projection["authority_exception"]
+    assert projection["verification"]["positive_surfacing"][0]["id"] == "startup-config-task-routes-to-config"
+    assert projection["verification"]["non_applicable_suppression"][0]["id"] == "ordinary-report-keeps-detail-sectioned"
+    assert projection["detail_command"].endswith(
+        "agentic-workspace report --target ./repo --section configuration_projection --format json"
+    )
     assert payload["update"]["wrapper_rule"] == "normal update execution stays behind agentic-workspace"
     assert {item["module"] for item in payload["update"]["modules"]} == {"planning", "memory"}
     assert {item["freshness"]["status"] for item in payload["update"]["modules"]} == {"unknown"}
@@ -307,7 +325,23 @@ requires_human_verification_on_pr = true
     assert payload["next_detail"]["select"].endswith("agentic-workspace config --target . --select <field.path> --format json")
     assert payload["next_detail"]["verbose"].endswith("agentic-workspace config --target . --verbose --format json")
     assert "config_effect_audit" not in payload
+    assert "configuration_projection" not in payload
     assert len(output) < 3000
+
+
+def test_config_command_compact_reports_projection_summary_without_fact_detail(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    full_payload = cli._config_payload(config=cli._load_workspace_config(target_root=tmp_path))
+    payload = cli._compact_config_payload(full_payload)
+    projection = payload["configuration_projection"]
+    assert projection["status"] == "present"
+    assert projection["projection_status_counts"]["active"] >= 1
+    assert projection["unprojected_field_count"] == 0
+    assert projection["detail_command"].endswith(
+        "agentic-workspace report --target ./repo --section configuration_projection --format json"
+    )
+    assert "facts" not in projection
 
 
 def test_config_command_accepts_reporting_improvement_latitude_mode(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_config_cli.py
+++ b/tests/test_workspace_config_cli.py
@@ -51,10 +51,22 @@ def test_config_command_reports_effective_defaults_without_repo_file(tmp_path: P
     projection = payload["configuration_projection"]
     assert projection["kind"] == "agentic-workspace/configuration-projection/v1"
     assert projection["projection_status_counts"]["active"] >= 1
+    assert projection["projection_status_counts"]["latent"] >= 1
     assert projection["projection_status_counts"]["unprojected"] == 0
     assert projection["unprojected_fields"] == []
+    projection_sources = {field["id"] for field in projection["facts"]}
+    assert {
+        "ownership:authority-ledger",
+        "system-intent:durable-intent",
+        "verification:manifest",
+        "memory:routing-metadata",
+        "planning:active-state-obligations",
+    } <= projection_sources
     obligation_projection = next(field for field in projection["facts"] if field["field"] == "workflow_obligations.<name>.*")
     assert obligation_projection["projection_status"] == "active"
+    assert obligation_projection["source_surface"] == ".agentic-workspace/config.toml"
+    assert obligation_projection["ordinary_path_routes"]
+    assert obligation_projection["trigger"]
     assert "scope_tags" in obligation_projection["applicability_signal"]
     assert "hide obligation detail" in obligation_projection["suppression_rule"]
     assert obligation_projection["owner_boundary"] == "human-owned"
@@ -66,6 +78,15 @@ def test_config_command_reports_effective_defaults_without_repo_file(tmp_path: P
     assert projection["detail_command"].endswith(
         "agentic-workspace report --target ./repo --section configuration_projection --format json"
     )
+    surfacing_eval = projection["selective_surfacing_evaluation"]
+    assert surfacing_eval["status"] == "pass"
+    assert {check["id"]: check["result"] for check in surfacing_eval["checks"]} == {
+        "required-guidance-present": "pass",
+        "positive-and-suppression-scenarios-present": "pass",
+        "irrelevant-guidance-suppressed-from-compact-output": "pass",
+        "compact-output-size-bounded": "pass",
+    }
+    assert surfacing_eval["metrics"]["projection_row_count"] == len(projection["facts"])
     assert payload["update"]["wrapper_rule"] == "normal update execution stays behind agentic-workspace"
     assert {item["module"] for item in payload["update"]["modules"]} == {"planning", "memory"}
     assert {item["freshness"]["status"] for item in payload["update"]["modules"]} == {"unknown"}
@@ -205,6 +226,40 @@ def test_config_command_reports_effective_defaults_without_repo_file(tmp_path: P
         "cheap switching across agents and subscriptions",
         "persisted shared knowledge beats rediscovery",
     ]
+
+
+def test_configuration_projection_reports_selector_backed_and_stale_sources(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write(
+        tmp_path / ".agentic-workspace/config.toml",
+        """
+schema_version = 1
+
+[modules]
+enabled = ["planning", "memory", "verification"]
+""".strip(),
+    )
+    verification_manifest = tmp_path / ".agentic-workspace/verification/manifest.toml"
+    if verification_manifest.exists():
+        verification_manifest.unlink()
+
+    assert cli.main(["config", "--verbose", "--target", str(tmp_path), "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    projection = payload["configuration_projection"]
+    facts = {field["id"]: field for field in projection["facts"]}
+    assert facts["ownership:authority-ledger"]["projection_status"] == "selector-backed"
+    assert facts["memory:routing-metadata"]["projection_status"] == "selector-backed"
+    assert facts["verification:manifest"]["projection_status"] == "stale"
+    assert projection["projection_status_counts"]["selector-backed"] >= 2
+    assert projection["projection_status_counts"]["stale"] >= 1
+    assert facts["verification:manifest"]["ordinary_path_routes"]
+    assert "missing enabled manifest" in facts["verification:manifest"]["suppression_rule"]
+    scenarios = {scenario["id"]: scenario["covered"] for scenario in projection["selective_surfacing_evaluation"]["scenarios"]}
+    assert scenarios["selector-backed-owner-memory-intent"] is True
+    assert scenarios["stale-or-unprojected-gap"] is True
 
 
 def test_config_command_reports_selected_fields_for_agent_startup(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Completes the full #1792 configuration-driven instruction surfacing lane, including the child issue scope for projection coverage, audience/authority posture routing, and executable selective-surfacing evaluation.

- Expands `configuration_projection` beyond config-field effects to compact rows for config, ownership, system intent, Verification, Memory, Planning active-state obligations, and local-memory posture.
- Records source surface, owner, ordinary-path routes, trigger/applicability signal, suppression rule, projection status, payload fields, owner-boundary exceptions, and proof/test coverage for each row.
- Keeps ordinary report output compact while exposing full projection detail behind `report --section configuration_projection` and exposing an executable `selective_surfacing_evaluation` section for cheap contract checks.
- Adds selector-backed and stale projection coverage, plus failing evaluator checks for missing required guidance and compact-output noise.
- Carries #1794 through the existing reusable changed-path audience/authority posture route in `implement --select change_impact`, with the projection report now pointing at that tested surface.
- Caches the computed projection payload in report assembly so the ordinary report and router reuse the same evaluation instead of recomputing it.

## Issue Coverage

Closes #1792.
Closes #1793.
Closes #1794.
Closes #1795.

Child issue evidence:

- #1793: `configuration_projection` now covers `.agentic-workspace/config.toml`, `OWNERSHIP.toml`, system intent, Verification manifest, Memory routing metadata, Planning active-state obligations, and local-only memory posture with active, selector-backed, latent, and stale status coverage.
- #1794: audience/authority posture routing is exercised through `implement --select change_impact`; ownership projection rows route readers to `test_implement_change_impact_routes_optimization_posture_by_audience_boundary` and the ordinary implementation posture surface.
- #1795: `selective_surfacing_evaluation` provides executable checks for required row guidance, positive surfacing, non-applicable suppression, compact-output noise, size bounds, scenario coverage, metrics, and finding routing.
- #1792: parent closure is based on all child surfaces plus tests/proof, not the earlier single config-field slice.

## Proof

Full lane proof:

- `uv run python scripts/run_agentic_workspace.py summary --target . --format json` passed with no warnings.
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` exited 0; it still reports a pre-existing repo-owned `AGENTS.md` pointer warning unrelated to this lane.
- `uv run pytest tests/test_workspace_config_cli.py tests/test_workspace_cli.py tests/test_workspace_implement_cli.py -q` passed: 218 tests.
- `make test-workspace` passed.
- `make lint-workspace` passed.
- `uv run pytest tests/test_workspace_cli.py -q` passed: 47 tests.

Review-cleanup proof after caching the projection payload:

- `uv run pytest tests/test_workspace_cli.py::test_report_exposes_configuration_projection_without_expanding_config_detail -q` passed.
- `uv run pytest tests/test_workspace_cli.py -q` passed: 47 tests.
- `make lint-workspace` passed.
- `make test-workspace` passed.

## Runtime Source Edit Review

`src/agentic_workspace/workspace_runtime_primitives.py` is an inventory-backed workspace runtime primitive surface. Edit reason: new primitive implementation and follow-up cleanup for the `config.report` / `report.combined` runtime payloads and report-router selector shape. Owner: workspace package runtime boundary. Proof: focused tests, full workspace test target, and lint passed.