### PR TITLE
Audit workspace lifecycle/provider runtime boundaries

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/p2-workspace-lifecycle-provider-boundaries.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/p2-workspace-lifecycle-provider-boundaries.plan.json
@@ -1,0 +1,384 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Audit workspace lifecycle and provider runtime boundaries",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "GitHub #1656",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Audit workspace lifecycle and provider runtime boundaries is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "P2 runtime boundary decomposition audits lane / #1657 next slice",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "GitHub #1656"
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "GitHub #1656",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "p2-workspace-lifecycle-provider-boundaries",
+      "status": "completed",
+      "next_step": "Continue via P2 runtime boundary decomposition audits lane / #1657 next slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "GitHub #1656",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "P2 runtime boundary decomposition audits lane / #1657 next slice"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "P2 runtime boundary decomposition audits lane / #1657 next slice",
+    "activation trigger": "when the continuation owner promotes the next slice"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via P2 runtime boundary decomposition audits lane / #1657 next slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Audit workspace lifecycle and provider runtime boundaries",
+    "inferred intended outcome": "GitHub #1656",
+    "chosen concrete what": "#1656 satisfied with disposition table, safe reconcile owner split, inventory/static-proof updates, and validation evidence.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "GitHub #1656",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [
+    {
+      "kind": "source",
+      "target": "GitHub #1656",
+      "label": "GitHub #1656",
+      "role": "intake",
+      "locator": ""
+    }
+  ],
+  "active_milestone": {
+    "id": "p2-workspace-lifecycle-provider-boundaries",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Audit workspace lifecycle and provider runtime boundaries is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Recorded #1656 symbol-by-symbol disposition, moved the root reconcile adapter implementation to the Planning runtime owner with compatibility exports, retained lifecycle/provider adapters behind explicit transaction/provider envelope blockers, updated runtime family inventory, and cleaned stale archived-lane schema residue.",
+    "scope touched": "workspace runtime Planning/core/primitives reconcile adapter ownership, runtime primitive family inventory, #1656 disposition review, focused owner-routing regression, planning residue cleanup",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_planning.py; src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/workspace_runtime_primitive_families.json; tests/test_workspace_cli.py; docs/reviews/workspace-lifecycle-provider-boundary-disposition-2026-06-27.md; .agentic-workspace/planning/lanes/archive/lane-p2-runtime-packet-owner-boundaries.lane.json",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from P2 runtime boundary decomposition audits lane / #1657 next slice",
+    "next step": "promote the next bounded slice from P2 runtime boundary decomposition audits lane / #1657 next slice"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope respected: #1656 only. Reconcile payload ownership moved to Planning; lifecycle mutation and GitHub provider refresh remain hand-owned until contract-backed transaction/provider envelopes exist. No generated minimization count reduction is claimed.",
+    "proof status": "passed",
+    "intent served": "yes for slice; parent remains open via P2 runtime boundary decomposition audits lane / #1657 next slice",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "P2 runtime boundary decomposition audits lane / #1657 next slice"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "focused reconcile owner tests; tests/test_workspace_cli.py; make test-workspace; make lint-workspace; contract tooling; structured file inventory; maintainer surfaces; generated command boundary and AW primitive ownership checks; planning summary/doctor; git diff --check",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "GitHub #1656",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "P2 runtime boundary decomposition audits lane / #1657 next slice"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1656 satisfied with disposition table, safe reconcile owner split, inventory/static-proof updates, and validation evidence.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "P2 runtime boundary decomposition audits lane / #1657 next slice",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "P2 runtime boundary decomposition audits lane / #1657 next slice",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed planning residue to P2 runtime boundary decomposition audits lane / #1657 next slice.",
+    "motivation worth preserving": "Future agents should continue from P2 runtime boundary decomposition audits lane / #1657 next slice rather than rediscover this closeout residue.",
+    "canonical owner now": "P2 runtime boundary decomposition audits lane / #1657 next slice",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "P2 runtime boundary decomposition audits lane / #1657 next slice",
+    "proposed durable intent": "Future agents should continue from P2 runtime boundary decomposition audits lane / #1657 next slice rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "P2 runtime boundary decomposition audits lane / #1657 next slice"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when P2 runtime boundary decomposition audits lane / #1657 next slice activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "P2 runtime boundary decomposition audits lane / #1657 next slice",
+          "owner": "P2 runtime boundary decomposition audits lane / #1657 next slice",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-27: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "P2 runtime boundary decomposition audits lane / #1657 next slice",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "continue-required",
+    "active_intent_satisfied": false,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "partial-progress",
+    "required_next_action": "create-follow-on-plan",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1656",
+          "authorized": false,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [
+          "done",
+          "implemented",
+          "complete",
+          "finished",
+          "all",
+          "full intent complete",
+          "Closes #1656"
+        ],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "P2 runtime boundary decomposition audits lane / #1657 next slice",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "no",
+      "reason": "P2 runtime boundary decomposition audits lane / #1657 next slice"
+    },
+    "continuation": {
+      "owner_surface": "P2 runtime boundary decomposition audits lane / #1657 next slice",
+      "created_or_required": true,
+      "reason": "P2 runtime boundary decomposition audits lane / #1657 next slice"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: GitHub #1656\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: focused reconcile owner tests; tests/test_workspace_cli.py; make test-workspace; make lint-workspace; contract tooling; structured file inventory; maintainer surfaces; generated command boundary and AW primitive ownership checks; planning summary/doctor; git diff --check\nChanged surfaces: src/agentic_workspace/workspace_runtime_planning.py; src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/workspace_runtime_primitive_families.json; tests/test_workspace_cli.py; docs/reviews/workspace-lifecycle-provider-boundary-disposition-2026-06-27.md; .agentic-workspace/planning/lanes/archive/lane-p2-runtime-packet-owner-boundaries.lane.json\nDurable residue: planning (P2 runtime boundary decomposition audits lane / #1657 next slice)\nMemory learning: route_to_planning\nFollow-up: P2 runtime boundary decomposition audits lane / #1657 next slice\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
+  }
+}

--- a/.agentic-workspace/planning/lanes/archive/lane-p2-runtime-packet-owner-boundaries.lane.json
+++ b/.agentic-workspace/planning/lanes/archive/lane-p2-runtime-packet-owner-boundaries.lane.json
@@ -56,7 +56,7 @@
   "acceptance_boundary": "The lane is complete when #1770 through #1773 each have owner-scoped runtime modules, stable compatibility imports, updated inventories, and focused tests proving unchanged emitted packet contracts.",
   "proof_strategy": "Run focused start/implement/planning/proof tests for each slice, generated command package checks when inventories change, and make test-workspace for cross-runtime extraction.",
   "proof_aggregation": {
-    "status": "complete",
+    "status": "satisfied",
     "evidence": [
       "#1770 startup-packets completed; proof is recorded in .agentic-workspace/planning/execplans/archive/p2-startup-runtime-packets.plan.json and included make test-workspace, make lint-workspace, generated command package checks, operation conformance, contract tooling, structured file inventory, ruff, maintainer surfaces, schema reference docs, AW defaults/summary/doctor, full tests/test_workspace_cli.py, generator --check, AW primitive ownership, and git diff --check.",
       "#1771 implement-packets completed; proof is recorded in .agentic-workspace/planning/execplans/archive/p2-implement-runtime-packets.plan.json and included make test-workspace, make lint-workspace, generated command package checks, operation conformance, contract tooling, structured file inventory, ruff, schema reference docs, AW defaults/summary/doctor, full tests/test_workspace_cli.py, generator --check, AW primitive ownership, and git diff --check.",

--- a/.agentic-workspace/planning/lanes/lane-p2-runtime-boundary-decomposition-audits.lane.json
+++ b/.agentic-workspace/planning/lanes/lane-p2-runtime-boundary-decomposition-audits.lane.json
@@ -18,15 +18,15 @@
     {
       "id": "workspace-lifecycle-provider-boundaries",
       "title": "Audit workspace lifecycle and provider runtime boundaries",
-      "status": "ready",
-      "execplan_ref": "",
+      "status": "completed",
+      "execplan_ref": ".agentic-workspace/planning/execplans/archive/p2-workspace-lifecycle-provider-boundaries.plan.json",
       "depends_on": [],
       "purpose_for_lane": "Satisfy #1656 with symbol-level dispositions and safe lifecycle/report extraction only where mutation/provider trust remains explicit."
     },
     {
       "id": "planning-runtime-boundaries",
       "title": "Audit Planning package runtime boundaries",
-      "status": "planned",
+      "status": "ready",
       "execplan_ref": "",
       "depends_on": [
         "workspace-lifecycle-provider-boundaries"
@@ -44,12 +44,14 @@
       "purpose_for_lane": "Satisfy #1658 with semantic-owner-after-split disposition and safe view/scaffold decompositions."
     }
   ],
-  "current_slice": "workspace-lifecycle-provider-boundaries",
+  "current_slice": "planning-runtime-boundaries",
   "acceptance_boundary": "The lane is complete when #1656, #1657, and #1658 each have symbol dispositions, retained-owner rationale, safe decompositions or explicit blockers, updated inventories, and proof evidence.",
   "proof_strategy": "Run generated command package checks, package-focused tests for affected runtime behavior, operation conformance for changed commands, and make test-workspace for cross-package changes.",
   "proof_aggregation": {
-    "status": "not-started",
-    "evidence": [],
+    "status": "partial",
+    "evidence": [
+      "#1656 workspace-lifecycle-provider-boundaries completed; proof is recorded in .agentic-workspace/planning/execplans/archive/p2-workspace-lifecycle-provider-boundaries.plan.json and included focused reconcile owner tests, tests/test_workspace_cli.py, make test-workspace, make lint-workspace, contract tooling, structured file inventory, maintainer surfaces, generated command boundary and AW primitive ownership checks, planning summary/doctor, and git diff --check."
+    ],
     "known_gaps": []
   },
   "residual_lane_work": "The lane may leave unresolved CG primitive/control-operation follow-ups open when safe decomposition requires new generic support.",
@@ -57,8 +59,8 @@
   "parent_close_permission": "do-not-close-parent",
   "closeout_state": {
     "status": "open",
-    "summary": "Ready after the runtime packet owner-boundary lane.",
-    "residual_work": "Implement #1656, #1657, and #1658 in order with disposition tables and proof.",
+    "summary": "#1656 workspace lifecycle/provider boundary disposition and safe reconcile owner split are complete.",
+    "residual_work": "Implement #1657 and #1658 in order with disposition tables and proof.",
     "next_owner": "current agent"
   },
   "references": [

--- a/docs/reviews/workspace-lifecycle-provider-boundary-disposition-2026-06-27.md
+++ b/docs/reviews/workspace-lifecycle-provider-boundary-disposition-2026-06-27.md
@@ -1,0 +1,55 @@
+# Workspace Lifecycle and Provider Runtime Boundary Disposition
+
+Date: 2026-06-27
+
+Issues: #1656, #1649
+
+## Purpose
+
+This review closes the #1656 workspace lifecycle/provider slice with symbol-by-symbol dispositions for the four scoped runtime boundaries. It treats lifecycle mutation, Planning reconciliation, and provider refresh as different risks, rather than one generic adapter group.
+
+Source command:
+
+```powershell
+uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json
+```
+
+Current checker baseline for this slice:
+
+- 75 accepted runtime symbols.
+- 19 workspace package runtime boundaries.
+- The scoped provider symbol remains classified as `provider-integration`.
+- The scoped lifecycle and reconcile symbols remain accepted hand-owned runtime boundaries; this PR changes semantic ownership for reconcile without claiming full generated minimization.
+
+## Disposition Table
+
+| Symbol | Current risk | Disposition | Semantic owner after this PR | CG/control shape needed before more migration | Proof/update |
+| --- | --- | --- | --- | --- | --- |
+| `_run_init_lifecycle_adapter` | lifecycle mutation orchestration | Retain as AW-owned runtime adapter. It already projects `lifecycle_plan`, but target/config/module selection and init/adopt/write policy are still coupled to managed-surface safety. | AW lifecycle runtime in `workspace_runtime_primitives.py` / `workspace_runtime_core.py`. | `transaction.envelope` with explicit plan/apply object, dry-run equivalence proof, managed-surface safety hooks, conflict policy hooks, and provenance hooks. | Keep conformance lifecycle dry-run cases plus generated package checks. |
+| `_run_lifecycle_mutation_adapter` | lifecycle mutation orchestration | Retain as AW-owned runtime adapter. The repair path and lifecycle command application still decide what mutation is allowed. | AW lifecycle runtime in `workspace_runtime_primitives.py` / `workspace_runtime_core.py`. | Same `transaction.envelope`; no generic move until safe dry-run/apply/provenance semantics are contract-backed. | Keep lifecycle destructive-refusal and dry-run conformance plus workspace tests. |
+| `_run_reconcile_report_adapter` | Planning reconciliation payload plus root CLI routing | Moved the implementation to `workspace_runtime_planning.py`; `workspace_runtime_core.py` now forwards lazily and `workspace_runtime_primitives.py` re-exports for generated/private compatibility. | Planning runtime owner owns reconciliation payload loading, safe-prune semantics, and text rendering handoff; workspace generated bindings still import the compatibility symbol until a Planning facade is introduced. | Generic report routing can move later after section/view routing is contract-backed. Planning reconciliation semantics stay Planning-owned. | Added owner-routing regression and retained reconcile JSON/safe-prune tests. |
+| `_run_external_intent_refresh_github_adapter` | provider integration | Retain as provider-owned runtime adapter. Repo resolution, `gh` invocation, issue filtering, evidence normalization/write semantics, and failure trust remain host-owned. | AW provider integration runtime in `workspace_runtime_primitives.py` / `workspace_runtime_core.py`. | Host-neutral `provider.envelope` with provider fixtures, uninterpreted raw-response capture, host-owned evidence schema, and failure-trust hooks. | Keep external-intent refresh tests and runtime-symbol working-set classification. |
+
+## Implementation Decision
+
+The only safe code movement in this slice is the reconcile owner split. The existing `planning.reconcile.load` primitive proves the reconciliation payload is Planning-owned, and the root `reconcile` command already exposes provider-agnostic Planning state. Moving the adapter implementation to `workspace_runtime_planning.py` names that ownership without hiding safe-prune policy in generic code.
+
+The lifecycle adapters are deliberately not moved behind a generic transaction primitive in this PR. A transaction primitive without explicit dry-run equivalence, plan/apply object shape, and provenance hooks would make mutation policy harder to review.
+
+The GitHub external-intent refresh adapter is not a lifecycle adapter. It remains a provider integration boundary until command-generation or shared runtime support has a host-neutral provider fixture and envelope.
+
+## Residual Follow-Up
+
+- Add a host-neutral `transaction.envelope` candidate in command-generation before attempting lifecycle mutation migration.
+- Add a host-neutral `provider.envelope` fixture before attempting provider refresh migration.
+- Consider a generated Planning runtime facade for root `reconcile` after generated bindings can name Planning owner modules directly without losing compatibility.
+
+## Proof
+
+Required checks for this artifact:
+
+```powershell
+uv run pytest tests/test_workspace_cli.py::test_reconcile_report_adapter_routes_through_planning_owner tests/test_workspace_summary_cli.py::test_workspace_reconcile_json_exposes_provider_agnostic_planning_state tests/test_workspace_summary_cli.py::test_workspace_reconcile_apply_safe_prune_removes_exact_closed_items -q
+uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json
+uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success
+```

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -314,9 +314,12 @@
       "id": "provider-mutation-safety",
       "title": "Provider integration and mutation safety behavior",
       "owner_class": "covered-by-other-issue",
-      "owner_surface": "src/agentic_workspace/workspace_runtime_primitives.py plus package lifecycle runtimes",
-      "runtime_role": "Lifecycle mutation, payload provenance, subprocess/provider behavior, and destructive safety checks stay runtime-owned while issue #1656 covers provider/mutation boundary work.",
+      "owner_surface": "src/agentic_workspace/workspace_runtime_primitives.py plus src/agentic_workspace/workspace_runtime_planning.py and package lifecycle runtimes",
+      "runtime_role": "Lifecycle mutation, payload provenance, subprocess/provider behavior, and destructive safety checks stay runtime-owned. The #1656 reconcile adapter implementation is split to the Planning runtime owner while generated/private compatibility imports remain available.",
       "source_symbols": [
+        "_run_init_lifecycle_adapter",
+        "_run_lifecycle_mutation_adapter",
+        "_run_reconcile_report_adapter",
         "_lifecycle_apply_command",
         "_workspace_init_or_upgrade_report",
         "_record_delegation_outcome",
@@ -324,15 +327,18 @@
       ],
       "generated_or_contract_refs": [
         "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
-        "src/agentic_workspace/contracts/preflight_policy.json"
+        "src/agentic_workspace/contracts/preflight_policy.json",
+        "docs/reviews/workspace-lifecycle-provider-boundary-disposition-2026-06-27.md"
       ],
       "proof_refs": [
-        "uv run pytest tests/test_workspace_cli.py tests/test_workspace_config_cli.py -q"
+        "uv run pytest tests/test_workspace_cli.py::test_reconcile_report_adapter_routes_through_planning_owner tests/test_workspace_summary_cli.py::test_workspace_reconcile_json_exposes_provider_agnostic_planning_state tests/test_workspace_summary_cli.py::test_workspace_reconcile_apply_safe_prune_removes_exact_closed_items -q",
+        "uv run pytest tests/test_workspace_cli.py tests/test_workspace_config_cli.py tests/test_workspace_summary_cli.py -q"
       ],
       "blocked_by": [
-        "#1656"
+        "transaction.envelope contract with dry-run equivalence and provenance hooks",
+        "provider.envelope contract with host-neutral provider fixture"
       ],
-      "remaining_hand_owned_reason": "Mutation safety and provider truth require live side-effect policy and cannot be replaced by declarative command metadata alone."
+      "remaining_hand_owned_reason": "Mutation safety and provider truth require live side-effect policy and cannot be replaced by declarative command metadata alone. Reconcile payload semantics are now Planning-owned; root generated bindings still import the compatibility symbol until a Planning runtime facade is introduced."
     },
     {
       "id": "planning-memory-verification-package-boundaries",
@@ -377,6 +383,7 @@
         "allowed_owner_modules": [
           "src/agentic_workspace/workspace_runtime_startup.py",
           "src/agentic_workspace/workspace_runtime_implement.py",
+          "src/agentic_workspace/workspace_runtime_planning.py",
           "src/agentic_workspace/workspace_runtime_proof.py"
         ],
         "source_symbols": [
@@ -562,6 +569,19 @@
         "exclusion_rule": "Do not add Planning packet assembly or Planning-owner decisions here; those belong in workspace_runtime_planning.py."
       },
       {
+        "id": "planning-reconcile-runtime-support",
+        "title": "Planning reconcile runtime support",
+        "allowed_owner_modules": [
+          "src/agentic_workspace/workspace_runtime_planning.py"
+        ],
+        "source_symbols": [
+          "_ensure_external_intent_cache_if_available",
+          "_rewrite_module_cli_commands"
+        ],
+        "core_role": "Shared core may expose the external-intent cache refresh shim and workspace command rewrite helper for the Planning-owned root reconcile adapter while Planning owns reconciliation semantics.",
+        "exclusion_rule": "Do not add provider interpretation, issue filtering, safe-prune policy, or Planning reconciliation payload assembly here; those stay in provider or Planning owner modules."
+      },
+      {
         "id": "proof-validation-and-closeout-routing",
         "title": "Proof, validation, and closeout routing",
         "allowed_owner_modules": [
@@ -651,6 +671,7 @@
         "allowed_owner_modules": [
           "src/agentic_workspace/workspace_runtime_startup.py",
           "src/agentic_workspace/workspace_runtime_implement.py",
+          "src/agentic_workspace/workspace_runtime_planning.py",
           "src/agentic_workspace/workspace_runtime_proof.py"
         ],
         "source_symbols": [

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -207,6 +207,12 @@ def _planning_safety_gate_payload(*args: Any, **kwargs: Any) -> Any:
     return owner(*args, **kwargs)
 
 
+def _run_reconcile_report_adapter(*args: Any, **kwargs: Any) -> Any:
+    from agentic_workspace.workspace_runtime_planning import _run_reconcile_report_adapter as owner
+
+    return owner(*args, **kwargs)
+
+
 def _closeout_report_payload(*args: Any, **kwargs: Any) -> Any:
     from agentic_workspace.workspace_runtime_proof import _closeout_report_payload as owner
 
@@ -34202,24 +34208,6 @@ def _run_planning_decision_adapter(args: argparse.Namespace) -> int:
     else:
         raise WorkspaceUsageError("planning decision support requires decision-scaffold or decision-promote.")
     _emit_payload(payload=payload, format_name=getattr(args, "format", "text"))
-    return 0
-
-
-def _run_reconcile_report_adapter(args: argparse.Namespace) -> int:
-    target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
-    _validate_target_root(command_name="reconcile", target_root=target_root)
-    from repo_planning_bootstrap.installer import planning_reconcile
-    from repo_planning_bootstrap.runtime_projection import _print_reconcile
-
-    _ensure_external_intent_cache_if_available(target_root=target_root)
-    payload = planning_reconcile(
-        target=target_root, apply_safe_prune=bool(getattr(args, "apply_safe_prune", False)), dry_run=bool(getattr(args, "dry_run", False))
-    )
-    payload = _rewrite_module_cli_commands(payload)
-    if args.format == "json":
-        _emit_payload(payload=payload, format_name=args.format)
-    else:
-        _print_reconcile(payload)
     return 0
 
 

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -6,6 +6,7 @@ compatibility re-exports for legacy private import names.
 
 from __future__ import annotations
 
+import argparse
 import copy
 import json
 import re
@@ -28,6 +29,8 @@ from agentic_workspace.workspace_runtime_core import (
     _candidate_with_canonical_route,
     _capability_structural_hints,
     _command_with_expected_planning_revision,
+    _emit_payload,
+    _ensure_external_intent_cache_if_available,
     _external_intent_status_by_ref,
     _fast_planning_active_summary,
     _fast_planning_lane_records,
@@ -39,12 +42,35 @@ from agentic_workspace.workspace_runtime_core import (
     _planning_safety_promotion_command,
     _pr_context_refs_from_task,
     _read_only_allowance_packet,
+    _resolve_target_root,
+    _rewrite_module_cli_commands,
+    _validate_target_root,
     _work_shape_guidance_payload,
 )
 from agentic_workspace.workspace_runtime_generated_surface import (
     _as_dict,
     _command_with_cli_invoke,
 )
+
+
+def _run_reconcile_report_adapter(args: argparse.Namespace) -> int:
+    target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
+    _validate_target_root(command_name="reconcile", target_root=target_root)
+    from repo_planning_bootstrap.installer import planning_reconcile
+    from repo_planning_bootstrap.runtime_projection import _print_reconcile
+
+    _ensure_external_intent_cache_if_available(target_root=target_root)
+    payload = planning_reconcile(
+        target=target_root,
+        apply_safe_prune=bool(getattr(args, "apply_safe_prune", False)),
+        dry_run=bool(getattr(args, "dry_run", False)),
+    )
+    payload = _rewrite_module_cli_commands(payload)
+    if args.format == "json":
+        _emit_payload(payload=payload, format_name=args.format)
+    else:
+        _print_reconcile(payload)
+    return 0
 
 
 def _active_planning_record_for_report_section(*, target_root: Path) -> dict[str, Any]:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -153,6 +153,7 @@ from agentic_workspace.workspace_runtime_planning import (
     _planning_candidate_pressure_payload,  # noqa: F401 - compatibility re-export for runtime inventory
     _planning_safety_gate_payload,
     _raw_active_planning_record_for_closeout,  # noqa: F401 - compatibility re-export for planning owner boundary
+    _run_reconcile_report_adapter,  # noqa: F401 - compatibility re-export for planning owner boundary
 )
 from agentic_workspace.workspace_runtime_projection import (
     _authority_boundary_payload,
@@ -33833,24 +33834,6 @@ def _run_planning_decision_adapter(args: argparse.Namespace) -> int:
     else:
         raise WorkspaceUsageError("planning decision support requires decision-scaffold or decision-promote.")
     _emit_payload(payload=payload, format_name=getattr(args, "format", "text"))
-    return 0
-
-
-def _run_reconcile_report_adapter(args: argparse.Namespace) -> int:
-    target_root = _resolve_target_root(args.target) if args.target else _resolve_target_root(None)
-    _validate_target_root(command_name="reconcile", target_root=target_root)
-    from repo_planning_bootstrap.installer import planning_reconcile
-    from repo_planning_bootstrap.runtime_projection import _print_reconcile
-
-    _ensure_external_intent_cache_if_available(target_root=target_root)
-    payload = planning_reconcile(
-        target=target_root, apply_safe_prune=bool(getattr(args, "apply_safe_prune", False)), dry_run=bool(getattr(args, "dry_run", False))
-    )
-    payload = _rewrite_module_cli_commands(payload)
-    if args.format == "json":
-        _emit_payload(payload=payload, format_name=args.format)
-    else:
-        _print_reconcile(payload)
     return 0
 
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -84,6 +84,11 @@ def test_active_planning_record_helpers_route_through_planning_owner(tmp_path: P
     assert workspace_runtime_core._active_planning_record_for_report_section(target_root=tmp_path) == {}
 
 
+def test_reconcile_report_adapter_routes_through_planning_owner() -> None:
+    assert workspace_runtime_primitives._run_reconcile_report_adapter is workspace_runtime_planning._run_reconcile_report_adapter
+    assert workspace_runtime_core._run_reconcile_report_adapter.__module__ == "agentic_workspace.workspace_runtime_core"
+
+
 def test_upgrade_preserves_host_owned_ownership_subsystems(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()


### PR DESCRIPTION
## Summary

Closes #1656.

This PR completes the workspace lifecycle/provider boundary slice in the P2 runtime boundary decomposition audits lane:

- adds a symbol-by-symbol #1656 disposition table for `_run_init_lifecycle_adapter`, `_run_lifecycle_mutation_adapter`, `_run_reconcile_report_adapter`, and `_run_external_intent_refresh_github_adapter`
- moves the root reconcile adapter implementation to `workspace_runtime_planning.py`, leaving `workspace_runtime_core.py` as a lazy forwarder and `workspace_runtime_primitives.py` as a compatibility re-export for generated/private callers
- updates the runtime primitive family inventory and shared-core import allowlist to record the Planning-owned reconcile split
- leaves lifecycle mutation and GitHub provider refresh hand-owned until contract-backed `transaction.envelope` and `provider.envelope` shapes exist
- archives the #1656 execplan, advances the active P2 lane to #1657, and fixes stale archived-lane proof status schema residue

## Boundary / parity note

This PR intentionally does not claim a generated-runtime minimization count reduction. The generated workspace runtime facade still imports the compatibility symbol from `workspace_runtime_primitives.py`; the semantic implementation is now Planning-owned. The checker still reports 75 accepted runtime symbols and 19 workspace package runtime boundaries. The retained lifecycle/provider boundaries are explicitly documented in the disposition table rather than hidden behind generic command-generation behavior.

## Validation

- `uv run pytest tests/test_workspace_cli.py::test_reconcile_report_adapter_routes_through_planning_owner tests/test_workspace_summary_cli.py::test_workspace_reconcile_json_exposes_provider_agnostic_planning_state tests/test_workspace_summary_cli.py::test_workspace_reconcile_apply_safe_prune_removes_exact_closed_items -q`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py src/agentic_workspace/workspace_runtime_planning.py src/agentic_workspace/workspace_runtime_core.py src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_cli.py`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_generated_command_packages.py --python-completion-blockers --format json`
- `uv run python scripts/check/check_generated_command_packages.py --aw-primitive-ownership --format json`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `git diff --check`