### PR TITLE
[codex] Implement P2 workflow routing lane

### DIFF
--- a/.agentic-workspace/docs/candidate-lanes-contract.md
+++ b/.agentic-workspace/docs/candidate-lanes-contract.md
@@ -34,6 +34,8 @@ When a user asks to implement several ordered lanes, keep the lane boundary inta
 
 Do not create one combined execplan for unrelated lanes. A lane is the broader intent owner; execplans are bounded implementation slices under one lane.
 
+For a new lane or major stacked PR group, prefer a fresh session seeded by the lane refs and a compact digest. Keep long shaping in issue comments, docs, or review artifacts; chat should carry current decisions, not durable lane storage.
+
 ## Shape
 
 Keep candidate lanes under `roadmap.lanes` in `.agentic-workspace/planning/state.toml`.

--- a/.agentic-workspace/docs/context-budget-contract.md
+++ b/.agentic-workspace/docs/context-budget-contract.md
@@ -77,6 +77,17 @@ For mixed-agent work:
 - prefer resumability notes plus minimal refs over broad rereads
 - reload only the live bundle needed for the next bounded step
 
+## External Shaping
+
+Long shaping input belongs in chat-external artifacts when it needs to outlive one bounded turn.
+
+- Put large issue analysis, design notes, and review residue in GitHub comments, checked-in docs, or review artifacts.
+- Paste only short pointers or decision summaries into chat.
+- Start a fresh session for each new lane or major PR stack when prior chat context would become a long-term cost.
+- Use a lane/session digest as first-read context instead of replaying long prior messages.
+
+See `docs/maintainer/external-shaping-and-fresh-sessions.md` for the operator-facing guidance.
+
 ## Interaction-Cost Rule
 
 Optimize for total costly interactions per successful tranche, not for one narrow proxy.

--- a/.agentic-workspace/planning/closeout-evidence/p2-workflow-routing.closeout.json
+++ b/.agentic-workspace/planning/closeout-evidence/p2-workflow-routing.closeout.json
@@ -1,0 +1,114 @@
+{
+  "kind": "planning-closeout-evidence/v1",
+  "title": "P2 workflow routing and fresh-session guidance",
+  "plan_id": "p2-workflow-routing",
+  "created_at": "2026-06-27T14:32:56.134326+00:00",
+  "source_plan": ".agentic-workspace/planning/execplans/p2-workflow-routing.plan.json",
+  "intended_archive": ".agentic-workspace/planning/execplans/archive/p2-workflow-routing.plan.json",
+  "retention": {
+    "state": "archive-retention-skipped",
+    "reason": "retained archive would exceed the structured-file inventory max_bytes guardrail; closing after distillation instead",
+    "canonical_evidence": "retained closeout evidence",
+    "ordinary_route": "agentic-workspace summary --format json or report --section closeout_report --format json",
+    "trust_rule": "When this record exists, agents should trust it as the closeout handoff surface without inspecting the omitted full execplan archive.",
+    "rule": "Retained closeout evidence preserves reportable closeout facts when the full execplan archive exceeds inventory size guardrails."
+  },
+  "active_milestone": {
+    "id": "p2-workflow-routing",
+    "status": "completed",
+    "scope": "Implement the #1697/#1698 workflow-routing lane and grouped P2 lane records.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement #1697/#1698 and group remaining P2 issues into lanes.",
+    "hard constraints": "Do not broaden into runtime packet extraction or decomposition audit implementation.",
+    "agent may decide locally": "Compact packet shape, tests, docs wording, and lane record grouping.",
+    "escalate when": "A correct fix requires changing generated command behavior or runtime owner-boundary architecture."
+  },
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented the base P2 workflow-routing slice for #1697/#1698: runtime symbol working-set projection for large runtime files, compact proof payload routing, durable external shaping guidance, and grouped follow-up P2 lane records.",
+    "scope touched": "#1697/#1698 plus P2 lane grouping records for #1770-#1773 and #1656-#1658.",
+    "changed surfaces": "src/agentic_workspace/runtime_symbol_working_set.py; src/agentic_workspace/workspace_runtime_proof.py; src/agentic_workspace/workspace_runtime_implement.py; src/agentic_workspace/workspace_runtime_primitives.py; tests/test_workspace_implement_cli.py; docs/maintainer/external-shaping-and-fresh-sessions.md; .agentic-workspace/docs/context-budget-contract.md; .agentic-workspace/docs/candidate-lanes-contract.md; .agentic-workspace/planning/*",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Acceptance satisfied for the base P2 slice. Remaining P2 issue groups are recorded as ready lanes and intentionally deferred to stacked follow-up PRs.",
+    "proof status": "passed",
+    "intent served": "yes for slice; parent remains open via .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "proof_report": {
+    "validation proof": "make test-workspace; make lint-workspace; make maintainer-surfaces; git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; uv run pytest tests/test_workspace_cli.py -q",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "current diff retrofit",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json activates a fresh bounded slice."
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "execution_summary": {
+    "outcome delivered": "Large-runtime edits now expose an AST/inventory-backed symbol working set and proof selector; operator guidance now routes long shaping into durable artifacts and fresh sessions; follow-up P2 lanes are grouped and ordered.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+          "owner": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": [
+        {
+          "summary": "Record operator guidance for external shaping and fresh-session lanes",
+          "owner": "github-issue",
+          "source": "#1698"
+        }
+      ]
+    }
+  }
+}

--- a/.agentic-workspace/planning/closeout-evidence/p2-workflow-routing.closeout.json
+++ b/.agentic-workspace/planning/closeout-evidence/p2-workflow-routing.closeout.json
@@ -53,10 +53,10 @@
     "evidence for \"proof achieved\" state": "See proof_report.validation proof."
   },
   "intent_satisfaction": {
-    "original intent": "current diff retrofit",
-    "was original intent fully satisfied?": "no",
-    "evidence of intent satisfaction": "See proof_report.validation proof.",
-    "unsolved intent passed to": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+    "original intent": "Implement GitHub #1697 and #1698 as the base P2 workflow-routing lane, then group the remaining P2 issues into follow-up lanes for stacked PRs.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "The execution_run and execution_summary record the #1697/#1698 runtime symbol working-set routing, compact proof payload routing, external shaping guidance, fresh-session guidance, and grouped follow-up P2 lane records; proof_report.validation proof lists the validation commands used for this closeout.",
+    "unsolved intent passed to": "None for #1697/#1698. Remaining P2 stack continuation starts at .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json."
   },
   "closure_check": {
     "closeout scope": "slice",

--- a/.agentic-workspace/planning/execplans/archive/p2-workflow-routing-closeout-normalization.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/p2-workflow-routing-closeout-normalization.plan.json
@@ -1,0 +1,385 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Normalize P2 workflow routing lane closeout state",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Normalize the P2 workflow-routing lane record after accepted slice closeout.",
+    "hard_constraints": "Do not reopen the completed #1697/#1698 implementation slice or claim the broader P2 parent complete.",
+    "agent_may_decide": "Exact lane closeout wording and proof evidence references.",
+    "escalate_when": "The next P2 lane needs to be activated or the closeout evidence contradicts the lane record.",
+    "next_action": "Run focused planning validation and close out this normalization owner.",
+    "proof_expectations": [
+      "uv run python -m json.tool .agentic-workspace/planning/lanes/lane-p2-workflow-routing.lane.json",
+      "uv run python scripts/run_agentic_workspace.py summary --target . --format json"
+    ],
+    "touched_scope": [
+      ".agentic-workspace/planning/lanes/lane-p2-workflow-routing.lane.json",
+      ".agentic-workspace/planning/state.toml"
+    ],
+    "completion_criteria": [
+      "Workflow-routing lane status matches the accepted closeout evidence.",
+      "No active execplan remains after this cleanup.",
+      "Runtime packet owner-boundary lane remains the next ready P2 stack owner."
+    ],
+    "continuation_owner": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "current diff retrofit"
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Normalize the P2 workflow-routing lane record after accepted slice closeout.",
+      "constraints": "Do not reopen the completed #1697/#1698 implementation slice or claim the broader P2 parent complete.",
+      "latitude": "Exact lane closeout wording and proof evidence references.",
+      "escalation": "Escalate when the next P2 lane needs to be activated or the closeout evidence contradicts the lane record.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "p2-workflow-routing-closeout-normalization",
+      "status": "completed",
+      "next_step": "Continue via .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        ".agentic-workspace/planning/lanes/lane-p2-workflow-routing.lane.json",
+        ".agentic-workspace/planning/state.toml"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Implement P2 issues in grouped lanes and stacked PRs.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "activation trigger": "After the base workflow-routing PR is opened."
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json."
+  },
+  "intent_interpretation": {
+    "literal request": "Normalize P2 workflow routing lane closeout state",
+    "inferred intended outcome": "Keep planning lane state consistent with the accepted closeout before publishing the base PR.",
+    "chosen concrete what": "Mark the completed workflow-routing lane closed and reference the closeout proof.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": ".agentic-workspace/planning/lanes/lane-p2-workflow-routing.lane.json and state updates written by closeout.",
+    "max changed files": "2 planning files plus closeout evidence generated by the previous closeout.",
+    "required validation commands": "JSON validation for the lane file and AW summary.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Close this normalization owner after proving lane state is valid.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Normalize the P2 workflow-routing lane record after accepted slice closeout.",
+    "hard constraints": "Do not reopen the completed #1697/#1698 implementation slice or claim the broader P2 parent complete.",
+    "agent may decide locally": "Exact lane closeout wording and proof evidence references.",
+    "escalate when": "The next P2 lane needs to be activated or the closeout evidence contradicts the lane record."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": ".agentic-workspace/planning/closeout-evidence/p2-workflow-routing.closeout.json",
+      "label": "P2 workflow-routing closeout evidence",
+      "role": "intake",
+      "locator": ""
+    }
+  ],
+  "active_milestone": {
+    "id": "p2-workflow-routing-closeout-normalization",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to lane closeout-state normalization.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run focused planning validation and close out this normalization owner."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    ".agentic-workspace/planning/lanes/lane-p2-workflow-routing.lane.json",
+    ".agentic-workspace/planning/state.toml"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run python -m json.tool .agentic-workspace/planning/lanes/lane-p2-workflow-routing.lane.json",
+    "uv run python scripts/run_agentic_workspace.py summary --target . --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Workflow-routing lane status matches the accepted closeout evidence.",
+    "No active execplan remains after this cleanup.",
+    "Runtime packet owner-boundary lane remains the next ready P2 stack owner."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Normalized the completed workflow-routing lane state and archived the closed lane record so live Planning now contains only open follow-up P2 lanes.",
+    "scope touched": ".agentic-workspace/planning/lanes/archive/lane-p2-workflow-routing.lane.json and .agentic-workspace/planning/state.toml.",
+    "changed surfaces": ".agentic-workspace/planning/lanes/archive/lane-p2-workflow-routing.lane.json; .agentic-workspace/planning/state.toml",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "The workflow-routing lane is no longer live selectable work; #1697/#1698 closeout evidence remains retained, and the runtime packet owner-boundary lane remains the next P2 stack owner.",
+    "proof status": "passed",
+    "intent served": "yes for slice; parent remains open via .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "uv run python -m json.tool .agentic-workspace/planning/lanes/lane-p2-workflow-routing.lane.json; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; uv run python scripts/run_agentic_workspace.py planning lane-archive lane-p2-workflow-routing --target . --format json",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "current diff retrofit",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "execution_summary": {
+    "outcome delivered": "Closed workflow-routing lane archived; planning summary and doctor report no warnings.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "proposed durable intent": "Future agents should continue from .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+          "owner": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-27: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "continue-required",
+    "active_intent_satisfied": false,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "partial-progress",
+    "required_next_action": "create-follow-on-plan",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [
+          "done",
+          "implemented",
+          "complete",
+          "finished",
+          "all",
+          "full intent complete"
+        ],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "no",
+      "reason": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+    },
+    "continuation": {
+      "owner_surface": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+      "created_or_required": true,
+      "reason": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: current diff retrofit\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: uv run python -m json.tool .agentic-workspace/planning/lanes/lane-p2-workflow-routing.lane.json; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; uv run python scripts/run_agentic_workspace.py planning lane-archive lane-p2-workflow-routing --target . --format json\nChanged surfaces: .agentic-workspace/planning/lanes/archive/lane-p2-workflow-routing.lane.json; .agentic-workspace/planning/state.toml\nDurable residue: planning (.agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json)\nMemory learning: route_to_planning\nFollow-up: .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
+  }
+}

--- a/.agentic-workspace/planning/lanes/archive/lane-p2-workflow-routing.lane.json
+++ b/.agentic-workspace/planning/lanes/archive/lane-p2-workflow-routing.lane.json
@@ -1,0 +1,70 @@
+{
+  "kind": "planning-lane/v1",
+  "id": "lane-p2-workflow-routing",
+  "title": "P2 workflow routing and fresh-session guidance",
+  "status": "archived",
+  "parent_decomposition_ref": "GitHub P2 roadmap candidate batch 2026-06-27",
+  "lane_outcome": "Large runtime edits expose compact symbol-level working sets and operators have durable guidance for external shaping and fresh-session lane work.",
+  "purpose_for_parent": "Reduce P2 dogfooding friction before the broader runtime-boundary stack by making large-file changes cheaper to orient and long shaping cheaper to carry.",
+  "subsystems": [
+    "workspace-runtime",
+    "planning",
+    "docs"
+  ],
+  "technical_strategy": "Add an advisory proof/implement packet derived from git diff hunks, AST symbol spans, explicit proof hints, and runtime inventories; document the chat-external shaping pattern in maintainer and planning docs.",
+  "slice_sequence": [
+    {
+      "id": "symbol-routing-and-fresh-session-guidance",
+      "title": "Surface runtime symbol working sets and external shaping guidance",
+      "status": "completed",
+      "execplan_ref": "",
+      "depends_on": [],
+      "purpose_for_lane": "Satisfy #1697 and #1698 as the base PR for the P2 stack.",
+      "proof": "implement/proof focused tests, docs lint, make test-workspace",
+      "residual_after_slice": "None expected for this lane; later lanes may add more symbol proof hints as runtime boundaries are extracted."
+    }
+  ],
+  "current_slice": "symbol-routing-and-fresh-session-guidance",
+  "acceptance_boundary": "The lane is complete when #1697 symbol working-set routing is visible in ordinary implement/proof output for large runtime files and #1698 guidance is in a durable repo-owned surface linked from lane/context-budget docs.",
+  "proof_strategy": "Run focused implement/proof tests for the symbol packet, docs lint through workspace lint, and workspace test proof before closeout.",
+  "proof_aggregation": {
+    "status": "satisfied",
+    "evidence": [
+      "make test-workspace",
+      "make lint-workspace",
+      "make maintainer-surfaces",
+      "git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md",
+      "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+      "uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json",
+      "uv run pytest tests/test_workspace_cli.py -q",
+      ".agentic-workspace/planning/closeout-evidence/p2-workflow-routing.closeout.json"
+    ],
+    "known_gaps": []
+  },
+  "residual_lane_work": "No planned residual work after this slice unless review asks for additional symbol hint coverage.",
+  "lane_to_epic_contribution": "Provides the routing and context-cost foundation for the remaining P2 runtime-boundary lanes.",
+  "parent_close_permission": "do-not-close-parent",
+  "closeout_state": {
+    "status": "closed",
+    "summary": "Base P2 workflow-routing slice completed and routed through closeout evidence.",
+    "residual_work": "No residual work for #1697/#1698; continue the P2 stack from the runtime packet owner-boundary lane.",
+    "next_owner": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1697",
+      "label": "Route giant runtime edits by symbol-level working set",
+      "role": "source_intent",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1697"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1698",
+      "label": "Record operator guidance for external shaping and fresh-session lanes",
+      "role": "source_intent",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1698"
+    }
+  ],
+  "notes": "Base lane for the P2 stack."
+}

--- a/.agentic-workspace/planning/lanes/lane-p2-runtime-boundary-decomposition-audits.lane.json
+++ b/.agentic-workspace/planning/lanes/lane-p2-runtime-boundary-decomposition-audits.lane.json
@@ -1,0 +1,88 @@
+{
+  "kind": "planning-lane/v1",
+  "id": "lane-p2-runtime-boundary-decomposition-audits",
+  "title": "P2 runtime boundary decomposition audits",
+  "status": "ready",
+  "parent_decomposition_ref": "GitHub P2 roadmap candidate batch 2026-06-27",
+  "lane_outcome": "Workspace lifecycle/provider, Planning, Memory, and Verification runtime boundaries have symbol-by-symbol disposition tables, safe decompositions applied, and retained semantic owners recorded.",
+  "purpose_for_parent": "Continue #1649 decomposition without hiding mutation, provider, Planning, Memory, or Verification judgment inside generic command-generation primitives.",
+  "subsystems": [
+    "workspace-runtime",
+    "planning",
+    "memory",
+    "verification",
+    "command-generation"
+  ],
+  "technical_strategy": "Treat #1656, #1657, and #1658 as audit-plus-safe-extraction slices. First record disposition tables by symbol group and semantic owner, then only implement high-confidence decompositions with existing CG support; file or reference narrower CG follow-ups for unresolved control-operation shapes.",
+  "slice_sequence": [
+    {
+      "id": "workspace-lifecycle-provider-boundaries",
+      "title": "Audit workspace lifecycle and provider runtime boundaries",
+      "status": "ready",
+      "execplan_ref": "",
+      "depends_on": [],
+      "purpose_for_lane": "Satisfy #1656 with symbol-level dispositions and safe lifecycle/report extraction only where mutation/provider trust remains explicit."
+    },
+    {
+      "id": "planning-runtime-boundaries",
+      "title": "Audit Planning package runtime boundaries",
+      "status": "planned",
+      "execplan_ref": "",
+      "depends_on": [
+        "workspace-lifecycle-provider-boundaries"
+      ],
+      "purpose_for_lane": "Satisfy #1657 with grouped Planning disposition and safe value-map/default/coercion decompositions."
+    },
+    {
+      "id": "memory-verification-runtime-boundaries",
+      "title": "Audit Memory and Verification runtime boundaries",
+      "status": "planned",
+      "execplan_ref": "",
+      "depends_on": [
+        "planning-runtime-boundaries"
+      ],
+      "purpose_for_lane": "Satisfy #1658 with semantic-owner-after-split disposition and safe view/scaffold decompositions."
+    }
+  ],
+  "current_slice": "workspace-lifecycle-provider-boundaries",
+  "acceptance_boundary": "The lane is complete when #1656, #1657, and #1658 each have symbol dispositions, retained-owner rationale, safe decompositions or explicit blockers, updated inventories, and proof evidence.",
+  "proof_strategy": "Run generated command package checks, package-focused tests for affected runtime behavior, operation conformance for changed commands, and make test-workspace for cross-package changes.",
+  "proof_aggregation": {
+    "status": "not-started",
+    "evidence": [],
+    "known_gaps": []
+  },
+  "residual_lane_work": "The lane may leave unresolved CG primitive/control-operation follow-ups open when safe decomposition requires new generic support.",
+  "lane_to_epic_contribution": "Provides the audit and safe-migration continuation for #1649 after the owner-boundary packet extraction lane.",
+  "parent_close_permission": "do-not-close-parent",
+  "closeout_state": {
+    "status": "open",
+    "summary": "Ready after the runtime packet owner-boundary lane.",
+    "residual_work": "Implement #1656, #1657, and #1658 in order with disposition tables and proof.",
+    "next_owner": "current agent"
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1656",
+      "label": "Investigate decomposition of workspace lifecycle and provider runtime boundaries",
+      "role": "source_intent",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1656"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1657",
+      "label": "Audit and decompose planning package runtime boundaries for #1649",
+      "role": "source_intent",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1657"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1658",
+      "label": "Audit and decompose Memory and Verification runtime boundaries for #1649",
+      "role": "source_intent",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1658"
+    }
+  ],
+  "notes": "Third lane in the P2 stack."
+}

--- a/.agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json
+++ b/.agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json
@@ -1,0 +1,103 @@
+{
+  "kind": "planning-lane/v1",
+  "id": "lane-p2-runtime-packet-owner-boundaries",
+  "title": "P2 runtime packet owner-boundary extraction",
+  "status": "ready",
+  "parent_decomposition_ref": "GitHub P2 roadmap candidate batch 2026-06-27",
+  "lane_outcome": "Startup, implement, Planning, proof, verification, and closeout packet construction live behind owner-scoped runtime modules without payload contract drift.",
+  "purpose_for_parent": "Shrink the workspace runtime monolith by owner boundary while preserving generated/runtime caller compatibility.",
+  "subsystems": [
+    "workspace-runtime",
+    "planning",
+    "verification"
+  ],
+  "technical_strategy": "Work issue-by-issue in stacked PRs: inventory retained primitives symbols, move owner-scoped builders into the existing startup, implement, planning, and proof modules, keep compatibility aliases, and update inventories/tests after each extraction.",
+  "slice_sequence": [
+    {
+      "id": "startup-packets",
+      "title": "Extract startup runtime packets",
+      "status": "ready",
+      "execplan_ref": "",
+      "depends_on": [],
+      "purpose_for_lane": "Satisfy #1770 without changing start payload contracts."
+    },
+    {
+      "id": "implement-packets",
+      "title": "Extract implement runtime packets",
+      "status": "planned",
+      "execplan_ref": "",
+      "depends_on": [
+        "startup-packets"
+      ],
+      "purpose_for_lane": "Satisfy #1771 without changing implement selector or tiny payload contracts."
+    },
+    {
+      "id": "planning-packets",
+      "title": "Extract Planning runtime packets",
+      "status": "planned",
+      "execplan_ref": "",
+      "depends_on": [
+        "implement-packets"
+      ],
+      "purpose_for_lane": "Satisfy #1772 while preserving Planning package semantics and live planning-state inspection."
+    },
+    {
+      "id": "proof-closeout-packets",
+      "title": "Extract proof and closeout runtime packets",
+      "status": "planned",
+      "execplan_ref": "",
+      "depends_on": [
+        "planning-packets"
+      ],
+      "purpose_for_lane": "Satisfy #1773 without weakening proof or closeout blocking."
+    }
+  ],
+  "current_slice": "startup-packets",
+  "acceptance_boundary": "The lane is complete when #1770 through #1773 each have owner-scoped runtime modules, stable compatibility imports, updated inventories, and focused tests proving unchanged emitted packet contracts.",
+  "proof_strategy": "Run focused start/implement/planning/proof tests for each slice, generated command package checks when inventories change, and make test-workspace for cross-runtime extraction.",
+  "proof_aggregation": {
+    "status": "not-started",
+    "evidence": [],
+    "known_gaps": []
+  },
+  "residual_lane_work": "The lane does not replace the runtime architecture; it only moves packet ownership out of primitives by declared owner boundary.",
+  "lane_to_epic_contribution": "Turns the P2 #1764 decomposition issues into ordered stack work with explicit owner boundaries.",
+  "parent_close_permission": "do-not-close-parent",
+  "closeout_state": {
+    "status": "open",
+    "summary": "Ready after the workflow-routing base lane.",
+    "residual_work": "Implement #1770, #1771, #1772, and #1773 in order.",
+    "next_owner": "current agent"
+  },
+  "references": [
+    {
+      "kind": "github-issue",
+      "target": "#1770",
+      "label": "Extract startup runtime packets by owner boundary",
+      "role": "source_intent",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1770"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1771",
+      "label": "Extract implement runtime packets by owner boundary",
+      "role": "source_intent",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1771"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1772",
+      "label": "Extract Planning runtime packets by owner boundary",
+      "role": "source_intent",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1772"
+    },
+    {
+      "kind": "github-issue",
+      "target": "#1773",
+      "label": "Extract proof and closeout runtime packets by owner boundary",
+      "role": "source_intent",
+      "locator": "https://github.com/rickardvh/agentic-workspace/issues/1773"
+    }
+  ],
+  "notes": "Second lane in the P2 stack."
+}

--- a/docs/maintainer/external-shaping-and-fresh-sessions.md
+++ b/docs/maintainer/external-shaping-and-fresh-sessions.md
@@ -1,0 +1,16 @@
+# External Shaping And Fresh Sessions
+
+Long shaping material should live in durable repo or provider artifacts, not in an indefinitely continuing chat thread.
+
+Use this pattern for new lanes, major PRs, or large design inputs:
+
+- Put detailed shaping in GitHub issues, issue comments, checked-in docs, or review artifacts.
+- Paste only short pointers, decisions, or corrections into chat.
+- Start a fresh session for each new lane or major stacked PR group.
+- Begin the fresh session from `AGENTS.md`, `agentic-workspace start`, and the lane or issue refs.
+- Use a short lane/session digest for handoff context instead of replaying long prior chat.
+
+One-off paste is acceptable when it is the cheapest way to transfer small current-turn context.
+Durable shaping material should be linked or summarized, then stored outside chat so future agents can reload it without carrying old thread state.
+
+This guidance does not excuse AW from reducing its own output, proof, and routing cost. It is an operator pattern for avoiding durable context bloat while the product continues to compress ordinary workflow surfaces.

--- a/src/agentic_workspace/runtime_symbol_working_set.py
+++ b/src/agentic_workspace/runtime_symbol_working_set.py
@@ -1,0 +1,240 @@
+"""Symbol-level working-set hints for large runtime files."""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from agentic_workspace.contract_tooling import python_runtime_projection_inventory_manifest
+
+LARGE_RUNTIME_PATHS = {
+    "src/agentic_workspace/workspace_runtime_core.py",
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "packages/planning/src/repo_planning_bootstrap/installer.py",
+    "packages/planning/src/repo_planning_bootstrap/runtime_projection.py",
+    "packages/memory/src/repo_memory_bootstrap/runtime_primitives.py",
+}
+
+SOURCE_MODULE_BY_PATH = {
+    "src/agentic_workspace/workspace_runtime_core.py": "agentic_workspace.workspace_runtime_core",
+    "src/agentic_workspace/workspace_runtime_primitives.py": "agentic_workspace.workspace_runtime_primitives",
+    "packages/planning/src/repo_planning_bootstrap/installer.py": "repo_planning_bootstrap.installer",
+    "packages/planning/src/repo_planning_bootstrap/runtime_projection.py": "repo_planning_bootstrap.runtime_projection",
+    "packages/memory/src/repo_memory_bootstrap/runtime_primitives.py": "repo_memory_bootstrap.runtime_primitives",
+}
+
+SYMBOL_PROOF_HINTS = {
+    (
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "_run_external_intent_refresh_github_adapter",
+    ): [
+        'uv run pytest tests/test_workspace_summary_cli.py -q -k "external_intent_refresh_applies_stale_candidate_reconciliation"',
+    ],
+    (
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "_run_external_intent_refresh_github_adapter",
+    ): [
+        'uv run pytest tests/test_workspace_summary_cli.py -q -k "external_intent_refresh_applies_stale_candidate_reconciliation"',
+    ],
+    (
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "_proof_selection_for_changed_paths",
+    ): [
+        'uv run pytest tests/test_workspace_implement_cli.py -q -k "proof or changed_path"',
+        "uv run pytest tests/test_workspace_proof_cli.py -q",
+    ],
+    (
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "_proof_selection_for_changed_paths",
+    ): [
+        'uv run pytest tests/test_workspace_implement_cli.py -q -k "proof or changed_path"',
+        "uv run pytest tests/test_workspace_proof_cli.py -q",
+    ],
+}
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _changed_line_ranges_from_git_diff(*, target_root: Path, path: str) -> list[tuple[int, int]]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(target_root), "diff", "--unified=0", "--", path],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+    ranges: list[tuple[int, int]] = []
+    hunk_pattern = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+    for line in result.stdout.splitlines():
+        match = hunk_pattern.match(line)
+        if not match:
+            continue
+        start = int(match.group(1))
+        length = int(match.group(2) or "1")
+        ranges.append((start, start if length == 0 else start + length - 1))
+    return ranges
+
+
+def _python_symbol_spans(*, target_root: Path, path: str) -> dict[str, tuple[int, int]]:
+    try:
+        module = ast.parse((target_root / path).read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return {}
+    spans: dict[str, tuple[int, int]] = {}
+    for node in ast.walk(module):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            continue
+        spans[node.name] = (node.lineno, int(getattr(node, "end_lineno", node.lineno)))
+    return spans
+
+
+def _ranges_intersect(left: tuple[int, int], right: tuple[int, int]) -> bool:
+    return left[0] <= right[1] and right[0] <= left[1]
+
+
+def _inventory_entries_by_symbol() -> dict[tuple[str, str], dict[str, Any]]:
+    try:
+        inventory = python_runtime_projection_inventory_manifest()
+    except Exception:
+        return {}
+    accepted = inventory.get("accepted_runtime_boundaries", {})
+    entries = accepted.get("entries", []) if isinstance(accepted, dict) else []
+    result: dict[tuple[str, str], dict[str, Any]] = {}
+    for entry in entries if isinstance(entries, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        source_module = str(entry.get("source_module", "")).strip()
+        source_symbol = str(entry.get("source_symbol", "")).strip()
+        if source_module and source_symbol:
+            result[(source_module, source_symbol)] = entry
+    return result
+
+
+def _symbol_inventory_payload(*, path: str, symbol: str, entries_by_symbol: dict[tuple[str, str], dict[str, Any]]) -> dict[str, Any]:
+    entry = entries_by_symbol.get((SOURCE_MODULE_BY_PATH.get(path, ""), symbol))
+    if not isinstance(entry, dict):
+        return {"status": "not-in-runtime-inventory"}
+    return {
+        "status": "inventory-backed",
+        "owner": entry.get("owner_package", ""),
+        "binding_kind": entry.get("binding_kind", ""),
+        "runtime_boundary_class": entry.get("runtime_boundary_class", ""),
+        "runtime_boundary_reason": entry.get("runtime_boundary_reason", ""),
+        "operation_ids": entry.get("operation_ids", []),
+        "primitive_refs": entry.get("primitive_refs", []),
+        "conformance_ref": entry.get("conformance_ref", ""),
+    }
+
+
+def runtime_symbol_working_set_for_changed_paths(changed_paths: list[str], *, target_root: Path | None = None) -> dict[str, Any]:
+    if target_root is None:
+        return {"kind": "agentic-workspace/runtime-symbol-working-set/v1", "status": "unavailable", "files": []}
+    files: list[dict[str, Any]] = []
+    entries_by_symbol = _inventory_entries_by_symbol()
+    for path in changed_paths:
+        if path not in LARGE_RUNTIME_PATHS:
+            continue
+        changed_ranges = _changed_line_ranges_from_git_diff(target_root=target_root, path=path)
+        if not changed_ranges:
+            continue
+        spans = _python_symbol_spans(target_root=target_root, path=path)
+        symbols: list[dict[str, Any]] = []
+        for symbol, span in sorted(spans.items(), key=lambda item: (item[1][0], item[0])):
+            if not any(_ranges_intersect(span, changed_range) for changed_range in changed_ranges):
+                continue
+            proof_hints = SYMBOL_PROOF_HINTS.get((path, symbol), [])
+            symbols.append(
+                {
+                    "name": symbol,
+                    "span": {"start": span[0], "end": span[1]},
+                    "inventory": _symbol_inventory_payload(path=path, symbol=symbol, entries_by_symbol=entries_by_symbol),
+                    "nearest_tests": proof_hints,
+                    "smallest_focused_proof": proof_hints[0] if proof_hints else "",
+                }
+            )
+        if symbols:
+            files.append(
+                {
+                    "path": path,
+                    "source_module": SOURCE_MODULE_BY_PATH.get(path, ""),
+                    "changed_line_ranges": [{"start": start, "end": end} for start, end in changed_ranges],
+                    "symbol_count": len(symbols),
+                    "symbols": symbols[:8],
+                }
+            )
+    proof_commands = _dedupe(
+        [
+            command
+            for file_payload in files
+            for symbol in file_payload.get("symbols", [])
+            for command in symbol.get("nearest_tests", [])
+            if isinstance(command, str) and command.strip()
+        ]
+    )
+    return {
+        "kind": "agentic-workspace/runtime-symbol-working-set/v1",
+        "status": "present" if files else "not-applicable",
+        "file_count": len(files),
+        "files": files,
+        "recommended_focused_proof_commands": proof_commands,
+        "rule": (
+            "Large runtime symbol routing is advisory and is derived from git diff hunks, AST symbol spans, "
+            "explicit test hints, and runtime inventories; it does not infer domain ownership from names or prose."
+        ),
+    }
+
+
+def tiny_runtime_symbol_working_set_payload(value: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, dict) or value.get("status") != "present":
+        return {}
+    files: list[dict[str, Any]] = []
+    for file_payload in value.get("files", []) if isinstance(value.get("files"), list) else []:
+        if not isinstance(file_payload, dict):
+            continue
+        symbols: list[dict[str, Any]] = []
+        for symbol in file_payload.get("symbols", [])[:5] if isinstance(file_payload.get("symbols"), list) else []:
+            if not isinstance(symbol, dict):
+                continue
+            inventory = symbol.get("inventory", {}) if isinstance(symbol.get("inventory"), dict) else {}
+            symbols.append(
+                {
+                    "name": symbol.get("name", ""),
+                    "span": symbol.get("span", {}),
+                    "inventory_status": inventory.get("status", "unknown"),
+                    "owner": inventory.get("owner", ""),
+                    "runtime_boundary_class": inventory.get("runtime_boundary_class", ""),
+                    "smallest_focused_proof": symbol.get("smallest_focused_proof", ""),
+                }
+            )
+        files.append(
+            {
+                "path": file_payload.get("path", ""),
+                "symbol_count": file_payload.get("symbol_count", len(symbols)),
+                "symbols": symbols,
+            }
+        )
+    return {
+        "kind": value.get("kind", "agentic-workspace/runtime-symbol-working-set/v1"),
+        "status": value.get("status", "unknown"),
+        "file_count": value.get("file_count", len(files)),
+        "files": files,
+        "recommended_focused_proof_commands": value.get("recommended_focused_proof_commands", [])[:5],
+        "rule": value.get("rule", ""),
+    }

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -14,6 +14,7 @@ from agentic_workspace.runtime_source_review import (
     tiny_generated_cli_freshness_payload,
     tiny_runtime_source_edit_review_payload,
 )
+from agentic_workspace.runtime_symbol_working_set import tiny_runtime_symbol_working_set_payload
 from agentic_workspace.workspace_runtime_core import (
     _CONTEXT_TEMPLATES,
     _acceptance_reconciliation_prompt_payload,
@@ -1006,6 +1007,13 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     else []
                 ),
                 *(
+                    [f"runtime_symbol_working_set={payload.get('proof', {}).get('runtime_symbol_working_set', {}).get('file_count')}"]
+                    if isinstance(payload.get("proof"), dict)
+                    and isinstance(payload.get("proof", {}).get("runtime_symbol_working_set"), dict)
+                    and payload.get("proof", {}).get("runtime_symbol_working_set", {}).get("status") == "present"
+                    else []
+                ),
+                *(
                     [f"reuse_pressure={reuse_pressure.get('state')}"]
                     if isinstance(reuse_pressure, dict) and reuse_pressure.get("state") not in {None, "", "none_found"}
                     else []
@@ -1047,6 +1055,11 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 payload.get("proof", {}).get("runtime_source_edit_review", {})
             )
             if isinstance(payload.get("proof"), dict) and isinstance(payload.get("proof", {}).get("runtime_source_edit_review"), dict)
+            else {},
+            "runtime_symbol_working_set": tiny_runtime_symbol_working_set_payload(
+                payload.get("proof", {}).get("runtime_symbol_working_set", {})
+            )
+            if isinstance(payload.get("proof"), dict) and isinstance(payload.get("proof", {}).get("runtime_symbol_working_set"), dict)
             else {},
             "proof_obligations": _tiny_proof_obligations_payload(
                 payload.get("proof", {}).get("proof_obligations", {}), required_commands=proof_commands
@@ -1254,6 +1267,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "change_impact",
                 "generated_surface_trust",
                 "proof.runtime_source_edit_review",
+                "proof.runtime_symbol_working_set",
                 "architecture_principles",
                 "assurance_requirements",
                 "verification",
@@ -1339,6 +1353,14 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     ):
         projected["proof"].pop("runtime_source_edit_review", None)
         remove_available_selector("proof.runtime_source_edit_review")
+    runtime_symbol_working_set = projected["proof"].get("runtime_symbol_working_set", {})
+    if not (
+        isinstance(runtime_symbol_working_set, dict)
+        and runtime_symbol_working_set.get("status") == "present"
+        and runtime_symbol_working_set.get("files")
+    ):
+        projected["proof"].pop("runtime_symbol_working_set", None)
+        remove_available_selector("proof.runtime_symbol_working_set")
     task_argument_mode = payload.get("task_intent", {}).get("task_argument_mode") if isinstance(payload.get("task_intent"), dict) else ""
     intent_proof = payload.get("proof", {}).get("intent_proof") if isinstance(payload.get("proof"), dict) else None
     acceptance_reconciliation = payload.get("acceptance_reconciliation", {})

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -131,6 +131,7 @@ from agentic_workspace.reporting_support import (
 )
 from agentic_workspace.repository_scanning import repository_scan_files
 from agentic_workspace.result_adapter import adapt_module_result, serialise_value
+from agentic_workspace.runtime_symbol_working_set import tiny_runtime_symbol_working_set_payload
 from agentic_workspace.workspace_output import (
     _display_path,
     _emit_init_text,
@@ -20280,6 +20281,9 @@ def _compact_start_proof_payload(proof: dict[str, Any]) -> dict[str, Any]:
             "classifications": cli_authority_review.get("classifications", []),
             "detail_command": "agentic-workspace proof --verbose --changed <paths> --format json",
         }
+    runtime_symbol_working_set = proof.get("runtime_symbol_working_set", {})
+    if isinstance(runtime_symbol_working_set, dict) and runtime_symbol_working_set.get("status") == "present":
+        compact["runtime_symbol_working_set"] = tiny_runtime_symbol_working_set_payload(runtime_symbol_working_set)
     changed = proof.get("changed_paths", [])
     if isinstance(changed, list) and changed:
         compact["detail_command"] = "agentic-workspace proof --verbose --changed <paths> --format json"

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -15,6 +15,7 @@ from agentic_workspace import config as config_lib
 from agentic_workspace._schema import ModuleDescriptor
 from agentic_workspace.config import DEFAULT_ASSURANCE_LEVEL, DEFAULT_CLI_INVOKE, WorkspaceConfig
 from agentic_workspace.runtime_source_review import runtime_source_edit_review_for_changed_paths
+from agentic_workspace.runtime_symbol_working_set import runtime_symbol_working_set_for_changed_paths
 from agentic_workspace.workspace_runtime_core import (
     _PROOF_EXECUTION_STATUSES,
     _PROOF_SELECTION_RULES,
@@ -1434,6 +1435,9 @@ def _proof_selection_for_changed_paths(
     surface_value_review = _surface_value_review_for_changed_paths(changed_paths=changed_paths, target_root=target_root)
     if surface_value_review["durable_surface_count"]:
         proof_selection["surface_value_review"] = surface_value_review
+    runtime_symbol_working_set = runtime_symbol_working_set_for_changed_paths(changed_paths, target_root=target_root)
+    if runtime_symbol_working_set.get("status") == "present":
+        proof_selection["runtime_symbol_working_set"] = runtime_symbol_working_set
     runtime_source_review = runtime_source_edit_review_for_changed_paths(changed_paths, target_root=target_root, task_text=task_text)
     if runtime_source_review["changed_paths"]:
         proof_selection["runtime_source_edit_review"] = runtime_source_review

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2587,6 +2587,61 @@ def test_implement_runtime_mirror_review_stays_off_for_unrelated_core_file_chang
     assert "proof.runtime_source_edit_review" not in payload["drill_down"]["available_selectors"]
 
 
+def test_implement_surfaces_runtime_symbol_working_set_for_large_runtime_change(tmp_path: Path, capsys) -> None:
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py",
+        """
+def _run_external_intent_refresh_github_adapter(args):
+    return {"status": "old"}
+
+
+def _unrelated_runtime_helper():
+    return "same"
+""",
+    )
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "agent@example.test"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Agent"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "baseline"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    _replace_text(
+        tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py",
+        '    return {"status": "old"}',
+        '    return {"status": "new"}',
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_primitives.py",
+                "--task",
+                "Fix external intent refresh behavior.",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    working_set = payload["proof"]["runtime_symbol_working_set"]
+    assert working_set["kind"] == "agentic-workspace/runtime-symbol-working-set/v1"
+    assert working_set["status"] == "present"
+    assert working_set["files"][0]["path"] == "src/agentic_workspace/workspace_runtime_primitives.py"
+    symbol = working_set["files"][0]["symbols"][0]
+    assert symbol["name"] == "_run_external_intent_refresh_github_adapter"
+    assert symbol["inventory_status"] == "inventory-backed"
+    assert symbol["runtime_boundary_class"] == "provider-integration"
+    assert "external_intent_refresh_applies_stale_candidate_reconciliation" in symbol["smallest_focused_proof"]
+    assert "proof.runtime_symbol_working_set" in payload["drill_down"]["available_selectors"]
+    assert any("runtime_symbol_working_set=1" == signal for signal in payload["action_signals"]["changed_signals"])
+
+
 def test_implement_keeps_active_intent_packets_selector_only(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)


### PR DESCRIPTION
## Summary

Implements the base P2 workflow-routing lane for #1697 and #1698.

- Adds an advisory runtime symbol working-set packet for large runtime files, derived from git diff hunks, AST symbol spans, explicit proof hints, and the runtime projection inventory.
- Surfaces the compact working set in implement/proof payloads, including selector routing and focused proof hints.
- Records durable external shaping and fresh-session guidance in maintainer/context-budget lane docs.
- Groups the remaining P2 issues into follow-up lanes for stacked PRs: #1770-#1773 next, then #1656-#1658.

Closes #1697.
Closes #1698.

## Stack

Base PR in the P2 stack. The next branch should stack on this one and promote `.agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json`.

## Runtime Source Edit Classification

`workspace_runtime_primitives.py` changes only the compact start/proof projection path to include the new symbol working-set packet. Edit reason: existing primitive/projection support. Owner: Agentic Workspace runtime. Source symbol: `_compact_start_proof_payload`. Command Generation is not the next owner for this change. Residual risk is covered by focused implement payload tests plus workspace proof.

The host-agnostic agent judgment principle is preserved: routing does not infer ownership, proof selection, or workflow state from arbitrary prose marker phrases or filename/name keywords. It uses explicit large-file allowlists, git hunks, AST spans, explicit proof hints, and inventory records.

## Validation

- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `git diff --check`
- `git diff -- README.md docs .agentic-workspace/docs packages/planning/README.md packages/memory/README.md`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run pytest tests/test_workspace_implement_cli.py -q -k "runtime_symbol_working_set or runtime_source_edit_review or runtime_mirror"`

Planning closeout is recorded in `.agentic-workspace/planning/closeout-evidence/p2-workflow-routing.closeout.json`; the completed workflow lane is archived, and live Planning has no active execplan.