### PR TITLE
[codex] Surface custody-only Planning

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -13461,6 +13461,22 @@ def _operating_loop_planning_state(
         return {"state": "closeout_required", "plan_ref": plan_ref, "blocks_full_closure": True}
     if gate.get("workflow_sufficient") is False:
         return {"state": "active", "plan_ref": plan_ref, "blocks_full_closure": True}
+    custody = _as_dict(gate.get("custody_planning"))
+    custody_effect = _as_dict(custody.get("action_effect"))
+    if str(custody_effect.get("force") or custody.get("force") or "") == "required_before_claim":
+        return {
+            "state": "closeout_required",
+            "plan_ref": plan_ref or _first_ref(custody.get("issue_refs"), custody.get("reason_codes")),
+            "blocks_full_closure": True,
+            "custody": "required-before-parent-closeout",
+        }
+    if str(custody.get("status") or "") == "recommended":
+        return {
+            "state": "continuation",
+            "plan_ref": plan_ref or _first_ref(custody.get("issue_refs"), custody.get("reason_codes")),
+            "blocks_full_closure": True,
+            "custody": "recommended",
+        }
     if str(reliance.get("status") or "") not in {"", "no-active-plan", "not-applicable", "clear", "satisfied"}:
         return {"state": "continuation", "plan_ref": plan_ref, "blocks_full_closure": True}
     if active_record.get("status") == "present":
@@ -21246,6 +21262,25 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         compact["changed_path_facts"] = gate.get("changed_path_facts") or gate.get("changed_path_classification")
     if "work_shape_guidance" in gate:
         compact["work_shape_guidance"] = _tiny_work_shape_guidance(gate["work_shape_guidance"])
+    custody_planning = gate.get("custody_planning")
+    if isinstance(custody_planning, dict) and custody_planning.get("status") not in (None, "", "not-applicable"):
+        compact["custody_planning"] = {
+            key: custody_planning.get(key)
+            for key in (
+                "kind",
+                "status",
+                "force",
+                "implementation_allowed",
+                "planning_roles",
+                "reason_codes",
+                "purpose",
+                "slice_boundary",
+                "action_effect",
+                "follow_up_route",
+                "rule",
+            )
+            if key in custody_planning
+        }
     active_delegation_requirement = gate.get("active_delegation_requirement")
     if isinstance(active_delegation_requirement, dict) and active_delegation_requirement.get("required"):
         compact["active_delegation_requirement"] = active_delegation_requirement
@@ -21559,7 +21594,9 @@ def _start_tiny_payload_fast(
     )
     payload["planning_revision"] = planning_safety_gate.get("planning_revision", {})
     payload["active_plan_reliance"] = planning_safety_gate.get("active_plan_reliance", {})
-    if planning_safety_gate["status"] not in {"satisfied", "clear"}:
+    custody_planning = planning_safety_gate.get("custody_planning", {})
+    custody_applies = isinstance(custody_planning, dict) and custody_planning.get("status") not in (None, "", "not-applicable")
+    if planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies:
         payload["planning_safety_gate"] = planning_safety_gate
     intent_acknowledgement = _intent_acknowledgement_payload(
         task_text=task_text, execution_posture=execution_posture, vague_orientation=vague_orientation
@@ -29430,6 +29467,32 @@ def _knowledge_gates_payload(
             record_resolution_to=".agentic-workspace/planning/state.toml",
             closeout_boundaries=["full_intent_complete", "issue_closure"],
             fallback="Use preflight or summary to repair or promote Planning ownership before editing.",
+        )
+
+    custody = _as_dict(planning_safety_gate.get("custody_planning"))
+    custody_effect = _as_dict(custody.get("action_effect"))
+    if str(custody.get("status") or "") in {"recommended", "required-reconciliation"}:
+        force = str(custody_effect.get("force") or custody.get("force") or "advisory")
+        add_gate(
+            gate_id="planning-intent-custody",
+            route_id="planning-custody-only",
+            trigger="broad lane, parent issue, multi-issue, or closure-sensitive custody evidence applies",
+            force="required_before_claim" if force == "required_before_claim" else "informational",
+            reason=str(
+                custody.get("purpose") or "Planning is relevant for shared intent custody, not necessarily step-by-step sequencing."
+            ),
+            next_allowed_action="reconcile custody before parent closeout"
+            if force == "required_before_claim"
+            else "continue direct slice; do not claim parent completion",
+            forbidden_actions=["claim parent lane complete or use PR closing keywords before custody is reconciled"]
+            if force == "required_before_claim"
+            else [],
+            required_actions=["record custody evidence or equivalent checked-in parent-scope reconciliation"]
+            if force == "required_before_claim"
+            else [],
+            record_resolution_to=".agentic-workspace/planning/ or equivalent checked-in custody evidence",
+            closeout_boundaries=["useful_slice_complete", "full_parent_satisfaction", "issue_closure"],
+            fallback="If cheap custody creation is unavailable, route creation to #1706 and keep parent completion claims partial.",
         )
 
     for index, obligation in enumerate(relevant_obligations, start=1):

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -1353,6 +1353,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             active_plan_reliance = _as_dict(compact_gate.get("active_plan_reliance"))
             keep_active_plan_reliance = active_plan_reliance.get("permission_claim") != "direct-work-no-active-plan"
             candidate_pressure = _as_dict(compact_gate.get("candidate_pressure"))
+            custody_planning = _as_dict(compact_gate.get("custody_planning"))
             issue_scope_evidence = _as_dict(compact_gate.get("issue_scope_evidence"))
             changed_path_facts = _as_dict(compact_gate.get("changed_path_facts"))
             compact_changed_path_facts = {
@@ -1376,9 +1377,12 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     "required_next_action",
                     "implementation_allowed",
                     "delegation_decision_required",
+                    "custody_planning",
                 )
                 if key in compact_gate
             }
+            if not custody_planning:
+                compact_gate.pop("custody_planning", None)
             if compact_changed_path_facts:
                 compact_gate["changed_path_facts"] = compact_changed_path_facts
             if candidate_pressure.get("status") == "observed":

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -228,6 +228,138 @@ def _active_execplan_record_payload(*, target_root: Path) -> tuple[str, dict[str
     return active_surface, loaded if isinstance(loaded, dict) else {}
 
 
+def _custody_only_planning_payload(
+    *,
+    active_planning_present: bool,
+    candidate_pressure: dict[str, Any],
+    issue_scope_evidence: dict[str, Any],
+    issue_refs: list[str],
+    work_shape: str | None,
+    task_text: str | None,
+    workflow_sufficient: bool,
+    planning_revision: dict[str, Any],
+    promotion_command: str,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    issue_kinds: list[str] = []
+    normalized_task = " ".join((task_text or "").lower().split())
+    closure_terms = (
+        "close ",
+        "closing ",
+        "closes ",
+        "closed ",
+        "fixes ",
+        "resolves ",
+        "parent closure",
+        "pr wording",
+        "closing keyword",
+    )
+    title_lane_terms = ("parent", "lane", "epic", "batch", "multi-issue", "roadmap", "closure", "closeout", "broad")
+    broad_issue_kinds = {
+        "parent-lane",
+        "lane",
+        "epic",
+        "roadmap",
+        "capability-lane",
+        "issue-batch",
+        "closure-sensitive",
+    }
+    for item in issue_scope_evidence.get("evidence", []) if isinstance(issue_scope_evidence.get("evidence"), list) else []:
+        if not isinstance(item, dict):
+            continue
+        kind = str(item.get("kind", "")).strip()
+        title = str(item.get("title", "")).strip().lower()
+        if kind:
+            issue_kinds.append(kind)
+        if kind in broad_issue_kinds:
+            reasons.append(kind if kind != "capability-lane" else "parent-lane")
+        if str(item.get("parent_id", "")).strip():
+            reasons.append("parent-lane")
+        if str(item.get("planning_residue_expected", "")).strip().lower() in {"required", "expected"}:
+            reasons.append("closure-sensitive")
+        if any(term in title for term in title_lane_terms):
+            reasons.append("parent-lane" if "parent" in title or "lane" in title else "broad-roadmap")
+    if len(issue_refs) > 1:
+        reasons.append("multi-issue")
+    if work_shape in {"lane", "epic"}:
+        reasons.append("parent-lane" if work_shape == "lane" else "broad-roadmap")
+    if int(candidate_pressure.get("matched_roadmap_candidate_count") or 0) > 0:
+        reasons.append("broad-roadmap")
+    if int(candidate_pressure.get("matched_decomposition_candidate_count") or 0) > 0:
+        reasons.append("parent-lane")
+    if issue_refs and any(term in f" {normalized_task} " for term in closure_terms):
+        reasons.append("closure-sensitive")
+
+    custody_reasons = sorted(set(reason for reason in reasons if reason))
+    if active_planning_present or not workflow_sufficient or not custody_reasons:
+        return {
+            "kind": "agentic-workspace/custody-only-planning/v1",
+            "status": "not-applicable",
+            "planning_roles": {
+                "implementation_gate": "not-required",
+                "sequencing_aid": "agent-owned",
+                "intent_custody": "not-needed",
+            },
+            "reason_codes": [],
+            "rule": "Narrow direct work stays quiet unless broad lane, issue-batch, closure-sensitive, or parent-intent evidence is present.",
+        }
+
+    force = "required_before_claim" if "closure-sensitive" in custody_reasons else "advisory"
+    blocked_claims = (
+        ["claim-full-parent-satisfaction", "use-pr-closing-keywords", "claim-lane-complete"]
+        if force == "required_before_claim"
+        else ["claim-full-parent-satisfaction", "claim-lane-complete"]
+    )
+    return {
+        "kind": "agentic-workspace/custody-only-planning/v1",
+        "status": "required-reconciliation" if force == "required_before_claim" else "recommended",
+        "force": force,
+        "implementation_allowed": True,
+        "planning_roles": {
+            "implementation_gate": "not-required",
+            "sequencing_aid": "not-required-for-current-slice",
+            "intent_custody": "required-before-parent-closeout" if force == "required_before_claim" else "recommended",
+        },
+        "reason_codes": custody_reasons,
+        "issue_refs": issue_refs,
+        "issue_kinds": sorted(set(kind for kind in issue_kinds if kind)),
+        "purpose": (
+            "Preserve shared lane intent, parent/child scope, closeout trust, continuation, and review evidence; "
+            "this is not necessarily a step-by-step execution plan."
+        ),
+        "slice_boundary": {
+            "useful_slice_completion": "allowed-after-normal-proof",
+            "full_parent_satisfaction": "requires-custody-or-equivalent-reconciliation",
+            "rule": "A useful direct slice can finish without claiming the parent lane or issue batch is complete.",
+        },
+        "minimal_record_shape": [
+            "parent intent",
+            "current useful slice",
+            "child issue or lane scope",
+            "non-goals",
+            "parent closure boundary",
+            "proof and review state",
+            "continuation owner/status",
+            "equivalent checked-in custody evidence",
+        ],
+        "action_effect": {
+            "force": force,
+            "allowed_now": "continue-direct-implementation",
+            "blocked_until_reconciled": blocked_claims if force == "required_before_claim" else [],
+            "claim_boundary": "direct-slice-completion-is-not-parent-lane-satisfaction",
+            "resolution_selector": "planning_safety_gate.custody_planning",
+            "resolution_command": promotion_command if force == "required_before_claim" else "",
+        },
+        "follow_up_route": {
+            "status": "creation-deferred",
+            "refs": ["#1706"],
+            "reason": "Cheap custody-record creation remains follow-up work; this packet only surfaces the route and claim boundary.",
+            "planning_revision": planning_revision,
+        },
+        "rule": "Custody-only Planning is shared intent custody, not an implementation gate, unless parent closeout or PR closing claims are being made.",
+    }
+
+
 def _planning_safety_gate_payload(
     *, target_root: Path, config: WorkspaceConfig, changed_paths: list[str], task_text: str | None, execution_posture: dict[str, Any]
 ) -> dict[str, Any]:
@@ -369,6 +501,17 @@ def _planning_safety_gate_payload(
         if isinstance(decomposition_delegation, dict) and isinstance(decomposition_delegation.get("candidates"), list)
         else []
     )
+    custody_planning = _custody_only_planning_payload(
+        active_planning_present=active_planning_present,
+        candidate_pressure=candidate_pressure,
+        issue_scope_evidence=issue_scope_evidence,
+        issue_refs=issue_refs,
+        work_shape=work_shape,
+        task_text=task_text,
+        workflow_sufficient=workflow_sufficient,
+        planning_revision=planning_revision,
+        promotion_command=promotion_command,
+    )
     authority_boundary = _authority_boundary_payload(
         surface="planning_safety_gate",
         enforced_by_aw=[decision] if not workflow_sufficient else [],
@@ -426,6 +569,7 @@ def _planning_safety_gate_payload(
         },
         "issue_scope_evidence": issue_scope_evidence,
         "candidate_pressure": candidate_pressure,
+        "custody_planning": custody_planning,
         "hierarchy_owner_requirement": hierarchy_owner_requirement,
         "repair_route": {
             "status": "available" if decision == "implementation-owner-missing" else "retired",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -13387,6 +13387,22 @@ def _operating_loop_planning_state(
         return {"state": "closeout_required", "plan_ref": plan_ref, "blocks_full_closure": True}
     if gate.get("workflow_sufficient") is False:
         return {"state": "active", "plan_ref": plan_ref, "blocks_full_closure": True}
+    custody = _as_dict(gate.get("custody_planning"))
+    custody_effect = _as_dict(custody.get("action_effect"))
+    if str(custody_effect.get("force") or custody.get("force") or "") == "required_before_claim":
+        return {
+            "state": "closeout_required",
+            "plan_ref": plan_ref or _first_ref(custody.get("issue_refs"), custody.get("reason_codes")),
+            "blocks_full_closure": True,
+            "custody": "required-before-parent-closeout",
+        }
+    if str(custody.get("status") or "") == "recommended":
+        return {
+            "state": "continuation",
+            "plan_ref": plan_ref or _first_ref(custody.get("issue_refs"), custody.get("reason_codes")),
+            "blocks_full_closure": True,
+            "custody": "recommended",
+        }
     if str(reliance.get("status") or "") not in {"", "no-active-plan", "not-applicable", "clear", "satisfied"}:
         return {"state": "continuation", "plan_ref": plan_ref, "blocks_full_closure": True}
     if active_record.get("status") == "present":
@@ -21171,6 +21187,25 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         compact["changed_path_facts"] = gate.get("changed_path_facts") or gate.get("changed_path_classification")
     if "work_shape_guidance" in gate:
         compact["work_shape_guidance"] = _tiny_work_shape_guidance(gate["work_shape_guidance"])
+    custody_planning = gate.get("custody_planning")
+    if isinstance(custody_planning, dict) and custody_planning.get("status") not in (None, "", "not-applicable"):
+        compact["custody_planning"] = {
+            key: custody_planning.get(key)
+            for key in (
+                "kind",
+                "status",
+                "force",
+                "implementation_allowed",
+                "planning_roles",
+                "reason_codes",
+                "purpose",
+                "slice_boundary",
+                "action_effect",
+                "follow_up_route",
+                "rule",
+            )
+            if key in custody_planning
+        }
     active_delegation_requirement = gate.get("active_delegation_requirement")
     if isinstance(active_delegation_requirement, dict) and active_delegation_requirement.get("required"):
         compact["active_delegation_requirement"] = active_delegation_requirement
@@ -21475,7 +21510,9 @@ def _start_tiny_payload_fast(
     )
     payload["planning_revision"] = planning_safety_gate.get("planning_revision", {})
     payload["active_plan_reliance"] = planning_safety_gate.get("active_plan_reliance", {})
-    if planning_safety_gate["status"] not in {"satisfied", "clear"}:
+    custody_planning = planning_safety_gate.get("custody_planning", {})
+    custody_applies = isinstance(custody_planning, dict) and custody_planning.get("status") not in (None, "", "not-applicable")
+    if planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies:
         payload["planning_safety_gate"] = planning_safety_gate
     intent_acknowledgement = _intent_acknowledgement_payload(
         task_text=task_text, execution_posture=execution_posture, vague_orientation=vague_orientation
@@ -29093,6 +29130,32 @@ def _knowledge_gates_payload(
             record_resolution_to=".agentic-workspace/planning/state.toml",
             closeout_boundaries=["full_intent_complete", "issue_closure"],
             fallback="Use preflight or summary to repair or promote Planning ownership before editing.",
+        )
+
+    custody = _as_dict(planning_safety_gate.get("custody_planning"))
+    custody_effect = _as_dict(custody.get("action_effect"))
+    if str(custody.get("status") or "") in {"recommended", "required-reconciliation"}:
+        force = str(custody_effect.get("force") or custody.get("force") or "advisory")
+        add_gate(
+            gate_id="planning-intent-custody",
+            route_id="planning-custody-only",
+            trigger="broad lane, parent issue, multi-issue, or closure-sensitive custody evidence applies",
+            force="required_before_claim" if force == "required_before_claim" else "informational",
+            reason=str(
+                custody.get("purpose") or "Planning is relevant for shared intent custody, not necessarily step-by-step sequencing."
+            ),
+            next_allowed_action="reconcile custody before parent closeout"
+            if force == "required_before_claim"
+            else "continue direct slice; do not claim parent completion",
+            forbidden_actions=["claim parent lane complete or use PR closing keywords before custody is reconciled"]
+            if force == "required_before_claim"
+            else [],
+            required_actions=["record custody evidence or equivalent checked-in parent-scope reconciliation"]
+            if force == "required_before_claim"
+            else [],
+            record_resolution_to=".agentic-workspace/planning/ or equivalent checked-in custody evidence",
+            closeout_boundaries=["useful_slice_complete", "full_parent_satisfaction", "issue_closure"],
+            fallback="If cheap custody creation is unavailable, route creation to #1706 and keep parent completion claims partial.",
         )
 
     for index, obligation in enumerate(relevant_obligations, start=1):

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -689,7 +689,9 @@ def _start_payload(
     )
     payload["planning_revision"] = planning_safety_gate.get("planning_revision", {})
     payload["active_plan_reliance"] = planning_safety_gate.get("active_plan_reliance", {})
-    if planning_safety_gate["status"] not in {"satisfied", "clear"}:
+    custody_planning = planning_safety_gate.get("custody_planning", {})
+    custody_applies = isinstance(custody_planning, dict) and custody_planning.get("status") not in (None, "", "not-applicable")
+    if planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies:
         payload["planning_safety_gate"] = planning_safety_gate
     if not planning_safety_gate["workflow_sufficient"] and (not _is_config_posture_task(task_text)):
         payload["workflow_sufficiency"] = _workflow_sufficiency_payload(

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -3724,6 +3724,52 @@ def test_start_surfaces_custody_only_planning_for_parent_lane_without_blocking_d
     assert custody["follow_up_route"]["refs"] == ["#1706"]
 
 
+def test_start_default_output_surfaces_custody_only_planning_for_parent_lane(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(
+        tmp_path / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json",
+        json.dumps(
+            {
+                "kind": "planning-external-intent-evidence/v1",
+                "items": [
+                    {
+                        "id": "#2200",
+                        "system": "github",
+                        "status": "open",
+                        "kind": "parent-lane",
+                        "title": "Parent lane: API migration",
+                    }
+                ],
+            }
+        ),
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Implement issue #2200",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    gate = payload["context"]["planning"]["planning_safety_gate"]
+    custody = gate["custody_planning"]
+    assert gate["implementation_allowed"] is True
+    assert custody["status"] == "recommended"
+    assert custody["planning_roles"]["intent_custody"] == "recommended"
+    assert "parent-lane" in custody["reason_codes"]
+
+
 def test_implement_custody_only_planning_blocks_parent_closure_claims_not_edits(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -3671,6 +3671,153 @@ candidates = [
     assert pressure["detail_visibility"] == "relevance and advisory backlog stay behind verbose implement context"
 
 
+def test_start_surfaces_custody_only_planning_for_parent_lane_without_blocking_direct_work(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(
+        tmp_path / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json",
+        json.dumps(
+            {
+                "kind": "planning-external-intent-evidence/v1",
+                "items": [
+                    {
+                        "id": "#2200",
+                        "system": "github",
+                        "status": "open",
+                        "kind": "parent-lane",
+                        "title": "Parent lane: API migration",
+                    }
+                ],
+            }
+        ),
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Implement issue #2200",
+                "--select",
+                "planning_safety_gate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    gate = payload["values"]["planning_safety_gate"]
+    custody = gate["custody_planning"]
+    assert gate["implementation_allowed"] is True
+    assert custody["status"] == "recommended"
+    assert custody["planning_roles"]["implementation_gate"] == "not-required"
+    assert custody["planning_roles"]["sequencing_aid"] == "not-required-for-current-slice"
+    assert custody["planning_roles"]["intent_custody"] == "recommended"
+    assert "parent-lane" in custody["reason_codes"]
+    assert "shared lane intent" in custody["purpose"]
+    assert custody["slice_boundary"]["full_parent_satisfaction"] == "requires-custody-or-equivalent-reconciliation"
+    assert custody["follow_up_route"]["refs"] == ["#1706"]
+
+
+def test_implement_custody_only_planning_blocks_parent_closure_claims_not_edits(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(tmp_path / "docs" / "note.md", "# Note\n")
+    _write(
+        tmp_path / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json",
+        json.dumps(
+            {
+                "kind": "planning-external-intent-evidence/v1",
+                "items": [
+                    {
+                        "id": "#2200",
+                        "system": "github",
+                        "status": "open",
+                        "kind": "parent-lane",
+                        "title": "Parent lane: API migration",
+                    }
+                ],
+            }
+        ),
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "docs/note.md",
+                "--task",
+                "Implement issue #2200 and close parent issue",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    gate = payload["context"]["planning_safety_gate"]
+    custody = gate["custody_planning"]
+    assert gate["implementation_allowed"] is True
+    assert custody["status"] == "required-reconciliation"
+    assert custody["action_effect"]["force"] == "required_before_claim"
+    assert "use-pr-closing-keywords" in custody["action_effect"]["blocked_until_reconciled"]
+    assert custody["slice_boundary"]["useful_slice_completion"] == "allowed-after-normal-proof"
+    assert custody["slice_boundary"]["full_parent_satisfaction"] == "requires-custody-or-equivalent-reconciliation"
+    assert payload["operating_loop"]["planning"]["state"] == "closeout_required"
+
+
+def test_start_keeps_narrow_direct_issue_quiet_without_custody_noise(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(
+        tmp_path / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json",
+        json.dumps(
+            {
+                "kind": "planning-external-intent-evidence/v1",
+                "items": [
+                    {
+                        "id": "#2201",
+                        "system": "github",
+                        "status": "open",
+                        "kind": "issue",
+                        "title": "Fix typo in README",
+                    }
+                ],
+            }
+        ),
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Implement issue #2201",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["next_safe_action"]["implementation_allowed"] is True
+    assert "planning_safety_gate" not in payload["context"]["planning"]
+
+
 def test_start_surfaces_lane_shaping_prompt_for_broad_unshaped_work(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(


### PR DESCRIPTION
## Summary

- Surface a distinct `custody_planning` route for broad parent/lane/closure-sensitive work while preserving direct implementation for bounded slices.
- Distinguish Planning roles as implementation gate, sequencing aid, and intent custody.
- Add parent closeout guidance so direct slice completion is separate from full parent satisfaction and PR closing claims.
- Route cheap custody-record creation follow-up to #1706 when the output only surfaces custody guidance.

## Validation

- `uv run pytest tests/test_workspace_implement_cli.py -q -k "custody_only or narrow_direct_issue_quiet"`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`
- `make lint-workspace`

Fixes #1800