### PR TITLE
[codex] Reduce test strategy and proof runner hotspots

### DIFF
--- a/.agentic-workspace/verification/test-suite-budget.json
+++ b/.agentic-workspace/verification/test-suite-budget.json
@@ -1,0 +1,42 @@
+{
+  "kind": "agentic-workspace/test-suite-budget/v1",
+  "source": "GitHub review #1858 / refined issues #1856 and #1857",
+  "provenance": {
+    "measurement_command": "uv run pytest --collect-only -q",
+    "recorded_by": "maintainer review evidence",
+    "recorded_at": "2026-06-29",
+    "notes": "Counts are repo-owned observations used only by this source checkout when fresh."
+  },
+  "scopes": [
+    {
+      "scope": "root",
+      "baseline": {
+        "date": "2026-06-15",
+        "collected_count": 613
+      },
+      "current": {
+        "observed_at": "2026-06-29",
+        "collected_count": 884,
+        "source": "review comment on PR #1858",
+        "max_age_days": 30
+      },
+      "target": {
+        "min": 500,
+        "max": 700
+      }
+    },
+    {
+      "scope": "all",
+      "baseline": {
+        "date": "2026-06-15",
+        "collected_count": 1118
+      },
+      "current": {
+        "observed_at": "2026-06-29",
+        "collected_count": 1426,
+        "source": "review comment on PR #1858",
+        "max_age_days": 30
+      }
+    }
+  ]
+}

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -3408,6 +3408,55 @@ def _validate_python_shipped_source_executable_retirement() -> list[str]:
     return errors
 
 
+def _validate_generated_mutation_target_routing(ir: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+    packages = {package.get("id"): package for package in ir.get("packages", []) if isinstance(package, dict)}
+    for package_id, package in packages.items():
+        has_mutating_generated_command = any(
+            isinstance(command, dict)
+            and command.get("status") == "generated"
+            and isinstance(command.get("effect_hints"), dict)
+            and (
+                command["effect_hints"].get("writes_repo_state") is True
+                or command["effect_hints"].get("destructive") is True
+                or command["effect_hints"].get("requires_preflight_gate") is True
+            )
+            for command in package.get("commands", [])
+        )
+        for target in package.get("targets", []):
+            if not isinstance(target, dict) or target.get("kind") not in {"python", "typescript"}:
+                continue
+            if has_mutating_generated_command and target.get("maturity_level_ref") == "weak-agent-safe-adapter":
+                errors.append(
+                    f"command_package_ir.json package {package_id!r} {target.get('kind')} target advertises "
+                    "weak-agent-safe-adapter while generated commands include mutation-capable effects"
+                )
+    return errors
+
+
+def _validate_primitive_conformance_surface() -> list[str]:
+    errors: list[str] = []
+    primitive_conformance_dockerfile = REPO_ROOT / "generated" / "python" / "Dockerfile.primitive-conformance"
+    if not primitive_conformance_dockerfile.is_file():
+        errors.append("generated/python/Dockerfile.primitive-conformance is missing")
+    try:
+        import command_generation.primitive_conformance as primitive_conformance  # noqa: PLC0415
+    except ModuleNotFoundError:
+        primitive_conformance_script = None
+    else:
+        primitive_conformance_script = Path(primitive_conformance.__file__).resolve()
+    if primitive_conformance_script is None:
+        errors.append("command_generation.primitive_conformance is missing")
+    elif not primitive_conformance_script.is_file():
+        errors.append("command_generation.primitive_conformance is missing")
+    else:
+        primitive_conformance_text = primitive_conformance_script.read_text(encoding="utf-8")
+        for primitive_id in sorted(REQUIRED_PORTABLE_PRIMITIVE_CONFORMANCE):
+            if primitive_id not in primitive_conformance_text:
+                errors.append(f"primitive conformance is missing required primitive case: {primitive_id}")
+    return errors
+
+
 def _validate_python_operation_execution_inventory(ir: dict[str, object]) -> list[str]:
     errors: list[str] = []
     try:
@@ -4913,26 +4962,8 @@ def _validate_static_surfaces() -> list[str]:
                 errors.append("command_package_ir.json root Bash transport candidate must remain explicit and deferred")
             if not powershell_targets or powershell_targets[0].get("maturity_level_ref") != "deferred":
                 errors.append("command_package_ir.json root PowerShell transport candidate must remain explicit and deferred")
+        errors.extend(_validate_generated_mutation_target_routing(ir))
         for package_id, package in packages.items():
-            has_mutating_generated_command = any(
-                isinstance(command, dict)
-                and command.get("status") == "generated"
-                and isinstance(command.get("effect_hints"), dict)
-                and (
-                    command["effect_hints"].get("writes_repo_state") is True
-                    or command["effect_hints"].get("destructive") is True
-                    or command["effect_hints"].get("requires_preflight_gate") is True
-                )
-                for command in package.get("commands", [])
-            )
-            for target in package.get("targets", []):
-                if not isinstance(target, dict) or target.get("kind") not in {"python", "typescript"}:
-                    continue
-                if has_mutating_generated_command and target.get("maturity_level_ref") == "weak-agent-safe-adapter":
-                    errors.append(
-                        f"command_package_ir.json package {package_id!r} {target.get('kind')} target advertises "
-                        "weak-agent-safe-adapter while generated commands include mutation-capable effects"
-                    )
             for command in package.get("commands", []):
                 if isinstance(command, dict) and command.get("status") == "generated":
                     errors.extend(_validate_generated_command_projection_boundary(package_id=str(package_id), command=command))
@@ -5101,25 +5132,8 @@ def _validate_static_surfaces() -> list[str]:
     python_conformance_dockerfile = REPO_ROOT / "generated" / "python" / "Dockerfile.conformance"
     if not python_conformance_dockerfile.is_file():
         errors.append("generated/python/Dockerfile.conformance is missing")
-    primitive_conformance_dockerfile = REPO_ROOT / "generated" / "python" / "Dockerfile.primitive-conformance"
-    if not primitive_conformance_dockerfile.is_file():
-        errors.append("generated/python/Dockerfile.primitive-conformance is missing")
     errors.extend(_validate_command_generation_release_provenance())
-    try:
-        import command_generation.primitive_conformance as primitive_conformance  # noqa: PLC0415
-    except ModuleNotFoundError:
-        primitive_conformance_script = None
-    else:
-        primitive_conformance_script = Path(primitive_conformance.__file__).resolve()
-    if primitive_conformance_script is None:
-        errors.append("command_generation.primitive_conformance is missing")
-    elif not primitive_conformance_script.is_file():
-        errors.append("command_generation.primitive_conformance is missing")
-    else:
-        primitive_conformance_text = primitive_conformance_script.read_text(encoding="utf-8")
-        for primitive_id in sorted(REQUIRED_PORTABLE_PRIMITIVE_CONFORMANCE):
-            if primitive_id not in primitive_conformance_text:
-                errors.append(f"primitive conformance is missing required primitive case: {primitive_id}")
+    errors.extend(_validate_primitive_conformance_surface())
     conformance_dockerfile = REPO_ROOT / "generated" / "typescript.conformance.Dockerfile"
     if not conformance_dockerfile.is_file():
         errors.append("generated/typescript.conformance.Dockerfile is missing")

--- a/src/agentic_workspace/contracts/structured_file_inventory.json
+++ b/src/agentic_workspace/contracts/structured_file_inventory.json
@@ -349,6 +349,18 @@
       "checked_in_justification": "Compact agent-recorded test strategy dispositions preserve evidence-owner decisions that would otherwise be lossy in chat or PR prose."
     },
     {
+      "pattern": ".agentic-workspace/verification/test-suite-budget.json",
+      "format": "json",
+      "owner": "verification",
+      "status": "typed-validator-backed",
+      "schema_or_validator": "agentic_workspace.workspace_runtime_primitives._load_test_suite_budget",
+      "editable_by_agents": true,
+      "generated": false,
+      "notes": "Optional repo-owned test suite budget observations with provenance and freshness semantics for test_strategy_check drift output.",
+      "storage_class": "non-reconstructable-decision",
+      "checked_in_justification": "Checked-in suite budget observations preserve maintainer-owned test strategy targets and measurement provenance without making package runtime code carry repo-specific counts."
+    },
+    {
       "pattern": ".agentic-workspace/memory/UPGRADE-SOURCE.toml",
       "format": "toml",
       "owner": "memory-payload",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -6087,6 +6087,7 @@ LOCAL_AGENT_REFERENCE_LINE = f"Follow instructions in `{LOCAL_AGENT_INSTRUCTIONS
 EXTERNAL_INTENT_CACHE_RELATIVE_PATH = Path(".agentic-workspace") / "local" / "cache" / "external-intent-evidence.json"
 EXTERNAL_INTENT_PLANNING_RELATIVE_PATH = Path(".agentic-workspace") / "planning" / "external-intent-evidence.json"
 TEST_STRATEGY_DISPOSITIONS_RELATIVE_PATH = Path(".agentic-workspace") / "verification" / "test-strategy-dispositions.json"
+TEST_SUITE_BUDGET_RELATIVE_PATH = Path(".agentic-workspace") / "verification" / "test-suite-budget.json"
 ASSURANCE_EVIDENCE_RECORDS_RELATIVE_PATH = Path(".agentic-workspace") / "verification" / "assurance-evidence-records.json"
 EXTERNAL_INTENT_CACHE_CLOSED_RETENTION_DAYS = 7
 LOCAL_ONLY_IGNORE_BLOCK = "# Agentic Workspace local-only storage\n.agentic-workspace/\nAGENTS.local.md\n"
@@ -27829,22 +27830,6 @@ _TEST_STRATEGY_DISPOSITION_VALUES = {
     "existing-proof-sufficient",
     "temporary-with-follow-up-consolidation",
 }
-_TEST_STRATEGY_ROOT_BUDGET = {
-    "scope": "root",
-    "baseline_date": "2026-06-15",
-    "baseline_collected_count": 613,
-    "current_observed_date": "2026-06-29",
-    "current_collected_count": 884,
-    "target_min": 500,
-    "target_max": 700,
-}
-_TEST_STRATEGY_TOTAL_BUDGET = {
-    "scope": "all",
-    "baseline_date": "2026-06-15",
-    "baseline_collected_count": 1118,
-    "current_observed_date": "2026-06-29",
-    "current_collected_count": 1426,
-}
 _TEST_STRATEGY_PLACEMENT_ALTERNATIVES = [
     "merge into an existing scenario matrix for the same contract",
     "move package-owned behavior to a package-local proof",
@@ -28161,8 +28146,150 @@ def _load_test_strategy_dispositions(target_root: Path) -> dict[str, Any]:
     }
 
 
+def _suite_budget_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _test_suite_budget_freshness(observed_at: str, max_age_days: int | None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "observed_at": observed_at,
+        "max_age_days": max_age_days,
+        "status": "unknown",
+    }
+    if not observed_at:
+        payload["reason"] = "current observation is missing observed_at"
+        return payload
+    if not isinstance(max_age_days, int) or max_age_days < 0:
+        payload["reason"] = "max_age_days is missing or invalid"
+        return payload
+    try:
+        observed_date = date.fromisoformat(observed_at[:10])
+    except ValueError:
+        payload["reason"] = "observed_at is not ISO-8601 date-like text"
+        return payload
+    age_days = (date.today() - observed_date).days
+    payload["age_days"] = age_days
+    if age_days < 0:
+        payload["status"] = "future-dated"
+    elif age_days <= max_age_days:
+        payload["status"] = "fresh"
+    else:
+        payload["status"] = "stale"
+    return payload
+
+
+def _normalize_test_suite_budget_scope(raw_scope: Any) -> tuple[dict[str, Any] | None, list[str]]:
+    if not isinstance(raw_scope, dict):
+        return None, ["scope entry must be an object"]
+    scope = str(raw_scope.get("scope") or "").strip()
+    baseline = _as_dict(raw_scope.get("baseline"))
+    current = _as_dict(raw_scope.get("current"))
+    target = _as_dict(raw_scope.get("target"))
+    baseline_count = _suite_budget_int(baseline.get("collected_count"))
+    current_count = _suite_budget_int(current.get("collected_count"))
+    target_min = _suite_budget_int(target.get("min"))
+    target_max = _suite_budget_int(target.get("max"))
+    observed_at = str(current.get("observed_at") or "").strip()
+    max_age_days = _suite_budget_int(current.get("max_age_days"))
+    missing = []
+    if not scope:
+        missing.append("scope")
+    if baseline_count is None:
+        missing.append("baseline.collected_count")
+    if current_count is None:
+        missing.append("current.collected_count")
+    if not observed_at:
+        missing.append("current.observed_at")
+    if missing:
+        return None, missing
+    normalized: dict[str, Any] = {
+        "scope": scope,
+        "baseline_date": str(baseline.get("date") or "").strip(),
+        "baseline_collected_count": baseline_count,
+        "current_observed_at": observed_at,
+        "current_collected_count": current_count,
+        "current_source": str(current.get("source") or "").strip(),
+        "freshness": _test_suite_budget_freshness(observed_at, max_age_days),
+    }
+    if target_min is not None:
+        normalized["target_min"] = target_min
+    if target_max is not None:
+        normalized["target_max"] = target_max
+    if target_min is not None and target_max is not None:
+        normalized["target_range"] = [target_min, target_max]
+    return normalized, []
+
+
+def _load_test_suite_budget(target_root: Path) -> dict[str, Any]:
+    path = target_root / TEST_SUITE_BUDGET_RELATIVE_PATH
+    if not path.exists():
+        return {
+            "kind": "agentic-workspace/test-suite-budget/v1",
+            "status": "not-configured",
+            "path": TEST_SUITE_BUDGET_RELATIVE_PATH.as_posix(),
+            "scopes": [],
+            "rule": "Host repositories only receive budget drift pressure when they provide a repo-owned suite budget artifact.",
+        }
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return {
+            "kind": "agentic-workspace/test-suite-budget/v1",
+            "status": "invalid",
+            "path": TEST_SUITE_BUDGET_RELATIVE_PATH.as_posix(),
+            "scopes": [],
+            "invalid_scopes": [{"id": "file", "missing_or_invalid_fields": ["json"], "error": str(exc)}],
+        }
+    if not isinstance(payload, dict):
+        return {
+            "kind": "agentic-workspace/test-suite-budget/v1",
+            "status": "invalid",
+            "path": TEST_SUITE_BUDGET_RELATIVE_PATH.as_posix(),
+            "scopes": [],
+            "invalid_scopes": [{"id": "file", "missing_or_invalid_fields": ["object"]}],
+        }
+    scopes: list[dict[str, Any]] = []
+    invalid_scopes: list[dict[str, Any]] = []
+    for index, raw_scope in enumerate(_list_payload(payload.get("scopes"))):
+        normalized, missing = _normalize_test_suite_budget_scope(raw_scope)
+        if normalized is None:
+            invalid_scopes.append({"id": f"scope-{index + 1}", "missing_or_invalid_fields": missing})
+        else:
+            scopes.append(normalized)
+    return {
+        "kind": "agentic-workspace/test-suite-budget/v1",
+        "status": "invalid" if invalid_scopes else "configured",
+        "path": TEST_SUITE_BUDGET_RELATIVE_PATH.as_posix(),
+        "source": str(payload.get("source") or "").strip(),
+        "provenance": _as_dict(payload.get("provenance")),
+        "scopes": scopes,
+        "invalid_scopes": invalid_scopes,
+    }
+
+
+def _test_suite_budget_scope_drift(scope: dict[str, Any] | None, *, over_target_by: int | None = None) -> dict[str, Any]:
+    if not isinstance(scope, dict):
+        return {"status": "not-configured"}
+    baseline_count = _suite_budget_int(scope.get("baseline_collected_count"))
+    current_count = _suite_budget_int(scope.get("current_collected_count"))
+    delta = current_count - baseline_count if baseline_count is not None and current_count is not None else None
+    payload = {
+        **scope,
+        "status": "configured",
+        "collected_count_delta_from_baseline": delta,
+    }
+    if over_target_by is not None:
+        payload["over_target_by"] = over_target_by
+    return payload
+
+
 def _test_strategy_budget_drift_payload(
     *,
+    suite_budget: dict[str, Any],
     files: list[dict[str, Any]],
     matched_dispositions: list[dict[str, Any]],
     missing_disposition_paths: list[str],
@@ -28170,10 +28297,9 @@ def _test_strategy_budget_drift_payload(
     root_files = [item for item in files if str(item.get("path", "")).startswith("tests/")]
     package_local_files = [item for item in files if str(item.get("path", "")).startswith("packages/")]
     root_hotspots = [item for item in root_files if item.get("is_hotspot")]
-    root_budget = dict(_TEST_STRATEGY_ROOT_BUDGET)
-    total_budget = dict(_TEST_STRATEGY_TOTAL_BUDGET)
-    root_delta = int(root_budget["current_collected_count"]) - int(root_budget["baseline_collected_count"])
-    root_over_target_by = max(0, int(root_budget["current_collected_count"]) - int(root_budget["target_max"]))
+    scopes = {str(item.get("scope")): item for item in _list_payload(suite_budget.get("scopes")) if isinstance(item, dict)}
+    root_budget = scopes.get("root")
+    total_budget = scopes.get("all")
     disposition_satisfied_paths = sorted(
         {
             str(path).strip().replace("\\", "/")
@@ -28182,9 +28308,24 @@ def _test_strategy_budget_drift_payload(
             if str(path).strip()
         }
     )
-    over_budget_hotspot_paths = [str(item.get("path")) for item in root_hotspots if str(item.get("path")) in missing_disposition_paths]
+    missing_root_disposition_paths = [path for path in missing_disposition_paths if path in {str(item.get("path")) for item in root_files}]
+    root_over_target_by = 0
+    if isinstance(root_budget, dict):
+        current_count = _suite_budget_int(root_budget.get("current_collected_count")) or 0
+        target_max = _suite_budget_int(root_budget.get("target_max"))
+        if target_max is not None:
+            root_over_target_by = max(0, current_count - target_max)
+    root_freshness = _as_dict(root_budget.get("freshness")) if isinstance(root_budget, dict) else {}
+    root_budget_can_apply = isinstance(root_budget, dict) and root_over_target_by > 0 and str(root_freshness.get("status") or "") == "fresh"
+    over_budget_hotspot_paths = [
+        str(item.get("path")) for item in root_hotspots if root_budget_can_apply and str(item.get("path")) in missing_root_disposition_paths
+    ]
     status = "not-applicable"
-    if package_local_files and not root_files:
+    if suite_budget.get("status") == "not-configured":
+        status = "not-configured"
+    elif suite_budget.get("status") == "invalid":
+        status = "invalid"
+    elif package_local_files and not root_files:
         status = "package-local"
     elif root_files:
         status = "attention" if root_over_target_by and root_hotspots else "context"
@@ -28193,27 +28334,25 @@ def _test_strategy_budget_drift_payload(
         "status": status,
         "advisory_only": True,
         "scope": "root" if root_files else "package-local" if package_local_files else "none",
-        "root": {
-            **root_budget,
-            "collected_count_delta_from_baseline": root_delta,
-            "over_target_by": root_over_target_by,
-            "target_range": [root_budget["target_min"], root_budget["target_max"]],
+        "budget_source": {
+            "status": suite_budget.get("status", "not-configured"),
+            "path": suite_budget.get("path", TEST_SUITE_BUDGET_RELATIVE_PATH.as_posix()),
+            "source": suite_budget.get("source", ""),
+            "provenance": suite_budget.get("provenance", {}),
+            "invalid_scopes": suite_budget.get("invalid_scopes", []),
         },
-        "total": {
-            **total_budget,
-            "collected_count_delta_from_baseline": int(total_budget["current_collected_count"])
-            - int(total_budget["baseline_collected_count"]),
-        },
+        "root": _test_suite_budget_scope_drift(root_budget, over_target_by=root_over_target_by),
+        "total": _test_suite_budget_scope_drift(total_budget),
         "changed_root_test_paths": [str(item.get("path")) for item in root_files],
         "changed_package_local_test_paths": [str(item.get("path")) for item in package_local_files],
         "changed_hotspot_files": [str(item.get("path")) for item in root_hotspots],
         "over_budget_hotspot_files_requiring_disposition": over_budget_hotspot_paths,
         "placement_alternatives": list(_TEST_STRATEGY_PLACEMENT_ALTERNATIVES),
         "disposition_paths": disposition_satisfied_paths,
-        "missing_disposition_paths": [path for path in missing_disposition_paths if path in {str(item.get("path")) for item in root_files}],
+        "missing_disposition_paths": missing_root_disposition_paths,
         "rule": (
-            "When root collected tests exceed the strategy target, changed root hotspots should state why evidence belongs "
-            "there or move the proof to a narrower owner. This is advisory during implementation and visible before closeout."
+            "When a target repo provides fresh suite-budget observations and root collected tests exceed its strategy target, "
+            "changed root hotspots should state why evidence belongs there or move the proof to a narrower owner."
         ),
     }
 
@@ -28242,6 +28381,7 @@ def _test_strategy_check_payload(
             }
         return {"kind": "agentic-workspace/test-strategy-check/v1", "status": "not-applicable", "changed_test_paths": []}
     disposition_record = _load_test_strategy_dispositions(target_root)
+    suite_budget = _load_test_suite_budget(target_root)
     disposition_items = [item for item in _list_payload(disposition_record.get("items")) if isinstance(item, dict)]
     matched_dispositions = [
         item
@@ -28306,6 +28446,7 @@ def _test_strategy_check_payload(
     task_lower = str(task_text or "").lower()
     reviewer_requested = any(term in task_lower for term in ("review", "comment", "pr feedback", "requested coverage", "regression"))
     budget_drift = _test_strategy_budget_drift_payload(
+        suite_budget=suite_budget,
         files=files,
         matched_dispositions=matched_dispositions,
         missing_disposition_paths=missing_disposition_paths,

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -27829,6 +27829,29 @@ _TEST_STRATEGY_DISPOSITION_VALUES = {
     "existing-proof-sufficient",
     "temporary-with-follow-up-consolidation",
 }
+_TEST_STRATEGY_ROOT_BUDGET = {
+    "scope": "root",
+    "baseline_date": "2026-06-15",
+    "baseline_collected_count": 613,
+    "current_observed_date": "2026-06-29",
+    "current_collected_count": 884,
+    "target_min": 500,
+    "target_max": 700,
+}
+_TEST_STRATEGY_TOTAL_BUDGET = {
+    "scope": "all",
+    "baseline_date": "2026-06-15",
+    "baseline_collected_count": 1118,
+    "current_observed_date": "2026-06-29",
+    "current_collected_count": 1426,
+}
+_TEST_STRATEGY_PLACEMENT_ALTERNATIVES = [
+    "merge into an existing scenario matrix for the same contract",
+    "move package-owned behavior to a package-local proof",
+    "encode stable behavior as contract or conformance evidence",
+    "cite an existing proof when it already answers the trust question",
+    "record temporary follow-up consolidation when standalone evidence is unavoidable",
+]
 
 _PRE_TEST_EVIDENCE_REQUIREMENT_IDS = {"test_evidence_change_decision"}
 _PRE_TEST_EVIDENCE_PROOF_PROFILES = {"test_evidence_change"}
@@ -28138,6 +28161,63 @@ def _load_test_strategy_dispositions(target_root: Path) -> dict[str, Any]:
     }
 
 
+def _test_strategy_budget_drift_payload(
+    *,
+    files: list[dict[str, Any]],
+    matched_dispositions: list[dict[str, Any]],
+    missing_disposition_paths: list[str],
+) -> dict[str, Any]:
+    root_files = [item for item in files if str(item.get("path", "")).startswith("tests/")]
+    package_local_files = [item for item in files if str(item.get("path", "")).startswith("packages/")]
+    root_hotspots = [item for item in root_files if item.get("is_hotspot")]
+    root_budget = dict(_TEST_STRATEGY_ROOT_BUDGET)
+    total_budget = dict(_TEST_STRATEGY_TOTAL_BUDGET)
+    root_delta = int(root_budget["current_collected_count"]) - int(root_budget["baseline_collected_count"])
+    root_over_target_by = max(0, int(root_budget["current_collected_count"]) - int(root_budget["target_max"]))
+    disposition_satisfied_paths = sorted(
+        {
+            str(path).strip().replace("\\", "/")
+            for item in matched_dispositions
+            for path in _list_payload(item.get("changed_test_paths"))
+            if str(path).strip()
+        }
+    )
+    over_budget_hotspot_paths = [str(item.get("path")) for item in root_hotspots if str(item.get("path")) in missing_disposition_paths]
+    status = "not-applicable"
+    if package_local_files and not root_files:
+        status = "package-local"
+    elif root_files:
+        status = "attention" if root_over_target_by and root_hotspots else "context"
+    return {
+        "kind": "agentic-workspace/test-suite-budget-drift/v1",
+        "status": status,
+        "advisory_only": True,
+        "scope": "root" if root_files else "package-local" if package_local_files else "none",
+        "root": {
+            **root_budget,
+            "collected_count_delta_from_baseline": root_delta,
+            "over_target_by": root_over_target_by,
+            "target_range": [root_budget["target_min"], root_budget["target_max"]],
+        },
+        "total": {
+            **total_budget,
+            "collected_count_delta_from_baseline": int(total_budget["current_collected_count"])
+            - int(total_budget["baseline_collected_count"]),
+        },
+        "changed_root_test_paths": [str(item.get("path")) for item in root_files],
+        "changed_package_local_test_paths": [str(item.get("path")) for item in package_local_files],
+        "changed_hotspot_files": [str(item.get("path")) for item in root_hotspots],
+        "over_budget_hotspot_files_requiring_disposition": over_budget_hotspot_paths,
+        "placement_alternatives": list(_TEST_STRATEGY_PLACEMENT_ALTERNATIVES),
+        "disposition_paths": disposition_satisfied_paths,
+        "missing_disposition_paths": [path for path in missing_disposition_paths if path in {str(item.get("path")) for item in root_files}],
+        "rule": (
+            "When root collected tests exceed the strategy target, changed root hotspots should state why evidence belongs "
+            "there or move the proof to a narrower owner. This is advisory during implementation and visible before closeout."
+        ),
+    }
+
+
 def _test_strategy_check_payload(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, verification: dict[str, Any]
 ) -> dict[str, Any]:
@@ -28225,6 +28305,12 @@ def _test_strategy_check_payload(
         )
     task_lower = str(task_text or "").lower()
     reviewer_requested = any(term in task_lower for term in ("review", "comment", "pr feedback", "requested coverage", "regression"))
+    budget_drift = _test_strategy_budget_drift_payload(
+        files=files,
+        matched_dispositions=matched_dispositions,
+        missing_disposition_paths=missing_disposition_paths,
+    )
+    budget_requires_disposition = bool(budget_drift.get("over_budget_hotspot_files_requiring_disposition"))
     return {
         "kind": "agentic-workspace/test-strategy-check/v1",
         "status": "advisory",
@@ -28241,6 +28327,8 @@ def _test_strategy_check_payload(
         "proof_decision_options": pre_test_guardrail.get("proof_decision_options", []),
         "pre_test_decision_questions": pre_test_guardrail.get("pre_test_decision_questions", []),
         "regression_sprawl_review_questions": pre_test_guardrail.get("regression_sprawl_review_questions", []),
+        "budget_drift": budget_drift,
+        "placement_alternatives": budget_drift.get("placement_alternatives", []),
         "verification_evidence_surfaces": {
             "evidence_strategy_status": evidence_strategy.get("status", "unavailable"),
             "proof_governance_status": proof_governance.get("status", "unavailable"),
@@ -28264,7 +28352,9 @@ def _test_strategy_check_payload(
             "temporary-with-follow-up-consolidation",
         ],
         "disposition_required_before_closeout": bool(
-            ((material_count or unknown_materiality_count) and missing_disposition_paths) or temporary_without_follow_up
+            ((material_count or unknown_materiality_count) and missing_disposition_paths)
+            or budget_requires_disposition
+            or temporary_without_follow_up
         ),
         "materiality_rule": (
             "Disposition pressure is strongest when tests are added, deleted, renamed, or change test function count. "
@@ -28288,6 +28378,7 @@ def _test_strategy_check_payload(
                 f"deleted_or_missing_test_file_count={deleted_count}",
                 f"material_evidence_change_count={material_count}",
                 f"unknown_materiality_count={unknown_materiality_count}",
+                f"root_budget_drift_status={budget_drift.get('status')}",
             ],
             recommended_by_aw=["record the testing evidence disposition before closeout"],
             proof_hints=["evidence_strategy.proof_governance", "proof_decision", "regression_sprawl", "nearby parametrized tests"],

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -1360,6 +1360,8 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "changed_test_paths": test_strategy_check.get("changed_test_paths", []),
                 "hotspot_file_count": test_strategy_check.get("hotspot_file_count", 0),
                 "scenario_matrix_candidate_count": test_strategy_check.get("scenario_matrix_candidate_count", 0),
+                "budget_drift_status": _as_dict(test_strategy_check.get("budget_drift")).get("status", "not-applicable"),
+                "changed_hotspot_files": _as_dict(test_strategy_check.get("budget_drift")).get("changed_hotspot_files", [])[:8],
                 "pre_test_guardrail_status": _as_dict(test_strategy_check.get("pre_test_evidence_guardrail")).get(
                     "status", "not-applicable"
                 ),

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -27706,6 +27706,29 @@ _TEST_STRATEGY_DISPOSITION_VALUES = {
     "existing-proof-sufficient",
     "temporary-with-follow-up-consolidation",
 }
+_TEST_STRATEGY_ROOT_BUDGET = {
+    "scope": "root",
+    "baseline_date": "2026-06-15",
+    "baseline_collected_count": 613,
+    "current_observed_date": "2026-06-29",
+    "current_collected_count": 884,
+    "target_min": 500,
+    "target_max": 700,
+}
+_TEST_STRATEGY_TOTAL_BUDGET = {
+    "scope": "all",
+    "baseline_date": "2026-06-15",
+    "baseline_collected_count": 1118,
+    "current_observed_date": "2026-06-29",
+    "current_collected_count": 1426,
+}
+_TEST_STRATEGY_PLACEMENT_ALTERNATIVES = [
+    "merge into an existing scenario matrix for the same contract",
+    "move package-owned behavior to a package-local proof",
+    "encode stable behavior as contract or conformance evidence",
+    "cite an existing proof when it already answers the trust question",
+    "record temporary follow-up consolidation when standalone evidence is unavoidable",
+]
 
 
 def _load_test_strategy_dispositions(target_root: Path) -> dict[str, Any]:
@@ -27773,6 +27796,63 @@ def _load_test_strategy_dispositions(target_root: Path) -> dict[str, Any]:
         "path": TEST_STRATEGY_DISPOSITIONS_RELATIVE_PATH.as_posix(),
         "items": normalized_items,
         "invalid_items": invalid_items,
+    }
+
+
+def _test_strategy_budget_drift_payload(
+    *,
+    files: list[dict[str, Any]],
+    matched_dispositions: list[dict[str, Any]],
+    missing_disposition_paths: list[str],
+) -> dict[str, Any]:
+    root_files = [item for item in files if str(item.get("path", "")).startswith("tests/")]
+    package_local_files = [item for item in files if str(item.get("path", "")).startswith("packages/")]
+    root_hotspots = [item for item in root_files if item.get("is_hotspot")]
+    root_budget = dict(_TEST_STRATEGY_ROOT_BUDGET)
+    total_budget = dict(_TEST_STRATEGY_TOTAL_BUDGET)
+    root_delta = int(root_budget["current_collected_count"]) - int(root_budget["baseline_collected_count"])
+    root_over_target_by = max(0, int(root_budget["current_collected_count"]) - int(root_budget["target_max"]))
+    disposition_satisfied_paths = sorted(
+        {
+            str(path).strip().replace("\\", "/")
+            for item in matched_dispositions
+            for path in _list_payload(item.get("changed_test_paths"))
+            if str(path).strip()
+        }
+    )
+    over_budget_hotspot_paths = [str(item.get("path")) for item in root_hotspots if str(item.get("path")) in missing_disposition_paths]
+    status = "not-applicable"
+    if package_local_files and not root_files:
+        status = "package-local"
+    elif root_files:
+        status = "attention" if root_over_target_by and root_hotspots else "context"
+    return {
+        "kind": "agentic-workspace/test-suite-budget-drift/v1",
+        "status": status,
+        "advisory_only": True,
+        "scope": "root" if root_files else "package-local" if package_local_files else "none",
+        "root": {
+            **root_budget,
+            "collected_count_delta_from_baseline": root_delta,
+            "over_target_by": root_over_target_by,
+            "target_range": [root_budget["target_min"], root_budget["target_max"]],
+        },
+        "total": {
+            **total_budget,
+            "collected_count_delta_from_baseline": int(total_budget["current_collected_count"])
+            - int(total_budget["baseline_collected_count"]),
+        },
+        "changed_root_test_paths": [str(item.get("path")) for item in root_files],
+        "changed_package_local_test_paths": [str(item.get("path")) for item in package_local_files],
+        "changed_hotspot_files": [str(item.get("path")) for item in root_hotspots],
+        "over_budget_hotspot_files_requiring_disposition": over_budget_hotspot_paths,
+        "placement_alternatives": list(_TEST_STRATEGY_PLACEMENT_ALTERNATIVES),
+        "disposition_paths": disposition_satisfied_paths,
+        "missing_disposition_paths": [path for path in missing_disposition_paths if path in {str(item.get("path")) for item in root_files}],
+        "rule": (
+            "When root collected tests exceed the strategy target, changed root hotspots should state why evidence belongs "
+            "there or move the proof to a narrower owner. This is advisory during implementation and visible before closeout."
+        ),
     }
 
 
@@ -27854,6 +27934,12 @@ def _test_strategy_check_payload(
         )
     task_lower = str(task_text or "").lower()
     reviewer_requested = any(term in task_lower for term in ("review", "comment", "pr feedback", "requested coverage", "regression"))
+    budget_drift = _test_strategy_budget_drift_payload(
+        files=files,
+        matched_dispositions=matched_dispositions,
+        missing_disposition_paths=missing_disposition_paths,
+    )
+    budget_requires_disposition = bool(budget_drift.get("over_budget_hotspot_files_requiring_disposition"))
     return {
         "kind": "agentic-workspace/test-strategy-check/v1",
         "status": "advisory",
@@ -27865,6 +27951,8 @@ def _test_strategy_check_payload(
         "unknown_materiality_count": unknown_materiality_count,
         "files": files,
         "reviewer_requested_coverage": reviewer_requested,
+        "budget_drift": budget_drift,
+        "placement_alternatives": budget_drift.get("placement_alternatives", []),
         "verification_evidence_surfaces": {
             "evidence_strategy_status": evidence_strategy.get("status", "unavailable"),
             "proof_governance_status": proof_governance.get("status", "unavailable"),
@@ -27888,7 +27976,9 @@ def _test_strategy_check_payload(
             "temporary-with-follow-up-consolidation",
         ],
         "disposition_required_before_closeout": bool(
-            ((material_count or unknown_materiality_count) and missing_disposition_paths) or temporary_without_follow_up
+            ((material_count or unknown_materiality_count) and missing_disposition_paths)
+            or budget_requires_disposition
+            or temporary_without_follow_up
         ),
         "materiality_rule": (
             "Disposition pressure is strongest when tests are added, deleted, renamed, or change test function count. "
@@ -27912,6 +28002,7 @@ def _test_strategy_check_payload(
                 f"deleted_or_missing_test_file_count={deleted_count}",
                 f"material_evidence_change_count={material_count}",
                 f"unknown_materiality_count={unknown_materiality_count}",
+                f"root_budget_drift_status={budget_drift.get('status')}",
             ],
             recommended_by_aw=["record the testing evidence disposition before closeout"],
             proof_hints=["evidence_strategy.proof_governance", "proof_decision", "regression_sprawl", "nearby parametrized tests"],

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -5981,6 +5981,7 @@ LOCAL_AGENT_REFERENCE_LINE = f"Follow instructions in `{LOCAL_AGENT_INSTRUCTIONS
 EXTERNAL_INTENT_CACHE_RELATIVE_PATH = Path(".agentic-workspace") / "local" / "cache" / "external-intent-evidence.json"
 EXTERNAL_INTENT_PLANNING_RELATIVE_PATH = Path(".agentic-workspace") / "planning" / "external-intent-evidence.json"
 TEST_STRATEGY_DISPOSITIONS_RELATIVE_PATH = Path(".agentic-workspace") / "verification" / "test-strategy-dispositions.json"
+TEST_SUITE_BUDGET_RELATIVE_PATH = Path(".agentic-workspace") / "verification" / "test-suite-budget.json"
 ASSURANCE_EVIDENCE_RECORDS_RELATIVE_PATH = Path(".agentic-workspace") / "verification" / "assurance-evidence-records.json"
 EXTERNAL_INTENT_CACHE_CLOSED_RETENTION_DAYS = 7
 LOCAL_ONLY_IGNORE_BLOCK = "# Agentic Workspace local-only storage\n.agentic-workspace/\nAGENTS.local.md\n"
@@ -27706,22 +27707,6 @@ _TEST_STRATEGY_DISPOSITION_VALUES = {
     "existing-proof-sufficient",
     "temporary-with-follow-up-consolidation",
 }
-_TEST_STRATEGY_ROOT_BUDGET = {
-    "scope": "root",
-    "baseline_date": "2026-06-15",
-    "baseline_collected_count": 613,
-    "current_observed_date": "2026-06-29",
-    "current_collected_count": 884,
-    "target_min": 500,
-    "target_max": 700,
-}
-_TEST_STRATEGY_TOTAL_BUDGET = {
-    "scope": "all",
-    "baseline_date": "2026-06-15",
-    "baseline_collected_count": 1118,
-    "current_observed_date": "2026-06-29",
-    "current_collected_count": 1426,
-}
 _TEST_STRATEGY_PLACEMENT_ALTERNATIVES = [
     "merge into an existing scenario matrix for the same contract",
     "move package-owned behavior to a package-local proof",
@@ -27799,8 +27784,150 @@ def _load_test_strategy_dispositions(target_root: Path) -> dict[str, Any]:
     }
 
 
+def _suite_budget_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _test_suite_budget_freshness(observed_at: str, max_age_days: int | None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "observed_at": observed_at,
+        "max_age_days": max_age_days,
+        "status": "unknown",
+    }
+    if not observed_at:
+        payload["reason"] = "current observation is missing observed_at"
+        return payload
+    if not isinstance(max_age_days, int) or max_age_days < 0:
+        payload["reason"] = "max_age_days is missing or invalid"
+        return payload
+    try:
+        observed_date = date.fromisoformat(observed_at[:10])
+    except ValueError:
+        payload["reason"] = "observed_at is not ISO-8601 date-like text"
+        return payload
+    age_days = (date.today() - observed_date).days
+    payload["age_days"] = age_days
+    if age_days < 0:
+        payload["status"] = "future-dated"
+    elif age_days <= max_age_days:
+        payload["status"] = "fresh"
+    else:
+        payload["status"] = "stale"
+    return payload
+
+
+def _normalize_test_suite_budget_scope(raw_scope: Any) -> tuple[dict[str, Any] | None, list[str]]:
+    if not isinstance(raw_scope, dict):
+        return None, ["scope entry must be an object"]
+    scope = str(raw_scope.get("scope") or "").strip()
+    baseline = _as_dict(raw_scope.get("baseline"))
+    current = _as_dict(raw_scope.get("current"))
+    target = _as_dict(raw_scope.get("target"))
+    baseline_count = _suite_budget_int(baseline.get("collected_count"))
+    current_count = _suite_budget_int(current.get("collected_count"))
+    target_min = _suite_budget_int(target.get("min"))
+    target_max = _suite_budget_int(target.get("max"))
+    observed_at = str(current.get("observed_at") or "").strip()
+    max_age_days = _suite_budget_int(current.get("max_age_days"))
+    missing = []
+    if not scope:
+        missing.append("scope")
+    if baseline_count is None:
+        missing.append("baseline.collected_count")
+    if current_count is None:
+        missing.append("current.collected_count")
+    if not observed_at:
+        missing.append("current.observed_at")
+    if missing:
+        return None, missing
+    normalized: dict[str, Any] = {
+        "scope": scope,
+        "baseline_date": str(baseline.get("date") or "").strip(),
+        "baseline_collected_count": baseline_count,
+        "current_observed_at": observed_at,
+        "current_collected_count": current_count,
+        "current_source": str(current.get("source") or "").strip(),
+        "freshness": _test_suite_budget_freshness(observed_at, max_age_days),
+    }
+    if target_min is not None:
+        normalized["target_min"] = target_min
+    if target_max is not None:
+        normalized["target_max"] = target_max
+    if target_min is not None and target_max is not None:
+        normalized["target_range"] = [target_min, target_max]
+    return normalized, []
+
+
+def _load_test_suite_budget(target_root: Path) -> dict[str, Any]:
+    path = target_root / TEST_SUITE_BUDGET_RELATIVE_PATH
+    if not path.exists():
+        return {
+            "kind": "agentic-workspace/test-suite-budget/v1",
+            "status": "not-configured",
+            "path": TEST_SUITE_BUDGET_RELATIVE_PATH.as_posix(),
+            "scopes": [],
+            "rule": "Host repositories only receive budget drift pressure when they provide a repo-owned suite budget artifact.",
+        }
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return {
+            "kind": "agentic-workspace/test-suite-budget/v1",
+            "status": "invalid",
+            "path": TEST_SUITE_BUDGET_RELATIVE_PATH.as_posix(),
+            "scopes": [],
+            "invalid_scopes": [{"id": "file", "missing_or_invalid_fields": ["json"], "error": str(exc)}],
+        }
+    if not isinstance(payload, dict):
+        return {
+            "kind": "agentic-workspace/test-suite-budget/v1",
+            "status": "invalid",
+            "path": TEST_SUITE_BUDGET_RELATIVE_PATH.as_posix(),
+            "scopes": [],
+            "invalid_scopes": [{"id": "file", "missing_or_invalid_fields": ["object"]}],
+        }
+    scopes: list[dict[str, Any]] = []
+    invalid_scopes: list[dict[str, Any]] = []
+    for index, raw_scope in enumerate(_list_payload(payload.get("scopes"))):
+        normalized, missing = _normalize_test_suite_budget_scope(raw_scope)
+        if normalized is None:
+            invalid_scopes.append({"id": f"scope-{index + 1}", "missing_or_invalid_fields": missing})
+        else:
+            scopes.append(normalized)
+    return {
+        "kind": "agentic-workspace/test-suite-budget/v1",
+        "status": "invalid" if invalid_scopes else "configured",
+        "path": TEST_SUITE_BUDGET_RELATIVE_PATH.as_posix(),
+        "source": str(payload.get("source") or "").strip(),
+        "provenance": _as_dict(payload.get("provenance")),
+        "scopes": scopes,
+        "invalid_scopes": invalid_scopes,
+    }
+
+
+def _test_suite_budget_scope_drift(scope: dict[str, Any] | None, *, over_target_by: int | None = None) -> dict[str, Any]:
+    if not isinstance(scope, dict):
+        return {"status": "not-configured"}
+    baseline_count = _suite_budget_int(scope.get("baseline_collected_count"))
+    current_count = _suite_budget_int(scope.get("current_collected_count"))
+    delta = current_count - baseline_count if baseline_count is not None and current_count is not None else None
+    payload = {
+        **scope,
+        "status": "configured",
+        "collected_count_delta_from_baseline": delta,
+    }
+    if over_target_by is not None:
+        payload["over_target_by"] = over_target_by
+    return payload
+
+
 def _test_strategy_budget_drift_payload(
     *,
+    suite_budget: dict[str, Any],
     files: list[dict[str, Any]],
     matched_dispositions: list[dict[str, Any]],
     missing_disposition_paths: list[str],
@@ -27808,10 +27935,9 @@ def _test_strategy_budget_drift_payload(
     root_files = [item for item in files if str(item.get("path", "")).startswith("tests/")]
     package_local_files = [item for item in files if str(item.get("path", "")).startswith("packages/")]
     root_hotspots = [item for item in root_files if item.get("is_hotspot")]
-    root_budget = dict(_TEST_STRATEGY_ROOT_BUDGET)
-    total_budget = dict(_TEST_STRATEGY_TOTAL_BUDGET)
-    root_delta = int(root_budget["current_collected_count"]) - int(root_budget["baseline_collected_count"])
-    root_over_target_by = max(0, int(root_budget["current_collected_count"]) - int(root_budget["target_max"]))
+    scopes = {str(item.get("scope")): item for item in _list_payload(suite_budget.get("scopes")) if isinstance(item, dict)}
+    root_budget = scopes.get("root")
+    total_budget = scopes.get("all")
     disposition_satisfied_paths = sorted(
         {
             str(path).strip().replace("\\", "/")
@@ -27820,9 +27946,24 @@ def _test_strategy_budget_drift_payload(
             if str(path).strip()
         }
     )
-    over_budget_hotspot_paths = [str(item.get("path")) for item in root_hotspots if str(item.get("path")) in missing_disposition_paths]
+    missing_root_disposition_paths = [path for path in missing_disposition_paths if path in {str(item.get("path")) for item in root_files}]
+    root_over_target_by = 0
+    if isinstance(root_budget, dict):
+        current_count = _suite_budget_int(root_budget.get("current_collected_count")) or 0
+        target_max = _suite_budget_int(root_budget.get("target_max"))
+        if target_max is not None:
+            root_over_target_by = max(0, current_count - target_max)
+    root_freshness = _as_dict(root_budget.get("freshness")) if isinstance(root_budget, dict) else {}
+    root_budget_can_apply = isinstance(root_budget, dict) and root_over_target_by > 0 and str(root_freshness.get("status") or "") == "fresh"
+    over_budget_hotspot_paths = [
+        str(item.get("path")) for item in root_hotspots if root_budget_can_apply and str(item.get("path")) in missing_root_disposition_paths
+    ]
     status = "not-applicable"
-    if package_local_files and not root_files:
+    if suite_budget.get("status") == "not-configured":
+        status = "not-configured"
+    elif suite_budget.get("status") == "invalid":
+        status = "invalid"
+    elif package_local_files and not root_files:
         status = "package-local"
     elif root_files:
         status = "attention" if root_over_target_by and root_hotspots else "context"
@@ -27831,27 +27972,25 @@ def _test_strategy_budget_drift_payload(
         "status": status,
         "advisory_only": True,
         "scope": "root" if root_files else "package-local" if package_local_files else "none",
-        "root": {
-            **root_budget,
-            "collected_count_delta_from_baseline": root_delta,
-            "over_target_by": root_over_target_by,
-            "target_range": [root_budget["target_min"], root_budget["target_max"]],
+        "budget_source": {
+            "status": suite_budget.get("status", "not-configured"),
+            "path": suite_budget.get("path", TEST_SUITE_BUDGET_RELATIVE_PATH.as_posix()),
+            "source": suite_budget.get("source", ""),
+            "provenance": suite_budget.get("provenance", {}),
+            "invalid_scopes": suite_budget.get("invalid_scopes", []),
         },
-        "total": {
-            **total_budget,
-            "collected_count_delta_from_baseline": int(total_budget["current_collected_count"])
-            - int(total_budget["baseline_collected_count"]),
-        },
+        "root": _test_suite_budget_scope_drift(root_budget, over_target_by=root_over_target_by),
+        "total": _test_suite_budget_scope_drift(total_budget),
         "changed_root_test_paths": [str(item.get("path")) for item in root_files],
         "changed_package_local_test_paths": [str(item.get("path")) for item in package_local_files],
         "changed_hotspot_files": [str(item.get("path")) for item in root_hotspots],
         "over_budget_hotspot_files_requiring_disposition": over_budget_hotspot_paths,
         "placement_alternatives": list(_TEST_STRATEGY_PLACEMENT_ALTERNATIVES),
         "disposition_paths": disposition_satisfied_paths,
-        "missing_disposition_paths": [path for path in missing_disposition_paths if path in {str(item.get("path")) for item in root_files}],
+        "missing_disposition_paths": missing_root_disposition_paths,
         "rule": (
-            "When root collected tests exceed the strategy target, changed root hotspots should state why evidence belongs "
-            "there or move the proof to a narrower owner. This is advisory during implementation and visible before closeout."
+            "When a target repo provides fresh suite-budget observations and root collected tests exceed its strategy target, "
+            "changed root hotspots should state why evidence belongs there or move the proof to a narrower owner."
         ),
     }
 
@@ -27871,6 +28010,7 @@ def _test_strategy_check_payload(
     if not test_paths:
         return {"kind": "agentic-workspace/test-strategy-check/v1", "status": "not-applicable", "changed_test_paths": []}
     disposition_record = _load_test_strategy_dispositions(target_root)
+    suite_budget = _load_test_suite_budget(target_root)
     disposition_items = [item for item in _list_payload(disposition_record.get("items")) if isinstance(item, dict)]
     matched_dispositions = [
         item
@@ -27935,6 +28075,7 @@ def _test_strategy_check_payload(
     task_lower = str(task_text or "").lower()
     reviewer_requested = any(term in task_lower for term in ("review", "comment", "pr feedback", "requested coverage", "regression"))
     budget_drift = _test_strategy_budget_drift_payload(
+        suite_budget=suite_budget,
         files=files,
         matched_dispositions=matched_dispositions,
         missing_disposition_paths=missing_disposition_paths,

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -7,7 +7,6 @@ import json
 import re
 import subprocess
 import sys
-import textwrap
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -48,6 +47,10 @@ def _load_test_ir_runner():
 
 
 def _run_checker_case(source: str) -> dict[str, object]:
+    return _run_checker_cases([source])[0]
+
+
+def _run_checker_cases(sources: list[str]) -> list[dict[str, object]]:
     script = f"""
 from __future__ import annotations
 
@@ -56,21 +59,50 @@ import importlib.util
 import json
 import subprocess
 import sys
+import textwrap
+import traceback
 from pathlib import Path
 
 CHECK_SCRIPT_PATH = Path({str(CHECK_SCRIPT_PATH)!r})
-spec = importlib.util.spec_from_file_location("check_generated_command_packages_case", CHECK_SCRIPT_PATH)
-assert spec is not None
-checker = importlib.util.module_from_spec(spec)
-assert spec.loader is not None
-sys.modules[spec.name] = checker
-spec.loader.exec_module(checker)
+SOURCES = json.loads({json.dumps(json.dumps(sources))})
 
 
-def _emit(payload):
-    print({str(_CHECKER_CASE_PREFIX)!r} + json.dumps(payload, sort_keys=True))
+def _load_checker(index):
+    spec = importlib.util.spec_from_file_location(f"check_generated_command_packages_case_{{index}}", CHECK_SCRIPT_PATH)
+    assert spec is not None
+    checker = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = checker
+    spec.loader.exec_module(checker)
+    return checker
 
-{textwrap.indent(textwrap.dedent(source).strip(), " " * 0)}
+
+results = []
+for index, source in enumerate(SOURCES):
+    emitted = []
+
+    def _emit(payload):
+        emitted.append(payload)
+
+    namespace = {{
+        "checker": _load_checker(index),
+        "copy": copy,
+        "json": json,
+        "Path": Path,
+        "subprocess": subprocess,
+        "_emit": _emit,
+    }}
+    try:
+        exec(textwrap.dedent(source).strip(), namespace)
+    except BaseException as exc:
+        results.append({{"__error__": str(exc), "__traceback__": traceback.format_exc()}})
+    else:
+        if not emitted:
+            results.append({{"__error__": "checker case did not emit a result"}})
+        else:
+            results.append(emitted[-1])
+
+print({str(_CHECKER_CASE_PREFIX)!r} + json.dumps(results, sort_keys=True))
 """
     completed = subprocess.run(
         [sys.executable, "-c", script],
@@ -85,17 +117,28 @@ def _emit(payload):
         )
     for line in reversed(completed.stdout.splitlines()):
         if line.startswith(_CHECKER_CASE_PREFIX):
-            payload = json.loads(line[len(_CHECKER_CASE_PREFIX) :])
-            assert isinstance(payload, dict)
-            return payload
+            payloads = json.loads(line[len(_CHECKER_CASE_PREFIX) :])
+            assert isinstance(payloads, list)
+            results: list[dict[str, object]] = []
+            for payload in payloads:
+                assert isinstance(payload, dict)
+                if "__error__" in payload:
+                    raise AssertionError(
+                        f"checker case failed\nerror={payload['__error__']}\ntraceback:\n{payload.get('__traceback__', '')}"
+                    )
+                results.append(payload)
+            return results
     raise AssertionError(f"checker subprocess did not emit a result\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}")
 
 
-def _checker_case_errors(source: str) -> list[str]:
-    payload = _run_checker_case(source)
+def _checker_payload_errors(payload: dict[str, object]) -> list[str]:
     errors = payload.get("errors")
     assert isinstance(errors, list)
     return [str(error) for error in errors]
+
+
+def _checker_case_errors(source: str) -> list[str]:
+    return _checker_payload_errors(_run_checker_case(source))
 
 
 def test_generated_command_package_proof_defaults_to_docker_steps() -> None:
@@ -1399,7 +1442,7 @@ def test_static_generated_package_proof_rejects_static_surface_regressions() -> 
             python_target["maturity_level_ref"] = "weak-agent-safe-adapter"
             python_target["generation_status"] = "weak-agent-safe-adapter"
             checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-            _emit({"errors": checker._validate_static_surfaces()})
+            _emit({"errors": checker._validate_generated_mutation_target_routing(ir)})
             """,
             "weak-agent-safe-adapter while generated commands include mutation-capable effects",
         ),
@@ -1413,7 +1456,7 @@ def test_static_generated_package_proof_rejects_static_surface_regressions() -> 
                     item["proof"] = "uv run python scripts/check/check_generated_command_packages.py"
                     break
             checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-            _emit({"errors": checker._validate_static_surfaces()})
+            _emit({"errors": checker._validate_python_cli_completion_policy(ir["generation_policy"]["python_cli_completion"])})
             """,
             "--python-docker-conformance --require-docker",
         ),
@@ -1464,7 +1507,7 @@ def test_static_generated_package_proof_rejects_static_surface_regressions() -> 
             ir["generation_policy"]["python_cli_completion"]["current_state"] = "adapter-layer-proven-not-full-generated-cli"
             ir["generation_policy"]["python_cli_completion"]["completion_gate"]["state"] = "satisfied"
             checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-            _emit({"errors": checker._validate_static_surfaces()})
+            _emit({"errors": checker._validate_python_cli_completion_policy(ir["generation_policy"]["python_cli_completion"])})
             """,
             "cannot mark the Python CLI completion gate satisfied",
         ),
@@ -1472,7 +1515,7 @@ def test_static_generated_package_proof_rejects_static_surface_regressions() -> 
             "missing-primitive-conformance-case",
             """
             checker.REQUIRED_PORTABLE_PRIMITIVE_CONFORMANCE = {"missing.primitive"}
-            _emit({"errors": checker._validate_static_surfaces()})
+            _emit({"errors": checker._validate_primitive_conformance_surface()})
             """,
             "primitive conformance is missing required primitive case: missing.primitive",
         ),
@@ -1485,7 +1528,7 @@ def test_static_generated_package_proof_rejects_static_surface_regressions() -> 
 
             checker._aw_owned_ordinary_python_check_paths = lambda: [retired_path]
             checker._python_function_symbols = lambda path: {"test_defaults_tiny_text_uses_generated_output"}
-            _emit({"errors": checker._validate_static_surfaces()})
+            _emit({"errors": checker._validate_generated_command_check_inventory_removals()})
 
             checker._aw_owned_ordinary_python_check_paths = original_paths
             checker._python_function_symbols = original_symbols
@@ -1493,8 +1536,9 @@ def test_static_generated_package_proof_rejects_static_surface_regressions() -> 
             "remove-from-aw retired check remains active",
         ),
     ]
-    for label, source, expected_fragment in scenarios:
-        errors = _checker_case_errors(source)
+    payloads = _run_checker_cases([source for _, source, _ in scenarios])
+    for (label, _, expected_fragment), payload in zip(scenarios, payloads, strict=True):
+        errors = _checker_payload_errors(payload)
 
         assert any(expected_fragment in error for error in errors), label
 
@@ -1505,9 +1549,8 @@ def test_static_generated_package_proof_requires_completion_gate_evidence() -> N
         "representative-operation-ir-runtime-consumed",
         "operation-execution-inventory-exhaustive",
     ]
-    for item_id in required_gate_items:
-        errors = _checker_case_errors(
-            f"""
+    sources = [
+        f"""
             ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
             ir["generation_policy"]["python_cli_completion"]["current_state"] = "full-generated-cli-complete"
             ir["generation_policy"]["python_cli_completion"]["completion_gate"]["satisfied_by"] = [
@@ -1516,9 +1559,13 @@ def test_static_generated_package_proof_requires_completion_gate_evidence() -> N
                 if item["id"] != {item_id!r}
             ]
             checker.load_workspace_command_package_ir = lambda *, repo_root: ir
-            _emit({{"errors": checker._validate_static_surfaces()}})
+            _emit({{"errors": checker._validate_python_cli_completion_policy(ir["generation_policy"]["python_cli_completion"])}})
             """
-        )
+        for item_id in required_gate_items
+    ]
+    payloads = _run_checker_cases(sources)
+    for item_id, payload in zip(required_gate_items, payloads, strict=True):
+        errors = _checker_payload_errors(payload)
 
         assert any(item_id in error for error in errors), item_id
 
@@ -1544,7 +1591,7 @@ def test_static_generated_package_proof_rejects_full_completion_with_runtime_deb
 
             checker.load_workspace_command_package_ir = lambda *, repo_root: ir
             checker._load_json = fake_load_json
-            _emit({"errors": checker._validate_static_surfaces()})
+            _emit({"errors": checker._validate_python_operation_execution_inventory(ir)})
             """,
             "compatibility-runtime-handler",
         ),
@@ -1569,7 +1616,7 @@ def test_static_generated_package_proof_rejects_full_completion_with_runtime_deb
 
             checker.load_workspace_command_package_ir = lambda *, repo_root: ir
             checker._load_json = fake_load_json
-            _emit({"errors": checker._validate_static_surfaces()})
+            _emit({"errors": checker._validate_python_operation_execution_inventory(ir)})
             """,
             "generic deterministic behavior as runtime debt",
         ),
@@ -1600,7 +1647,7 @@ def test_static_generated_package_proof_rejects_full_completion_with_runtime_deb
 
             checker.load_workspace_command_package_ir = lambda *, repo_root: ir
             checker.Path.read_text = fake_read_text
-            _emit({"errors": checker._validate_static_surfaces()})
+            _emit({"errors": checker._validate_full_python_completion_runtime_ownership(ir)})
             """,
             "missing generated-main boundary fragment",
         ),
@@ -1628,7 +1675,7 @@ def test_static_generated_package_proof_rejects_full_completion_with_runtime_deb
             checker.PYTHON_FULL_COMPLETION_BLOCKING_EXECUTABLE_PATHS = (product_runtime_source,)
             checker.Path.read_text = fake_read_text
             checker.Path.is_file = fake_is_file
-            _emit({"errors": checker._validate_static_surfaces()})
+            _emit({"errors": checker._validate_full_python_completion_executable_ownership(ir)})
             """,
             "scratch/product_runtime.py owns executable behavior markers",
         ),
@@ -1658,7 +1705,7 @@ def test_static_generated_package_proof_rejects_full_completion_with_runtime_deb
 
             checker.load_workspace_command_package_ir = lambda *, repo_root: ir
             checker.render_workspace_command_package_outputs = fake_render_outputs
-            _emit({"errors": checker._validate_static_surfaces()})
+            _emit({"errors": checker._validate_full_python_completion_executable_ownership(ir)})
             """,
             "not produced by command-generation render_outputs()",
         ),
@@ -1682,8 +1729,9 @@ def test_static_generated_package_proof_rejects_full_completion_with_runtime_deb
             "transitional-generated-output-debt",
         ),
     ]
-    for label, code, expected_fragment in scenarios:
-        errors = _checker_case_errors(code)
+    payloads = _run_checker_cases([code for _, code, _ in scenarios])
+    for (label, _, expected_fragment), payload in zip(scenarios, payloads, strict=True):
+        errors = _checker_payload_errors(payload)
 
         assert any(expected_fragment in error for error in errors), label
 
@@ -1737,13 +1785,15 @@ def test_static_generated_package_proof_accepts_current_static_surfaces() -> Non
         (
             "python-completion-gate",
             """
-            _emit({"errors": checker._validate_static_surfaces()})
+            ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)
+            _emit({"errors": checker._validate_python_cli_completion_policy(ir["generation_policy"]["python_cli_completion"])})
             """,
             lambda errors: not [error for error in errors if "Python CLI completion" in error or "Python completion" in error],
         ),
     ]
-    for label, script, assertion in scenarios:
-        errors = _checker_case_errors(script)
+    payloads = _run_checker_cases([script for _, script, _ in scenarios])
+    for (label, _, assertion), payload in zip(scenarios, payloads, strict=True):
+        errors = _checker_payload_errors(payload)
 
         assert assertion(errors), label
 

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -5246,10 +5246,48 @@ force = "required-before-closeout"
     )
 
 
+def _write_test_suite_budget(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / ".agentic-workspace" / "verification" / "test-suite-budget.json",
+        {
+            "kind": "agentic-workspace/test-suite-budget/v1",
+            "source": "test fixture",
+            "provenance": {
+                "measurement_command": "pytest --collect-only",
+                "recorded_at": "2026-06-29",
+            },
+            "scopes": [
+                {
+                    "scope": "root",
+                    "baseline": {"date": "2026-06-15", "collected_count": 613},
+                    "current": {
+                        "observed_at": "2026-06-29",
+                        "collected_count": 884,
+                        "source": "fixture",
+                        "max_age_days": 99999,
+                    },
+                    "target": {"min": 500, "max": 700},
+                },
+                {
+                    "scope": "all",
+                    "baseline": {"date": "2026-06-15", "collected_count": 1118},
+                    "current": {
+                        "observed_at": "2026-06-29",
+                        "collected_count": 1426,
+                        "source": "fixture",
+                        "max_age_days": 99999,
+                    },
+                },
+            ],
+        },
+    )
+
+
 def test_implement_surfaces_test_strategy_check_for_hotspot_tests(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
     _write_python_test_evidence_config(tmp_path)
+    _write_test_suite_budget(tmp_path)
     _write(
         tmp_path / "tests" / "test_runtime.py",
         """
@@ -5303,6 +5341,9 @@ def test_runtime_warning_eta(): assert True
     assert budget["root"]["current_collected_count"] == 884
     assert budget["root"]["baseline_collected_count"] == 613
     assert budget["root"]["over_target_by"] == 184
+    assert budget["root"]["freshness"]["status"] == "fresh"
+    assert budget["budget_source"]["source"] == "test fixture"
+    assert budget["budget_source"]["provenance"]["measurement_command"] == "pytest --collect-only"
     assert budget["changed_hotspot_files"] == ["tests/test_runtime.py"]
     assert budget["over_budget_hotspot_files_requiring_disposition"] == ["tests/test_runtime.py"]
     assert any("contract or conformance" in option for option in budget["placement_alternatives"])
@@ -5411,10 +5452,53 @@ def test_implement_tiny_omits_not_applicable_test_strategy_advisory(tmp_path: Pa
     assert "test_strategy_check" not in payload["context"]
 
 
+def test_test_strategy_check_degrades_without_target_suite_budget(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write_python_test_evidence_config(tmp_path)
+    _write(
+        tmp_path / "tests" / "test_runtime.py",
+        """
+def test_runtime_alpha(): assert True
+def test_runtime_beta(): assert True
+def test_runtime_gamma(): assert True
+def test_runtime_delta(): assert True
+def test_runtime_epsilon(): assert True
+def test_runtime_zeta(): assert True
+def test_runtime_eta(): assert True
+def test_runtime_theta(): assert True
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "tests/test_runtime.py",
+                "--select",
+                "test_strategy_check",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    check = json.loads(capsys.readouterr().out)["values"]["test_strategy_check"]
+    assert check["budget_drift"]["status"] == "not-configured"
+    assert check["budget_drift"]["budget_source"]["path"] == ".agentic-workspace/verification/test-suite-budget.json"
+    assert check["budget_drift"]["root"]["status"] == "not-configured"
+    assert check["budget_drift"]["over_budget_hotspot_files_requiring_disposition"] == []
+
+
 def test_test_strategy_check_reads_recorded_disposition(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
     _write_python_test_evidence_config(tmp_path)
+    _write_test_suite_budget(tmp_path)
     _write(
         tmp_path / "tests" / "test_runtime.py",
         """
@@ -5483,6 +5567,7 @@ def test_test_strategy_check_distinguishes_non_material_retained_test_edit(tmp_p
     subprocess.run(["git", "config", "user.name", "Agent"], cwd=tmp_path, check=True)
     _write_empty_planning_state(tmp_path)
     _write_python_test_evidence_config(tmp_path)
+    _write_test_suite_budget(tmp_path)
     _write(tmp_path / "tests" / "test_runtime.py", "def test_runtime_case():\n    assert True\n")
     subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-m", "baseline"], cwd=tmp_path, check=True, capture_output=True, text=True)
@@ -5524,6 +5609,7 @@ def test_test_strategy_check_marks_package_local_budget_context(tmp_path: Path, 
     subprocess.run(["git", "config", "user.email", "agent@example.test"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.name", "Agent"], cwd=tmp_path, check=True)
     _write_empty_planning_state(tmp_path)
+    _write_test_suite_budget(tmp_path)
     _write(
         tmp_path / ".agentic-workspace" / "config.toml",
         """

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -5298,6 +5298,14 @@ def test_runtime_warning_eta(): assert True
     assert check["scenario_matrix_candidate_count"] == 1
     assert check["reviewer_requested_coverage"] is True
     assert check["disposition_required_before_closeout"] is True
+    budget = check["budget_drift"]
+    assert budget["status"] == "attention"
+    assert budget["root"]["current_collected_count"] == 884
+    assert budget["root"]["baseline_collected_count"] == 613
+    assert budget["root"]["over_target_by"] == 184
+    assert budget["changed_hotspot_files"] == ["tests/test_runtime.py"]
+    assert budget["over_budget_hotspot_files_requiring_disposition"] == ["tests/test_runtime.py"]
+    assert any("contract or conformance" in option for option in budget["placement_alternatives"])
     assert check["verification_evidence_surfaces"]["proof_decision_status"]
     assert check["pre_test_evidence_guardrail"]["status"] == "advisory"
     assert check["pre_test_evidence_guardrail"]["blocking"] is False
@@ -5407,7 +5415,19 @@ def test_test_strategy_check_reads_recorded_disposition(tmp_path: Path, capsys) 
     _init_git_repo(tmp_path)
     _write_empty_planning_state(tmp_path)
     _write_python_test_evidence_config(tmp_path)
-    _write(tmp_path / "tests" / "test_runtime.py", "def test_runtime_case():\n    assert True\n")
+    _write(
+        tmp_path / "tests" / "test_runtime.py",
+        """
+def test_runtime_alpha(): assert True
+def test_runtime_beta(): assert True
+def test_runtime_gamma(): assert True
+def test_runtime_delta(): assert True
+def test_runtime_epsilon(): assert True
+def test_runtime_zeta(): assert True
+def test_runtime_eta(): assert True
+def test_runtime_theta(): assert True
+""",
+    )
     _write_json(
         tmp_path / ".agentic-workspace" / "verification" / "test-strategy-dispositions.json",
         {
@@ -5450,6 +5470,10 @@ def test_test_strategy_check_reads_recorded_disposition(tmp_path: Path, capsys) 
     assert check["disposition_record"]["matched_count"] == 1
     assert check["recorded_disposition"]["id"] == "runtime-matrix"
     assert check["missing_disposition_paths"] == []
+    assert check["budget_drift"]["status"] == "attention"
+    assert check["budget_drift"]["changed_hotspot_files"] == ["tests/test_runtime.py"]
+    assert check["budget_drift"]["disposition_paths"] == ["tests/test_runtime.py"]
+    assert check["budget_drift"]["over_budget_hotspot_files_requiring_disposition"] == []
     assert check["disposition_required_before_closeout"] is False
 
 
@@ -5488,6 +5512,62 @@ def test_test_strategy_check_distinguishes_non_material_retained_test_edit(tmp_p
     assert materiality["material_evidence_change"] is False
     assert materiality["route_pressure"] == "ordinary-test-edit"
     assert check["material_evidence_change_count"] == 0
+    assert check["budget_drift"]["status"] == "context"
+    assert check["budget_drift"]["changed_root_test_paths"] == ["tests/test_runtime.py"]
+    assert check["budget_drift"]["changed_hotspot_files"] == []
+    assert check["budget_drift"]["over_budget_hotspot_files_requiring_disposition"] == []
+    assert check["disposition_required_before_closeout"] is False
+
+
+def test_test_strategy_check_marks_package_local_budget_context(tmp_path: Path, capsys) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "agent@example.test"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Agent"], cwd=tmp_path, check=True)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[workspace]
+cli_invoke = "uv run python scripts/run_agentic_workspace.py"
+
+[assurance.requirements.package_test_evidence_change_decision]
+level = "high"
+applies_to_paths = ["packages/memory/tests/**"]
+required_evidence = ["verification_proof_decision_review"]
+proof_profile = "test_evidence_change"
+review_owner = "maintainer"
+force = "required-before-closeout"
+""",
+    )
+    _write(tmp_path / "packages" / "memory" / "tests" / "test_runtime.py", "def test_runtime_case():\n    assert True\n")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "baseline"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    _write(tmp_path / "packages" / "memory" / "tests" / "test_runtime.py", "def test_runtime_case():\n    assert 1 == 1\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "packages/memory/tests/test_runtime.py",
+                "--select",
+                "test_strategy_check",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    check = json.loads(capsys.readouterr().out)["values"]["test_strategy_check"]
+    assert check["budget_drift"]["status"] == "package-local"
+    assert check["budget_drift"]["changed_package_local_test_paths"] == ["packages/memory/tests/test_runtime.py"]
+    assert check["budget_drift"]["changed_root_test_paths"] == []
+    assert check["budget_drift"]["changed_hotspot_files"] == []
     assert check["disposition_required_before_closeout"] is False
 
 

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -4,6 +4,168 @@ from __future__ import annotations
 from tests.workspace_cli_support import *
 
 
+def _write_repo_local_proof_target(target: Path) -> None:
+    _init_git_repo(target)
+    _write(
+        target / "Makefile",
+        """
+schema-reference-docs:
+\tpython -c "print('schema docs')"
+
+typecheck:
+\tpython -m compileall src
+
+typecheck-planning:
+\tpython -m compileall packages/planning/src
+
+check-planning:
+\tpython -c "print('planning checks')"
+
+test-workspace:
+\tpython -c "print('workspace tests')"
+
+test-planning:
+\tpython -c "print('planning tests')"
+""",
+    )
+    _write(target / "scripts" / "check" / "check_agent_aids.py", "print('agent aids ok')\n")
+    _write(target / "scripts" / "check" / "check_generated_command_packages.py", "print('generated packages ok')\n")
+    _write(target / "scripts" / "generate" / "generate_command_packages.py", "print('generate packages ok')\n")
+    _write(target / "README.md", "# Fixture\n")
+    _write(target / "docs" / ".keep", "")
+    _write(target / ".agentic-workspace" / "docs" / "agent-installation.md", "# Install\n")
+    _write(target / "packages" / "planning" / "README.md", "# Planning\n")
+    _write(target / "packages" / "memory" / "README.md", "# Memory\n")
+    _write(
+        target / ".agentic-workspace" / "config.toml",
+        f"""
+schema_version = 1
+
+[workspace]
+cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
+
+[assurance.proof_profiles.workspace_behavior]
+required_commands = ["make test-workspace"]
+optional_commands = []
+review_aids = []
+
+[assurance.subsystem_profiles.workspace-cli-runtime]
+assurance_level = "high"
+scope_refs = ["ownership.subsystems.workspace-cli-runtime"]
+requirement_refs = [".agentic-workspace/OWNERSHIP.toml#subsystems.workspace-cli-runtime"]
+required_evidence = ["workspace_runtime_proof"]
+proof_profile = "workspace_behavior"
+force = "required-before-closeout"
+blocked_without_evidence = ["claim-work-complete"]
+claim_boundary = "workspace-runtime-routing"
+""",
+    )
+    _write(
+        target / ".agentic-workspace" / "OWNERSHIP.toml",
+        """
+[[subsystems]]
+id = "workspace-cli-runtime"
+paths = ["generated/workspace/python/**", "src/agentic_workspace/workspace_runtime*.py"]
+owns = ["workspace command routing"]
+proof = ["uv run pytest tests/test_workspace_cli.py -q"]
+""",
+    )
+    _write(
+        target / ".agentic-workspace" / "verification" / "manifest.toml",
+        """
+schema_version = "agentic-workspace/verification-manifest/v1"
+
+[scenarios.generated_adapter_local_conformance]
+protocol_id = "generated_adapter_conformance"
+title = "Generated adapter local conformance"
+steps = []
+expected_observations = []
+pass_evidence_labels = ["generated_adapter_conformance"]
+fail_evidence_labels = ["generated_adapter_conformance_drift"]
+
+[scenarios.closeout_intent_satisfaction_review]
+protocol_id = "closeout_intent_satisfaction"
+title = "Closeout intent satisfaction review"
+steps = []
+expected_observations = []
+pass_evidence_labels = ["closeout_intent_satisfaction"]
+fail_evidence_labels = ["closeout_intent_gap"]
+
+[scenarios.requirement_grounding_delegation_review]
+protocol_id = "requirement_grounding_delegation"
+title = "Requirement grounding delegation review"
+steps = []
+expected_observations = []
+pass_evidence_labels = ["requirement_grounding_delegation"]
+fail_evidence_labels = ["requirement_grounding_gap"]
+
+[protocols.generated_adapter_conformance]
+title = "Generated adapter conformance"
+purpose = "Generated workspace adapter changes need conformance evidence."
+applies_to_paths = ["generated/workspace/python/**"]
+scenario_refs = ["generated_adapter_local_conformance"]
+steps = []
+expected_evidence = ["generated_adapter_conformance"]
+review_owner = "maintainer"
+
+[protocols.closeout_intent_satisfaction]
+title = "Closeout intent satisfaction"
+purpose = "Workspace runtime changes need closeout intent review."
+applies_to_paths = ["generated/workspace/python/**", "src/agentic_workspace/workspace_runtime*.py"]
+scenario_refs = ["closeout_intent_satisfaction_review"]
+steps = []
+expected_evidence = ["closeout_intent_satisfaction"]
+review_owner = "maintainer"
+
+[protocols.requirement_grounding_delegation]
+title = "Requirement grounding delegation"
+purpose = "Workspace runtime changes need requirement grounding review."
+applies_to_paths = ["generated/workspace/python/**", "src/agentic_workspace/workspace_runtime*.py"]
+scenario_refs = ["requirement_grounding_delegation_review"]
+steps = []
+expected_evidence = ["requirement_grounding_delegation"]
+review_owner = "maintainer"
+
+[proof_routes.generated_adapter_conformance]
+protocol_refs = ["generated_adapter_conformance"]
+scenario_refs = ["generated_adapter_local_conformance"]
+commands = [
+  "uv run python scripts/generate/generate_command_packages.py --check",
+  "uv run python scripts/check/check_generated_command_packages.py --require-node",
+]
+proof_lane_hint = "generated-adapter-conformance"
+
+[proof_routes.closeout_intent_satisfaction]
+protocol_refs = ["closeout_intent_satisfaction"]
+scenario_refs = ["closeout_intent_satisfaction_review"]
+commands = ["uv run python scripts/run_agentic_workspace.py report --target . --section closeout_trust --format json"]
+proof_lane_hint = "closeout-intent-satisfaction"
+
+[proof_routes.requirement_grounding_delegation]
+protocol_refs = ["requirement_grounding_delegation"]
+scenario_refs = ["requirement_grounding_delegation_review"]
+commands = [
+  "uv run python scripts/run_agentic_workspace.py implement --changed <paths> --select requirement_grounding,context.delegation_decision,context.plan_delegation_packet --format json",
+]
+proof_lane_hint = "requirement-grounding-delegation"
+""",
+    )
+    _write(
+        target / ".agentic-workspace" / "system-intent" / "intent.toml",
+        """
+schema_version = 1
+kind = "workspace-system-intent/v1"
+summary = "Keep proof routing scoped."
+governing_intents = []
+anti_intents = []
+decision_tests = ["Use focused proof selection for changed paths."]
+open_questions = []
+confidence = "high"
+needs_review = false
+""",
+    )
+
+
 def test_proof_runtime_helpers_route_through_proof_owner(tmp_path: Path) -> None:
     assert workspace_runtime_primitives._verification_report_payload is workspace_runtime_proof._verification_report_payload
     assert workspace_runtime_primitives._tiny_proof_payload is workspace_runtime_proof._tiny_proof_payload
@@ -116,26 +278,43 @@ def test_proof_route_selector_smoke_works_without_mocked_lifecycle(tmp_path: Pat
     assert payload["answer"]["command"] == "agentic-workspace proof --target ./repo --format json"
 
 
-def test_proof_changed_selector_returns_path_based_validation_lane(capsys) -> None:
-    assert cli.main(["proof", "--verbose", "--changed", ".agentic-workspace/planning/state.toml", "--format", "json"]) == 0
+def test_proof_changed_selector_returns_path_based_validation_lane(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--verbose",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                ".agentic-workspace/planning/state.toml",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["surface"] == "proof"
     assert payload["selector"] == {"changed": [".agentic-workspace/planning/state.toml"]}
     answer = payload["answer"]
+    expected_target = tmp_path.as_posix()
     assert answer["kind"] == "proof-selection/v1"
     assert answer["selected_lanes"][0]["id"] == "planning_surfaces"
     assert answer["required_commands"] == [
-        f"{REPO_LOCAL_CLI_INVOKE} summary --target . --format json",
-        f"{REPO_LOCAL_CLI_INVOKE} doctor --target . --modules planning --format json",
+        f'{REPO_LOCAL_CLI_INVOKE} summary --target "{expected_target}" --format json',
+        f'{REPO_LOCAL_CLI_INVOKE} doctor --target "{expected_target}" --modules planning --format json',
     ]
     assert answer["validation_plan"]["kind"] == "validation-plan/v1"
     assert answer["validation_plan"]["status"] == "inspect-before-run"
     first_step = answer["validation_plan"]["required"][0]
     assert first_step["order"] == 1
-    assert first_step["command"] == f"{REPO_LOCAL_CLI_INVOKE} summary --target . --format json"
+    assert first_step["command"] == f'{REPO_LOCAL_CLI_INVOKE} summary --target "{expected_target}" --format json'
     assert first_step["cwd"] == "."
-    assert first_step["run"] == f"{REPO_LOCAL_CLI_INVOKE} summary --target . --format json"
+    assert first_step["run"] == f'{REPO_LOCAL_CLI_INVOKE} summary --target "{expected_target}" --format json'
     assert first_step["required"] is True
     assert first_step["lane_id"] == "planning_surfaces"
     assert first_step["action"] == "run-validation-command"
@@ -1796,12 +1975,16 @@ candidates = []
     assert waived["waiver_state"] == "waived-with-reason"
 
 
-def test_proof_changed_selector_routes_agent_aid_changes_to_manifest_lane(capsys) -> None:
+def test_proof_changed_selector_routes_agent_aid_changes_to_manifest_lane(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 ".agentic-workspace/agent-aids/scripts/workspace-validation/manifest.json",
                 ".agentic-workspace/agent-aids/scripts/workspace-validation/workspace_validation.py",
@@ -1820,8 +2003,10 @@ def test_proof_changed_selector_routes_agent_aid_changes_to_manifest_lane(capsys
     assert "uv run pytest tests -q" not in answer["required_commands"]
 
 
-def test_proof_changed_selector_routes_readme_to_docs_review(capsys) -> None:
-    assert cli.main(["proof", "--verbose", "--changed", "README.md", "--format", "json"]) == 0
+def test_proof_changed_selector_routes_readme_to_docs_review(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
+    assert cli.main(["proof", "--verbose", "--target", str(tmp_path), "--changed", "README.md", "--format", "json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
     answer = payload["answer"]
@@ -1835,8 +2020,10 @@ def test_proof_changed_selector_routes_readme_to_docs_review(capsys) -> None:
     assert answer["surface_value_review"]["reviewed_paths"][0]["surface_class"] == "adapter_or_repo_intent_surface"
 
 
-def test_proof_changed_selector_routes_package_readmes_to_docs_review(capsys) -> None:
-    assert cli.main(["proof", "--verbose", "--changed", "packages/planning/README.md", "--format", "json"]) == 0
+def test_proof_changed_selector_routes_package_readmes_to_docs_review(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
+    assert cli.main(["proof", "--verbose", "--target", str(tmp_path), "--changed", "packages/planning/README.md", "--format", "json"]) == 0
 
     payload = json.loads(capsys.readouterr().out)
     answer = payload["answer"]
@@ -2034,12 +2221,16 @@ def test_proof_failed_receipt_marks_excerpt_failure_summary_lower_trust(tmp_path
     }
 
 
-def test_proof_changed_selector_routes_installed_docs_to_docs_review(capsys) -> None:
+def test_proof_changed_selector_routes_installed_docs_to_docs_review(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 ".agentic-workspace/docs/agent-installation.md",
                 "--format",
@@ -2056,8 +2247,12 @@ def test_proof_changed_selector_routes_installed_docs_to_docs_review(capsys) -> 
     assert ".agentic-workspace/docs" in answer["required_commands"][0]
 
 
-def test_proof_changed_selector_reduces_package_docs_prefix_to_review(capsys) -> None:
-    assert cli.main(["proof", "--verbose", "--changed", "packages/planning/docs/usage.md", "--format", "json"]) == 0
+def test_proof_changed_selector_reduces_package_docs_prefix_to_review(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
+    assert (
+        cli.main(["proof", "--verbose", "--target", str(tmp_path), "--changed", "packages/planning/docs/usage.md", "--format", "json"]) == 0
+    )
 
     payload = json.loads(capsys.readouterr().out)
     answer = payload["answer"]
@@ -2075,12 +2270,16 @@ def test_proof_changed_selector_reduces_package_docs_prefix_to_review(capsys) ->
     ]
 
 
-def test_proof_changed_selector_does_not_escalate_review_only_cross_lane_changes(capsys) -> None:
+def test_proof_changed_selector_does_not_escalate_review_only_cross_lane_changes(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 "packages/planning/README.md",
                 "src/agentic_workspace/contracts/proof_selection_rules.json",
@@ -2098,12 +2297,16 @@ def test_proof_changed_selector_does_not_escalate_review_only_cross_lane_changes
     assert not answer["escalate_when"] or not answer["escalate_when"][0].startswith("changed paths span multiple validation lanes")
 
 
-def test_proof_changed_selector_includes_schema_reference_docs_for_workspace_schema(capsys) -> None:
+def test_proof_changed_selector_includes_schema_reference_docs_for_workspace_schema(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 "src/agentic_workspace/contracts/schemas/operation_primitives.schema.json",
                 "--format",
@@ -2163,12 +2366,16 @@ def test_proof_changed_surfaces_compact_intent_proof_prompt(capsys) -> None:
     assert "proof strength" not in json.dumps(answer["required_commands"]).lower()
 
 
-def test_proof_changed_verbose_surfaces_proof_confidence(capsys) -> None:
+def test_proof_changed_verbose_surfaces_proof_confidence(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 "src/agentic_workspace/workspace_runtime_primitives.py",
                 "--format",
@@ -2197,12 +2404,16 @@ def test_proof_changed_verbose_surfaces_proof_confidence(capsys) -> None:
     assert proof_adequacy["proof_confidence"]["claim_boundary"] == "slice"
 
 
-def test_proof_changed_selector_includes_planning_schema_reference_wrapper(capsys) -> None:
+def test_proof_changed_selector_includes_planning_schema_reference_wrapper(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 "packages/planning/src/repo_planning_bootstrap/contracts/schemas/planning-execplan.schema.json",
                 "--format",
@@ -2219,12 +2430,16 @@ def test_proof_changed_selector_includes_planning_schema_reference_wrapper(capsy
     assert "make check-planning" in answer["required_commands"]
 
 
-def test_proof_changed_selector_includes_planning_source_typecheck_ci_parity(capsys) -> None:
+def test_proof_changed_selector_includes_planning_source_typecheck_ci_parity(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 "packages/planning/src/repo_planning_bootstrap/installer.py",
                 "--format",
@@ -2261,12 +2476,16 @@ def test_proof_changed_selector_includes_planning_source_typecheck_ci_parity(cap
     assert typecheck_command["intent_type"] == "static-check"
 
 
-def test_proof_changed_selector_includes_workspace_runtime_typecheck_ci_parity(capsys) -> None:
+def test_proof_changed_selector_includes_workspace_runtime_typecheck_ci_parity(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 "src/agentic_workspace/workspace_runtime_proof.py",
                 "--format",
@@ -2359,20 +2578,26 @@ def test_proof_changed_learned_route_table_can_override_package_default_authorit
     assert "package-seed-or-default-route" in overridden_authorities
 
 
-def test_proof_changed_selector_keeps_docs_only_work_off_workspace_runtime_typecheck(capsys) -> None:
-    assert cli.main(["proof", "--verbose", "--changed", "README.md", "--format", "json"]) == 0
+def test_proof_changed_selector_keeps_docs_only_work_off_workspace_runtime_typecheck(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
+    assert cli.main(["proof", "--verbose", "--target", str(tmp_path), "--changed", "README.md", "--format", "json"]) == 0
 
     answer = json.loads(capsys.readouterr().out)["answer"]
     assert "make typecheck" not in answer["required_commands"]
     assert "workspace_runtime_typecheck_ci_parity" not in [lane["id"] for lane in answer["selected_lanes"]]
 
 
-def test_proof_changed_selector_flags_high_impact_skill_behavior_evidence(capsys) -> None:
+def test_proof_changed_selector_flags_high_impact_skill_behavior_evidence(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 "packages/planning/skills/planning-closeout-trust/SKILL.md",
                 "--format",
@@ -2403,12 +2628,16 @@ def test_proof_tiny_readme_profile_keeps_docs_only_validation_light(capsys) -> N
     assert len(encoded) < 2500
 
 
-def test_proof_changed_selector_flags_direct_cli_edits(capsys) -> None:
+def test_proof_changed_selector_flags_direct_cli_edits(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 "generated/workspace/python/cli.py",
                 "--format",
@@ -2448,12 +2677,16 @@ def test_proof_changed_selector_flags_direct_cli_edits(capsys) -> None:
     assert answer["subsystem_ownership"]["matched_subsystems"][0]["id"] == "workspace-cli-runtime"
 
 
-def test_proof_changed_selector_broadens_contract_plus_cli_changes(capsys) -> None:
+def test_proof_changed_selector_broadens_contract_plus_cli_changes(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 "src/agentic_workspace/contracts/proof_selection_rules.json",
                 "generated/workspace/python/cli.py",
@@ -2481,12 +2714,16 @@ def test_proof_changed_selector_broadens_contract_plus_cli_changes(capsys) -> No
     assert "make test-workspace" in answer["required_commands"]
 
 
-def test_proof_changed_selector_escalates_for_cross_lane_changes(capsys) -> None:
+def test_proof_changed_selector_escalates_for_cross_lane_changes(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
     assert (
         cli.main(
             [
                 "proof",
                 "--verbose",
+                "--target",
+                str(tmp_path),
                 "--changed",
                 "packages/planning/src/repo_planning_bootstrap/installer.py",
                 "generated/workspace/python/cli.py",


### PR DESCRIPTION
## Summary

- Split targeted generated-package static proof checks out of the full static proof matrix, then updated hotspot scenario tests to call the narrow owning validators.
- Added AW `test_strategy_check` budget drift context backed by a target-owned `.agentic-workspace/verification/test-suite-budget.json` artifact with provenance and freshness semantics.
- Moved proof selector tests onto repo-local fixtures so they no longer depend on the live checkout.

## Timing evidence (#1856)

- Before narrowing the generated-package static proof scenario rows, `uv run pytest tests/test_generated_command_package_proof_runner.py -q --durations=20` was measured at about 80.82s during the investigation.
- After this branch's narrowing, the same command reports `65 passed in 24.38s` on 2026-06-29. The slowest remaining calls are the intentional full static proof checks: 5.76s for drift rejection and 3.18s for accepting the current static surfaces.

## Review response

- Removed hardcoded AW suite counts from runtime constants; AW-owned counts now live in `.agentic-workspace/verification/test-suite-budget.json` and are registered in the structured file inventory.
- Budget drift now reports `budget_source` provenance plus freshness status (`fresh`, `stale`, `future-dated`, or `unknown`) before applying over-budget hotspot pressure.
- Host repositories without a suite budget artifact now degrade to `not-configured` and do not inherit AW's repo-specific counts or disposition pressure.

## Validation

- `uv run pytest tests/test_generated_command_package_proof_runner.py -q --durations=20`
- `uv run pytest tests/test_workspace_implement_cli.py -q -k "test_strategy_check or implement_surfaces_test_strategy_check or proof_surfaces_test_strategy_check"`
- `uv run pytest tests/test_workspace_proof_cli.py -q --durations=10`
- `uv run ruff check scripts/check/check_generated_command_packages.py src/agentic_workspace/workspace_runtime_core.py src/agentic_workspace/workspace_runtime_primitives.py src/agentic_workspace/workspace_runtime_implement.py tests/test_generated_command_package_proof_runner.py tests/test_workspace_implement_cli.py tests/test_workspace_proof_cli.py`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`
