### PR TITLE
[codex] Extract proof closeout runtime packets

### DIFF
--- a/.agentic-workspace/planning/closeout-evidence/p2-proof-closeout-runtime-packets.closeout.json
+++ b/.agentic-workspace/planning/closeout-evidence/p2-proof-closeout-runtime-packets.closeout.json
@@ -1,0 +1,108 @@
+{
+  "kind": "planning-closeout-evidence/v1",
+  "title": "Extract proof and closeout runtime packets by owner boundary",
+  "plan_id": "p2-proof-closeout-runtime-packets",
+  "created_at": "2026-06-27T15:52:31.939153+00:00",
+  "source_plan": ".agentic-workspace/planning/execplans/p2-proof-closeout-runtime-packets.plan.json",
+  "intended_archive": ".agentic-workspace/planning/execplans/archive/p2-proof-closeout-runtime-packets.plan.json",
+  "retention": {
+    "state": "archive-retention-skipped",
+    "reason": "retained archive would exceed the structured-file inventory max_bytes guardrail; closing after distillation instead",
+    "canonical_evidence": "retained closeout evidence",
+    "ordinary_route": "agentic-workspace summary --format json or report --section closeout_report --format json",
+    "trust_rule": "When this record exists, agents should trust it as the closeout handoff surface without inspecting the omitted full execplan archive.",
+    "rule": "Retained closeout evidence preserves reportable closeout facts when the full execplan archive exceeds inventory size guardrails."
+  },
+  "active_milestone": {
+    "id": "p2-proof-closeout-runtime-packets",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "delegated_judgment": {
+    "requested outcome": "GitHub #1773",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Moved proof-owned verification aggregation, active planning record for proof, tiny proof payload, and tiny proof obligations helpers from core/primitives into workspace_runtime_proof.py; retained core lazy forwarders and primitives compatibility re-exports; switched implement to import proof-owned helpers directly; updated primitive family inventory and focused proof owner regression.",
+    "scope touched": "GitHub #1773 proof and closeout runtime packet owner-boundary extraction",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_proof.py; src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/workspace_runtime_implement.py; src/agentic_workspace/contracts/workspace_runtime_primitive_families.json; tests/test_workspace_proof_cli.py",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "next step": "promote the next bounded slice from .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Acceptance satisfied for #1773: proof-owned helper implementations now build outside primitives behind workspace_runtime_proof.py; compatibility aliases remain; proof selection and closeout blocking semantics are unchanged; host-agnostic routing principle preserved.",
+    "proof status": "passed",
+    "intent served": "yes for slice; parent remains open via .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_proof_cli.py::test_proof_runtime_helpers_route_through_proof_owner -q; uv run pytest tests/test_workspace_proof_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_summary_cli.py -q; uv run pytest tests/test_workspace_cli.py -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run python scripts/check/check_generated_command_packages.py --aw-primitive-ownership --format json; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; stale-reference sweep rg command; git diff --check",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "GitHub #1773",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json activates a fresh bounded slice."
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json.",
+    "motivation worth preserving": "Future agents should continue from .agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json rather than rediscover this closeout residue.",
+    "canonical owner now": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "execution_summary": {
+    "outcome delivered": "Proof verification and tiny proof helper ownership now routes through workspace_runtime_proof.py with focused regression proof and full workspace validation.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+          "owner": ".agentic-workspace/planning/lanes/lane-p2-runtime-packet-owner-boundaries.lane.json",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  }
+}

--- a/.agentic-workspace/planning/lanes/archive/lane-p2-runtime-packet-owner-boundaries.lane.json
+++ b/.agentic-workspace/planning/lanes/archive/lane-p2-runtime-packet-owner-boundaries.lane.json
@@ -2,7 +2,7 @@
   "kind": "planning-lane/v1",
   "id": "lane-p2-runtime-packet-owner-boundaries",
   "title": "P2 runtime packet owner-boundary extraction",
-  "status": "ready",
+  "status": "archived",
   "parent_decomposition_ref": "GitHub P2 roadmap candidate batch 2026-06-27",
   "lane_outcome": "Startup, implement, Planning, proof, verification, and closeout packet construction live behind owner-scoped runtime modules without payload contract drift.",
   "purpose_for_parent": "Shrink the workspace runtime monolith by owner boundary while preserving generated/runtime caller compatibility.",
@@ -44,36 +44,35 @@
     {
       "id": "proof-closeout-packets",
       "title": "Extract proof and closeout runtime packets",
-      "status": "planned",
-      "execplan_ref": "",
+      "status": "completed",
+      "execplan_ref": ".agentic-workspace/planning/closeout-evidence/p2-proof-closeout-runtime-packets.closeout.json",
       "depends_on": [
         "planning-packets"
       ],
       "purpose_for_lane": "Satisfy #1773 without weakening proof or closeout blocking."
     }
   ],
-  "current_slice": "proof-closeout-packets",
+  "current_slice": "",
   "acceptance_boundary": "The lane is complete when #1770 through #1773 each have owner-scoped runtime modules, stable compatibility imports, updated inventories, and focused tests proving unchanged emitted packet contracts.",
   "proof_strategy": "Run focused start/implement/planning/proof tests for each slice, generated command package checks when inventories change, and make test-workspace for cross-runtime extraction.",
   "proof_aggregation": {
-    "status": "partial",
+    "status": "complete",
     "evidence": [
       "#1770 startup-packets completed; proof is recorded in .agentic-workspace/planning/execplans/archive/p2-startup-runtime-packets.plan.json and included make test-workspace, make lint-workspace, generated command package checks, operation conformance, contract tooling, structured file inventory, ruff, maintainer surfaces, schema reference docs, AW defaults/summary/doctor, full tests/test_workspace_cli.py, generator --check, AW primitive ownership, and git diff --check.",
       "#1771 implement-packets completed; proof is recorded in .agentic-workspace/planning/execplans/archive/p2-implement-runtime-packets.plan.json and included make test-workspace, make lint-workspace, generated command package checks, operation conformance, contract tooling, structured file inventory, ruff, schema reference docs, AW defaults/summary/doctor, full tests/test_workspace_cli.py, generator --check, AW primitive ownership, and git diff --check.",
-      "#1772 planning-packets completed; proof is recorded in .agentic-workspace/planning/execplans/archive/p2-planning-runtime-packets.plan.json and included focused active planning owner-boundary regression, full tests/test_workspace_cli.py, make test-workspace, make lint-workspace, contract tooling, structured file inventory, AW primitive ownership, ruff contract check, AW summary/doctor, and git diff --check."
+      "#1772 planning-packets completed; proof is recorded in .agentic-workspace/planning/execplans/archive/p2-planning-runtime-packets.plan.json and included focused active planning owner-boundary regression, full tests/test_workspace_cli.py, make test-workspace, make lint-workspace, contract tooling, structured file inventory, AW primitive ownership, ruff contract check, AW summary/doctor, and git diff --check.",
+      "#1773 proof-closeout-packets completed; proof is recorded in .agentic-workspace/planning/closeout-evidence/p2-proof-closeout-runtime-packets.closeout.json and included focused proof owner-boundary regression, proof/implement/summary tests, full tests/test_workspace_cli.py, make test-workspace, make lint-workspace, contract tooling, structured file inventory, AW primitive ownership, ruff contract check, AW summary/doctor, stale-reference sweep, and git diff --check."
     ],
-    "known_gaps": [
-      "#1773 proof and closeout runtime packets"
-    ]
+    "known_gaps": []
   },
   "residual_lane_work": "The lane does not replace the runtime architecture; it only moves packet ownership out of primitives by declared owner boundary.",
   "lane_to_epic_contribution": "Turns the P2 #1764 decomposition issues into ordered stack work with explicit owner boundaries.",
   "parent_close_permission": "do-not-close-parent",
   "closeout_state": {
-    "status": "open",
-    "summary": "#1770 startup, #1771 implement, and #1772 Planning runtime packet extractions are complete.",
-    "residual_work": "Implement #1773 proof and closeout runtime packets.",
-    "next_owner": "current agent"
+    "status": "closed",
+    "summary": "#1770 startup, #1771 implement, #1772 Planning, and #1773 proof/closeout runtime packet extractions are complete.",
+    "residual_work": "none for this lane",
+    "next_owner": "none"
   },
   "references": [
     {

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -119,7 +119,6 @@
       "owner_surface": "src/agentic_workspace/contracts/schemas/* plus future generated projection helpers",
       "runtime_role": "workspace_runtime_primitives.py still contains many compact projection helpers that shape live payloads and selector responses.",
       "source_symbols": [
-        "_tiny_proof_payload",
         "_compact_start_delegation_decision",
         "_compact_status_payload",
         "_tiny_config_payload"
@@ -246,7 +245,11 @@
         "_proof_payload",
         "_proof_selection_for_changed_paths",
         "_proof_obligations_payload",
-        "_closeout_report_payload"
+        "_closeout_report_payload",
+        "_verification_report_payload",
+        "_active_planning_record_for_proof",
+        "_tiny_proof_payload",
+        "_tiny_proof_obligations_payload"
       ],
       "generated_or_contract_refs": [
         "src/agentic_workspace/contracts/workspace_runtime_primitive_families.json",
@@ -339,7 +342,6 @@
       "runtime_role": "Package-specific Planning, Memory, and Verification behavior is already tracked in package-owned runtime inventories and related issues.",
       "source_symbols": [
         "_module_operations",
-        "_verification_report_payload",
         "_selected_module_reports"
       ],
       "generated_or_contract_refs": [
@@ -438,7 +440,6 @@
           "_tiny_adaptive_routing_payload",
           "_tiny_generated_surface_trust",
           "_tiny_objective_drift",
-          "_tiny_proof_obligations_payload",
           "_tiny_required_proof_commands",
           "_tiny_work_shape_guidance",
           "_transient_validation_retry_guidance",
@@ -611,8 +612,7 @@
           "_startup_closeout_report_route",
           "_supplemental_proof_lanes_for_changed_paths",
           "_surface_value_review_for_changed_paths",
-          "_validation_plan_for_proof",
-          "_verification_report_payload"
+          "_validation_plan_for_proof"
         ],
         "core_role": "Shared core may expose proof route facts, validation command discovery, and closeout evidence helpers used by implement and proof packets.",
         "exclusion_rule": "Do not add proof packet assembly, closeout report layout, or final completion decisions here; those belong in workspace_runtime_proof.py."

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -29,13 +29,6 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, cast, overload
 
-from repo_verification_bootstrap.runtime_primitives import (
-    VerificationUsageError,
-)
-from repo_verification_bootstrap.runtime_primitives import (
-    verification_report_payload as verification_module_report_payload,
-)
-
 from agentic_workspace import __version__, doctor
 from agentic_workspace import config as config_lib
 from agentic_workspace._schema import ModuleDescriptor, ModuleResultContract, RootAgentsCleanupBlock
@@ -234,6 +227,30 @@ def _proof_payload(*args: Any, **kwargs: Any) -> Any:
 
 def _proof_selection_for_changed_paths(*args: Any, **kwargs: Any) -> Any:
     from agentic_workspace.workspace_runtime_proof import _proof_selection_for_changed_paths as owner
+
+    return owner(*args, **kwargs)
+
+
+def _active_planning_record_for_proof(*args: Any, **kwargs: Any) -> Any:
+    from agentic_workspace.workspace_runtime_proof import _active_planning_record_for_proof as owner
+
+    return owner(*args, **kwargs)
+
+
+def _tiny_proof_obligations_payload(*args: Any, **kwargs: Any) -> Any:
+    from agentic_workspace.workspace_runtime_proof import _tiny_proof_obligations_payload as owner
+
+    return owner(*args, **kwargs)
+
+
+def _tiny_proof_payload(*args: Any, **kwargs: Any) -> Any:
+    from agentic_workspace.workspace_runtime_proof import _tiny_proof_payload as owner
+
+    return owner(*args, **kwargs)
+
+
+def _verification_report_payload(*args: Any, **kwargs: Any) -> Any:
+    from agentic_workspace.workspace_runtime_proof import _verification_report_payload as owner
 
     return owner(*args, **kwargs)
 
@@ -2143,26 +2160,6 @@ def _compact_assurance_requirements(value: Any) -> dict[str, Any]:
         ],
         "detail_command": "agentic-workspace report --target ./repo --section assurance_requirements --format json",
     }
-
-
-def _verification_report_payload(
-    *,
-    target_root: Path | None,
-    changed_paths: list[str] | None = None,
-    task_text: str | None = None,
-    active_planning_record: dict[str, Any] | None = None,
-    assurance_requirements: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    try:
-        return verification_module_report_payload(
-            target_root=target_root,
-            changed_paths=changed_paths,
-            task_text=task_text,
-            active_planning_record=active_planning_record,
-            assurance_requirements=assurance_requirements,
-        )
-    except VerificationUsageError as exc:
-        raise WorkspaceUsageError(str(exc)) from exc
 
 
 def _compact_verification(value: Any) -> dict[str, Any]:
@@ -33379,144 +33376,6 @@ def _tiny_required_proof_commands(answer: dict[str, Any]) -> list[str]:
     return _compact_tiny_required_proof_commands(non_verification_commands or required_commands)
 
 
-def _compact_tiny_intent_proof(intent_proof: Any) -> dict[str, Any]:
-    if not isinstance(intent_proof, dict):
-        return {}
-    compact = dict(intent_proof)
-    compact.pop("behavior_preservation_prompt", None)
-    compact.pop("rule", None)
-    for key in ("intended_behavior", "unproven_after_tests"):
-        if compact.get(key) == []:
-            compact.pop(key, None)
-    return compact
-
-
-def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
-    if payload.get("profile") == "compact-contract-answer/v1":
-        answer = payload.get("answer", {})
-        tiny_required_commands = _tiny_required_proof_commands(answer) if isinstance(answer, dict) else []
-        include_intent_proof = False
-        if isinstance(answer, dict) and answer.get("intent_proof"):
-            required_for_intent = tiny_required_commands
-            include_intent_proof = not required_for_intent or not all(command.startswith("git diff --") for command in required_for_intent)
-        if isinstance(answer, dict) and isinstance(answer.get("proof_next_decision"), dict):
-            next_decision = dict(answer["proof_next_decision"])
-            next_decision["required_commands"] = tiny_required_commands
-            next_decision.setdefault("target", payload.get("target"))
-            next_decision.setdefault("selector", payload.get("selector", {}))
-            next_decision.setdefault("sufficiency", _tiny_workflow_sufficiency(answer.get("sufficiency", {})))
-            if answer.get("proof_route_decision"):
-                route_decision = dict(answer["proof_route_decision"])
-                route_decision.pop("next_action", None)
-                route_decision.pop("required_commands", None)
-                next_decision["proof_route_selection"] = route_decision
-            if answer.get("proof_command_adjustments"):
-                next_decision["proof_command_adjustments"] = answer["proof_command_adjustments"]
-            if answer.get("unavailable_proof_commands"):
-                next_decision["unavailable_proof_commands"] = answer["unavailable_proof_commands"]
-            if answer.get("target_proof_capabilities") and (
-                answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands")
-            ):
-                next_decision["target_proof_capabilities"] = answer["target_proof_capabilities"]
-            if answer.get("proof_strategy") and (answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands")):
-                next_decision["proof_strategy"] = {
-                    "kind": answer.get("proof_strategy", {}).get("kind"),
-                    "selection_order": answer.get("proof_strategy", {}).get("selection_order", []),
-                }
-            if include_intent_proof:
-                next_decision["intent_proof"] = _compact_tiny_intent_proof(answer["intent_proof"])
-            next_decision.setdefault(
-                "detail_command",
-                _command_with_cli_invoke(
-                    command="agentic-workspace proof --verbose --changed <paths> --format json", cli_invoke=cli_invoke
-                ),
-            )
-            next_decision = _guidance_with_cli_invoke(value=next_decision, cli_invoke=cli_invoke)
-            return next_decision
-        required_commands = tiny_required_commands
-        validation_plan = answer.get("validation_plan", {}) if isinstance(answer, dict) else {}
-        primary = validation_plan.get("primary_next_action") if isinstance(validation_plan, dict) else None
-        if isinstance(answer, dict) and (not required_commands) and answer.get("unavailable_proof_commands"):
-            primary = {"action": "select-proof-scope", "command": None, "run": None, "required": False}
-        elif not isinstance(primary, dict):
-            primary = {
-                "action": "run-validation-command" if required_commands else "select-proof-scope",
-                "command": required_commands[0] if required_commands else None,
-                "run": required_commands[0] if required_commands else None,
-            }
-        surface_value = answer.get("surface_value_review") if isinstance(answer, dict) else None
-        warnings: list[dict[str, Any]] = []
-        if isinstance(surface_value, dict) and surface_value.get("status") in {"blocked", "needs-review"}:
-            warnings.append({"status": surface_value.get("status"), "summary": surface_value.get("summary") or surface_value.get("rule")})
-        next_payload = {
-            "kind": "proof-next-decision/v1",
-            "target": payload.get("target"),
-            "selector": payload.get("selector", {}),
-            "sufficiency": _tiny_workflow_sufficiency(answer.get("sufficiency", {})) if isinstance(answer, dict) else {},
-            "next": {
-                "action": primary.get("action", "run-validation-command"),
-                "command": primary.get("command"),
-                "run": primary.get("run"),
-                "required": primary.get("required", bool(required_commands)),
-            },
-            "required_commands": required_commands,
-            **({"intent_proof": _compact_tiny_intent_proof(answer["intent_proof"])} if include_intent_proof else {}),
-            **(
-                {"proof_command_adjustments": answer["proof_command_adjustments"]}
-                if isinstance(answer, dict) and answer.get("proof_command_adjustments")
-                else {}
-            ),
-            **(
-                {"unavailable_proof_commands": answer["unavailable_proof_commands"]}
-                if isinstance(answer, dict) and answer.get("unavailable_proof_commands")
-                else {}
-            ),
-            **(
-                {
-                    "proof_strategy": {
-                        "kind": answer.get("proof_strategy", {}).get("kind"),
-                        "selection_order": answer.get("proof_strategy", {}).get("selection_order", []),
-                    }
-                }
-                if isinstance(answer, dict)
-                and answer.get("proof_strategy")
-                and (answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands"))
-                else {}
-            ),
-            **(
-                {"target_proof_capabilities": answer["target_proof_capabilities"]}
-                if isinstance(answer, dict)
-                and answer.get("target_proof_capabilities")
-                and (answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands"))
-                else {}
-            ),
-            **(
-                {"manual_verification": answer["manual_verification"]}
-                if isinstance(answer, dict) and answer.get("manual_verification")
-                else {}
-            ),
-            "warnings": warnings,
-            "detail_command": _command_with_cli_invoke(
-                command="agentic-workspace proof --verbose --changed <paths> --format json", cli_invoke=cli_invoke
-            ),
-        }
-        return _guidance_with_cli_invoke(value=next_payload, cli_invoke=cli_invoke)
-    return {
-        "kind": "proof-next-decision/v1",
-        "target": payload.get("target"),
-        "selector": {},
-        "next": {
-            "action": "select-proof-scope",
-            "command": _command_with_cli_invoke(command="agentic-workspace proof --changed <paths> --format json", cli_invoke=cli_invoke),
-            "run": None,
-            "required": False,
-        },
-        "required_commands": [],
-        "warnings": [],
-        "detail_command": _command_with_cli_invoke(command="agentic-workspace proof --verbose --format json", cli_invoke=cli_invoke),
-    }
-
-
 PROOF_RECEIPT_RELATIVE_PATH = Path(".agentic-workspace") / "local" / "proof-receipts" / "last.json"
 
 
@@ -36591,50 +36450,6 @@ def _active_planning_assurance_for_proof(*, target_root: Path | None) -> dict[st
     }
 
 
-def _active_planning_record_for_proof(*, target_root: Path) -> dict[str, Any]:
-    state_path = target_root / ".agentic-workspace" / "planning" / "state.toml"
-    try:
-        state = tomllib.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return {"status": "unavailable", "reason": "planning state unavailable"}
-    todo = state.get("todo", {})
-    active_items = todo.get("active_items", []) if isinstance(todo, dict) else []
-    active_item = next((item for item in active_items if isinstance(item, dict)), None)
-    if not isinstance(active_item, dict):
-        return {"status": "unavailable", "reason": "no active planning item"}
-    surface = str(active_item.get("surface") or "").strip()
-    record_path = target_root / surface if surface else None
-    raw_record: dict[str, Any] = {}
-    if record_path is not None and record_path.is_file() and record_path.suffix == ".json":
-        try:
-            loaded_record = json.loads(record_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            loaded_record = {}
-        raw_record = loaded_record if isinstance(loaded_record, dict) else {}
-    canonical = raw_record.get("canonical_core", {}) if isinstance(raw_record.get("canonical_core"), dict) else {}
-    machine = raw_record.get("machine_readable_contract", {}) if isinstance(raw_record.get("machine_readable_contract"), dict) else {}
-    execution = machine.get("execution", {}) if isinstance(machine.get("execution"), dict) else {}
-    proof_expectations = _list_payload(canonical.get("proof_expectations")) or _list_payload(active_item.get("proof"))
-    validation_commands = _list_payload(raw_record.get("validation_commands")) or _list_payload(execution.get("proof"))
-    return {
-        "status": "present",
-        "task": {"id": active_item.get("id", ""), "title": active_item.get("title", ""), "surface": surface},
-        "validation_commands": validation_commands,
-        "proof_expectations": proof_expectations,
-        "adaptive_assurance": raw_record.get("adaptive_assurance", {}),
-        "traceability_refs": raw_record.get("traceability_refs", {}),
-        "control_gates": raw_record.get("control_gates", []),
-        "implementation_blockers": raw_record.get("implementation_blockers", []),
-        "risk_registry_refs": raw_record.get("risk_registry_refs", []),
-        "invariant_refs": raw_record.get("invariant_refs", []),
-        "test_data_policy": raw_record.get("test_data_policy", {}),
-        "layer_scaffold": raw_record.get("layer_scaffold", {}),
-        "architecture_decision_promotion": raw_record.get("architecture_decision_promotion", {}),
-        "threat_failure_aids": raw_record.get("threat_failure_aids", []),
-        "proof_report": raw_record.get("proof_report", {}),
-    }
-
-
 def _assurance_item_state(
     *, item_id: str, declared_status: str, blocking: bool = False, evidence: list[Any] | None = None, reason: str | None = None
 ) -> dict[str, Any]:
@@ -37082,29 +36897,6 @@ def _proof_adequacy_payload(
             "whether extra task-specific validation is needed",
         ],
         "rule": "Proof Adequacy judges evidence against a claim boundary; closeout owns completion permission and intent satisfaction.",
-    }
-
-
-def _tiny_proof_obligations_payload(value: dict[str, Any], *, required_commands: list[str] | None = None) -> dict[str, Any]:
-    required = value.get("required_proof", {}) if isinstance(value.get("required_proof"), dict) else {}
-    recommended = value.get("recommended_confidence_checks", {}) if isinstance(value.get("recommended_confidence_checks"), dict) else {}
-    visible_required_commands = list(required_commands) if required_commands is not None else required.get("commands", [])
-    return {
-        "kind": value.get("kind", "agentic-workspace/proof-obligations/v1"),
-        "required_proof": {
-            "status": required.get("status", "unknown"),
-            "commands": visible_required_commands,
-            "manual_verification_required": bool(required.get("manual_verification_required", False)),
-            "action_effect": _tiny_action_effect(
-                required.get("action_effect", {}), include_allowed=False, include_resolution_commands=False
-            ),
-        },
-        "recommended_confidence_checks": {
-            "status": recommended.get("status", "unknown"),
-            "commands": recommended.get("commands", []),
-            "rule": recommended.get("rule", ""),
-        },
-        "completion_claim_rule": value.get("completion_claim_rule", ""),
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -93,7 +93,6 @@ from agentic_workspace.workspace_runtime_core import (
     _tiny_adaptive_routing_payload,
     _tiny_generated_surface_trust,
     _tiny_objective_drift,
-    _tiny_proof_obligations_payload,
     _tiny_required_proof_commands,
     _tiny_task_intent_promotion_guidance,
     _tiny_work_shape_guidance,
@@ -101,7 +100,6 @@ from agentic_workspace.workspace_runtime_core import (
     _unplanned_parent_intent_status_payload,
     _vague_outcome_orientation_payload,
     _validate_target_root,
-    _verification_report_payload,
     _workflow_obligations_report_payload,
     _workflow_sufficiency_payload,
 )
@@ -119,6 +117,8 @@ from agentic_workspace.workspace_runtime_planning import (
 )
 from agentic_workspace.workspace_runtime_proof import (
     _proof_selection_for_changed_paths,
+    _tiny_proof_obligations_payload,
+    _verification_report_payload,
 )
 
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -29,13 +29,6 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, cast, overload
 
-from repo_verification_bootstrap.runtime_primitives import (
-    VerificationUsageError,
-)
-from repo_verification_bootstrap.runtime_primitives import (
-    verification_report_payload as verification_module_report_payload,
-)
-
 from agentic_workspace import __version__, doctor
 from agentic_workspace import config as config_lib
 from agentic_workspace._schema import ModuleDescriptor, ModuleResultContract, RootAgentsCleanupBlock
@@ -168,10 +161,14 @@ from agentic_workspace.workspace_runtime_projection import (
     _tiny_action_effect,
 )
 from agentic_workspace.workspace_runtime_proof import (
+    _active_planning_record_for_proof,  # noqa: F401 - compatibility re-export for proof owner boundary
     _closeout_report_payload,  # noqa: F401 - compatibility re-export for runtime inventory
     _proof_obligations_payload,  # noqa: F401 - compatibility re-export for runtime inventory
     _proof_payload,
     _proof_selection_for_changed_paths,
+    _tiny_proof_obligations_payload,  # noqa: F401 - compatibility re-export for proof owner boundary
+    _tiny_proof_payload,  # noqa: F401 - compatibility re-export for proof owner boundary
+    _verification_report_payload,  # noqa: F401 - compatibility re-export for proof owner boundary
 )
 from agentic_workspace.workspace_runtime_startup import (
     _hydrate_selected_start_advisory_payloads,  # noqa: F401 - compatibility re-export for startup owner boundary
@@ -2062,26 +2059,6 @@ def _compact_assurance_requirements(value: Any) -> dict[str, Any]:
         ],
         "detail_command": "agentic-workspace report --target ./repo --section assurance_requirements --format json",
     }
-
-
-def _verification_report_payload(
-    *,
-    target_root: Path | None,
-    changed_paths: list[str] | None = None,
-    task_text: str | None = None,
-    active_planning_record: dict[str, Any] | None = None,
-    assurance_requirements: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    try:
-        return verification_module_report_payload(
-            target_root=target_root,
-            changed_paths=changed_paths,
-            task_text=task_text,
-            active_planning_record=active_planning_record,
-            assurance_requirements=assurance_requirements,
-        )
-    except VerificationUsageError as exc:
-        raise WorkspaceUsageError(str(exc)) from exc
 
 
 def _compact_verification(value: Any) -> dict[str, Any]:
@@ -33030,144 +33007,6 @@ def _tiny_required_proof_commands(answer: dict[str, Any]) -> list[str]:
     return _compact_tiny_required_proof_commands(non_verification_commands or required_commands)
 
 
-def _compact_tiny_intent_proof(intent_proof: Any) -> dict[str, Any]:
-    if not isinstance(intent_proof, dict):
-        return {}
-    compact = dict(intent_proof)
-    compact.pop("behavior_preservation_prompt", None)
-    compact.pop("rule", None)
-    for key in ("intended_behavior", "unproven_after_tests"):
-        if compact.get(key) == []:
-            compact.pop(key, None)
-    return compact
-
-
-def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
-    if payload.get("profile") == "compact-contract-answer/v1":
-        answer = payload.get("answer", {})
-        tiny_required_commands = _tiny_required_proof_commands(answer) if isinstance(answer, dict) else []
-        include_intent_proof = False
-        if isinstance(answer, dict) and answer.get("intent_proof"):
-            required_for_intent = tiny_required_commands
-            include_intent_proof = not required_for_intent or not all(command.startswith("git diff --") for command in required_for_intent)
-        if isinstance(answer, dict) and isinstance(answer.get("proof_next_decision"), dict):
-            next_decision = dict(answer["proof_next_decision"])
-            next_decision["required_commands"] = tiny_required_commands
-            next_decision.setdefault("target", payload.get("target"))
-            next_decision.setdefault("selector", payload.get("selector", {}))
-            next_decision.setdefault("sufficiency", _tiny_workflow_sufficiency(answer.get("sufficiency", {})))
-            if answer.get("proof_route_decision"):
-                route_decision = dict(answer["proof_route_decision"])
-                route_decision.pop("next_action", None)
-                route_decision.pop("required_commands", None)
-                next_decision["proof_route_selection"] = route_decision
-            if answer.get("proof_command_adjustments"):
-                next_decision["proof_command_adjustments"] = answer["proof_command_adjustments"]
-            if answer.get("unavailable_proof_commands"):
-                next_decision["unavailable_proof_commands"] = answer["unavailable_proof_commands"]
-            if answer.get("target_proof_capabilities") and (
-                answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands")
-            ):
-                next_decision["target_proof_capabilities"] = answer["target_proof_capabilities"]
-            if answer.get("proof_strategy") and (answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands")):
-                next_decision["proof_strategy"] = {
-                    "kind": answer.get("proof_strategy", {}).get("kind"),
-                    "selection_order": answer.get("proof_strategy", {}).get("selection_order", []),
-                }
-            if include_intent_proof:
-                next_decision["intent_proof"] = _compact_tiny_intent_proof(answer["intent_proof"])
-            next_decision.setdefault(
-                "detail_command",
-                _command_with_cli_invoke(
-                    command="agentic-workspace proof --verbose --changed <paths> --format json", cli_invoke=cli_invoke
-                ),
-            )
-            next_decision = _guidance_with_cli_invoke(value=next_decision, cli_invoke=cli_invoke)
-            return next_decision
-        required_commands = tiny_required_commands
-        validation_plan = answer.get("validation_plan", {}) if isinstance(answer, dict) else {}
-        primary = validation_plan.get("primary_next_action") if isinstance(validation_plan, dict) else None
-        if isinstance(answer, dict) and (not required_commands) and answer.get("unavailable_proof_commands"):
-            primary = {"action": "select-proof-scope", "command": None, "run": None, "required": False}
-        elif not isinstance(primary, dict):
-            primary = {
-                "action": "run-validation-command" if required_commands else "select-proof-scope",
-                "command": required_commands[0] if required_commands else None,
-                "run": required_commands[0] if required_commands else None,
-            }
-        surface_value = answer.get("surface_value_review") if isinstance(answer, dict) else None
-        warnings: list[dict[str, Any]] = []
-        if isinstance(surface_value, dict) and surface_value.get("status") in {"blocked", "needs-review"}:
-            warnings.append({"status": surface_value.get("status"), "summary": surface_value.get("summary") or surface_value.get("rule")})
-        next_payload = {
-            "kind": "proof-next-decision/v1",
-            "target": payload.get("target"),
-            "selector": payload.get("selector", {}),
-            "sufficiency": _tiny_workflow_sufficiency(answer.get("sufficiency", {})) if isinstance(answer, dict) else {},
-            "next": {
-                "action": primary.get("action", "run-validation-command"),
-                "command": primary.get("command"),
-                "run": primary.get("run"),
-                "required": primary.get("required", bool(required_commands)),
-            },
-            "required_commands": required_commands,
-            **({"intent_proof": _compact_tiny_intent_proof(answer["intent_proof"])} if include_intent_proof else {}),
-            **(
-                {"proof_command_adjustments": answer["proof_command_adjustments"]}
-                if isinstance(answer, dict) and answer.get("proof_command_adjustments")
-                else {}
-            ),
-            **(
-                {"unavailable_proof_commands": answer["unavailable_proof_commands"]}
-                if isinstance(answer, dict) and answer.get("unavailable_proof_commands")
-                else {}
-            ),
-            **(
-                {
-                    "proof_strategy": {
-                        "kind": answer.get("proof_strategy", {}).get("kind"),
-                        "selection_order": answer.get("proof_strategy", {}).get("selection_order", []),
-                    }
-                }
-                if isinstance(answer, dict)
-                and answer.get("proof_strategy")
-                and (answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands"))
-                else {}
-            ),
-            **(
-                {"target_proof_capabilities": answer["target_proof_capabilities"]}
-                if isinstance(answer, dict)
-                and answer.get("target_proof_capabilities")
-                and (answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands"))
-                else {}
-            ),
-            **(
-                {"manual_verification": answer["manual_verification"]}
-                if isinstance(answer, dict) and answer.get("manual_verification")
-                else {}
-            ),
-            "warnings": warnings,
-            "detail_command": _command_with_cli_invoke(
-                command="agentic-workspace proof --verbose --changed <paths> --format json", cli_invoke=cli_invoke
-            ),
-        }
-        return _guidance_with_cli_invoke(value=next_payload, cli_invoke=cli_invoke)
-    return {
-        "kind": "proof-next-decision/v1",
-        "target": payload.get("target"),
-        "selector": {},
-        "next": {
-            "action": "select-proof-scope",
-            "command": _command_with_cli_invoke(command="agentic-workspace proof --changed <paths> --format json", cli_invoke=cli_invoke),
-            "run": None,
-            "required": False,
-        },
-        "required_commands": [],
-        "warnings": [],
-        "detail_command": _command_with_cli_invoke(command="agentic-workspace proof --verbose --format json", cli_invoke=cli_invoke),
-    }
-
-
 PROOF_RECEIPT_RELATIVE_PATH = Path(".agentic-workspace") / "local" / "proof-receipts" / "last.json"
 
 
@@ -36242,50 +36081,6 @@ def _active_planning_assurance_for_proof(*, target_root: Path | None) -> dict[st
     }
 
 
-def _active_planning_record_for_proof(*, target_root: Path) -> dict[str, Any]:
-    state_path = target_root / ".agentic-workspace" / "planning" / "state.toml"
-    try:
-        state = tomllib.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return {"status": "unavailable", "reason": "planning state unavailable"}
-    todo = state.get("todo", {})
-    active_items = todo.get("active_items", []) if isinstance(todo, dict) else []
-    active_item = next((item for item in active_items if isinstance(item, dict)), None)
-    if not isinstance(active_item, dict):
-        return {"status": "unavailable", "reason": "no active planning item"}
-    surface = str(active_item.get("surface") or "").strip()
-    record_path = target_root / surface if surface else None
-    raw_record: dict[str, Any] = {}
-    if record_path is not None and record_path.is_file() and record_path.suffix == ".json":
-        try:
-            loaded_record = json.loads(record_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            loaded_record = {}
-        raw_record = loaded_record if isinstance(loaded_record, dict) else {}
-    canonical = raw_record.get("canonical_core", {}) if isinstance(raw_record.get("canonical_core"), dict) else {}
-    machine = raw_record.get("machine_readable_contract", {}) if isinstance(raw_record.get("machine_readable_contract"), dict) else {}
-    execution = machine.get("execution", {}) if isinstance(machine.get("execution"), dict) else {}
-    proof_expectations = _list_payload(canonical.get("proof_expectations")) or _list_payload(active_item.get("proof"))
-    validation_commands = _list_payload(raw_record.get("validation_commands")) or _list_payload(execution.get("proof"))
-    return {
-        "status": "present",
-        "task": {"id": active_item.get("id", ""), "title": active_item.get("title", ""), "surface": surface},
-        "validation_commands": validation_commands,
-        "proof_expectations": proof_expectations,
-        "adaptive_assurance": raw_record.get("adaptive_assurance", {}),
-        "traceability_refs": raw_record.get("traceability_refs", {}),
-        "control_gates": raw_record.get("control_gates", []),
-        "implementation_blockers": raw_record.get("implementation_blockers", []),
-        "risk_registry_refs": raw_record.get("risk_registry_refs", []),
-        "invariant_refs": raw_record.get("invariant_refs", []),
-        "test_data_policy": raw_record.get("test_data_policy", {}),
-        "layer_scaffold": raw_record.get("layer_scaffold", {}),
-        "architecture_decision_promotion": raw_record.get("architecture_decision_promotion", {}),
-        "threat_failure_aids": raw_record.get("threat_failure_aids", []),
-        "proof_report": raw_record.get("proof_report", {}),
-    }
-
-
 def _assurance_item_state(
     *, item_id: str, declared_status: str, blocking: bool = False, evidence: list[Any] | None = None, reason: str | None = None
 ) -> dict[str, Any]:
@@ -36733,29 +36528,6 @@ def _proof_adequacy_payload(
             "whether extra task-specific validation is needed",
         ],
         "rule": "Proof Adequacy judges evidence against a claim boundary; closeout owns completion permission and intent satisfaction.",
-    }
-
-
-def _tiny_proof_obligations_payload(value: dict[str, Any], *, required_commands: list[str] | None = None) -> dict[str, Any]:
-    required = value.get("required_proof", {}) if isinstance(value.get("required_proof"), dict) else {}
-    recommended = value.get("recommended_confidence_checks", {}) if isinstance(value.get("recommended_confidence_checks"), dict) else {}
-    visible_required_commands = list(required_commands) if required_commands is not None else required.get("commands", [])
-    return {
-        "kind": value.get("kind", "agentic-workspace/proof-obligations/v1"),
-        "required_proof": {
-            "status": required.get("status", "unknown"),
-            "commands": visible_required_commands,
-            "manual_verification_required": bool(required.get("manual_verification_required", False)),
-            "action_effect": _tiny_action_effect(
-                required.get("action_effect", {}), include_allowed=False, include_resolution_commands=False
-            ),
-        },
-        "recommended_confidence_checks": {
-            "status": recommended.get("status", "unknown"),
-            "commands": recommended.get("commands", []),
-            "rule": recommended.get("rule", ""),
-        },
-        "completion_claim_rule": value.get("completion_claim_rule", ""),
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -7,13 +7,22 @@ monolith keeps compatibility re-exports for legacy private import names.
 from __future__ import annotations
 
 import copy
+import json
 import re
+import tomllib
 from pathlib import Path
 from typing import Any
 
+from repo_verification_bootstrap.runtime_primitives import (
+    VerificationUsageError,
+)
+from repo_verification_bootstrap.runtime_primitives import (
+    verification_report_payload as verification_module_report_payload,
+)
+
 from agentic_workspace import config as config_lib
 from agentic_workspace._schema import ModuleDescriptor
-from agentic_workspace.config import DEFAULT_ASSURANCE_LEVEL, DEFAULT_CLI_INVOKE, WorkspaceConfig
+from agentic_workspace.config import DEFAULT_ASSURANCE_LEVEL, DEFAULT_CLI_INVOKE, WorkspaceConfig, WorkspaceUsageError
 from agentic_workspace.runtime_source_review import runtime_source_edit_review_for_changed_paths
 from agentic_workspace.runtime_symbol_working_set import runtime_symbol_working_set_for_changed_paths
 from agentic_workspace.workspace_runtime_core import (
@@ -44,6 +53,7 @@ from agentic_workspace.workspace_runtime_core import (
     _defaults_payload,
     _direct_cli_edit_review_for_changed_paths,
     _docs_only_reduction_lane,
+    _guidance_with_cli_invoke,
     _host_repo_learning_posture_payload,
     _intent_decision_projection,
     _intent_proof_prompt_payload,
@@ -84,9 +94,11 @@ from agentic_workspace.workspace_runtime_core import (
     _surface_value_review_for_changed_paths,
     _target_proof_capabilities,
     _test_strategy_check_payload,
+    _tiny_action_effect,
+    _tiny_required_proof_commands,
+    _tiny_workflow_sufficiency,
     _transient_validation_retry_guidance,
     _validation_plan_for_proof,
-    _verification_report_payload,
     _workflow_obligation_closeout_contract_payload,
     _workflow_obligations_report_payload,
     _workflow_sufficiency_payload,
@@ -113,6 +125,231 @@ def _proof_lifecycle_command(*args: Any, **kwargs: Any) -> dict[str, Any]:
         if patched is not None and patched is not _run_lifecycle_command:
             return patched(*args, **kwargs)
     return _run_lifecycle_command(*args, **kwargs)
+
+
+def _verification_report_payload(
+    *,
+    target_root: Path | None,
+    changed_paths: list[str] | None = None,
+    task_text: str | None = None,
+    active_planning_record: dict[str, Any] | None = None,
+    assurance_requirements: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        return verification_module_report_payload(
+            target_root=target_root,
+            changed_paths=changed_paths,
+            task_text=task_text,
+            active_planning_record=active_planning_record,
+            assurance_requirements=assurance_requirements,
+        )
+    except VerificationUsageError as exc:
+        raise WorkspaceUsageError(str(exc)) from exc
+
+
+def _compact_tiny_intent_proof(intent_proof: Any) -> dict[str, Any]:
+    if not isinstance(intent_proof, dict):
+        return {}
+    compact = dict(intent_proof)
+    compact.pop("behavior_preservation_prompt", None)
+    compact.pop("rule", None)
+    for key in ("intended_behavior", "unproven_after_tests"):
+        if compact.get(key) == []:
+            compact.pop(key, None)
+    return compact
+
+
+def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
+    if payload.get("profile") == "compact-contract-answer/v1":
+        answer = payload.get("answer", {})
+        tiny_required_commands = _tiny_required_proof_commands(answer) if isinstance(answer, dict) else []
+        include_intent_proof = False
+        if isinstance(answer, dict) and answer.get("intent_proof"):
+            required_for_intent = tiny_required_commands
+            include_intent_proof = not required_for_intent or not all(command.startswith("git diff --") for command in required_for_intent)
+        if isinstance(answer, dict) and isinstance(answer.get("proof_next_decision"), dict):
+            next_decision = dict(answer["proof_next_decision"])
+            next_decision["required_commands"] = tiny_required_commands
+            next_decision.setdefault("target", payload.get("target"))
+            next_decision.setdefault("selector", payload.get("selector", {}))
+            next_decision.setdefault("sufficiency", _tiny_workflow_sufficiency(answer.get("sufficiency", {})))
+            if answer.get("proof_route_decision"):
+                route_decision = dict(answer["proof_route_decision"])
+                route_decision.pop("next_action", None)
+                route_decision.pop("required_commands", None)
+                next_decision["proof_route_selection"] = route_decision
+            if answer.get("proof_command_adjustments"):
+                next_decision["proof_command_adjustments"] = answer["proof_command_adjustments"]
+            if answer.get("unavailable_proof_commands"):
+                next_decision["unavailable_proof_commands"] = answer["unavailable_proof_commands"]
+            if answer.get("target_proof_capabilities") and (
+                answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands")
+            ):
+                next_decision["target_proof_capabilities"] = answer["target_proof_capabilities"]
+            if answer.get("proof_strategy") and (answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands")):
+                next_decision["proof_strategy"] = {
+                    "kind": answer.get("proof_strategy", {}).get("kind"),
+                    "selection_order": answer.get("proof_strategy", {}).get("selection_order", []),
+                }
+            if include_intent_proof:
+                next_decision["intent_proof"] = _compact_tiny_intent_proof(answer["intent_proof"])
+            next_decision.setdefault(
+                "detail_command",
+                _command_with_cli_invoke(
+                    command="agentic-workspace proof --verbose --changed <paths> --format json", cli_invoke=cli_invoke
+                ),
+            )
+            next_decision = _guidance_with_cli_invoke(value=next_decision, cli_invoke=cli_invoke)
+            return next_decision
+        required_commands = tiny_required_commands
+        validation_plan = answer.get("validation_plan", {}) if isinstance(answer, dict) else {}
+        primary = validation_plan.get("primary_next_action") if isinstance(validation_plan, dict) else None
+        if isinstance(answer, dict) and (not required_commands) and answer.get("unavailable_proof_commands"):
+            primary = {"action": "select-proof-scope", "command": None, "run": None, "required": False}
+        elif not isinstance(primary, dict):
+            primary = {
+                "action": "run-validation-command" if required_commands else "select-proof-scope",
+                "command": required_commands[0] if required_commands else None,
+                "run": required_commands[0] if required_commands else None,
+            }
+        surface_value = answer.get("surface_value_review") if isinstance(answer, dict) else None
+        warnings: list[dict[str, Any]] = []
+        if isinstance(surface_value, dict) and surface_value.get("status") in {"blocked", "needs-review"}:
+            warnings.append({"status": surface_value.get("status"), "summary": surface_value.get("summary") or surface_value.get("rule")})
+        next_payload = {
+            "kind": "proof-next-decision/v1",
+            "target": payload.get("target"),
+            "selector": payload.get("selector", {}),
+            "sufficiency": _tiny_workflow_sufficiency(answer.get("sufficiency", {})) if isinstance(answer, dict) else {},
+            "next": {
+                "action": primary.get("action", "run-validation-command"),
+                "command": primary.get("command"),
+                "run": primary.get("run"),
+                "required": primary.get("required", bool(required_commands)),
+            },
+            "required_commands": required_commands,
+            **({"intent_proof": _compact_tiny_intent_proof(answer["intent_proof"])} if include_intent_proof else {}),
+            **(
+                {"proof_command_adjustments": answer["proof_command_adjustments"]}
+                if isinstance(answer, dict) and answer.get("proof_command_adjustments")
+                else {}
+            ),
+            **(
+                {"unavailable_proof_commands": answer["unavailable_proof_commands"]}
+                if isinstance(answer, dict) and answer.get("unavailable_proof_commands")
+                else {}
+            ),
+            **(
+                {
+                    "proof_strategy": {
+                        "kind": answer.get("proof_strategy", {}).get("kind"),
+                        "selection_order": answer.get("proof_strategy", {}).get("selection_order", []),
+                    }
+                }
+                if isinstance(answer, dict)
+                and answer.get("proof_strategy")
+                and (answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands"))
+                else {}
+            ),
+            **(
+                {"target_proof_capabilities": answer["target_proof_capabilities"]}
+                if isinstance(answer, dict)
+                and answer.get("target_proof_capabilities")
+                and (answer.get("proof_command_adjustments") or answer.get("unavailable_proof_commands"))
+                else {}
+            ),
+            **(
+                {"manual_verification": answer["manual_verification"]}
+                if isinstance(answer, dict) and answer.get("manual_verification")
+                else {}
+            ),
+            "warnings": warnings,
+            "detail_command": _command_with_cli_invoke(
+                command="agentic-workspace proof --verbose --changed <paths> --format json", cli_invoke=cli_invoke
+            ),
+        }
+        return _guidance_with_cli_invoke(value=next_payload, cli_invoke=cli_invoke)
+    return {
+        "kind": "proof-next-decision/v1",
+        "target": payload.get("target"),
+        "selector": {},
+        "next": {
+            "action": "select-proof-scope",
+            "command": _command_with_cli_invoke(command="agentic-workspace proof --changed <paths> --format json", cli_invoke=cli_invoke),
+            "run": None,
+            "required": False,
+        },
+        "required_commands": [],
+        "warnings": [],
+        "detail_command": _command_with_cli_invoke(command="agentic-workspace proof --verbose --format json", cli_invoke=cli_invoke),
+    }
+
+
+def _active_planning_record_for_proof(*, target_root: Path) -> dict[str, Any]:
+    state_path = target_root / ".agentic-workspace" / "planning" / "state.toml"
+    try:
+        state = tomllib.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return {"status": "unavailable", "reason": "planning state unavailable"}
+    todo = state.get("todo", {})
+    active_items = todo.get("active_items", []) if isinstance(todo, dict) else []
+    active_item = next((item for item in active_items if isinstance(item, dict)), None)
+    if not isinstance(active_item, dict):
+        return {"status": "unavailable", "reason": "no active planning item"}
+    surface = str(active_item.get("surface") or "").strip()
+    record_path = target_root / surface if surface else None
+    raw_record: dict[str, Any] = {}
+    if record_path is not None and record_path.is_file() and record_path.suffix == ".json":
+        try:
+            loaded_record = json.loads(record_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            loaded_record = {}
+        raw_record = loaded_record if isinstance(loaded_record, dict) else {}
+    canonical = raw_record.get("canonical_core", {}) if isinstance(raw_record.get("canonical_core"), dict) else {}
+    machine = raw_record.get("machine_readable_contract", {}) if isinstance(raw_record.get("machine_readable_contract"), dict) else {}
+    execution = machine.get("execution", {}) if isinstance(machine.get("execution"), dict) else {}
+    proof_expectations = _list_payload(canonical.get("proof_expectations")) or _list_payload(active_item.get("proof"))
+    validation_commands = _list_payload(raw_record.get("validation_commands")) or _list_payload(execution.get("proof"))
+    return {
+        "status": "present",
+        "task": {"id": active_item.get("id", ""), "title": active_item.get("title", ""), "surface": surface},
+        "validation_commands": validation_commands,
+        "proof_expectations": proof_expectations,
+        "adaptive_assurance": raw_record.get("adaptive_assurance", {}),
+        "traceability_refs": raw_record.get("traceability_refs", {}),
+        "control_gates": raw_record.get("control_gates", []),
+        "implementation_blockers": raw_record.get("implementation_blockers", []),
+        "risk_registry_refs": raw_record.get("risk_registry_refs", []),
+        "invariant_refs": raw_record.get("invariant_refs", []),
+        "test_data_policy": raw_record.get("test_data_policy", {}),
+        "layer_scaffold": raw_record.get("layer_scaffold", {}),
+        "architecture_decision_promotion": raw_record.get("architecture_decision_promotion", {}),
+        "threat_failure_aids": raw_record.get("threat_failure_aids", []),
+        "proof_report": raw_record.get("proof_report", {}),
+    }
+
+
+def _tiny_proof_obligations_payload(value: dict[str, Any], *, required_commands: list[str] | None = None) -> dict[str, Any]:
+    required = value.get("required_proof", {}) if isinstance(value.get("required_proof"), dict) else {}
+    recommended = value.get("recommended_confidence_checks", {}) if isinstance(value.get("recommended_confidence_checks"), dict) else {}
+    visible_required_commands = list(required_commands) if required_commands is not None else required.get("commands", [])
+    return {
+        "kind": value.get("kind", "agentic-workspace/proof-obligations/v1"),
+        "required_proof": {
+            "status": required.get("status", "unknown"),
+            "commands": visible_required_commands,
+            "manual_verification_required": bool(required.get("manual_verification_required", False)),
+            "action_effect": _tiny_action_effect(
+                required.get("action_effect", {}), include_allowed=False, include_resolution_commands=False
+            ),
+        },
+        "recommended_confidence_checks": {
+            "status": recommended.get("status", "unknown"),
+            "commands": recommended.get("commands", []),
+            "rule": recommended.get("rule", ""),
+        },
+        "completion_claim_rule": value.get("completion_claim_rule", ""),
+    }
 
 
 def _closeout_report_payload(

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -4,6 +4,19 @@ from __future__ import annotations
 from tests.workspace_cli_support import *
 
 
+def test_proof_runtime_helpers_route_through_proof_owner(tmp_path: Path) -> None:
+    assert workspace_runtime_primitives._verification_report_payload is workspace_runtime_proof._verification_report_payload
+    assert workspace_runtime_primitives._tiny_proof_payload is workspace_runtime_proof._tiny_proof_payload
+    assert workspace_runtime_primitives._tiny_proof_obligations_payload is workspace_runtime_proof._tiny_proof_obligations_payload
+    assert workspace_runtime_primitives._active_planning_record_for_proof is workspace_runtime_proof._active_planning_record_for_proof
+    assert workspace_runtime_implement._verification_report_payload is workspace_runtime_proof._verification_report_payload
+    assert workspace_runtime_implement._tiny_proof_obligations_payload is workspace_runtime_proof._tiny_proof_obligations_payload
+    assert workspace_runtime_core._active_planning_record_for_proof(target_root=tmp_path) == {
+        "status": "unavailable",
+        "reason": "planning state unavailable",
+    }
+
+
 def test_proof_command_reports_routes_and_current_health(tmp_path: Path, monkeypatch, capsys) -> None:
     calls: list[tuple[str, str, dict[str, object]]] = []
     _init_git_repo(tmp_path)


### PR DESCRIPTION
## Summary

- Moves proof-owned verification aggregation, proof active-planning record, tiny proof payload, and tiny proof obligations helpers into `workspace_runtime_proof.py`.
- Leaves lazy compatibility forwarders in `workspace_runtime_core.py` and compatibility re-exports in `workspace_runtime_primitives.py`.
- Updates implement runtime to import proof-owned verification/tiny proof helpers directly.
- Updates primitive family inventory, adds a proof owner-boundary regression, closes out and archives the P2 runtime packet owner-boundary lane.

Closes #1773.

## Stack

Base: #1819 / `codex/p2-planning-runtime-packets`

## Runtime Boundary / Parity

The moved proof/checkpoint projections are not mirrored through `workspace_runtime_primitives.py` as implementations. `workspace_runtime_primitives.py` only re-exports the proof-owner helpers for compatibility, and `workspace_runtime_core.py` only retains lazy forwarding shims. The owner implementation is `workspace_runtime_proof.py`, with contract inventory updated under `proof-verification-closeout-runtime-packets`.

## Validation

- `uv run pytest tests/test_workspace_proof_cli.py::test_proof_runtime_helpers_route_through_proof_owner -q`
- `uv run pytest tests/test_workspace_proof_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_summary_cli.py -q`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/check/check_generated_command_packages.py --aw-primitive-ownership --format json`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- stale-reference sweep for moved proof helper names
- `git diff --check`