### PR TITLE
[codex] Fix AW workflow and intake issue routing

### DIFF
--- a/.agentic-workspace/WORKFLOW.md
+++ b/.agentic-workspace/WORKFLOW.md
@@ -2,7 +2,7 @@
 
 Conservative fallback/projection workflow for Agentic Workspace systems installed in a repository.
 
-Canonical workflow decisions live in compact CLI JSON and structured contracts. Use `start` as the ordinary Startup Router, `next_safe_action` for the current decision packet, `skill_specs.json` for skill and transition semantics, `cli_commands.json` for command surface facts, and package skills for routed human-readable projections. This file is only the conservative no-CLI fallback and readable projection; do not treat it as an independent workflow authority or a second operating manual.
+Canonical workflow decisions live in compact CLI JSON and structured contracts. When Agentic Workspace is enabled, workflow participation is mandatory for non-trivial work; `advisory` fields describe internal routing support only after the workflow has been entered. Use `start` as the ordinary Startup Router, `next_safe_action` for the current decision packet, `skill_specs.json` for skill and transition semantics, `cli_commands.json` for command surface facts, and package skills for routed human-readable projections. This file is only the conservative no-CLI fallback and readable projection; do not treat it as an independent workflow authority or a second operating manual.
 
 Keep this file concise, product-managed, and replaceable. It answers what to do when compact CLI or structured JSON output is unavailable, which minimal files to inspect first, which actions remain forbidden, and where to resume when the CLI becomes available again. When the CLI works, stop reading this file and follow the compact packet.
 
@@ -34,12 +34,12 @@ Ordinary first contact is one routed decision, not a checklist of root commands:
 
 Active work is Work Shaping plus Planning Autopilot:
 
-- `start` owns ordinary first-contact routing, work-shape pressure, and the next safe action.
+- `start` owns ordinary first-contact routing, mandatory when AW is enabled, plus work-shape pressure and the next safe action.
 - `summary` owns active continuation, Planning state projection, proof posture, and claim-boundary inspection after routing points there.
 - `implement --changed` owns known changed-path work context, task posture, proof hints, and changed-surface gates.
 - `planning` owns routed state mutation: new plans, promotions, handoffs, delegation decisions, closeout, and archive.
 
-The agent still owns semantic judgment about intent clarity, direct/bounded/lane/epic shape, proof proportionality, and completion claim level. Do not treat the command list as the workflow, and do not hand-edit Planning state when a command-owned mutation is available.
+The agent still owns semantic judgment about intent clarity, direct/bounded/lane/epic shape, proof proportionality, and completion claim level inside the mandatory enabled-AW workflow. `implementation_allowed` and `advisory-support` are not permission to skip startup, planning, proof, or closeout routing. Do not treat the command list as the workflow, and do not hand-edit Planning state when a command-owned mutation is available.
 
 When implementing an issue, satisfy the intended end state in the ordinary path. Do not treat a smaller change as complete merely because checks pass if that smaller change preserves the old ordinary-path behavior. If the full intended outcome appears larger than the issue safely permits, ask for clarification instead of closing the issue with a partial path.
 
@@ -75,9 +75,9 @@ Use this only when compact routing is unavailable or the compact packet explicit
 - `lane`: work spans milestones, managed payloads, proof scope, or handoff risk. When Planning is installed, create checked-in active planning and an execplan with package commands before edits; otherwise leave an equivalent durable handoff in the repo's configured workflow surface.
 - `epic`: work contains multiple lanes or needs product shaping. Use a schema-backed decomposition record when Planning provides one, split it into bounded lanes or slices, then write implementation execplans only for ready slices.
 
-For lane or epic work, do not jump straight from the prompt to implementation. Assess risk and scope first; record `adaptive_assurance` when the Planning module is installed and risk is medium or higher, and keep decomposition evidence with the durable workflow surface.
+For lane, epic, milestone-scale, or high-assurance work, do not jump straight from the prompt to implementation. Assess risk and scope first; route through Planning custody or checked-in active planning before edits or closure claims, record `adaptive_assurance` when the Planning module is installed and risk is medium or higher, and keep decomposition evidence with the durable workflow surface.
 
-Skipping compact workspace orientation may be faster for a local edit, but it lowers continuation and review trust for planned, lane, epic, high-risk, or unclear-proof work. Do not use this fallback section to bypass a working `start`, `implement`, `summary`, or `proof` packet.
+Skipping compact workspace orientation may be faster for a local edit, but it lowers continuation and review trust for planned, lane, epic, high-risk, or unclear-proof work. Do not use this fallback section to bypass a working `start`, `implement`, `summary`, or `proof` packet, and do not treat advisory wording in those packets as optional participation.
 
 ## Fallback Procedure
 

--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,8 +13,8 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:50a338819b20",
-    "version": "0.9.0"
+    "source_identity": "git:e92fce4cb7c5",
+    "version": "0.9.1"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
   "payload_files": [
@@ -37,8 +37,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.9.0",
-    "version": "0.9.0"
+    "tag": "v0.9.1",
+    "version": "0.9.1"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/.agentic-workspace/planning/skills/planning-high-assurance-lifecycle/SKILL.md
+++ b/.agentic-workspace/planning/skills/planning-high-assurance-lifecycle/SKILL.md
@@ -6,6 +6,7 @@ description: Preserve intent, decomposition, assurance, delegation, proof, and c
 # Planning High-Assurance Lifecycle
 
 Use this skill when work is broad, multi-lane, high-assurance, cross-boundary, or likely to grow beyond an initially bounded slice.
+This skill is the mandatory routed path when enabled-AW startup reports broad, milestone-scale, or high-assurance work without active Planning custody; do not treat advisory routing or `implementation_allowed` as permission to skip Planning before implementation.
 
 ## Primary Ownership
 

--- a/.agentic-workspace/planning/skills/planning-reporting/SKILL.md
+++ b/.agentic-workspace/planning/skills/planning-reporting/SKILL.md
@@ -7,6 +7,7 @@ description: Report active planning state, proof expectations, and next-action g
 
 Use this skill when you need a compact, comparable picture of what is active and what should happen next, without rereading `.agentic-workspace/planning/state.toml` or execplan prose first.
 Use `agentic-workspace report --target <repo> --format json` first when the question is broader than planning state alone.
+This reporting skill is not a bypass around enabled-AW participation: consult it when `start`, `next_safe_action`, `skill_routing`, or active Planning state routes here, and preserve any planning or proof gate before implementation or closeout.
 
 ## Primary Ownership
 

--- a/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -6,6 +6,7 @@ description: Orient through compact Agentic Workspace commands before opening ra
 # Workspace Startup
 
 Use this skill when the task is about ordinary startup, task routing, config obligations, proof selection, closeout, or module boundaries in an installed Agentic Workspace repo.
+When Agentic Workspace is enabled, this skill is inside mandatory workflow participation; advisory skill routing and `implementation_allowed` never mean startup, planning gates, proof, or closeout can be skipped.
 
 ## Route
 
@@ -31,7 +32,7 @@ Use instead:
 This skill is the hand-authored startup pilot for the `startup-router` SkillSpec contract in `src/agentic_workspace/contracts/skill_specs.json`.
 
 - Preferred CLI: `agentic-workspace start --target . --task "<task>" --format json`.
-- Interpreted fields: `immediate_next_allowed_action`, `next_safe_action`, `planning_safety_gate`, `skill_routing.preferred_routes`, and `detail_commands`.
+- Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `next_safe_action`, `planning_safety_gate`, `skill_routing.preferred_routes`, and `detail_commands`.
 - Direct work: if compact startup does not require planning and proof is obvious, keep the work direct and avoid planning, review, Memory, or handoff artifacts.
 - Planning work: if `planning_safety_gate.implementation_allowed` is false, run the named planning command before implementation.
 - No-CLI fallback: read `.agentic-workspace/WORKFLOW.md` only far enough to preserve the same forbidden actions and no-artifact-by-default rule.

--- a/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
+++ b/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
@@ -8,6 +8,7 @@ description: Apply SkillSpec-backed gates to workspace transitions. Use when mov
 This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
 
 Use it to make workflow transitions inspectable instead of relying on ambient judgement.
+When AW is enabled, these gates are mandatory workflow boundaries. Advisory routing explains agent-owned choices inside the workflow; it is not permission to skip `start`, `implement`, Planning gates, proof, or closeout.
 
 Each gate is a compact SkillSpec-shaped record:
 
@@ -25,9 +26,9 @@ Each gate is a compact SkillSpec-shaped record:
 
 - Trigger: first contact, takeover, or uncertain task shape.
 - Preferred CLI: `agentic-workspace start --task "<task>" --format json`.
-- Interpreted fields: `immediate_next_allowed_action`, `workflow_sufficiency`, `next_safe_action`, `skill_routing`.
+- Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `workflow_sufficiency`, `next_safe_action`, `skill_routing`.
 - Allowed: follow `next_safe_action.preferred_cli`, request a selector, or continue direct work when the packet says enough.
-- Forbidden: open broad raw planning files before the compact summary when the packet forbids it.
+- Forbidden: open broad raw planning files before the compact summary when the packet forbids it; treat advisory routing or `implementation_allowed` as a bypass around enabled-AW workflow participation.
 - Fallback: read `.agentic-workspace/WORKFLOW.md` and preserve forbidden actions.
 
 ### Work To Planning

--- a/.agentic-workspace/skills/workspace-work-shape/SKILL.md
+++ b/.agentic-workspace/skills/workspace-work-shape/SKILL.md
@@ -6,6 +6,7 @@ description: Classify work shape and route direct, bounded, lane, or epic work b
 # Workspace Work Shape
 
 Use this skill before implementation when task size, proof cost, handoff needs, or the user's intended outcome are unclear.
+This skill does not make AW optional: when AW is enabled, work-shape judgment happens after `start`/`implement` routing, and `implementation_allowed` only applies inside that routed workflow.
 
 ## Route
 

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -13,6 +13,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | (root) | object | yes |  | Startup routing payload returned when an agent needs the minimum safe context for entering or resuming work in a repository. |  | x-agentic-workspace-doc-role: "contract-reference" |
 | `kind` | const `"startup-context/v1"` | yes |  | Discriminator for the startup context payload shape. |  |  |
 | `target` | string | yes |  | Resolved target repository for the startup decision. |  |  |
+| `workflow_participation` | object | no |  | Compact reminder that enabled Agentic Workspace workflow participation is mandatory; advisory fields only guide choices inside that workflow. |  |  |
 | `action_signals` | object | no |  | Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment. |  |  |
 | `pre_test_evidence_guardrail` | object | no |  | Optional non-blocking pre-test evidence-owner advisory surfaced when configured assurance signals or declared changed evidence/test paths indicate proof-shape decisions. |  |  |
 | `task_posture_packet` | ref `#/$defs/task_posture_packet` | no |  | Optional dynamic instruction packet emitted when task facts, config posture, workflow obligations, or module contributions change startup routing. |  |  |

--- a/generated/planning/python/_skills/planning-high-assurance-lifecycle/SKILL.md
+++ b/generated/planning/python/_skills/planning-high-assurance-lifecycle/SKILL.md
@@ -6,6 +6,7 @@ description: Preserve intent, decomposition, assurance, delegation, proof, and c
 # Planning High-Assurance Lifecycle
 
 Use this skill when work is broad, multi-lane, high-assurance, cross-boundary, or likely to grow beyond an initially bounded slice.
+This skill is the mandatory routed path when enabled-AW startup reports broad, milestone-scale, or high-assurance work without active Planning custody; do not treat advisory routing or `implementation_allowed` as permission to skip Planning before implementation.
 
 ## Primary Ownership
 

--- a/generated/planning/python/_skills/planning-reporting/SKILL.md
+++ b/generated/planning/python/_skills/planning-reporting/SKILL.md
@@ -7,6 +7,7 @@ description: Report active planning state, proof expectations, and next-action g
 
 Use this skill when you need a compact, comparable picture of what is active and what should happen next, without rereading `.agentic-workspace/planning/state.toml` or execplan prose first.
 Use `agentic-workspace report --target <repo> --format json` first when the question is broader than planning state alone.
+This reporting skill is not a bypass around enabled-AW participation: consult it when `start`, `next_safe_action`, `skill_routing`, or active Planning state routes here, and preserve any planning or proof gate before implementation or closeout.
 
 ## Primary Ownership
 

--- a/generated/planning/typescript/resources/_skills/planning-high-assurance-lifecycle/SKILL.md
+++ b/generated/planning/typescript/resources/_skills/planning-high-assurance-lifecycle/SKILL.md
@@ -6,6 +6,7 @@ description: Preserve intent, decomposition, assurance, delegation, proof, and c
 # Planning High-Assurance Lifecycle
 
 Use this skill when work is broad, multi-lane, high-assurance, cross-boundary, or likely to grow beyond an initially bounded slice.
+This skill is the mandatory routed path when enabled-AW startup reports broad, milestone-scale, or high-assurance work without active Planning custody; do not treat advisory routing or `implementation_allowed` as permission to skip Planning before implementation.
 
 ## Primary Ownership
 

--- a/generated/planning/typescript/resources/_skills/planning-reporting/SKILL.md
+++ b/generated/planning/typescript/resources/_skills/planning-reporting/SKILL.md
@@ -7,6 +7,7 @@ description: Report active planning state, proof expectations, and next-action g
 
 Use this skill when you need a compact, comparable picture of what is active and what should happen next, without rereading `.agentic-workspace/planning/state.toml` or execplan prose first.
 Use `agentic-workspace report --target <repo> --format json` first when the question is broader than planning state alone.
+This reporting skill is not a bypass around enabled-AW participation: consult it when `start`, `next_safe_action`, `skill_routing`, or active Planning state routes here, and preserve any planning or proof gate before implementation or closeout.
 
 ## Primary Ownership
 

--- a/packages/planning/skills/planning-high-assurance-lifecycle/SKILL.md
+++ b/packages/planning/skills/planning-high-assurance-lifecycle/SKILL.md
@@ -6,6 +6,7 @@ description: Preserve intent, decomposition, assurance, delegation, proof, and c
 # Planning High-Assurance Lifecycle
 
 Use this skill when work is broad, multi-lane, high-assurance, cross-boundary, or likely to grow beyond an initially bounded slice.
+This skill is the mandatory routed path when enabled-AW startup reports broad, milestone-scale, or high-assurance work without active Planning custody; do not treat advisory routing or `implementation_allowed` as permission to skip Planning before implementation.
 
 ## Primary Ownership
 

--- a/packages/planning/skills/planning-reporting/SKILL.md
+++ b/packages/planning/skills/planning-reporting/SKILL.md
@@ -7,6 +7,7 @@ description: Report active planning state, proof expectations, and next-action g
 
 Use this skill when you need a compact, comparable picture of what is active and what should happen next, without rereading `.agentic-workspace/planning/state.toml` or execplan prose first.
 Use `agentic-workspace report --target <repo> --format json` first when the question is broader than planning state alone.
+This reporting skill is not a bypass around enabled-AW participation: consult it when `start`, `next_safe_action`, `skill_routing`, or active Planning state routes here, and preserve any planning or proof gate before implementation or closeout.
 
 ## Primary Ownership
 

--- a/src/agentic_workspace/_payload/.agentic-workspace/WORKFLOW.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/WORKFLOW.md
@@ -2,7 +2,7 @@
 
 Conservative fallback/projection workflow for Agentic Workspace systems installed in a repository.
 
-Canonical workflow decisions live in compact CLI JSON and structured contracts. Use `start` as the ordinary Startup Router, `next_safe_action` for the current decision packet, `skill_specs.json` for skill and transition semantics, `cli_commands.json` for command surface facts, and package skills for routed human-readable projections. This file is only the conservative no-CLI fallback and readable projection; do not treat it as an independent workflow authority or a second operating manual.
+Canonical workflow decisions live in compact CLI JSON and structured contracts. When Agentic Workspace is enabled, workflow participation is mandatory for non-trivial work; `advisory` fields describe internal routing support only after the workflow has been entered. Use `start` as the ordinary Startup Router, `next_safe_action` for the current decision packet, `skill_specs.json` for skill and transition semantics, `cli_commands.json` for command surface facts, and package skills for routed human-readable projections. This file is only the conservative no-CLI fallback and readable projection; do not treat it as an independent workflow authority or a second operating manual.
 
 Keep this file concise, product-managed, and replaceable. It answers what to do when compact CLI or structured JSON output is unavailable, which minimal files to inspect first, which actions remain forbidden, and where to resume when the CLI becomes available again. When the CLI works, stop reading this file and follow the compact packet.
 
@@ -34,12 +34,12 @@ Ordinary first contact is one routed decision, not a checklist of root commands:
 
 Active work is Work Shaping plus Planning Autopilot:
 
-- `start` owns ordinary first-contact routing, work-shape pressure, and the next safe action.
+- `start` owns ordinary first-contact routing, mandatory when AW is enabled, plus work-shape pressure and the next safe action.
 - `summary` owns active continuation, Planning state projection, proof posture, and claim-boundary inspection after routing points there.
 - `implement --changed` owns known changed-path work context, task posture, proof hints, and changed-surface gates.
 - `planning` owns routed state mutation: new plans, promotions, handoffs, delegation decisions, closeout, and archive.
 
-The agent still owns semantic judgment about intent clarity, direct/bounded/lane/epic shape, proof proportionality, and completion claim level. Do not treat the command list as the workflow, and do not hand-edit Planning state when a command-owned mutation is available.
+The agent still owns semantic judgment about intent clarity, direct/bounded/lane/epic shape, proof proportionality, and completion claim level inside the mandatory enabled-AW workflow. `implementation_allowed` and `advisory-support` are not permission to skip startup, planning, proof, or closeout routing. Do not treat the command list as the workflow, and do not hand-edit Planning state when a command-owned mutation is available.
 
 When implementing an issue, satisfy the intended end state in the ordinary path. Do not treat a smaller change as complete merely because checks pass if that smaller change preserves the old ordinary-path behavior. If the full intended outcome appears larger than the issue safely permits, ask for clarification instead of closing the issue with a partial path.
 
@@ -75,9 +75,9 @@ Use this only when compact routing is unavailable or the compact packet explicit
 - `lane`: work spans milestones, managed payloads, proof scope, or handoff risk. When Planning is installed, create checked-in active planning and an execplan with package commands before edits; otherwise leave an equivalent durable handoff in the repo's configured workflow surface.
 - `epic`: work contains multiple lanes or needs product shaping. Use a schema-backed decomposition record when Planning provides one, split it into bounded lanes or slices, then write implementation execplans only for ready slices.
 
-For lane or epic work, do not jump straight from the prompt to implementation. Assess risk and scope first; record `adaptive_assurance` when the Planning module is installed and risk is medium or higher, and keep decomposition evidence with the durable workflow surface.
+For lane, epic, milestone-scale, or high-assurance work, do not jump straight from the prompt to implementation. Assess risk and scope first; route through Planning custody or checked-in active planning before edits or closure claims, record `adaptive_assurance` when the Planning module is installed and risk is medium or higher, and keep decomposition evidence with the durable workflow surface.
 
-Skipping compact workspace orientation may be faster for a local edit, but it lowers continuation and review trust for planned, lane, epic, high-risk, or unclear-proof work. Do not use this fallback section to bypass a working `start`, `implement`, `summary`, or `proof` packet.
+Skipping compact workspace orientation may be faster for a local edit, but it lowers continuation and review trust for planned, lane, epic, high-risk, or unclear-proof work. Do not use this fallback section to bypass a working `start`, `implement`, `summary`, or `proof` packet, and do not treat advisory wording in those packets as optional participation.
 
 ## Fallback Procedure
 

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -6,6 +6,7 @@ description: Orient through compact Agentic Workspace commands before opening ra
 # Workspace Startup
 
 Use this skill when the task is about ordinary startup, task routing, config obligations, proof selection, closeout, or module boundaries in an installed Agentic Workspace repo.
+When Agentic Workspace is enabled, this skill is inside mandatory workflow participation; advisory skill routing and `implementation_allowed` never mean startup, planning gates, proof, or closeout can be skipped.
 
 ## Route
 
@@ -31,7 +32,7 @@ Use instead:
 This skill is the hand-authored startup pilot for the `startup-router` SkillSpec contract in `src/agentic_workspace/contracts/skill_specs.json`.
 
 - Preferred CLI: `agentic-workspace start --target . --task "<task>" --format json`.
-- Interpreted fields: `immediate_next_allowed_action`, `next_safe_action`, `planning_safety_gate`, `skill_routing.preferred_routes`, and `detail_commands`.
+- Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `next_safe_action`, `planning_safety_gate`, `skill_routing.preferred_routes`, and `detail_commands`.
 - Direct work: if compact startup does not require planning and proof is obvious, keep the work direct and avoid planning, review, Memory, or handoff artifacts.
 - Planning work: if `planning_safety_gate.implementation_allowed` is false, run the named planning command before implementation.
 - No-CLI fallback: read `.agentic-workspace/WORKFLOW.md` only far enough to preserve the same forbidden actions and no-artifact-by-default rule.

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
@@ -8,6 +8,7 @@ description: Apply SkillSpec-backed gates to workspace transitions. Use when mov
 This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
 
 Use it to make workflow transitions inspectable instead of relying on ambient judgement.
+When AW is enabled, these gates are mandatory workflow boundaries. Advisory routing explains agent-owned choices inside the workflow; it is not permission to skip `start`, `implement`, Planning gates, proof, or closeout.
 
 Each gate is a compact SkillSpec-shaped record:
 
@@ -25,9 +26,9 @@ Each gate is a compact SkillSpec-shaped record:
 
 - Trigger: first contact, takeover, or uncertain task shape.
 - Preferred CLI: `agentic-workspace start --task "<task>" --format json`.
-- Interpreted fields: `immediate_next_allowed_action`, `workflow_sufficiency`, `next_safe_action`, `skill_routing`.
+- Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `workflow_sufficiency`, `next_safe_action`, `skill_routing`.
 - Allowed: follow `next_safe_action.preferred_cli`, request a selector, or continue direct work when the packet says enough.
-- Forbidden: open broad raw planning files before the compact summary when the packet forbids it.
+- Forbidden: open broad raw planning files before the compact summary when the packet forbids it; treat advisory routing or `implementation_allowed` as a bypass around enabled-AW workflow participation.
 - Fallback: read `.agentic-workspace/WORKFLOW.md` and preserve forbidden actions.
 
 ### Work To Planning

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-work-shape/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-work-shape/SKILL.md
@@ -6,6 +6,7 @@ description: Classify work shape and route direct, bounded, lane, or epic work b
 # Workspace Work Shape
 
 Use this skill before implementation when task size, proof cost, handoff needs, or the user's intended outcome are unclear.
+This skill does not make AW optional: when AW is enabled, work-shape judgment happens after `start`/`implement` routing, and `implementation_allowed` only applies inside that routed workflow.
 
 ## Route
 

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -17,6 +17,11 @@
       "type": "string",
       "description": "Resolved target repository for the startup decision."
     },
+    "workflow_participation": {
+      "type": "object",
+      "description": "Compact reminder that enabled Agentic Workspace workflow participation is mandatory; advisory fields only guide choices inside that workflow.",
+      "additionalProperties": true
+    },
     "action_signals": {
       "type": "object",
       "description": "Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment.",

--- a/src/agentic_workspace/contracts/skill_specs.json
+++ b/src/agentic_workspace/contracts/skill_specs.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "agentic-workspace/skill-spec/v1",
-  "rule": "Skills steer agent behavior and proportionality; the CLI is preferred for robust state inspection, mutation, validation, and reporting when it is available.",
+  "rule": "Skills steer agent behavior and proportionality inside the mandatory enabled-AW workflow; advisory skill routing and implementation_allowed never bypass start/implement routing, planning gates, proof, or closeout.",
   "transition_gates": [
     {
       "id": "startup-to-work",
@@ -14,6 +14,7 @@
       ],
       "interpreted_fields": [
         "immediate_next_allowed_action",
+        "workflow_participation",
         "workflow_sufficiency",
         "next_safe_action",
         "skill_routing"
@@ -24,7 +25,8 @@
         "continue direct work when the packet says enough"
       ],
       "forbidden_actions": [
-        "open broad raw planning files before compact routing when the packet forbids it"
+        "open broad raw planning files before compact routing when the packet forbids it",
+        "treat advisory skill routing or implementation_allowed as permission to skip enabled-AW workflow participation"
       ],
       "proof_obligations": [
         "preserve next_safe_action proof_required before claiming completion"
@@ -497,6 +499,7 @@
       ],
       "interpreted_fields": [
         "immediate_next_allowed_action",
+        "workflow_participation",
         "workflow_sufficiency",
         "next_safe_action",
         "skill_routing",
@@ -508,6 +511,7 @@
       ],
       "forbidden_actions": [
         "Open raw planning or memory state before compact startup routing points there.",
+        "Treat advisory skill routing or implementation_allowed as permission to skip start/implement routing.",
         "Create planning, review, memory, or handoff artifacts for routine direct work.",
         "Treat generated skill or adapter output as the source of product behavior."
       ],
@@ -614,6 +618,7 @@
           "mutates_state": false,
           "key_output_fields": [
             "immediate_next_allowed_action",
+            "workflow_participation",
             "next_safe_action",
             "planning_safety_gate",
             "skill_routing.preferred_routes",
@@ -639,7 +644,7 @@
         },
         {
           "path": "next_safe_action.implementation_allowed",
-          "decision": "Whether implementation can start without additional planning or proof setup.",
+          "decision": "Whether implementation can start without additional planning or proof setup after enabled-AW routing has already been followed.",
           "fallback_when_missing": "Treat implementation as provisional and inspect the compact planning safety gate before editing."
         }
       ],
@@ -662,6 +667,7 @@
       ],
       "forbidden_actions": [
         "Open raw planning or memory state before compact startup routing points there.",
+        "Treat advisory skill routing or implementation_allowed as permission to skip start/implement routing.",
         "Create planning, review, memory, or handoff artifacts for routine direct work.",
         "Treat generated skill or adapter output as the source of product behavior."
       ],

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -143,6 +143,7 @@ from agentic_workspace.workspace_runtime_projection import (
     _compact_authority_boundary,
     _compact_authority_text,
     _tiny_action_effect,
+    _workflow_participation_payload,
 )
 
 
@@ -4655,6 +4656,10 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
     cache_path = ".agentic-workspace/local/cache/dogfooding-signal-status.json"
     cache = _read_local_cache_json(target_root, cache_path)
     repo_wide_command = _command_with_cli_invoke(
+        command="agentic-workspace defaults --section improvement_intake --format json",
+        cli_invoke=cli_invoke,
+    )
+    full_repo_wide_command = _command_with_cli_invoke(
         command="agentic-workspace report --target ./repo --section improvement_intake --format json",
         cli_invoke=cli_invoke,
     )
@@ -4668,9 +4673,11 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             "session_observed_signals": [],
             "routing_decisions": [],
             "repo_wide_existing": {
-                "status": "available_on_request",
+                "status": "bounded_index_available",
                 "command": repo_wide_command,
+                "full_scan_command": full_repo_wide_command,
                 "included_by_default": False,
+                "rule": "Use the bounded defaults selector first; full repo-wide scan can be expensive.",
             },
             "claim_boundary": "Session-scoped improvement state is unavailable; do not claim no dogfooding residue from this packet.",
         }
@@ -4684,9 +4691,11 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             "session_observed_signals": [],
             "routing_decisions": [],
             "repo_wide_existing": {
-                "status": "available_on_request",
+                "status": "bounded_index_available",
                 "command": repo_wide_command,
+                "full_scan_command": full_repo_wide_command,
                 "included_by_default": False,
+                "rule": "Use the bounded defaults selector first; full repo-wide scan can be expensive.",
             },
             "claim_boundary": "No session signal source exists; broad repo-wide candidates stay behind explicit improvement_intake.",
         }
@@ -4720,9 +4729,11 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             }
         ],
         "repo_wide_existing": {
-            "status": "available_on_request",
+            "status": "bounded_index_available",
             "command": repo_wide_command,
+            "full_scan_command": full_repo_wide_command,
             "included_by_default": False,
+            "rule": "Use the bounded defaults selector first; full repo-wide scan can be expensive.",
         },
         "claim_boundary": (
             "Unresolved session improvement signals remain closeout-visible."
@@ -20981,7 +20992,7 @@ def _attach_start_router_fields(payload: dict[str, Any]) -> None:
             proof_required=bool(next_safe_action.get("proof_required")),
             proof_commands=_tiny_required_proof_commands(payload.get("proof", {})) if isinstance(payload.get("proof"), dict) else [],
             advisory_selectors=["skill_routing", "workflow_sufficiency"],
-            agent_judgment="Agent owns work-shape choice unless hard_blockers names a gate.",
+            agent_judgment="Agent owns work-shape unless blocked.",
         )
 
 
@@ -22980,6 +22991,7 @@ def _start_tiny_payload_fast(
     payload: dict[str, Any] = {
         "kind": "startup-context/v1",
         "target": target_root.as_posix(),
+        "workflow_participation": _workflow_participation_payload(surface="start", compact=True),
         "invoked_cli_identity": _invoked_cli_identity_payload(target_root=target_root, compact=True),
         "cli_invocation": _cli_invocation_payload(config=config),
         "startup_sequence": startup_sequence,

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -580,6 +580,12 @@ def _planning_safety_gate_payload(
         reason = "Checked-in Planning candidates indicate broad or lane-shaped work; promote or decompose a bounded lane first."
         required_next_action = "select-or-promote-candidate-lane"
         workflow_sufficient = False
+    elif (not active_planning_present) and (not changed_paths) and (work_shape in {"lane", "epic"} or proof_burden == "high"):
+        status = "blocked"
+        decision = "planning-escalation-required"
+        reason = "Broad, milestone-scale, or high-assurance task posture needs checked-in Planning custody before implementation."
+        required_next_action = "create-or-promote-active-execplan"
+        workflow_sufficient = False
     elif (
         (not active_planning_present)
         and issue_refs

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -160,6 +160,7 @@ from agentic_workspace.workspace_runtime_projection import (
     _compact_authority_boundary,
     _compact_authority_text,
     _tiny_action_effect,
+    _workflow_participation_payload,
 )
 from agentic_workspace.workspace_runtime_proof import (
     _active_planning_record_for_proof,  # noqa: F401 - compatibility re-export for proof owner boundary
@@ -4549,6 +4550,10 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
     cache_path = ".agentic-workspace/local/cache/dogfooding-signal-status.json"
     cache = _read_local_cache_json(target_root, cache_path)
     repo_wide_command = _command_with_cli_invoke(
+        command="agentic-workspace defaults --section improvement_intake --format json",
+        cli_invoke=cli_invoke,
+    )
+    full_repo_wide_command = _command_with_cli_invoke(
         command="agentic-workspace report --target ./repo --section improvement_intake --format json",
         cli_invoke=cli_invoke,
     )
@@ -4562,9 +4567,11 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             "session_observed_signals": [],
             "routing_decisions": [],
             "repo_wide_existing": {
-                "status": "available_on_request",
+                "status": "bounded_index_available",
                 "command": repo_wide_command,
+                "full_scan_command": full_repo_wide_command,
                 "included_by_default": False,
+                "rule": "Use the bounded defaults selector first; full repo-wide scan can be expensive.",
             },
             "claim_boundary": "Session-scoped improvement state is unavailable; do not claim no dogfooding residue from this packet.",
         }
@@ -4578,9 +4585,11 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             "session_observed_signals": [],
             "routing_decisions": [],
             "repo_wide_existing": {
-                "status": "available_on_request",
+                "status": "bounded_index_available",
                 "command": repo_wide_command,
+                "full_scan_command": full_repo_wide_command,
                 "included_by_default": False,
+                "rule": "Use the bounded defaults selector first; full repo-wide scan can be expensive.",
             },
             "claim_boundary": "No session signal source exists; broad repo-wide candidates stay behind explicit improvement_intake.",
         }
@@ -4614,9 +4623,11 @@ def _session_improvement_intake_payload(*, target_root: Path, config: WorkspaceC
             }
         ],
         "repo_wide_existing": {
-            "status": "available_on_request",
+            "status": "bounded_index_available",
             "command": repo_wide_command,
+            "full_scan_command": full_repo_wide_command,
             "included_by_default": False,
+            "rule": "Use the bounded defaults selector first; full repo-wide scan can be expensive.",
         },
         "claim_boundary": (
             "Unresolved session improvement signals remain closeout-visible."
@@ -21116,7 +21127,7 @@ def _attach_start_router_fields(payload: dict[str, Any]) -> None:
             proof_required=bool(next_safe_action.get("proof_required")),
             proof_commands=_tiny_required_proof_commands(payload.get("proof", {})) if isinstance(payload.get("proof"), dict) else [],
             advisory_selectors=["skill_routing", "workflow_sufficiency"],
-            agent_judgment="Agent owns work-shape choice unless hard_blockers names a gate.",
+            agent_judgment="Agent owns work-shape unless blocked.",
         )
 
 
@@ -23115,6 +23126,7 @@ def _start_tiny_payload_fast(
     payload: dict[str, Any] = {
         "kind": "startup-context/v1",
         "target": target_root.as_posix(),
+        "workflow_participation": _workflow_participation_payload(surface="start", compact=True),
         "invoked_cli_identity": _invoked_cli_identity_payload(target_root=target_root, compact=True),
         "cli_invocation": _cli_invocation_payload(config=config),
         "startup_sequence": startup_sequence,

--- a/src/agentic_workspace/workspace_runtime_projection.py
+++ b/src/agentic_workspace/workspace_runtime_projection.py
@@ -13,6 +13,32 @@ def _list_payload(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
 
 
+def _workflow_participation_payload(*, surface: str, compact: bool = False) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "kind": "agentic-workspace/workflow-participation/v1",
+        "surface": surface,
+        "status": "mandatory",
+        "rule": (
+            "When Agentic Workspace is enabled, run and follow the routed AW workflow for non-trivial work. "
+            "Advisory routing only scopes agent judgment inside that mandatory workflow."
+        ),
+        "agent_judgment_scope": (
+            "The agent owns semantic work-shape, proof-proportionality, and completion judgment only after the "
+            "required start/implement route has been consulted and any gates have been followed."
+        ),
+        "not_permission": [
+            "implementation_allowed is not permission to skip AW startup, planning, proof, or closeout routing",
+            "advisory-support is not optional workflow participation",
+        ],
+    }
+    if compact:
+        return {
+            "status": payload["status"],
+            "rule": "AW mandatory; advisory guidance and implementation_allowed cannot bypass workflow.",
+        }
+    return payload
+
+
 def _authority_boundary_payload(
     *,
     surface: str,
@@ -51,7 +77,11 @@ def _authority_boundary_payload(
         "proof_hints": hints,
         "agent_owned_decisions": agent,
         "human_owned_decisions": human,
-        "reporting_rule": rule or "Report AW facts, constraints, and suggestions separately from the agent's semantic decision.",
+        "reporting_rule": rule
+        or (
+            "Report AW facts, constraints, and suggestions separately from the agent's semantic decision; "
+            "advisory route support is internal to the mandatory enabled-AW workflow."
+        ),
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -121,6 +121,7 @@ from agentic_workspace.workspace_runtime_planning import (
     _planning_safety_gate_payload,
     _raw_active_planning_record_for_closeout,
 )
+from agentic_workspace.workspace_runtime_projection import _workflow_participation_payload
 from agentic_workspace.workspace_runtime_proof import (
     _proof_selection_for_changed_paths,
 )
@@ -441,7 +442,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "workflow_sufficiency",
             *(["pre_test_evidence_guardrail"] if "pre_test_evidence_guardrail" in payload else []),
         ],
-        agent_judgment="Agent owns work-shape choice unless hard_blockers names a gate.",
+        agent_judgment="Agent owns work-shape unless blocked.",
     )
     return projected
 
@@ -576,6 +577,7 @@ def _start_payload(
     payload: dict[str, Any] = {
         "kind": "startup-context/v1",
         "target": target_root.as_posix(),
+        "workflow_participation": _workflow_participation_payload(surface="start", compact=True),
         "invoked_cli_identity": _invoked_cli_identity_payload(target_root=target_root, compact=True),
         "startup_sequence": startup_sequence,
         "context_router": _context_router_family_payload(cli_invoke=config.cli_invoke, compact=True),
@@ -1401,6 +1403,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     startup_proof = payload.get("proof", {})
     startup_proof_commands = _tiny_required_proof_commands(startup_proof) if isinstance(startup_proof, dict) else []
     available_selectors = _available_selectors_for_payload(payload)
+    available_selectors = [selector for selector in available_selectors if not selector.startswith("workflow_participation")]
     if "routine_work_context" not in available_selectors:
         available_selectors.append("routine_work_context")
     if (
@@ -1436,6 +1439,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     selected: dict[str, Any] = {
         "kind": payload["kind"],
         "target": ".",
+        "workflow_participation": _workflow_participation_payload(surface="start", compact=True),
         "action_signals": _compact_action_signals_payload(
             surface="start",
             allowed_next_action=str(next_safe_action.get("next_safe_action", "")),
@@ -1446,7 +1450,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             proof_commands=startup_proof_commands,
             changed_signals=startup_changed_signals,
             advisory_selectors=advisory_selectors,
-            agent_judgment="Agent owns work-shape choice unless hard_blockers names a gate.",
+            agent_judgment="Agent owns work-shape unless blocked.",
         ),
         "next_safe_action": next_safe_action,
         "skills": _startup_skills_projection(

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -702,6 +702,37 @@ def test_start_default_stays_under_tiny_output_budget_for_docs_task(tmp_path: Pa
     assert "memory_decision_packet" in payload["drill_down"]["available_selectors"]
     assert "routine_work_context" in payload["drill_down"]["available_selectors"]
     assert "workflow_sufficiency" in payload["drill_down"]["available_selectors"]
+    assert payload["workflow_participation"]["status"] == "mandatory"
+    assert "implementation_allowed cannot bypass workflow" in payload["workflow_participation"]["rule"]
+
+
+def test_start_routes_high_assurance_milestone_to_planning_before_implementation(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Implement an entire high-assurance milestone",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["workflow_participation"]["status"] == "mandatory"
+    assert payload["next_safe_action"]["next_safe_action"] == "create-or-promote-active-execplan"
+    assert payload["next_safe_action"]["implementation_allowed"] is False
+    assert "continue implementation without active planning ownership" in payload["next_safe_action"]["forbidden_actions"]
+    assert payload["action_signals"]["allowed_next_action"] == "create-or-promote-active-execplan"
+    assert payload["context"]["planning"]["workflow_sufficiency"]["sufficiency_result"] == "planning-escalation-required"
 
 
 def test_start_low_risk_docs_task_keeps_checkpoint_detail_selector_only(tmp_path: Path, capsys) -> None:
@@ -2274,6 +2305,9 @@ def test_session_improvement_intake_separates_session_and_repo_wide_scopes(tmp_p
     assert unavailable["status"] == "unavailable"
     assert unavailable["session_signal_source"]["status"] == "missing"
     assert unavailable["repo_wide_existing"]["included_by_default"] is False
+    assert unavailable["repo_wide_existing"]["status"] == "bounded_index_available"
+    assert "defaults --section improvement_intake --format json" in unavailable["repo_wide_existing"]["command"]
+    assert "report --target ./repo --section improvement_intake --format json" in unavailable["repo_wide_existing"]["full_scan_command"]
     assert "large_file" not in json.dumps(unavailable)
 
     cache_path.write_text(

--- a/tests/test_workspace_skills_cli.py
+++ b/tests/test_workspace_skills_cli.py
@@ -18,6 +18,33 @@ def test_workspace_startup_skill_declares_skillspec_pilot_contract() -> None:
         assert "No-CLI fallback" in text
 
 
+def test_routed_skill_surfaces_preserve_mandatory_aw_boundary() -> None:
+    root = Path(__file__).resolve().parents[1]
+    spec = json.loads((root / "src" / "agentic_workspace" / "contracts" / "skill_specs.json").read_text(encoding="utf-8"))
+
+    assert "mandatory enabled-AW workflow" in spec["rule"]
+    startup_gate = next(gate for gate in spec["transition_gates"] if gate["id"] == "startup-to-work")
+    assert "workflow_participation" in startup_gate["interpreted_fields"]
+    assert any("implementation_allowed" in action and "skip" in action for action in startup_gate["forbidden_actions"])
+
+    skill_paths = [
+        root / ".agentic-workspace" / "skills" / "workspace-startup" / "SKILL.md",
+        root / "src" / "agentic_workspace" / "_payload" / ".agentic-workspace" / "skills" / "workspace-startup" / "SKILL.md",
+        root / ".agentic-workspace" / "skills" / "workspace-transition-gates" / "SKILL.md",
+        root / "src" / "agentic_workspace" / "_payload" / ".agentic-workspace" / "skills" / "workspace-transition-gates" / "SKILL.md",
+        root / ".agentic-workspace" / "skills" / "workspace-work-shape" / "SKILL.md",
+        root / "src" / "agentic_workspace" / "_payload" / ".agentic-workspace" / "skills" / "workspace-work-shape" / "SKILL.md",
+        root / ".agentic-workspace" / "planning" / "skills" / "planning-reporting" / "SKILL.md",
+        root / "packages" / "planning" / "skills" / "planning-reporting" / "SKILL.md",
+        root / ".agentic-workspace" / "planning" / "skills" / "planning-high-assurance-lifecycle" / "SKILL.md",
+        root / "packages" / "planning" / "skills" / "planning-high-assurance-lifecycle" / "SKILL.md",
+    ]
+    for path in skill_paths:
+        text = path.read_text(encoding="utf-8")
+        assert "enabled-AW" in text or "Agentic Workspace is enabled" in text or "AW is enabled" in text or "AW optional" in text
+        assert "implementation_allowed" in text or "planning or proof gate" in text
+
+
 def test_generated_startup_router_skill_is_compact_adapter_projection() -> None:
     root = Path(__file__).resolve().parents[1]
     generated = (root / "generated" / "workspace" / "skills" / "startup-router" / "SKILL.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Closes #1869.
Closes #1870.

This PR fixes the two open issues from `master` as one coherent lane:

- Adds an explicit mandatory enabled-AW workflow participation packet to startup output, with compact wording that keeps tiny startup payloads under budget.
- Routes broad, milestone-scale, or high-assurance startup tasks without active planning to Planning custody before implementation.
- Keeps advisory routing scoped inside the mandatory workflow, including fallback `WORKFLOW.md`, SkillSpec, workspace skills, Planning skills, and payload mirror wording.
- Changes `session_improvement_intake.repo_wide_existing.command` to the bounded `defaults --section improvement_intake` selector and preserves the full repo-wide scan as `full_scan_command`.
- Updates startup schema/reference docs and syncs managed payload provenance to v0.9.1.

## Root Cause

The startup packet mixed mandatory AW entry with advisory internal routing language, so weak consumers could treat `implementation_allowed` or `advisory-support` as permission to abandon AW after `start`. Separately, the session improvement-intake packet pointed routine users directly at a potentially expensive repo-wide report command instead of a bounded first-page selector.

## Diagnosis And Rationale

The review failure mode happens at first contact: an agent can run `start`, see advisory routing plus `implementation_allowed`, and leave the workflow before any routed skill has a chance to correct it. Skills-only wording is therefore useful for consistency, but too indirect to be the primary fix.

The compact `workflow_participation` startup field is the smallest durable correction because it is visible in the default `start` payload, states that enabled AW is mandatory, and avoids adding a larger workflow mechanism or forcing extra artifact work onto direct tasks. The Planning safety gate is the behavior change for milestone-scale or high-assurance work: when no active Planning custody exists, implementation is blocked until the routed Planning command runs.

The routed projection surfaces now repeat the same boundary in `skill_specs.json`, workspace startup/transition/work-shape skills, and the selected Planning skills so later explanations do not reintroduce an advisory-routing interpretation.

## Validation

- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run pytest tests/test_workspace_skills_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `make maintainer-surfaces`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `make absolute-paths`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --format json`
- `git diff --check`
