### PR TITLE
Make dogfooding diagnostics actionable

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -4672,6 +4672,8 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             "claim_boundary": "No session signal source exists; broad repo-wide candidates stay behind explicit improvement_intake.",
         }
     outcome = _dogfooding_signal_status_outcome(cache)
+    signals = cast(list[str], outcome["signals"])
+    destinations = cast(list[str], outcome["destinations"])
     routing_decision = str(cache.get("routing_decision") or outcome["status"])
     session_signals = [
         {
@@ -4680,7 +4682,7 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             "routing_decision": routing_decision,
             "durability": outcome["durability"],
         }
-        for signal in outcome["signals"]
+        for signal in signals
     ]
     status = "checked_none" if outcome["status"] == "checked_none" else "session_observed"
     return {
@@ -4693,7 +4695,7 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             {
                 "outcome": outcome["status"],
                 "decision": routing_decision,
-                "destinations": outcome["destinations"],
+                "destinations": destinations,
                 "durable_residue": outcome["durable_residue"],
                 "closeout_blocked": outcome["closeout_blocked"],
             }
@@ -22445,6 +22447,8 @@ def _dogfooding_signal_status_payload(
         status = outcome["status"]
         reason = str(cache.get("reason") or "").strip()
         closeout_blocked = bool(outcome["closeout_blocked"])
+    signals = cast(list[str], outcome["signals"])
+    destinations = cast(list[str], outcome["destinations"])
     payload = {
         "kind": "agentic-workspace/dogfooding-signal-status/v1",
         "status": status,
@@ -22452,11 +22456,11 @@ def _dogfooding_signal_status_payload(
         "applies_to_current_work": True,
         "closeout_blocked": closeout_blocked,
         "reason": reason or ("Dogfooding review has not been recorded for this maintenance shape." if status == "not_checked" else ""),
-        "destinations": list(outcome["destinations"])[:5],
+        "destinations": destinations[:5],
         "dismissal_reason": str(outcome["dismissal_reason"]),
         "deferred_reason": str(outcome["deferred_reason"]),
-        "signal_count": len(outcome["signals"]),
-        "sample_signals": list(outcome["signals"])[:3],
+        "signal_count": len(signals),
+        "sample_signals": signals[:3],
         "durability": str(outcome["durability"]),
         "durable_residue": bool(outcome["durable_residue"]),
         "canonical_repo_history": bool(outcome["canonical_repo_history"]),

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -4479,6 +4479,12 @@ def _improvement_intake_payload(
         "kind": "workspace-improvement-intake/v1",
         "role": "router-not-backlog",
         "command": "agentic-workspace report --target ./repo --section improvement_intake --format json",
+        "intake_scope": {
+            "status": "explicit_repo_wide_requested" if isinstance(repo_friction, dict) else "session_scoped_default",
+            "session_section": "session_improvement_intake",
+            "repo_wide_section": "improvement_intake",
+            "rule": "Fresh session signals stay in session_improvement_intake; repo-wide diagnostics are available when this section is requested explicitly.",
+        },
         "audience_boundary": {
             "status": "source-checkout" if source_checkout else "target-repo",
             "rule": "Reusable host-repo diagnostics are shipped; package-development signals stay source-checkout-only.",
@@ -4528,6 +4534,8 @@ def _improvement_intake_payload(
             "Preserve provenance and confidence when a signal is routed.",
         ],
         "improvement_signal_candidates": signal_candidates,
+        "repo_wide_existing_candidates": signal_candidates,
+        "session_observed_signals": [],
         "candidate_count": len(signal_candidates),
         "setup_findings": {
             "status": setup_findings.get("status"),
@@ -4552,6 +4560,155 @@ def _improvement_intake_payload(
             "hidden_subtype_count": len(source_checkout_only_subtypes),
         }
     return payload
+
+
+def _dogfooding_signal_status_outcome(cache: dict[str, Any]) -> dict[str, Any]:
+    signals = [str(item) for item in _list_payload(cache.get("signals")) if str(item).strip()]
+    destinations = [str(item) for item in _list_payload(cache.get("destinations")) if str(item).strip()]
+    raw_status = str(cache.get("status") or cache.get("outcome") or "").strip()
+    dismissal_reason = str(cache.get("dismissal_reason") or cache.get("reason") or "").strip()
+    deferred_reason = str(cache.get("deferred_reason") or cache.get("reason") or "").strip()
+    durable_route_statuses = {
+        "routed_to_issue",
+        "routed_to_planning",
+        "routed_to_memory",
+        "routed_to_docs",
+    }
+    legacy_map = {
+        "no_signal_found": "checked_none",
+        "signals_routed": "routed_to_issue" if destinations else "unresolved",
+        "signals_dismissed_with_reason": "dismissed_with_reason",
+    }
+    status = legacy_map.get(raw_status, raw_status)
+    if status not in {
+        "not_checked",
+        "checked_none",
+        "recorded_chat_only",
+        "recorded_session_only",
+        "routed_to_issue",
+        "routed_to_planning",
+        "routed_to_memory",
+        "routed_to_docs",
+        "deferred_to_roadmap",
+        "dismissed_with_reason",
+        "unresolved",
+    }:
+        status = "unresolved" if signals else "not_checked"
+    if signals and status == "not_checked":
+        status = "unresolved"
+    if status in durable_route_statuses and not destinations:
+        status = "unresolved"
+    if status == "dismissed_with_reason" and not dismissal_reason:
+        status = "unresolved"
+    if status == "deferred_to_roadmap" and not (destinations or deferred_reason):
+        status = "unresolved"
+    closeout_blocked = status == "unresolved"
+    durable_residue = status in durable_route_statuses or status in {"deferred_to_roadmap", "unresolved"}
+    durability = (
+        "canonical_repo_history"
+        if status in durable_route_statuses
+        else "roadmap_or_future_work"
+        if status == "deferred_to_roadmap"
+        else "local_chat_only"
+        if status == "recorded_chat_only"
+        else "local_session_only"
+        if status == "recorded_session_only"
+        else "none"
+        if status in {"checked_none", "dismissed_with_reason"}
+        else "unresolved"
+        if status == "unresolved"
+        else "not_checked"
+    )
+    return {
+        "status": status,
+        "signals": signals,
+        "destinations": destinations,
+        "dismissal_reason": dismissal_reason,
+        "deferred_reason": deferred_reason,
+        "closeout_blocked": closeout_blocked,
+        "durable_residue": durable_residue,
+        "durability": durability,
+        "canonical_repo_history": durability == "canonical_repo_history",
+    }
+
+
+def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceConfig, cli_invoke: str) -> dict[str, Any]:
+    cache_path = ".agentic-workspace/local/cache/dogfooding-signal-status.json"
+    cache = _read_local_cache_json(target_root, cache_path)
+    repo_wide_command = _command_with_cli_invoke(
+        command="agentic-workspace report --target ./repo --section improvement_intake --format json",
+        cli_invoke=cli_invoke,
+    )
+    if cache.get("_cache_error"):
+        return {
+            "kind": "workspace-session-improvement-intake/v1",
+            "status": "unavailable",
+            "scope": "session_observed",
+            "reason": str(cache["_cache_error"]),
+            "session_signal_source": {"status": "unavailable", "cache_path": cache_path},
+            "session_observed_signals": [],
+            "routing_decisions": [],
+            "repo_wide_existing": {
+                "status": "available_on_request",
+                "command": repo_wide_command,
+                "included_by_default": False,
+            },
+            "claim_boundary": "Session-scoped improvement state is unavailable; do not claim no dogfooding residue from this packet.",
+        }
+    if not cache:
+        return {
+            "kind": "workspace-session-improvement-intake/v1",
+            "status": "unavailable",
+            "scope": "session_observed",
+            "reason": "No local session dogfooding signal cache was found.",
+            "session_signal_source": {"status": "missing", "cache_path": cache_path},
+            "session_observed_signals": [],
+            "routing_decisions": [],
+            "repo_wide_existing": {
+                "status": "available_on_request",
+                "command": repo_wide_command,
+                "included_by_default": False,
+            },
+            "claim_boundary": "No session signal source exists; broad repo-wide candidates stay behind explicit improvement_intake.",
+        }
+    outcome = _dogfooding_signal_status_outcome(cache)
+    routing_decision = str(cache.get("routing_decision") or outcome["status"])
+    session_signals = [
+        {
+            "signal": signal,
+            "outcome": outcome["status"],
+            "routing_decision": routing_decision,
+            "durability": outcome["durability"],
+        }
+        for signal in outcome["signals"]
+    ]
+    status = "checked_none" if outcome["status"] == "checked_none" else "session_observed"
+    return {
+        "kind": "workspace-session-improvement-intake/v1",
+        "status": status,
+        "scope": "session_observed",
+        "session_signal_source": {"status": "present", "cache_path": cache_path},
+        "session_observed_signals": session_signals,
+        "routing_decisions": [
+            {
+                "outcome": outcome["status"],
+                "decision": routing_decision,
+                "destinations": outcome["destinations"],
+                "durable_residue": outcome["durable_residue"],
+                "closeout_blocked": outcome["closeout_blocked"],
+            }
+        ],
+        "repo_wide_existing": {
+            "status": "available_on_request",
+            "command": repo_wide_command,
+            "included_by_default": False,
+        },
+        "claim_boundary": (
+            "Unresolved session improvement signals remain closeout-visible."
+            if outcome["closeout_blocked"]
+            else "Session improvement signals have an explicit non-blocking outcome."
+        ),
+    }
 
 
 def _with_agent_instructions_file(config: WorkspaceConfig, *, filename: str, source: str) -> WorkspaceConfig:
@@ -9724,8 +9881,14 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
     {
         "section": "dogfooding_signal_status",
         "kind": "agentic-workspace/dogfooding-signal-status/v1",
-        "purpose": "compact closeout status for package dogfooding signals: not checked, none found, routed, or dismissed",
+        "purpose": "compact closeout status for package dogfooding signal outcomes and residue",
         "when_to_use": "for planned lanes, stacked PR sequences, release/recovery work, and non-trivial maintenance closeout",
+    },
+    {
+        "section": "session_improvement_intake",
+        "kind": "workspace-session-improvement-intake/v1",
+        "purpose": "cheap session-scoped dogfooding/improvement intake without repo-wide diagnostics",
+        "when_to_use": "for quick dogfooding reports or closeout when current-session signals should be routed, recorded, dismissed, deferred, or left visibly unresolved",
     },
     {
         "section": "closeout_trust",
@@ -11921,6 +12084,14 @@ def _run_lazy_report_section_command(
             task_text="planned lane or maintenance report section requested",
             cli_invoke=config.cli_invoke,
             active_planning_present=bool(active_planning_record),
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "session_improvement_intake":
+        payload["session_improvement_intake"] = _session_improvement_intake_payload(
+            target_root=target_root,
+            config=config,
+            cli_invoke=config.cli_invoke,
         )
         return _select_report_payload(payload, profile="router", section=normalized)
 
@@ -22241,42 +22412,59 @@ def _dogfooding_signal_status_payload(
             "reason": "No planned lane, stacked PR, release/recovery, or maintainer dogfooding context detected.",
         }
     command = _command_with_cli_invoke(
-        command="agentic-workspace report --target ./repo --section improvement_intake --format json",
-        cli_invoke=cli_invoke,
+        command="agentic-workspace report --target ./repo --section session_improvement_intake --format json", cli_invoke=cli_invoke
     )
-    allowed_statuses = {"not_checked", "no_signal_found", "signals_routed", "signals_dismissed_with_reason"}
+    allowed_statuses = {
+        "not_checked",
+        "checked_none",
+        "recorded_chat_only",
+        "recorded_session_only",
+        "routed_to_issue",
+        "routed_to_planning",
+        "routed_to_memory",
+        "routed_to_docs",
+        "deferred_to_roadmap",
+        "dismissed_with_reason",
+        "unresolved",
+    }
     if cache.get("_cache_error"):
         status = "not_checked"
         reason = str(cache["_cache_error"])
         closeout_blocked = True
+        outcome = {
+            "signals": [],
+            "destinations": [],
+            "dismissal_reason": "",
+            "deferred_reason": "",
+            "durability": "not_checked",
+            "durable_residue": False,
+            "canonical_repo_history": False,
+        }
     else:
-        raw_status = str(cache.get("status") or "").strip()
-        signals = [item for item in _list_payload(cache.get("signals")) if str(item).strip()]
-        destinations = [item for item in _list_payload(cache.get("destinations")) if str(item).strip()]
-        dismissal_reason = str(cache.get("dismissal_reason") or "").strip()
-        if raw_status in allowed_statuses:
-            status = raw_status
-        elif signals:
-            status = "not_checked"
-        else:
-            status = "not_checked"
+        outcome = _dogfooding_signal_status_outcome(cache)
+        status = outcome["status"]
         reason = str(cache.get("reason") or "").strip()
-        closeout_blocked = bool(signals and not destinations and not dismissal_reason and status not in {"no_signal_found"})
+        closeout_blocked = bool(outcome["closeout_blocked"])
     payload = {
         "kind": "agentic-workspace/dogfooding-signal-status/v1",
         "status": status,
+        "outcome": status,
         "applies_to_current_work": True,
         "closeout_blocked": closeout_blocked,
         "reason": reason or ("Dogfooding review has not been recorded for this maintenance shape." if status == "not_checked" else ""),
-        "destinations": [str(item) for item in _list_payload(cache.get("destinations")) if str(item).strip()][:5],
-        "dismissal_reason": str(cache.get("dismissal_reason") or ""),
-        "signal_count": len([item for item in _list_payload(cache.get("signals")) if str(item).strip()]),
-        "sample_signals": [str(item) for item in _list_payload(cache.get("signals")) if str(item).strip()][:3],
+        "destinations": list(outcome["destinations"])[:5],
+        "dismissal_reason": str(outcome["dismissal_reason"]),
+        "deferred_reason": str(outcome["deferred_reason"]),
+        "signal_count": len(outcome["signals"]),
+        "sample_signals": list(outcome["signals"])[:3],
+        "durability": str(outcome["durability"]),
+        "durable_residue": bool(outcome["durable_residue"]),
+        "canonical_repo_history": bool(outcome["canonical_repo_history"]),
         "cache_path": cache_path,
         "detail_command": command,
         "selector": "dogfooding_signal_status",
         "allowed_statuses": sorted(allowed_statuses),
-        "claim_boundary": "A broad done claim is qualified until dogfooding signals are routed, dismissed with a reason, or recorded as no_signal_found.",
+        "claim_boundary": "A broad done claim is qualified until dogfooding signals are checked and routed, recorded locally, deferred, dismissed, or left visibly unresolved.",
     }
     return {key: value for key, value in payload.items() if value not in ("", [], {})}
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -4566,6 +4566,8 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             "claim_boundary": "No session signal source exists; broad repo-wide candidates stay behind explicit improvement_intake.",
         }
     outcome = _dogfooding_signal_status_outcome(cache)
+    signals = cast(list[str], outcome["signals"])
+    destinations = cast(list[str], outcome["destinations"])
     routing_decision = str(cache.get("routing_decision") or outcome["status"])
     session_signals = [
         {
@@ -4574,7 +4576,7 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             "routing_decision": routing_decision,
             "durability": outcome["durability"],
         }
-        for signal in outcome["signals"]
+        for signal in signals
     ]
     status = "checked_none" if outcome["status"] == "checked_none" else "session_observed"
     return {
@@ -4587,7 +4589,7 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             {
                 "outcome": outcome["status"],
                 "decision": routing_decision,
-                "destinations": outcome["destinations"],
+                "destinations": destinations,
                 "durable_residue": outcome["durable_residue"],
                 "closeout_blocked": outcome["closeout_blocked"],
             }
@@ -22339,6 +22341,8 @@ def _dogfooding_signal_status_payload(
         status = outcome["status"]
         reason = str(cache.get("reason") or "").strip()
         closeout_blocked = bool(outcome["closeout_blocked"])
+    signals = cast(list[str], outcome["signals"])
+    destinations = cast(list[str], outcome["destinations"])
     payload = {
         "kind": "agentic-workspace/dogfooding-signal-status/v1",
         "status": status,
@@ -22346,11 +22350,11 @@ def _dogfooding_signal_status_payload(
         "applies_to_current_work": True,
         "closeout_blocked": closeout_blocked,
         "reason": reason or ("Dogfooding review has not been recorded for this maintenance shape." if status == "not_checked" else ""),
-        "destinations": list(outcome["destinations"])[:5],
+        "destinations": destinations[:5],
         "dismissal_reason": str(outcome["dismissal_reason"]),
         "deferred_reason": str(outcome["deferred_reason"]),
-        "signal_count": len(outcome["signals"]),
-        "sample_signals": list(outcome["signals"])[:3],
+        "signal_count": len(signals),
+        "sample_signals": signals[:3],
         "durability": str(outcome["durability"]),
         "durable_residue": bool(outcome["durable_residue"]),
         "canonical_repo_history": bool(outcome["canonical_repo_history"]),

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -4373,6 +4373,12 @@ def _improvement_intake_payload(
         "kind": "workspace-improvement-intake/v1",
         "role": "router-not-backlog",
         "command": "agentic-workspace report --target ./repo --section improvement_intake --format json",
+        "intake_scope": {
+            "status": "explicit_repo_wide_requested" if isinstance(repo_friction, dict) else "session_scoped_default",
+            "session_section": "session_improvement_intake",
+            "repo_wide_section": "improvement_intake",
+            "rule": "Fresh session signals stay in session_improvement_intake; repo-wide diagnostics are available when this section is requested explicitly.",
+        },
         "audience_boundary": {
             "status": "source-checkout" if source_checkout else "target-repo",
             "rule": "Reusable host-repo diagnostics are shipped; package-development signals stay source-checkout-only.",
@@ -4422,6 +4428,8 @@ def _improvement_intake_payload(
             "Preserve provenance and confidence when a signal is routed.",
         ],
         "improvement_signal_candidates": signal_candidates,
+        "repo_wide_existing_candidates": signal_candidates,
+        "session_observed_signals": [],
         "candidate_count": len(signal_candidates),
         "setup_findings": {
             "status": setup_findings.get("status"),
@@ -4446,6 +4454,155 @@ def _improvement_intake_payload(
             "hidden_subtype_count": len(source_checkout_only_subtypes),
         }
     return payload
+
+
+def _dogfooding_signal_status_outcome(cache: dict[str, Any]) -> dict[str, Any]:
+    signals = [str(item) for item in _list_payload(cache.get("signals")) if str(item).strip()]
+    destinations = [str(item) for item in _list_payload(cache.get("destinations")) if str(item).strip()]
+    raw_status = str(cache.get("status") or cache.get("outcome") or "").strip()
+    dismissal_reason = str(cache.get("dismissal_reason") or cache.get("reason") or "").strip()
+    deferred_reason = str(cache.get("deferred_reason") or cache.get("reason") or "").strip()
+    durable_route_statuses = {
+        "routed_to_issue",
+        "routed_to_planning",
+        "routed_to_memory",
+        "routed_to_docs",
+    }
+    legacy_map = {
+        "no_signal_found": "checked_none",
+        "signals_routed": "routed_to_issue" if destinations else "unresolved",
+        "signals_dismissed_with_reason": "dismissed_with_reason",
+    }
+    status = legacy_map.get(raw_status, raw_status)
+    if status not in {
+        "not_checked",
+        "checked_none",
+        "recorded_chat_only",
+        "recorded_session_only",
+        "routed_to_issue",
+        "routed_to_planning",
+        "routed_to_memory",
+        "routed_to_docs",
+        "deferred_to_roadmap",
+        "dismissed_with_reason",
+        "unresolved",
+    }:
+        status = "unresolved" if signals else "not_checked"
+    if signals and status == "not_checked":
+        status = "unresolved"
+    if status in durable_route_statuses and not destinations:
+        status = "unresolved"
+    if status == "dismissed_with_reason" and not dismissal_reason:
+        status = "unresolved"
+    if status == "deferred_to_roadmap" and not (destinations or deferred_reason):
+        status = "unresolved"
+    closeout_blocked = status == "unresolved"
+    durable_residue = status in durable_route_statuses or status in {"deferred_to_roadmap", "unresolved"}
+    durability = (
+        "canonical_repo_history"
+        if status in durable_route_statuses
+        else "roadmap_or_future_work"
+        if status == "deferred_to_roadmap"
+        else "local_chat_only"
+        if status == "recorded_chat_only"
+        else "local_session_only"
+        if status == "recorded_session_only"
+        else "none"
+        if status in {"checked_none", "dismissed_with_reason"}
+        else "unresolved"
+        if status == "unresolved"
+        else "not_checked"
+    )
+    return {
+        "status": status,
+        "signals": signals,
+        "destinations": destinations,
+        "dismissal_reason": dismissal_reason,
+        "deferred_reason": deferred_reason,
+        "closeout_blocked": closeout_blocked,
+        "durable_residue": durable_residue,
+        "durability": durability,
+        "canonical_repo_history": durability == "canonical_repo_history",
+    }
+
+
+def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceConfig, cli_invoke: str) -> dict[str, Any]:
+    cache_path = ".agentic-workspace/local/cache/dogfooding-signal-status.json"
+    cache = _read_local_cache_json(target_root, cache_path)
+    repo_wide_command = _command_with_cli_invoke(
+        command="agentic-workspace report --target ./repo --section improvement_intake --format json",
+        cli_invoke=cli_invoke,
+    )
+    if cache.get("_cache_error"):
+        return {
+            "kind": "workspace-session-improvement-intake/v1",
+            "status": "unavailable",
+            "scope": "session_observed",
+            "reason": str(cache["_cache_error"]),
+            "session_signal_source": {"status": "unavailable", "cache_path": cache_path},
+            "session_observed_signals": [],
+            "routing_decisions": [],
+            "repo_wide_existing": {
+                "status": "available_on_request",
+                "command": repo_wide_command,
+                "included_by_default": False,
+            },
+            "claim_boundary": "Session-scoped improvement state is unavailable; do not claim no dogfooding residue from this packet.",
+        }
+    if not cache:
+        return {
+            "kind": "workspace-session-improvement-intake/v1",
+            "status": "unavailable",
+            "scope": "session_observed",
+            "reason": "No local session dogfooding signal cache was found.",
+            "session_signal_source": {"status": "missing", "cache_path": cache_path},
+            "session_observed_signals": [],
+            "routing_decisions": [],
+            "repo_wide_existing": {
+                "status": "available_on_request",
+                "command": repo_wide_command,
+                "included_by_default": False,
+            },
+            "claim_boundary": "No session signal source exists; broad repo-wide candidates stay behind explicit improvement_intake.",
+        }
+    outcome = _dogfooding_signal_status_outcome(cache)
+    routing_decision = str(cache.get("routing_decision") or outcome["status"])
+    session_signals = [
+        {
+            "signal": signal,
+            "outcome": outcome["status"],
+            "routing_decision": routing_decision,
+            "durability": outcome["durability"],
+        }
+        for signal in outcome["signals"]
+    ]
+    status = "checked_none" if outcome["status"] == "checked_none" else "session_observed"
+    return {
+        "kind": "workspace-session-improvement-intake/v1",
+        "status": status,
+        "scope": "session_observed",
+        "session_signal_source": {"status": "present", "cache_path": cache_path},
+        "session_observed_signals": session_signals,
+        "routing_decisions": [
+            {
+                "outcome": outcome["status"],
+                "decision": routing_decision,
+                "destinations": outcome["destinations"],
+                "durable_residue": outcome["durable_residue"],
+                "closeout_blocked": outcome["closeout_blocked"],
+            }
+        ],
+        "repo_wide_existing": {
+            "status": "available_on_request",
+            "command": repo_wide_command,
+            "included_by_default": False,
+        },
+        "claim_boundary": (
+            "Unresolved session improvement signals remain closeout-visible."
+            if outcome["closeout_blocked"]
+            else "Session improvement signals have an explicit non-blocking outcome."
+        ),
+    }
 
 
 def _with_agent_instructions_file(config: WorkspaceConfig, *, filename: str, source: str) -> WorkspaceConfig:
@@ -9618,8 +9775,14 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
     {
         "section": "dogfooding_signal_status",
         "kind": "agentic-workspace/dogfooding-signal-status/v1",
-        "purpose": "compact closeout status for package dogfooding signals: not checked, none found, routed, or dismissed",
+        "purpose": "compact closeout status for package dogfooding signal outcomes and residue",
         "when_to_use": "for planned lanes, stacked PR sequences, release/recovery work, and non-trivial maintenance closeout",
+    },
+    {
+        "section": "session_improvement_intake",
+        "kind": "workspace-session-improvement-intake/v1",
+        "purpose": "cheap session-scoped dogfooding/improvement intake without repo-wide diagnostics",
+        "when_to_use": "for quick dogfooding reports or closeout when current-session signals should be routed, recorded, dismissed, deferred, or left visibly unresolved",
     },
     {
         "section": "closeout_trust",
@@ -11815,6 +11978,14 @@ def _run_lazy_report_section_command(
             task_text="planned lane or maintenance report section requested",
             cli_invoke=config.cli_invoke,
             active_planning_present=bool(active_planning_record),
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "session_improvement_intake":
+        payload["session_improvement_intake"] = _session_improvement_intake_payload(
+            target_root=target_root,
+            config=config,
+            cli_invoke=config.cli_invoke,
         )
         return _select_report_payload(payload, profile="router", section=normalized)
 
@@ -22135,42 +22306,59 @@ def _dogfooding_signal_status_payload(
             "reason": "No planned lane, stacked PR, release/recovery, or maintainer dogfooding context detected.",
         }
     command = _command_with_cli_invoke(
-        command="agentic-workspace report --target ./repo --section improvement_intake --format json",
-        cli_invoke=cli_invoke,
+        command="agentic-workspace report --target ./repo --section session_improvement_intake --format json", cli_invoke=cli_invoke
     )
-    allowed_statuses = {"not_checked", "no_signal_found", "signals_routed", "signals_dismissed_with_reason"}
+    allowed_statuses = {
+        "not_checked",
+        "checked_none",
+        "recorded_chat_only",
+        "recorded_session_only",
+        "routed_to_issue",
+        "routed_to_planning",
+        "routed_to_memory",
+        "routed_to_docs",
+        "deferred_to_roadmap",
+        "dismissed_with_reason",
+        "unresolved",
+    }
     if cache.get("_cache_error"):
         status = "not_checked"
         reason = str(cache["_cache_error"])
         closeout_blocked = True
+        outcome = {
+            "signals": [],
+            "destinations": [],
+            "dismissal_reason": "",
+            "deferred_reason": "",
+            "durability": "not_checked",
+            "durable_residue": False,
+            "canonical_repo_history": False,
+        }
     else:
-        raw_status = str(cache.get("status") or "").strip()
-        signals = [item for item in _list_payload(cache.get("signals")) if str(item).strip()]
-        destinations = [item for item in _list_payload(cache.get("destinations")) if str(item).strip()]
-        dismissal_reason = str(cache.get("dismissal_reason") or "").strip()
-        if raw_status in allowed_statuses:
-            status = raw_status
-        elif signals:
-            status = "not_checked"
-        else:
-            status = "not_checked"
+        outcome = _dogfooding_signal_status_outcome(cache)
+        status = outcome["status"]
         reason = str(cache.get("reason") or "").strip()
-        closeout_blocked = bool(signals and not destinations and not dismissal_reason and status not in {"no_signal_found"})
+        closeout_blocked = bool(outcome["closeout_blocked"])
     payload = {
         "kind": "agentic-workspace/dogfooding-signal-status/v1",
         "status": status,
+        "outcome": status,
         "applies_to_current_work": True,
         "closeout_blocked": closeout_blocked,
         "reason": reason or ("Dogfooding review has not been recorded for this maintenance shape." if status == "not_checked" else ""),
-        "destinations": [str(item) for item in _list_payload(cache.get("destinations")) if str(item).strip()][:5],
-        "dismissal_reason": str(cache.get("dismissal_reason") or ""),
-        "signal_count": len([item for item in _list_payload(cache.get("signals")) if str(item).strip()]),
-        "sample_signals": [str(item) for item in _list_payload(cache.get("signals")) if str(item).strip()][:3],
+        "destinations": list(outcome["destinations"])[:5],
+        "dismissal_reason": str(outcome["dismissal_reason"]),
+        "deferred_reason": str(outcome["deferred_reason"]),
+        "signal_count": len(outcome["signals"]),
+        "sample_signals": list(outcome["signals"])[:3],
+        "durability": str(outcome["durability"]),
+        "durable_residue": bool(outcome["durable_residue"]),
+        "canonical_repo_history": bool(outcome["canonical_repo_history"]),
         "cache_path": cache_path,
         "detail_command": command,
         "selector": "dogfooding_signal_status",
         "allowed_statuses": sorted(allowed_statuses),
-        "claim_boundary": "A broad done claim is qualified until dogfooding signals are routed, dismissed with a reason, or recorded as no_signal_found.",
+        "claim_boundary": "A broad done claim is qualified until dogfooding signals are checked and routed, recorded locally, deferred, dismissed, or left visibly unresolved.",
     }
     return {key: value for key, value in payload.items() if value not in ("", [], {})}
 

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1310,14 +1310,20 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             for key in (
                 "kind",
                 "status",
+                "outcome",
                 "closeout_blocked",
                 "destinations",
                 "dismissal_reason",
+                "deferred_reason",
                 "signal_count",
+                "sample_signals",
+                "durability",
+                "durable_residue",
+                "canonical_repo_history",
                 "detail_command",
                 "selector",
             )
-            if key in dogfooding_signal_status
+            if key in dogfooding_signal_status and dogfooding_signal_status.get(key) not in (None, "", [], {}, False, 0)
         }
     uv_guidance = payload.get("uv_cache_guidance", {})
     if not (isinstance(uv_guidance, dict) and uv_guidance.get("status") == "available"):

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -785,6 +785,40 @@ def test_start_keeps_planned_and_release_closeout_signals_visible(tmp_path: Path
     assert "dogfooding_signal_status" in release["action_signals"]["advisory_detail"]["selectors"]
 
 
+def test_start_surfaces_unresolved_dogfooding_signal_outcome(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    cache_path = tmp_path / ".agentic-workspace" / "local" / "cache" / "dogfooding-signal-status.json"
+    cache_path.write_text(
+        json.dumps({"status": "unresolved", "signals": ["diagnostic did not change routing"]}),
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue planned lane in stacked PR sequence",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    status = payload["context"]["dogfooding_signal_status"]
+    assert status["status"] == "unresolved"
+    assert status["closeout_blocked"] is True
+    assert status["durable_residue"] is True
+    assert status["sample_signals"] == ["diagnostic did not change routing"]
+    assert "dogfooding_signal_status=unresolved" in payload["action_signals"]["changed_signals"]
+
+
 def test_start_report_meta_task_keeps_routine_context_selector_only_with_background_drift(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
@@ -2147,27 +2181,59 @@ def test_report_dogfooding_signal_status_covers_closeout_states(tmp_path: Path, 
     assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
     not_checked = json.loads(capsys.readouterr().out)["answer"]
     assert not_checked["status"] == "not_checked"
+    assert not_checked["outcome"] == "not_checked"
     assert not_checked["closeout_blocked"] is False
+    assert "session_improvement_intake" in not_checked["detail_command"]
 
-    cache_path.write_text(json.dumps({"status": "no_signal_found", "reason": "reviewed; no durable signal"}), encoding="utf-8")
+    cache_path.write_text(json.dumps({"status": "checked_none", "reason": "reviewed; no durable signal"}), encoding="utf-8")
     assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
     no_signal = json.loads(capsys.readouterr().out)["answer"]
-    assert no_signal["status"] == "no_signal_found"
+    assert no_signal["status"] == "checked_none"
+    assert no_signal["durable_residue"] is False
 
     cache_path.write_text(
-        json.dumps({"status": "signals_routed", "signals": ["startup missed PR comments"], "destinations": ["#1831"]}),
+        json.dumps({"status": "recorded_chat_only", "signals": ["in-chat dogfooding note"]}),
+        encoding="utf-8",
+    )
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
+    chat_only = json.loads(capsys.readouterr().out)["answer"]
+    assert chat_only["status"] == "recorded_chat_only"
+    assert chat_only["durability"] == "local_chat_only"
+    assert chat_only["canonical_repo_history"] is False
+
+    cache_path.write_text(
+        json.dumps({"status": "recorded_session_only", "signals": ["temporary validation friction"]}),
+        encoding="utf-8",
+    )
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
+    session_only = json.loads(capsys.readouterr().out)["answer"]
+    assert session_only["status"] == "recorded_session_only"
+    assert session_only["durability"] == "local_session_only"
+
+    cache_path.write_text(
+        json.dumps({"status": "routed_to_issue", "signals": ["startup missed PR comments"], "destinations": ["#1831"]}),
         encoding="utf-8",
     )
     assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
     routed = json.loads(capsys.readouterr().out)["answer"]
-    assert routed["status"] == "signals_routed"
+    assert routed["status"] == "routed_to_issue"
     assert routed["destinations"] == ["#1831"]
     assert routed["closeout_blocked"] is False
+    assert routed["durable_residue"] is True
+
+    cache_path.write_text(
+        json.dumps({"status": "deferred_to_roadmap", "signals": ["larger design concern"], "deferred_reason": "roadmap batch"}),
+        encoding="utf-8",
+    )
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
+    deferred = json.loads(capsys.readouterr().out)["answer"]
+    assert deferred["status"] == "deferred_to_roadmap"
+    assert deferred["durability"] == "roadmap_or_future_work"
 
     cache_path.write_text(
         json.dumps(
             {
-                "status": "signals_dismissed_with_reason",
+                "status": "dismissed_with_reason",
                 "signals": ["one-off shell typo"],
                 "dismissal_reason": "operator typo, not product friction",
             }
@@ -2176,14 +2242,51 @@ def test_report_dogfooding_signal_status_covers_closeout_states(tmp_path: Path, 
     )
     assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
     dismissed = json.loads(capsys.readouterr().out)["answer"]
-    assert dismissed["status"] == "signals_dismissed_with_reason"
+    assert dismissed["status"] == "dismissed_with_reason"
     assert dismissed["dismissal_reason"] == "operator typo, not product friction"
 
     cache_path.write_text(json.dumps({"signals": ["unrouted friction"]}), encoding="utf-8")
     assert cli.main(["report", "--target", str(tmp_path), "--section", "dogfooding_signal_status", "--format", "json"]) == 0
     blocked = json.loads(capsys.readouterr().out)["answer"]
-    assert blocked["status"] == "not_checked"
+    assert blocked["status"] == "unresolved"
     assert blocked["closeout_blocked"] is True
+    assert blocked["durable_residue"] is True
+
+
+def test_session_improvement_intake_separates_session_and_repo_wide_scopes(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    cache_path = tmp_path / ".agentic-workspace" / "local" / "cache" / "dogfooding-signal-status.json"
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "session_improvement_intake", "--format", "json"]) == 0
+    unavailable = json.loads(capsys.readouterr().out)["answer"]
+    assert unavailable["status"] == "unavailable"
+    assert unavailable["session_signal_source"]["status"] == "missing"
+    assert unavailable["repo_wide_existing"]["included_by_default"] is False
+    assert "large_file" not in json.dumps(unavailable)
+
+    cache_path.write_text(
+        json.dumps(
+            {
+                "status": "unresolved",
+                "signals": ["improvement diagnostics did not change next action"],
+                "routing_decision": "route_now",
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "session_improvement_intake", "--format", "json"]) == 0
+    session = json.loads(capsys.readouterr().out)["answer"]
+    assert session["status"] == "session_observed"
+    assert session["session_observed_signals"][0]["outcome"] == "unresolved"
+    assert session["routing_decisions"][0]["decision"] == "route_now"
+    assert session["routing_decisions"][0]["closeout_blocked"] is True
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "improvement_intake", "--format", "json"]) == 0
+    repo_wide = json.loads(capsys.readouterr().out)["answer"]
+    assert repo_wide["intake_scope"]["status"] == "explicit_repo_wide_requested"
+    assert "repo_wide_existing_candidates" in repo_wide
 
 
 def test_start_surfaces_recovery_for_obsolete_default_preset(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Model dogfooding signal outcomes with explicit statuses for checked-none, chat/session-only records, routed destinations, roadmap deferrals, dismissals, and unresolved residue.
- Add a cheap `session_improvement_intake` report section that reads current-session dogfooding signals without running repo-wide diagnostics.
- Keep repo-wide improvement intake available explicitly and annotate its scope separately from session-observed signals.
- Surface unresolved dogfooding residue in startup closeout context while keeping nonblocking report/meta startup output compact.

Closes #1846
Closes #1847

#1848 remains open as the broader diagnostics-consequence umbrella per review feedback.

## Proof
- `make typecheck`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json` reported `status=in_sync`
- `uv run python scripts/run_agentic_workspace.py report --target . --section session_improvement_intake --format json`