### PR TITLE
[codex] Expose release recovery status

### DIFF
--- a/scripts/github/release_recovery_status.py
+++ b/scripts/github/release_recovery_status.py
@@ -82,6 +82,21 @@ def _timestamp(value: Any) -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def _parse_timestamp(value: Any) -> datetime | None:
+    text = _text(value)
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def _error_lines(text: str, *, limit: int = 8) -> list[str]:
     lines: list[str] = []
     for line in text.splitlines():
@@ -136,23 +151,126 @@ def release_failure_status(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _run_sort_key(run: dict[str, Any]) -> datetime:
+    return _parse_timestamp(run.get("updatedAt") or run.get("updated_at") or run.get("createdAt") or run.get("created_at")) or datetime.min.replace(
+        tzinfo=timezone.utc
+    )
+
+
+def _run_conclusion(run: dict[str, Any]) -> str:
+    return _text(run.get("conclusion") or run.get("status")).lower()
+
+
+def _run_identity(run: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "run_id": _text(run.get("databaseId") or run.get("id")),
+        "run_url": _text(run.get("url") or run.get("html_url")),
+        "head_branch": _text(run.get("headBranch") or run.get("head_branch")),
+        "head_sha": _text(run.get("headSha") or run.get("head_sha")),
+        "updated_at": _timestamp(run.get("updatedAt") or run.get("updated_at") or run.get("createdAt") or run.get("created_at")),
+        "conclusion": _text(run.get("conclusion") or run.get("status")),
+    }
+
+
+def _run_gh_text(args: list[str], *, allow_failure: bool = False) -> str:
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, encoding="utf-8", check=False)
+    if result.returncode != 0 and not allow_failure:
+        raise SystemExit(result.stderr.strip() or result.stdout.strip() or f"gh exited {result.returncode}")
+    return result.stdout if result.returncode == 0 else ""
+
+
+def live_release_failure_status(*, repo: str, workflow: str = DEFAULT_WORKFLOW, limit: int = 10) -> dict[str, Any]:
+    try:
+        runs = _run_gh_json(
+            [
+                "run",
+                "list",
+                "--repo",
+                repo,
+                "--workflow",
+                workflow,
+                "--limit",
+                str(limit),
+                "--json",
+                "databaseId,url,conclusion,status,updatedAt,createdAt,workflowName,headBranch,headSha,event",
+            ]
+        )
+    except SystemExit as exc:
+        return {
+            "kind": "agentic-workspace/release-ci-failure-summary/v1",
+            "status": "release_run_status_unavailable",
+            "workflow": workflow,
+            "reason": str(exc),
+            "freshness": {"status": "unavailable", "source": "gh-run-list-failed"},
+            "next_command": f"gh run list --repo {repo} --workflow {json.dumps(workflow)} --limit {limit}",
+        }
+    if not isinstance(runs, list):
+        runs = []
+    ordered_runs = sorted([run for run in runs if isinstance(run, dict)], key=_run_sort_key, reverse=True)
+    failed_run = next((run for run in ordered_runs if _run_conclusion(run) in {"failure", "failed", "error", "timed_out"}), None)
+    latest_success = next((run for run in ordered_runs if _run_conclusion(run) in {"success", "completed"}), None)
+    if failed_run is None:
+        return {
+            "kind": "agentic-workspace/release-ci-failure-summary/v1",
+            "status": "no-failed-release-run",
+            "workflow": workflow,
+            "latest_run": _run_identity(ordered_runs[0]) if ordered_runs else {},
+            "freshness": {
+                "status": "clear" if ordered_runs else "no-runs-found",
+                "source": "gh-run-list",
+                "observed_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            },
+            "next_command": f"gh run list --repo {repo} --workflow {json.dumps(workflow)} --limit {limit}",
+        }
+    failed_id = _text(failed_run.get("databaseId") or failed_run.get("id"))
+    try:
+        detail = _run_gh_json(["run", "view", failed_id, "--repo", repo, "--json", "jobs,url,databaseId,workflowName,updatedAt,headBranch,headSha"])
+    except SystemExit:
+        detail = dict(failed_run)
+    log = _run_gh_text(["run", "view", failed_id, "--repo", repo, "--log-failed"], allow_failure=True)
+    run_payload = dict(failed_run)
+    if isinstance(detail, dict):
+        run_payload.update(detail)
+        if "jobs" not in run_payload and isinstance(detail.get("jobs"), list):
+            run_payload["jobs"] = detail["jobs"]
+    summary = release_failure_status({"run": run_payload, "log": log})
+    failed_at = _run_sort_key(failed_run)
+    superseding_success = None
+    if latest_success is not None and _run_sort_key(latest_success) > failed_at:
+        superseding_success = latest_success
+    summary["freshness"] = {
+        **summary.get("freshness", {}),
+        "status": "superseded_by_newer_success" if superseding_success else "active_failed_release",
+        "source": "gh-run-list + gh-run-view",
+        "observed_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "superseding_success": _run_identity(superseding_success) if superseding_success else {},
+    }
+    summary["next_command"] = f"gh run view {failed_id} --repo {repo} --log-failed"
+    return summary
+
+
 def recovery_packet(
     *,
     repo_root: Path,
     labels: list[str],
     changed_files: list[str],
     run_payload: dict[str, Any] | None = None,
+    release_failure: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     ownership = _ownership_payload(repo_root)
     semver = semver_pr_status(labels=labels, changed_files=changed_files, ownership=ownership)
-    release_failure = release_failure_status(run_payload) if run_payload else {
+    release_failure = release_failure or (release_failure_status(run_payload) if run_payload else {
         "kind": "agentic-workspace/release-ci-failure-summary/v1",
         "status": "not-fetched",
         "workflow": DEFAULT_WORKFLOW,
         "next_command": "gh run list --workflow 'Release From Semver Label' --limit 5",
         "freshness": {"status": "unavailable", "source": "not-fetched"},
-    }
-    recovery_needed = semver["status"] == "repair-only-semver-pr" or release_failure["status"] == "failed-release-run"
+    })
+    active_failed_release = (
+        release_failure["status"] == "failed-release-run"
+        and release_failure.get("freshness", {}).get("status") != "superseded_by_newer_success"
+    )
+    recovery_needed = semver["status"] == "repair-only-semver-pr" or active_failed_release
     version_paths = [package["pyproject"] for package in ownership.get("packages", []) if isinstance(package, dict)] + [
         package["package_json"] for package in ownership.get("typescript_packages", []) if isinstance(package, dict)
     ]
@@ -160,6 +278,21 @@ def recovery_packet(
         "kind": PACKET_KIND,
         "semver_release_action": semver,
         "release_ci_failure": release_failure,
+        "release_publication_state": {
+            "status": "failed-release-unpublished"
+            if active_failed_release
+            else "repair-only-pr-does-not-publish"
+            if semver["status"] == "repair-only-semver-pr"
+            else "cleared-by-newer-success"
+            if release_failure.get("freshness", {}).get("status") == "superseded_by_newer_success"
+            else "no-active-failed-release",
+            "failed_run_url": release_failure.get("run_url", ""),
+            "superseding_run_url": release_failure.get("freshness", {}).get("superseding_success", {}).get("run_url", "")
+            if isinstance(release_failure.get("freshness"), dict)
+            else "",
+            "release_action": semver["status"],
+            "rule": "Repair-only PRs can fix blockers but do not publish; an active failed release needs a coordinated package-affecting release PR unless a newer successful run supersedes it.",
+        },
         "coordinated_recovery": {
             "status": "required" if recovery_needed else "not-required",
             "next_action": (
@@ -203,6 +336,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
     parser.add_argument("--repo", help="GitHub repository in owner/name form for live PR reads.")
     parser.add_argument("--pr", type=int, help="Pull request number for live PR reads.")
+    parser.add_argument("--include-release-runs", action="store_true", help="Fetch recent release workflow runs through gh.")
+    parser.add_argument("--workflow", default=DEFAULT_WORKFLOW, help="Release workflow name for --include-release-runs.")
+    parser.add_argument("--run-limit", type=int, default=10, help="Number of release workflow runs to inspect.")
     parser.add_argument("--labels", nargs="*", default=[], help="Semver and other labels for fixture mode.")
     parser.add_argument("--changed-file", action="append", default=[], help="Changed file path for fixture mode.")
     parser.add_argument("--run-fixture", type=Path, help="Optional failed release run fixture JSON.")
@@ -212,17 +348,23 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    if bool(args.repo) ^ bool(args.pr):
-        raise SystemExit("--repo and --pr must be supplied together")
+    if bool(args.repo) ^ bool(args.pr) and not (args.repo and args.include_release_runs):
+        raise SystemExit("--repo and --pr must be supplied together unless --include-release-runs is used")
     labels, changed_files = (args.labels, args.changed_file)
     if args.repo and args.pr:
         labels, changed_files = _live_pr_inputs(args.repo, args.pr)
     run_payload = _load_json(args.run_fixture) if args.run_fixture else None
+    release_failure = (
+        live_release_failure_status(repo=args.repo, workflow=args.workflow, limit=args.run_limit)
+        if args.repo and args.include_release_runs
+        else None
+    )
     packet = recovery_packet(
         repo_root=args.repo_root,
         labels=labels,
         changed_files=changed_files,
         run_payload=run_payload,
+        release_failure=release_failure,
     )
     print(json.dumps(packet, indent=2, sort_keys=True))
     return 0

--- a/scripts/github/release_recovery_status.py
+++ b/scripts/github/release_recovery_status.py
@@ -1,0 +1,232 @@
+"""Build compact release recovery status packets for semver PRs and release runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+PACKET_KIND = "agentic-workspace/release-recovery-status/v1"
+DEFAULT_WORKFLOW = "Release From Semver Label"
+ERROR_MARKERS = ("error", "failed", "failure", "traceback", "exception", "assertionerror")
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _ownership_payload(repo_root: Path) -> dict[str, Any]:
+    return _load_json(repo_root / ".github" / "release-ownership.json")
+
+
+def _path_matches(path: str, patterns: list[str]) -> bool:
+    normalized = path.replace("\\", "/")
+    for pattern in patterns:
+        candidate = pattern.replace("\\", "/")
+        if normalized == candidate or normalized.startswith(candidate):
+            return True
+    return False
+
+
+def semver_pr_status(*, labels: list[str], changed_files: list[str], ownership: dict[str, Any]) -> dict[str, Any]:
+    semver_labels = [label for label in labels if label in set(ownership.get("semver_labels", []))]
+    package_affecting = any(_path_matches(path, list(ownership.get("package_affecting_paths", []))) for path in changed_files)
+    if not package_affecting:
+        status = "repair-only-semver-pr" if semver_labels else "no-release-needed"
+        return {
+            "kind": "agentic-workspace/semver-pr-release-action/v1",
+            "status": status,
+            "will_publish_release": False,
+            "package_affecting": False,
+            "semver_labels": semver_labels,
+            "changed_file_count": len(changed_files),
+            "next_action": (
+                "This PR can repair release blockers, but merge will not publish a release; follow with a coordinated explicit version bump if a failed release still needs publication."
+                if semver_labels
+                else "No release action is expected because no package-affecting paths changed."
+            ),
+        }
+    if len(semver_labels) != 1:
+        return {
+            "kind": "agentic-workspace/semver-pr-release-action/v1",
+            "status": "blocked-semver-label-selection",
+            "will_publish_release": False,
+            "package_affecting": True,
+            "semver_labels": semver_labels,
+            "changed_file_count": len(changed_files),
+            "next_action": "Apply exactly one semver label before merge so the release workflow can compute the coordinated version.",
+        }
+    return {
+        "kind": "agentic-workspace/semver-pr-release-action/v1",
+        "status": "will-publish-release",
+        "will_publish_release": True,
+        "package_affecting": True,
+        "semver_labels": semver_labels,
+        "changed_file_count": len(changed_files),
+        "next_action": "Merge will attempt a coordinated release bump through the Release From Semver Label workflow.",
+    }
+
+
+def _timestamp(value: Any) -> str:
+    text = _text(value)
+    if text:
+        return text
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _error_lines(text: str, *, limit: int = 8) -> list[str]:
+    lines: list[str] = []
+    for line in text.splitlines():
+        lowered = line.lower()
+        if any(marker in lowered for marker in ERROR_MARKERS):
+            lines.append(line.strip())
+        if len(lines) >= limit:
+            break
+    return lines
+
+
+def release_failure_status(payload: dict[str, Any]) -> dict[str, Any]:
+    run = payload.get("run") if isinstance(payload.get("run"), dict) else payload
+    jobs = run.get("jobs", []) if isinstance(run.get("jobs"), list) else payload.get("jobs", [])
+    failed_job: dict[str, Any] | None = None
+    failed_step: dict[str, Any] | None = None
+    for job in jobs if isinstance(jobs, list) else []:
+        if not isinstance(job, dict):
+            continue
+        conclusion = _text(job.get("conclusion") or job.get("status")).lower()
+        steps = job.get("steps", []) if isinstance(job.get("steps"), list) else []
+        step = next(
+            (
+                item
+                for item in steps
+                if isinstance(item, dict) and _text(item.get("conclusion") or item.get("status")).lower() in {"failure", "failed", "error"}
+            ),
+            None,
+        )
+        if conclusion in {"failure", "failed", "error", "cancelled", "timed_out"} or step is not None:
+            failed_job = job
+            failed_step = step if isinstance(step, dict) else None
+            break
+    status = "failed-release-run" if failed_job is not None else "no-failed-release-run"
+    log_text = _text(payload.get("log") or run.get("log"))
+    error_summary = _error_lines(log_text)
+    return {
+        "kind": "agentic-workspace/release-ci-failure-summary/v1",
+        "status": status,
+        "workflow": _text(run.get("workflowName") or run.get("workflow") or payload.get("workflow") or DEFAULT_WORKFLOW),
+        "run_url": _text(run.get("url") or run.get("html_url") or payload.get("run_url")),
+        "run_id": _text(run.get("databaseId") or run.get("id") or payload.get("run_id")),
+        "failed_job": _text(failed_job.get("name") if failed_job else ""),
+        "failed_step": _text(failed_step.get("name") if failed_step else ""),
+        "error_summary": error_summary,
+        "freshness": {
+            "observed_at": _timestamp(payload.get("observed_at") or run.get("updatedAt") or run.get("updated_at")),
+            "source": "fixture-or-gh-actions-run",
+            "stale_when": "a newer release workflow run succeeds or supersedes this run",
+        },
+        "next_command": "gh run view <run-id> --log-failed",
+    }
+
+
+def recovery_packet(
+    *,
+    repo_root: Path,
+    labels: list[str],
+    changed_files: list[str],
+    run_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    ownership = _ownership_payload(repo_root)
+    semver = semver_pr_status(labels=labels, changed_files=changed_files, ownership=ownership)
+    release_failure = release_failure_status(run_payload) if run_payload else {
+        "kind": "agentic-workspace/release-ci-failure-summary/v1",
+        "status": "not-fetched",
+        "workflow": DEFAULT_WORKFLOW,
+        "next_command": "gh run list --workflow 'Release From Semver Label' --limit 5",
+        "freshness": {"status": "unavailable", "source": "not-fetched"},
+    }
+    recovery_needed = semver["status"] == "repair-only-semver-pr" or release_failure["status"] == "failed-release-run"
+    version_paths = [package["pyproject"] for package in ownership.get("packages", []) if isinstance(package, dict)] + [
+        package["package_json"] for package in ownership.get("typescript_packages", []) if isinstance(package, dict)
+    ]
+    return {
+        "kind": PACKET_KIND,
+        "semver_release_action": semver,
+        "release_ci_failure": release_failure,
+        "coordinated_recovery": {
+            "status": "required" if recovery_needed else "not-required",
+            "next_action": (
+                "Create a coordinated explicit version-bump PR touching all release-owned version files, then run release proof."
+                if recovery_needed
+                else "No failed-release recovery action is active in this packet."
+            ),
+            "pr_shape": {
+                "required_paths": version_paths,
+                "proof": [
+                    "uv lock",
+                    "make test-workspace",
+                    "make lint-workspace",
+                    "uv run pytest tests/test_release_workflows.py -q",
+                ],
+            },
+        },
+        "write_safety": {
+            "github_writes_performed": False,
+            "rule": "This packet is read-only; create recovery branches or labels separately and intentionally.",
+        },
+    }
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, encoding="utf-8", check=False)
+    if result.returncode != 0:
+        raise SystemExit(result.stderr.strip() or result.stdout.strip() or f"gh exited {result.returncode}")
+    return json.loads(result.stdout or "[]")
+
+
+def _live_pr_inputs(repo: str, pr: int) -> tuple[list[str], list[str]]:
+    labels_payload = _run_gh_json(["pr", "view", str(pr), "--repo", repo, "--json", "labels,files"])
+    labels = [item["name"] for item in labels_payload.get("labels", []) if isinstance(item, dict) and item.get("name")]
+    files = [item["path"] for item in labels_payload.get("files", []) if isinstance(item, dict) and item.get("path")]
+    return labels, files
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--repo", help="GitHub repository in owner/name form for live PR reads.")
+    parser.add_argument("--pr", type=int, help="Pull request number for live PR reads.")
+    parser.add_argument("--labels", nargs="*", default=[], help="Semver and other labels for fixture mode.")
+    parser.add_argument("--changed-file", action="append", default=[], help="Changed file path for fixture mode.")
+    parser.add_argument("--run-fixture", type=Path, help="Optional failed release run fixture JSON.")
+    parser.add_argument("--format", choices=("json",), default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if bool(args.repo) ^ bool(args.pr):
+        raise SystemExit("--repo and --pr must be supplied together")
+    labels, changed_files = (args.labels, args.changed_file)
+    if args.repo and args.pr:
+        labels, changed_files = _live_pr_inputs(args.repo, args.pr)
+    run_payload = _load_json(args.run_fixture) if args.run_fixture else None
+    packet = recovery_packet(
+        repo_root=args.repo_root,
+        labels=labels,
+        changed_files=changed_files,
+        run_payload=run_payload,
+    )
+    print(json.dumps(packet, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -9459,6 +9459,20 @@ def _release_recovery_payload(
         command=("python scripts/github/release_recovery_status.py --repo <owner/name> --pr <number> --format json"),
         cli_invoke=cli_invoke,
     )
+    release_state = _release_recovery_live_state(target_root=target_root, cli_invoke=cli_invoke)
+    release_ci_failure = release_state.get("release_ci_failure", {})
+    if not release_ci_failure:
+        release_ci_failure = {
+            "status": "not-fetched",
+            "workflow": "Release From Semver Label",
+            "command": _command_with_cli_invoke(
+                command="python scripts/github/release_recovery_status.py --repo <owner/name> --include-release-runs --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "deeper_log_command": "gh run view <run-id> --log-failed",
+            "rule": "AW keeps compact run pointers and summaries; full GitHub Actions logs stay outside repo state.",
+        }
+    release_publication_state = release_state.get("release_publication_state", {})
     return {
         "kind": "agentic-workspace/release-recovery/v1",
         "status": "available" if ownership else "unavailable",
@@ -9478,18 +9492,14 @@ def _release_recovery_payload(
                 "A semver-labeled PR that changes no package-affecting path can fix a blocker, but it will not publish the failed release."
             ),
         },
-        "release_ci_failure": {
-            "status": "not-fetched",
-            "workflow": "Release From Semver Label",
-            "command": _command_with_cli_invoke(
-                command="python scripts/github/release_recovery_status.py --repo <owner/name> --pr <number> --run-fixture <run.json> --format json",
-                cli_invoke=cli_invoke,
-            ),
-            "deeper_log_command": "gh run view <run-id> --log-failed",
-            "rule": "AW keeps compact run pointers and summaries; full GitHub Actions logs stay outside repo state.",
-        },
+        "release_ci_failure": release_ci_failure,
+        "release_publication_state": release_publication_state,
         "coordinated_recovery": {
-            "status": "available",
+            "status": "required"
+            if release_publication_state.get("status") == "failed-release-unpublished"
+            else "not-required"
+            if release_publication_state.get("status") == "cleared-by-newer-success"
+            else "available",
             "next_action": "When a failed release remains unpublished after a repair-only PR, create a coordinated explicit version-bump PR.",
             "pr_shape": {
                 "required_version_paths": version_paths,
@@ -9505,6 +9515,106 @@ def _release_recovery_payload(
             command="agentic-workspace report --target ./repo --section release_recovery --format json",
             cli_invoke=cli_invoke,
         ),
+    }
+
+
+def _release_recovery_repo_slug(target_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(target_root), "config", "--get", "remote.origin.url"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    match = re.search(r"github\.com[:/](?P<repo>[^/\s]+/[^/\s]+?)(?:\.git)?$", result.stdout.strip())
+    return match.group("repo") if match else ""
+
+
+def _release_recovery_live_state(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
+    repo = _release_recovery_repo_slug(target_root)
+    command = _command_with_cli_invoke(
+        command=f"python scripts/github/release_recovery_status.py --repo {repo or '<owner/name>'} --include-release-runs --format json",
+        cli_invoke=cli_invoke,
+    )
+    if not repo:
+        return {
+            "release_ci_failure": {
+                "kind": "agentic-workspace/release-ci-failure-summary/v1",
+                "status": "release_run_status_unavailable",
+                "workflow": "Release From Semver Label",
+                "reason": "No GitHub origin remote was available for live release-run discovery.",
+                "command": command,
+                "freshness": {"status": "unavailable", "source": "missing-github-remote"},
+            },
+            "release_publication_state": {
+                "status": "unknown",
+                "rule": "Live release publication state needs a GitHub repo remote or an explicit run fixture.",
+            },
+        }
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/github/release_recovery_status.py",
+                "--repo-root",
+                str(target_root),
+                "--repo",
+                repo,
+                "--include-release-runs",
+                "--format",
+                "json",
+            ],
+            cwd=target_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {
+            "release_ci_failure": {
+                "kind": "agentic-workspace/release-ci-failure-summary/v1",
+                "status": "release_run_status_unavailable",
+                "workflow": "Release From Semver Label",
+                "reason": str(exc),
+                "command": command,
+                "freshness": {"status": "unavailable", "source": "helper-execution-failed"},
+            },
+            "release_publication_state": {"status": "unknown", "rule": "Live release helper could not be executed."},
+        }
+    if result.returncode != 0:
+        return {
+            "release_ci_failure": {
+                "kind": "agentic-workspace/release-ci-failure-summary/v1",
+                "status": "release_run_status_unavailable",
+                "workflow": "Release From Semver Label",
+                "reason": (result.stderr or result.stdout).strip(),
+                "command": command,
+                "freshness": {"status": "unavailable", "source": "helper-returned-error"},
+            },
+            "release_publication_state": {"status": "unknown", "rule": "Live release helper returned an error."},
+        }
+    try:
+        packet = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        packet = {}
+    if not isinstance(packet, dict):
+        packet = {}
+    release_ci_failure = packet.get("release_ci_failure", {})
+    if isinstance(release_ci_failure, dict):
+        release_ci_failure.setdefault("command", command)
+    return {
+        "release_ci_failure": release_ci_failure if isinstance(release_ci_failure, dict) else {},
+        "release_publication_state": packet.get("release_publication_state", {})
+        if isinstance(packet.get("release_publication_state"), dict)
+        else {},
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -985,6 +985,14 @@ def _installed_state_compatibility_payload(
     generated_status = "stale" if stale_generated_surfaces else "compatible"
     payload_status = "sync-required" if stale_generated_surfaces or payload_provenance_drift != "none" else "observed-compatible"
     action_effect = _installed_state_action_effect(status=status, next_action=next_action, config=config)
+    dry_run_sync_command = _command_with_cli_invoke(
+        command=f"agentic-workspace upgrade --target {target_root.as_posix()} --dry-run --format json",
+        cli_invoke=config.cli_invoke,
+    )
+    apply_sync_command = _command_with_cli_invoke(
+        command=f"agentic-workspace upgrade --target {target_root.as_posix()} --format json",
+        cli_invoke=config.cli_invoke,
+    )
     payload: dict[str, Any] = {
         "kind": "agentic-workspace/installed-state-compatibility/v1",
         "status": status,
@@ -1010,10 +1018,15 @@ def _installed_state_compatibility_payload(
             "stale_generated_surfaces": stale_generated_surfaces,
             "provenance": provenance_status,
             "provenance_drift": payload_provenance_drift,
-            "sync_command": _command_with_cli_invoke(
-                command=f"agentic-workspace upgrade --target {target_root.as_posix()} --dry-run --format json",
-                cli_invoke=config.cli_invoke,
-            ),
+            "expected_release_identity": {
+                "package": "agentic-workspace",
+                "version": __version__,
+                "source_class": current_identity.get("source_class"),
+                "source_identity": current_identity.get("source_identity"),
+            },
+            "sync_command": dry_run_sync_command,
+            "dry_run_command": dry_run_sync_command,
+            "apply_command": apply_sync_command,
             "rule": "Repo payload state is authoritative; stale payloads should be synced deliberately before trusting newer executables.",
         },
         "generated_artifacts": {
@@ -1036,6 +1049,16 @@ def _installed_state_compatibility_payload(
             },
         ],
         "next_action": next_action,
+        "repair_route": {
+            "status": "available" if status == "payload-upgrade-required" else "not-required",
+            "dry_run_command": dry_run_sync_command,
+            "apply_command": apply_sync_command,
+            "waiver": {
+                "allowed": status == "payload-upgrade-required",
+                "claim": "source-behavior-validated-installed-payload-freshness-unproven",
+                "rule": "A waiver can keep narrow source work moving, but final reporting must not claim installed payload freshness.",
+            },
+        },
         "action_effect": action_effect,
         "rule": (
             "Every entry surface should classify executable, payload, generated-artifact, and adapter posture through this "
@@ -1054,12 +1077,23 @@ def _installed_state_compatibility_payload(
             },
             "payload": {
                 key: payload["payload"][key]
-                for key in ("status", "installed_modules", "stale_generated_surfaces", "provenance", "provenance_drift")
+                for key in (
+                    "status",
+                    "release_identity",
+                    "expected_release_identity",
+                    "installed_modules",
+                    "stale_generated_surfaces",
+                    "provenance",
+                    "provenance_drift",
+                    "dry_run_command",
+                    "apply_command",
+                )
                 if payload["payload"].get(key) not in (None, [], "")
             },
             "generated_artifacts": payload["generated_artifacts"],
             "adapter_contracts": payload["adapter_contracts"],
             "next_action": payload["next_action"],
+            "repair_route": payload["repair_route"],
             "action_effect": payload["action_effect"],
         }
         if compact_payload["next_action"] is None:
@@ -9396,6 +9430,84 @@ def _automation_readiness_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> di
     }
 
 
+def _release_recovery_payload(
+    *,
+    target_root: Path,
+    config: WorkspaceConfig,
+    selected_modules: list[str],
+    cli_invoke: str = DEFAULT_CLI_INVOKE,
+) -> dict[str, Any]:
+    installed_modules = _fast_installed_modules(target_root=target_root)
+    installed_state = _installed_state_compatibility_payload(
+        config=config,
+        selected_modules=selected_modules,
+        installed_modules=installed_modules,
+        compact=True,
+    )
+    ownership_path = target_root / ".github" / "release-ownership.json"
+    ownership: dict[str, Any] = {}
+    if ownership_path.is_file():
+        try:
+            ownership = json.loads(ownership_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            ownership = {}
+    semver_labels = [str(label) for label in ownership.get("semver_labels", []) if str(label)]
+    version_paths = [package["pyproject"] for package in ownership.get("packages", []) if isinstance(package, dict)] + [
+        package["package_json"] for package in ownership.get("typescript_packages", []) if isinstance(package, dict)
+    ]
+    helper = _command_with_cli_invoke(
+        command=("python scripts/github/release_recovery_status.py --repo <owner/name> --pr <number> --format json"),
+        cli_invoke=cli_invoke,
+    )
+    return {
+        "kind": "agentic-workspace/release-recovery/v1",
+        "status": "available" if ownership else "unavailable",
+        "release_model": str(ownership.get("release_model", "unknown")),
+        "release_ownership_path": ".github/release-ownership.json",
+        "semver_labels": semver_labels,
+        "payload_drift": {
+            "status": installed_state.get("status", "unknown"),
+            "claim_boundary": installed_state.get("action_effect", {}).get("claim_boundary", ""),
+            "repair_route": installed_state.get("repair_route", {}),
+        },
+        "semver_release_action": {
+            "status": "not-fetched",
+            "rule": "Use the helper to classify whether a PR will publish, is repair-only, or is blocked by semver label state.",
+            "command": helper,
+            "repair_only_boundary": (
+                "A semver-labeled PR that changes no package-affecting path can fix a blocker, but it will not publish the failed release."
+            ),
+        },
+        "release_ci_failure": {
+            "status": "not-fetched",
+            "workflow": "Release From Semver Label",
+            "command": _command_with_cli_invoke(
+                command="python scripts/github/release_recovery_status.py --repo <owner/name> --pr <number> --run-fixture <run.json> --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "deeper_log_command": "gh run view <run-id> --log-failed",
+            "rule": "AW keeps compact run pointers and summaries; full GitHub Actions logs stay outside repo state.",
+        },
+        "coordinated_recovery": {
+            "status": "available",
+            "next_action": "When a failed release remains unpublished after a repair-only PR, create a coordinated explicit version-bump PR.",
+            "pr_shape": {
+                "required_version_paths": version_paths,
+                "proof": [
+                    "uv lock",
+                    "make test-workspace",
+                    "make lint-workspace",
+                    "uv run pytest tests/test_release_workflows.py -q",
+                ],
+            },
+        },
+        "detail_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section release_recovery --format json",
+            cli_invoke=cli_invoke,
+        ),
+    }
+
+
 _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
     {
         "section": "section_catalog",
@@ -9522,6 +9634,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "kind": "agentic-workspace/automation-readiness/v1",
         "purpose": "provider-agnostic automation-readiness checklist that keeps execution outside AW",
         "when_to_use": "before adding external automation, bot, CI, ticket, or agent workflow integration",
+    },
+    {
+        "section": "release_recovery",
+        "kind": "agentic-workspace/release-recovery/v1",
+        "purpose": "source-checkout release recovery posture for semver PR action, failed release summaries, and payload drift repair",
+        "when_to_use": "during coordinated release, semver-label recovery, payload drift, or failed release CI diagnosis",
     },
 )
 
@@ -11630,6 +11748,15 @@ def _run_lazy_report_section_command(
             task_text=None,
             active_planning_record=active_planning_record,
             durable_intent=durable_intent,
+            cli_invoke=config.cli_invoke,
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "release_recovery":
+        payload["release_recovery"] = _release_recovery_payload(
+            target_root=target_root,
+            config=config,
+            selected_modules=selected_modules,
             cli_invoke=config.cli_invoke,
         )
         return _select_report_payload(payload, profile="router", section=normalized)

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -9353,6 +9353,20 @@ def _release_recovery_payload(
         command=("python scripts/github/release_recovery_status.py --repo <owner/name> --pr <number> --format json"),
         cli_invoke=cli_invoke,
     )
+    release_state = _release_recovery_live_state(target_root=target_root, cli_invoke=cli_invoke)
+    release_ci_failure = release_state.get("release_ci_failure", {})
+    if not release_ci_failure:
+        release_ci_failure = {
+            "status": "not-fetched",
+            "workflow": "Release From Semver Label",
+            "command": _command_with_cli_invoke(
+                command="python scripts/github/release_recovery_status.py --repo <owner/name> --include-release-runs --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "deeper_log_command": "gh run view <run-id> --log-failed",
+            "rule": "AW keeps compact run pointers and summaries; full GitHub Actions logs stay outside repo state.",
+        }
+    release_publication_state = release_state.get("release_publication_state", {})
     return {
         "kind": "agentic-workspace/release-recovery/v1",
         "status": "available" if ownership else "unavailable",
@@ -9372,18 +9386,14 @@ def _release_recovery_payload(
                 "A semver-labeled PR that changes no package-affecting path can fix a blocker, but it will not publish the failed release."
             ),
         },
-        "release_ci_failure": {
-            "status": "not-fetched",
-            "workflow": "Release From Semver Label",
-            "command": _command_with_cli_invoke(
-                command="python scripts/github/release_recovery_status.py --repo <owner/name> --pr <number> --run-fixture <run.json> --format json",
-                cli_invoke=cli_invoke,
-            ),
-            "deeper_log_command": "gh run view <run-id> --log-failed",
-            "rule": "AW keeps compact run pointers and summaries; full GitHub Actions logs stay outside repo state.",
-        },
+        "release_ci_failure": release_ci_failure,
+        "release_publication_state": release_publication_state,
         "coordinated_recovery": {
-            "status": "available",
+            "status": "required"
+            if release_publication_state.get("status") == "failed-release-unpublished"
+            else "not-required"
+            if release_publication_state.get("status") == "cleared-by-newer-success"
+            else "available",
             "next_action": "When a failed release remains unpublished after a repair-only PR, create a coordinated explicit version-bump PR.",
             "pr_shape": {
                 "required_version_paths": version_paths,
@@ -9399,6 +9409,106 @@ def _release_recovery_payload(
             command="agentic-workspace report --target ./repo --section release_recovery --format json",
             cli_invoke=cli_invoke,
         ),
+    }
+
+
+def _release_recovery_repo_slug(target_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(target_root), "config", "--get", "remote.origin.url"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    match = re.search(r"github\.com[:/](?P<repo>[^/\s]+/[^/\s]+?)(?:\.git)?$", result.stdout.strip())
+    return match.group("repo") if match else ""
+
+
+def _release_recovery_live_state(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
+    repo = _release_recovery_repo_slug(target_root)
+    command = _command_with_cli_invoke(
+        command=f"python scripts/github/release_recovery_status.py --repo {repo or '<owner/name>'} --include-release-runs --format json",
+        cli_invoke=cli_invoke,
+    )
+    if not repo:
+        return {
+            "release_ci_failure": {
+                "kind": "agentic-workspace/release-ci-failure-summary/v1",
+                "status": "release_run_status_unavailable",
+                "workflow": "Release From Semver Label",
+                "reason": "No GitHub origin remote was available for live release-run discovery.",
+                "command": command,
+                "freshness": {"status": "unavailable", "source": "missing-github-remote"},
+            },
+            "release_publication_state": {
+                "status": "unknown",
+                "rule": "Live release publication state needs a GitHub repo remote or an explicit run fixture.",
+            },
+        }
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/github/release_recovery_status.py",
+                "--repo-root",
+                str(target_root),
+                "--repo",
+                repo,
+                "--include-release-runs",
+                "--format",
+                "json",
+            ],
+            cwd=target_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {
+            "release_ci_failure": {
+                "kind": "agentic-workspace/release-ci-failure-summary/v1",
+                "status": "release_run_status_unavailable",
+                "workflow": "Release From Semver Label",
+                "reason": str(exc),
+                "command": command,
+                "freshness": {"status": "unavailable", "source": "helper-execution-failed"},
+            },
+            "release_publication_state": {"status": "unknown", "rule": "Live release helper could not be executed."},
+        }
+    if result.returncode != 0:
+        return {
+            "release_ci_failure": {
+                "kind": "agentic-workspace/release-ci-failure-summary/v1",
+                "status": "release_run_status_unavailable",
+                "workflow": "Release From Semver Label",
+                "reason": (result.stderr or result.stdout).strip(),
+                "command": command,
+                "freshness": {"status": "unavailable", "source": "helper-returned-error"},
+            },
+            "release_publication_state": {"status": "unknown", "rule": "Live release helper returned an error."},
+        }
+    try:
+        packet = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        packet = {}
+    if not isinstance(packet, dict):
+        packet = {}
+    release_ci_failure = packet.get("release_ci_failure", {})
+    if isinstance(release_ci_failure, dict):
+        release_ci_failure.setdefault("command", command)
+    return {
+        "release_ci_failure": release_ci_failure if isinstance(release_ci_failure, dict) else {},
+        "release_publication_state": packet.get("release_publication_state", {})
+        if isinstance(packet.get("release_publication_state"), dict)
+        else {},
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -879,6 +879,14 @@ def _installed_state_compatibility_payload(
     generated_status = "stale" if stale_generated_surfaces else "compatible"
     payload_status = "sync-required" if stale_generated_surfaces or payload_provenance_drift != "none" else "observed-compatible"
     action_effect = _installed_state_action_effect(status=status, next_action=next_action, config=config)
+    dry_run_sync_command = _command_with_cli_invoke(
+        command=f"agentic-workspace upgrade --target {target_root.as_posix()} --dry-run --format json",
+        cli_invoke=config.cli_invoke,
+    )
+    apply_sync_command = _command_with_cli_invoke(
+        command=f"agentic-workspace upgrade --target {target_root.as_posix()} --format json",
+        cli_invoke=config.cli_invoke,
+    )
     payload: dict[str, Any] = {
         "kind": "agentic-workspace/installed-state-compatibility/v1",
         "status": status,
@@ -904,10 +912,15 @@ def _installed_state_compatibility_payload(
             "stale_generated_surfaces": stale_generated_surfaces,
             "provenance": provenance_status,
             "provenance_drift": payload_provenance_drift,
-            "sync_command": _command_with_cli_invoke(
-                command=f"agentic-workspace upgrade --target {target_root.as_posix()} --dry-run --format json",
-                cli_invoke=config.cli_invoke,
-            ),
+            "expected_release_identity": {
+                "package": "agentic-workspace",
+                "version": __version__,
+                "source_class": current_identity.get("source_class"),
+                "source_identity": current_identity.get("source_identity"),
+            },
+            "sync_command": dry_run_sync_command,
+            "dry_run_command": dry_run_sync_command,
+            "apply_command": apply_sync_command,
             "rule": "Repo payload state is authoritative; stale payloads should be synced deliberately before trusting newer executables.",
         },
         "generated_artifacts": {
@@ -930,6 +943,16 @@ def _installed_state_compatibility_payload(
             },
         ],
         "next_action": next_action,
+        "repair_route": {
+            "status": "available" if status == "payload-upgrade-required" else "not-required",
+            "dry_run_command": dry_run_sync_command,
+            "apply_command": apply_sync_command,
+            "waiver": {
+                "allowed": status == "payload-upgrade-required",
+                "claim": "source-behavior-validated-installed-payload-freshness-unproven",
+                "rule": "A waiver can keep narrow source work moving, but final reporting must not claim installed payload freshness.",
+            },
+        },
         "action_effect": action_effect,
         "rule": (
             "Every entry surface should classify executable, payload, generated-artifact, and adapter posture through this "
@@ -948,12 +971,23 @@ def _installed_state_compatibility_payload(
             },
             "payload": {
                 key: payload["payload"][key]
-                for key in ("status", "installed_modules", "stale_generated_surfaces", "provenance", "provenance_drift")
+                for key in (
+                    "status",
+                    "release_identity",
+                    "expected_release_identity",
+                    "installed_modules",
+                    "stale_generated_surfaces",
+                    "provenance",
+                    "provenance_drift",
+                    "dry_run_command",
+                    "apply_command",
+                )
                 if payload["payload"].get(key) not in (None, [], "")
             },
             "generated_artifacts": payload["generated_artifacts"],
             "adapter_contracts": payload["adapter_contracts"],
             "next_action": payload["next_action"],
+            "repair_route": payload["repair_route"],
             "action_effect": payload["action_effect"],
         }
         if compact_payload["next_action"] is None:
@@ -9290,6 +9324,84 @@ def _automation_readiness_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> di
     }
 
 
+def _release_recovery_payload(
+    *,
+    target_root: Path,
+    config: WorkspaceConfig,
+    selected_modules: list[str],
+    cli_invoke: str = DEFAULT_CLI_INVOKE,
+) -> dict[str, Any]:
+    installed_modules = _fast_installed_modules(target_root=target_root)
+    installed_state = _installed_state_compatibility_payload(
+        config=config,
+        selected_modules=selected_modules,
+        installed_modules=installed_modules,
+        compact=True,
+    )
+    ownership_path = target_root / ".github" / "release-ownership.json"
+    ownership: dict[str, Any] = {}
+    if ownership_path.is_file():
+        try:
+            ownership = json.loads(ownership_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            ownership = {}
+    semver_labels = [str(label) for label in ownership.get("semver_labels", []) if str(label)]
+    version_paths = [package["pyproject"] for package in ownership.get("packages", []) if isinstance(package, dict)] + [
+        package["package_json"] for package in ownership.get("typescript_packages", []) if isinstance(package, dict)
+    ]
+    helper = _command_with_cli_invoke(
+        command=("python scripts/github/release_recovery_status.py --repo <owner/name> --pr <number> --format json"),
+        cli_invoke=cli_invoke,
+    )
+    return {
+        "kind": "agentic-workspace/release-recovery/v1",
+        "status": "available" if ownership else "unavailable",
+        "release_model": str(ownership.get("release_model", "unknown")),
+        "release_ownership_path": ".github/release-ownership.json",
+        "semver_labels": semver_labels,
+        "payload_drift": {
+            "status": installed_state.get("status", "unknown"),
+            "claim_boundary": installed_state.get("action_effect", {}).get("claim_boundary", ""),
+            "repair_route": installed_state.get("repair_route", {}),
+        },
+        "semver_release_action": {
+            "status": "not-fetched",
+            "rule": "Use the helper to classify whether a PR will publish, is repair-only, or is blocked by semver label state.",
+            "command": helper,
+            "repair_only_boundary": (
+                "A semver-labeled PR that changes no package-affecting path can fix a blocker, but it will not publish the failed release."
+            ),
+        },
+        "release_ci_failure": {
+            "status": "not-fetched",
+            "workflow": "Release From Semver Label",
+            "command": _command_with_cli_invoke(
+                command="python scripts/github/release_recovery_status.py --repo <owner/name> --pr <number> --run-fixture <run.json> --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "deeper_log_command": "gh run view <run-id> --log-failed",
+            "rule": "AW keeps compact run pointers and summaries; full GitHub Actions logs stay outside repo state.",
+        },
+        "coordinated_recovery": {
+            "status": "available",
+            "next_action": "When a failed release remains unpublished after a repair-only PR, create a coordinated explicit version-bump PR.",
+            "pr_shape": {
+                "required_version_paths": version_paths,
+                "proof": [
+                    "uv lock",
+                    "make test-workspace",
+                    "make lint-workspace",
+                    "uv run pytest tests/test_release_workflows.py -q",
+                ],
+            },
+        },
+        "detail_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section release_recovery --format json",
+            cli_invoke=cli_invoke,
+        ),
+    }
+
+
 _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
     {
         "section": "section_catalog",
@@ -9416,6 +9528,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "kind": "agentic-workspace/automation-readiness/v1",
         "purpose": "provider-agnostic automation-readiness checklist that keeps execution outside AW",
         "when_to_use": "before adding external automation, bot, CI, ticket, or agent workflow integration",
+    },
+    {
+        "section": "release_recovery",
+        "kind": "agentic-workspace/release-recovery/v1",
+        "purpose": "source-checkout release recovery posture for semver PR action, failed release summaries, and payload drift repair",
+        "when_to_use": "during coordinated release, semver-label recovery, payload drift, or failed release CI diagnosis",
     },
 )
 
@@ -11524,6 +11642,15 @@ def _run_lazy_report_section_command(
             task_text=None,
             active_planning_record=active_planning_record,
             durable_intent=durable_intent,
+            cli_invoke=config.cli_invoke,
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "release_recovery":
+        payload["release_recovery"] = _release_recovery_payload(
+            target_root=target_root,
+            config=config,
+            selected_modules=selected_modules,
             cli_invoke=config.cli_invoke,
         )
         return _select_report_payload(payload, profile="router", section=normalized)

--- a/tests/test_release_recovery_status.py
+++ b/tests/test_release_recovery_status.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "github" / "release_recovery_status.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("release_recovery_status", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_semver_repair_only_pr_reports_that_it_will_not_publish() -> None:
+    module = _load_module()
+    ownership = json.loads((REPO_ROOT / ".github" / "release-ownership.json").read_text(encoding="utf-8"))
+
+    packet = module.semver_pr_status(
+        labels=["semver:patch"],
+        changed_files=["docs/reviews/release-repair-note.md"],
+        ownership=ownership,
+    )
+
+    assert packet["status"] == "repair-only-semver-pr"
+    assert packet["will_publish_release"] is False
+    assert "will not publish" in packet["next_action"]
+
+
+def test_release_failure_fixture_identifies_failed_job_step_and_error() -> None:
+    module = _load_module()
+    packet = module.release_failure_status(
+        {
+            "run": {
+                "workflowName": "Release From Semver Label",
+                "databaseId": 28300736651,
+                "url": "https://github.com/example/repo/actions/runs/28300736651",
+                "updatedAt": "2026-06-28T10:00:00Z",
+                "jobs": [
+                    {
+                        "name": "release-from-label",
+                        "conclusion": "failure",
+                        "steps": [
+                            {"name": "Run coordinated release proof", "conclusion": "failure"},
+                        ],
+                    }
+                ],
+            },
+            "log": "ok\nERROR tests/test_external_agent_evaluation_lane.py::test_model_cli_harness failed\n",
+        }
+    )
+
+    assert packet["status"] == "failed-release-run"
+    assert packet["workflow"] == "Release From Semver Label"
+    assert packet["failed_job"] == "release-from-label"
+    assert packet["failed_step"] == "Run coordinated release proof"
+    assert packet["error_summary"] == ["ERROR tests/test_external_agent_evaluation_lane.py::test_model_cli_harness failed"]
+    assert packet["next_command"] == "gh run view <run-id> --log-failed"
+
+
+def test_release_recovery_cli_reads_fixture_inputs(tmp_path: Path) -> None:
+    fixture = tmp_path / "run.json"
+    fixture.write_text(
+        json.dumps(
+            {
+                "run": {
+                    "workflowName": "Release From Semver Label",
+                    "url": "https://github.com/example/repo/actions/runs/1",
+                    "jobs": [{"name": "release", "conclusion": "failure", "steps": []}],
+                },
+                "log": "AssertionError: release proof failed",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(REPO_ROOT),
+            "--labels",
+            "semver:patch",
+            "--changed-file",
+            "docs/reviews/release-repair-note.md",
+            "--run-fixture",
+            str(fixture),
+            "--format",
+            "json",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    packet = json.loads(result.stdout)
+    assert packet["kind"] == "agentic-workspace/release-recovery-status/v1"
+    assert packet["semver_release_action"]["status"] == "repair-only-semver-pr"
+    assert packet["release_ci_failure"]["status"] == "failed-release-run"
+    assert packet["coordinated_recovery"]["status"] == "required"

--- a/tests/test_release_recovery_status.py
+++ b/tests/test_release_recovery_status.py
@@ -109,3 +109,96 @@ def test_release_recovery_cli_reads_fixture_inputs(tmp_path: Path) -> None:
     assert packet["semver_release_action"]["status"] == "repair-only-semver-pr"
     assert packet["release_ci_failure"]["status"] == "failed-release-run"
     assert packet["coordinated_recovery"]["status"] == "required"
+
+
+def test_live_release_failure_status_identifies_active_failed_run(monkeypatch) -> None:
+    module = _load_module()
+
+    def fake_gh_json(args: list[str]):
+        if args[:2] == ["run", "list"]:
+            return [
+                {
+                    "databaseId": 101,
+                    "url": "https://github.com/example/repo/actions/runs/101",
+                    "conclusion": "failure",
+                    "updatedAt": "2026-06-28T10:00:00Z",
+                    "workflowName": "Release From Semver Label",
+                    "headBranch": "main",
+                    "headSha": "abc123",
+                }
+            ]
+        if args[:2] == ["run", "view"]:
+            return {
+                "databaseId": 101,
+                "url": "https://github.com/example/repo/actions/runs/101",
+                "workflowName": "Release From Semver Label",
+                "updatedAt": "2026-06-28T10:00:00Z",
+                "jobs": [
+                    {
+                        "name": "release",
+                        "conclusion": "failure",
+                        "steps": [{"name": "Run proof", "conclusion": "failure"}],
+                    }
+                ],
+            }
+        raise AssertionError(args)
+
+    monkeypatch.setattr(module, "_run_gh_json", fake_gh_json)
+    monkeypatch.setattr(module, "_run_gh_text", lambda args, allow_failure=False: "AssertionError: release proof failed")
+
+    packet = module.live_release_failure_status(repo="example/repo")
+
+    assert packet["status"] == "failed-release-run"
+    assert packet["run_url"] == "https://github.com/example/repo/actions/runs/101"
+    assert packet["failed_job"] == "release"
+    assert packet["failed_step"] == "Run proof"
+    assert packet["freshness"]["status"] == "active_failed_release"
+    assert packet["error_summary"] == ["AssertionError: release proof failed"]
+
+
+def test_recovery_packet_marks_failed_release_superseded_by_newer_success(monkeypatch) -> None:
+    module = _load_module()
+
+    def fake_gh_json(args: list[str]):
+        if args[:2] == ["run", "list"]:
+            return [
+                {
+                    "databaseId": 202,
+                    "url": "https://github.com/example/repo/actions/runs/202",
+                    "conclusion": "success",
+                    "updatedAt": "2026-06-28T11:00:00Z",
+                    "workflowName": "Release From Semver Label",
+                },
+                {
+                    "databaseId": 201,
+                    "url": "https://github.com/example/repo/actions/runs/201",
+                    "conclusion": "failure",
+                    "updatedAt": "2026-06-28T10:00:00Z",
+                    "workflowName": "Release From Semver Label",
+                },
+            ]
+        if args[:2] == ["run", "view"]:
+            return {
+                "databaseId": 201,
+                "url": "https://github.com/example/repo/actions/runs/201",
+                "workflowName": "Release From Semver Label",
+                "updatedAt": "2026-06-28T10:00:00Z",
+                "jobs": [{"name": "release", "conclusion": "failure", "steps": []}],
+            }
+        raise AssertionError(args)
+
+    monkeypatch.setattr(module, "_run_gh_json", fake_gh_json)
+    monkeypatch.setattr(module, "_run_gh_text", lambda args, allow_failure=False: "ERROR old failure")
+
+    failure = module.live_release_failure_status(repo="example/repo")
+    packet = module.recovery_packet(
+        repo_root=REPO_ROOT,
+        labels=["semver:patch"],
+        changed_files=["packages/agentic-workspace/pyproject.toml"],
+        release_failure=failure,
+    )
+
+    assert failure["freshness"]["status"] == "superseded_by_newer_success"
+    assert failure["freshness"]["superseding_success"]["run_url"] == "https://github.com/example/repo/actions/runs/202"
+    assert packet["release_publication_state"]["status"] == "cleared-by-newer-success"
+    assert packet["coordinated_recovery"]["status"] == "not-required"

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1466,8 +1466,28 @@ def test_start_select_surfaces_installed_state_compatibility(tmp_path: Path, cap
     )
 
 
-def test_report_release_recovery_section_exposes_payload_and_semver_recovery_routes(capsys) -> None:
+def test_report_release_recovery_section_exposes_payload_and_semver_recovery_routes(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
     repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(
+        cli,
+        "_release_recovery_live_state",
+        lambda **kwargs: {
+            "release_ci_failure": {
+                "kind": "agentic-workspace/release-ci-failure-summary/v1",
+                "status": "failed-release-run",
+                "workflow": "Release From Semver Label",
+                "run_url": "https://github.com/example/repo/actions/runs/1",
+                "failed_job": "release",
+                "failed_step": "Run proof",
+                "error_summary": ["ERROR release proof failed"],
+                "freshness": {"status": "active_failed_release"},
+            },
+            "release_publication_state": {
+                "status": "failed-release-unpublished",
+                "failed_run_url": "https://github.com/example/repo/actions/runs/1",
+            },
+        },
+    )
 
     assert (
         cli.main(
@@ -1489,6 +1509,9 @@ def test_report_release_recovery_section_exposes_payload_and_semver_recovery_rou
     assert recovery["kind"] == "agentic-workspace/release-recovery/v1"
     assert recovery["release_model"] == "coordinated-workspace"
     assert recovery["semver_release_action"]["status"] == "not-fetched"
+    assert recovery["release_ci_failure"]["status"] == "failed-release-run"
+    assert recovery["release_ci_failure"]["failed_step"] == "Run proof"
+    assert recovery["release_publication_state"]["status"] == "failed-release-unpublished"
     assert "release_recovery_status.py" in recovery["semver_release_action"]["command"]
     assert "repair_route" in recovery["payload_drift"]
     assert "required_version_paths" in recovery["coordinated_recovery"]["pr_shape"]

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1466,6 +1466,34 @@ def test_start_select_surfaces_installed_state_compatibility(tmp_path: Path, cap
     )
 
 
+def test_report_release_recovery_section_exposes_payload_and_semver_recovery_routes(capsys) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(repo_root),
+                "--section",
+                "release_recovery",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    recovery = payload["answer"]
+
+    assert recovery["kind"] == "agentic-workspace/release-recovery/v1"
+    assert recovery["release_model"] == "coordinated-workspace"
+    assert recovery["semver_release_action"]["status"] == "not-fetched"
+    assert "release_recovery_status.py" in recovery["semver_release_action"]["command"]
+    assert "repair_route" in recovery["payload_drift"]
+    assert "required_version_paths" in recovery["coordinated_recovery"]["pr_shape"]
+
+
 def test_start_surfaces_recovery_for_obsolete_default_preset(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     workspace = tmp_path / ".agentic-workspace"


### PR DESCRIPTION
## Summary
- Add a read-only release recovery packet helper for semver PR publishability, repair-only PRs, and failed release-run summaries.
- Add a lazy `report --section release_recovery` surface with payload drift dry-run/apply/waiver routes and coordinated recovery PR shape.
- Keep live GitHub log inspection outside ordinary startup/report output.

Fixes #1827
Fixes #1828
Fixes #1832

## Stack
- Base: #1836 (`codex/open-issue-intake-housekeeping`)

## Validation
- `uv run pytest tests/test_release_recovery_status.py tests/test_workspace_cli.py::test_report_release_recovery_section_exposes_payload_and_semver_recovery_routes tests/test_release_workflows.py -q`
- `uv run python scripts/run_agentic_workspace.py implement --changed scripts/github/release_recovery_status.py src/agentic_workspace/workspace_runtime_core.py src/agentic_workspace/workspace_runtime_primitives.py tests/test_release_recovery_status.py tests/test_workspace_cli.py --task "Implement release recovery lane for issues 1827 1828 1832" --format json`
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`