### PR TITLE
Surface open issue intake routing

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -18362,6 +18362,68 @@ def _planning_candidate_suggestions_from_external_items(*, target_root: Path, it
     }
 
 
+def _external_issue_grouping_hints(*, items: list[dict[str, Any]], candidates: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    open_items = [item for item in items if isinstance(item, dict) and str(item.get("status", "")).strip() == "open"]
+    by_id = {str(item.get("id", "")).strip(): item for item in open_items if str(item.get("id", "")).strip()}
+    candidate_refs: set[str] = set()
+    for candidate in candidates or []:
+        refs = str(candidate.get("refs", "")).strip()
+        candidate_refs.update(f"#{match}" for match in re.findall(r"#(\d+)\b", refs))
+    parent_lanes: list[dict[str, Any]] = []
+    child_clusters: dict[str, dict[str, Any]] = {}
+    standalone: list[dict[str, Any]] = []
+    for item in open_items:
+        ref = str(item.get("id", "")).strip()
+        title = str(item.get("title", "")).strip()
+        kind = str(item.get("kind", "")).strip()
+        parent_id = str(item.get("parent_id", "")).strip()
+        compact_item = {
+            "id": ref,
+            "title": title,
+            "kind": kind or "issue",
+            "has_planning_candidate": ref in candidate_refs,
+        }
+        if kind in {"lane", "epic"}:
+            parent_lanes.append(compact_item)
+            continue
+        if parent_id:
+            cluster = child_clusters.setdefault(
+                parent_id,
+                {
+                    "parent_id": parent_id,
+                    "parent_title": str(by_id.get(parent_id, {}).get("title", "")).strip(),
+                    "child_count": 0,
+                    "children": [],
+                },
+            )
+            cluster["child_count"] += 1
+            if len(cluster["children"]) < 3:
+                cluster["children"].append(compact_item)
+            continue
+        standalone.append(compact_item)
+    parent_lanes = sorted(parent_lanes, key=lambda item: int(str(item.get("id", "0")).lstrip("#") or "0"))[:3]
+    clusters = sorted(child_clusters.values(), key=lambda item: (-int(item.get("child_count", 0)), str(item.get("parent_id", ""))))[:3]
+    standalone = sorted(standalone, key=lambda item: int(str(item.get("id", "0")).lstrip("#") or "0"))[:3]
+    return {
+        "kind": "external-issue-grouping-hints/v1",
+        "status": "present" if open_items else "none",
+        "open_item_count": len(open_items),
+        "parent_lane_count": sum(1 for item in open_items if str(item.get("kind", "")).strip() in {"lane", "epic"}),
+        "child_slice_count": sum(1 for item in open_items if str(item.get("parent_id", "")).strip()),
+        "standalone_count": sum(
+            1
+            for item in open_items
+            if str(item.get("kind", "")).strip() not in {"lane", "epic"} and not str(item.get("parent_id", "")).strip()
+        ),
+        "candidate_backed_count": len(candidate_refs),
+        "parent_lanes": parent_lanes,
+        "child_issue_clusters": clusters,
+        "standalone_candidates": standalone,
+        "detail_selector": "open_issue_intake.grouping_hints",
+        "rule": "Grouping hints are compact routing clues from provider-agnostic evidence, not a priority decision or full issue list.",
+    }
+
+
 def _toml_inline_string(value: str) -> str:
     return json.dumps(value, ensure_ascii=True)
 
@@ -18782,6 +18844,12 @@ def _refresh_github_external_intent_evidence(
     if cache_compaction is not None:
         next_payload["refresh_metadata"]["cache_compaction"] = cache_compaction
     planning_candidate_suggestions = _planning_candidate_suggestions_from_external_items(target_root=target_root, items=items)
+    planning_candidate_grouping = _external_issue_grouping_hints(
+        items=items,
+        candidates=[
+            candidate for candidate in _list_payload(planning_candidate_suggestions.get("candidates")) if isinstance(candidate, dict)
+        ],
+    )
     stale_planning_candidate_reconciliation = _stale_planning_candidate_reconciliation(
         target_root=target_root,
         items=items,
@@ -18829,6 +18897,7 @@ def _refresh_github_external_intent_evidence(
         "state_source": state_source,
         "limit_source": limit_source,
         "planning_candidate_suggestions": planning_candidate_suggestions,
+        "planning_candidate_grouping": planning_candidate_grouping,
         "planning_candidate_apply": planning_candidate_apply,
         "stale_planning_candidate_reconciliation": stale_planning_candidate_reconciliation,
         "provider_rule": "Core planning consumes only provider-agnostic external intent evidence; GitHub access stays in this optional adapter.",
@@ -20759,6 +20828,7 @@ _START_TINY_ONLY_SELECTORS = {
     "durable_intent",
     "immediate_next_allowed_action",
     "issue_reference_intent",
+    "open_issue_intake",
     "intent_custody",
     "intent_elicitation_protocol",
     "next_safe_action",
@@ -21825,6 +21895,35 @@ def _start_tiny_payload_fast(
                 "read_first": [command],
                 "open_execplan_only_when": startup_template["open_execplan_only_when"],
             }
+    open_issue_intake = _open_issue_intake_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)
+    if (
+        open_issue_intake.get("status") != "not-applicable"
+        and not active_planning_present
+        and not changed_paths
+        and not _is_config_posture_task(task_text)
+        and not _is_prep_only_handoff_task(task_text)
+    ):
+        payload["open_issue_intake"] = open_issue_intake
+        command = str(open_issue_intake.get("command_owned_intake") or "")
+        if payload["immediate_next_allowed_action"].get("action") == "choose-smallest-workflow-shape":
+            payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
+                surface="start",
+                decision="open-issue-intake-route",
+                reason="The task asks to ingest, refresh, triage, or prioritise open issues; use the command-owned external-intent intake path first.",
+                required_next_action="refresh-open-issue-intake",
+                evidence_required=["external-intent evidence refresh/apply result"],
+            )
+            payload["immediate_next_allowed_action"] = {
+                "action": "refresh-open-issue-intake",
+                "summary": "Refresh/apply external issue intake, then inspect compact grouping hints before promoting a lane.",
+                "command": command,
+                "run": command,
+                "risk": "read-only-plus-planning-candidate-intake",
+                "required_inputs": ["target repo", "open issue intake task"],
+                "next_proof": "rerun start or summary after intake and use grouping hints before promotion.",
+                "read_first": [command],
+                "open_execplan_only_when": startup_template["open_execplan_only_when"],
+            }
     _apply_lane_shaping_gate_to_start_payload(
         payload=payload,
         config=config,
@@ -22400,6 +22499,101 @@ def _issue_scope_evidence_payload(*, target_root: Path, config: WorkspaceConfig,
             cli_invoke=config.cli_invoke,
         ),
         "rule": "Issue refs are external-intent handles until cached provider-agnostic evidence or active Planning owns the scope.",
+    }
+
+
+def _is_open_issue_intake_task(task_text: str | None) -> bool:
+    text = " ".join(str(task_text or "").lower().split())
+    if not text:
+        return False
+    issue_terms = ("open issue", "open issues", "github issue", "github issues", "external issue", "external issues", "backlog")
+    intake_terms = (
+        "ingest",
+        "intake",
+        "prioritise",
+        "prioritize",
+        "triage",
+        "review",
+        "refresh",
+        "group",
+        "lane",
+        "lanes",
+    )
+    return any(term in text for term in issue_terms) and any(term in text for term in intake_terms)
+
+
+def _planning_state_roadmap_candidates(*, target_root: Path) -> list[dict[str, Any]]:
+    state_path = target_root / ".agentic-workspace" / "planning" / "state.toml"
+    if not state_path.exists():
+        return []
+    try:
+        payload = tomllib.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return []
+    roadmap = payload.get("roadmap", {}) if isinstance(payload, dict) else {}
+    candidates = roadmap.get("candidates", []) if isinstance(roadmap, dict) else []
+    return [candidate for candidate in candidates if isinstance(candidate, dict)]
+
+
+def _open_issue_intake_payload(*, target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
+    if not _is_open_issue_intake_task(task_text):
+        return {"kind": "agentic-workspace/open-issue-intake/v1", "status": "not-applicable"}
+    path, relative_path, storage = _external_intent_evidence_read_location(target_root)
+    evidence: dict[str, Any] = {}
+    if path.exists():
+        try:
+            evidence = json.loads(path.read_text(encoding="utf-8-sig"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            evidence = {}
+    items = [item for item in _list_payload(evidence.get("items")) if isinstance(item, dict)]
+    candidates = _planning_state_roadmap_candidates(target_root=target_root)
+    refreshed_at = str(evidence.get("refreshed_at") or _as_dict(evidence.get("refresh_metadata")).get("refreshed_at") or "").strip()
+    freshness_status = "fresh-enough" if path.exists() and refreshed_at else "needs-refresh"
+    grouping = _external_issue_grouping_hints(items=items, candidates=candidates)
+    refresh_command = _command_with_cli_invoke(
+        command="agentic-workspace external-intent refresh-github --target . --state all --storage cache --apply-planning-candidates --format json",
+        cli_invoke=cli_invoke,
+    )
+    status = "ready-to-review" if items or candidates else "refresh-needed"
+    recommended = "refresh-apply-intake" if freshness_status == "needs-refresh" else "inspect-candidate-grouping"
+    if candidates and freshness_status == "fresh-enough":
+        recommended = "promote-or-review-first-lane"
+    return {
+        "kind": "agentic-workspace/open-issue-intake/v1",
+        "status": status,
+        "trigger": "open-issue-intake-task",
+        "command_owned_intake": refresh_command,
+        "recommended_next_action": recommended,
+        "freshness": {
+            "status": freshness_status,
+            "source_path": relative_path if path.exists() else "",
+            "storage": storage if path.exists() else "none",
+            "refreshed_at": refreshed_at,
+            "refresh_before_relying_on_grouping": freshness_status != "fresh-enough",
+        },
+        "counts": {
+            "evidence_item_count": len(items),
+            "open_issue_count": sum(1 for item in items if str(item.get("status", "")).strip() == "open"),
+            "planning_candidate_count": len(candidates),
+        },
+        "grouping_hints": grouping,
+        "first_lane_hint": (
+            grouping.get("parent_lanes") or grouping.get("child_issue_clusters") or grouping.get("standalone_candidates") or [{}]
+        )[0],
+        "detail_selectors": ["open_issue_intake.grouping_hints", "routine_work_context"],
+        "detailed_issue_list_rule": "Detailed issue bodies and full issue lists stay behind external-intent evidence or explicit follow-up commands.",
+        "authority_boundary": _authority_boundary_payload(
+            surface="open_issue_intake",
+            observed_by_aw=[
+                "task requests open issue intake",
+                f"cached_evidence={path.exists()}",
+                f"planning_candidate_count={len(candidates)}",
+            ],
+            recommended_by_aw=[recommended],
+            agent_owned_decisions=["priority judgment", "which lane or candidate to promote first"],
+            human_owned_decisions=["business priority when grouping hints are insufficient"],
+            rule="AW exposes command-owned intake and grouping hints; it does not replace human issue prioritization.",
+        ),
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -18288,6 +18288,68 @@ def _planning_candidate_suggestions_from_external_items(*, target_root: Path, it
     }
 
 
+def _external_issue_grouping_hints(*, items: list[dict[str, Any]], candidates: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    open_items = [item for item in items if isinstance(item, dict) and str(item.get("status", "")).strip() == "open"]
+    by_id = {str(item.get("id", "")).strip(): item for item in open_items if str(item.get("id", "")).strip()}
+    candidate_refs: set[str] = set()
+    for candidate in candidates or []:
+        refs = str(candidate.get("refs", "")).strip()
+        candidate_refs.update(f"#{match}" for match in re.findall(r"#(\d+)\b", refs))
+    parent_lanes: list[dict[str, Any]] = []
+    child_clusters: dict[str, dict[str, Any]] = {}
+    standalone: list[dict[str, Any]] = []
+    for item in open_items:
+        ref = str(item.get("id", "")).strip()
+        title = str(item.get("title", "")).strip()
+        kind = str(item.get("kind", "")).strip()
+        parent_id = str(item.get("parent_id", "")).strip()
+        compact_item = {
+            "id": ref,
+            "title": title,
+            "kind": kind or "issue",
+            "has_planning_candidate": ref in candidate_refs,
+        }
+        if kind in {"lane", "epic"}:
+            parent_lanes.append(compact_item)
+            continue
+        if parent_id:
+            cluster = child_clusters.setdefault(
+                parent_id,
+                {
+                    "parent_id": parent_id,
+                    "parent_title": str(by_id.get(parent_id, {}).get("title", "")).strip(),
+                    "child_count": 0,
+                    "children": [],
+                },
+            )
+            cluster["child_count"] += 1
+            if len(cluster["children"]) < 3:
+                cluster["children"].append(compact_item)
+            continue
+        standalone.append(compact_item)
+    parent_lanes = sorted(parent_lanes, key=lambda item: int(str(item.get("id", "0")).lstrip("#") or "0"))[:3]
+    clusters = sorted(child_clusters.values(), key=lambda item: (-int(item.get("child_count", 0)), str(item.get("parent_id", ""))))[:3]
+    standalone = sorted(standalone, key=lambda item: int(str(item.get("id", "0")).lstrip("#") or "0"))[:3]
+    return {
+        "kind": "external-issue-grouping-hints/v1",
+        "status": "present" if open_items else "none",
+        "open_item_count": len(open_items),
+        "parent_lane_count": sum(1 for item in open_items if str(item.get("kind", "")).strip() in {"lane", "epic"}),
+        "child_slice_count": sum(1 for item in open_items if str(item.get("parent_id", "")).strip()),
+        "standalone_count": sum(
+            1
+            for item in open_items
+            if str(item.get("kind", "")).strip() not in {"lane", "epic"} and not str(item.get("parent_id", "")).strip()
+        ),
+        "candidate_backed_count": len(candidate_refs),
+        "parent_lanes": parent_lanes,
+        "child_issue_clusters": clusters,
+        "standalone_candidates": standalone,
+        "detail_selector": "open_issue_intake.grouping_hints",
+        "rule": "Grouping hints are compact routing clues from provider-agnostic evidence, not a priority decision or full issue list.",
+    }
+
+
 def _toml_inline_string(value: str) -> str:
     return json.dumps(value, ensure_ascii=True)
 
@@ -18708,6 +18770,12 @@ def _refresh_github_external_intent_evidence(
     if cache_compaction is not None:
         next_payload["refresh_metadata"]["cache_compaction"] = cache_compaction
     planning_candidate_suggestions = _planning_candidate_suggestions_from_external_items(target_root=target_root, items=items)
+    planning_candidate_grouping = _external_issue_grouping_hints(
+        items=items,
+        candidates=[
+            candidate for candidate in _list_payload(planning_candidate_suggestions.get("candidates")) if isinstance(candidate, dict)
+        ],
+    )
     stale_planning_candidate_reconciliation = _stale_planning_candidate_reconciliation(
         target_root=target_root,
         items=items,
@@ -18755,6 +18823,7 @@ def _refresh_github_external_intent_evidence(
         "state_source": state_source,
         "limit_source": limit_source,
         "planning_candidate_suggestions": planning_candidate_suggestions,
+        "planning_candidate_grouping": planning_candidate_grouping,
         "planning_candidate_apply": planning_candidate_apply,
         "stale_planning_candidate_reconciliation": stale_planning_candidate_reconciliation,
         "provider_rule": "Core planning consumes only provider-agnostic external intent evidence; GitHub access stays in this optional adapter.",
@@ -20685,6 +20754,7 @@ _START_TINY_ONLY_SELECTORS = {
     "durable_intent",
     "immediate_next_allowed_action",
     "issue_reference_intent",
+    "open_issue_intake",
     "intent_custody",
     "intent_elicitation_protocol",
     "next_safe_action",
@@ -21741,6 +21811,35 @@ def _start_tiny_payload_fast(
                 "read_first": [command],
                 "open_execplan_only_when": startup_template["open_execplan_only_when"],
             }
+    open_issue_intake = _open_issue_intake_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)
+    if (
+        open_issue_intake.get("status") != "not-applicable"
+        and not active_planning_present
+        and not changed_paths
+        and not _is_config_posture_task(task_text)
+        and not _is_prep_only_handoff_task(task_text)
+    ):
+        payload["open_issue_intake"] = open_issue_intake
+        command = str(open_issue_intake.get("command_owned_intake") or "")
+        if payload["immediate_next_allowed_action"].get("action") == "choose-smallest-workflow-shape":
+            payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
+                surface="start",
+                decision="open-issue-intake-route",
+                reason="The task asks to ingest, refresh, triage, or prioritise open issues; use the command-owned external-intent intake path first.",
+                required_next_action="refresh-open-issue-intake",
+                evidence_required=["external-intent evidence refresh/apply result"],
+            )
+            payload["immediate_next_allowed_action"] = {
+                "action": "refresh-open-issue-intake",
+                "summary": "Refresh/apply external issue intake, then inspect compact grouping hints before promoting a lane.",
+                "command": command,
+                "run": command,
+                "risk": "read-only-plus-planning-candidate-intake",
+                "required_inputs": ["target repo", "open issue intake task"],
+                "next_proof": "rerun start or summary after intake and use grouping hints before promotion.",
+                "read_first": [command],
+                "open_execplan_only_when": startup_template["open_execplan_only_when"],
+            }
     _apply_lane_shaping_gate_to_start_payload(
         payload=payload,
         config=config,
@@ -22316,6 +22415,101 @@ def _issue_scope_evidence_payload(*, target_root: Path, config: WorkspaceConfig,
             cli_invoke=config.cli_invoke,
         ),
         "rule": "Issue refs are external-intent handles until cached provider-agnostic evidence or active Planning owns the scope.",
+    }
+
+
+def _is_open_issue_intake_task(task_text: str | None) -> bool:
+    text = " ".join(str(task_text or "").lower().split())
+    if not text:
+        return False
+    issue_terms = ("open issue", "open issues", "github issue", "github issues", "external issue", "external issues", "backlog")
+    intake_terms = (
+        "ingest",
+        "intake",
+        "prioritise",
+        "prioritize",
+        "triage",
+        "review",
+        "refresh",
+        "group",
+        "lane",
+        "lanes",
+    )
+    return any(term in text for term in issue_terms) and any(term in text for term in intake_terms)
+
+
+def _planning_state_roadmap_candidates(*, target_root: Path) -> list[dict[str, Any]]:
+    state_path = target_root / ".agentic-workspace" / "planning" / "state.toml"
+    if not state_path.exists():
+        return []
+    try:
+        payload = tomllib.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return []
+    roadmap = payload.get("roadmap", {}) if isinstance(payload, dict) else {}
+    candidates = roadmap.get("candidates", []) if isinstance(roadmap, dict) else []
+    return [candidate for candidate in candidates if isinstance(candidate, dict)]
+
+
+def _open_issue_intake_payload(*, target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
+    if not _is_open_issue_intake_task(task_text):
+        return {"kind": "agentic-workspace/open-issue-intake/v1", "status": "not-applicable"}
+    path, relative_path, storage = _external_intent_evidence_read_location(target_root)
+    evidence: dict[str, Any] = {}
+    if path.exists():
+        try:
+            evidence = json.loads(path.read_text(encoding="utf-8-sig"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            evidence = {}
+    items = [item for item in _list_payload(evidence.get("items")) if isinstance(item, dict)]
+    candidates = _planning_state_roadmap_candidates(target_root=target_root)
+    refreshed_at = str(evidence.get("refreshed_at") or _as_dict(evidence.get("refresh_metadata")).get("refreshed_at") or "").strip()
+    freshness_status = "fresh-enough" if path.exists() and refreshed_at else "needs-refresh"
+    grouping = _external_issue_grouping_hints(items=items, candidates=candidates)
+    refresh_command = _command_with_cli_invoke(
+        command="agentic-workspace external-intent refresh-github --target . --state all --storage cache --apply-planning-candidates --format json",
+        cli_invoke=cli_invoke,
+    )
+    status = "ready-to-review" if items or candidates else "refresh-needed"
+    recommended = "refresh-apply-intake" if freshness_status == "needs-refresh" else "inspect-candidate-grouping"
+    if candidates and freshness_status == "fresh-enough":
+        recommended = "promote-or-review-first-lane"
+    return {
+        "kind": "agentic-workspace/open-issue-intake/v1",
+        "status": status,
+        "trigger": "open-issue-intake-task",
+        "command_owned_intake": refresh_command,
+        "recommended_next_action": recommended,
+        "freshness": {
+            "status": freshness_status,
+            "source_path": relative_path if path.exists() else "",
+            "storage": storage if path.exists() else "none",
+            "refreshed_at": refreshed_at,
+            "refresh_before_relying_on_grouping": freshness_status != "fresh-enough",
+        },
+        "counts": {
+            "evidence_item_count": len(items),
+            "open_issue_count": sum(1 for item in items if str(item.get("status", "")).strip() == "open"),
+            "planning_candidate_count": len(candidates),
+        },
+        "grouping_hints": grouping,
+        "first_lane_hint": (
+            grouping.get("parent_lanes") or grouping.get("child_issue_clusters") or grouping.get("standalone_candidates") or [{}]
+        )[0],
+        "detail_selectors": ["open_issue_intake.grouping_hints", "routine_work_context"],
+        "detailed_issue_list_rule": "Detailed issue bodies and full issue lists stay behind external-intent evidence or explicit follow-up commands.",
+        "authority_boundary": _authority_boundary_payload(
+            surface="open_issue_intake",
+            observed_by_aw=[
+                "task requests open issue intake",
+                f"cached_evidence={path.exists()}",
+                f"planning_candidate_count={len(candidates)}",
+            ],
+            recommended_by_aw=[recommended],
+            agent_owned_decisions=["priority judgment", "which lane or candidate to promote first"],
+            human_owned_decisions=["business priority when grouping hints are insufficient"],
+            rule="AW exposes command-owned intake and grouping hints; it does not replace human issue prioritization.",
+        ),
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -373,6 +373,8 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         projected["intent_evidence"] = _compact_intent_evidence(payload.get("intent_evidence", {}))
     if "issue_reference_intent" in payload:
         projected["issue_reference_intent"] = payload["issue_reference_intent"]
+    if "open_issue_intake" in payload:
+        projected["open_issue_intake"] = payload["open_issue_intake"]
     if isinstance(task_intent, dict) and task_intent.get("status") == "present":
         acceptance = task_intent.get("acceptance", {})
         read_only_response = payload.get("read_only_response", {})
@@ -1394,6 +1396,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         "vague_outcome_orientation",
         "intent_acknowledgement",
         "lane_shaping_gate",
+        "open_issue_intake",
         "pre_test_evidence_guardrail",
     ):
         if optional_key in payload:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1003,6 +1003,89 @@ def test_start_issue_reference_wording_keeps_issue_scope_warning(tmp_path: Path,
     assert "external-intent refresh-github" in effect["resolution_command"]
 
 
+def test_start_open_issue_intake_routes_refresh_and_grouping(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    evidence_path = tmp_path / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json"
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "kind": "planning-external-intent-evidence/v1",
+                "refreshed_at": "2026-06-26T08:00:00+00:00",
+                "refresh_metadata": {"adapter": "fixture", "open_count": 4, "closed_count": 0},
+                "items": [
+                    {"id": "#1739", "system": "github", "status": "open", "kind": "lane", "title": "Dogfooding friction lane"},
+                    {
+                        "id": "#1804",
+                        "system": "github",
+                        "status": "open",
+                        "kind": "slice",
+                        "parent_id": "#1739",
+                        "title": "Warn on unsupported lane status",
+                    },
+                    {
+                        "id": "#1803",
+                        "system": "github",
+                        "status": "open",
+                        "kind": "slice",
+                        "parent_id": "#1739",
+                        "title": "Repair affordances",
+                    },
+                    {"id": "#1802", "system": "github", "status": "open", "kind": "issue", "title": "Open issue intake"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "github-1739-dogfooding", maturity = "candidate", status = "next", priority = "P1", refs = "GitHub #1739", title = "Dogfooding friction lane", promotion_signal = "Promote first.", suggested_first_slice = "Review child slices." },
+  { id = "github-1802-open-issue-intake", maturity = "candidate", status = "next", priority = "P2", refs = "GitHub #1802", title = "Open issue intake", promotion_signal = "Promote when selected.", suggested_first_slice = "Add intake routing." },
+]
+""",
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Ingest and prioritise open issues",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["next_safe_action"]["next_safe_action"] == "refresh-open-issue-intake"
+    intake = payload["context"]["open_issue_intake"]
+    assert "external-intent refresh-github" in intake["command_owned_intake"]
+    assert "--apply-planning-candidates" in intake["command_owned_intake"]
+    assert intake["freshness"]["status"] == "fresh-enough"
+    assert intake["counts"]["open_issue_count"] == 4
+    assert intake["counts"]["planning_candidate_count"] == 2
+    grouping = intake["grouping_hints"]
+    assert grouping["parent_lanes"][0]["id"] == "#1739"
+    assert grouping["child_issue_clusters"][0]["parent_id"] == "#1739"
+    assert grouping["child_issue_clusters"][0]["child_count"] == 2
+    assert grouping["standalone_candidates"][0]["id"] == "#1802"
+    assert intake["detailed_issue_list_rule"]
+
+
 def test_start_cached_issue_reference_intent_is_advisory(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -776,7 +776,31 @@ candidates = [
                         "closedAt": "2026-05-20T00:00:00Z",
                         "body": "",
                         "comments": 0,
-                    }
+                    },
+                    {
+                        "number": 11,
+                        "title": "Parent intake lane",
+                        "state": "OPEN",
+                        "url": "https://github.com/acme/project/issues/11",
+                        "labels": [{"name": "priority/high"}],
+                        "createdAt": "2026-04-28T00:00:00Z",
+                        "updatedAt": "2026-05-20T00:00:00Z",
+                        "closedAt": "",
+                        "body": "## Issue kind\nlane\n",
+                        "comments": 0,
+                    },
+                    {
+                        "number": 12,
+                        "title": "Child intake slice",
+                        "state": "OPEN",
+                        "url": "https://github.com/acme/project/issues/12",
+                        "labels": [{"name": "priority/medium"}],
+                        "createdAt": "2026-04-28T00:00:00Z",
+                        "updatedAt": "2026-05-20T00:00:00Z",
+                        "closedAt": "",
+                        "body": "## Issue kind\nslice\n\nParent: #11\n",
+                        "comments": 0,
+                    },
                 ]
             )
         )
@@ -801,6 +825,10 @@ candidates = [
     dry_run_payload = json.loads(capsys.readouterr().out)
 
     assert dry_run_exit_code == 0
+    grouping = dry_run_payload["planning_candidate_grouping"]
+    assert grouping["parent_lanes"][0]["id"] == "#11"
+    assert grouping["child_issue_clusters"][0]["parent_id"] == "#11"
+    assert grouping["child_issue_clusters"][0]["child_count"] == 1
     stale_candidate = dry_run_payload["stale_planning_candidate_reconciliation"]["stale_candidates"][0]
     assert stale_candidate["id"] == "github-10-stale"
     assert stale_candidate["reconcile_command"] == (
@@ -830,7 +858,9 @@ candidates = [
     assert reconciliation["status"] == "applied"
     assert reconciliation["stale_candidates"][0]["id"] == "github-10-stale"
     state = tomllib.loads(state_path.read_text(encoding="utf-8"))
-    assert state["roadmap"]["candidates"] == []
+    candidate_ids = {candidate["id"] for candidate in state["roadmap"]["candidates"]}
+    assert "github-10-stale" not in candidate_ids
+    assert candidate_ids == {"github-11-parent-intake-lane", "github-12-child-intake-slice"}
     cache_payload = json.loads(cache_path.read_text(encoding="utf-8"))
     assert cache_payload["previous_items"][0]["id"] == "#10"
 


### PR DESCRIPTION
Stack 3/3. Base PR: #1807.

Summary:
- Route open-issue intake tasks to the command-owned external-intent refresh/apply path from startup.
- Add compact grouping hints for parent lanes, child issue clusters, and standalone candidates.
- Surface grouping on the GitHub external-intent refresh payload and startup projections.
- Keep the core and primitives runtime payloads in sync for the live CLI path.

Validation:
- uv run pytest tests/test_workspace_cli.py -k "open_issue_intake_routes" -q
- uv run pytest tests/test_workspace_summary_cli.py -k "external_intent_refresh_applies_stale_candidate_reconciliation" -q
- make test-workspace
- make lint-workspace
- uv run pytest tests/test_workspace_cli.py -q
- git diff --check

Closes #1802.