### PR TITLE
[codex] Surface continuation closeout attention

### DIFF
--- a/scripts/github/pr_comment_delta.py
+++ b/scripts/github/pr_comment_delta.py
@@ -147,6 +147,7 @@ def _normalize_graphql(payload: dict[str, Any]) -> dict[str, Any]:
         "repository": payload.get("repository") or payload.get("repo"),
         "pr_number": payload.get("pr_number") or payload.get("number"),
         "pr_url": pr.get("url") or payload.get("pr_url"),
+        "pr_head_sha": pr.get("headRefOid") or payload.get("pr_head_sha") or payload.get("head_sha"),
         "comments": comments if comments else payload.get("comments", []),
         "pagination": {
             "truncated": bool(truncated_surfaces),
@@ -275,6 +276,17 @@ def build_packet(payload: dict[str, Any], *, since: datetime | None = None, seen
         "repository": normalized.get("repository") or "",
         "pr_number": normalized.get("pr_number") or "",
         "pr_url": normalized.get("pr_url") or "",
+        "freshness": {
+            "observed_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "pr_head_sha": normalized.get("pr_head_sha") or "",
+            "status": "current_at_observed_head" if normalized.get("pr_head_sha") else "baseline_only",
+            "source": "gh-graphql-pr-head" if normalized.get("pr_head_sha") else "fixture-or-legacy-cache",
+            "readiness_claim_rule": (
+                "A no-actionable-comments result may support readiness only for the recorded PR head."
+                if normalized.get("pr_head_sha")
+                else "Refresh PR comments before readiness claims; this packet has no PR-head freshness proof."
+            ),
+        },
         "baseline": {
             "since": since.isoformat().replace("+00:00", "Z") if since else "",
             "seen_comment_url_count": len(seen_urls),
@@ -334,9 +346,10 @@ def _fetch_with_gh(*, repo: str, pr_number: int) -> dict[str, Any]:
     owner, name = repo.split("/", 1)
     query = """
 query($owner: String!, $name: String!, $number: Int!) {
-  repository(owner: $owner, name: $name) {
+    repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
       url
+      headRefOid
       comments(first: 100) {
         nodes { databaseId url body createdAt updatedAt author { login } }
         pageInfo { hasNextPage endCursor }

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -9704,6 +9704,18 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "before broad closeout when external issue, CI, scanner, or ticket evidence may be stale or divergent",
     },
     {
+        "section": "pr_comment_attention",
+        "kind": "agentic-workspace/pr-comment-attention/v1",
+        "purpose": "compact PR comment/review attention status from cached delta evidence or an explicit no-polling fallback",
+        "when_to_use": "during PR-oriented continuation, stacked PR work, or readiness closeout before claiming review comments are handled",
+    },
+    {
+        "section": "dogfooding_signal_status",
+        "kind": "agentic-workspace/dogfooding-signal-status/v1",
+        "purpose": "compact closeout status for package dogfooding signals: not checked, none found, routed, or dismissed",
+        "when_to_use": "for planned lanes, stacked PR sequences, release/recovery work, and non-trivial maintenance closeout",
+    },
+    {
         "section": "closeout_trust",
         "kind": "agentic-workspace/closeout-trust/v1",
         "purpose": "compact strict closeout gate, claim permission, proof, and residue routing posture",
@@ -11871,6 +11883,24 @@ def _run_lazy_report_section_command(
         )
         return _select_report_payload(payload, profile="router", section=normalized)
 
+    if normalized == "pr_comment_attention":
+        payload["pr_comment_attention"] = _pr_comment_attention_payload(
+            target_root=target_root,
+            task_text="PR-oriented report section requested",
+            cli_invoke=config.cli_invoke,
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "dogfooding_signal_status":
+        payload["dogfooding_signal_status"] = _dogfooding_signal_status_payload(
+            target_root=target_root,
+            config=config,
+            task_text="planned lane or maintenance report section requested",
+            cli_invoke=config.cli_invoke,
+            active_planning_present=bool(active_planning_record),
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
     if normalized == "architecture_principles":
         payload["architecture_principles"] = _architecture_principles_payload(
             target_root=target_root,
@@ -12373,6 +12403,14 @@ def _run_report_router_command(
             "run": next_command,
         }
     configuration_projection = _configuration_projection_payload(config=config)
+    pr_comment_attention = _pr_comment_attention_payload(target_root=target_root, task_text=None, cli_invoke=config.cli_invoke)
+    dogfooding_signal_status = _dogfooding_signal_status_payload(
+        target_root=target_root,
+        config=config,
+        task_text=None,
+        cli_invoke=config.cli_invoke,
+        active_planning_present=bool(active_planning_record),
+    )
     router_source = {
         "kind": "workspace-report/v1",
         "schema": _reporting_schema_payload(),
@@ -12408,6 +12446,14 @@ def _run_report_router_command(
         ),
         "authority_hierarchy": _authority_hierarchy_payload(cli_invoke=config.cli_invoke),
         "continuation_state": _compact_continuation_state_contract(cli_invoke=config.cli_invoke),
+        **(
+            {"pr_comment_attention": pr_comment_attention} if pr_comment_attention.get("status") not in {None, "", "not_applicable"} else {}
+        ),
+        **(
+            {"dogfooding_signal_status": dogfooding_signal_status}
+            if dogfooding_signal_status.get("status") not in {None, "", "not_applicable"}
+            else {}
+        ),
         "compliance_economics": _compliance_economics_payload(cli_invoke=config.cli_invoke),
         "final_report_budget": _final_report_budget_payload(),
         "improvement_intake": _improvement_intake_payload(target_root=target_root, config=config, repo_friction=None),
@@ -21386,6 +21432,8 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "durable_intent",
         "workflow_obligations",
         "closeout_obligations",
+        "pr_comment_attention",
+        "dogfooding_signal_status",
         "routine_work_context",
         "local_chat_checkpoint",
         "continuation_view",
@@ -21416,6 +21464,8 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "context.objective_drift",
         "context.reuse_pressure",
         "context.routine_work_context",
+        "context.pr_comment_attention",
+        "context.dogfooding_signal_status",
         "context.read_only_response",
         "context.detail_commands",
         "routing",
@@ -21690,6 +21740,233 @@ def _uv_cache_guidance_payload(*, cli_invoke: str) -> dict[str, Any]:
     }
 
 
+def _read_local_cache_json(target_root: Path, relative_path: str) -> dict[str, Any]:
+    path = target_root / relative_path
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"_cache_error": f"{relative_path} could not be read as JSON"}
+    return payload if isinstance(payload, dict) else {"_cache_error": f"{relative_path} did not contain a JSON object"}
+
+
+def _current_git_branch(target_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(target_root), "branch", "--show-current"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _github_repo_from_origin(target_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(target_root), "config", "--get", "remote.origin.url"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    remote = result.stdout.strip()
+    if not remote:
+        return ""
+    match = re.search(r"github\.com[:/](?P<repo>[^/\s]+/[^/\s]+?)(?:\.git)?$", remote)
+    return match.group("repo") if match else ""
+
+
+def _task_pr_number(task_text: str | None) -> str:
+    text = str(task_text or "")
+    patterns = (
+        r"(?:pull\s+request|pr)\s*#?\s*(\d+)",
+        r"github\.com/[^/\s]+/[^/\s]+/pull/(\d+)",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def _branch_pr_number(branch: str) -> str:
+    match = re.search(r"(?:^|[/_-])(?:pr|pull|pull-request)[/_-]?(\d+)(?:$|[/_-])", branch, flags=re.IGNORECASE)
+    return match.group(1) if match else ""
+
+
+def _pr_comment_attention_relevant(*, task_text: str | None, branch: str, cache: dict[str, Any]) -> bool:
+    task = str(task_text or "").lower()
+    if cache and "_cache_error" not in cache:
+        return True
+    if _task_pr_number(task_text) or _branch_pr_number(branch):
+        return True
+    if any(token in task for token in (" pull request", " pr ", "stacked pr", "review comment", "review thread")):
+        return True
+    return branch.startswith("codex/")
+
+
+def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
+    cache_path = ".agentic-workspace/local/cache/pr-comment-delta.json"
+    cache = _read_local_cache_json(target_root, cache_path)
+    branch = _current_git_branch(target_root)
+    repo = str(cache.get("repository") or _github_repo_from_origin(target_root) or "<owner/name>")
+    pr_number = str(cache.get("pr_number") or _task_pr_number(task_text) or _branch_pr_number(branch) or "")
+    if not _pr_comment_attention_relevant(task_text=task_text, branch=branch, cache=cache):
+        return {
+            "kind": "agentic-workspace/pr-comment-attention/v1",
+            "status": "not_applicable",
+            "reason": "No PR context detected; ordinary direct work does not scan GitHub comments.",
+        }
+    command = _command_with_cli_invoke(
+        command=f"python scripts/github/pr_comment_delta.py --repo {repo} --pr {pr_number or '<number>'} --format json",
+        cli_invoke=cli_invoke,
+    )
+    if cache.get("_cache_error"):
+        return {
+            "kind": "agentic-workspace/pr-comment-attention/v1",
+            "status": "pr_comment_status_unavailable",
+            "reason": str(cache["_cache_error"]),
+            "pr_number": pr_number,
+            "repository": repo,
+            "cache_path": cache_path,
+            "recommended_command": command,
+            "selector": "pr_comment_attention",
+        }
+    if cache:
+        counts = cache.get("category_counts", {}) if isinstance(cache.get("category_counts"), dict) else {}
+        actionable_categories = (
+            "actionable_code_doc_body_change",
+            "pr_metadata_body_only_change",
+            "ci_label_only_issue",
+            "ambiguous_needs_human",
+        )
+        actionable_count = sum(_as_int(counts.get(category)) for category in actionable_categories)
+        items = [item for item in _list_payload(cache.get("items")) if isinstance(item, dict)]
+        actionable_items = [item for item in items if str(item.get("category") or "") in actionable_categories]
+        status = "actionable_pr_comments_present" if actionable_count else "no_actionable_pr_comments_detected"
+        return {
+            "kind": "agentic-workspace/pr-comment-attention/v1",
+            "status": status,
+            "repository": repo,
+            "pr_number": str(cache.get("pr_number") or pr_number),
+            "pr_url": str(cache.get("pr_url") or ""),
+            "actionable_count": actionable_count,
+            "new_comment_count": _as_int(cache.get("new_comment_count")),
+            "category_counts": counts,
+            "sample": [
+                {
+                    key: item.get(key)
+                    for key in ("kind", "category", "path", "line", "url", "author", "created_at", "proof_hint")
+                    if item.get(key) not in (None, "")
+                }
+                for item in actionable_items[:3]
+            ],
+            "baseline": cache.get("baseline", {}) if isinstance(cache.get("baseline"), dict) else {},
+            "pagination": cache.get("pagination", {}) if isinstance(cache.get("pagination"), dict) else {},
+            "cache_path": cache_path,
+            "recommended_command": command,
+            "selector": "pr_comment_attention",
+            "claim_boundary": "Do not claim PR readiness while actionable PR comments are present unless they are addressed or explicitly deferred.",
+        }
+    return {
+        "kind": "agentic-workspace/pr-comment-attention/v1",
+        "status": "pr_comment_status_unavailable",
+        "reason": "PR context is relevant, but no cached PR comment delta was found and startup/report do not poll GitHub by default.",
+        "repository": repo,
+        "pr_number": pr_number,
+        "branch": branch,
+        "cache_path": cache_path,
+        "recommended_command": command,
+        "selector": "pr_comment_attention",
+        "degraded_explicitly": True,
+    }
+
+
+def _dogfooding_signal_relevant(
+    *, task_text: str | None, config: WorkspaceConfig, active_planning_present: bool = False, source_checkout: bool | None = None
+) -> bool:
+    task = str(task_text or "").lower()
+    if active_planning_present or config.maintainer_mode:
+        return True
+    if source_checkout is True and any(token in task for token in ("lane", "stack", "stacked", "release", "recovery", "closeout")):
+        return True
+    return any(token in task for token in ("dogfood", "dogfooding", "stacked pr", "release recovery", "planned lane"))
+
+
+def _dogfooding_signal_status_payload(
+    *,
+    target_root: Path,
+    config: WorkspaceConfig,
+    task_text: str | None,
+    cli_invoke: str,
+    active_planning_present: bool = False,
+) -> dict[str, Any]:
+    cache_path = ".agentic-workspace/local/cache/dogfooding-signal-status.json"
+    cache = _read_local_cache_json(target_root, cache_path)
+    source_checkout = _is_agentic_workspace_source_checkout(target_root)
+    if not cache and not _dogfooding_signal_relevant(
+        task_text=task_text,
+        config=config,
+        active_planning_present=active_planning_present,
+        source_checkout=source_checkout,
+    ):
+        return {
+            "kind": "agentic-workspace/dogfooding-signal-status/v1",
+            "status": "not_applicable",
+            "reason": "No planned lane, stacked PR, release/recovery, or maintainer dogfooding context detected.",
+        }
+    command = _command_with_cli_invoke(
+        command="agentic-workspace report --target ./repo --section improvement_intake --format json",
+        cli_invoke=cli_invoke,
+    )
+    allowed_statuses = {"not_checked", "no_signal_found", "signals_routed", "signals_dismissed_with_reason"}
+    if cache.get("_cache_error"):
+        status = "not_checked"
+        reason = str(cache["_cache_error"])
+        closeout_blocked = True
+    else:
+        raw_status = str(cache.get("status") or "").strip()
+        signals = [item for item in _list_payload(cache.get("signals")) if str(item).strip()]
+        destinations = [item for item in _list_payload(cache.get("destinations")) if str(item).strip()]
+        dismissal_reason = str(cache.get("dismissal_reason") or "").strip()
+        if raw_status in allowed_statuses:
+            status = raw_status
+        elif signals:
+            status = "not_checked"
+        else:
+            status = "not_checked"
+        reason = str(cache.get("reason") or "").strip()
+        closeout_blocked = bool(signals and not destinations and not dismissal_reason and status not in {"no_signal_found"})
+    payload = {
+        "kind": "agentic-workspace/dogfooding-signal-status/v1",
+        "status": status,
+        "applies_to_current_work": True,
+        "closeout_blocked": closeout_blocked,
+        "reason": reason or ("Dogfooding review has not been recorded for this maintenance shape." if status == "not_checked" else ""),
+        "destinations": [str(item) for item in _list_payload(cache.get("destinations")) if str(item).strip()][:5],
+        "dismissal_reason": str(cache.get("dismissal_reason") or ""),
+        "signal_count": len([item for item in _list_payload(cache.get("signals")) if str(item).strip()]),
+        "sample_signals": [str(item) for item in _list_payload(cache.get("signals")) if str(item).strip()][:3],
+        "cache_path": cache_path,
+        "detail_command": command,
+        "selector": "dogfooding_signal_status",
+        "allowed_statuses": sorted(allowed_statuses),
+        "claim_boundary": "A broad done claim is qualified until dogfooding signals are routed, dismissed with a reason, or recorded as no_signal_found.",
+    }
+    return {key: value for key, value in payload.items() if value not in ("", [], {})}
+
+
 def _start_tiny_payload_fast(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, config: WorkspaceConfig, startup_template: dict[str, Any]
 ) -> dict[str, Any]:
@@ -21834,6 +22111,18 @@ def _start_tiny_payload_fast(
         changed_paths=changed_paths,
         task_text=task_text,
     )
+    pr_comment_attention = _pr_comment_attention_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)
+    if pr_comment_attention.get("status") != "not_applicable":
+        payload["pr_comment_attention"] = pr_comment_attention
+    dogfooding_signal_status = _dogfooding_signal_status_payload(
+        target_root=target_root,
+        config=config,
+        task_text=task_text,
+        cli_invoke=config.cli_invoke,
+        active_planning_present=active_planning_present,
+    )
+    if dogfooding_signal_status.get("status") != "not_applicable":
+        payload["dogfooding_signal_status"] = dogfooding_signal_status
     if installed_state_compatibility["status"] != "compatible":
         payload["installed_state_compatibility"] = installed_state_compatibility
     sibling_freshness = _sibling_repo_aw_freshness_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -21855,6 +21855,26 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
         items = [item for item in _list_payload(cache.get("items")) if isinstance(item, dict)]
         actionable_items = [item for item in items if str(item.get("category") or "") in actionable_categories]
         status = "actionable_pr_comments_present" if actionable_count else "no_actionable_pr_comments_detected"
+        freshness = cache.get("freshness", {}) if isinstance(cache.get("freshness"), dict) else {}
+        cache_is_fresh = freshness.get("status") == "current_at_observed_head" and bool(str(freshness.get("pr_head_sha") or "").strip())
+        if actionable_count == 0 and not cache_is_fresh:
+            return {
+                "kind": "agentic-workspace/pr-comment-attention/v1",
+                "status": "pr_comment_status_unavailable",
+                "reason": "Cached PR comment delta has no PR-head freshness proof; refresh before readiness claims.",
+                "repository": repo,
+                "pr_number": str(cache.get("pr_number") or pr_number),
+                "cached_status": status,
+                "freshness": freshness
+                or {
+                    "status": "missing",
+                    "readiness_claim_rule": "Refresh PR comments before claiming there are no actionable comments.",
+                },
+                "cache_path": cache_path,
+                "recommended_command": command,
+                "selector": "pr_comment_attention",
+                "degraded_explicitly": True,
+            }
         return {
             "kind": "agentic-workspace/pr-comment-attention/v1",
             "status": status,
@@ -21873,6 +21893,7 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
                 for item in actionable_items[:3]
             ],
             "baseline": cache.get("baseline", {}) if isinstance(cache.get("baseline"), dict) else {},
+            "freshness": freshness,
             "pagination": cache.get("pagination", {}) if isinstance(cache.get("pagination"), dict) else {},
             "cache_path": cache_path,
             "recommended_command": command,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -9598,6 +9598,18 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "before broad closeout when external issue, CI, scanner, or ticket evidence may be stale or divergent",
     },
     {
+        "section": "pr_comment_attention",
+        "kind": "agentic-workspace/pr-comment-attention/v1",
+        "purpose": "compact PR comment/review attention status from cached delta evidence or an explicit no-polling fallback",
+        "when_to_use": "during PR-oriented continuation, stacked PR work, or readiness closeout before claiming review comments are handled",
+    },
+    {
+        "section": "dogfooding_signal_status",
+        "kind": "agentic-workspace/dogfooding-signal-status/v1",
+        "purpose": "compact closeout status for package dogfooding signals: not checked, none found, routed, or dismissed",
+        "when_to_use": "for planned lanes, stacked PR sequences, release/recovery work, and non-trivial maintenance closeout",
+    },
+    {
         "section": "closeout_trust",
         "kind": "agentic-workspace/closeout-trust/v1",
         "purpose": "compact strict closeout gate, claim permission, proof, and residue routing posture",
@@ -11765,6 +11777,24 @@ def _run_lazy_report_section_command(
         )
         return _select_report_payload(payload, profile="router", section=normalized)
 
+    if normalized == "pr_comment_attention":
+        payload["pr_comment_attention"] = _pr_comment_attention_payload(
+            target_root=target_root,
+            task_text="PR-oriented report section requested",
+            cli_invoke=config.cli_invoke,
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "dogfooding_signal_status":
+        payload["dogfooding_signal_status"] = _dogfooding_signal_status_payload(
+            target_root=target_root,
+            config=config,
+            task_text="planned lane or maintenance report section requested",
+            cli_invoke=config.cli_invoke,
+            active_planning_present=bool(active_planning_record),
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
     if normalized == "architecture_principles":
         payload["architecture_principles"] = _architecture_principles_payload(
             target_root=target_root,
@@ -12267,6 +12297,14 @@ def _run_report_router_command(
             "run": next_command,
         }
     configuration_projection = _configuration_projection_payload(config=config)
+    pr_comment_attention = _pr_comment_attention_payload(target_root=target_root, task_text=None, cli_invoke=config.cli_invoke)
+    dogfooding_signal_status = _dogfooding_signal_status_payload(
+        target_root=target_root,
+        config=config,
+        task_text=None,
+        cli_invoke=config.cli_invoke,
+        active_planning_present=bool(active_planning_record),
+    )
     router_source = {
         "kind": "workspace-report/v1",
         "schema": _reporting_schema_payload(),
@@ -12302,6 +12340,14 @@ def _run_report_router_command(
         ),
         "authority_hierarchy": _authority_hierarchy_payload(cli_invoke=config.cli_invoke),
         "continuation_state": _compact_continuation_state_contract(cli_invoke=config.cli_invoke),
+        **(
+            {"pr_comment_attention": pr_comment_attention} if pr_comment_attention.get("status") not in {None, "", "not_applicable"} else {}
+        ),
+        **(
+            {"dogfooding_signal_status": dogfooding_signal_status}
+            if dogfooding_signal_status.get("status") not in {None, "", "not_applicable"}
+            else {}
+        ),
         "compliance_economics": _compliance_economics_payload(cli_invoke=config.cli_invoke),
         "final_report_budget": _final_report_budget_payload(),
         "improvement_intake": _improvement_intake_payload(target_root=target_root, config=config, repo_friction=None),
@@ -21282,6 +21328,8 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "durable_intent",
         "workflow_obligations",
         "closeout_obligations",
+        "pr_comment_attention",
+        "dogfooding_signal_status",
         "routine_work_context",
         "local_chat_checkpoint",
         "continuation_view",
@@ -21312,6 +21360,8 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "context.objective_drift",
         "context.reuse_pressure",
         "context.routine_work_context",
+        "context.pr_comment_attention",
+        "context.dogfooding_signal_status",
         "context.read_only_response",
         "context.detail_commands",
         "routing",
@@ -21586,6 +21636,233 @@ def _uv_cache_guidance_payload(*, cli_invoke: str) -> dict[str, Any]:
     }
 
 
+def _read_local_cache_json(target_root: Path, relative_path: str) -> dict[str, Any]:
+    path = target_root / relative_path
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"_cache_error": f"{relative_path} could not be read as JSON"}
+    return payload if isinstance(payload, dict) else {"_cache_error": f"{relative_path} did not contain a JSON object"}
+
+
+def _current_git_branch(target_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(target_root), "branch", "--show-current"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _github_repo_from_origin(target_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(target_root), "config", "--get", "remote.origin.url"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    remote = result.stdout.strip()
+    if not remote:
+        return ""
+    match = re.search(r"github\.com[:/](?P<repo>[^/\s]+/[^/\s]+?)(?:\.git)?$", remote)
+    return match.group("repo") if match else ""
+
+
+def _task_pr_number(task_text: str | None) -> str:
+    text = str(task_text or "")
+    patterns = (
+        r"(?:pull\s+request|pr)\s*#?\s*(\d+)",
+        r"github\.com/[^/\s]+/[^/\s]+/pull/(\d+)",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def _branch_pr_number(branch: str) -> str:
+    match = re.search(r"(?:^|[/_-])(?:pr|pull|pull-request)[/_-]?(\d+)(?:$|[/_-])", branch, flags=re.IGNORECASE)
+    return match.group(1) if match else ""
+
+
+def _pr_comment_attention_relevant(*, task_text: str | None, branch: str, cache: dict[str, Any]) -> bool:
+    task = str(task_text or "").lower()
+    if cache and "_cache_error" not in cache:
+        return True
+    if _task_pr_number(task_text) or _branch_pr_number(branch):
+        return True
+    if any(token in task for token in (" pull request", " pr ", "stacked pr", "review comment", "review thread")):
+        return True
+    return branch.startswith("codex/")
+
+
+def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
+    cache_path = ".agentic-workspace/local/cache/pr-comment-delta.json"
+    cache = _read_local_cache_json(target_root, cache_path)
+    branch = _current_git_branch(target_root)
+    repo = str(cache.get("repository") or _github_repo_from_origin(target_root) or "<owner/name>")
+    pr_number = str(cache.get("pr_number") or _task_pr_number(task_text) or _branch_pr_number(branch) or "")
+    if not _pr_comment_attention_relevant(task_text=task_text, branch=branch, cache=cache):
+        return {
+            "kind": "agentic-workspace/pr-comment-attention/v1",
+            "status": "not_applicable",
+            "reason": "No PR context detected; ordinary direct work does not scan GitHub comments.",
+        }
+    command = _command_with_cli_invoke(
+        command=f"python scripts/github/pr_comment_delta.py --repo {repo} --pr {pr_number or '<number>'} --format json",
+        cli_invoke=cli_invoke,
+    )
+    if cache.get("_cache_error"):
+        return {
+            "kind": "agentic-workspace/pr-comment-attention/v1",
+            "status": "pr_comment_status_unavailable",
+            "reason": str(cache["_cache_error"]),
+            "pr_number": pr_number,
+            "repository": repo,
+            "cache_path": cache_path,
+            "recommended_command": command,
+            "selector": "pr_comment_attention",
+        }
+    if cache:
+        counts = cache.get("category_counts", {}) if isinstance(cache.get("category_counts"), dict) else {}
+        actionable_categories = (
+            "actionable_code_doc_body_change",
+            "pr_metadata_body_only_change",
+            "ci_label_only_issue",
+            "ambiguous_needs_human",
+        )
+        actionable_count = sum(_as_int(counts.get(category)) for category in actionable_categories)
+        items = [item for item in _list_payload(cache.get("items")) if isinstance(item, dict)]
+        actionable_items = [item for item in items if str(item.get("category") or "") in actionable_categories]
+        status = "actionable_pr_comments_present" if actionable_count else "no_actionable_pr_comments_detected"
+        return {
+            "kind": "agentic-workspace/pr-comment-attention/v1",
+            "status": status,
+            "repository": repo,
+            "pr_number": str(cache.get("pr_number") or pr_number),
+            "pr_url": str(cache.get("pr_url") or ""),
+            "actionable_count": actionable_count,
+            "new_comment_count": _as_int(cache.get("new_comment_count")),
+            "category_counts": counts,
+            "sample": [
+                {
+                    key: item.get(key)
+                    for key in ("kind", "category", "path", "line", "url", "author", "created_at", "proof_hint")
+                    if item.get(key) not in (None, "")
+                }
+                for item in actionable_items[:3]
+            ],
+            "baseline": cache.get("baseline", {}) if isinstance(cache.get("baseline"), dict) else {},
+            "pagination": cache.get("pagination", {}) if isinstance(cache.get("pagination"), dict) else {},
+            "cache_path": cache_path,
+            "recommended_command": command,
+            "selector": "pr_comment_attention",
+            "claim_boundary": "Do not claim PR readiness while actionable PR comments are present unless they are addressed or explicitly deferred.",
+        }
+    return {
+        "kind": "agentic-workspace/pr-comment-attention/v1",
+        "status": "pr_comment_status_unavailable",
+        "reason": "PR context is relevant, but no cached PR comment delta was found and startup/report do not poll GitHub by default.",
+        "repository": repo,
+        "pr_number": pr_number,
+        "branch": branch,
+        "cache_path": cache_path,
+        "recommended_command": command,
+        "selector": "pr_comment_attention",
+        "degraded_explicitly": True,
+    }
+
+
+def _dogfooding_signal_relevant(
+    *, task_text: str | None, config: WorkspaceConfig, active_planning_present: bool = False, source_checkout: bool | None = None
+) -> bool:
+    task = str(task_text or "").lower()
+    if active_planning_present or config.maintainer_mode:
+        return True
+    if source_checkout is True and any(token in task for token in ("lane", "stack", "stacked", "release", "recovery", "closeout")):
+        return True
+    return any(token in task for token in ("dogfood", "dogfooding", "stacked pr", "release recovery", "planned lane"))
+
+
+def _dogfooding_signal_status_payload(
+    *,
+    target_root: Path,
+    config: WorkspaceConfig,
+    task_text: str | None,
+    cli_invoke: str,
+    active_planning_present: bool = False,
+) -> dict[str, Any]:
+    cache_path = ".agentic-workspace/local/cache/dogfooding-signal-status.json"
+    cache = _read_local_cache_json(target_root, cache_path)
+    source_checkout = _is_agentic_workspace_source_checkout(target_root)
+    if not cache and not _dogfooding_signal_relevant(
+        task_text=task_text,
+        config=config,
+        active_planning_present=active_planning_present,
+        source_checkout=source_checkout,
+    ):
+        return {
+            "kind": "agentic-workspace/dogfooding-signal-status/v1",
+            "status": "not_applicable",
+            "reason": "No planned lane, stacked PR, release/recovery, or maintainer dogfooding context detected.",
+        }
+    command = _command_with_cli_invoke(
+        command="agentic-workspace report --target ./repo --section improvement_intake --format json",
+        cli_invoke=cli_invoke,
+    )
+    allowed_statuses = {"not_checked", "no_signal_found", "signals_routed", "signals_dismissed_with_reason"}
+    if cache.get("_cache_error"):
+        status = "not_checked"
+        reason = str(cache["_cache_error"])
+        closeout_blocked = True
+    else:
+        raw_status = str(cache.get("status") or "").strip()
+        signals = [item for item in _list_payload(cache.get("signals")) if str(item).strip()]
+        destinations = [item for item in _list_payload(cache.get("destinations")) if str(item).strip()]
+        dismissal_reason = str(cache.get("dismissal_reason") or "").strip()
+        if raw_status in allowed_statuses:
+            status = raw_status
+        elif signals:
+            status = "not_checked"
+        else:
+            status = "not_checked"
+        reason = str(cache.get("reason") or "").strip()
+        closeout_blocked = bool(signals and not destinations and not dismissal_reason and status not in {"no_signal_found"})
+    payload = {
+        "kind": "agentic-workspace/dogfooding-signal-status/v1",
+        "status": status,
+        "applies_to_current_work": True,
+        "closeout_blocked": closeout_blocked,
+        "reason": reason or ("Dogfooding review has not been recorded for this maintenance shape." if status == "not_checked" else ""),
+        "destinations": [str(item) for item in _list_payload(cache.get("destinations")) if str(item).strip()][:5],
+        "dismissal_reason": str(cache.get("dismissal_reason") or ""),
+        "signal_count": len([item for item in _list_payload(cache.get("signals")) if str(item).strip()]),
+        "sample_signals": [str(item) for item in _list_payload(cache.get("signals")) if str(item).strip()][:3],
+        "cache_path": cache_path,
+        "detail_command": command,
+        "selector": "dogfooding_signal_status",
+        "allowed_statuses": sorted(allowed_statuses),
+        "claim_boundary": "A broad done claim is qualified until dogfooding signals are routed, dismissed with a reason, or recorded as no_signal_found.",
+    }
+    return {key: value for key, value in payload.items() if value not in ("", [], {})}
+
+
 def _start_tiny_payload_fast(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, config: WorkspaceConfig, startup_template: dict[str, Any]
 ) -> dict[str, Any]:
@@ -21721,6 +21998,18 @@ def _start_tiny_payload_fast(
         changed_paths=changed_paths,
         task_text=task_text,
     )
+    pr_comment_attention = _pr_comment_attention_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)
+    if pr_comment_attention.get("status") != "not_applicable":
+        payload["pr_comment_attention"] = pr_comment_attention
+    dogfooding_signal_status = _dogfooding_signal_status_payload(
+        target_root=target_root,
+        config=config,
+        task_text=task_text,
+        cli_invoke=config.cli_invoke,
+        active_planning_present=active_planning_present,
+    )
+    if dogfooding_signal_status.get("status") != "not_applicable":
+        payload["dogfooding_signal_status"] = dogfooding_signal_status
     if installed_state_compatibility["status"] != "compatible":
         payload["installed_state_compatibility"] = installed_state_compatibility
     sibling_freshness = _sibling_repo_aw_freshness_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -21751,6 +21751,26 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
         items = [item for item in _list_payload(cache.get("items")) if isinstance(item, dict)]
         actionable_items = [item for item in items if str(item.get("category") or "") in actionable_categories]
         status = "actionable_pr_comments_present" if actionable_count else "no_actionable_pr_comments_detected"
+        freshness = cache.get("freshness", {}) if isinstance(cache.get("freshness"), dict) else {}
+        cache_is_fresh = freshness.get("status") == "current_at_observed_head" and bool(str(freshness.get("pr_head_sha") or "").strip())
+        if actionable_count == 0 and not cache_is_fresh:
+            return {
+                "kind": "agentic-workspace/pr-comment-attention/v1",
+                "status": "pr_comment_status_unavailable",
+                "reason": "Cached PR comment delta has no PR-head freshness proof; refresh before readiness claims.",
+                "repository": repo,
+                "pr_number": str(cache.get("pr_number") or pr_number),
+                "cached_status": status,
+                "freshness": freshness
+                or {
+                    "status": "missing",
+                    "readiness_claim_rule": "Refresh PR comments before claiming there are no actionable comments.",
+                },
+                "cache_path": cache_path,
+                "recommended_command": command,
+                "selector": "pr_comment_attention",
+                "degraded_explicitly": True,
+            }
         return {
             "kind": "agentic-workspace/pr-comment-attention/v1",
             "status": status,
@@ -21769,6 +21789,7 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
                 for item in actionable_items[:3]
             ],
             "baseline": cache.get("baseline", {}) if isinstance(cache.get("baseline"), dict) else {},
+            "freshness": freshness,
             "pagination": cache.get("pagination", {}) if isinstance(cache.get("pagination"), dict) else {},
             "cache_path": cache_path,
             "recommended_command": command,

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -246,6 +246,12 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "delegation_decision": _compact_start_delegation_decision(payload.get("delegation_decision", {})),
         **({"task_path_references": payload["task_path_references"]} if isinstance(payload.get("task_path_references"), dict) else {}),
         **({"pre_test_evidence_guardrail": payload["pre_test_evidence_guardrail"]} if "pre_test_evidence_guardrail" in payload else {}),
+        **({"pr_comment_attention": payload["pr_comment_attention"]} if isinstance(payload.get("pr_comment_attention"), dict) else {}),
+        **(
+            {"dogfooding_signal_status": payload["dogfooding_signal_status"]}
+            if isinstance(payload.get("dogfooding_signal_status"), dict)
+            else {}
+        ),
         "skill_routing": {
             "status": skill_routing.get("status", "unknown") if isinstance(skill_routing, dict) else "unknown",
             "rule": "Use listed skills only when directly relevant; otherwise proceed from the next action.",
@@ -1237,6 +1243,39 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     task_path_references = payload.get("task_path_references", {})
     if isinstance(task_path_references, dict) and task_path_references.get("status") == "present":
         context["task_path_references"] = task_path_references
+    pr_comment_attention = payload.get("pr_comment_attention", {})
+    if isinstance(pr_comment_attention, dict) and pr_comment_attention.get("status") not in {None, "", "not_applicable"}:
+        context["pr_comment_attention"] = {
+            key: pr_comment_attention.get(key)
+            for key in (
+                "kind",
+                "status",
+                "repository",
+                "pr_number",
+                "actionable_count",
+                "new_comment_count",
+                "recommended_command",
+                "selector",
+                "degraded_explicitly",
+            )
+            if key in pr_comment_attention
+        }
+    dogfooding_signal_status = payload.get("dogfooding_signal_status", {})
+    if isinstance(dogfooding_signal_status, dict) and dogfooding_signal_status.get("status") not in {None, "", "not_applicable"}:
+        context["dogfooding_signal_status"] = {
+            key: dogfooding_signal_status.get(key)
+            for key in (
+                "kind",
+                "status",
+                "closeout_blocked",
+                "destinations",
+                "dismissal_reason",
+                "signal_count",
+                "detail_command",
+                "selector",
+            )
+            if key in dogfooding_signal_status
+        }
     uv_guidance = payload.get("uv_cache_guidance", {})
     if not (isinstance(uv_guidance, dict) and uv_guidance.get("status") == "available"):
         cli_invocation = payload.get("cli_invocation", {})
@@ -1306,6 +1345,10 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         startup_changed_signals.append("sibling_repo_aw_freshness=attention")
     if isinstance(pre_test_guardrail, dict) and pre_test_guardrail.get("status") == "advisory":
         startup_changed_signals.append("pre_test_evidence=advisory")
+    if isinstance(pr_comment_attention, dict) and pr_comment_attention.get("status") not in {None, "", "not_applicable"}:
+        startup_changed_signals.append(f"pr_comment_attention={pr_comment_attention.get('status')}")
+    if isinstance(dogfooding_signal_status, dict) and dogfooding_signal_status.get("status") not in {None, "", "not_applicable"}:
+        startup_changed_signals.append(f"dogfooding_signal_status={dogfooding_signal_status.get('status')}")
     startup_proof = payload.get("proof", {})
     startup_proof_commands = _tiny_required_proof_commands(startup_proof) if isinstance(startup_proof, dict) else []
     available_selectors = _available_selectors_for_payload(payload)
@@ -1327,6 +1370,10 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         advisory_selectors.append("local_chat_checkpoint")
     if isinstance(pre_test_guardrail, dict) and pre_test_guardrail.get("status") == "advisory":
         advisory_selectors.append("pre_test_evidence_guardrail")
+    if isinstance(pr_comment_attention, dict) and pr_comment_attention.get("status") not in {None, "", "not_applicable"}:
+        advisory_selectors.append("pr_comment_attention")
+    if isinstance(dogfooding_signal_status, dict) and dogfooding_signal_status.get("status") not in {None, "", "not_applicable"}:
+        advisory_selectors.append("dogfooding_signal_status")
     selected: dict[str, Any] = {
         "kind": payload["kind"],
         "target": ".",

--- a/tests/test_pr_comment_delta.py
+++ b/tests/test_pr_comment_delta.py
@@ -91,6 +91,8 @@ def test_pr_comment_delta_classifies_new_review_response_scope() -> None:
 
     assert packet["kind"] == "agentic-workspace/pr-comment-delta/v1"
     assert packet["new_comment_count"] == 5
+    assert packet["freshness"]["status"] == "baseline_only"
+    assert packet["freshness"]["readiness_claim_rule"].startswith("Refresh PR comments")
     assert packet["category_counts"]["pr_metadata_body_only_change"] == 1
     assert packet["category_counts"]["actionable_code_doc_body_change"] == 1
     assert packet["category_counts"]["ci_label_only_issue"] == 1
@@ -128,6 +130,7 @@ def test_pr_comment_delta_normalizes_graphql_review_threads() -> None:
             "repository": {
                 "pullRequest": {
                     "url": "https://github.com/rickardvh/agentic-workspace/pull/42",
+                    "headRefOid": "abc123",
                     "comments": {"nodes": []},
                     "reviews": {"nodes": []},
                     "reviewThreads": {
@@ -162,6 +165,8 @@ def test_pr_comment_delta_normalizes_graphql_review_threads() -> None:
     packet = module.build_packet(payload)
 
     assert packet["new_comment_count"] == 1
+    assert packet["freshness"]["status"] == "current_at_observed_head"
+    assert packet["freshness"]["pr_head_sha"] == "abc123"
     item = packet["items"][0]
     assert item["kind"] == "review_thread_comment"
     assert item["category"] == "actionable_code_doc_body_change"

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1593,6 +1593,8 @@ def test_report_pr_comment_attention_reads_cached_actionable_and_empty_deltas(tm
     assert actionable["actionable_count"] == 1
     assert actionable["sample"][0]["path"] == "src/app.py"
 
+    # Legacy empty caches are not enough to support readiness claims because they
+    # do not prove which PR head was observed.
     cache_path.write_text(
         json.dumps(
             {
@@ -1614,9 +1616,41 @@ def test_report_pr_comment_attention_reads_cached_actionable_and_empty_deltas(tm
     )
 
     assert cli.main(["report", "--target", str(tmp_path), "--section", "pr_comment_attention", "--format", "json"]) == 0
-    empty = json.loads(capsys.readouterr().out)["answer"]
-    assert empty["status"] == "no_actionable_pr_comments_detected"
-    assert empty["actionable_count"] == 0
+    stale_empty = json.loads(capsys.readouterr().out)["answer"]
+    assert stale_empty["status"] == "pr_comment_status_unavailable"
+    assert stale_empty["cached_status"] == "no_actionable_pr_comments_detected"
+    assert stale_empty["degraded_explicitly"] is True
+
+    cache_path.write_text(
+        json.dumps(
+            {
+                "kind": "agentic-workspace/pr-comment-delta/v1",
+                "repository": "rickardvh/agentic-workspace",
+                "pr_number": 1831,
+                "new_comment_count": 0,
+                "category_counts": {
+                    "actionable_code_doc_body_change": 0,
+                    "pr_metadata_body_only_change": 0,
+                    "ci_label_only_issue": 0,
+                    "ambiguous_needs_human": 0,
+                    "informational_no_local_change": 0,
+                },
+                "items": [],
+                "freshness": {
+                    "status": "current_at_observed_head",
+                    "pr_head_sha": "abc123",
+                    "observed_at": "2026-06-28T00:00:00Z",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "pr_comment_attention", "--format", "json"]) == 0
+    fresh_empty = json.loads(capsys.readouterr().out)["answer"]
+    assert fresh_empty["status"] == "no_actionable_pr_comments_detected"
+    assert fresh_empty["actionable_count"] == 0
+    assert fresh_empty["freshness"]["pr_head_sha"] == "abc123"
 
 
 def test_report_dogfooding_signal_status_covers_closeout_states(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1517,6 +1517,156 @@ def test_report_release_recovery_section_exposes_payload_and_semver_recovery_rou
     assert "required_version_paths" in recovery["coordinated_recovery"]["pr_shape"]
 
 
+def test_start_surfaces_pr_comment_attention_only_for_pr_context(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["start", "--target", str(tmp_path), "--task", "Fix one docs typo", "--format", "json"]) == 0
+    quiet_payload = json.loads(capsys.readouterr().out)
+    assert "pr_comment_attention" not in quiet_payload["context"]
+    assert "pr_comment_attention" not in quiet_payload["action_signals"]["advisory_detail"]["selectors"]
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue PR #1831 review fixes",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    attention = payload["context"]["pr_comment_attention"]
+    assert attention["status"] == "pr_comment_status_unavailable"
+    assert attention["pr_number"] == "1831"
+    assert "pr_comment_delta.py" in attention["recommended_command"]
+    assert "pr_comment_attention=pr_comment_status_unavailable" in payload["action_signals"]["changed_signals"]
+    assert "pr_comment_attention" in payload["action_signals"]["advisory_detail"]["selectors"]
+
+
+def test_report_pr_comment_attention_reads_cached_actionable_and_empty_deltas(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    cache_path = tmp_path / ".agentic-workspace" / "local" / "cache" / "pr-comment-delta.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "kind": "agentic-workspace/pr-comment-delta/v1",
+                "repository": "rickardvh/agentic-workspace",
+                "pr_number": 1831,
+                "pr_url": "https://github.com/rickardvh/agentic-workspace/pull/1831",
+                "new_comment_count": 1,
+                "category_counts": {
+                    "actionable_code_doc_body_change": 1,
+                    "pr_metadata_body_only_change": 0,
+                    "ci_label_only_issue": 0,
+                    "ambiguous_needs_human": 0,
+                    "informational_no_local_change": 0,
+                },
+                "items": [
+                    {
+                        "kind": "review_thread_comment",
+                        "category": "actionable_code_doc_body_change",
+                        "path": "src/app.py",
+                        "line": 12,
+                        "url": "https://example.test/pr#thread",
+                        "proof_hint": "Run focused tests.",
+                    }
+                ],
+                "baseline": {"since": "2026-06-28T00:00:00Z"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "pr_comment_attention", "--format", "json"]) == 0
+    actionable = json.loads(capsys.readouterr().out)["answer"]
+    assert actionable["status"] == "actionable_pr_comments_present"
+    assert actionable["actionable_count"] == 1
+    assert actionable["sample"][0]["path"] == "src/app.py"
+
+    cache_path.write_text(
+        json.dumps(
+            {
+                "kind": "agentic-workspace/pr-comment-delta/v1",
+                "repository": "rickardvh/agentic-workspace",
+                "pr_number": 1831,
+                "new_comment_count": 0,
+                "category_counts": {
+                    "actionable_code_doc_body_change": 0,
+                    "pr_metadata_body_only_change": 0,
+                    "ci_label_only_issue": 0,
+                    "ambiguous_needs_human": 0,
+                    "informational_no_local_change": 0,
+                },
+                "items": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "pr_comment_attention", "--format", "json"]) == 0
+    empty = json.loads(capsys.readouterr().out)["answer"]
+    assert empty["status"] == "no_actionable_pr_comments_detected"
+    assert empty["actionable_count"] == 0
+
+
+def test_report_dogfooding_signal_status_covers_closeout_states(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    cache_path = tmp_path / ".agentic-workspace" / "local" / "cache" / "dogfooding-signal-status.json"
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
+    not_checked = json.loads(capsys.readouterr().out)["answer"]
+    assert not_checked["status"] == "not_checked"
+    assert not_checked["closeout_blocked"] is False
+
+    cache_path.write_text(json.dumps({"status": "no_signal_found", "reason": "reviewed; no durable signal"}), encoding="utf-8")
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
+    no_signal = json.loads(capsys.readouterr().out)["answer"]
+    assert no_signal["status"] == "no_signal_found"
+
+    cache_path.write_text(
+        json.dumps({"status": "signals_routed", "signals": ["startup missed PR comments"], "destinations": ["#1831"]}),
+        encoding="utf-8",
+    )
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
+    routed = json.loads(capsys.readouterr().out)["answer"]
+    assert routed["status"] == "signals_routed"
+    assert routed["destinations"] == ["#1831"]
+    assert routed["closeout_blocked"] is False
+
+    cache_path.write_text(
+        json.dumps(
+            {
+                "status": "signals_dismissed_with_reason",
+                "signals": ["one-off shell typo"],
+                "dismissal_reason": "operator typo, not product friction",
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
+    dismissed = json.loads(capsys.readouterr().out)["answer"]
+    assert dismissed["status"] == "signals_dismissed_with_reason"
+    assert dismissed["dismissal_reason"] == "operator typo, not product friction"
+
+    cache_path.write_text(json.dumps({"signals": ["unrouted friction"]}), encoding="utf-8")
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
+    blocked = json.loads(capsys.readouterr().out)["answer"]
+    assert blocked["status"] == "not_checked"
+    assert blocked["closeout_blocked"] is True
+
+
 def test_start_surfaces_recovery_for_obsolete_default_preset(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     workspace = tmp_path / ".agentic-workspace"


### PR DESCRIPTION
## Summary
- add compact PR comment attention status for PR-oriented startup/report flows
- add dogfooding signal closeout status with not checked, no signal, routed, dismissed, and unrouted-blocked states
- keep both surfaces selector-backed so unrelated direct work does not pay a broad comment/dogfooding scan cost

Fixes #1829
Fixes #1831

## Proof
- make test-workspace
- make lint-workspace
- uv run pytest tests/test_workspace_cli.py -q
- uv run pytest tests/test_pr_comment_delta.py -q