### PR TITLE
[codex] Block stale proof path commands

### DIFF
--- a/src/agentic_workspace/contracts/conformance/proof.report.process.json
+++ b/src/agentic_workspace/contracts/conformance/proof.report.process.json
@@ -21,7 +21,8 @@
       "id": "minimal-repo",
       "files": {
         ".git/.keep": "",
-        "README.md": "# Fixture\n"
+        "README.md": "# Fixture\n",
+        "Makefile": "test-workspace:\n\tpython -c \"print('ok')\"\n\nlint-workspace:\n\tpython -c \"print('ok')\"\n"
       }
     }
   ],
@@ -43,7 +44,7 @@
             "next",
             "action"
           ],
-          "equals": "run-validation-command"
+          "equals": "manual-verification"
         },
         {
           "path": [
@@ -60,7 +61,8 @@
       "allowed_write_paths": [],
       "required_paths": [
         ".git/.keep",
-        "README.md"
+        "README.md",
+        "Makefile"
       ],
       "forbidden_paths": [
         ".agentic-workspace"

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -73,7 +73,6 @@ from agentic_workspace.workspace_runtime_core import (
     _project_roots_for_changed_paths,
     _proof_adequacy_payload,
     _proof_command_for_target,
-    _proof_command_is_search_sweep,
     _proof_command_tiers,
     _proof_completion_options,
     _proof_confidence_payload,
@@ -1192,11 +1191,7 @@ def _proof_selection_for_changed_paths(
                     proof_command_adjustments.append(adjustment)
             if adapted_command is None:
                 continue
-            missing_path_refs = (
-                _missing_repo_path_references_in_command(command=adapted_command, target_root=target_root)
-                if lane.get("subsystem") and _proof_command_is_search_sweep(adapted_command)
-                else []
-            )
+            missing_path_refs = _missing_repo_path_references_in_command(command=adapted_command, target_root=target_root)
             if missing_path_refs:
                 unavailable_proof_commands.append(
                     {

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1739,6 +1739,7 @@ def test_summary_task_scoped_profile_omits_historical_audit_detail(tmp_path: Pat
 def test_adaptive_assurance_end_to_end_closeout_flow(tmp_path: Path, capsys) -> None:
     from repo_planning_bootstrap import installer as planning_installer
 
+    _write(tmp_path / "tests" / "test_access_control.py", "def test_access_control_fixture():\n    assert True\n")
     _write(
         tmp_path / ".agentic-workspace" / "config.toml",
         """

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -468,6 +468,8 @@ def test_implement_surfaces_pre_work_knowledge_gate_for_source_authority_task(tm
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path)]) == 0
     capsys.readouterr()
+    _write(tmp_path / "packages" / "planning" / "README.md", "# Planning\n")
+    _write(tmp_path / "packages" / "memory" / "README.md", "# Memory\n")
     _write(tmp_path / "docs" / "package" / "knowledge-gates.md", "# Pre-Work Knowledge Gates\n")
 
     assert (
@@ -495,7 +497,7 @@ def test_implement_surfaces_pre_work_knowledge_gate_for_source_authority_task(tm
     assert "blocked_claims" not in packet
     assert all("blocked_claims" not in gate for gate in packet["knowledge_gates"])
     assert "change gate vocabulary without checking source authority" in packet["blocked_actions"]
-    assert "full_intent_complete" in packet["closeout_boundaries"]
+    assert "allowed-after-proof" in packet["closeout_boundaries"]
     assert packet["gate_summary"]["blocking_count"] >= 1
 
 
@@ -503,6 +505,12 @@ def test_implement_command_returns_bounded_context_and_boundary_warnings(tmp_pat
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
     _write(tmp_path / "src" / "agentic_workspace" / "contracts" / "command_package_ir.json", "{}")
+    _write(
+        tmp_path / "tests" / "test_workspace_proof_generated_packages_cli.py",
+        "def test_generated_package_fixture():\n    assert True\n",
+    )
+    _write(tmp_path / "scripts" / "check" / "check_generated_command_packages.py", "print('ok')\n")
+    _write(tmp_path / "scripts" / "check" / "run_operation_conformance_tests.py", "print('ok')\n")
 
     assert (
         cli.main(
@@ -1803,6 +1811,9 @@ def test_implement_selector_surfaces_task_contract_view(tmp_path: Path, capsys) 
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
     _write(tmp_path / "Makefile", "test-workspace:\n\tpytest tests\n\nlint-workspace:\n\truff check src tests\n")
+    _write(tmp_path / ".agentic-workspace" / "docs" / "guide.md", "# Guide\n")
+    _write(tmp_path / "packages" / "planning" / "README.md", "# Planning\n")
+    _write(tmp_path / "packages" / "memory" / "README.md", "# Memory\n")
     _write(tmp_path / "README.md", "hello\n")
 
     assert (
@@ -1852,6 +1863,9 @@ def test_implement_task_contract_names_missing_task_inputs(tmp_path: Path, capsy
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
     _write(tmp_path / "Makefile", "test-workspace:\n\tpytest tests\n\nlint-workspace:\n\truff check src tests\n")
+    _write(tmp_path / ".agentic-workspace" / "docs" / "guide.md", "# Guide\n")
+    _write(tmp_path / "packages" / "planning" / "README.md", "# Planning\n")
+    _write(tmp_path / "packages" / "memory" / "README.md", "# Memory\n")
     _write(tmp_path / "README.md", "hello\n")
 
     assert (
@@ -2085,6 +2099,10 @@ blocking_claims = ["claim-work-complete"]
 def test_implement_default_stays_under_tiny_output_budget_for_docs_task(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "Makefile", "test-workspace:\n\tpytest tests\n\nlint-workspace:\n\truff check src tests\n")
+    _write(tmp_path / ".agentic-workspace" / "docs" / "guide.md", "# Guide\n")
+    _write(tmp_path / "packages" / "planning" / "README.md", "# Planning\n")
+    _write(tmp_path / "packages" / "memory" / "README.md", "# Memory\n")
     _write(tmp_path / "README.md", "hello\n")
 
     assert (
@@ -2200,6 +2218,12 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     _write_empty_planning_state(tmp_path)
     _write(tmp_path / "Makefile", "test-workspace:\n\tpytest tests\n\nlint-workspace:\n\truff check src tests\n")
     _write(tmp_path / "src" / "agentic_workspace" / "contracts" / "command_package_ir.json", "{}")
+    _write(
+        tmp_path / "tests" / "test_workspace_proof_generated_packages_cli.py",
+        "def test_generated_package_fixture():\n    assert True\n",
+    )
+    _write(tmp_path / "scripts" / "check" / "check_generated_command_packages.py", "print('ok')\n")
+    _write(tmp_path / "scripts" / "check" / "run_operation_conformance_tests.py", "print('ok')\n")
 
     assert (
         cli.main(

--- a/tests/test_workspace_intent_cli.py
+++ b/tests/test_workspace_intent_cli.py
@@ -206,6 +206,7 @@ def test_report_durable_intent_section_returns_compact_projection(capsys) -> Non
 
 def test_proof_changed_paths_include_subsystem_proof_hints(tmp_path: Path, monkeypatch, capsys) -> None:
     _init_git_repo(tmp_path)
+    _write(tmp_path / "tests" / "test_workspace_cli.py", "def test_workspace_cli_fixture():\n    assert True\n")
     (tmp_path / ".agentic-workspace").mkdir()
     (tmp_path / ".agentic-workspace" / "OWNERSHIP.toml").write_text(
         "schema_version = 1\n\n"

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -193,6 +193,7 @@ review_hint = "Workspace orchestration applies to workspace paths."
 
 def test_proof_routes_changed_path_to_verification_protocol(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
+    _write(tmp_path / "tests" / "test_runbook_review.py", "def test_runbook_review_fixture():\n    assert True\n")
     _write(
         tmp_path / ".agentic-workspace/verification/manifest.toml",
         """
@@ -254,6 +255,7 @@ proof_lane_hint = "runbook-verification"
 
 def test_proof_routes_active_assurance_requirement_to_verification_protocol(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
+    _write(tmp_path / "tests" / "test_privacy.py", "def test_privacy_fixture():\n    assert True\n")
     _write(
         tmp_path / ".agentic-workspace/config.toml",
         """
@@ -1162,6 +1164,7 @@ def test_proof_tiny_detail_commands_use_resolved_cli_invoke(tmp_path: Path, caps
 def test_proof_changed_includes_active_assurance_concern_profiles(tmp_path: Path, capsys) -> None:
     from repo_planning_bootstrap import installer as planning_installer
 
+    _write(tmp_path / "tests" / "test_access_control.py", "def test_access_control_fixture():\n    assert True\n")
     _write(
         tmp_path / ".agentic-workspace" / "config.toml",
         """
@@ -1260,6 +1263,7 @@ candidates = []
 
 
 def test_proof_changed_includes_matched_assurance_requirement_profile(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / "tests" / "privacy" / "test_privacy.py", "def test_privacy_fixture():\n    assert True\n")
     _write(
         tmp_path / ".agentic-workspace" / "config.toml",
         """
@@ -1306,7 +1310,107 @@ blocking_claims = ["claim-work-complete", "close-parent-lane"]
     assert lane["applies_because"] == ["changed path matched db/migrations/**"]
 
 
+def test_proof_changed_marks_missing_path_specific_proof_unavailable(tmp_path: Path, capsys) -> None:
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance.proof_profiles.model_harness]
+required_commands = ["uv run pytest tests/test_model_cli_harness.py -q"]
+
+[assurance.requirements.model_harness]
+level = "medium"
+applies_to_paths = ["scripts/model_cli_harness/**"]
+authority_refs = ["docs/maintainer/test-knowledge-inventory.md"]
+required_evidence = ["current harness proof selected"]
+proof_profile = "model_harness"
+force = "required-before-closeout"
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--verbose",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "scripts/model_cli_harness/run_model_cli_harness.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    assert "uv run pytest tests/test_model_cli_harness.py -q" not in answer["required_commands"]
+    assert answer["unavailable_proof_commands"] == [
+        {
+            "lane": "assurance-requirement:model_harness",
+            "command": "uv run pytest tests/test_model_cli_harness.py -q",
+            "reason": "selected proof command references path-like arguments absent from the target repo",
+            "missing_paths": "tests/test_model_cli_harness.py",
+        }
+    ]
+    assert answer["unavailable_commands"] == [
+        {
+            "kind": "proof-command-unavailable/v1",
+            "command": "uv run pytest tests/test_model_cli_harness.py -q",
+            "lane": "assurance-requirement:model_harness",
+            "reason": "selected proof command references path-like arguments absent from the target repo",
+            "missing_paths": "tests/test_model_cli_harness.py",
+        }
+    ]
+    assert answer["manual_verification"]["status"] == "required"
+    assert answer["manual_verification"]["unavailable_commands"] == answer["unavailable_commands"]
+
+
+def test_proof_changed_keeps_existing_path_specific_proof_required(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / "tests" / "test_model_cli_harness.py", "def test_harness_fixture():\n    assert True\n")
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance.proof_profiles.model_harness]
+required_commands = ["uv run pytest tests/test_model_cli_harness.py -q"]
+
+[assurance.requirements.model_harness]
+level = "medium"
+applies_to_paths = ["scripts/model_cli_harness/**"]
+authority_refs = ["docs/maintainer/test-knowledge-inventory.md"]
+required_evidence = ["current harness proof selected"]
+proof_profile = "model_harness"
+force = "required-before-closeout"
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--verbose",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "scripts/model_cli_harness/run_model_cli_harness.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    assert "uv run pytest tests/test_model_cli_harness.py -q" in answer["required_commands"]
+    assert answer.get("unavailable_proof_commands", []) == []
+
+
 def test_proof_changed_includes_matched_subsystem_assurance_profile(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / "tests" / "audit" / "test_audit.py", "def test_audit_fixture():\n    assert True\n")
     _write(
         tmp_path / ".agentic-workspace" / "OWNERSHIP.toml",
         """
@@ -1367,6 +1471,7 @@ claim_boundary = "subsystem-scoped"
 def test_proof_current_includes_active_planning_assurance_requirement_profile(tmp_path: Path, capsys) -> None:
     from repo_planning_bootstrap import installer as planning_installer
 
+    _write(tmp_path / "tests" / "privacy" / "test_privacy.py", "def test_privacy_fixture():\n    assert True\n")
     _write(
         tmp_path / ".agentic-workspace" / "config.toml",
         """
@@ -1430,6 +1535,10 @@ candidates = []
 def test_proof_current_selects_active_plan_validation_commands(tmp_path: Path, capsys) -> None:
     from repo_planning_bootstrap import installer as planning_installer
 
+    _write(
+        tmp_path / "tests" / "test_workspace_proof_cli.py",
+        "def test_proof_current_selects_active_plan_validation_commands():\n    assert True\n",
+    )
     _write(
         tmp_path / ".agentic-workspace" / "planning" / "state.toml",
         """


### PR DESCRIPTION
## Summary
- Treat selected proof commands with missing path-like arguments as unavailable instead of runnable required proof.
- Preserve valid path-specific proof commands when their referenced files or directories exist.
- Update conformance and fixture tests so path-specific proof expectations model current repo paths explicitly.

Fixes #1826

## Validation
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` (completed with existing README startup-guidance warning and payload-upgrade-required signal)
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run python scripts/run_agentic_workspace.py proof --target . --changed scripts/model_cli_harness/run_model_cli_harness.py --format json` shows stale `tests/test_model_cli_harness.py` under `unavailable_proof_commands`