### PR TITLE
[codex] Keep low-risk startup output selector-first

### DIFF
--- a/docs/reviews/selector-first-output-policy-2026-06-28.md
+++ b/docs/reviews/selector-first-output-policy-2026-06-28.md
@@ -1,0 +1,28 @@
+# Selector-First Output Policy
+
+Date: 2026-06-28
+
+This note records the visibility rule used for low-risk direct work after the long-thread dogfooding review. The goal is lower successful-completion cost: the first packet should let an agent choose the next safe action without scanning bulky context, while hard gates and claim boundaries remain visible.
+
+## Always First Packet
+
+- `next_safe_action` and `action_signals`: hard blockers, allowed next action, proof requirement, and compact changed signals.
+- Scope facts: changed paths or the likely work surface.
+- Required proof summary: narrow proof commands and missing-proof closeout state.
+- Blocking compatibility, stale proof, payload drift, or safety-critical claim boundaries.
+
+## Selector-Only by Default
+
+- `local_chat_checkpoint` when it is present but unrelated to the current low-risk task.
+- `routine_work_context`, broad candidate-route detail, compatibility detail, and generated-surface detail when they are non-blocking.
+- `pr_comment_attention` when no PR context is detected.
+- Full `dogfooding_signal_status` detail when no planned lane, stacked PR, release/recovery, or maintainer-dogfooding context is active.
+
+## Escalates Into First Packet
+
+- `local_chat_checkpoint` when stale, unreadable, explicitly resumed, or carrying matched planning candidate routes.
+- `pr_comment_attention` when the task or branch is PR-oriented, or a cached PR comment delta is present.
+- `dogfooding_signal_status` for planned lanes, stacked PR sequences, release/recovery work, or maintainer-mode dogfooding.
+- Any selector-only surface that becomes a hard blocker or required-before-claim boundary.
+
+This policy is a routing rule, not a deletion rule. Detailed packets remain available through `--select` or `report --section`.

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import json
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -226,7 +227,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         **(
             {"local_chat_checkpoint": payload["local_chat_checkpoint"]}
             if isinstance(payload.get("local_chat_checkpoint"), dict)
-            and payload["local_chat_checkpoint"].get("status") in {"present", "stale", "unreadable"}
+            and _local_chat_checkpoint_default_visible(payload["local_chat_checkpoint"], payload=payload)
             else {}
         ),
         "memory_decision_packet": payload.get("memory_decision_packet", {}),
@@ -436,6 +437,20 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         agent_judgment="Agent owns work-shape choice unless hard_blockers names a gate.",
     )
     return projected
+
+
+def _local_chat_checkpoint_default_visible(local_checkpoint: dict[str, Any], *, payload: dict[str, Any]) -> bool:
+    status = str(local_checkpoint.get("status") or "").strip()
+    if status in {"stale", "unreadable"}:
+        return True
+    if status != "present":
+        return False
+    routes = local_checkpoint.get("planning_candidate_routes", {})
+    if isinstance(routes, dict) and routes.get("status") == "matched":
+        return True
+    task_intent = payload.get("task_intent", {})
+    task_text = json.dumps(task_intent, sort_keys=True).lower() if isinstance(task_intent, dict) else ""
+    return any(token in task_text for token in ("resume", "checkpoint", "continue", "handoff", "takeover"))
 
 
 def _start_payload(
@@ -1189,7 +1204,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         "memory": payload.get("memory_consult", {}),
     }
     local_checkpoint = payload.get("local_chat_checkpoint", {})
-    if isinstance(local_checkpoint, dict) and local_checkpoint.get("status") in {"present", "stale", "unreadable"}:
+    if isinstance(local_checkpoint, dict) and _local_chat_checkpoint_default_visible(local_checkpoint, payload=payload):
         context["local_chat_checkpoint"] = {
             key: local_checkpoint.get(key)
             for key in (
@@ -1352,6 +1367,12 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     startup_proof = payload.get("proof", {})
     startup_proof_commands = _tiny_required_proof_commands(startup_proof) if isinstance(startup_proof, dict) else []
     available_selectors = _available_selectors_for_payload(payload)
+    if (
+        target_root is not None
+        and "local_chat_checkpoint" not in available_selectors
+        and (target_root / ".agentic-workspace" / "local" / "chat-checkpoint.json").is_file()
+    ):
+        available_selectors.append("local_chat_checkpoint")
     if "read_only_response" in payload and "acceptance" not in available_selectors:
         insert_at = (
             available_selectors.index("durable_intent_promotion")

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -692,6 +692,97 @@ def test_start_default_stays_under_tiny_output_budget_for_docs_task(tmp_path: Pa
     assert "workflow_sufficiency" in payload["drill_down"]["available_selectors"]
 
 
+def test_start_low_risk_docs_task_keeps_checkpoint_detail_selector_only(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    assert (
+        cli.main(
+            [
+                "checkpoint",
+                "write",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #1700 checkpoint slice",
+                "--issue",
+                "#1700",
+                "--durable-source",
+                "docs/reference/local-chat-checkpoints.md",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert cli.main(["start", "--target", str(tmp_path), "--task", "Fix one docs typo", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    _assert_json_payload_under(payload, 10_000, label="start tiny docs-task payload with checkpoint", sort_keys=False)
+    assert "local_chat_checkpoint" not in payload["context"]
+    assert "local_chat_checkpoint=present" not in payload["action_signals"]["changed_signals"]
+    assert "local_chat_checkpoint" not in payload["action_signals"]["advisory_detail"]["selectors"]
+    assert "local_chat_checkpoint" in payload["drill_down"]["available_selectors"]
+
+    assert cli.main(["start", "--target", str(tmp_path), "--task", "Resume checkpoint slice", "--format", "json"]) == 0
+    resume_payload = json.loads(capsys.readouterr().out)
+    assert resume_payload["context"]["local_chat_checkpoint"]["status"] == "present"
+
+
+def test_selector_first_output_policy_note_documents_visibility_tiers() -> None:
+    note = Path("docs/reviews/selector-first-output-policy-2026-06-28.md").read_text(encoding="utf-8")
+    assert "Always First Packet" in note
+    assert "Selector-Only by Default" in note
+    assert "Escalates Into First Packet" in note
+    assert "local_chat_checkpoint" in note
+    assert "dogfooding_signal_status" in note
+    assert "pr_comment_attention" in note
+
+
+def test_start_keeps_planned_and_release_closeout_signals_visible(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue planned lane in stacked PR sequence",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    planned = json.loads(capsys.readouterr().out)
+    assert planned["context"]["dogfooding_signal_status"]["status"] == "not_checked"
+    assert "dogfooding_signal_status=not_checked" in planned["action_signals"]["changed_signals"]
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Diagnose release recovery after failed semver release",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    release = json.loads(capsys.readouterr().out)
+    assert release["context"]["dogfooding_signal_status"]["status"] == "not_checked"
+    assert "dogfooding_signal_status" in release["action_signals"]["advisory_detail"]["selectors"]
+
+
 def test_start_treats_named_path_question_as_conceptual_reference(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0


### PR DESCRIPTION
## Summary
- keep present local checkpoint detail behind selectors for unrelated low-risk startup tasks
- keep resume/stale/matched checkpoint cases visible when they affect orientation
- add selector-first output policy note and regression coverage for low-risk, planned/stacked, and release/recovery startup shapes

Fixes #1833

## Proof
- make test-workspace
- make lint-workspace
- make maintainer-surfaces
- uv run pytest tests/test_workspace_cli.py -q