### PR TITLE
[codex] Surface runtime mirror drift review

### DIFF
--- a/src/agentic_workspace/runtime_source_review.py
+++ b/src/agentic_workspace/runtime_source_review.py
@@ -26,6 +26,40 @@ GENERATED_CLI_RUNTIME_SOURCE_MODULE_PATHS = {
     "repo_verification_bootstrap.runtime_primitives": "packages/verification/src/repo_verification_bootstrap/runtime_primitives.py",
 }
 
+MIRRORED_RUNTIME_PAYLOAD_HELPER_PAIRS = [
+    {
+        "id": "workspace-runtime-core-primitives-payload-helpers",
+        "paths": [
+            "src/agentic_workspace/workspace_runtime_core.py",
+            "src/agentic_workspace/workspace_runtime_primitives.py",
+        ],
+        "why": (
+            "workspace runtime payload/helper behavior is currently mirrored between the hand-owned core surface "
+            "and the generated-CLI primitive runtime surface"
+        ),
+        "smallest_parity_proof_command": (
+            'uv run pytest tests/test_workspace_summary_cli.py -q -k "external_intent_refresh_applies_stale_candidate_reconciliation"'
+        ),
+        "maintainer_check_command": (
+            "uv run python scripts/check/check_generated_command_packages.py --aw-primitive-ownership --format json"
+        ),
+        "represented_regression": (
+            "#1802-style startup path passed while external-intent refresh used the unsynced primitives runtime path"
+        ),
+    }
+]
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
 
 def _list_payload(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
@@ -121,7 +155,81 @@ def tiny_runtime_source_edit_review_payload(value: dict[str, Any]) -> dict[str, 
     }
     if review_items:
         payload["review_items"] = review_items
+    mirror_review = value.get("mirror_drift_review")
+    if isinstance(mirror_review, dict) and mirror_review.get("status") != "not-applicable":
+        records = []
+        for record in _list_payload(mirror_review.get("records"))[:3]:
+            if not isinstance(record, dict):
+                continue
+            records.append(
+                {
+                    "id": record.get("id", ""),
+                    "status": record.get("status", "unknown"),
+                    "changed_paths": record.get("changed_paths", []),
+                    "paired_paths": record.get("paired_paths", []),
+                    "paired_file_changed": record.get("paired_file_changed", False),
+                    "likely_paired_file": record.get("likely_paired_file", ""),
+                    "smallest_parity_proof_command": record.get("smallest_parity_proof_command", ""),
+                    "maintainer_check_command": record.get("maintainer_check_command", ""),
+                    "expected_action": record.get("expected_action", ""),
+                    "represented_regression": record.get("represented_regression", ""),
+                }
+            )
+        payload["mirror_drift_review"] = {
+            "kind": mirror_review.get("kind", "agentic-workspace/runtime-mirror-drift-review/v1"),
+            "status": mirror_review.get("status", "unknown"),
+            "record_count": mirror_review.get("record_count", len(records)),
+            "records": records,
+            "rule": mirror_review.get("rule", ""),
+        }
     return payload
+
+
+def runtime_mirror_drift_review_for_changed_paths(changed_paths: list[str]) -> dict[str, Any]:
+    changed_set = set(changed_paths)
+    records: list[dict[str, Any]] = []
+    for pair in MIRRORED_RUNTIME_PAYLOAD_HELPER_PAIRS:
+        pair_paths = [str(path) for path in _list_payload(pair.get("paths")) if str(path).strip()]
+        touched = [path for path in pair_paths if path in changed_set]
+        if not touched:
+            continue
+        paired_paths = [path for path in pair_paths if path not in set(touched)]
+        paired_file_changed = not paired_paths
+        records.append(
+            {
+                "id": str(pair.get("id", "")),
+                "status": "paired-change-requires-parity-proof" if paired_file_changed else "warning-asymmetric-mirror-change",
+                "changed_paths": touched,
+                "paired_paths": paired_paths,
+                "paired_file_changed": paired_file_changed,
+                "likely_paired_file": paired_paths[0] if len(paired_paths) == 1 else "",
+                "why": str(pair.get("why", "")),
+                "smallest_parity_proof_command": str(pair.get("smallest_parity_proof_command", "")),
+                "maintainer_check_command": str(pair.get("maintainer_check_command", "")),
+                "expected_action": (
+                    "mirror the payload/helper change, prove it is intentionally one-sided, "
+                    "or run the named parity proof before claiming completion"
+                ),
+                "represented_regression": str(pair.get("represented_regression", "")),
+            }
+        )
+    if not records:
+        return {"kind": "agentic-workspace/runtime-mirror-drift-review/v1", "status": "not-applicable", "records": []}
+    status = (
+        "warning"
+        if any(record["status"] == "warning-asymmetric-mirror-change" for record in records)
+        else "paired-change-requires-parity-proof"
+    )
+    return {
+        "kind": "agentic-workspace/runtime-mirror-drift-review/v1",
+        "status": status,
+        "record_count": len(records),
+        "records": records,
+        "rule": (
+            "Known mirrored runtime payload/helper surfaces must be reviewed for pair drift before completion claims; "
+            "this is an early signal, not a claim that all file edits are mirrored behavior."
+        ),
+    }
 
 
 def runtime_source_inventory_entries_for_path(changed_path: str) -> list[dict[str, Any]]:
@@ -161,8 +269,17 @@ def runtime_source_inventory_entries_for_path(changed_path: str) -> list[dict[st
 
 
 def runtime_source_edit_review_for_changed_paths(changed_paths: list[str]) -> dict[str, Any]:
+    mirror_drift_review = runtime_mirror_drift_review_for_changed_paths(changed_paths)
+    mirror_paths = [
+        str(path)
+        for record in _list_payload(mirror_drift_review.get("records"))
+        if isinstance(record, dict)
+        for path in _list_payload(record.get("changed_paths"))
+        if str(path).strip()
+    ]
     runtime_paths = [path for path in changed_paths if path in GENERATED_CLI_RUNTIME_SOURCE_EDIT_PATHS]
-    if not runtime_paths:
+    review_changed_paths = _dedupe([*runtime_paths, *mirror_paths])
+    if not review_changed_paths:
         return {"kind": "agentic-workspace/runtime-source-edit-review/v1", "status": "not-applicable", "changed_paths": []}
     inventory_by_path = {path: runtime_source_inventory_entries_for_path(path) for path in runtime_paths}
     review_items = [
@@ -182,14 +299,20 @@ def runtime_source_edit_review_for_changed_paths(changed_paths: list[str]) -> di
         for path in runtime_paths
     ]
     missing_inventory = [item["changed_path"] for item in review_items if item["status"] == "inventory-missing"]
-    status = "blocked-missing-inventory" if missing_inventory else "classification-required"
+    if missing_inventory:
+        status = "blocked-missing-inventory"
+    elif mirror_drift_review.get("status") == "warning":
+        status = "mirror-drift-warning"
+    else:
+        status = "classification-required"
     return {
         "kind": "agentic-workspace/runtime-source-edit-review/v1",
         "status": status,
-        "changed_paths": runtime_paths,
+        "changed_paths": review_changed_paths,
         "review_items": review_items,
         "inventory_source": "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
         "missing_inventory_paths": missing_inventory,
+        "mirror_drift_review": mirror_drift_review,
         "accepted_direct_edit_reasons": [
             "existing-primitive-bugfix",
             "new-primitive-implementation",

--- a/src/agentic_workspace/runtime_source_review.py
+++ b/src/agentic_workspace/runtime_source_review.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import re
 import subprocess
 from pathlib import Path
@@ -49,17 +50,37 @@ MIRRORED_RUNTIME_PAYLOAD_HELPER_PAIRS = [
         "represented_regression": (
             "#1802-style startup path passed while external-intent refresh used the unsynced primitives runtime path"
         ),
-        "region_terms": [
-            "payload",
-            "projection",
-            "context",
-            "packet",
-            "review",
-            "route",
-            "candidate",
-            "checkpoint",
-            "external_intent",
-            "planning_candidate",
+        "regions": [
+            {
+                "id": "external-issue-intake-helper-region",
+                "kind": "declared-region",
+                "anchors_by_path": {
+                    "src/agentic_workspace/workspace_runtime_core.py": {
+                        "start_symbol": "_planning_candidate_suggestions_from_external_items",
+                        "end_symbol": "_stale_planning_candidate_reconciliation",
+                    },
+                    "src/agentic_workspace/workspace_runtime_primitives.py": {
+                        "start_symbol": "_planning_candidate_suggestions_from_external_items",
+                        "end_symbol": "_stale_planning_candidate_reconciliation",
+                    },
+                },
+            },
+            {
+                "id": "external-intent-refresh-payload",
+                "kind": "declared-symbol",
+                "symbols_by_path": {
+                    "src/agentic_workspace/workspace_runtime_core.py": ["_refresh_github_external_intent_evidence"],
+                    "src/agentic_workspace/workspace_runtime_primitives.py": ["_refresh_github_external_intent_evidence"],
+                },
+            },
+            {
+                "id": "open-issue-intake-payload",
+                "kind": "declared-symbol",
+                "symbols_by_path": {
+                    "src/agentic_workspace/workspace_runtime_core.py": ["_open_issue_intake_payload"],
+                    "src/agentic_workspace/workspace_runtime_primitives.py": ["_open_issue_intake_payload"],
+                },
+            },
         ],
     }
 ]
@@ -76,11 +97,7 @@ def _dedupe(values: list[str]) -> list[str]:
     return deduped
 
 
-def _normalized_region_terms(pair: dict[str, Any]) -> list[str]:
-    return [str(term).strip().lower().replace("-", "_") for term in _list_payload(pair.get("region_terms")) if str(term).strip()]
-
-
-def _changed_python_symbols_from_git_diff(*, target_root: Path | None, path: str) -> list[str]:
+def _changed_line_ranges_from_git_diff(*, target_root: Path | None, path: str) -> list[tuple[int, int]]:
     if target_root is None:
         return []
     try:
@@ -90,28 +107,123 @@ def _changed_python_symbols_from_git_diff(*, target_root: Path | None, path: str
         return []
     if result.returncode != 0 or not result.stdout.strip():
         return []
-    symbols: list[str] = []
+    ranges: list[tuple[int, int]] = []
+    hunk_pattern = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
     for line in result.stdout.splitlines():
-        candidate = ""
-        if line.startswith("@@"):
-            candidate = line.rsplit("@@", 1)[-1]
-        elif line.startswith("+") and not line.startswith("+++"):
-            candidate = line[1:]
-        match = re.search(r"\b(?:def|class)\s+([A-Za-z_][A-Za-z0-9_]*)", candidate)
-        if match:
-            symbols.append(match.group(1))
-    return _dedupe(symbols)
+        match = hunk_pattern.match(line)
+        if not match:
+            continue
+        start = int(match.group(1))
+        length = int(match.group(2) or "1")
+        if length == 0:
+            ranges.append((start, start))
+        else:
+            ranges.append((start, start + length - 1))
+    return ranges
 
 
-def _runtime_mirror_region_signal(
-    *, pair: dict[str, Any], touched_paths: list[str], target_root: Path | None, task_text: str | None
-) -> tuple[bool, list[str]]:
-    terms = _normalized_region_terms(pair)
-    symbols = [symbol for path in touched_paths for symbol in _changed_python_symbols_from_git_diff(target_root=target_root, path=path)]
-    matched = [f"symbol:{symbol}" for symbol in symbols if any(term in symbol.lower() for term in terms)]
-    task_haystack = str(task_text or "").lower().replace("-", "_")
-    matched.extend(f"task_term:{term}" for term in terms if term in task_haystack)
-    return bool(matched), _dedupe(matched)
+def _python_symbol_spans(*, target_root: Path | None, path: str) -> dict[str, tuple[int, int]]:
+    if target_root is None:
+        return {}
+    source_path = target_root / path
+    try:
+        module = ast.parse(source_path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return {}
+    spans: dict[str, tuple[int, int]] = {}
+    for node in ast.walk(module):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            continue
+        end_lineno = getattr(node, "end_lineno", node.lineno)
+        spans[node.name] = (node.lineno, int(end_lineno))
+    return spans
+
+
+def _ranges_intersect(left: tuple[int, int], right: tuple[int, int]) -> bool:
+    return left[0] <= right[1] and right[0] <= left[1]
+
+
+def _region_spans_for_path(*, target_root: Path | None, region: dict[str, Any], path: str) -> list[dict[str, Any]]:
+    spans = _python_symbol_spans(target_root=target_root, path=path)
+    resolved: list[dict[str, Any]] = []
+    symbols_by_path = region.get("symbols_by_path")
+    if isinstance(symbols_by_path, dict):
+        for symbol in _list_payload(symbols_by_path.get(path)):
+            symbol_name = str(symbol).strip()
+            if symbol_name in spans:
+                resolved.append(
+                    {
+                        "kind": "declared-symbol",
+                        "symbol": symbol_name,
+                        "span": spans[symbol_name],
+                    }
+                )
+    anchors_by_path = region.get("anchors_by_path")
+    anchors = anchors_by_path.get(path) if isinstance(anchors_by_path, dict) else None
+    if isinstance(anchors, dict):
+        start_symbol = str(anchors.get("start_symbol", "")).strip()
+        end_symbol = str(anchors.get("end_symbol", "")).strip()
+        if start_symbol in spans and end_symbol in spans:
+            resolved.append(
+                {
+                    "kind": "declared-region",
+                    "start_symbol": start_symbol,
+                    "end_symbol": end_symbol,
+                    "span": (spans[start_symbol][0], spans[end_symbol][1]),
+                }
+            )
+    return resolved
+
+
+def _changed_declared_regions(
+    *, pair: dict[str, Any], touched_paths: list[str], target_root: Path | None
+) -> tuple[list[dict[str, Any]], list[str]]:
+    changed: list[dict[str, Any]] = []
+    evidence: list[str] = []
+    changed_ranges_by_path = {path: _changed_line_ranges_from_git_diff(target_root=target_root, path=path) for path in touched_paths}
+    for region in _list_payload(pair.get("regions")):
+        if not isinstance(region, dict):
+            continue
+        region_id = str(region.get("id", "")).strip()
+        if not region_id:
+            continue
+        for path in touched_paths:
+            changed_ranges = changed_ranges_by_path.get(path, [])
+            if not changed_ranges:
+                continue
+            for declared_span in _region_spans_for_path(target_root=target_root, region=region, path=path):
+                span = declared_span.get("span")
+                if not isinstance(span, tuple):
+                    continue
+                if not any(_ranges_intersect(span, changed_range) for changed_range in changed_ranges):
+                    continue
+                item = {
+                    "id": region_id,
+                    "path": path,
+                    "kind": declared_span.get("kind", str(region.get("kind", "declared-region"))),
+                }
+                if declared_span.get("symbol"):
+                    item["symbol"] = declared_span["symbol"]
+                    evidence.append(f"declared_symbol:{path}:{declared_span['symbol']}")
+                else:
+                    item["start_symbol"] = declared_span.get("start_symbol", "")
+                    item["end_symbol"] = declared_span.get("end_symbol", "")
+                    evidence.append(f"declared_region:{path}:{region_id}")
+                changed.append(item)
+                break
+    return changed, _dedupe(evidence)
+
+
+def _paired_declared_regions_for_missing_paths(*, pair: dict[str, Any], changed_regions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    paired: list[dict[str, Any]] = []
+    pair_paths = [str(path) for path in _list_payload(pair.get("paths")) if str(path).strip()]
+    for changed_region in changed_regions:
+        region_id = str(changed_region.get("id", "")).strip()
+        changed_path = str(changed_region.get("path", "")).strip()
+        missing_paths = [path for path in pair_paths if path != changed_path]
+        for missing_path in missing_paths:
+            paired.append({"id": region_id, "path": missing_path, "kind": changed_region.get("kind", "declared-region")})
+    return paired
 
 
 def _list_payload(value: Any) -> list[Any]:
@@ -217,12 +329,16 @@ def tiny_runtime_source_edit_review_payload(value: dict[str, Any]) -> dict[str, 
             records.append(
                 {
                     "id": record.get("id", ""),
+                    "mirror_pair_id": record.get("mirror_pair_id", ""),
+                    "region_id": record.get("region_id", ""),
                     "status": record.get("status", "unknown"),
                     "changed_paths": record.get("changed_paths", []),
                     "paired_paths": record.get("paired_paths", []),
                     "paired_file_changed": record.get("paired_file_changed", False),
                     "likely_paired_file": record.get("likely_paired_file", ""),
                     "trigger_evidence": record.get("trigger_evidence", []),
+                    "changed_regions": record.get("changed_regions", []),
+                    "paired_regions": record.get("paired_regions", []),
                     "smallest_parity_proof_command": record.get("smallest_parity_proof_command", ""),
                     "maintainer_check_command": record.get("maintainer_check_command", ""),
                     "expected_action": record.get("expected_action", ""),
@@ -239,9 +355,7 @@ def tiny_runtime_source_edit_review_payload(value: dict[str, Any]) -> dict[str, 
     return payload
 
 
-def runtime_mirror_drift_review_for_changed_paths(
-    changed_paths: list[str], *, target_root: Path | None = None, task_text: str | None = None
-) -> dict[str, Any]:
+def runtime_mirror_drift_review_for_changed_paths(changed_paths: list[str], *, target_root: Path | None = None) -> dict[str, Any]:
     changed_set = set(changed_paths)
     records: list[dict[str, Any]] = []
     for pair in MIRRORED_RUNTIME_PAYLOAD_HELPER_PAIRS:
@@ -249,32 +363,44 @@ def runtime_mirror_drift_review_for_changed_paths(
         touched = [path for path in pair_paths if path in changed_set]
         if not touched:
             continue
-        has_region_signal, trigger_evidence = _runtime_mirror_region_signal(
-            pair=pair, touched_paths=touched, target_root=target_root, task_text=task_text
-        )
-        if not has_region_signal:
+        changed_regions, trigger_evidence = _changed_declared_regions(pair=pair, touched_paths=touched, target_root=target_root)
+        if not changed_regions:
             continue
-        paired_paths = [path for path in pair_paths if path not in set(touched)]
-        paired_file_changed = not paired_paths
-        records.append(
-            {
-                "id": str(pair.get("id", "")),
-                "status": "paired-change-requires-parity-proof" if paired_file_changed else "warning-asymmetric-mirror-change",
-                "changed_paths": touched,
-                "paired_paths": paired_paths,
-                "paired_file_changed": paired_file_changed,
-                "likely_paired_file": paired_paths[0] if len(paired_paths) == 1 else "",
-                "trigger_evidence": trigger_evidence,
-                "why": str(pair.get("why", "")),
-                "smallest_parity_proof_command": str(pair.get("smallest_parity_proof_command", "")),
-                "maintainer_check_command": str(pair.get("maintainer_check_command", "")),
-                "expected_action": (
-                    "mirror the payload/helper change, prove it is intentionally one-sided, "
-                    "or run the named parity proof before claiming completion"
-                ),
-                "represented_regression": str(pair.get("represented_regression", "")),
-            }
-        )
+        region_ids = _dedupe([str(region.get("id", "")) for region in changed_regions if str(region.get("id", "")).strip()])
+        for region_id in region_ids:
+            region_changes = [region for region in changed_regions if str(region.get("id", "")) == region_id]
+            touched_region_paths = _dedupe(
+                [str(region.get("path", "")) for region in region_changes if str(region.get("path", "")).strip()]
+            )
+            paired_paths = [path for path in pair_paths if path not in set(touched_region_paths)]
+            paired_file_changed = not paired_paths
+            records.append(
+                {
+                    "id": f"{pair.get('id', '')}:{region_id}",
+                    "mirror_pair_id": str(pair.get("id", "")),
+                    "region_id": region_id,
+                    "status": "paired-change-requires-parity-proof" if paired_file_changed else "warning-asymmetric-mirror-change",
+                    "changed_paths": touched_region_paths,
+                    "paired_paths": paired_paths,
+                    "paired_file_changed": paired_file_changed,
+                    "likely_paired_file": paired_paths[0] if len(paired_paths) == 1 else "",
+                    "trigger_evidence": [
+                        item
+                        for item in trigger_evidence
+                        if any(str(region.get("path", "")) in item and str(region.get("id", "")) == region_id for region in region_changes)
+                    ],
+                    "changed_regions": region_changes,
+                    "paired_regions": _paired_declared_regions_for_missing_paths(pair=pair, changed_regions=region_changes),
+                    "why": str(pair.get("why", "")),
+                    "smallest_parity_proof_command": str(pair.get("smallest_parity_proof_command", "")),
+                    "maintainer_check_command": str(pair.get("maintainer_check_command", "")),
+                    "expected_action": (
+                        "mirror the payload/helper change, prove it is intentionally one-sided, "
+                        "or run the named parity proof before claiming completion"
+                    ),
+                    "represented_regression": str(pair.get("represented_regression", "")),
+                }
+            )
     if not records:
         return {"kind": "agentic-workspace/runtime-mirror-drift-review/v1", "status": "not-applicable", "records": []}
     status = (
@@ -288,8 +414,8 @@ def runtime_mirror_drift_review_for_changed_paths(
         "record_count": len(records),
         "records": records,
         "rule": (
-            "Known mirrored runtime payload/helper surfaces must be reviewed for pair drift before completion claims; "
-            "this is an early signal, not a claim that all file edits are mirrored behavior."
+            "Known mirrored runtime payload/helper surfaces are declared by exact symbols or regions; "
+            "only changed code inside that contract surfaces pair-drift review before completion claims."
         ),
     }
 
@@ -333,7 +459,7 @@ def runtime_source_inventory_entries_for_path(changed_path: str) -> list[dict[st
 def runtime_source_edit_review_for_changed_paths(
     changed_paths: list[str], *, target_root: Path | None = None, task_text: str | None = None
 ) -> dict[str, Any]:
-    mirror_drift_review = runtime_mirror_drift_review_for_changed_paths(changed_paths, target_root=target_root, task_text=task_text)
+    mirror_drift_review = runtime_mirror_drift_review_for_changed_paths(changed_paths, target_root=target_root)
     mirror_paths = [
         str(path)
         for record in _list_payload(mirror_drift_review.get("records"))

--- a/src/agentic_workspace/runtime_source_review.py
+++ b/src/agentic_workspace/runtime_source_review.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import re
+import subprocess
+from pathlib import Path
 from typing import Any
 
 from agentic_workspace.contract_tooling import python_runtime_projection_inventory_manifest
@@ -46,6 +49,18 @@ MIRRORED_RUNTIME_PAYLOAD_HELPER_PAIRS = [
         "represented_regression": (
             "#1802-style startup path passed while external-intent refresh used the unsynced primitives runtime path"
         ),
+        "region_terms": [
+            "payload",
+            "projection",
+            "context",
+            "packet",
+            "review",
+            "route",
+            "candidate",
+            "checkpoint",
+            "external_intent",
+            "planning_candidate",
+        ],
     }
 ]
 
@@ -59,6 +74,44 @@ def _dedupe(values: list[str]) -> list[str]:
         seen.add(value)
         deduped.append(value)
     return deduped
+
+
+def _normalized_region_terms(pair: dict[str, Any]) -> list[str]:
+    return [str(term).strip().lower().replace("-", "_") for term in _list_payload(pair.get("region_terms")) if str(term).strip()]
+
+
+def _changed_python_symbols_from_git_diff(*, target_root: Path | None, path: str) -> list[str]:
+    if target_root is None:
+        return []
+    try:
+        command = ["git", "-C", str(target_root), "diff", "--unified=0", "--", path]
+        result = subprocess.run(command, capture_output=True, text=True, timeout=5, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0 or not result.stdout.strip():
+        return []
+    symbols: list[str] = []
+    for line in result.stdout.splitlines():
+        candidate = ""
+        if line.startswith("@@"):
+            candidate = line.rsplit("@@", 1)[-1]
+        elif line.startswith("+") and not line.startswith("+++"):
+            candidate = line[1:]
+        match = re.search(r"\b(?:def|class)\s+([A-Za-z_][A-Za-z0-9_]*)", candidate)
+        if match:
+            symbols.append(match.group(1))
+    return _dedupe(symbols)
+
+
+def _runtime_mirror_region_signal(
+    *, pair: dict[str, Any], touched_paths: list[str], target_root: Path | None, task_text: str | None
+) -> tuple[bool, list[str]]:
+    terms = _normalized_region_terms(pair)
+    symbols = [symbol for path in touched_paths for symbol in _changed_python_symbols_from_git_diff(target_root=target_root, path=path)]
+    matched = [f"symbol:{symbol}" for symbol in symbols if any(term in symbol.lower() for term in terms)]
+    task_haystack = str(task_text or "").lower().replace("-", "_")
+    matched.extend(f"task_term:{term}" for term in terms if term in task_haystack)
+    return bool(matched), _dedupe(matched)
 
 
 def _list_payload(value: Any) -> list[Any]:
@@ -169,6 +222,7 @@ def tiny_runtime_source_edit_review_payload(value: dict[str, Any]) -> dict[str, 
                     "paired_paths": record.get("paired_paths", []),
                     "paired_file_changed": record.get("paired_file_changed", False),
                     "likely_paired_file": record.get("likely_paired_file", ""),
+                    "trigger_evidence": record.get("trigger_evidence", []),
                     "smallest_parity_proof_command": record.get("smallest_parity_proof_command", ""),
                     "maintainer_check_command": record.get("maintainer_check_command", ""),
                     "expected_action": record.get("expected_action", ""),
@@ -185,13 +239,20 @@ def tiny_runtime_source_edit_review_payload(value: dict[str, Any]) -> dict[str, 
     return payload
 
 
-def runtime_mirror_drift_review_for_changed_paths(changed_paths: list[str]) -> dict[str, Any]:
+def runtime_mirror_drift_review_for_changed_paths(
+    changed_paths: list[str], *, target_root: Path | None = None, task_text: str | None = None
+) -> dict[str, Any]:
     changed_set = set(changed_paths)
     records: list[dict[str, Any]] = []
     for pair in MIRRORED_RUNTIME_PAYLOAD_HELPER_PAIRS:
         pair_paths = [str(path) for path in _list_payload(pair.get("paths")) if str(path).strip()]
         touched = [path for path in pair_paths if path in changed_set]
         if not touched:
+            continue
+        has_region_signal, trigger_evidence = _runtime_mirror_region_signal(
+            pair=pair, touched_paths=touched, target_root=target_root, task_text=task_text
+        )
+        if not has_region_signal:
             continue
         paired_paths = [path for path in pair_paths if path not in set(touched)]
         paired_file_changed = not paired_paths
@@ -203,6 +264,7 @@ def runtime_mirror_drift_review_for_changed_paths(changed_paths: list[str]) -> d
                 "paired_paths": paired_paths,
                 "paired_file_changed": paired_file_changed,
                 "likely_paired_file": paired_paths[0] if len(paired_paths) == 1 else "",
+                "trigger_evidence": trigger_evidence,
                 "why": str(pair.get("why", "")),
                 "smallest_parity_proof_command": str(pair.get("smallest_parity_proof_command", "")),
                 "maintainer_check_command": str(pair.get("maintainer_check_command", "")),
@@ -268,8 +330,10 @@ def runtime_source_inventory_entries_for_path(changed_path: str) -> list[dict[st
     return sorted(matched, key=lambda item: (str(item["source_module"]), str(item["source_symbol"])))
 
 
-def runtime_source_edit_review_for_changed_paths(changed_paths: list[str]) -> dict[str, Any]:
-    mirror_drift_review = runtime_mirror_drift_review_for_changed_paths(changed_paths)
+def runtime_source_edit_review_for_changed_paths(
+    changed_paths: list[str], *, target_root: Path | None = None, task_text: str | None = None
+) -> dict[str, Any]:
+    mirror_drift_review = runtime_mirror_drift_review_for_changed_paths(changed_paths, target_root=target_root, task_text=task_text)
     mirror_paths = [
         str(path)
         for record in _list_payload(mirror_drift_review.get("records"))

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -1434,7 +1434,7 @@ def _proof_selection_for_changed_paths(
     surface_value_review = _surface_value_review_for_changed_paths(changed_paths=changed_paths, target_root=target_root)
     if surface_value_review["durable_surface_count"]:
         proof_selection["surface_value_review"] = surface_value_review
-    runtime_source_review = runtime_source_edit_review_for_changed_paths(changed_paths)
+    runtime_source_review = runtime_source_edit_review_for_changed_paths(changed_paths, target_root=target_root, task_text=task_text)
     if runtime_source_review["changed_paths"]:
         proof_selection["runtime_source_edit_review"] = runtime_source_review
     direct_cli_review = _direct_cli_edit_review_for_changed_paths(changed_paths)

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -936,7 +936,7 @@ def _start_payload(
     normalized_paths = _normalize_changed_paths(changed_paths)
     if normalized_paths and not active_planning_present:
         proof_payload = _proof_selection_for_changed_paths(
-            changed_paths=normalized_paths, target_root=target_root, include_durable_intent=False
+            changed_paths=normalized_paths, target_root=target_root, include_durable_intent=False, task_text=task_text
         )
         proof_command = str(
             _command_with_cli_invoke(
@@ -965,7 +965,7 @@ def _start_payload(
         ]
     elif normalized_paths:
         proof_payload = _proof_selection_for_changed_paths(
-            changed_paths=normalized_paths, target_root=target_root, include_durable_intent=False
+            changed_paths=normalized_paths, target_root=target_root, include_durable_intent=False, task_text=task_text
         )
         payload["proof"] = _compact_start_proof_payload(proof_payload)
         repair_profile = _compact_repair_plan_profile(

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2339,7 +2339,7 @@ def test_implement_surfaces_runtime_source_edit_review_for_generated_cli_boundar
     payload = json.loads(capsys.readouterr().out)
     review = payload["proof"]["runtime_source_edit_review"]
     assert review["kind"] == "agentic-workspace/runtime-source-edit-review/v1"
-    assert review["status"] == "classification-required"
+    assert review["status"] == "mirror-drift-warning"
     assert review["changed_paths"] == ["src/agentic_workspace/workspace_runtime_primitives.py"]
     assert review["inventory_source"] == "src/agentic_workspace/contracts/python_runtime_projection_inventory.json"
     assert review["missing_inventory_paths"] == []
@@ -2354,7 +2354,121 @@ def test_implement_surfaces_runtime_source_edit_review_for_generated_cli_boundar
     assert review["accepted_direct_edit_reasons"] == ["existing-primitive-bugfix", "new-primitive-implementation"]
     assert "package-domain boundary" in review["rejected_vague_reasons"]
     assert "inventory-backed symbol/primitive" in review["completion_claim_rule"]
+    mirror_review = review["mirror_drift_review"]
+    assert mirror_review["status"] == "warning"
+    mirror_record = mirror_review["records"][0]
+    assert mirror_record["status"] == "warning-asymmetric-mirror-change"
+    assert mirror_record["changed_paths"] == ["src/agentic_workspace/workspace_runtime_primitives.py"]
+    assert mirror_record["likely_paired_file"] == "src/agentic_workspace/workspace_runtime_core.py"
+    assert mirror_record["paired_file_changed"] is False
+    assert "external_intent_refresh_applies_stale_candidate_reconciliation" in mirror_record["smallest_parity_proof_command"]
+    assert "--aw-primitive-ownership" in mirror_record["maintainer_check_command"]
+    assert "#1802-style" in mirror_record["represented_regression"]
     assert "proof.runtime_source_edit_review" in payload["drill_down"]["available_selectors"]
+
+
+def test_implement_surfaces_runtime_mirror_warning_for_core_only_payload_helper_change(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py", "VALUE = 1\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_core.py",
+                "--task",
+                "Add a runtime payload helper.",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    review = payload["proof"]["runtime_source_edit_review"]
+    assert review["status"] == "mirror-drift-warning"
+    assert review["changed_paths"] == ["src/agentic_workspace/workspace_runtime_core.py"]
+    assert "review_items" not in review
+    mirror_review = review["mirror_drift_review"]
+    assert mirror_review["kind"] == "agentic-workspace/runtime-mirror-drift-review/v1"
+    assert mirror_review["status"] == "warning"
+    record = mirror_review["records"][0]
+    assert record["id"] == "workspace-runtime-core-primitives-payload-helpers"
+    assert record["likely_paired_file"] == "src/agentic_workspace/workspace_runtime_primitives.py"
+    assert record["paired_paths"] == ["src/agentic_workspace/workspace_runtime_primitives.py"]
+    assert "mirror the payload/helper change" in record["expected_action"]
+    assert "external_intent_refresh_applies_stale_candidate_reconciliation" in record["smallest_parity_proof_command"]
+
+
+def test_implement_runtime_mirror_review_accepts_paired_core_and_primitives_changes(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py", "VALUE = 1\n")
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_core.py",
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_primitives.py",
+                "--task",
+                "Mirror a runtime payload helper across core and primitives.",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    review = payload["proof"]["runtime_source_edit_review"]
+    assert review["status"] == "classification-required"
+    assert review["changed_paths"] == [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/workspace_runtime_core.py",
+    ]
+    record = review["mirror_drift_review"]["records"][0]
+    assert record["status"] == "paired-change-requires-parity-proof"
+    assert record["paired_file_changed"] is True
+    assert record["likely_paired_file"] == ""
+    assert "--aw-primitive-ownership" in record["maintainer_check_command"]
+
+
+def test_implement_runtime_mirror_review_stays_off_for_unrelated_changes(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "agentic_workspace" / "runtime_source_review.py", "VALUE = 1\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/runtime_source_review.py",
+                "--task",
+                "Refactor runtime source review internals.",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert "runtime_source_edit_review" not in payload["proof"]
+    assert "proof.runtime_source_edit_review" not in payload["drill_down"]["available_selectors"]
 
 
 def test_implement_keeps_active_intent_packets_selector_only(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2358,10 +2358,76 @@ def test_implement_surfaces_runtime_source_edit_review_for_generated_cli_boundar
     assert "proof.runtime_source_edit_review" in payload["drill_down"]["available_selectors"]
 
 
+_RUNTIME_MIRROR_CONTRACT_SNIPPET = """
+def _planning_candidate_suggestions_from_external_items():
+    return {"candidates": []}
+
+
+def _external_issue_grouping_hints():
+    return {"kind": "external-issue-grouping-hints/v1", "status": "present"}
+
+
+def _toml_inline_string(value):
+    return value
+
+
+def _planning_candidate_toml_row(candidate):
+    return ""
+
+
+def _append_planning_candidate_rows():
+    return {"status": "applied"}
+
+
+def _candidate_refs(candidate):
+    return set()
+
+
+def _candidate_has_local_continuation(candidate):
+    return False
+
+
+def _stale_planning_candidate_reconciliation():
+    return {"status": "no-stale-candidates"}
+
+
+def _refresh_github_external_intent_evidence():
+    planning_candidate_grouping = _external_issue_grouping_hints()
+    return {"planning_candidate_grouping": planning_candidate_grouping}
+
+
+def _open_issue_intake_payload():
+    grouping = _external_issue_grouping_hints()
+    return {"grouping_hints": grouping}
+
+
+def _unrelated_runtime_helper():
+    return "old"
+"""
+
+
+def _seed_runtime_mirror_contract_repo(target_root: Path) -> None:
+    _write_empty_planning_state(target_root)
+    _write(target_root / "src" / "agentic_workspace" / "workspace_runtime_core.py", _RUNTIME_MIRROR_CONTRACT_SNIPPET)
+    _write(target_root / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", _RUNTIME_MIRROR_CONTRACT_SNIPPET)
+    subprocess.run(["git", "init"], cwd=target_root, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "agent@example.test"], cwd=target_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Agent"], cwd=target_root, check=True)
+    subprocess.run(["git", "add", "."], cwd=target_root, check=True)
+    subprocess.run(["git", "commit", "-m", "baseline"], cwd=target_root, check=True, capture_output=True, text=True)
+
+
+def _replace_text(path: Path, old: str, new: str) -> None:
+    path.write_text(path.read_text(encoding="utf-8").replace(old, new), encoding="utf-8")
+
+
 def test_implement_surfaces_runtime_mirror_warning_for_primitives_payload_helper_change(tmp_path: Path, capsys) -> None:
-    _init_git_repo(tmp_path)
-    _write_empty_planning_state(tmp_path)
-    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
+    _seed_runtime_mirror_contract_repo(tmp_path)
+    _replace_text(
+        tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py",
+        '    return {"kind": "external-issue-grouping-hints/v1", "status": "present"}',
+        '    return {"kind": "external-issue-grouping-hints/v1", "status": "present", "child_slice_count": 0}',
+    )
 
     assert (
         cli.main(
@@ -2372,7 +2438,7 @@ def test_implement_surfaces_runtime_mirror_warning_for_primitives_payload_helper
                 "--changed",
                 "src/agentic_workspace/workspace_runtime_primitives.py",
                 "--task",
-                "Add a runtime payload helper under the generated CLI boundary.",
+                "Fix an existing primitive bug under the generated CLI boundary.",
                 "--format",
                 "json",
             ]
@@ -2390,16 +2456,25 @@ def test_implement_surfaces_runtime_mirror_warning_for_primitives_payload_helper
     assert mirror_record["changed_paths"] == ["src/agentic_workspace/workspace_runtime_primitives.py"]
     assert mirror_record["likely_paired_file"] == "src/agentic_workspace/workspace_runtime_core.py"
     assert mirror_record["paired_file_changed"] is False
-    assert "task_term:payload" in mirror_record["trigger_evidence"]
+    assert mirror_record["region_id"] == "external-issue-intake-helper-region"
+    assert (
+        "declared_region:src/agentic_workspace/workspace_runtime_primitives.py:external-issue-intake-helper-region"
+        in mirror_record["trigger_evidence"]
+    )
+    assert mirror_record["changed_regions"][0]["kind"] == "declared-region"
+    assert mirror_record["paired_regions"][0]["path"] == "src/agentic_workspace/workspace_runtime_core.py"
     assert "external_intent_refresh_applies_stale_candidate_reconciliation" in mirror_record["smallest_parity_proof_command"]
     assert "--aw-primitive-ownership" in mirror_record["maintainer_check_command"]
     assert "#1802-style" in mirror_record["represented_regression"]
 
 
 def test_implement_surfaces_runtime_mirror_warning_for_core_only_payload_helper_change(tmp_path: Path, capsys) -> None:
-    _init_git_repo(tmp_path)
-    _write_empty_planning_state(tmp_path)
-    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py", "VALUE = 1\n")
+    _seed_runtime_mirror_contract_repo(tmp_path)
+    _replace_text(
+        tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py",
+        '    return {"planning_candidate_grouping": planning_candidate_grouping}',
+        '    return {"planning_candidate_grouping": planning_candidate_grouping, "source": "refresh"}',
+    )
 
     assert (
         cli.main(
@@ -2410,7 +2485,7 @@ def test_implement_surfaces_runtime_mirror_warning_for_core_only_payload_helper_
                 "--changed",
                 "src/agentic_workspace/workspace_runtime_core.py",
                 "--task",
-                "Add a runtime payload helper.",
+                "Terse runtime refactor.",
                 "--format",
                 "json",
             ]
@@ -2427,18 +2502,26 @@ def test_implement_surfaces_runtime_mirror_warning_for_core_only_payload_helper_
     assert mirror_review["kind"] == "agentic-workspace/runtime-mirror-drift-review/v1"
     assert mirror_review["status"] == "warning"
     record = mirror_review["records"][0]
-    assert record["id"] == "workspace-runtime-core-primitives-payload-helpers"
+    assert record["mirror_pair_id"] == "workspace-runtime-core-primitives-payload-helpers"
+    assert record["region_id"] == "external-intent-refresh-payload"
     assert record["likely_paired_file"] == "src/agentic_workspace/workspace_runtime_primitives.py"
     assert record["paired_paths"] == ["src/agentic_workspace/workspace_runtime_primitives.py"]
+    assert record["changed_regions"][0]["symbol"] == "_refresh_github_external_intent_evidence"
     assert "mirror the payload/helper change" in record["expected_action"]
     assert "external_intent_refresh_applies_stale_candidate_reconciliation" in record["smallest_parity_proof_command"]
 
 
 def test_implement_runtime_mirror_review_accepts_paired_core_and_primitives_changes(tmp_path: Path, capsys) -> None:
-    _init_git_repo(tmp_path)
-    _write_empty_planning_state(tmp_path)
-    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py", "VALUE = 1\n")
-    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
+    _seed_runtime_mirror_contract_repo(tmp_path)
+    for runtime_path in (
+        tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py",
+        tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py",
+    ):
+        _replace_text(
+            runtime_path,
+            '    return {"grouping_hints": grouping}',
+            '    return {"grouping_hints": grouping, "source": "intake"}',
+        )
 
     assert (
         cli.main(
@@ -2451,7 +2534,7 @@ def test_implement_runtime_mirror_review_accepts_paired_core_and_primitives_chan
                 "--changed",
                 "src/agentic_workspace/workspace_runtime_primitives.py",
                 "--task",
-                "Mirror a runtime payload helper across core and primitives.",
+                "Terse runtime refactor.",
                 "--format",
                 "json",
             ]
@@ -2468,15 +2551,19 @@ def test_implement_runtime_mirror_review_accepts_paired_core_and_primitives_chan
     ]
     record = review["mirror_drift_review"]["records"][0]
     assert record["status"] == "paired-change-requires-parity-proof"
+    assert record["region_id"] == "open-issue-intake-payload"
     assert record["paired_file_changed"] is True
     assert record["likely_paired_file"] == ""
     assert "--aw-primitive-ownership" in record["maintainer_check_command"]
 
 
 def test_implement_runtime_mirror_review_stays_off_for_unrelated_core_file_changes(tmp_path: Path, capsys) -> None:
-    _init_git_repo(tmp_path)
-    _write_empty_planning_state(tmp_path)
-    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py", "VALUE = 1\n")
+    _seed_runtime_mirror_contract_repo(tmp_path)
+    _replace_text(
+        tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py",
+        '    return "old"',
+        '    return "new"',
+    )
 
     assert (
         cli.main(

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2339,7 +2339,7 @@ def test_implement_surfaces_runtime_source_edit_review_for_generated_cli_boundar
     payload = json.loads(capsys.readouterr().out)
     review = payload["proof"]["runtime_source_edit_review"]
     assert review["kind"] == "agentic-workspace/runtime-source-edit-review/v1"
-    assert review["status"] == "mirror-drift-warning"
+    assert review["status"] == "classification-required"
     assert review["changed_paths"] == ["src/agentic_workspace/workspace_runtime_primitives.py"]
     assert review["inventory_source"] == "src/agentic_workspace/contracts/python_runtime_projection_inventory.json"
     assert review["missing_inventory_paths"] == []
@@ -2354,6 +2354,35 @@ def test_implement_surfaces_runtime_source_edit_review_for_generated_cli_boundar
     assert review["accepted_direct_edit_reasons"] == ["existing-primitive-bugfix", "new-primitive-implementation"]
     assert "package-domain boundary" in review["rejected_vague_reasons"]
     assert "inventory-backed symbol/primitive" in review["completion_claim_rule"]
+    assert "mirror_drift_review" not in review
+    assert "proof.runtime_source_edit_review" in payload["drill_down"]["available_selectors"]
+
+
+def test_implement_surfaces_runtime_mirror_warning_for_primitives_payload_helper_change(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_primitives.py",
+                "--task",
+                "Add a runtime payload helper under the generated CLI boundary.",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    review = payload["proof"]["runtime_source_edit_review"]
+    assert review["status"] == "mirror-drift-warning"
     mirror_review = review["mirror_drift_review"]
     assert mirror_review["status"] == "warning"
     mirror_record = mirror_review["records"][0]
@@ -2361,10 +2390,10 @@ def test_implement_surfaces_runtime_source_edit_review_for_generated_cli_boundar
     assert mirror_record["changed_paths"] == ["src/agentic_workspace/workspace_runtime_primitives.py"]
     assert mirror_record["likely_paired_file"] == "src/agentic_workspace/workspace_runtime_core.py"
     assert mirror_record["paired_file_changed"] is False
+    assert "task_term:payload" in mirror_record["trigger_evidence"]
     assert "external_intent_refresh_applies_stale_candidate_reconciliation" in mirror_record["smallest_parity_proof_command"]
     assert "--aw-primitive-ownership" in mirror_record["maintainer_check_command"]
     assert "#1802-style" in mirror_record["represented_regression"]
-    assert "proof.runtime_source_edit_review" in payload["drill_down"]["available_selectors"]
 
 
 def test_implement_surfaces_runtime_mirror_warning_for_core_only_payload_helper_change(tmp_path: Path, capsys) -> None:
@@ -2444,10 +2473,10 @@ def test_implement_runtime_mirror_review_accepts_paired_core_and_primitives_chan
     assert "--aw-primitive-ownership" in record["maintainer_check_command"]
 
 
-def test_implement_runtime_mirror_review_stays_off_for_unrelated_changes(tmp_path: Path, capsys) -> None:
+def test_implement_runtime_mirror_review_stays_off_for_unrelated_core_file_changes(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
-    _write(tmp_path / "src" / "agentic_workspace" / "runtime_source_review.py", "VALUE = 1\n")
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py", "VALUE = 1\n")
 
     assert (
         cli.main(
@@ -2456,9 +2485,9 @@ def test_implement_runtime_mirror_review_stays_off_for_unrelated_changes(tmp_pat
                 "--target",
                 str(tmp_path),
                 "--changed",
-                "src/agentic_workspace/runtime_source_review.py",
+                "src/agentic_workspace/workspace_runtime_core.py",
                 "--task",
-                "Refactor runtime source review internals.",
+                "Terse runtime refactor.",
                 "--format",
                 "json",
             ]


### PR DESCRIPTION
## Summary
- Add a small explicit mirror contract for the known `workspace_runtime_core.py` / `workspace_runtime_primitives.py` runtime mirror.
- Declare mirrored runtime surfaces by exact symbols and named regions: the external-issue intake helper region, external-intent refresh payload, and open-issue intake payload.
- Detect changed code by intersecting `git diff --unified=0` line ranges with AST-derived declared symbol/region spans.
- Surface compact `mirror_drift_review` records with mirror pair id, region id, changed regions, paired regions, paired file, expected action, #1802-style regression command, and AW primitive ownership maintainer check.
- Keep unrelated edits in either mirror file quiet when changed code does not intersect the declared contract.

## Acceptance coverage
- Asymmetric changes inside a declared mirrored region surface `mirror-drift-warning` before completion claims.
- Asymmetric changes inside a declared mirrored symbol name the paired file and paired symbol/region.
- Paired changes to the same declared region surface `paired-change-requires-parity-proof` instead of a one-sided warning.
- Generic generated-CLI runtime edits still use the existing runtime source classification path without mirror drift noise.
- Unrelated same-file edits outside declared mirrored symbols/regions do not surface the mirror drift review.
- The #1802 external-intent refresh failure mode is represented by the named regression command and focused test coverage.

## Validation
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run pytest tests/test_workspace_implement_cli.py -q -k "runtime_source_edit_review or runtime_mirror"`
- `uv run pytest tests/test_workspace_summary_cli.py -q -k "external_intent_refresh_applies_stale_candidate_reconciliation"`
- `uv run python scripts/check/check_generated_command_packages.py --aw-primitive-ownership --format json`
- `git diff --check`

Closes #1809