### PR TITLE
Show repair affordances for planning warnings

### DIFF
--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -3650,9 +3650,9 @@ def _planning_lane_projection(*, target_root: Path) -> dict[str, Any]:
     }
 
 
-def _planning_lane_surface_warnings(*, target_root: Path, lane_projection: dict[str, Any] | None = None) -> list[dict[str, str]]:
+def _planning_lane_surface_warnings(*, target_root: Path, lane_projection: dict[str, Any] | None = None) -> list[dict[str, Any]]:
     projection = lane_projection if lane_projection is not None else _planning_lane_projection(target_root=target_root)
-    warnings: list[dict[str, str]] = []
+    warnings: list[dict[str, Any]] = []
     invalid_records = projection.get("invalid_records", []) if isinstance(projection, dict) else []
     if isinstance(invalid_records, list):
         for record in invalid_records:
@@ -3682,6 +3682,26 @@ def _planning_lane_surface_warnings(*, target_root: Path, lane_projection: dict[
                         "Repair the lane record against planning-lane.schema.json before relying on summary or lane closeout; "
                         "accepted status values are exposed at lanes.invalid_records[].status_details."
                     ),
+                    "repair_affordance": {
+                        "kind": "planning-lane-schema-repair/v1",
+                        "owner_surface": path,
+                        "schema": LANE_RECORD_SCHEMA_PATH.as_posix(),
+                        "reference_shape": {"kind": "artifact", "path": "<repo-relative-path>", "role": "context"},
+                        "slice_sequence_entry_shape": {
+                            "id": "<stable-slice-id>",
+                            "title": "<slice title>",
+                            "status": list(LANE_SLICE_STATUS_VALUES),
+                            "execplan_ref": ".agentic-workspace/planning/execplans/<slice>.plan.json",
+                            "depends_on": [],
+                            "purpose_for_lane": "<how this slice advances the lane>",
+                        },
+                        "status_details": status_details if isinstance(status_details, list) else [],
+                        "smallest_safe_next_step": (
+                            "Edit only the named lane record so references are objects and each slice has execplan_ref, "
+                            "depends_on, and purpose_for_lane; then rerun summary or doctor."
+                        ),
+                        "proof_after": "agentic-workspace summary --target . --format json",
+                    },
                 }
             )
     records = projection.get("records", []) if isinstance(projection, dict) else []
@@ -5414,20 +5434,22 @@ def _planning_surface_health(
     *,
     collaboration_pressure: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    health_warnings: list[dict[str, str]] = []
+    health_warnings: list[dict[str, Any]] = []
     for warning in warnings:
         warning_class = str(warning.get("warning_class", "")).strip()
         path = str(warning.get("path", "")).strip()
         message = str(warning.get("message", "")).strip()
         suggested_fix = str(warning.get("suggested_fix", "")).strip() or _warning_remediation(warning_class) or ""
-        health_warnings.append(
-            {
-                "warning_class": warning_class,
-                "path": path,
-                "message": message,
-                "suggested_fix": suggested_fix,
-            }
-        )
+        health_warning: dict[str, Any] = {
+            "warning_class": warning_class,
+            "path": path,
+            "message": message,
+            "suggested_fix": suggested_fix,
+        }
+        repair_affordance = warning.get("repair_affordance")
+        if isinstance(repair_affordance, dict) and repair_affordance:
+            health_warning["repair_affordance"] = repair_affordance
+        health_warnings.append(health_warning)
     if not health_warnings:
         return {
             "status": "clean",
@@ -5705,13 +5727,13 @@ def _stale_completed_active_execplan_warnings(
     return warnings
 
 
-def _planning_state_v1_warnings(*, target_root: Path, state: dict[str, Any] | None) -> list[dict[str, str]]:
+def _planning_state_v1_warnings(*, target_root: Path, state: dict[str, Any] | None) -> list[dict[str, Any]]:
     del target_root
     if not isinstance(state, dict):
         return []
     if state.get("schema_version") != PLANNING_STATE_SCHEMA_VERSION:
         return []
-    warnings: list[dict[str, str]] = []
+    warnings: list[dict[str, Any]] = []
     if state.get("kind") != PLANNING_STATE_KIND:
         warnings.append(_planning_state_v1_warning("kind", 'planning-state/v1 requires kind = "agentic-planning-state".'))
 
@@ -5943,8 +5965,8 @@ def _is_reconstructable_closed_state_history(*, bucket_path: str, item: dict[str
     return True
 
 
-def _planning_state_v1_item_warnings(*, bucket_path: str, item_id: str, item: dict[str, Any], maturity: str) -> list[dict[str, str]]:
-    warnings: list[dict[str, str]] = []
+def _planning_state_v1_item_warnings(*, bucket_path: str, item_id: str, item: dict[str, Any], maturity: str) -> list[dict[str, Any]]:
+    warnings: list[dict[str, Any]] = []
     for role_field in PLANNING_STATE_ROLE_FIELDS:
         if role_field in item and not _non_empty_string(item.get(role_field)):
             warnings.append(
@@ -5966,7 +5988,26 @@ def _planning_state_v1_item_warnings(*, bucket_path: str, item_id: str, item: di
     if maturity == "active":
         surface = str(item.get("execplan") or item.get("surface") or item.get("path") or "").strip()
         if not surface or not _surface_execplan_reference(surface):
-            warnings.append(_planning_state_v1_warning(bucket_path, f"active item {item_id} requires an execplan or execplan surface."))
+            warnings.append(
+                _planning_state_v1_warning(
+                    bucket_path,
+                    f"active item {item_id} requires an execplan or execplan surface.",
+                    repair_affordance={
+                        "kind": "planning-active-owner-repair/v1",
+                        "missing_owner": "execplan surface",
+                        "owner_surface": f"{PLANNING_STATE_PATH.as_posix()}#{bucket_path}",
+                        "item_id": item_id,
+                        "observed_surface": surface,
+                        "expected_state_field": "execplan or surface",
+                        "expected_shape": ".agentic-workspace/planning/execplans/<id>.plan.json",
+                        "command_owned_repair": (
+                            f"agentic-planning new-plan --id {item_id} --title <title> --target . --activate --format json"
+                        ),
+                        "stale_closeout_repair": f"agentic-planning close-item {item_id} --target . --format json",
+                        "field_absent_after_closeout": "todo.active_items[] entry",
+                    },
+                )
+            )
     return warnings
 
 
@@ -6146,14 +6187,22 @@ def _next_role_needed_from_metadata(role_metadata: dict[str, Any]) -> str:
     return ""
 
 
-def _planning_state_v1_warning(path: str, message: str, *, suggested_fix: str = "") -> dict[str, str]:
-    warning = {
+def _planning_state_v1_warning(
+    path: str,
+    message: str,
+    *,
+    suggested_fix: str = "",
+    repair_affordance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    warning: dict[str, Any] = {
         "warning_class": "planning_state_v1_schema",
         "path": f"{PLANNING_STATE_PATH.as_posix()}#{path}",
         "message": message,
     }
     if suggested_fix:
         warning["suggested_fix"] = suggested_fix
+    if repair_affordance:
+        warning["repair_affordance"] = repair_affordance
     return warning
 
 

--- a/packages/planning/tests/test_lanes.py
+++ b/packages/planning/tests/test_lanes.py
@@ -279,6 +279,12 @@ def test_summary_and_doctor_validate_invalid_active_lane_schema(tmp_path: Path) 
     assert schema_warning["path"].endswith("invalid-lane.lane.json")
     assert "slice_sequence.0" in schema_warning["message"]
     assert "execplan_ref" in schema_warning["message"]
+    affordance = schema_warning["repair_affordance"]
+    assert affordance["kind"] == "planning-lane-schema-repair/v1"
+    assert affordance["reference_shape"] == {"kind": "artifact", "path": "<repo-relative-path>", "role": "context"}
+    assert affordance["slice_sequence_entry_shape"]["execplan_ref"].endswith("<slice>.plan.json")
+    assert affordance["slice_sequence_entry_shape"]["depends_on"] == []
+    assert "purpose_for_lane" in affordance["slice_sequence_entry_shape"]
 
     doctor = doctor_bootstrap(target=tmp_path)
     doctor_warning = next(warning for warning in doctor.warnings if warning["warning_class"] == "planning_lane_schema_invalid")

--- a/packages/planning/tests/test_promote.py
+++ b/packages/planning/tests/test_promote.py
@@ -488,10 +488,21 @@ candidates = [
         for warning in summary["planning_surface_health"]["warnings"]
         if warning["warning_class"] == "historical_work_in_live_planning_state"
     )
+    active_owner_warning = next(
+        warning
+        for warning in summary["planning_surface_health"]["warnings"]
+        if "active item active-without-plan requires an execplan" in warning["message"]
+    )
     live_state_rule = summary["planning_surface_health"]["authoring_affordances"]["live_state_rule"]
 
     assert summary["planning_surface_health"]["status"] == "not-clean"
     assert any("active item active-without-plan requires an execplan" in message for message in messages)
+    owner_repair = active_owner_warning["repair_affordance"]
+    assert owner_repair["missing_owner"] == "execplan surface"
+    assert owner_repair["expected_state_field"] == "execplan or surface"
+    assert owner_repair["expected_shape"] == ".agentic-workspace/planning/execplans/<id>.plan.json"
+    assert "new-plan --id active-without-plan" in owner_repair["command_owned_repair"]
+    assert owner_repair["field_absent_after_closeout"] == "todo.active_items[] entry"
     assert any("ready item ready-missing-proof requires proof" in message for message in messages)
     assert any("ready item ready-missing-proof requires review_role" in message for message in messages)
     assert any("ready item ready-missing-proof requires handoff_ready = true" in message for message in messages)

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -5229,6 +5229,7 @@ def _workspace_repair_payload(
                     "Do not replace unfenced repo instructions while restoring the workspace pointer.",
                     "Do not widen the pointer into a second workflow handbook.",
                 ],
+                repair_affordance=_workspace_pointer_repair_affordance(cli_invoke=cli_invoke),
             )
         )
     if contract_drift_surfaces:
@@ -5439,6 +5440,7 @@ def _workspace_manual_review_action(
     risk: str,
     do_not: list[str],
     package_command_bug_signal: dict[str, Any] | None = None,
+    repair_affordance: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     proof_after = [
         _command_with_cli_invoke(command=f"agentic-workspace doctor --target {target_root.as_posix()} --format json", cli_invoke=cli_invoke)
@@ -5469,7 +5471,27 @@ def _workspace_manual_review_action(
     }
     if package_command_bug_signal is not None:
         payload["package_command_bug_signal"] = package_command_bug_signal
+    if repair_affordance is not None:
+        payload["repair_affordance"] = repair_affordance
     return payload
+
+
+def _workspace_pointer_repair_affordance(*, cli_invoke: str) -> dict[str, Any]:
+    return {
+        "kind": "workspace-startup-pointer-repair/v1",
+        "expected_managed_fence": {
+            "start": "<!-- agentic-workspace:workflow:start -->",
+            "end": "<!-- agentic-workspace:workflow:end -->",
+            "block": workspace_pointer_block(cli_invoke=cli_invoke),
+        },
+        "safe_patch_target": "AGENTS.md managed workflow pointer fence only",
+        "repo_specific_content_rule": "Keep repo-specific obligations outside the managed agentic-workspace workflow fence.",
+        "preferred_check_command": "agentic-workspace doctor --target . --format json",
+        "smallest_safe_next_step": (
+            "Restore exactly one managed workflow pointer block in AGENTS.md; move repo-specific dogfooding or project policy "
+            "lines outside the fence instead of editing the managed block body."
+        ),
+    }
 
 
 _MERGE_CONFLICT_MARKERS = ("<<<<<<< ", "=======", ">>>>>>> ")

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -5155,6 +5155,7 @@ def _workspace_repair_payload(
                     "Do not replace unfenced repo instructions while restoring the workspace pointer.",
                     "Do not widen the pointer into a second workflow handbook.",
                 ],
+                repair_affordance=_workspace_pointer_repair_affordance(cli_invoke=cli_invoke),
             )
         )
     if contract_drift_surfaces:
@@ -5365,6 +5366,7 @@ def _workspace_manual_review_action(
     risk: str,
     do_not: list[str],
     package_command_bug_signal: dict[str, Any] | None = None,
+    repair_affordance: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     proof_after = [
         _command_with_cli_invoke(command=f"agentic-workspace doctor --target {target_root.as_posix()} --format json", cli_invoke=cli_invoke)
@@ -5395,7 +5397,27 @@ def _workspace_manual_review_action(
     }
     if package_command_bug_signal is not None:
         payload["package_command_bug_signal"] = package_command_bug_signal
+    if repair_affordance is not None:
+        payload["repair_affordance"] = repair_affordance
     return payload
+
+
+def _workspace_pointer_repair_affordance(*, cli_invoke: str) -> dict[str, Any]:
+    return {
+        "kind": "workspace-startup-pointer-repair/v1",
+        "expected_managed_fence": {
+            "start": "<!-- agentic-workspace:workflow:start -->",
+            "end": "<!-- agentic-workspace:workflow:end -->",
+            "block": workspace_pointer_block(cli_invoke=cli_invoke),
+        },
+        "safe_patch_target": "AGENTS.md managed workflow pointer fence only",
+        "repo_specific_content_rule": "Keep repo-specific obligations outside the managed agentic-workspace workflow fence.",
+        "preferred_check_command": "agentic-workspace doctor --target . --format json",
+        "smallest_safe_next_step": (
+            "Restore exactly one managed workflow pointer block in AGENTS.md; move repo-specific dogfooding or project policy "
+            "lines outside the fence instead of editing the managed block body."
+        ),
+    }
 
 
 _MERGE_CONFLICT_MARKERS = ("<<<<<<< ", "=======", ">>>>>>> ")

--- a/tests/test_workspace_doctor_status_cli.py
+++ b/tests/test_workspace_doctor_status_cli.py
@@ -52,6 +52,14 @@ def test_doctor_emits_affordance_shaped_repair_and_manual_review_actions(tmp_pat
     assert manual_action["safe_to_apply"] is False
     assert manual_action["command"] is None
     assert manual_action["proof_after"][0].startswith("agentic-workspace doctor --target ")
+    pointer_repair = manual_action["repair_affordance"]
+    assert pointer_repair["kind"] == "workspace-startup-pointer-repair/v1"
+    assert pointer_repair["expected_managed_fence"]["start"] == "<!-- agentic-workspace:workflow:start -->"
+    assert pointer_repair["expected_managed_fence"]["end"] == "<!-- agentic-workspace:workflow:end -->"
+    assert "Ordinary route:" in pointer_repair["expected_managed_fence"]["block"]
+    assert pointer_repair["safe_patch_target"] == "AGENTS.md managed workflow pointer fence only"
+    assert "outside the managed" in pointer_repair["repo_specific_content_rule"]
+    assert pointer_repair["preferred_check_command"] == "agentic-workspace doctor --target . --format json"
 
     repair_plan = workspace_report["repair_plan"]
     assert repair_plan["status"] == "safe-action-available"


### PR DESCRIPTION
Stack 2/3. Base PR: #1806.

Summary:
- Add structured repair affordances to lane schema warnings and active-owner warnings.
- Preserve repair affordance metadata through compact/tiny warning projection.
- Add pointer repair affordance details for managed workspace instruction drift.

Validation:
- uv run pytest packages/planning/tests/test_lanes.py packages/planning/tests/test_promote.py tests/test_workspace_doctor_status_cli.py -q
- make test-planning
- make lint-planning
- make typecheck-planning
- make lint-workspace
- uv run pytest tests/test_workspace_cli.py -q
- make test-workspace

Closes #1803.