### PR TITLE
Implement dogfooding follow-up surfaces

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -9710,6 +9710,18 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "during PR-oriented continuation, stacked PR work, or readiness closeout before claiming review comments are handled",
     },
     {
+        "section": "proof_reuse_guidance",
+        "kind": "agentic-workspace/proof-reuse-guidance/v1",
+        "purpose": "conservative proof reuse, focused-rerun, or rerun-required guidance from compact proof receipts",
+        "when_to_use": "after stacked PR rebases or continuation when prior proof may or may not still support a closeout claim",
+    },
+    {
+        "section": "runtime_mirror_consistency",
+        "kind": "agentic-workspace/runtime-mirror-surface-consistency/v1",
+        "purpose": "focused consistency proof for known mirrored AW runtime report/helper surfaces",
+        "when_to_use": "when changing core or runtime/primitives report helpers, selectors, or packet shapes",
+    },
+    {
         "section": "dogfooding_signal_status",
         "kind": "agentic-workspace/dogfooding-signal-status/v1",
         "purpose": "compact closeout status for package dogfooding signals: not checked, none found, routed, or dismissed",
@@ -11887,6 +11899,17 @@ def _run_lazy_report_section_command(
         payload["pr_comment_attention"] = _pr_comment_attention_payload(
             target_root=target_root,
             task_text="PR-oriented report section requested",
+            cli_invoke=config.cli_invoke,
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "proof_reuse_guidance":
+        payload["proof_reuse_guidance"] = _proof_reuse_guidance_payload(target_root=target_root, cli_invoke=config.cli_invoke)
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "runtime_mirror_consistency":
+        payload["runtime_mirror_consistency"] = _runtime_mirror_surface_consistency_payload(
+            target_root=target_root,
             cli_invoke=config.cli_invoke,
         )
         return _select_report_payload(payload, profile="router", section=normalized)
@@ -21082,6 +21105,7 @@ _START_TINY_ONLY_SELECTORS = {
     "delegation_decision",
     "durable_intent",
     "immediate_next_allowed_action",
+    "installed_state_drift_triage",
     "issue_reference_intent",
     "open_issue_intake",
     "intent_custody",
@@ -21432,6 +21456,7 @@ def _available_selectors_for_payload(payload: dict[str, Any]) -> list[str]:
         "durable_intent",
         "workflow_obligations",
         "closeout_obligations",
+        "installed_state_drift_triage",
         "pr_comment_attention",
         "dogfooding_signal_status",
         "routine_work_context",
@@ -21805,6 +21830,186 @@ def _branch_pr_number(branch: str) -> str:
     return match.group(1) if match else ""
 
 
+def _read_only_meta_task(task_text: str | None) -> bool:
+    task = " ".join(str(task_text or "").lower().split())
+    if not task:
+        return False
+    meta_terms = (
+        "dogfooding report",
+        "dogfood report",
+        "retrospective",
+        "status report",
+        "status check",
+        "summarize",
+        "summary",
+        "review current",
+        "read-only",
+        "meta analysis",
+        "operating behavior",
+        "issue review",
+        "pr review",
+        "release state",
+        "in-chat report",
+    )
+    if any(term in task for term in meta_terms):
+        return True
+    return bool(re.search(r"\b(?:what|why|how|which|do|does|did|are|is)\b", task)) and not any(
+        term in task for term in ("implement", "fix", "edit", "change", "add", "remove", "create pr")
+    )
+
+
+def _installed_state_drift_triage_payload(
+    *, installed_state: dict[str, Any], task_text: str | None, changed_paths: Sequence[str], cli_invoke: str
+) -> dict[str, Any]:
+    status = str(installed_state.get("status") or "compatible")
+    action_effect = installed_state.get("action_effect", {}) if isinstance(installed_state.get("action_effect"), dict) else {}
+    force = str(action_effect.get("force") or "advisory")
+    task = " ".join(str(task_text or "").lower().split())
+    freshness_terms = (
+        "installed state",
+        "payload freshness",
+        "payload fresh",
+        "payload drift",
+        "upgrade",
+        "release",
+        "version",
+        "semver",
+        "generated surface",
+        "generated artifact",
+        "adapter compatibility",
+        "source checkout parity",
+    )
+    claim_relevant = bool(changed_paths) or any(term in task for term in freshness_terms)
+    if status == "compatible":
+        triage = "not_applicable"
+    elif force == "required_before_execution":
+        triage = "claim_blocking"
+    elif claim_relevant:
+        triage = "actionable_now"
+    elif _read_only_meta_task(task_text):
+        triage = "background_advisory"
+    else:
+        triage = "waived_for_narrow_work"
+    resolution_command = str(action_effect.get("resolution_command") or "")
+    if resolution_command:
+        resolution_command = _command_with_cli_invoke(command=resolution_command, cli_invoke=cli_invoke)
+    return {
+        "kind": "agentic-workspace/installed-state-drift-triage/v1",
+        "status": triage,
+        "installed_state_status": status,
+        "force": force,
+        "claim_relevant": claim_relevant,
+        "repair_command": resolution_command,
+        "selector": "installed_state_compatibility",
+        "claim_boundary": action_effect.get(
+            "claim_boundary",
+            "source behavior may be validated, but installed payload freshness remains unproven until drift is reconciled.",
+        ),
+        "detail_visibility": "expanded installed-state diagnostics stay behind installed_state_compatibility unless drift blocks the current claim",
+    }
+
+
+def _compact_installed_state_drift_triage(triage: Any) -> dict[str, Any]:
+    if not isinstance(triage, dict):
+        return {}
+    return {
+        key: triage.get(key)
+        for key in (
+            "kind",
+            "status",
+            "installed_state_status",
+            "force",
+            "claim_relevant",
+            "repair_command",
+            "selector",
+            "claim_boundary",
+            "detail_visibility",
+        )
+        if key in triage and triage.get(key) not in (None, "", [], {})
+    }
+
+
+def _pr_stack_comment_cache_payload(*, target_root: Path, repo: str, branch: str, cli_invoke: str) -> dict[str, Any]:
+    cache_path = ".agentic-workspace/local/cache/pr-comment-stack.json"
+    cache = _read_local_cache_json(target_root, cache_path)
+    if not cache:
+        return {}
+    command_repo = str(cache.get("repository") or repo)
+    if cache.get("_cache_error"):
+        return {
+            "kind": "agentic-workspace/pr-stack-comment-attention/v1",
+            "status": "stack_comment_status_unavailable",
+            "reason": str(cache["_cache_error"]),
+            "repository": command_repo,
+            "branch": branch,
+            "cache_path": cache_path,
+            "degraded_because": "unreadable-cache",
+        }
+    raw_members = [item for item in _list_payload(cache.get("stack_members")) if isinstance(item, dict)]
+    if not raw_members:
+        return {}
+    members: list[dict[str, Any]] = []
+    actionable_present = False
+    unavailable_present = False
+    for item in raw_members:
+        pr_number = str(item.get("pr_number") or "").strip()
+        member_cache = item.get("delta", {}) if isinstance(item.get("delta"), dict) else item
+        counts = member_cache.get("category_counts", {}) if isinstance(member_cache.get("category_counts"), dict) else {}
+        actionable_count = sum(
+            _as_int(counts.get(category))
+            for category in (
+                "actionable_code_doc_body_change",
+                "pr_metadata_body_only_change",
+                "ci_label_only_issue",
+                "ambiguous_needs_human",
+            )
+        )
+        freshness = member_cache.get("freshness", {}) if isinstance(member_cache.get("freshness"), dict) else {}
+        fresh = freshness.get("status") == "current_at_observed_head" and bool(str(freshness.get("pr_head_sha") or "").strip())
+        comment_status = str(item.get("status") or member_cache.get("status") or "")
+        if actionable_count:
+            comment_status = "actionable_pr_comments_present"
+            actionable_present = True
+        elif fresh:
+            comment_status = "no_actionable_pr_comments_detected"
+        else:
+            comment_status = "pr_comment_status_unavailable"
+            unavailable_present = True
+        refresh_command = _command_with_cli_invoke(
+            command=f"python scripts/github/pr_comment_delta.py --repo {command_repo} --pr {pr_number or '<number>'} --format json",
+            cli_invoke=cli_invoke,
+        )
+        members.append(
+            {
+                "pr_number": pr_number,
+                "branch": str(item.get("branch") or item.get("head_ref") or ""),
+                "head_sha": str(item.get("head_sha") or freshness.get("pr_head_sha") or ""),
+                "comment_status": comment_status,
+                "freshness": freshness or {"status": "missing"},
+                "actionable_count": actionable_count,
+                "refresh_command": refresh_command,
+            }
+        )
+    status = (
+        "actionable_stack_comments_present"
+        if actionable_present
+        else "stack_comment_status_unavailable"
+        if unavailable_present
+        else "stack_comments_current"
+    )
+    return {
+        "kind": "agentic-workspace/pr-stack-comment-attention/v1",
+        "status": status,
+        "repository": command_repo,
+        "branch": branch,
+        "stack_member_count": len(members),
+        "stack_members": members,
+        "cache_path": cache_path,
+        "claim_boundary": "A broad stack-ready claim is blocked while any stack member has actionable, stale, or unavailable comment status.",
+        "degraded_because": "stale-or-missing-member-freshness" if unavailable_present else "",
+    }
+
+
 def _pr_comment_attention_relevant(*, task_text: str | None, branch: str, cache: dict[str, Any]) -> bool:
     task = str(task_text or "").lower()
     if cache and "_cache_error" not in cache:
@@ -21822,11 +22027,32 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
     branch = _current_git_branch(target_root)
     repo = str(cache.get("repository") or _github_repo_from_origin(target_root) or "<owner/name>")
     pr_number = str(cache.get("pr_number") or _task_pr_number(task_text) or _branch_pr_number(branch) or "")
+    stack = _pr_stack_comment_cache_payload(target_root=target_root, repo=repo, branch=branch, cli_invoke=cli_invoke)
     if not _pr_comment_attention_relevant(task_text=task_text, branch=branch, cache=cache):
         return {
             "kind": "agentic-workspace/pr-comment-attention/v1",
             "status": "not_applicable",
             "reason": "No PR context detected; ordinary direct work does not scan GitHub comments.",
+        }
+    if stack:
+        status = str(stack.get("status") or "stack_comment_status_unavailable")
+        return {
+            "kind": "agentic-workspace/pr-comment-attention/v1",
+            "status": status,
+            "repository": repo,
+            "pr_number": pr_number,
+            "branch": branch,
+            "stack": stack,
+            "stack_member_count": stack.get("stack_member_count", 0),
+            "recommended_command": str(stack.get("stack_members", [{}])[0].get("refresh_command", ""))
+            if isinstance(stack.get("stack_members"), list) and stack.get("stack_members")
+            else _command_with_cli_invoke(
+                command=f"python scripts/github/pr_comment_delta.py --repo {repo} --pr {pr_number or '<number>'} --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "selector": "pr_comment_attention",
+            "degraded_explicitly": status == "stack_comment_status_unavailable",
+            "claim_boundary": stack.get("claim_boundary"),
         }
     command = _command_with_cli_invoke(
         command=f"python scripts/github/pr_comment_delta.py --repo {repo} --pr {pr_number or '<number>'} --format json",
@@ -21988,6 +22214,232 @@ def _dogfooding_signal_status_payload(
     return {key: value for key, value in payload.items() if value not in ("", [], {})}
 
 
+def _file_sha256(path: Path) -> str:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return ""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _proof_reuse_guidance_payload(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
+    receipt_path = target_root / ".agentic-workspace" / "local" / "cache" / "proof-reuse.json"
+    relative_path = ".agentic-workspace/local/cache/proof-reuse.json"
+    detail_command = _command_with_cli_invoke(
+        command="agentic-workspace report --target ./repo --section proof_reuse_guidance --format json",
+        cli_invoke=cli_invoke,
+    )
+    if not receipt_path.is_file():
+        return {
+            "kind": "agentic-workspace/proof-reuse-guidance/v1",
+            "status": "reuse_unknown",
+            "reason": "No compact proof reuse receipt is available.",
+            "cache_path": relative_path,
+            "proof_groups": [],
+            "recommended_next_action": "Run current changed-path proof selection and validation.",
+            "detail_command": detail_command,
+            "rule": "Missing, stale, or ambiguous proof metadata degrades to rerun guidance.",
+        }
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "kind": "agentic-workspace/proof-reuse-guidance/v1",
+            "status": "rerun_required",
+            "reason": f"Compact proof reuse receipt is unreadable: {exc}",
+            "cache_path": relative_path,
+            "proof_groups": [],
+            "recommended_next_action": "Rerun required proof before any completion claim.",
+            "detail_command": detail_command,
+        }
+    if not isinstance(receipt, dict):
+        return {
+            "kind": "agentic-workspace/proof-reuse-guidance/v1",
+            "status": "rerun_required",
+            "reason": "Compact proof reuse receipt is not a JSON object.",
+            "cache_path": relative_path,
+            "proof_groups": [],
+            "recommended_next_action": "Rerun required proof before any completion claim.",
+            "detail_command": detail_command,
+        }
+    path_fingerprints = receipt.get("path_fingerprints", {}) if isinstance(receipt.get("path_fingerprints"), dict) else {}
+    changed_paths = [str(item) for item in _list_payload(receipt.get("changed_paths")) if str(item).strip()]
+    missing_paths: list[str] = []
+    changed_fingerprints: list[str] = []
+    for relative in changed_paths:
+        path = target_root / relative
+        current_hash = _file_sha256(path)
+        expected_hash = str(path_fingerprints.get(relative) or "")
+        if not current_hash:
+            missing_paths.append(relative)
+        elif expected_hash and current_hash != expected_hash:
+            changed_fingerprints.append(relative)
+        elif not expected_hash:
+            changed_fingerprints.append(relative)
+    proof_groups: list[dict[str, Any]] = []
+    raw_groups = receipt.get("proof_groups", []) if isinstance(receipt.get("proof_groups"), list) else []
+    for raw in raw_groups:
+        if not isinstance(raw, dict):
+            continue
+        command = str(raw.get("command") or raw.get("proof_command") or "").strip()
+        prior_status = str(raw.get("status") or "passed").strip()
+        if missing_paths or changed_fingerprints:
+            classification = "rerun_required"
+            rationale = "changed proof input fingerprints"
+        elif prior_status not in {"passed", "success", "ok"}:
+            classification = "rerun_required"
+            rationale = "prior proof did not pass"
+        elif not command:
+            classification = "reuse_unknown"
+            rationale = "proof command identity missing"
+        else:
+            classification = "reuse_safe_with_evidence"
+            rationale = "changed path fingerprints match the compact proof receipt"
+        proof_groups.append(
+            {
+                "command": command,
+                "classification": classification,
+                "evidence": {
+                    "prior_head": receipt.get("prior_head") or receipt.get("head"),
+                    "prior_base": receipt.get("prior_base") or receipt.get("base"),
+                    "changed_paths": changed_paths,
+                    "fingerprint_count": len(path_fingerprints),
+                },
+                "rationale": rationale,
+            }
+        )
+    if missing_paths or changed_fingerprints:
+        status = "rerun_required"
+        recommended = "Rerun proof for changed or missing proof inputs."
+    elif proof_groups and all(group["classification"] == "reuse_safe_with_evidence" for group in proof_groups):
+        status = "reuse_safe_with_evidence"
+        recommended = "Focused proof may reuse the named prior proof groups; record the reuse rationale in closeout."
+    elif proof_groups:
+        status = "focused_rerun_required"
+        recommended = "Rerun only proof groups without reuse evidence."
+    else:
+        status = "reuse_unknown"
+        recommended = "Run current changed-path proof selection and validation."
+    return {
+        "kind": "agentic-workspace/proof-reuse-guidance/v1",
+        "status": status,
+        "cache_path": relative_path,
+        "observed_changed_paths": changed_paths,
+        "missing_paths": missing_paths,
+        "changed_fingerprints": changed_fingerprints,
+        "proof_groups": proof_groups,
+        "recommended_next_action": recommended,
+        "detail_command": detail_command,
+        "rule": "This is claim-safety guidance, not a test-skipping feature; unknown evidence requires rerun.",
+    }
+
+
+def _function_dict_return_keys(tree: ast.AST, function_name: str) -> set[str]:
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or node.name != function_name:
+            continue
+        keys: set[str] = set()
+        for child in ast.walk(node):
+            if isinstance(child, ast.Dict):
+                for key in child.keys:
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                        keys.add(key.value)
+        return keys
+    return set()
+
+
+def _parse_python_module(path: Path) -> ast.AST | None:
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return None
+
+
+def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
+    core_path = target_root / "src" / "agentic_workspace" / "workspace_runtime_core.py"
+    primitive_path = target_root / "src" / "agentic_workspace" / "workspace_runtime_primitives.py"
+    relative_core = "src/agentic_workspace/workspace_runtime_core.py"
+    relative_primitives = "src/agentic_workspace/workspace_runtime_primitives.py"
+    surfaces = [
+        {
+            "mirrored_surface": "pr_comment_attention",
+            "function": "_pr_comment_attention_payload",
+            "packet_kind": "agentic-workspace/pr-comment-attention/v1",
+        },
+        {
+            "mirrored_surface": "dogfooding_signal_status",
+            "function": "_dogfooding_signal_status_payload",
+            "packet_kind": "agentic-workspace/dogfooding-signal-status/v1",
+        },
+        {
+            "mirrored_surface": "installed_state_drift_triage",
+            "function": "_installed_state_drift_triage_payload",
+            "packet_kind": "agentic-workspace/installed-state-drift-triage/v1",
+        },
+        {
+            "mirrored_surface": "proof_reuse_guidance",
+            "function": "_proof_reuse_guidance_payload",
+            "packet_kind": "agentic-workspace/proof-reuse-guidance/v1",
+        },
+        {
+            "mirrored_surface": "runtime_mirror_consistency",
+            "function": "_runtime_mirror_surface_consistency_payload",
+            "packet_kind": "agentic-workspace/runtime-mirror-surface-consistency/v1",
+        },
+    ]
+    core_tree = _parse_python_module(core_path)
+    primitive_tree = _parse_python_module(primitive_path)
+    records: list[dict[str, Any]] = []
+    for surface in surfaces:
+        function = str(surface["function"])
+        if core_tree is None or primitive_tree is None:
+            status = "not_applicable"
+            reason = "core or runtime primitives module could not be parsed"
+            core_keys: set[str] = set()
+            primitive_keys: set[str] = set()
+        else:
+            core_keys = _function_dict_return_keys(core_tree, function)
+            primitive_keys = _function_dict_return_keys(primitive_tree, function)
+            if not core_keys and not primitive_keys:
+                status = "not_applicable"
+                reason = "surface is not mirrored in either module"
+            elif not core_keys or not primitive_keys:
+                status = "mirror_missing"
+                reason = "surface exists in only one mirrored runtime module"
+            elif core_keys != primitive_keys:
+                status = "shape_mismatch"
+                reason = "mirrored helper return-key shape differs"
+            else:
+                status = "in_sync"
+                reason = "mirrored helper return-key shape matches"
+        records.append(
+            {
+                **surface,
+                "status": status,
+                "core_owner": relative_core,
+                "runtime_mirror_owner": relative_primitives,
+                "core_keys": sorted(core_keys),
+                "runtime_mirror_keys": sorted(primitive_keys),
+                "reason": reason,
+            }
+        )
+    failing = [record for record in records if record["status"] in {"mirror_missing", "shape_mismatch"}]
+    return {
+        "kind": "agentic-workspace/runtime-mirror-surface-consistency/v1",
+        "status": "in_sync" if not failing else "shape_mismatch",
+        "mirrored_surface_count": len(records),
+        "records": records,
+        "recommended_next_action": "Mirror the missing helper/packet shape or document that the surface is intentionally core-only."
+        if failing
+        else "No mirror repair needed for known AW runtime report surfaces.",
+        "proof_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section runtime_mirror_consistency --format json",
+            cli_invoke=cli_invoke,
+        ),
+        "rule": "Compare the smallest durable mirrored contract: known helper existence and public packet return-key shape.",
+    }
+
+
 def _start_tiny_payload_fast(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, config: WorkspaceConfig, startup_template: dict[str, Any]
 ) -> dict[str, Any]:
@@ -22146,6 +22598,12 @@ def _start_tiny_payload_fast(
         payload["dogfooding_signal_status"] = dogfooding_signal_status
     if installed_state_compatibility["status"] != "compatible":
         payload["installed_state_compatibility"] = installed_state_compatibility
+        payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
+            installed_state=installed_state_compatibility,
+            task_text=task_text,
+            changed_paths=changed_paths,
+            cli_invoke=config.cli_invoke,
+        )
     sibling_freshness = _sibling_repo_aw_freshness_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)
     if sibling_freshness["status"] != "not-referenced":
         payload["sibling_repo_aw_freshness"] = sibling_freshness
@@ -24002,6 +24460,18 @@ def _read_only_response_posture_payload(*, task_text: str | None, changed_paths:
             "status": "not-applicable",
             "reason": "changed paths are present, so implementation/proof guidance remains the default",
             "compact_default": False,
+        }
+    if _read_only_meta_task(task):
+        return {
+            "kind": "agentic-workspace/read-only-response-posture/v1",
+            "status": "read-only-reporting",
+            "reason": "task text matches report, status, review, or meta-analysis posture without changed paths",
+            "compact_default": True,
+            "matched_read_only_signals": ["report/meta task shape"],
+            "matched_mutation_signals": [],
+            "default_projection": "selector-first-reporting",
+            "detail_selector": "acceptance",
+            "rule": "Report/meta/read-only task shapes get compact first packets while hard gates and claim boundaries remain visible.",
         }
     return {
         "kind": "agentic-workspace/read-only-response-posture/v1",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -21853,9 +21853,36 @@ def _read_only_meta_task(task_text: str | None) -> bool:
     )
     if any(term in task for term in meta_terms):
         return True
-    return bool(re.search(r"\b(?:what|why|how|which|do|does|did|are|is)\b", task)) and not any(
-        term in task for term in ("implement", "fix", "edit", "change", "add", "remove", "create pr")
+    return False
+
+
+def _installed_state_drift_relevant_changed_paths(changed_paths: Sequence[str]) -> list[str]:
+    exact = {
+        ".agentic-workspace/config.toml",
+        ".agentic-workspace/payload-provenance.json",
+        "pyproject.toml",
+        "uv.lock",
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/workspace_runtime_startup.py",
+    }
+    prefixes = (
+        "generated/",
+        "scripts/generate/",
+        "scripts/release/",
+        "src/agentic_workspace/contracts/",
     )
+    suffixes = (
+        "/pyproject.toml",
+        "/package.json",
+        "/package-lock.json",
+        "/pnpm-lock.yaml",
+    )
+    relevant: list[str] = []
+    for path in _normalize_changed_paths(changed_paths):
+        if path in exact or path.startswith(prefixes) or path.endswith(suffixes):
+            relevant.append(path)
+    return relevant
 
 
 def _installed_state_drift_triage_payload(
@@ -21879,7 +21906,8 @@ def _installed_state_drift_triage_payload(
         "adapter compatibility",
         "source checkout parity",
     )
-    claim_relevant = bool(changed_paths) or any(term in task for term in freshness_terms)
+    claim_relevant_paths = _installed_state_drift_relevant_changed_paths(changed_paths)
+    claim_relevant = bool(claim_relevant_paths) or any(term in task for term in freshness_terms)
     if status == "compatible":
         triage = "not_applicable"
     elif force == "required_before_execution":
@@ -21899,6 +21927,7 @@ def _installed_state_drift_triage_payload(
         "installed_state_status": status,
         "force": force,
         "claim_relevant": claim_relevant,
+        "claim_relevant_paths": claim_relevant_paths,
         "repair_command": resolution_command,
         "selector": "installed_state_compatibility",
         "claim_boundary": action_effect.get(
@@ -21920,6 +21949,7 @@ def _compact_installed_state_drift_triage(triage: Any) -> dict[str, Any]:
             "installed_state_status",
             "force",
             "claim_relevant",
+            "claim_relevant_paths",
             "repair_command",
             "selector",
             "claim_boundary",
@@ -22021,6 +22051,40 @@ def _pr_comment_attention_relevant(*, task_text: str | None, branch: str, cache:
     return branch.startswith("codex/")
 
 
+def _pr_stack_comment_context_relevant(*, task_text: str | None, branch: str) -> bool:
+    task = str(task_text or "").lower()
+    if any(token in task for token in ("stack", "stacked", "stacked pr", "stacked pull request")):
+        return True
+    return any(token in branch.lower() for token in ("stack", "stacked"))
+
+
+def _pr_stack_comment_unavailable_payload(*, repo: str, branch: str, pr_number: str, cli_invoke: str) -> dict[str, Any]:
+    cache_path = ".agentic-workspace/local/cache/pr-comment-stack.json"
+    recommended_command = _command_with_cli_invoke(
+        command=f"python scripts/github/pr_comment_delta.py --repo {repo} --pr {pr_number or '<number>'} --format json",
+        cli_invoke=cli_invoke,
+    )
+    return {
+        "kind": "agentic-workspace/pr-stack-comment-attention/v1",
+        "status": "stack_comment_status_unavailable",
+        "repository": repo,
+        "branch": branch,
+        "stack_member_count": 0,
+        "stack_members": [],
+        "cache_path": cache_path,
+        "stack_discovery": {
+            "status": "unavailable",
+            "degraded_because": "missing-stack-cache-or-branch-pr-metadata",
+            "branch": branch,
+            "repository": repo,
+            "cache_path": cache_path,
+            "refresh_command": recommended_command,
+        },
+        "claim_boundary": "A broad stack-ready claim is blocked until stack members are discovered or the stack scope is explicitly narrowed.",
+        "degraded_because": "missing-stack-discovery-evidence",
+    }
+
+
 def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
     cache_path = ".agentic-workspace/local/cache/pr-comment-delta.json"
     cache = _read_local_cache_json(target_root, cache_path)
@@ -22034,6 +22098,8 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
             "status": "not_applicable",
             "reason": "No PR context detected; ordinary direct work does not scan GitHub comments.",
         }
+    if not stack and _pr_stack_comment_context_relevant(task_text=task_text, branch=branch):
+        stack = _pr_stack_comment_unavailable_payload(repo=repo, branch=branch, pr_number=pr_number, cli_invoke=cli_invoke)
     if stack:
         status = str(stack.get("status") or "stack_comment_status_unavailable")
         return {
@@ -22043,6 +22109,7 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
             "pr_number": pr_number,
             "branch": branch,
             "stack": stack,
+            "stack_discovery": stack.get("stack_discovery", {}),
             "stack_member_count": stack.get("stack_member_count", 0),
             "recommended_command": str(stack.get("stack_members", [{}])[0].get("refresh_command", ""))
             if isinstance(stack.get("stack_members"), list) and stack.get("stack_members")
@@ -22264,6 +22331,35 @@ def _proof_reuse_guidance_payload(*, target_root: Path, cli_invoke: str) -> dict
         }
     path_fingerprints = receipt.get("path_fingerprints", {}) if isinstance(receipt.get("path_fingerprints"), dict) else {}
     changed_paths = [str(item) for item in _list_payload(receipt.get("changed_paths")) if str(item).strip()]
+    parent_proof_reference = str(receipt.get("parent_proof_reference") or receipt.get("parent_proof_ref") or "").strip()
+    proof_selection_identity = str(
+        receipt.get("proof_selection_identity")
+        or receipt.get("proof_selection_fingerprint")
+        or receipt.get("selected_proof_fingerprint")
+        or ""
+    ).strip()
+    dependency_config_state = str(
+        receipt.get("dependency_config_state")
+        or receipt.get("dependency_config_fingerprint")
+        or receipt.get("dependency_fingerprint")
+        or receipt.get("config_fingerprint")
+        or ""
+    ).strip()
+    generated_surface_freshness = receipt.get("generated_surface_freshness")
+    generated_surface_status = (
+        str(generated_surface_freshness.get("status") or "").strip()
+        if isinstance(generated_surface_freshness, dict)
+        else str(generated_surface_freshness or "").strip()
+    )
+    missing_reuse_evidence: list[str] = []
+    if not parent_proof_reference:
+        missing_reuse_evidence.append("parent_proof_reference")
+    if not proof_selection_identity:
+        missing_reuse_evidence.append("proof_selection_identity")
+    if not dependency_config_state:
+        missing_reuse_evidence.append("dependency_config_state")
+    if generated_surface_status not in {"current", "fresh", "verified", "not_applicable"}:
+        missing_reuse_evidence.append("generated_surface_freshness")
     missing_paths: list[str] = []
     changed_fingerprints: list[str] = []
     for relative in changed_paths:
@@ -22282,26 +22378,38 @@ def _proof_reuse_guidance_payload(*, target_root: Path, cli_invoke: str) -> dict
         if not isinstance(raw, dict):
             continue
         command = str(raw.get("command") or raw.get("proof_command") or "").strip()
+        command_identity = str(
+            raw.get("command_identity") or raw.get("command_fingerprint") or raw.get("command_digest") or raw.get("command_sha256") or ""
+        ).strip()
         prior_status = str(raw.get("status") or "passed").strip()
+        group_missing_evidence = list(missing_reuse_evidence)
+        if not command_identity:
+            group_missing_evidence.append("command_identity")
         if missing_paths or changed_fingerprints:
             classification = "rerun_required"
             rationale = "changed proof input fingerprints"
         elif prior_status not in {"passed", "success", "ok"}:
             classification = "rerun_required"
             rationale = "prior proof did not pass"
-        elif not command:
+        elif not command or group_missing_evidence:
             classification = "reuse_unknown"
-            rationale = "proof command identity missing"
+            rationale = "explicit proof identity or gate-input evidence missing"
         else:
             classification = "reuse_safe_with_evidence"
-            rationale = "changed path fingerprints match the compact proof receipt"
+            rationale = "proof identity, gate inputs, command identity, generated freshness, and changed path fingerprints match"
         proof_groups.append(
             {
                 "command": command,
                 "classification": classification,
+                "missing_reuse_evidence": group_missing_evidence,
                 "evidence": {
                     "prior_head": receipt.get("prior_head") or receipt.get("head"),
                     "prior_base": receipt.get("prior_base") or receipt.get("base"),
+                    "parent_proof_reference": parent_proof_reference,
+                    "proof_selection_identity": proof_selection_identity,
+                    "dependency_config_state": dependency_config_state,
+                    "generated_surface_freshness": generated_surface_status,
+                    "command_identity": command_identity,
                     "changed_paths": changed_paths,
                     "fingerprint_count": len(path_fingerprints),
                 },
@@ -22314,6 +22422,9 @@ def _proof_reuse_guidance_payload(*, target_root: Path, cli_invoke: str) -> dict
     elif proof_groups and all(group["classification"] == "reuse_safe_with_evidence" for group in proof_groups):
         status = "reuse_safe_with_evidence"
         recommended = "Focused proof may reuse the named prior proof groups; record the reuse rationale in closeout."
+    elif proof_groups and all(group["classification"] == "reuse_unknown" for group in proof_groups):
+        status = "reuse_unknown"
+        recommended = "Run current changed-path proof selection; cached proof lacks explicit reuse evidence."
     elif proof_groups:
         status = "focused_rerun_required"
         recommended = "Rerun only proof groups without reuse evidence."
@@ -22327,6 +22438,7 @@ def _proof_reuse_guidance_payload(*, target_root: Path, cli_invoke: str) -> dict
         "observed_changed_paths": changed_paths,
         "missing_paths": missing_paths,
         "changed_fingerprints": changed_fingerprints,
+        "missing_reuse_evidence": missing_reuse_evidence,
         "proof_groups": proof_groups,
         "recommended_next_action": recommended,
         "detail_command": detail_command,
@@ -35829,6 +35941,29 @@ def _changed_paths_matching_contract_path_match(*, changed_paths: list[str], pat
 
 def _supplemental_proof_lanes_for_changed_paths(*, changed_paths: list[str]) -> list[dict[str, Any]]:
     supplemental_lanes: list[dict[str, Any]] = []
+    runtime_mirror_paths = [
+        path
+        for path in changed_paths
+        if path
+        in {
+            "src/agentic_workspace/workspace_runtime_core.py",
+            "src/agentic_workspace/workspace_runtime_primitives.py",
+        }
+    ]
+    if runtime_mirror_paths:
+        supplemental_lanes.append(
+            {
+                "id": "runtime_mirror_consistency",
+                "when": "changed path edits mirrored runtime packet surfaces",
+                "enough_proof": [
+                    "uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json"
+                ],
+                "recovery_signal": "runtime mirror mismatches should block closeout until core and primitives expose the same packet shape",
+                "proof_kind": "targeted-static-check",
+                "proof_responsibility": "local-closeout",
+                "matched_paths": runtime_mirror_paths,
+            }
+        )
     for raw_lane in _PROOF_SELECTION_RULES.get("supplemental_lanes", []):
         if not isinstance(raw_lane, dict):
             continue

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -35941,29 +35941,6 @@ def _changed_paths_matching_contract_path_match(*, changed_paths: list[str], pat
 
 def _supplemental_proof_lanes_for_changed_paths(*, changed_paths: list[str]) -> list[dict[str, Any]]:
     supplemental_lanes: list[dict[str, Any]] = []
-    runtime_mirror_paths = [
-        path
-        for path in changed_paths
-        if path
-        in {
-            "src/agentic_workspace/workspace_runtime_core.py",
-            "src/agentic_workspace/workspace_runtime_primitives.py",
-        }
-    ]
-    if runtime_mirror_paths:
-        supplemental_lanes.append(
-            {
-                "id": "runtime_mirror_consistency",
-                "when": "changed path edits mirrored runtime packet surfaces",
-                "enough_proof": [
-                    "uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json"
-                ],
-                "recovery_signal": "runtime mirror mismatches should block closeout until core and primitives expose the same packet shape",
-                "proof_kind": "targeted-static-check",
-                "proof_responsibility": "local-closeout",
-                "matched_paths": runtime_mirror_paths,
-            }
-        )
     for raw_lane in _PROOF_SELECTION_RULES.get("supplemental_lanes", []):
         if not isinstance(raw_lane, dict):
             continue

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -9604,6 +9604,18 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "during PR-oriented continuation, stacked PR work, or readiness closeout before claiming review comments are handled",
     },
     {
+        "section": "proof_reuse_guidance",
+        "kind": "agentic-workspace/proof-reuse-guidance/v1",
+        "purpose": "conservative proof reuse, focused-rerun, or rerun-required guidance from compact proof receipts",
+        "when_to_use": "after stacked PR rebases or continuation when prior proof may or may not still support a closeout claim",
+    },
+    {
+        "section": "runtime_mirror_consistency",
+        "kind": "agentic-workspace/runtime-mirror-surface-consistency/v1",
+        "purpose": "focused consistency proof for known mirrored AW runtime report/helper surfaces",
+        "when_to_use": "when changing core or runtime/primitives report helpers, selectors, or packet shapes",
+    },
+    {
         "section": "dogfooding_signal_status",
         "kind": "agentic-workspace/dogfooding-signal-status/v1",
         "purpose": "compact closeout status for package dogfooding signals: not checked, none found, routed, or dismissed",
@@ -11781,6 +11793,17 @@ def _run_lazy_report_section_command(
         payload["pr_comment_attention"] = _pr_comment_attention_payload(
             target_root=target_root,
             task_text="PR-oriented report section requested",
+            cli_invoke=config.cli_invoke,
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "proof_reuse_guidance":
+        payload["proof_reuse_guidance"] = _proof_reuse_guidance_payload(target_root=target_root, cli_invoke=config.cli_invoke)
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "runtime_mirror_consistency":
+        payload["runtime_mirror_consistency"] = _runtime_mirror_surface_consistency_payload(
+            target_root=target_root,
             cli_invoke=config.cli_invoke,
         )
         return _select_report_payload(payload, profile="router", section=normalized)
@@ -21701,6 +21724,186 @@ def _branch_pr_number(branch: str) -> str:
     return match.group(1) if match else ""
 
 
+def _read_only_meta_task(task_text: str | None) -> bool:
+    task = " ".join(str(task_text or "").lower().split())
+    if not task:
+        return False
+    meta_terms = (
+        "dogfooding report",
+        "dogfood report",
+        "retrospective",
+        "status report",
+        "status check",
+        "summarize",
+        "summary",
+        "review current",
+        "read-only",
+        "meta analysis",
+        "operating behavior",
+        "issue review",
+        "pr review",
+        "release state",
+        "in-chat report",
+    )
+    if any(term in task for term in meta_terms):
+        return True
+    return bool(re.search(r"\b(?:what|why|how|which|do|does|did|are|is)\b", task)) and not any(
+        term in task for term in ("implement", "fix", "edit", "change", "add", "remove", "create pr")
+    )
+
+
+def _installed_state_drift_triage_payload(
+    *, installed_state: dict[str, Any], task_text: str | None, changed_paths: Sequence[str], cli_invoke: str
+) -> dict[str, Any]:
+    status = str(installed_state.get("status") or "compatible")
+    action_effect = installed_state.get("action_effect", {}) if isinstance(installed_state.get("action_effect"), dict) else {}
+    force = str(action_effect.get("force") or "advisory")
+    task = " ".join(str(task_text or "").lower().split())
+    freshness_terms = (
+        "installed state",
+        "payload freshness",
+        "payload fresh",
+        "payload drift",
+        "upgrade",
+        "release",
+        "version",
+        "semver",
+        "generated surface",
+        "generated artifact",
+        "adapter compatibility",
+        "source checkout parity",
+    )
+    claim_relevant = bool(changed_paths) or any(term in task for term in freshness_terms)
+    if status == "compatible":
+        triage = "not_applicable"
+    elif force == "required_before_execution":
+        triage = "claim_blocking"
+    elif claim_relevant:
+        triage = "actionable_now"
+    elif _read_only_meta_task(task_text):
+        triage = "background_advisory"
+    else:
+        triage = "waived_for_narrow_work"
+    resolution_command = str(action_effect.get("resolution_command") or "")
+    if resolution_command:
+        resolution_command = _command_with_cli_invoke(command=resolution_command, cli_invoke=cli_invoke)
+    return {
+        "kind": "agentic-workspace/installed-state-drift-triage/v1",
+        "status": triage,
+        "installed_state_status": status,
+        "force": force,
+        "claim_relevant": claim_relevant,
+        "repair_command": resolution_command,
+        "selector": "installed_state_compatibility",
+        "claim_boundary": action_effect.get(
+            "claim_boundary",
+            "source behavior may be validated, but installed payload freshness remains unproven until drift is reconciled.",
+        ),
+        "detail_visibility": "expanded installed-state diagnostics stay behind installed_state_compatibility unless drift blocks the current claim",
+    }
+
+
+def _compact_installed_state_drift_triage(triage: Any) -> dict[str, Any]:
+    if not isinstance(triage, dict):
+        return {}
+    return {
+        key: triage.get(key)
+        for key in (
+            "kind",
+            "status",
+            "installed_state_status",
+            "force",
+            "claim_relevant",
+            "repair_command",
+            "selector",
+            "claim_boundary",
+            "detail_visibility",
+        )
+        if key in triage and triage.get(key) not in (None, "", [], {})
+    }
+
+
+def _pr_stack_comment_cache_payload(*, target_root: Path, repo: str, branch: str, cli_invoke: str) -> dict[str, Any]:
+    cache_path = ".agentic-workspace/local/cache/pr-comment-stack.json"
+    cache = _read_local_cache_json(target_root, cache_path)
+    if not cache:
+        return {}
+    command_repo = str(cache.get("repository") or repo)
+    if cache.get("_cache_error"):
+        return {
+            "kind": "agentic-workspace/pr-stack-comment-attention/v1",
+            "status": "stack_comment_status_unavailable",
+            "reason": str(cache["_cache_error"]),
+            "repository": command_repo,
+            "branch": branch,
+            "cache_path": cache_path,
+            "degraded_because": "unreadable-cache",
+        }
+    raw_members = [item for item in _list_payload(cache.get("stack_members")) if isinstance(item, dict)]
+    if not raw_members:
+        return {}
+    members: list[dict[str, Any]] = []
+    actionable_present = False
+    unavailable_present = False
+    for item in raw_members:
+        pr_number = str(item.get("pr_number") or "").strip()
+        member_cache = item.get("delta", {}) if isinstance(item.get("delta"), dict) else item
+        counts = member_cache.get("category_counts", {}) if isinstance(member_cache.get("category_counts"), dict) else {}
+        actionable_count = sum(
+            _as_int(counts.get(category))
+            for category in (
+                "actionable_code_doc_body_change",
+                "pr_metadata_body_only_change",
+                "ci_label_only_issue",
+                "ambiguous_needs_human",
+            )
+        )
+        freshness = member_cache.get("freshness", {}) if isinstance(member_cache.get("freshness"), dict) else {}
+        fresh = freshness.get("status") == "current_at_observed_head" and bool(str(freshness.get("pr_head_sha") or "").strip())
+        comment_status = str(item.get("status") or member_cache.get("status") or "")
+        if actionable_count:
+            comment_status = "actionable_pr_comments_present"
+            actionable_present = True
+        elif fresh:
+            comment_status = "no_actionable_pr_comments_detected"
+        else:
+            comment_status = "pr_comment_status_unavailable"
+            unavailable_present = True
+        refresh_command = _command_with_cli_invoke(
+            command=f"python scripts/github/pr_comment_delta.py --repo {command_repo} --pr {pr_number or '<number>'} --format json",
+            cli_invoke=cli_invoke,
+        )
+        members.append(
+            {
+                "pr_number": pr_number,
+                "branch": str(item.get("branch") or item.get("head_ref") or ""),
+                "head_sha": str(item.get("head_sha") or freshness.get("pr_head_sha") or ""),
+                "comment_status": comment_status,
+                "freshness": freshness or {"status": "missing"},
+                "actionable_count": actionable_count,
+                "refresh_command": refresh_command,
+            }
+        )
+    status = (
+        "actionable_stack_comments_present"
+        if actionable_present
+        else "stack_comment_status_unavailable"
+        if unavailable_present
+        else "stack_comments_current"
+    )
+    return {
+        "kind": "agentic-workspace/pr-stack-comment-attention/v1",
+        "status": status,
+        "repository": command_repo,
+        "branch": branch,
+        "stack_member_count": len(members),
+        "stack_members": members,
+        "cache_path": cache_path,
+        "claim_boundary": "A broad stack-ready claim is blocked while any stack member has actionable, stale, or unavailable comment status.",
+        "degraded_because": "stale-or-missing-member-freshness" if unavailable_present else "",
+    }
+
+
 def _pr_comment_attention_relevant(*, task_text: str | None, branch: str, cache: dict[str, Any]) -> bool:
     task = str(task_text or "").lower()
     if cache and "_cache_error" not in cache:
@@ -21718,11 +21921,32 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
     branch = _current_git_branch(target_root)
     repo = str(cache.get("repository") or _github_repo_from_origin(target_root) or "<owner/name>")
     pr_number = str(cache.get("pr_number") or _task_pr_number(task_text) or _branch_pr_number(branch) or "")
+    stack = _pr_stack_comment_cache_payload(target_root=target_root, repo=repo, branch=branch, cli_invoke=cli_invoke)
     if not _pr_comment_attention_relevant(task_text=task_text, branch=branch, cache=cache):
         return {
             "kind": "agentic-workspace/pr-comment-attention/v1",
             "status": "not_applicable",
             "reason": "No PR context detected; ordinary direct work does not scan GitHub comments.",
+        }
+    if stack:
+        status = str(stack.get("status") or "stack_comment_status_unavailable")
+        return {
+            "kind": "agentic-workspace/pr-comment-attention/v1",
+            "status": status,
+            "repository": repo,
+            "pr_number": pr_number,
+            "branch": branch,
+            "stack": stack,
+            "stack_member_count": stack.get("stack_member_count", 0),
+            "recommended_command": str(stack.get("stack_members", [{}])[0].get("refresh_command", ""))
+            if isinstance(stack.get("stack_members"), list) and stack.get("stack_members")
+            else _command_with_cli_invoke(
+                command=f"python scripts/github/pr_comment_delta.py --repo {repo} --pr {pr_number or '<number>'} --format json",
+                cli_invoke=cli_invoke,
+            ),
+            "selector": "pr_comment_attention",
+            "degraded_explicitly": status == "stack_comment_status_unavailable",
+            "claim_boundary": stack.get("claim_boundary"),
         }
     command = _command_with_cli_invoke(
         command=f"python scripts/github/pr_comment_delta.py --repo {repo} --pr {pr_number or '<number>'} --format json",
@@ -21884,6 +22108,232 @@ def _dogfooding_signal_status_payload(
     return {key: value for key, value in payload.items() if value not in ("", [], {})}
 
 
+def _file_sha256(path: Path) -> str:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return ""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _proof_reuse_guidance_payload(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
+    receipt_path = target_root / ".agentic-workspace" / "local" / "cache" / "proof-reuse.json"
+    relative_path = ".agentic-workspace/local/cache/proof-reuse.json"
+    detail_command = _command_with_cli_invoke(
+        command="agentic-workspace report --target ./repo --section proof_reuse_guidance --format json",
+        cli_invoke=cli_invoke,
+    )
+    if not receipt_path.is_file():
+        return {
+            "kind": "agentic-workspace/proof-reuse-guidance/v1",
+            "status": "reuse_unknown",
+            "reason": "No compact proof reuse receipt is available.",
+            "cache_path": relative_path,
+            "proof_groups": [],
+            "recommended_next_action": "Run current changed-path proof selection and validation.",
+            "detail_command": detail_command,
+            "rule": "Missing, stale, or ambiguous proof metadata degrades to rerun guidance.",
+        }
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "kind": "agentic-workspace/proof-reuse-guidance/v1",
+            "status": "rerun_required",
+            "reason": f"Compact proof reuse receipt is unreadable: {exc}",
+            "cache_path": relative_path,
+            "proof_groups": [],
+            "recommended_next_action": "Rerun required proof before any completion claim.",
+            "detail_command": detail_command,
+        }
+    if not isinstance(receipt, dict):
+        return {
+            "kind": "agentic-workspace/proof-reuse-guidance/v1",
+            "status": "rerun_required",
+            "reason": "Compact proof reuse receipt is not a JSON object.",
+            "cache_path": relative_path,
+            "proof_groups": [],
+            "recommended_next_action": "Rerun required proof before any completion claim.",
+            "detail_command": detail_command,
+        }
+    path_fingerprints = receipt.get("path_fingerprints", {}) if isinstance(receipt.get("path_fingerprints"), dict) else {}
+    changed_paths = [str(item) for item in _list_payload(receipt.get("changed_paths")) if str(item).strip()]
+    missing_paths: list[str] = []
+    changed_fingerprints: list[str] = []
+    for relative in changed_paths:
+        path = target_root / relative
+        current_hash = _file_sha256(path)
+        expected_hash = str(path_fingerprints.get(relative) or "")
+        if not current_hash:
+            missing_paths.append(relative)
+        elif expected_hash and current_hash != expected_hash:
+            changed_fingerprints.append(relative)
+        elif not expected_hash:
+            changed_fingerprints.append(relative)
+    proof_groups: list[dict[str, Any]] = []
+    raw_groups = receipt.get("proof_groups", []) if isinstance(receipt.get("proof_groups"), list) else []
+    for raw in raw_groups:
+        if not isinstance(raw, dict):
+            continue
+        command = str(raw.get("command") or raw.get("proof_command") or "").strip()
+        prior_status = str(raw.get("status") or "passed").strip()
+        if missing_paths or changed_fingerprints:
+            classification = "rerun_required"
+            rationale = "changed proof input fingerprints"
+        elif prior_status not in {"passed", "success", "ok"}:
+            classification = "rerun_required"
+            rationale = "prior proof did not pass"
+        elif not command:
+            classification = "reuse_unknown"
+            rationale = "proof command identity missing"
+        else:
+            classification = "reuse_safe_with_evidence"
+            rationale = "changed path fingerprints match the compact proof receipt"
+        proof_groups.append(
+            {
+                "command": command,
+                "classification": classification,
+                "evidence": {
+                    "prior_head": receipt.get("prior_head") or receipt.get("head"),
+                    "prior_base": receipt.get("prior_base") or receipt.get("base"),
+                    "changed_paths": changed_paths,
+                    "fingerprint_count": len(path_fingerprints),
+                },
+                "rationale": rationale,
+            }
+        )
+    if missing_paths or changed_fingerprints:
+        status = "rerun_required"
+        recommended = "Rerun proof for changed or missing proof inputs."
+    elif proof_groups and all(group["classification"] == "reuse_safe_with_evidence" for group in proof_groups):
+        status = "reuse_safe_with_evidence"
+        recommended = "Focused proof may reuse the named prior proof groups; record the reuse rationale in closeout."
+    elif proof_groups:
+        status = "focused_rerun_required"
+        recommended = "Rerun only proof groups without reuse evidence."
+    else:
+        status = "reuse_unknown"
+        recommended = "Run current changed-path proof selection and validation."
+    return {
+        "kind": "agentic-workspace/proof-reuse-guidance/v1",
+        "status": status,
+        "cache_path": relative_path,
+        "observed_changed_paths": changed_paths,
+        "missing_paths": missing_paths,
+        "changed_fingerprints": changed_fingerprints,
+        "proof_groups": proof_groups,
+        "recommended_next_action": recommended,
+        "detail_command": detail_command,
+        "rule": "This is claim-safety guidance, not a test-skipping feature; unknown evidence requires rerun.",
+    }
+
+
+def _function_dict_return_keys(tree: ast.AST, function_name: str) -> set[str]:
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or node.name != function_name:
+            continue
+        keys: set[str] = set()
+        for child in ast.walk(node):
+            if isinstance(child, ast.Dict):
+                for key in child.keys:
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                        keys.add(key.value)
+        return keys
+    return set()
+
+
+def _parse_python_module(path: Path) -> ast.AST | None:
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return None
+
+
+def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke: str) -> dict[str, Any]:
+    core_path = target_root / "src" / "agentic_workspace" / "workspace_runtime_core.py"
+    primitive_path = target_root / "src" / "agentic_workspace" / "workspace_runtime_primitives.py"
+    relative_core = "src/agentic_workspace/workspace_runtime_core.py"
+    relative_primitives = "src/agentic_workspace/workspace_runtime_primitives.py"
+    surfaces = [
+        {
+            "mirrored_surface": "pr_comment_attention",
+            "function": "_pr_comment_attention_payload",
+            "packet_kind": "agentic-workspace/pr-comment-attention/v1",
+        },
+        {
+            "mirrored_surface": "dogfooding_signal_status",
+            "function": "_dogfooding_signal_status_payload",
+            "packet_kind": "agentic-workspace/dogfooding-signal-status/v1",
+        },
+        {
+            "mirrored_surface": "installed_state_drift_triage",
+            "function": "_installed_state_drift_triage_payload",
+            "packet_kind": "agentic-workspace/installed-state-drift-triage/v1",
+        },
+        {
+            "mirrored_surface": "proof_reuse_guidance",
+            "function": "_proof_reuse_guidance_payload",
+            "packet_kind": "agentic-workspace/proof-reuse-guidance/v1",
+        },
+        {
+            "mirrored_surface": "runtime_mirror_consistency",
+            "function": "_runtime_mirror_surface_consistency_payload",
+            "packet_kind": "agentic-workspace/runtime-mirror-surface-consistency/v1",
+        },
+    ]
+    core_tree = _parse_python_module(core_path)
+    primitive_tree = _parse_python_module(primitive_path)
+    records: list[dict[str, Any]] = []
+    for surface in surfaces:
+        function = str(surface["function"])
+        if core_tree is None or primitive_tree is None:
+            status = "not_applicable"
+            reason = "core or runtime primitives module could not be parsed"
+            core_keys: set[str] = set()
+            primitive_keys: set[str] = set()
+        else:
+            core_keys = _function_dict_return_keys(core_tree, function)
+            primitive_keys = _function_dict_return_keys(primitive_tree, function)
+            if not core_keys and not primitive_keys:
+                status = "not_applicable"
+                reason = "surface is not mirrored in either module"
+            elif not core_keys or not primitive_keys:
+                status = "mirror_missing"
+                reason = "surface exists in only one mirrored runtime module"
+            elif core_keys != primitive_keys:
+                status = "shape_mismatch"
+                reason = "mirrored helper return-key shape differs"
+            else:
+                status = "in_sync"
+                reason = "mirrored helper return-key shape matches"
+        records.append(
+            {
+                **surface,
+                "status": status,
+                "core_owner": relative_core,
+                "runtime_mirror_owner": relative_primitives,
+                "core_keys": sorted(core_keys),
+                "runtime_mirror_keys": sorted(primitive_keys),
+                "reason": reason,
+            }
+        )
+    failing = [record for record in records if record["status"] in {"mirror_missing", "shape_mismatch"}]
+    return {
+        "kind": "agentic-workspace/runtime-mirror-surface-consistency/v1",
+        "status": "in_sync" if not failing else "shape_mismatch",
+        "mirrored_surface_count": len(records),
+        "records": records,
+        "recommended_next_action": "Mirror the missing helper/packet shape or document that the surface is intentionally core-only."
+        if failing
+        else "No mirror repair needed for known AW runtime report surfaces.",
+        "proof_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section runtime_mirror_consistency --format json",
+            cli_invoke=cli_invoke,
+        ),
+        "rule": "Compare the smallest durable mirrored contract: known helper existence and public packet return-key shape.",
+    }
+
+
 def _start_tiny_payload_fast(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, config: WorkspaceConfig, startup_template: dict[str, Any]
 ) -> dict[str, Any]:
@@ -22033,6 +22483,12 @@ def _start_tiny_payload_fast(
         payload["dogfooding_signal_status"] = dogfooding_signal_status
     if installed_state_compatibility["status"] != "compatible":
         payload["installed_state_compatibility"] = installed_state_compatibility
+        payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
+            installed_state=installed_state_compatibility,
+            task_text=task_text,
+            changed_paths=changed_paths,
+            cli_invoke=config.cli_invoke,
+        )
     sibling_freshness = _sibling_repo_aw_freshness_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)
     if sibling_freshness["status"] != "not-referenced":
         payload["sibling_repo_aw_freshness"] = sibling_freshness
@@ -23881,6 +24337,18 @@ def _read_only_response_posture_payload(*, task_text: str | None, changed_paths:
             "status": "not-applicable",
             "reason": "changed paths are present, so implementation/proof guidance remains the default",
             "compact_default": False,
+        }
+    if _read_only_meta_task(task):
+        return {
+            "kind": "agentic-workspace/read-only-response-posture/v1",
+            "status": "read-only-reporting",
+            "reason": "task text matches report, status, review, or meta-analysis posture without changed paths",
+            "compact_default": True,
+            "matched_read_only_signals": ["report/meta task shape"],
+            "matched_mutation_signals": [],
+            "default_projection": "selector-first-reporting",
+            "detail_selector": "acceptance",
+            "rule": "Report/meta/read-only task shapes get compact first packets while hard gates and claim boundaries remain visible.",
         }
     return {
         "kind": "agentic-workspace/read-only-response-posture/v1",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -21747,9 +21747,36 @@ def _read_only_meta_task(task_text: str | None) -> bool:
     )
     if any(term in task for term in meta_terms):
         return True
-    return bool(re.search(r"\b(?:what|why|how|which|do|does|did|are|is)\b", task)) and not any(
-        term in task for term in ("implement", "fix", "edit", "change", "add", "remove", "create pr")
+    return False
+
+
+def _installed_state_drift_relevant_changed_paths(changed_paths: Sequence[str]) -> list[str]:
+    exact = {
+        ".agentic-workspace/config.toml",
+        ".agentic-workspace/payload-provenance.json",
+        "pyproject.toml",
+        "uv.lock",
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/workspace_runtime_startup.py",
+    }
+    prefixes = (
+        "generated/",
+        "scripts/generate/",
+        "scripts/release/",
+        "src/agentic_workspace/contracts/",
     )
+    suffixes = (
+        "/pyproject.toml",
+        "/package.json",
+        "/package-lock.json",
+        "/pnpm-lock.yaml",
+    )
+    relevant: list[str] = []
+    for path in _normalize_changed_paths(changed_paths):
+        if path in exact or path.startswith(prefixes) or path.endswith(suffixes):
+            relevant.append(path)
+    return relevant
 
 
 def _installed_state_drift_triage_payload(
@@ -21773,7 +21800,8 @@ def _installed_state_drift_triage_payload(
         "adapter compatibility",
         "source checkout parity",
     )
-    claim_relevant = bool(changed_paths) or any(term in task for term in freshness_terms)
+    claim_relevant_paths = _installed_state_drift_relevant_changed_paths(changed_paths)
+    claim_relevant = bool(claim_relevant_paths) or any(term in task for term in freshness_terms)
     if status == "compatible":
         triage = "not_applicable"
     elif force == "required_before_execution":
@@ -21793,6 +21821,7 @@ def _installed_state_drift_triage_payload(
         "installed_state_status": status,
         "force": force,
         "claim_relevant": claim_relevant,
+        "claim_relevant_paths": claim_relevant_paths,
         "repair_command": resolution_command,
         "selector": "installed_state_compatibility",
         "claim_boundary": action_effect.get(
@@ -21814,6 +21843,7 @@ def _compact_installed_state_drift_triage(triage: Any) -> dict[str, Any]:
             "installed_state_status",
             "force",
             "claim_relevant",
+            "claim_relevant_paths",
             "repair_command",
             "selector",
             "claim_boundary",
@@ -21915,6 +21945,40 @@ def _pr_comment_attention_relevant(*, task_text: str | None, branch: str, cache:
     return branch.startswith("codex/")
 
 
+def _pr_stack_comment_context_relevant(*, task_text: str | None, branch: str) -> bool:
+    task = str(task_text or "").lower()
+    if any(token in task for token in ("stack", "stacked", "stacked pr", "stacked pull request")):
+        return True
+    return any(token in branch.lower() for token in ("stack", "stacked"))
+
+
+def _pr_stack_comment_unavailable_payload(*, repo: str, branch: str, pr_number: str, cli_invoke: str) -> dict[str, Any]:
+    cache_path = ".agentic-workspace/local/cache/pr-comment-stack.json"
+    recommended_command = _command_with_cli_invoke(
+        command=f"python scripts/github/pr_comment_delta.py --repo {repo} --pr {pr_number or '<number>'} --format json",
+        cli_invoke=cli_invoke,
+    )
+    return {
+        "kind": "agentic-workspace/pr-stack-comment-attention/v1",
+        "status": "stack_comment_status_unavailable",
+        "repository": repo,
+        "branch": branch,
+        "stack_member_count": 0,
+        "stack_members": [],
+        "cache_path": cache_path,
+        "stack_discovery": {
+            "status": "unavailable",
+            "degraded_because": "missing-stack-cache-or-branch-pr-metadata",
+            "branch": branch,
+            "repository": repo,
+            "cache_path": cache_path,
+            "refresh_command": recommended_command,
+        },
+        "claim_boundary": "A broad stack-ready claim is blocked until stack members are discovered or the stack scope is explicitly narrowed.",
+        "degraded_because": "missing-stack-discovery-evidence",
+    }
+
+
 def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
     cache_path = ".agentic-workspace/local/cache/pr-comment-delta.json"
     cache = _read_local_cache_json(target_root, cache_path)
@@ -21928,6 +21992,8 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
             "status": "not_applicable",
             "reason": "No PR context detected; ordinary direct work does not scan GitHub comments.",
         }
+    if not stack and _pr_stack_comment_context_relevant(task_text=task_text, branch=branch):
+        stack = _pr_stack_comment_unavailable_payload(repo=repo, branch=branch, pr_number=pr_number, cli_invoke=cli_invoke)
     if stack:
         status = str(stack.get("status") or "stack_comment_status_unavailable")
         return {
@@ -21937,6 +22003,7 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
             "pr_number": pr_number,
             "branch": branch,
             "stack": stack,
+            "stack_discovery": stack.get("stack_discovery", {}),
             "stack_member_count": stack.get("stack_member_count", 0),
             "recommended_command": str(stack.get("stack_members", [{}])[0].get("refresh_command", ""))
             if isinstance(stack.get("stack_members"), list) and stack.get("stack_members")
@@ -22158,6 +22225,35 @@ def _proof_reuse_guidance_payload(*, target_root: Path, cli_invoke: str) -> dict
         }
     path_fingerprints = receipt.get("path_fingerprints", {}) if isinstance(receipt.get("path_fingerprints"), dict) else {}
     changed_paths = [str(item) for item in _list_payload(receipt.get("changed_paths")) if str(item).strip()]
+    parent_proof_reference = str(receipt.get("parent_proof_reference") or receipt.get("parent_proof_ref") or "").strip()
+    proof_selection_identity = str(
+        receipt.get("proof_selection_identity")
+        or receipt.get("proof_selection_fingerprint")
+        or receipt.get("selected_proof_fingerprint")
+        or ""
+    ).strip()
+    dependency_config_state = str(
+        receipt.get("dependency_config_state")
+        or receipt.get("dependency_config_fingerprint")
+        or receipt.get("dependency_fingerprint")
+        or receipt.get("config_fingerprint")
+        or ""
+    ).strip()
+    generated_surface_freshness = receipt.get("generated_surface_freshness")
+    generated_surface_status = (
+        str(generated_surface_freshness.get("status") or "").strip()
+        if isinstance(generated_surface_freshness, dict)
+        else str(generated_surface_freshness or "").strip()
+    )
+    missing_reuse_evidence: list[str] = []
+    if not parent_proof_reference:
+        missing_reuse_evidence.append("parent_proof_reference")
+    if not proof_selection_identity:
+        missing_reuse_evidence.append("proof_selection_identity")
+    if not dependency_config_state:
+        missing_reuse_evidence.append("dependency_config_state")
+    if generated_surface_status not in {"current", "fresh", "verified", "not_applicable"}:
+        missing_reuse_evidence.append("generated_surface_freshness")
     missing_paths: list[str] = []
     changed_fingerprints: list[str] = []
     for relative in changed_paths:
@@ -22176,26 +22272,38 @@ def _proof_reuse_guidance_payload(*, target_root: Path, cli_invoke: str) -> dict
         if not isinstance(raw, dict):
             continue
         command = str(raw.get("command") or raw.get("proof_command") or "").strip()
+        command_identity = str(
+            raw.get("command_identity") or raw.get("command_fingerprint") or raw.get("command_digest") or raw.get("command_sha256") or ""
+        ).strip()
         prior_status = str(raw.get("status") or "passed").strip()
+        group_missing_evidence = list(missing_reuse_evidence)
+        if not command_identity:
+            group_missing_evidence.append("command_identity")
         if missing_paths or changed_fingerprints:
             classification = "rerun_required"
             rationale = "changed proof input fingerprints"
         elif prior_status not in {"passed", "success", "ok"}:
             classification = "rerun_required"
             rationale = "prior proof did not pass"
-        elif not command:
+        elif not command or group_missing_evidence:
             classification = "reuse_unknown"
-            rationale = "proof command identity missing"
+            rationale = "explicit proof identity or gate-input evidence missing"
         else:
             classification = "reuse_safe_with_evidence"
-            rationale = "changed path fingerprints match the compact proof receipt"
+            rationale = "proof identity, gate inputs, command identity, generated freshness, and changed path fingerprints match"
         proof_groups.append(
             {
                 "command": command,
                 "classification": classification,
+                "missing_reuse_evidence": group_missing_evidence,
                 "evidence": {
                     "prior_head": receipt.get("prior_head") or receipt.get("head"),
                     "prior_base": receipt.get("prior_base") or receipt.get("base"),
+                    "parent_proof_reference": parent_proof_reference,
+                    "proof_selection_identity": proof_selection_identity,
+                    "dependency_config_state": dependency_config_state,
+                    "generated_surface_freshness": generated_surface_status,
+                    "command_identity": command_identity,
                     "changed_paths": changed_paths,
                     "fingerprint_count": len(path_fingerprints),
                 },
@@ -22208,6 +22316,9 @@ def _proof_reuse_guidance_payload(*, target_root: Path, cli_invoke: str) -> dict
     elif proof_groups and all(group["classification"] == "reuse_safe_with_evidence" for group in proof_groups):
         status = "reuse_safe_with_evidence"
         recommended = "Focused proof may reuse the named prior proof groups; record the reuse rationale in closeout."
+    elif proof_groups and all(group["classification"] == "reuse_unknown" for group in proof_groups):
+        status = "reuse_unknown"
+        recommended = "Run current changed-path proof selection; cached proof lacks explicit reuse evidence."
     elif proof_groups:
         status = "focused_rerun_required"
         recommended = "Rerun only proof groups without reuse evidence."
@@ -22221,6 +22332,7 @@ def _proof_reuse_guidance_payload(*, target_root: Path, cli_invoke: str) -> dict
         "observed_changed_paths": changed_paths,
         "missing_paths": missing_paths,
         "changed_fingerprints": changed_fingerprints,
+        "missing_reuse_evidence": missing_reuse_evidence,
         "proof_groups": proof_groups,
         "recommended_next_action": recommended,
         "detail_command": detail_command,
@@ -35453,6 +35565,29 @@ def _changed_paths_matching_contract_path_match(*, changed_paths: list[str], pat
 
 def _supplemental_proof_lanes_for_changed_paths(*, changed_paths: list[str]) -> list[dict[str, Any]]:
     supplemental_lanes: list[dict[str, Any]] = []
+    runtime_mirror_paths = [
+        path
+        for path in changed_paths
+        if path
+        in {
+            "src/agentic_workspace/workspace_runtime_core.py",
+            "src/agentic_workspace/workspace_runtime_primitives.py",
+        }
+    ]
+    if runtime_mirror_paths:
+        supplemental_lanes.append(
+            {
+                "id": "runtime_mirror_consistency",
+                "when": "changed path edits mirrored runtime packet surfaces",
+                "enough_proof": [
+                    "uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json"
+                ],
+                "recovery_signal": "runtime mirror mismatches should block closeout until core and primitives expose the same packet shape",
+                "proof_kind": "targeted-static-check",
+                "proof_responsibility": "local-closeout",
+                "matched_paths": runtime_mirror_paths,
+            }
+        )
     for raw_lane in _PROOF_SELECTION_RULES.get("supplemental_lanes", []):
         if not isinstance(raw_lane, dict):
             continue

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -35565,29 +35565,6 @@ def _changed_paths_matching_contract_path_match(*, changed_paths: list[str], pat
 
 def _supplemental_proof_lanes_for_changed_paths(*, changed_paths: list[str]) -> list[dict[str, Any]]:
     supplemental_lanes: list[dict[str, Any]] = []
-    runtime_mirror_paths = [
-        path
-        for path in changed_paths
-        if path
-        in {
-            "src/agentic_workspace/workspace_runtime_core.py",
-            "src/agentic_workspace/workspace_runtime_primitives.py",
-        }
-    ]
-    if runtime_mirror_paths:
-        supplemental_lanes.append(
-            {
-                "id": "runtime_mirror_consistency",
-                "when": "changed path edits mirrored runtime packet surfaces",
-                "enough_proof": [
-                    "uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json"
-                ],
-                "recovery_signal": "runtime mirror mismatches should block closeout until core and primitives expose the same packet shape",
-                "proof_kind": "targeted-static-check",
-                "proof_responsibility": "local-closeout",
-                "matched_paths": runtime_mirror_paths,
-            }
-        )
     for raw_lane in _PROOF_SELECTION_RULES.get("supplemental_lanes", []):
         if not isinstance(raw_lane, dict):
             continue

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -839,6 +839,31 @@ def _coordinated_release_proof_lane(*, target_root: Path | None, changed_paths: 
     }
 
 
+def _runtime_mirror_consistency_proof_lane(*, changed_paths: list[str]) -> dict[str, Any] | None:
+    matched_paths = [
+        path
+        for path in changed_paths
+        if path
+        in {
+            "src/agentic_workspace/workspace_runtime_core.py",
+            "src/agentic_workspace/workspace_runtime_primitives.py",
+        }
+    ]
+    if not matched_paths:
+        return None
+    return {
+        "id": "runtime_mirror_consistency",
+        "when": "changed path edits mirrored runtime packet surfaces",
+        "enough_proof": [
+            "uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json"
+        ],
+        "recovery_signal": "runtime mirror mismatches should block closeout until core and primitives expose the same packet shape",
+        "proof_kind": "targeted-static-check",
+        "proof_responsibility": "local-closeout",
+        "matched_paths": matched_paths,
+    }
+
+
 def _release_group_command(command: str) -> str:
     text = command.lower()
     if "test-memory" in text or "lint-memory" in text or "packages/memory" in text:
@@ -1127,6 +1152,9 @@ def _proof_selection_for_changed_paths(
         )
     selected_lanes.extend(subsystem_lanes)
     selected_lanes.extend(_supplemental_proof_lanes_for_changed_paths(changed_paths=changed_paths))
+    runtime_mirror_proof_lane = _runtime_mirror_consistency_proof_lane(changed_paths=changed_paths)
+    if runtime_mirror_proof_lane is not None:
+        selected_lanes.append(runtime_mirror_proof_lane)
     release_proof_lane = _coordinated_release_proof_lane(target_root=target_root, changed_paths=changed_paths)
     if release_proof_lane is not None:
         selected_lanes.append(release_proof_lane)

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -29,6 +29,7 @@ from agentic_workspace.workspace_runtime_core import (
     _compact_action_signals_payload,
     _compact_assurance_requirements,
     _compact_continuation_state_contract,
+    _compact_installed_state_drift_triage,
     _compact_intent_evidence,
     _compact_repair_plan_profile,
     _compact_repo_posture_projection,
@@ -50,6 +51,7 @@ from agentic_workspace.workspace_runtime_core import (
     _feature_tier_payload,
     _guidance_with_cli_invoke,
     _installed_state_compatibility_payload,
+    _installed_state_drift_triage_payload,
     _intent_acknowledgement_payload,
     _intent_custody_payload,
     _intent_decision_projection,
@@ -161,6 +163,8 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         for key in ("kind", "package", "version", "source_class", "module_path", "target_relation", "compatibility")
         if isinstance(identity, dict) and key in identity
     }
+    read_only_response = payload.get("read_only_response", {})
+    read_only_compact_default = bool(isinstance(read_only_response, dict) and read_only_response.get("compact_default") is True)
     projected = {
         "kind": payload["kind"],
         "target": ".",
@@ -238,7 +242,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
             and payload["continuation_reorientation"].get("status") == "required"
             else {}
         ),
-        "routine_work_context": payload.get("routine_work_context", {}),
+        **({"routine_work_context": payload.get("routine_work_context", {})} if not read_only_compact_default else {}),
         "operating_posture": {
             "status": payload.get("operating_posture", {}).get("status", "unknown"),
             "required_behavior_summary": payload.get("operating_posture", {}).get("required_behavior_summary", ""),
@@ -313,6 +317,9 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
     installed_state = payload.get("installed_state_compatibility", {})
     if isinstance(installed_state, dict) and installed_state.get("status") not in {None, "", "compatible"}:
         projected["installed_state_compatibility"] = _compact_startup_installed_state_signal(installed_state)
+    installed_state_triage = payload.get("installed_state_drift_triage", {})
+    if isinstance(installed_state_triage, dict) and installed_state_triage.get("status") not in {None, "", "not_applicable"}:
+        projected["installed_state_drift_triage"] = _compact_installed_state_drift_triage(installed_state_triage)
     sibling_freshness = payload.get("sibling_repo_aw_freshness", {})
     if isinstance(sibling_freshness, dict) and sibling_freshness.get("status") not in {None, "", "not-referenced"}:
         projected["sibling_repo_aw_freshness"] = sibling_freshness
@@ -665,6 +672,12 @@ def _start_payload(
     )
     if installed_state_compatibility["status"] != "compatible":
         payload["installed_state_compatibility"] = installed_state_compatibility
+        payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
+            installed_state=installed_state_compatibility,
+            task_text=task_text,
+            changed_paths=changed_paths,
+            cli_invoke=config.cli_invoke,
+        )
     if parent_intent_status.get("status") != "guidance-only":
         payload["parent_intent_status"] = parent_intent_status
     if applicable_intent_status.get("status") != "guidance-only":
@@ -1111,7 +1124,7 @@ def _hydrate_selected_start_advisory_payloads(
             )
     if _selector_requests(select, "local_chat_checkpoint"):
         payload["local_chat_checkpoint"] = _local_chat_checkpoint_projection(target_root=target_root, cli_invoke=config.cli_invoke)
-    if _selector_requests(select, "installed_state_compatibility"):
+    if _selector_requests(select, "installed_state_compatibility") or _selector_requests(select, "installed_state_drift_triage"):
         installed_modules = _fast_installed_modules(target_root=target_root)
         selected_modules = list(config.enabled_modules)
         payload["installed_state_compatibility"] = _installed_state_compatibility_payload(
@@ -1120,6 +1133,12 @@ def _hydrate_selected_start_advisory_payloads(
             installed_modules=installed_modules,
             cli_compatibility=_cli_compatibility_payload(config=config, compact=True),
             compact=True,
+        )
+        payload["installed_state_drift_triage"] = _installed_state_drift_triage_payload(
+            installed_state=payload["installed_state_compatibility"],
+            task_text=task_text,
+            changed_paths=[],
+            cli_invoke=config.cli_invoke,
         )
     if _selector_requests(select, "intent_custody"):
         payload["intent_custody"] = _intent_custody_payload(
@@ -1169,6 +1188,8 @@ def _hydrate_selected_start_advisory_payloads(
 
 def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, target_root: Path | None = None) -> dict[str, Any]:
     skill_routing = payload.get("skill_routing", {}) if isinstance(payload.get("skill_routing"), dict) else {}
+    read_only_response = payload.get("read_only_response", {})
+    read_only_compact_default = bool(isinstance(read_only_response, dict) and read_only_response.get("compact_default") is True)
     next_safe_action = _next_safe_action_packet(
         immediate=payload["immediate_next_allowed_action"],
         workflow_sufficiency=payload.get("workflow_sufficiency"),
@@ -1269,12 +1290,18 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                 "pr_number",
                 "actionable_count",
                 "new_comment_count",
+                "stack_member_count",
+                "stack",
                 "recommended_command",
                 "selector",
                 "degraded_explicitly",
+                "claim_boundary",
             )
             if key in pr_comment_attention
         }
+    installed_state_triage = payload.get("installed_state_drift_triage", {})
+    if isinstance(installed_state_triage, dict) and installed_state_triage.get("status") in {"actionable_now", "claim_blocking"}:
+        context["installed_state_drift_triage"] = _compact_installed_state_drift_triage(installed_state_triage)
     dogfooding_signal_status = payload.get("dogfooding_signal_status", {})
     if isinstance(dogfooding_signal_status, dict) and dogfooding_signal_status.get("status") not in {None, "", "not_applicable"}:
         context["dogfooding_signal_status"] = {
@@ -1301,8 +1328,6 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     prep_only_active = "prep_only_handoff" in payload
     if "task_intent" in payload:
         task_intent = payload["task_intent"]
-        read_only_response = payload.get("read_only_response", {})
-        read_only_compact_default = bool(isinstance(read_only_response, dict) and read_only_response.get("compact_default") is True)
         context["task"] = (
             {
                 "status": task_intent.get("status", "unknown") if isinstance(task_intent, dict) else "unknown",
@@ -1353,6 +1378,8 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     installed_state = payload.get("installed_state_compatibility", {})
     if isinstance(installed_state, dict) and installed_state.get("status") not in {None, "", "compatible"}:
         startup_changed_signals.append(f"installed_state_compatibility={installed_state.get('status')}")
+    if isinstance(installed_state_triage, dict) and installed_state_triage.get("status") not in {None, "", "not_applicable"}:
+        startup_changed_signals.append(f"installed_state_drift_triage={installed_state_triage.get('status')}")
     if isinstance(local_checkpoint, dict) and local_checkpoint.get("status") in {"present", "stale", "unreadable"}:
         startup_changed_signals.append(f"local_chat_checkpoint={local_checkpoint.get('status')}")
     sibling_freshness = payload.get("sibling_repo_aw_freshness", {})
@@ -1367,6 +1394,8 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     startup_proof = payload.get("proof", {})
     startup_proof_commands = _tiny_required_proof_commands(startup_proof) if isinstance(startup_proof, dict) else []
     available_selectors = _available_selectors_for_payload(payload)
+    if "routine_work_context" not in available_selectors:
+        available_selectors.append("routine_work_context")
     if (
         target_root is not None
         and "local_chat_checkpoint" not in available_selectors
@@ -1387,6 +1416,8 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     ]
     if isinstance(installed_state, dict) and installed_state.get("status") not in {None, "", "compatible"}:
         advisory_selectors.append("installed_state_compatibility")
+    if isinstance(installed_state_triage, dict) and installed_state_triage.get("status") not in {None, "", "not_applicable"}:
+        advisory_selectors.append("installed_state_drift_triage")
     if isinstance(local_checkpoint, dict) and local_checkpoint.get("status") in {"present", "stale", "unreadable"}:
         advisory_selectors.append("local_chat_checkpoint")
     if isinstance(pre_test_guardrail, dict) and pre_test_guardrail.get("status") == "advisory":
@@ -1491,6 +1522,8 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         "pre_test_evidence_guardrail",
     ):
         if optional_key in payload:
+            if optional_key == "routine_work_context" and read_only_compact_default:
+                continue
             context[optional_key] = payload[optional_key]
     maintainer_mode = payload.get("maintainer_mode", {})
     if isinstance(maintainer_mode, dict) and maintainer_mode.get("status") == "enabled":

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1292,6 +1292,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                 "new_comment_count",
                 "stack_member_count",
                 "stack",
+                "stack_discovery",
                 "recommended_command",
                 "selector",
                 "degraded_explicitly",

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -819,6 +819,35 @@ def test_start_report_meta_task_keeps_routine_context_selector_only_with_backgro
     assert "installed_state_drift_triage" in payload["action_signals"]["advisory_detail"]["selectors"]
 
 
+def test_start_broad_question_words_do_not_trigger_meta_report_compaction(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (tmp_path / ".agentic-workspace" / "payload-provenance.json").write_text(
+        json.dumps({"kind": "wrong-kind"}),
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "How should we implement the runtime proof selector?",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert "routine_work_context" in payload["context"]
+    assert "installed_state_drift_triage=waived_for_narrow_work" in payload["action_signals"]["changed_signals"]
+
+
 def test_start_narrow_source_work_qualifies_unrelated_installed_state_drift(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
@@ -833,6 +862,37 @@ def test_start_narrow_source_work_qualifies_unrelated_installed_state_drift(tmp_
 
     assert "installed_state_drift_triage=waived_for_narrow_work" in payload["action_signals"]["changed_signals"]
     assert "installed_state_drift_triage" in payload["action_signals"]["advisory_detail"]["selectors"]
+    assert "installed_state_drift_triage" not in payload["context"]
+
+
+def test_start_unrelated_changed_path_does_not_make_payload_drift_actionable(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (tmp_path / ".agentic-workspace" / "payload-provenance.json").write_text(
+        json.dumps({"kind": "wrong-kind"}),
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "docs/typo.md",
+                "--task",
+                "Fix one docs typo",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert "installed_state_drift_triage=waived_for_narrow_work" in payload["action_signals"]["changed_signals"]
     assert "installed_state_drift_triage" not in payload["context"]
 
 
@@ -863,6 +923,7 @@ def test_start_installed_state_drift_triage_is_actionable_for_payload_claims(tmp
 
     triage = payload["context"]["installed_state_drift_triage"]
     assert triage["status"] == "actionable_now"
+    assert triage["claim_relevant"] is True
     assert "agentic-workspace upgrade" in triage["repair_command"]
     assert "installed_state_drift_triage=actionable_now" in payload["action_signals"]["changed_signals"]
 
@@ -1834,6 +1895,27 @@ def test_start_pr_comment_attention_reads_stack_cache_with_concrete_refresh_comm
     capsys.readouterr()
     cache_path = tmp_path / ".agentic-workspace" / "local" / "cache" / "pr-comment-stack.json"
     cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue stacked PR review fixes",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    unavailable = json.loads(capsys.readouterr().out)
+    unavailable_attention = unavailable["context"]["pr_comment_attention"]
+    assert unavailable_attention["status"] == "stack_comment_status_unavailable"
+    assert unavailable_attention["stack_discovery"]["status"] == "unavailable"
+    assert unavailable_attention["stack_member_count"] == 0
+
     fresh_stack = {
         "repository": "rickardvh/agentic-workspace",
         "stack_members": [
@@ -1951,18 +2033,36 @@ def test_report_proof_reuse_guidance_classifies_safe_and_stale_receipts(tmp_path
     unknown = json.loads(capsys.readouterr().out)["answer"]
     assert unknown["status"] == "reuse_unknown"
 
-    cache_path.write_text(
-        json.dumps(
+    minimal_receipt = {
+        "prior_head": "abc123",
+        "prior_base": "base123",
+        "changed_paths": ["src/app.py"],
+        "path_fingerprints": {"src/app.py": hashlib.sha256(changed_path.read_bytes()).hexdigest()},
+        "proof_groups": [{"command": "uv run pytest tests/test_app.py -q", "status": "passed"}],
+    }
+    cache_path.write_text(json.dumps(minimal_receipt), encoding="utf-8")
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "proof_reuse_guidance", "--format", "json"]) == 0
+    under_evidenced = json.loads(capsys.readouterr().out)["answer"]
+    assert under_evidenced["status"] == "reuse_unknown"
+    assert "parent_proof_reference" in under_evidenced["missing_reuse_evidence"]
+    assert "command_identity" in under_evidenced["proof_groups"][0]["missing_reuse_evidence"]
+
+    safe_receipt = {
+        **minimal_receipt,
+        "parent_proof_reference": "proof-receipt:abc123",
+        "proof_selection_fingerprint": "selection:runtime-tests",
+        "dependency_config_fingerprint": "deps:locked",
+        "generated_surface_freshness": {"status": "verified"},
+        "proof_groups": [
             {
-                "prior_head": "abc123",
-                "prior_base": "base123",
-                "changed_paths": ["src/app.py"],
-                "path_fingerprints": {"src/app.py": hashlib.sha256(changed_path.read_bytes()).hexdigest()},
-                "proof_groups": [{"command": "uv run pytest tests/test_app.py -q", "status": "passed"}],
+                "command": "uv run pytest tests/test_app.py -q",
+                "command_fingerprint": "cmd:test-app",
+                "status": "passed",
             }
-        ),
-        encoding="utf-8",
-    )
+        ],
+    }
+    cache_path.write_text(json.dumps(safe_receipt), encoding="utf-8")
 
     assert cli.main(["report", "--target", str(tmp_path), "--section", "proof_reuse_guidance", "--format", "json"]) == 0
     safe = json.loads(capsys.readouterr().out)["answer"]
@@ -1972,13 +2072,16 @@ def test_report_proof_reuse_guidance_classifies_safe_and_stale_receipts(tmp_path
     cache_path.write_text(
         json.dumps(
             {
-                "prior_head": "abc123",
-                "prior_base": "base123",
+                **safe_receipt,
                 "changed_paths": ["src/app.py"],
                 "path_fingerprints": {"src/app.py": hashlib.sha256(changed_path.read_bytes()).hexdigest()},
                 "proof_groups": [
-                    {"command": "uv run pytest tests/test_app.py -q", "status": "passed"},
-                    {"command": "make lint-workspace", "status": "failed"},
+                    {
+                        "command": "uv run pytest tests/test_app.py -q",
+                        "command_fingerprint": "cmd:test-app",
+                        "status": "passed",
+                    },
+                    {"command": "make lint-workspace", "command_fingerprint": "cmd:lint", "status": "failed"},
                 ],
             }
         ),

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 # ruff: noqa: F403,F405
+import copy
+import hashlib
 import re
 from datetime import date
 
@@ -781,6 +783,88 @@ def test_start_keeps_planned_and_release_closeout_signals_visible(tmp_path: Path
     release = json.loads(capsys.readouterr().out)
     assert release["context"]["dogfooding_signal_status"]["status"] == "not_checked"
     assert "dogfooding_signal_status" in release["action_signals"]["advisory_detail"]["selectors"]
+
+
+def test_start_report_meta_task_keeps_routine_context_selector_only_with_background_drift(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (tmp_path / ".agentic-workspace" / "payload-provenance.json").write_text(
+        json.dumps({"kind": "wrong-kind"}),
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Give me an in-chat dogfooding report about this session",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    _assert_json_payload_under(payload, 10_000, label="start report/meta compact payload", sort_keys=False)
+    assert "routine_work_context" not in payload["context"]
+    assert "routine_work_context" in payload["drill_down"]["available_selectors"]
+    assert "installed_state_compatibility" not in payload
+    assert "installed_state_drift_triage" not in payload["context"]
+    assert "installed_state_drift_triage=background_advisory" in payload["action_signals"]["changed_signals"]
+    assert "installed_state_drift_triage" in payload["action_signals"]["advisory_detail"]["selectors"]
+
+
+def test_start_narrow_source_work_qualifies_unrelated_installed_state_drift(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (tmp_path / ".agentic-workspace" / "payload-provenance.json").write_text(
+        json.dumps({"kind": "wrong-kind"}),
+        encoding="utf-8",
+    )
+
+    assert cli.main(["start", "--target", str(tmp_path), "--task", "Fix one docs typo", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert "installed_state_drift_triage=waived_for_narrow_work" in payload["action_signals"]["changed_signals"]
+    assert "installed_state_drift_triage" in payload["action_signals"]["advisory_detail"]["selectors"]
+    assert "installed_state_drift_triage" not in payload["context"]
+
+
+def test_start_installed_state_drift_triage_is_actionable_for_payload_claims(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (tmp_path / ".agentic-workspace" / "payload-provenance.json").write_text(
+        json.dumps({"kind": "wrong-kind"}),
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Verify payload freshness before release",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    triage = payload["context"]["installed_state_drift_triage"]
+    assert triage["status"] == "actionable_now"
+    assert "agentic-workspace upgrade" in triage["repair_command"]
+    assert "installed_state_drift_triage=actionable_now" in payload["action_signals"]["changed_signals"]
 
 
 def test_start_treats_named_path_question_as_conceptual_reference(tmp_path: Path, capsys) -> None:
@@ -1742,6 +1826,213 @@ def test_report_pr_comment_attention_reads_cached_actionable_and_empty_deltas(tm
     assert fresh_empty["status"] == "no_actionable_pr_comments_detected"
     assert fresh_empty["actionable_count"] == 0
     assert fresh_empty["freshness"]["pr_head_sha"] == "abc123"
+
+
+def test_start_pr_comment_attention_reads_stack_cache_with_concrete_refresh_commands(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    cache_path = tmp_path / ".agentic-workspace" / "local" / "cache" / "pr-comment-stack.json"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    fresh_stack = {
+        "repository": "rickardvh/agentic-workspace",
+        "stack_members": [
+            {
+                "pr_number": 1840,
+                "branch": "codex/proof-reuse",
+                "head_sha": "aaa111",
+                "delta": {
+                    "category_counts": {
+                        "actionable_code_doc_body_change": 0,
+                        "pr_metadata_body_only_change": 0,
+                        "ci_label_only_issue": 0,
+                        "ambiguous_needs_human": 0,
+                    },
+                    "freshness": {"status": "current_at_observed_head", "pr_head_sha": "aaa111"},
+                },
+            },
+            {
+                "pr_number": 1841,
+                "branch": "codex/stack-comments",
+                "head_sha": "bbb222",
+                "delta": {
+                    "category_counts": {
+                        "actionable_code_doc_body_change": 0,
+                        "pr_metadata_body_only_change": 0,
+                        "ci_label_only_issue": 0,
+                        "ambiguous_needs_human": 0,
+                    },
+                    "freshness": {"status": "current_at_observed_head", "pr_head_sha": "bbb222"},
+                },
+            },
+        ],
+    }
+    cache_path.write_text(json.dumps(fresh_stack), encoding="utf-8")
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue stacked PR review fixes",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    current = json.loads(capsys.readouterr().out)
+    assert current["context"]["pr_comment_attention"]["status"] == "stack_comments_current"
+
+    actionable_stack = copy.deepcopy(fresh_stack)
+    actionable_stack["stack_members"][1]["delta"]["category_counts"]["actionable_code_doc_body_change"] = 1
+    cache_path.write_text(
+        json.dumps(actionable_stack),
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue stacked PR review fixes",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    attention = payload["context"]["pr_comment_attention"]
+    assert attention["status"] == "actionable_stack_comments_present"
+    assert attention["stack_member_count"] == 2
+    assert attention["stack"]["stack_members"][0]["refresh_command"].endswith("--pr 1840 --format json")
+    assert attention["stack"]["stack_members"][1]["comment_status"] == "actionable_pr_comments_present"
+    assert "pr_comment_attention=actionable_stack_comments_present" in payload["action_signals"]["changed_signals"]
+
+    stale_stack = copy.deepcopy(fresh_stack)
+    stale_stack["stack_members"][0]["delta"].pop("freshness")
+    cache_path.write_text(json.dumps(stale_stack), encoding="utf-8")
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue stacked PR review fixes",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    stale = json.loads(capsys.readouterr().out)
+    assert stale["context"]["pr_comment_attention"]["status"] == "stack_comment_status_unavailable"
+
+
+def test_report_proof_reuse_guidance_classifies_safe_and_stale_receipts(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    changed_path = tmp_path / "src" / "app.py"
+    changed_path.parent.mkdir(parents=True, exist_ok=True)
+    changed_path.write_text("VALUE = 1\n", encoding="utf-8")
+    cache_path = tmp_path / ".agentic-workspace" / "local" / "cache" / "proof-reuse.json"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "proof_reuse_guidance", "--format", "json"]) == 0
+    unknown = json.loads(capsys.readouterr().out)["answer"]
+    assert unknown["status"] == "reuse_unknown"
+
+    cache_path.write_text(
+        json.dumps(
+            {
+                "prior_head": "abc123",
+                "prior_base": "base123",
+                "changed_paths": ["src/app.py"],
+                "path_fingerprints": {"src/app.py": hashlib.sha256(changed_path.read_bytes()).hexdigest()},
+                "proof_groups": [{"command": "uv run pytest tests/test_app.py -q", "status": "passed"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "proof_reuse_guidance", "--format", "json"]) == 0
+    safe = json.loads(capsys.readouterr().out)["answer"]
+    assert safe["status"] == "reuse_safe_with_evidence"
+    assert safe["proof_groups"][0]["classification"] == "reuse_safe_with_evidence"
+
+    cache_path.write_text(
+        json.dumps(
+            {
+                "prior_head": "abc123",
+                "prior_base": "base123",
+                "changed_paths": ["src/app.py"],
+                "path_fingerprints": {"src/app.py": hashlib.sha256(changed_path.read_bytes()).hexdigest()},
+                "proof_groups": [
+                    {"command": "uv run pytest tests/test_app.py -q", "status": "passed"},
+                    {"command": "make lint-workspace", "status": "failed"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "proof_reuse_guidance", "--format", "json"]) == 0
+    partial = json.loads(capsys.readouterr().out)["answer"]
+    assert partial["status"] == "focused_rerun_required"
+    assert partial["proof_groups"][1]["classification"] == "rerun_required"
+
+    changed_path.write_text("VALUE = 2\n", encoding="utf-8")
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "proof_reuse_guidance", "--format", "json"]) == 0
+    stale = json.loads(capsys.readouterr().out)["answer"]
+    assert stale["status"] == "rerun_required"
+    assert stale["changed_fingerprints"] == ["src/app.py"]
+
+
+def test_report_runtime_mirror_consistency_detects_missing_and_mismatched_shapes(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    core = tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py"
+    primitives = tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py"
+    core.parent.mkdir(parents=True, exist_ok=True)
+    core.write_text(
+        """
+def _pr_comment_attention_payload():
+    return {"kind": "agentic-workspace/pr-comment-attention/v1", "status": "present", "extra": True}
+
+def _dogfooding_signal_status_payload():
+    return {"kind": "agentic-workspace/dogfooding-signal-status/v1", "status": "present"}
+""",
+        encoding="utf-8",
+    )
+    primitives.write_text(
+        """
+def _pr_comment_attention_payload():
+    return {"kind": "agentic-workspace/pr-comment-attention/v1", "status": "present"}
+""",
+        encoding="utf-8",
+    )
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "runtime_mirror_consistency", "--format", "json"]) == 0
+    mirror = json.loads(capsys.readouterr().out)["answer"]
+
+    assert mirror["status"] == "shape_mismatch"
+    by_surface = {record["mirrored_surface"]: record for record in mirror["records"]}
+    assert by_surface["pr_comment_attention"]["status"] == "shape_mismatch"
+    assert by_surface["dogfooding_signal_status"]["status"] == "mirror_missing"
+
+    primitives.write_text(core.read_text(encoding="utf-8"), encoding="utf-8")
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "runtime_mirror_consistency", "--format", "json"]) == 0
+    in_sync = json.loads(capsys.readouterr().out)["answer"]
+    assert in_sync["status"] == "in_sync"
 
 
 def test_report_dogfooding_signal_status_covers_closeout_states(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -320,6 +320,9 @@ review_aids = ["Confirm data minimisation and retention assumptions."]
 
 def test_proof_accumulates_repeated_changed_flags(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
+    script_path = tmp_path / "scripts" / "run_agentic_workspace.py"
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    script_path.write_text("print('ok')\n", encoding="utf-8")
 
     assert (
         cli.main(
@@ -344,6 +347,12 @@ def test_proof_accumulates_repeated_changed_flags(tmp_path: Path, capsys) -> Non
         "src/agentic_workspace/workspace_runtime_primitives.py",
         "tests/test_workspace_proof_cli.py",
     ]
+    lanes = {lane["id"]: lane for lane in payload["answer"]["selected_lanes"]}
+    assert "runtime_mirror_consistency" in lanes
+    assert (
+        "uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json"
+        in lanes["runtime_mirror_consistency"]["required_commands"]
+    )
 
 
 def test_proof_tiny_profile_returns_next_validation_action(capsys) -> None:


### PR DESCRIPTION
## Summary
- Keep report/meta startup compact while preserving selectors and hard claim-safety signals.
- Triage installed-state drift as actionable, claim-blocking, background advisory, or waived-for-narrow-work.
- Add stack-aware PR comment attention from local stack cache with concrete per-PR refresh commands.
- Add lazy `proof_reuse_guidance` and `runtime_mirror_consistency` report sections.
- Cover safe/partial/unknown proof reuse, current/actionable/stale stack comments, and in-sync/missing/mismatched mirror shapes.

Closes #1840
Closes #1841
Closes #1842
Closes #1843
Closes #1844

## Proof
- `uv run pytest tests/test_workspace_cli.py -q`
- `make lint-workspace`
- `make test-workspace`
- `uv run pytest tests/test_workspace_implement_cli.py -q -k "runtime_mirror"`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json` reported `status=in_sync`