### PR TITLE
[codex] Fix POSIX local path leak detection

### DIFF
--- a/scripts/model_cli_harness/run_model_cli_harness.py
+++ b/scripts/model_cli_harness/run_model_cli_harness.py
@@ -1512,7 +1512,7 @@ def _full_response_text(result: dict[str, Any]) -> str:
 
 _LOCAL_ABSOLUTE_PATH_PATTERNS = (
     re.compile(r"\b[A-Za-z]:[\\/][^\s)`>\"']+"),
-    re.compile(r"\b/(?:Users|home|tmp|var/tmp|private/tmp)/[^\s)`>\"']+"),
+    re.compile(r"(?<![\w/.-])/(?:Users|home|tmp|var/tmp|private/tmp)/[^\s)`>\"']+"),
 )
 
 

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -434,6 +434,29 @@ def test_model_cli_harness_scores_local_absolute_path_leak_with_owner(tmp_path: 
     assert leak["evidence"].startswith(f"{drive}\\Users\\agent")
 
 
+def test_model_cli_harness_scores_posix_tmp_path_leak_with_owner(tmp_path: Path) -> None:
+    module = _load_harness_module()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    leaked_path = "/".join(["", "tmp", "pytest-of-runner", "pytest-0", "popen-gw1", "session.md"])
+
+    warnings = module._metadata_workflow_warnings(
+        scenario={"id": "memory-consult-before-edit"},
+        result={
+            "status": "success",
+            "final_message": f"Updated README.md and wrote notes at {leaked_path}",
+        },
+        mutation_summary={"created": [], "modified": ["README.md"], "deleted": []},
+        repo_path=repo,
+    )
+
+    leak = next(warning for warning in warnings if warning["warning_class"] == "model_cli_local_path_leak")
+    assert leak["failure_id"] == "LOCAL_ABSOLUTE_PATH_LEAK"
+    assert leak["owner_surface"] == "harness"
+    assert leak["remediation_ref"] == "#1616"
+    assert leak["evidence"].startswith("/".join(["", "tmp", "pytest-of-runner"]))
+
+
 def test_model_cli_harness_repairs_exported_final_message_without_suppressing_warning(tmp_path: Path) -> None:
     module = _load_harness_module()
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Summary

Fixes the release workflow failure in `make test-workspace` after #1824 merged.

The model CLI harness POSIX local-path detector used `\b/`, which does not match Linux absolute paths such as runner `/tmp/...` paths because `/` is not a word character. That made the harness miss the expected `model_cli_local_path_leak` warning on the Linux release runner.

This PR changes the POSIX matcher to use an explicit left boundary and adds a regression test for the release-runner `/tmp/...` shape without storing a literal absolute path in tracked files.

## Validation

- `uv run pytest tests/test_external_agent_evaluation_lane.py::test_model_cli_harness_scores_posix_tmp_path_leak_with_owner tests/test_external_agent_evaluation_lane.py::test_model_cli_harness_repairs_exported_final_message_without_suppressing_warning -q`
- `uv run pytest tests/test_external_agent_evaluation_lane.py -q`
- `make test-workspace`
- `make lint-workspace`
- commit hook: `sync-all`, workspace lint, prompt semantic markers, memory/planning/verification lint, absolute path guard

## Release note

Patch release: fixes Linux release-runner local path leak scoring in the model CLI harness.