### PR TITLE
[codex] Surface checkpoint candidate routes

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -22336,6 +22336,10 @@ def _planning_roadmap_candidates(target_root: Path) -> list[dict[str, Any]]:
                 "priority": str(candidate.get("priority", "")).strip(),
                 "status": status or "unknown",
                 "maturity": maturity or "unknown",
+                "route_kind": str(candidate.get("kind") or candidate.get("route_kind") or "").strip(),
+                "parent_id": str(candidate.get("parent_id") or candidate.get("parent") or "").strip(),
+                "lane_id": str(candidate.get("lane_id") or "").strip(),
+                "owner_surface": str(candidate.get("owner_surface") or "").strip(),
                 "outcome": str(candidate.get("outcome", "")).strip(),
                 "promotion_signal": str(candidate.get("promotion_signal", "")).strip(),
                 "suggested_first_slice": str(candidate.get("suggested_first_slice", "")).strip(),
@@ -24277,6 +24281,97 @@ def _checkpoint_resume_checklist() -> list[dict[str, str]]:
     ]
 
 
+def _local_checkpoint_issue_refs(*, checkpoint: dict[str, Any], durable_sources: list[Any]) -> list[str]:
+    raw_values: list[Any] = [
+        *_list_payload(checkpoint.get("current_issue_refs")),
+        *durable_sources,
+        checkpoint.get("task"),
+    ]
+    volatile_refs = _as_dict(_as_dict(checkpoint.get("volatile_observations")).get("current_issue_refs")).get("value")
+    raw_values.extend(_list_payload(volatile_refs))
+    refs: set[str] = set()
+    for raw in raw_values:
+        text = str(raw or "")
+        refs.update(f"#{match}" for match in re.findall(r"#(\d+)\b", text))
+        refs.update(f"#{match}" for match in re.findall(r"/issues/(\d+)\b", text))
+    return sorted(refs, key=lambda value: int(value.lstrip("#")) if value.lstrip("#").isdigit() else value)
+
+
+def _checkpoint_route_kind(candidate: dict[str, Any]) -> str:
+    route_kind = str(candidate.get("route_kind", "")).strip().lower()
+    if route_kind in {"parent-lane", "parent", "lane"}:
+        return "parent-lane"
+    if route_kind in {"child-slice", "child", "slice"}:
+        return "child-slice"
+    if str(candidate.get("parent_id", "")).strip() or str(candidate.get("lane_id", "")).strip():
+        return "child-slice"
+    return "standalone"
+
+
+def _checkpoint_candidate_matched_refs(relevance: dict[str, Any]) -> list[str]:
+    refs: list[str] = []
+    for item in _list_payload(relevance.get("strong_evidence")):
+        text = str(item)
+        if text.startswith("issue_ref:"):
+            refs.append(text.removeprefix("issue_ref:"))
+    return _dedupe(refs)
+
+
+def _local_checkpoint_planning_candidate_routes(
+    *, target_root: Path, cli_invoke: str, checkpoint: dict[str, Any], durable_sources: list[Any]
+) -> dict[str, Any]:
+    issue_refs = _local_checkpoint_issue_refs(checkpoint=checkpoint, durable_sources=durable_sources)
+    if not issue_refs:
+        return {"status": "no-issue-refs"}
+    candidates = []
+    for candidate in _planning_roadmap_candidates(target_root):
+        relevance = _candidate_relevance_payload(candidate, issue_refs=issue_refs, task_text=str(checkpoint.get("task", "")))
+        if not relevance.get("strong_evidence"):
+            continue
+        candidates.append((candidate, relevance))
+    if not candidates:
+        return {"status": "no-matches", "issue_refs": issue_refs}
+    planning_revision = _planning_revision_payload(target_root=target_root)
+    route_options: list[dict[str, Any]] = []
+    for candidate, relevance in candidates[:3]:
+        candidate_id = str(candidate.get("id", "")).strip()
+        if not candidate_id:
+            continue
+        route_options.append(
+            {
+                "id": candidate_id,
+                "title": str(candidate.get("title", "")).strip(),
+                "refs": str(candidate.get("refs", "")).strip(),
+                "matched_issue_refs": _checkpoint_candidate_matched_refs(relevance),
+                "route_kind": _checkpoint_route_kind(candidate),
+                "parent_id": str(candidate.get("parent_id", "")).strip(),
+                "lane_id": str(candidate.get("lane_id", "")).strip(),
+                "priority": str(candidate.get("priority", "")).strip(),
+                "evidence": relevance.get("strong_evidence", [])[:3],
+                "next_action": "promote-roadmap-candidate-to-durable-planning-owner",
+                "command": _command_with_expected_planning_revision(
+                    _command_with_cli_invoke(
+                        command=f"agentic-workspace planning promote-to-plan --item-id {candidate_id} --target . --format json",
+                        cli_invoke=cli_invoke,
+                    ),
+                    planning_revision=planning_revision,
+                ),
+            }
+        )
+    return {
+        "kind": "agentic-workspace/local-checkpoint-planning-candidate-routes/v1",
+        "status": "matched",
+        "issue_refs": issue_refs,
+        "matched_candidate_count": len(candidates),
+        "candidate_ids": [option["id"] for option in route_options],
+        "route_options": route_options,
+        "planning_revision": planning_revision,
+        "authority": "advisory-from-local-checkpoint-and-checked-in-planning",
+        "claim_boundary": "Verify checkpoint refs against durable sources before claims; priority and intent judgment remain agent/human-owned.",
+        "rule": "Local checkpoint issue refs can point at checked-in Planning candidates, but the checkpoint remains advisory and local-only.",
+    }
+
+
 def _local_chat_checkpoint_projection(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
     path = _local_chat_checkpoint_path(target_root)
     relative_path = LOCAL_CHAT_CHECKPOINT_PATH.as_posix()
@@ -24311,7 +24406,7 @@ def _local_chat_checkpoint_projection(*, target_root: Path, cli_invoke: str) -> 
         }
     durable_sources = _list_payload(checkpoint.get("durable_sources"))
     status = "present" if checkpoint.get("kind") == LOCAL_CHAT_CHECKPOINT_KIND else "stale"
-    return {
+    payload = {
         **base,
         "status": status,
         "checkpoint_kind": str(checkpoint.get("kind", "")).strip(),
@@ -24337,6 +24432,15 @@ def _local_chat_checkpoint_projection(*, target_root: Path, cli_invoke: str) -> 
         "limits": _as_dict(checkpoint.get("limits")),
         "rule": "Local checkpoints are advisory continuity hints; fresh local/remote truth and durable sources remain authoritative.",
     }
+    candidate_routes = _local_checkpoint_planning_candidate_routes(
+        target_root=target_root,
+        cli_invoke=cli_invoke,
+        checkpoint=checkpoint,
+        durable_sources=durable_sources,
+    )
+    if candidate_routes.get("status") == "matched":
+        payload["planning_candidate_routes"] = candidate_routes
+    return payload
 
 
 def _local_chat_checkpoint_record(

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -22244,6 +22244,10 @@ def _planning_roadmap_candidates(target_root: Path) -> list[dict[str, Any]]:
                 "priority": str(candidate.get("priority", "")).strip(),
                 "status": status or "unknown",
                 "maturity": maturity or "unknown",
+                "route_kind": str(candidate.get("kind") or candidate.get("route_kind") or "").strip(),
+                "parent_id": str(candidate.get("parent_id") or candidate.get("parent") or "").strip(),
+                "lane_id": str(candidate.get("lane_id") or "").strip(),
+                "owner_surface": str(candidate.get("owner_surface") or "").strip(),
                 "outcome": str(candidate.get("outcome", "")).strip(),
                 "promotion_signal": str(candidate.get("promotion_signal", "")).strip(),
                 "suggested_first_slice": str(candidate.get("suggested_first_slice", "")).strip(),
@@ -24185,6 +24189,97 @@ def _checkpoint_resume_checklist() -> list[dict[str, str]]:
     ]
 
 
+def _local_checkpoint_issue_refs(*, checkpoint: dict[str, Any], durable_sources: list[Any]) -> list[str]:
+    raw_values: list[Any] = [
+        *_list_payload(checkpoint.get("current_issue_refs")),
+        *durable_sources,
+        checkpoint.get("task"),
+    ]
+    volatile_refs = _as_dict(_as_dict(checkpoint.get("volatile_observations")).get("current_issue_refs")).get("value")
+    raw_values.extend(_list_payload(volatile_refs))
+    refs: set[str] = set()
+    for raw in raw_values:
+        text = str(raw or "")
+        refs.update(f"#{match}" for match in re.findall(r"#(\d+)\b", text))
+        refs.update(f"#{match}" for match in re.findall(r"/issues/(\d+)\b", text))
+    return sorted(refs, key=lambda value: int(value.lstrip("#")) if value.lstrip("#").isdigit() else value)
+
+
+def _checkpoint_route_kind(candidate: dict[str, Any]) -> str:
+    route_kind = str(candidate.get("route_kind", "")).strip().lower()
+    if route_kind in {"parent-lane", "parent", "lane"}:
+        return "parent-lane"
+    if route_kind in {"child-slice", "child", "slice"}:
+        return "child-slice"
+    if str(candidate.get("parent_id", "")).strip() or str(candidate.get("lane_id", "")).strip():
+        return "child-slice"
+    return "standalone"
+
+
+def _checkpoint_candidate_matched_refs(relevance: dict[str, Any]) -> list[str]:
+    refs: list[str] = []
+    for item in _list_payload(relevance.get("strong_evidence")):
+        text = str(item)
+        if text.startswith("issue_ref:"):
+            refs.append(text.removeprefix("issue_ref:"))
+    return _dedupe(refs)
+
+
+def _local_checkpoint_planning_candidate_routes(
+    *, target_root: Path, cli_invoke: str, checkpoint: dict[str, Any], durable_sources: list[Any]
+) -> dict[str, Any]:
+    issue_refs = _local_checkpoint_issue_refs(checkpoint=checkpoint, durable_sources=durable_sources)
+    if not issue_refs:
+        return {"status": "no-issue-refs"}
+    candidates = []
+    for candidate in _planning_roadmap_candidates(target_root):
+        relevance = _candidate_relevance_payload(candidate, issue_refs=issue_refs, task_text=str(checkpoint.get("task", "")))
+        if not relevance.get("strong_evidence"):
+            continue
+        candidates.append((candidate, relevance))
+    if not candidates:
+        return {"status": "no-matches", "issue_refs": issue_refs}
+    planning_revision = _planning_revision_payload(target_root=target_root)
+    route_options: list[dict[str, Any]] = []
+    for candidate, relevance in candidates[:3]:
+        candidate_id = str(candidate.get("id", "")).strip()
+        if not candidate_id:
+            continue
+        route_options.append(
+            {
+                "id": candidate_id,
+                "title": str(candidate.get("title", "")).strip(),
+                "refs": str(candidate.get("refs", "")).strip(),
+                "matched_issue_refs": _checkpoint_candidate_matched_refs(relevance),
+                "route_kind": _checkpoint_route_kind(candidate),
+                "parent_id": str(candidate.get("parent_id", "")).strip(),
+                "lane_id": str(candidate.get("lane_id", "")).strip(),
+                "priority": str(candidate.get("priority", "")).strip(),
+                "evidence": relevance.get("strong_evidence", [])[:3],
+                "next_action": "promote-roadmap-candidate-to-durable-planning-owner",
+                "command": _command_with_expected_planning_revision(
+                    _command_with_cli_invoke(
+                        command=f"agentic-workspace planning promote-to-plan --item-id {candidate_id} --target . --format json",
+                        cli_invoke=cli_invoke,
+                    ),
+                    planning_revision=planning_revision,
+                ),
+            }
+        )
+    return {
+        "kind": "agentic-workspace/local-checkpoint-planning-candidate-routes/v1",
+        "status": "matched",
+        "issue_refs": issue_refs,
+        "matched_candidate_count": len(candidates),
+        "candidate_ids": [option["id"] for option in route_options],
+        "route_options": route_options,
+        "planning_revision": planning_revision,
+        "authority": "advisory-from-local-checkpoint-and-checked-in-planning",
+        "claim_boundary": "Verify checkpoint refs against durable sources before claims; priority and intent judgment remain agent/human-owned.",
+        "rule": "Local checkpoint issue refs can point at checked-in Planning candidates, but the checkpoint remains advisory and local-only.",
+    }
+
+
 def _local_chat_checkpoint_projection(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
     path = _local_chat_checkpoint_path(target_root)
     relative_path = LOCAL_CHAT_CHECKPOINT_PATH.as_posix()
@@ -24219,7 +24314,7 @@ def _local_chat_checkpoint_projection(*, target_root: Path, cli_invoke: str) -> 
         }
     durable_sources = _list_payload(checkpoint.get("durable_sources"))
     status = "present" if checkpoint.get("kind") == LOCAL_CHAT_CHECKPOINT_KIND else "stale"
-    return {
+    payload = {
         **base,
         "status": status,
         "checkpoint_kind": str(checkpoint.get("kind", "")).strip(),
@@ -24245,6 +24340,15 @@ def _local_chat_checkpoint_projection(*, target_root: Path, cli_invoke: str) -> 
         "limits": _as_dict(checkpoint.get("limits")),
         "rule": "Local checkpoints are advisory continuity hints; fresh local/remote truth and durable sources remain authoritative.",
     }
+    candidate_routes = _local_checkpoint_planning_candidate_routes(
+        target_root=target_root,
+        cli_invoke=cli_invoke,
+        checkpoint=checkpoint,
+        durable_sources=durable_sources,
+    )
+    if candidate_routes.get("status") == "matched":
+        payload["planning_candidate_routes"] = candidate_routes
+    return payload
 
 
 def _local_chat_checkpoint_record(

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1191,6 +1191,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                 "local_notes",
                 "proof_state",
                 "resume_checklist",
+                "planning_candidate_routes",
                 "detail_command",
                 "authority",
             )

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -841,6 +841,130 @@ def test_local_chat_checkpoint_write_creates_valid_local_record_and_startup_pack
     assert "local_chat_checkpoint=present" in startup["action_signals"]["changed_signals"]
 
 
+def test_local_chat_checkpoint_surfaces_matching_planning_candidate_routes(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "github-1700-local-checkpoints", kind = "lane", maturity = "candidate", status = "next", priority = "P1", refs = "GitHub #1700", title = "Local checkpoints", outcome = "Experiment with checkpoints.", promotion_signal = "Promote before parent closeout.", suggested_first_slice = "Shape checkpoint work." },
+  { id = "github-1704-checkpoint-dogfood", kind = "slice", parent_id = "#1700", maturity = "candidate", status = "next", priority = "P2", refs = "GitHub #1704", title = "Checkpoint dogfood", outcome = "Dogfood checkpoint resume.", promotion_signal = "Promote before implementation.", suggested_first_slice = "Run checkpoint dogfood." },
+  { id = "github-9999-unrelated", maturity = "candidate", status = "next", priority = "P2", refs = "GitHub #9999", title = "Unrelated", outcome = "Do something else." },
+]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "checkpoint",
+                "write",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Dogfood #1700 checkpoint resume",
+                "--issue",
+                "#1700",
+                "--issue",
+                "#1704",
+                "--durable-source",
+                "https://github.com/rickardvh/agentic-workspace/issues/1704",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert cli.main(["start", "--target", str(tmp_path), "--select", "local_chat_checkpoint", "--format", "json"]) == 0
+    selected = json.loads(capsys.readouterr().out)["values"]["local_chat_checkpoint"]
+    routes = selected["planning_candidate_routes"]
+    assert routes["status"] == "matched"
+    assert routes["issue_refs"] == ["#1700", "#1704"]
+    assert routes["candidate_ids"] == ["github-1700-local-checkpoints", "github-1704-checkpoint-dogfood"]
+    assert routes["matched_candidate_count"] == 2
+    assert routes["route_options"][0]["id"] == "github-1700-local-checkpoints"
+    assert routes["route_options"][0]["title"] == "Local checkpoints"
+    assert routes["route_options"][0]["matched_issue_refs"] == ["#1700"]
+    assert routes["route_options"][0]["route_kind"] == "parent-lane"
+    assert routes["route_options"][0]["next_action"] == "promote-roadmap-candidate-to-durable-planning-owner"
+    assert routes["route_options"][1]["route_kind"] == "child-slice"
+    assert routes["route_options"][1]["parent_id"] == "#1700"
+    assert "planning promote-to-plan --item-id github-1700-local-checkpoints" in routes["route_options"][0]["command"]
+    assert "--expect-planning-revision" in routes["route_options"][0]["command"]
+    assert "github-9999-unrelated" not in json.dumps(routes)
+    assert routes["authority"] == "advisory-from-local-checkpoint-and-checked-in-planning"
+    assert "Verify checkpoint refs against durable sources" in routes["claim_boundary"]
+
+    assert cli.main(["start", "--target", str(tmp_path), "--task", "Resume checkpoint slice", "--format", "json"]) == 0
+    startup = json.loads(capsys.readouterr().out)
+    context_routes = startup["context"]["local_chat_checkpoint"]["planning_candidate_routes"]
+    assert context_routes["candidate_ids"] == routes["candidate_ids"]
+    assert context_routes["route_options"][1]["id"] == "github-1704-checkpoint-dogfood"
+
+
+def test_local_chat_checkpoint_omits_route_suggestions_when_no_candidate_matches(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = []
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = [
+  { id = "github-1700-local-checkpoints", maturity = "candidate", status = "next", priority = "P1", refs = "GitHub #1700", title = "Local checkpoints" },
+]
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "checkpoint",
+                "write",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Resume unrelated checkpoint",
+                "--issue",
+                "#1801",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert cli.main(["start", "--target", str(tmp_path), "--select", "local_chat_checkpoint", "--format", "json"]) == 0
+    selected = json.loads(capsys.readouterr().out)["values"]["local_chat_checkpoint"]
+    assert selected["status"] == "present"
+    assert "planning_candidate_routes" not in selected
+
+    assert cli.main(["start", "--target", str(tmp_path), "--task", "Resume unrelated checkpoint", "--format", "json"]) == 0
+    startup = json.loads(capsys.readouterr().out)
+    assert "planning_candidate_routes" not in startup["context"]["local_chat_checkpoint"]
+
+
 def test_local_chat_checkpoint_write_preserves_and_replaces_values(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0


### PR DESCRIPTION
## Summary
- Surface checkpoint-matched roadmap candidate routes in the local checkpoint projection.
- Include matched issue refs, candidate ids/titles, route kind hints, and the command-owned promote action with planning revision guard.
- Keep checkpoint routing advisory/local-only and require durable-source verification before claims.
- Sync the checkpoint projection/helper changes through both mirrored runtime surfaces: `src/agentic_workspace/workspace_runtime_core.py` and `src/agentic_workspace/workspace_runtime_primitives.py`.

## Runtime mirror parity
- #1809 caveat checked: `local_chat_checkpoint` projection is mirrored in `workspace_runtime_primitives.py`, so this PR includes the same helper/payload changes there rather than treating the change as core-only.
- Parity-oriented check run: `uv run python scripts/check/check_generated_command_packages.py --aw-primitive-ownership --format json` (`status: satisfied`).

## Validation
- `uv run python scripts/check/check_generated_command_packages.py --aw-primitive-ownership --format json`
- `uv run pytest tests/test_workspace_cli.py -q -k "local_chat_checkpoint"`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`

Closes #1810