### PR TITLE
[codex] Add command-generation release promotion helper

### DIFF
--- a/docs/maintainer/maintainer-commands.md
+++ b/docs/maintainer/maintainer-commands.md
@@ -24,6 +24,7 @@ Use this page when you need the canonical command to run, not the broader routin
 | `python scripts/check/check_source_payload_operational_install.py` | Run advisory checks for source/payload/root-install boundary drift |
 | `make maintainer-surfaces` | Run the maintainer-surface liveness path for generated docs, startup-policy consistency, packaged payload contracts, and source/payload/root-install boundary drift |
 | `make planning-surfaces` | Run the underlying planning-surface audit directly |
+| `uv run python scripts/release/promote_command_generation_release.py --version <version>` | Promote the AW `command-generation` dependency pin to a released wheel, update generated conformance Dockerfile refs, and refresh `uv.lock` |
 
 ## Validation Lanes
 

--- a/docs/maintainer/maintainer-commands.md
+++ b/docs/maintainer/maintainer-commands.md
@@ -24,7 +24,7 @@ Use this page when you need the canonical command to run, not the broader routin
 | `python scripts/check/check_source_payload_operational_install.py` | Run advisory checks for source/payload/root-install boundary drift |
 | `make maintainer-surfaces` | Run the maintainer-surface liveness path for generated docs, startup-policy consistency, packaged payload contracts, and source/payload/root-install boundary drift |
 | `make planning-surfaces` | Run the underlying planning-surface audit directly |
-| `uv run python scripts/release/promote_command_generation_release.py --version <version>` | Promote the AW `command-generation` dependency pin to a released wheel, update generated conformance Dockerfile refs, and refresh `uv.lock` |
+| `uv run python scripts/release/promote_command_generation_release.py --version <version>` | Promote the AW `command-generation` dependency pin to a released wheel, verify the wheel SHA-256, update generated conformance Dockerfile refs, and refresh `uv.lock` |
 
 ## Validation Lanes
 

--- a/docs/release-and-versioning.md
+++ b/docs/release-and-versioning.md
@@ -124,6 +124,22 @@ its `Requires-Dist` entries for `agentic-memory`, `agentic-planning`, and
 hashes. Host repositories should be able to depend on the public root wheel as a
 single normal dependency and let `uv sync` resolve the coordinated stack.
 
+## Command-Generation Pin Promotion
+
+`command-generation` is consumed as a hash-pinned maintainer dependency for
+generated CLI package rendering and proof. When promoting a temporary immutable
+git ref or older released wheel to a command-generation release, use:
+
+```bash
+uv run python scripts/release/promote_command_generation_release.py --version <version>
+```
+
+The helper discovers the GitHub release wheel, verifies or computes its SHA-256
+digest, updates `pyproject.toml`, refreshes the generated conformance Dockerfile
+install URLs, and runs `uv lock` unless `--no-lock` is supplied. Use `--check`
+to fail when the checked-in pin or Dockerfile refs do not match the selected
+release.
+
 ## All-Or-Nothing Invariant
 
 Coordinated releases are all-or-nothing. If any Python package version,

--- a/docs/release-and-versioning.md
+++ b/docs/release-and-versioning.md
@@ -136,9 +136,11 @@ uv run python scripts/release/promote_command_generation_release.py --version <v
 
 The helper discovers the GitHub release wheel, verifies or computes its SHA-256
 digest, updates `pyproject.toml`, refreshes the generated conformance Dockerfile
-install URLs, and runs `uv lock` unless `--no-lock` is supplied. Use `--check`
-to fail when the checked-in pin or Dockerfile refs do not match the selected
-release.
+install URLs, and runs `uv lock` unless `--no-lock` is supplied. Explicit
+`--wheel-url --sha256` input still verifies the downloaded wheel bytes by
+default; use the deliberately named `--trust-supplied-sha256` escape hatch only
+for offline/no-network maintenance. Use `--check` to fail when the checked-in pin
+or Dockerfile refs do not match the selected release.
 
 ## All-Or-Nothing Invariant
 

--- a/scripts/release/promote_command_generation_release.py
+++ b/scripts/release/promote_command_generation_release.py
@@ -63,6 +63,13 @@ def _sha256_url(url: str) -> str:
     return digest.hexdigest()
 
 
+def _normalize_sha256(value: str) -> str:
+    digest = value.removeprefix("sha256:").lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise ValueError(f"invalid sha256 digest {value!r}")
+    return digest
+
+
 def _release_from_payload(payload: dict[str, Any], *, requested_version: str | None = None) -> CommandGenerationRelease:
     tag_name = str(payload.get("tag_name") or "").strip()
     version = requested_version or tag_name.removeprefix("v")
@@ -81,9 +88,7 @@ def _release_from_payload(payload: dict[str, Any], *, requested_version: str | N
             digest = digest.removeprefix("sha256:")
         if not digest:
             digest = _sha256_url(wheel_url)
-        if not re.fullmatch(r"[0-9a-f]{64}", digest):
-            raise ValueError(f"{expected_asset} has invalid sha256 digest {digest!r}")
-        return CommandGenerationRelease(version=version, wheel_url=wheel_url, sha256=digest)
+        return CommandGenerationRelease(version=version, wheel_url=wheel_url, sha256=_normalize_sha256(digest))
     raise ValueError(f"command-generation release {tag_name or version!r} has no {expected_asset} asset")
 
 
@@ -166,6 +171,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--version", help="command-generation release version to promote, for example 1.1.0. Defaults to latest.")
     parser.add_argument("--wheel-url", help="Explicit wheel URL. Use with --sha256 to skip GitHub release discovery.")
     parser.add_argument("--sha256", help="Explicit wheel SHA-256. Use with --wheel-url to skip GitHub release discovery.")
+    parser.add_argument(
+        "--trust-supplied-sha256",
+        action="store_true",
+        help="Offline escape hatch: trust --sha256 without downloading and verifying the explicit --wheel-url bytes.",
+    )
     parser.add_argument("--check", action="store_true", help="Fail if pyproject or generated Dockerfile refs do not match the release.")
     parser.add_argument("--no-lock", action="store_true", help="Do not run uv lock after updating pyproject.toml.")
     parser.add_argument("--format", choices=["text", "json"], default="text")
@@ -182,7 +192,15 @@ def _release_from_args(args: argparse.Namespace) -> CommandGenerationRelease:
             version = match.group("version") if match else ""
         if not version:
             raise SystemExit("--version is required when --wheel-url does not contain the wheel version")
-        return CommandGenerationRelease(version=version, wheel_url=str(args.wheel_url), sha256=str(args.sha256))
+        supplied_digest = _normalize_sha256(str(args.sha256))
+        if not args.trust_supplied_sha256:
+            computed_digest = _sha256_url(str(args.wheel_url))
+            if computed_digest != supplied_digest:
+                raise SystemExit(
+                    "explicit command-generation wheel SHA-256 mismatch: "
+                    f"supplied {supplied_digest}, computed {computed_digest}"
+                )
+        return CommandGenerationRelease(version=version, wheel_url=str(args.wheel_url), sha256=supplied_digest)
     return discover_release(version=args.version)
 
 

--- a/scripts/release/promote_command_generation_release.py
+++ b/scripts/release/promote_command_generation_release.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GITHUB_API_RELEASES = "https://api.github.com/repos/rickardvh/command-generation/releases"
+DOCKERFILE_REFS = (
+    "generated/python/Dockerfile.conformance",
+    "generated/python/Dockerfile.primitive-conformance",
+    "generated/typescript.conformance.Dockerfile",
+)
+DEPENDENCY_PATTERN = re.compile(
+    r"command-generation @ (?P<url>https://github\.com/rickardvh/command-generation/[^\"]+|git\+https://github\.com/rickardvh/command-generation\.git@[0-9a-f]{40})"
+)
+DOCKER_DEPENDENCY_PATTERN = re.compile(
+    r"command-generation @ (?P<url>https://github\.com/rickardvh/command-generation/[^\"]+|git\+https://github\.com/rickardvh/command-generation\.git@[0-9a-f]{40})"
+)
+
+
+@dataclass(frozen=True)
+class CommandGenerationRelease:
+    version: str
+    wheel_url: str
+    sha256: str
+
+    @property
+    def dependency_url(self) -> str:
+        return f"{self.wheel_url}#sha256={self.sha256}"
+
+    @property
+    def dependency_spec(self) -> str:
+        return f"command-generation @ {self.dependency_url}"
+
+
+@dataclass(frozen=True)
+class PromotionResult:
+    changed_paths: tuple[str, ...]
+    stale_paths: tuple[str, ...]
+    dependency_spec: str
+    lock_refreshed: bool
+
+
+def _fetch_json(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json", "User-Agent": "agentic-workspace"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _sha256_url(url: str) -> str:
+    digest = hashlib.sha256()
+    request = urllib.request.Request(url, headers={"User-Agent": "agentic-workspace"})
+    with urllib.request.urlopen(request, timeout=120) as response:
+        while chunk := response.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _release_from_payload(payload: dict[str, Any], *, requested_version: str | None = None) -> CommandGenerationRelease:
+    tag_name = str(payload.get("tag_name") or "").strip()
+    version = requested_version or tag_name.removeprefix("v")
+    if not version:
+        raise ValueError("command-generation release payload does not include a version")
+    expected_asset = f"command_generation-{version}-py3-none-any.whl"
+    assets = payload.get("assets", [])
+    for asset in assets if isinstance(assets, list) else []:
+        if not isinstance(asset, dict) or asset.get("name") != expected_asset:
+            continue
+        wheel_url = str(asset.get("browser_download_url") or "").strip()
+        if not wheel_url:
+            raise ValueError(f"{expected_asset} is missing browser_download_url")
+        digest = str(asset.get("digest") or "").strip()
+        if digest.startswith("sha256:"):
+            digest = digest.removeprefix("sha256:")
+        if not digest:
+            digest = _sha256_url(wheel_url)
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError(f"{expected_asset} has invalid sha256 digest {digest!r}")
+        return CommandGenerationRelease(version=version, wheel_url=wheel_url, sha256=digest)
+    raise ValueError(f"command-generation release {tag_name or version!r} has no {expected_asset} asset")
+
+
+def discover_release(*, version: str | None = None) -> CommandGenerationRelease:
+    if version:
+        payload = _fetch_json(f"{GITHUB_API_RELEASES}/tags/v{version}")
+        return _release_from_payload(payload, requested_version=version)
+    return _release_from_payload(_fetch_json(f"{GITHUB_API_RELEASES}/latest"))
+
+
+def _replace_dependency(text: str, *, release: CommandGenerationRelease, pattern: re.Pattern[str]) -> str:
+    replacement = release.dependency_spec
+    updated, count = pattern.subn(replacement, text)
+    if count != 1:
+        raise ValueError("expected exactly one command-generation dependency reference")
+    return updated
+
+
+def _write_if_changed(path: Path, content: str, *, check: bool, changed: list[str], stale: list[str], repo_root: Path) -> None:
+    current = path.read_text(encoding="utf-8")
+    if current == content:
+        return
+    relative = path.relative_to(repo_root).as_posix()
+    stale.append(relative)
+    if check:
+        return
+    path.write_text(content, encoding="utf-8", newline="\n")
+    changed.append(relative)
+
+
+def promote_command_generation_release(
+    *,
+    repo_root: Path,
+    release: CommandGenerationRelease,
+    check: bool = False,
+    refresh_lock: bool = True,
+) -> PromotionResult:
+    changed: list[str] = []
+    stale: list[str] = []
+
+    pyproject = repo_root / "pyproject.toml"
+    pyproject_text = pyproject.read_text(encoding="utf-8")
+    _write_if_changed(
+        pyproject,
+        _replace_dependency(pyproject_text, release=release, pattern=DEPENDENCY_PATTERN),
+        check=check,
+        changed=changed,
+        stale=stale,
+        repo_root=repo_root,
+    )
+
+    for relative in DOCKERFILE_REFS:
+        path = repo_root / relative
+        dockerfile_text = path.read_text(encoding="utf-8")
+        _write_if_changed(
+            path,
+            _replace_dependency(dockerfile_text, release=release, pattern=DOCKER_DEPENDENCY_PATTERN),
+            check=check,
+            changed=changed,
+            stale=stale,
+            repo_root=repo_root,
+        )
+
+    lock_refreshed = False
+    if refresh_lock and not check and stale:
+        subprocess.run(["uv", "lock"], cwd=repo_root, check=True)
+        changed.append("uv.lock")
+        lock_refreshed = True
+
+    return PromotionResult(
+        changed_paths=tuple(dict.fromkeys(changed)),
+        stale_paths=tuple(dict.fromkeys(stale)),
+        dependency_spec=release.dependency_spec,
+        lock_refreshed=lock_refreshed,
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Promote AW's command-generation dependency pin to a released wheel.")
+    parser.add_argument("--version", help="command-generation release version to promote, for example 1.1.0. Defaults to latest.")
+    parser.add_argument("--wheel-url", help="Explicit wheel URL. Use with --sha256 to skip GitHub release discovery.")
+    parser.add_argument("--sha256", help="Explicit wheel SHA-256. Use with --wheel-url to skip GitHub release discovery.")
+    parser.add_argument("--check", action="store_true", help="Fail if pyproject or generated Dockerfile refs do not match the release.")
+    parser.add_argument("--no-lock", action="store_true", help="Do not run uv lock after updating pyproject.toml.")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser.parse_args(argv)
+
+
+def _release_from_args(args: argparse.Namespace) -> CommandGenerationRelease:
+    if bool(args.wheel_url) != bool(args.sha256):
+        raise SystemExit("--wheel-url and --sha256 must be provided together")
+    if args.wheel_url and args.sha256:
+        version = args.version
+        if not version:
+            match = re.search(r"command_generation-(?P<version>[0-9][^-/]*)-py3-none-any\.whl", str(args.wheel_url))
+            version = match.group("version") if match else ""
+        if not version:
+            raise SystemExit("--version is required when --wheel-url does not contain the wheel version")
+        return CommandGenerationRelease(version=version, wheel_url=str(args.wheel_url), sha256=str(args.sha256))
+    return discover_release(version=args.version)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    release = _release_from_args(args)
+    result = promote_command_generation_release(
+        repo_root=REPO_ROOT,
+        release=release,
+        check=bool(args.check),
+        refresh_lock=not bool(args.no_lock),
+    )
+    payload = {
+        "kind": "agentic-workspace/command-generation-release-promotion/v1",
+        "version": release.version,
+        "dependency": result.dependency_spec,
+        "changed_paths": list(result.changed_paths),
+        "stale_paths": list(result.stale_paths),
+        "lock_refreshed": result.lock_refreshed,
+        "status": "stale" if args.check and result.stale_paths else "updated" if result.changed_paths else "current",
+    }
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"command-generation {release.version}: {payload['status']}")
+        for path in result.changed_paths or result.stale_paths:
+            print(f"- {path}")
+    return 1 if args.check and result.stale_paths else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_command_generation_release_promotion.py
+++ b/tests/test_command_generation_release_promotion.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "release" / "promote_command_generation_release.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("promote_command_generation_release", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_fixture_repo(repo: Path, *, dependency_url: str) -> None:
+    (repo / "generated" / "python").mkdir(parents=True)
+    (repo / "generated").mkdir(exist_ok=True)
+    (repo / "pyproject.toml").write_text(
+        f'[dependency-groups]\ndev = [\n  "command-generation @ {dependency_url}",\n]\n',
+        encoding="utf-8",
+    )
+    for relative in (
+        "generated/python/Dockerfile.conformance",
+        "generated/python/Dockerfile.primitive-conformance",
+        "generated/typescript.conformance.Dockerfile",
+    ):
+        (repo / relative).write_text(
+            f'RUN python -m pip install "command-generation @ {dependency_url}"\n',
+            encoding="utf-8",
+        )
+
+
+def test_promote_command_generation_release_updates_pyproject_and_dockerfiles(tmp_path: Path) -> None:
+    module = _load_module()
+    old_url = (
+        "https://github.com/rickardvh/command-generation/releases/download/v1.0.0/"
+        "command_generation-1.0.0-py3-none-any.whl#sha256=" + "0" * 64
+    )
+    release = module.CommandGenerationRelease(
+        version="1.2.3",
+        wheel_url="https://github.com/rickardvh/command-generation/releases/download/v1.2.3/command_generation-1.2.3-py3-none-any.whl",
+        sha256="a" * 64,
+    )
+    _write_fixture_repo(tmp_path, dependency_url=old_url)
+
+    result = module.promote_command_generation_release(repo_root=tmp_path, release=release, refresh_lock=False)
+
+    assert result.changed_paths == (
+        "pyproject.toml",
+        "generated/python/Dockerfile.conformance",
+        "generated/python/Dockerfile.primitive-conformance",
+        "generated/typescript.conformance.Dockerfile",
+    )
+    assert release.dependency_spec in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    for relative in module.DOCKERFILE_REFS:
+        assert release.dependency_spec in (tmp_path / relative).read_text(encoding="utf-8")
+
+
+def test_promote_command_generation_release_check_reports_stale_refs(tmp_path: Path) -> None:
+    module = _load_module()
+    old_url = (
+        "https://github.com/rickardvh/command-generation/releases/download/v1.0.0/"
+        "command_generation-1.0.0-py3-none-any.whl#sha256=" + "0" * 64
+    )
+    release = module.CommandGenerationRelease(
+        version="1.2.3",
+        wheel_url="https://github.com/rickardvh/command-generation/releases/download/v1.2.3/command_generation-1.2.3-py3-none-any.whl",
+        sha256="a" * 64,
+    )
+    _write_fixture_repo(tmp_path, dependency_url=old_url)
+
+    result = module.promote_command_generation_release(repo_root=tmp_path, release=release, check=True)
+
+    assert result.changed_paths == ()
+    assert set(result.stale_paths) == {"pyproject.toml", *module.DOCKERFILE_REFS}
+    assert old_url in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+
+
+def test_release_from_payload_uses_release_asset_digest() -> None:
+    module = _load_module()
+    payload = {
+        "tag_name": "v1.2.3",
+        "assets": [
+            {
+                "name": "command_generation-1.2.3-py3-none-any.whl",
+                "browser_download_url": (
+                    "https://github.com/rickardvh/command-generation/releases/download/v1.2.3/command_generation-1.2.3-py3-none-any.whl"
+                ),
+                "digest": "sha256:" + "b" * 64,
+            }
+        ],
+    }
+
+    release = module._release_from_payload(payload)
+
+    assert release.version == "1.2.3"
+    assert release.sha256 == "b" * 64
+    assert release.dependency_spec.endswith("#sha256=" + "b" * 64)
+
+
+def test_release_from_payload_rejects_missing_wheel_asset() -> None:
+    module = _load_module()
+
+    with pytest.raises(ValueError, match="has no command_generation-1.2.3-py3-none-any.whl asset"):
+        module._release_from_payload({"tag_name": "v1.2.3", "assets": []})

--- a/tests/test_command_generation_release_promotion.py
+++ b/tests/test_command_generation_release_promotion.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -111,3 +112,36 @@ def test_release_from_payload_rejects_missing_wheel_asset() -> None:
 
     with pytest.raises(ValueError, match="has no command_generation-1.2.3-py3-none-any.whl asset"):
         module._release_from_payload({"tag_name": "v1.2.3", "assets": []})
+
+
+def test_explicit_wheel_url_rejects_sha_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+    monkeypatch.setattr(module, "_sha256_url", lambda _url: "b" * 64)
+    args = SimpleNamespace(
+        version="1.2.3",
+        wheel_url="https://github.com/rickardvh/command-generation/releases/download/v1.2.3/command_generation-1.2.3-py3-none-any.whl",
+        sha256="a" * 64,
+        trust_supplied_sha256=False,
+    )
+
+    with pytest.raises(SystemExit, match="SHA-256 mismatch"):
+        module._release_from_args(args)
+
+
+def test_explicit_wheel_url_can_trust_supplied_sha_for_offline_use(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_module()
+
+    def fail_if_called(_url: str) -> str:
+        raise AssertionError("offline trust mode must not download the wheel")
+
+    monkeypatch.setattr(module, "_sha256_url", fail_if_called)
+    args = SimpleNamespace(
+        version="1.2.3",
+        wheel_url="https://github.com/rickardvh/command-generation/releases/download/v1.2.3/command_generation-1.2.3-py3-none-any.whl",
+        sha256="A" * 64,
+        trust_supplied_sha256=True,
+    )
+
+    release = module._release_from_args(args)
+
+    assert release.sha256 == "a" * 64


### PR DESCRIPTION
## Summary

Implements #1751 by adding a maintainer helper for promoting AW's command-generation dependency pin to a released wheel.

- Adds `scripts/release/promote_command_generation_release.py` to discover or accept a command-generation wheel release, verify or compute the SHA-256 digest, update `pyproject.toml`, refresh generated conformance Dockerfile install refs, and optionally run `uv lock`.
- Adds offline unit coverage for promotion writes, check-mode drift detection, and GitHub release payload parsing.
- Documents the helper in release/versioning docs and the maintainer command index.

Closes #1751.

## Completed Issue Cleanup

Before this PR, the only other open issues were stale completed items. I closed #1603, #1604, #1611, #1612, and #1750 with evidence from current `master`.

## Validation

- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py validate --format json`
- `uv run python scripts/model_cli_harness/external_agent_evaluation_lane.py report --format json`
- `uv run pytest tests/test_external_agent_evaluation_lane.py -q`
- `uv run pytest tests/test_command_generation_release_promotion.py -q`
- `uv run ruff check scripts/release/promote_command_generation_release.py tests/test_command_generation_release_promotion.py`
- `uv run python scripts/release/promote_command_generation_release.py --version 1.1.0 --wheel-url https://github.com/rickardvh/command-generation/releases/download/v1.1.0/command_generation-1.1.0-py3-none-any.whl --sha256 7ed7f6fd59a29183dc18a360d6e38b105133ffcd05dadd9257101b14d270eeff --check --no-lock --format json`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_generated_command_packages.py`
- `git diff --check`
