### PR TITLE
[codex] Implement local overlay substrate and high-risk profile

### DIFF
--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,8 +13,8 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:e92fce4cb7c5",
-    "version": "0.9.1"
+    "source_identity": "git:69af600834fe",
+    "version": "0.9.2"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
   "payload_files": [
@@ -37,8 +37,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.9.1",
-    "version": "0.9.1"
+    "tag": "v0.9.2",
+    "version": "0.9.2"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/.agentic-workspace/planning/execplans/archive/high-risk-host-overlays-1872.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/high-risk-host-overlays-1872.plan.json
@@ -1,0 +1,383 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement local-only high-risk host workflow overlays",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Close #1872's local-only high-risk host workflow overlay lane by implementing the child capabilities (#1873-#1879) through ordinary AW config, implement, proof, report, and closeout routing.",
+    "hard_constraints": "Reuse existing config, assurance, proof-decision, validation-plan, closeout, and Planning machinery; keep local-only overlay signals provenance-aware and non-authoritative for checked-in host policy.",
+    "agent_may_decide": "Exact field names, compact packet shape, tests, docs, and whether a child issue is satisfied by a shared projection rather than a separate mechanism.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Implement a local high-risk overlay contract in config.local.toml, project matches through proof/implement/report/closeout, and validate with focused CLI tests plus maintainer surface checks.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_proof_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_summary_cli.py tests/test_workspace_cli.py -q",
+      "make maintainer-surfaces",
+      "uv run python scripts/generate/generate_command_packages.py --check"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/config.py",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "src/agentic_workspace/workspace_runtime_proof.py",
+      "src/agentic_workspace/workspace_runtime_implement.py",
+      "src/agentic_workspace/workspace_runtime_startup.py",
+      "src/agentic_workspace/contracts/schemas/workspace_local_override.schema.json",
+      "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+      "src/agentic_workspace/contracts/schemas/startup_context.schema.json",
+      "src/agentic_workspace/contracts/schemas/workspace_report.schema.json",
+      "docs/reference/workspace-config.md",
+      "tests/test_workspace_proof_cli.py",
+      "tests/test_workspace_implement_cli.py",
+      "tests/test_workspace_summary_cli.py",
+      "tests/test_workspace_cli.py",
+      ".agentic-workspace/planning/execplans/high-risk-host-overlays-1872.plan.json"
+    ],
+    "completion_criteria": [
+      "#1873-#1879 overlay lane capabilities are visible through ordinary AW surfaces with quiet no-match behavior, provenance, validation/CI classification, template preservation, guardrails, validation profiles, and unresolved-question closeout effects."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Implement local-only high-risk host workflow overlays."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Implement local-only high-risk host workflow overlays.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "high-risk-host-overlays-1872",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Implement local-only high-risk host workflow overlays.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement local-only high-risk host workflow overlays",
+    "inferred intended outcome": "Create a bounded plan for Implement local-only high-risk host workflow overlays.",
+    "chosen concrete what": "#1873-#1879 capabilities are represented by one coherent local high-risk overlay lane; no-match stays quiet, matches shape proof/implement/report closeout guidance, and doctor payload state is compatible.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Implement local-only high-risk host workflow overlays.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "high-risk-host-overlays-1872",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement local-only high-risk host workflow overlays is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented local-only high-risk overlay config contract and projected matching overlay records through report, proof, implement, and startup surfaces with provenance, validation/CI/template/guardrail/unresolved-question effects.",
+    "scope touched": "config loader, local override schema/reference docs, proof selection, implement/start compact surfaces, report/config projection, runtime mirror compatibility, focused CLI tests, managed AW payload provenance.",
+    "changed surfaces": "src/agentic_workspace/config.py; src/agentic_workspace/workspace_runtime_proof.py; src/agentic_workspace/workspace_runtime_implement.py; src/agentic_workspace/workspace_runtime_startup.py; src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/workspace_local_override.schema.json; docs/reference/workspace-local-override.md; tests/test_workspace_*; .agentic-workspace/payload-provenance.json.",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #1872-#1879 lane plus doctor-required payload provenance sync. Host-agnostic agent-judgment principle preserved: overlay values are local-only structured facts with provenance and explicit claim effects, not package-owned host assumptions.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Passed: focused overlay tests; make test-workspace; make lint-workspace; make typecheck; make maintainer-surfaces; make schema-reference-docs; make absolute-paths; generated command package check; contract tooling; structured file inventory; runtime_mirror_consistency report; git diff --check.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement local-only high-risk host workflow overlays.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1873-#1879 capabilities are represented by one coherent local high-risk overlay lane; no-match stays quiet, matches shape proof/implement/report closeout guidance, and doctor payload state is compatible.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed issue residue to #1880.",
+    "motivation worth preserving": "Future agents should continue from #1880 rather than rediscover this closeout residue.",
+    "canonical owner now": "#1880",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "#1880",
+    "proposed durable intent": "Future agents should continue from #1880 rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "#1880"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a lane claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      {
+        "summary": "Closeout routed issue residue to #1880.",
+        "owner": "#1880",
+        "source": "durable_residue"
+      }
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      {
+        "summary": "Closeout routed issue residue to #1880.",
+        "owner": "#1880",
+        "source": "durable_residue"
+      }
+    ],
+    "signals dismissed": [],
+    "next owner": "see routed signal owner"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-06-29: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "#1880",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement local-only high-risk host workflow overlays.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Passed: focused overlay tests; make test-workspace; make lint-workspace; make typecheck; make maintainer-surfaces; make schema-reference-docs; make absolute-paths; generated command package check; contract tooling; structured file inventory; runtime_mirror_consistency report; git diff --check.\nChanged surfaces: src/agentic_workspace/config.py; src/agentic_workspace/workspace_runtime_proof.py; src/agentic_workspace/workspace_runtime_implement.py; src/agentic_workspace/workspace_runtime_startup.py; src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/contracts/schemas/workspace_local_override.schema.json; docs/reference/workspace-local-override.md; tests/test_workspace_*; .agentic-workspace/payload-provenance.json.\nDurable residue: planning (#1880)\nMemory learning: route_to_planning\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/docs/reference/workspace-local-override.md
+++ b/docs/reference/workspace-local-override.md
@@ -32,217 +32,233 @@ Machine-local override schema for invocation preferences, delegation capabilitie
 | `local_memory` | object | no |  | Machine-local memory opt-in and path configuration. |  |  |
 | `local_memory.enabled` | boolean | no |  | Whether this machine may use local-only repo memory in addition to checked-in shared Memory. |  |  |
 | `local_memory.path` | string | no |  | Repository-relative path for local-only memory; it must stay ignored and non-authoritative. |  |  |
-| `high_risk_overlay` | object | no |  | Machine-local high-risk workflow overlay. It may shape the acting checkout workflow but is not checked-in host policy. |  |  |
-| `high_risk_overlay.source_maps` | ref `#/$defs/overlay_items` | no |  | Local-only path or task mappings to host-owned authority refs, sources, proof profiles, and review expectations. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
-| `high_risk_overlay.source_maps.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
-| `high_risk_overlay.validation_profiles` | ref `#/$defs/overlay_items` | no |  | Local-only validation profile mappings for changed paths or task markers. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
-| `high_risk_overlay.validation_profiles.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
-| `high_risk_overlay.ci_validation` | ref `#/$defs/overlay_items` | no |  | Local-only CI availability and substitute-validation declarations. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
-| `high_risk_overlay.ci_validation.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
-| `high_risk_overlay.templates` | ref `#/$defs/overlay_items` | no |  | Local-only issue or PR template preservation requirements for API-created work items. |  |  |
-| `high_risk_overlay.templates.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
-| `high_risk_overlay.templates.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
-| `high_risk_overlay.templates.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
-| `high_risk_overlay.templates.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
-| `high_risk_overlay.templates.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
-| `high_risk_overlay.templates.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
-| `high_risk_overlay.templates.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
-| `high_risk_overlay.templates.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
-| `high_risk_overlay.templates.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
-| `high_risk_overlay.templates.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
-| `high_risk_overlay.templates.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
-| `high_risk_overlay.templates.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
-| `high_risk_overlay.templates.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
-| `high_risk_overlay.templates.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
-| `high_risk_overlay.templates.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
-| `high_risk_overlay.templates.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
-| `high_risk_overlay.templates.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
-| `high_risk_overlay.templates.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
-| `high_risk_overlay.templates.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
-| `high_risk_overlay.templates.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.templates.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.templates.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
-| `high_risk_overlay.templates.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
-| `high_risk_overlay.templates.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
-| `high_risk_overlay.templates.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
-| `high_risk_overlay.templates.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
-| `high_risk_overlay.templates.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
-| `high_risk_overlay.templates.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
-| `high_risk_overlay.templates.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
-| `high_risk_overlay.templates.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
-| `high_risk_overlay.templates.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
-| `high_risk_overlay.templates.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
-| `high_risk_overlay.templates.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
-| `high_risk_overlay.templates.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
-| `high_risk_overlay.guardrails` | ref `#/$defs/overlay_items` | no |  | Local-only sensitive-data and synthetic-fixture guardrails. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
-| `high_risk_overlay.guardrails.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
-| `high_risk_overlay.unresolved_questions` | ref `#/$defs/overlay_items` | no |  | Local-only unresolved assumption/question classifications for high-risk closeout. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
-| `high_risk_overlay.unresolved_questions.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `local_overlay` | object | no |  | Machine-local guidance overlay. It may shape the acting checkout workflow but is not checked-in host policy. |  |  |
+| `local_overlay.guidance` | ref `#/$defs/local_guidance_items` | no |  | General local guidance overlay items for ordinary checkout-local facts such as tool availability, validation commands, branch conventions, access constraints, and adoption-time hints. |  |  |
+| `local_overlay.guidance.<^.+$>` | object | no |  | One named ordinary local guidance overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `local_overlay.guidance.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local guidance item for changed paths. |  |  |
+| `local_overlay.guidance.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local guidance item. |  |  |
+| `local_overlay.guidance.<^.+$>.signal` | string | no |  | Short local guidance signal label, such as local-tool-availability or access-constraint. |  |  |
+| `local_overlay.guidance.<^.+$>.category` | string | no |  | Optional category for grouping ordinary local guidance. |  |  |
+| `local_overlay.guidance.<^.+$>.guidance` | string | no |  | Human-readable local guidance for the acting agent. |  |  |
+| `local_overlay.guidance.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Local or host references that explain why this guidance exists. |  |  |
+| `local_overlay.guidance.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Local validation commands required when this guidance item matches. |  |  |
+| `local_overlay.guidance.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional local commands that may improve confidence. |  |  |
+| `local_overlay.guidance.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named local tools, CI routes, or access paths that are unavailable in this checkout. |  |  |
+| `local_overlay.guidance.<^.+$>.review_owner` | string | no |  | Local review owner label for this guidance item. |  |  |
+| `local_overlay.guidance.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this local guidance item. |  |  |
+| `local_overlay.guidance.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this local guidance item affects routing and closeout claims. |  |  |
+| `local_overlay.guidance.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `local_overlay.high_risk` | object | no |  | High-assurance workflow profile that consumes the general local overlay substrate. |  |  |
+| `local_overlay.high_risk.source_maps` | ref `#/$defs/overlay_items` | no |  | High-assurance profile path or task mappings to host-owned authority refs, sources, proof profiles, and review expectations. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `local_overlay.high_risk.source_maps.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `local_overlay.high_risk.validation_profiles` | ref `#/$defs/overlay_items` | no |  | High-assurance profile validation mappings for changed paths or task markers. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `local_overlay.high_risk.validation_profiles.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `local_overlay.high_risk.ci_validation` | ref `#/$defs/overlay_items` | no |  | High-assurance profile CI availability and substitute-validation declarations. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `local_overlay.high_risk.ci_validation.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `local_overlay.high_risk.templates` | ref `#/$defs/overlay_items` | no |  | High-assurance profile issue or PR template preservation requirements for API-created work items. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `local_overlay.high_risk.templates.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `local_overlay.high_risk.guardrails` | ref `#/$defs/overlay_items` | no |  | High-assurance profile sensitive-data and synthetic-fixture guardrails. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `local_overlay.high_risk.guardrails.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `local_overlay.high_risk.unresolved_questions` | ref `#/$defs/overlay_items` | no |  | High-assurance profile unresolved assumption/question classifications for closeout. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `local_overlay.high_risk.unresolved_questions.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
 | `delegation_targets` | object | no |  | Named local delegation targets available to this runtime. |  |  |
 | `delegation_targets.<^.+$>` | object | no |  | One local delegation target profile. Availability fields are human-owned controls; confidence, task fit, and capability classes are advisory estimates. |  |  |
 | `delegation_targets.<^.+$>.strength` | enum `"strong"`, `"medium"`, `"weak"` | yes |  | Human- or agent-declared capability strength for this target. Use it as a routing hint, not as proof that the target can close the work. |  |  |

--- a/docs/reference/workspace-local-override.md
+++ b/docs/reference/workspace-local-override.md
@@ -32,6 +32,217 @@ Machine-local override schema for invocation preferences, delegation capabilitie
 | `local_memory` | object | no |  | Machine-local memory opt-in and path configuration. |  |  |
 | `local_memory.enabled` | boolean | no |  | Whether this machine may use local-only repo memory in addition to checked-in shared Memory. |  |  |
 | `local_memory.path` | string | no |  | Repository-relative path for local-only memory; it must stay ignored and non-authoritative. |  |  |
+| `high_risk_overlay` | object | no |  | Machine-local high-risk workflow overlay. It may shape the acting checkout workflow but is not checked-in host policy. |  |  |
+| `high_risk_overlay.source_maps` | ref `#/$defs/overlay_items` | no |  | Local-only path or task mappings to host-owned authority refs, sources, proof profiles, and review expectations. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `high_risk_overlay.source_maps.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `high_risk_overlay.validation_profiles` | ref `#/$defs/overlay_items` | no |  | Local-only validation profile mappings for changed paths or task markers. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `high_risk_overlay.validation_profiles.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `high_risk_overlay.ci_validation` | ref `#/$defs/overlay_items` | no |  | Local-only CI availability and substitute-validation declarations. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `high_risk_overlay.ci_validation.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `high_risk_overlay.templates` | ref `#/$defs/overlay_items` | no |  | Local-only issue or PR template preservation requirements for API-created work items. |  |  |
+| `high_risk_overlay.templates.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `high_risk_overlay.templates.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `high_risk_overlay.templates.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `high_risk_overlay.templates.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `high_risk_overlay.templates.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `high_risk_overlay.templates.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `high_risk_overlay.templates.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `high_risk_overlay.templates.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `high_risk_overlay.templates.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `high_risk_overlay.templates.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `high_risk_overlay.templates.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `high_risk_overlay.templates.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `high_risk_overlay.templates.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `high_risk_overlay.templates.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `high_risk_overlay.templates.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `high_risk_overlay.templates.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `high_risk_overlay.templates.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `high_risk_overlay.templates.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `high_risk_overlay.templates.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `high_risk_overlay.templates.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.templates.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.templates.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `high_risk_overlay.templates.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `high_risk_overlay.templates.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `high_risk_overlay.templates.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `high_risk_overlay.templates.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `high_risk_overlay.templates.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `high_risk_overlay.templates.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `high_risk_overlay.templates.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `high_risk_overlay.templates.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `high_risk_overlay.templates.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `high_risk_overlay.templates.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `high_risk_overlay.templates.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `high_risk_overlay.templates.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `high_risk_overlay.guardrails` | ref `#/$defs/overlay_items` | no |  | Local-only sensitive-data and synthetic-fixture guardrails. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `high_risk_overlay.guardrails.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
+| `high_risk_overlay.unresolved_questions` | ref `#/$defs/overlay_items` | no |  | Local-only unresolved assumption/question classifications for high-risk closeout. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>` | object | no |  | One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.applies_to_paths` | ref `#/$defs/string_list` | no |  | Repository-relative glob patterns that activate this local overlay item for changed paths. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.applies_to_task_markers` | ref `#/$defs/string_list` | no |  | Case-insensitive task text markers that activate this local overlay item. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.authority_refs` | ref `#/$defs/string_list` | no |  | Host-owned authority references that explain why this overlay exists. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.required_sources` | ref `#/$defs/string_list` | no |  | Local source-of-truth references that should be consulted before claims are made. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.review_owner` | string | no |  | Local review owner label for this overlay item. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.review_aids` | ref `#/$defs/string_list` | no |  | Optional local references, commands, or notes that help the reviewer evaluate the work. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.proof_profiles` | ref `#/$defs/string_list` | no |  | Proof profile labels this overlay item contributes when it matches current work. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.required_commands` | ref `#/$defs/string_list` | no |  | Validation commands required by this local overlay item when it matches. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.manual_evidence` | ref `#/$defs/string_list` | no |  | Manual evidence handles or records required before making bounded claims. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.optional_commands` | ref `#/$defs/string_list` | no |  | Optional validation commands that may improve confidence but are not required by this overlay item. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.manual_checks` | ref `#/$defs/string_list` | no |  | Manual checks the acting agent should record or route to a reviewer. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.unavailable_routes` | ref `#/$defs/string_list` | no |  | Named CI or validation routes that are unavailable for this checkout. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.validation_state` | enum `"ci_failed"`, `"ci_pending"`, `"ci_skipped"`, `"ci_not_run"`, `"ci_unavailable"`, `"quota_exhausted"`, `"logs_unavailable"`, `"local_substitute"` | no |  | Current CI or validation availability state for this local overlay item. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.local_substitute_commands` | ref `#/$defs/string_list` | no |  | Local substitute commands available when host CI or another validation route is unavailable. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.local_substitute_policy` | enum `"advisory"`, `"sufficient-for-bounded-claim"`, `"insufficient"`, `"human-review-only"` | no |  | How local substitute validation may support or limit completion claims. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.host` | string | no |  | Host system name for a template or work-item preservation rule. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.kind` | string | no |  | Host work-item or artifact kind affected by this overlay item. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.paths` | ref `#/$defs/string_list` | no |  | Repository-relative template or artifact paths that should be preserved. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.headings` | ref `#/$defs/string_list` | no |  | Template headings expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.required_fields` | ref `#/$defs/string_list` | no |  | Template fields expected to remain available for API-created work items. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.state` | string | no |  | Local state classification such as present, missing, or drifted. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.sensitive_data` | ref `#/$defs/string_list` | no |  | Sensitive data classes that must not be exposed in fixtures or examples. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.synthetic_fixture_guidance` | ref `#/$defs/string_list` | no |  | Guidance for acceptable synthetic fixtures or examples. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.safe_examples` | ref `#/$defs/string_list` | no |  | Known-safe example values that may be used instead of sensitive data. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.category` | enum `"merge-blocker"`, `"release-blocker"`, `"human-review-required"`, `"safe-follow-up"`, `"intentionally-deferred"` | no |  | Unresolved assumption category used to decide whether closeout needs human review or can defer residue. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.question` | string | no |  | Unresolved question that must be answered, reviewed, or explicitly routed. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.owner` | string | no |  | Human or team owner for the unresolved question or overlay item. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.residue_route` | string | no |  | Where unresolved residue should be routed if it cannot be closed in the current work. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.reason` | string | no |  | Local explanation for why this overlay item applies. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.claim_boundary` | string | no |  | Claim boundary imposed by this overlay item. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.drift_state` | string | no |  | Local drift classification for source, template, or validation expectations. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.impact` | enum `"advisory"`, `"blocking"`, `"human-review-only"`, `"claim-limiting"` | no |  | How strongly this overlay item affects routing and closeout claims. |  |  |
+| `high_risk_overlay.unresolved_questions.<^.+$>.notes` | string | no |  | Optional local notes for reviewers or future agents. |  |  |
 | `delegation_targets` | object | no |  | Named local delegation targets available to this runtime. |  |  |
 | `delegation_targets.<^.+$>` | object | no |  | One local delegation target profile. Availability fields are human-owned controls; confidence, task fit, and capability classes are advisory estimates. |  |  |
 | `delegation_targets.<^.+$>.strength` | enum `"strong"`, `"medium"`, `"weak"` | yes |  | Human- or agent-declared capability strength for this target. Use it as a routing hint, not as proof that the target can close the work. |  |  |

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -320,6 +320,7 @@ class MixedAgentLocalOverride:
     local_memory_enabled: bool | None
     local_memory_path: Path
     delegation_targets: tuple[DelegationTargetProfile, ...]
+    local_overlay: dict[str, Any]
     high_risk_overlay: dict[str, Any]
     field_sources: dict[str, str]
 
@@ -1526,6 +1527,7 @@ def empty_mixed_agent_local_override(*, path: Path | None, exists: bool) -> Mixe
         local_memory_enabled=None,
         local_memory_path=WORKSPACE_LOCAL_MEMORY_DEFAULT_PATH,
         delegation_targets=(),
+        local_overlay={},
         high_risk_overlay={},
         field_sources={},
     )
@@ -1566,12 +1568,25 @@ def _local_config_nested_source(
     *,
     local_payload: dict[str, Any],
     shared_payload: dict[str, Any] | None,
+    table: str,
     section: str,
     item_id: str,
 ) -> str:
-    if item_id in _local_config_table(_local_config_table(local_payload, "high_risk_overlay"), section):
+    if item_id in _local_config_table(_local_config_table(local_payload, table), section):
         return "repo-local-override"
-    if item_id in _local_config_table(_local_config_table(shared_payload, "high_risk_overlay"), section):
+    if item_id in _local_config_table(_local_config_table(shared_payload, table), section):
+        return "shared-local-config"
+    return "merged-local-config"
+
+
+def _local_overlay_high_risk_source(
+    *, local_payload: dict[str, Any], shared_payload: dict[str, Any] | None, section: str, item_id: str
+) -> str:
+    local_overlay = _local_config_table(local_payload, "local_overlay")
+    shared_overlay = _local_config_table(shared_payload, "local_overlay")
+    if item_id in _local_config_table(_local_config_table(local_overlay, "high_risk"), section):
+        return "repo-local-override"
+    if item_id in _local_config_table(_local_config_table(shared_overlay, "high_risk"), section):
         return "shared-local-config"
     return "merged-local-config"
 
@@ -1602,12 +1617,117 @@ def _optional_overlay_enum(
         return default
 
 
+def _normalize_local_guidance_overlay(
+    *,
+    raw_guidance: Any,
+    local_payload: dict[str, Any],
+    shared_payload: dict[str, Any] | None,
+    warnings: list[str],
+) -> dict[str, Any]:
+    allowed_fields = {
+        "applies_to_paths",
+        "applies_to_task_markers",
+        "signal",
+        "category",
+        "guidance",
+        "authority_refs",
+        "required_commands",
+        "optional_commands",
+        "unavailable_routes",
+        "review_owner",
+        "claim_boundary",
+        "impact",
+        "notes",
+    }
+    if raw_guidance in (None, {}):
+        return {"status": "absent", "items": [], "warnings": []}
+    if not isinstance(raw_guidance, dict):
+        message = f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} local_overlay.guidance must be a table of named items."
+        warnings.append(message)
+        return {"status": "invalid", "items": [], "warnings": [message]}
+    guidance_warnings: list[str] = []
+    items: list[dict[str, Any]] = []
+    for item_id, raw_item in sorted(raw_guidance.items()):
+        item_path = Path(f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} local_overlay.guidance.{item_id}")
+        if not isinstance(raw_item, dict):
+            message = f"{item_path.as_posix()} must be a table."
+            warnings.append(message)
+            guidance_warnings.append(message)
+            continue
+        raw_item = dict(raw_item)
+        unknown_fields = sorted(set(raw_item) - allowed_fields)
+        if unknown_fields:
+            message = f"{item_path.as_posix()} contains unsupported field(s): {', '.join(unknown_fields)}."
+            warnings.append(message)
+            guidance_warnings.append(message)
+        items.append(
+            {
+                "id": str(item_id).strip(),
+                "section": "guidance",
+                "source_layer": _local_config_nested_source(
+                    local_payload=local_payload,
+                    shared_payload=shared_payload,
+                    table="local_overlay",
+                    section="guidance",
+                    item_id=str(item_id),
+                ),
+                "surface": f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [local_overlay.guidance.{item_id}]",
+                "applies_to_paths": list(
+                    _optional_overlay_string_list(payload=raw_item, key="applies_to_paths", item_path=item_path, warnings=guidance_warnings)
+                ),
+                "applies_to_task_markers": list(
+                    _optional_overlay_string_list(
+                        payload=raw_item, key="applies_to_task_markers", item_path=item_path, warnings=guidance_warnings
+                    )
+                ),
+                "signal": _optional_overlay_string(payload=raw_item, key="signal", item_path=item_path, warnings=guidance_warnings),
+                "category": _optional_overlay_string(payload=raw_item, key="category", item_path=item_path, warnings=guidance_warnings),
+                "guidance": _optional_overlay_string(payload=raw_item, key="guidance", item_path=item_path, warnings=guidance_warnings),
+                "authority_refs": list(
+                    _optional_overlay_string_list(payload=raw_item, key="authority_refs", item_path=item_path, warnings=guidance_warnings)
+                ),
+                "required_commands": list(
+                    _optional_overlay_string_list(
+                        payload=raw_item, key="required_commands", item_path=item_path, warnings=guidance_warnings
+                    )
+                ),
+                "optional_commands": list(
+                    _optional_overlay_string_list(
+                        payload=raw_item, key="optional_commands", item_path=item_path, warnings=guidance_warnings
+                    )
+                ),
+                "unavailable_routes": list(
+                    _optional_overlay_string_list(
+                        payload=raw_item, key="unavailable_routes", item_path=item_path, warnings=guidance_warnings
+                    )
+                ),
+                "review_owner": _optional_overlay_string(
+                    payload=raw_item, key="review_owner", item_path=item_path, warnings=guidance_warnings
+                ),
+                "claim_boundary": _optional_overlay_string(
+                    payload=raw_item, key="claim_boundary", item_path=item_path, warnings=guidance_warnings
+                ),
+                "impact": _optional_overlay_enum(
+                    payload=raw_item,
+                    key="impact",
+                    item_path=item_path,
+                    allowed=SUPPORTED_LOCAL_HIGH_RISK_IMPACTS,
+                    default="advisory",
+                    warnings=guidance_warnings,
+                ),
+                "notes": _optional_overlay_string(payload=raw_item, key="notes", item_path=item_path, warnings=guidance_warnings),
+            }
+        )
+    return {"status": "configured" if items else "absent", "items": items, "warnings": guidance_warnings}
+
+
 def _normalize_local_high_risk_overlay(
     *,
     raw_overlay: Any,
     local_payload: dict[str, Any],
     shared_payload: dict[str, Any] | None,
     warnings: list[str],
+    surface_prefix: str = "high_risk_overlay",
 ) -> dict[str, Any]:
     if raw_overlay in (None, {}):
         return {
@@ -1617,12 +1737,12 @@ def _normalize_local_high_risk_overlay(
             "warnings": [],
         }
     if not isinstance(raw_overlay, dict):
-        warnings.append(f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [high_risk_overlay] section must be a table.")
+        warnings.append(f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [{surface_prefix}] section must be a table.")
         return {
             "kind": "agentic-workspace/local-high-risk-overlay-config/v1",
             "status": "invalid",
             "sections": {},
-            "warnings": [f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [high_risk_overlay] section must be a table."],
+            "warnings": [f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [{surface_prefix}] section must be a table."],
         }
     section_fields = {
         "source_maps": {
@@ -1704,7 +1824,7 @@ def _normalize_local_high_risk_overlay(
     unknown_sections = sorted(set(raw_overlay) - set(section_fields))
     if unknown_sections:
         warnings.append(
-            f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [high_risk_overlay] contains unsupported section(s): {', '.join(unknown_sections)}."
+            f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [{surface_prefix}] contains unsupported section(s): {', '.join(unknown_sections)}."
         )
     overlay_warnings: list[str] = []
     sections: dict[str, list[dict[str, Any]]] = {}
@@ -1714,14 +1834,14 @@ def _normalize_local_high_risk_overlay(
             sections[section] = []
             continue
         if not isinstance(raw_section, dict):
-            message = f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} high_risk_overlay.{section} must be a table of named items."
+            message = f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} {surface_prefix}.{section} must be a table of named items."
             warnings.append(message)
             overlay_warnings.append(message)
             sections[section] = []
             continue
         items: list[dict[str, Any]] = []
         for item_id, raw_item in sorted(raw_section.items()):
-            item_path = Path(f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} high_risk_overlay.{section}.{item_id}")
+            item_path = Path(f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} {surface_prefix}.{section}.{item_id}")
             if not isinstance(raw_item, dict):
                 message = f"{item_path.as_posix()} must be a table."
                 warnings.append(message)
@@ -1739,10 +1859,18 @@ def _normalize_local_high_risk_overlay(
                 "source_layer": _local_config_nested_source(
                     local_payload=local_payload,
                     shared_payload=shared_payload,
+                    table="high_risk_overlay",
+                    section=section,
+                    item_id=str(item_id),
+                )
+                if surface_prefix == "high_risk_overlay"
+                else _local_overlay_high_risk_source(
+                    local_payload=local_payload,
+                    shared_payload=shared_payload,
                     section=section,
                     item_id=str(item_id),
                 ),
-                "surface": f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [high_risk_overlay.{section}.{item_id}]",
+                "surface": f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [{surface_prefix}.{section}.{item_id}]",
                 "applies_to_paths": list(
                     _optional_overlay_string_list(payload=raw_item, key="applies_to_paths", item_path=item_path, warnings=overlay_warnings)
                 ),
@@ -1847,6 +1975,75 @@ def _normalize_local_high_risk_overlay(
     }
 
 
+def _normalize_local_overlay(
+    *,
+    raw_overlay: Any,
+    legacy_high_risk_overlay: Any,
+    local_payload: dict[str, Any],
+    shared_payload: dict[str, Any] | None,
+    warnings: list[str],
+) -> dict[str, Any]:
+    overlay_warnings: list[str] = []
+    if raw_overlay in (None, {}):
+        raw_overlay = {}
+    if not isinstance(raw_overlay, dict):
+        message = f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [local_overlay] section must be a table."
+        warnings.append(message)
+        overlay_warnings.append(message)
+        raw_overlay = {}
+    unknown_sections = sorted(set(raw_overlay) - {"guidance", "high_risk"})
+    if unknown_sections:
+        message = (
+            f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [local_overlay] contains unsupported section(s): {', '.join(unknown_sections)}."
+        )
+        warnings.append(message)
+        overlay_warnings.append(message)
+    if legacy_high_risk_overlay not in (None, {}):
+        message = (
+            f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [high_risk_overlay] is deprecated; "
+            "use [local_overlay.high_risk] so high-risk workflow guidance consumes the general local overlay substrate."
+        )
+        warnings.append(message)
+        overlay_warnings.append(message)
+    guidance = _normalize_local_guidance_overlay(
+        raw_guidance=raw_overlay.get("guidance", {}),
+        local_payload=local_payload,
+        shared_payload=shared_payload,
+        warnings=warnings,
+    )
+    raw_high_risk = raw_overlay.get("high_risk", {})
+    if raw_high_risk in (None, {}) and legacy_high_risk_overlay not in (None, {}):
+        raw_high_risk = legacy_high_risk_overlay
+    high_risk = _normalize_local_high_risk_overlay(
+        raw_overlay=raw_high_risk,
+        local_payload=local_payload,
+        shared_payload=shared_payload,
+        warnings=warnings,
+        surface_prefix="local_overlay.high_risk",
+    )
+    overlay_warnings.extend(guidance.get("warnings", []))
+    overlay_warnings.extend(high_risk.get("warnings", []))
+    guidance_count = len(guidance.get("items", [])) if isinstance(guidance.get("items"), list) else 0
+    high_risk_count = int(high_risk.get("item_count", 0) or 0) if isinstance(high_risk, dict) else 0
+    return {
+        "kind": "agentic-workspace/local-overlay-config/v1",
+        "status": "configured" if guidance_count or high_risk_count else "absent",
+        "item_count": guidance_count + high_risk_count,
+        "ordinary_guidance_count": guidance_count,
+        "high_risk_profile_count": high_risk_count,
+        "sections": {
+            "guidance": guidance.get("items", []),
+            "high_risk": high_risk.get("sections", {}),
+        },
+        "high_risk_profile": high_risk,
+        "warnings": overlay_warnings,
+        "authority_boundary": {
+            "source": "local-overlay",
+            "rule": "Local overlay guidance may shape the acting checkout workflow, but it is not checked-in host policy.",
+        },
+    }
+
+
 def _local_config_display_path(*, path: Path, target_root: Path) -> str:
     try:
         return path.relative_to(target_root).as_posix()
@@ -1927,6 +2124,7 @@ def load_mixed_agent_local_override(*, target_root: Path) -> tuple[MixedAgentLoc
             "delegation",
             "clarification",
             "local_memory",
+            "local_overlay",
             "high_risk_overlay",
             "delegation_targets",
         }
@@ -2063,12 +2261,14 @@ def load_mixed_agent_local_override(*, target_root: Path) -> tuple[MixedAgentLoc
         config_path=WORKSPACE_LOCAL_CONFIG_PATH,
     )
     warnings.extend(delegation_target_warnings)
-    high_risk_overlay = _normalize_local_high_risk_overlay(
-        raw_overlay=payload.get("high_risk_overlay", {}),
+    local_overlay = _normalize_local_overlay(
+        raw_overlay=payload.get("local_overlay", {}),
+        legacy_high_risk_overlay=payload.get("high_risk_overlay", {}),
         local_payload=local_payload,
         shared_payload=shared_payload,
         warnings=warnings,
     )
+    high_risk_overlay = local_overlay.get("high_risk_profile", {}) if isinstance(local_overlay, dict) else {}
 
     return MixedAgentLocalOverride(
         path=local_path,
@@ -2123,6 +2323,7 @@ def load_mixed_agent_local_override(*, target_root: Path) -> tuple[MixedAgentLoc
             default=WORKSPACE_LOCAL_MEMORY_DEFAULT_PATH,
         ),
         delegation_targets=delegation_targets,
+        local_overlay=local_overlay,
         high_risk_overlay=high_risk_overlay,
         field_sources=field_sources
         | {

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -231,6 +231,35 @@ SUPPORTED_CLI_TARGET_RELATIONS = (
     "outside-target",
     "no-target",
 )
+SUPPORTED_LOCAL_HIGH_RISK_IMPACTS = (
+    "advisory",
+    "blocking",
+    "human-review-only",
+    "claim-limiting",
+)
+SUPPORTED_LOCAL_HIGH_RISK_VALIDATION_STATES = (
+    "ci_failed",
+    "ci_pending",
+    "ci_skipped",
+    "ci_not_run",
+    "ci_unavailable",
+    "quota_exhausted",
+    "logs_unavailable",
+    "local_substitute",
+)
+SUPPORTED_LOCAL_HIGH_RISK_SUBSTITUTE_POLICIES = (
+    "advisory",
+    "sufficient-for-bounded-claim",
+    "insufficient",
+    "human-review-only",
+)
+SUPPORTED_LOCAL_HIGH_RISK_UNRESOLVED_CLASSES = (
+    "merge-blocker",
+    "release-blocker",
+    "human-review-required",
+    "safe-follow-up",
+    "intentionally-deferred",
+)
 
 
 class WorkspaceUsageError(ValueError):
@@ -291,6 +320,7 @@ class MixedAgentLocalOverride:
     local_memory_enabled: bool | None
     local_memory_path: Path
     delegation_targets: tuple[DelegationTargetProfile, ...]
+    high_risk_overlay: dict[str, Any]
     field_sources: dict[str, str]
 
 
@@ -1496,6 +1526,7 @@ def empty_mixed_agent_local_override(*, path: Path | None, exists: bool) -> Mixe
         local_memory_enabled=None,
         local_memory_path=WORKSPACE_LOCAL_MEMORY_DEFAULT_PATH,
         delegation_targets=(),
+        high_risk_overlay={},
         field_sources={},
     )
 
@@ -1529,6 +1560,291 @@ def _local_config_field_source(
     if key in _local_config_table(shared_payload, table):
         return "shared-local-config"
     return "unset"
+
+
+def _local_config_nested_source(
+    *,
+    local_payload: dict[str, Any],
+    shared_payload: dict[str, Any] | None,
+    section: str,
+    item_id: str,
+) -> str:
+    if item_id in _local_config_table(_local_config_table(local_payload, "high_risk_overlay"), section):
+        return "repo-local-override"
+    if item_id in _local_config_table(_local_config_table(shared_payload, "high_risk_overlay"), section):
+        return "shared-local-config"
+    return "merged-local-config"
+
+
+def _optional_overlay_string_list(*, payload: dict[str, Any], key: str, item_path: Path, warnings: list[str]) -> tuple[str, ...]:
+    try:
+        return require_optional_string_list(payload=payload, key=key, config_path=item_path)
+    except WorkspaceUsageError as exc:
+        warnings.append(str(exc))
+        return ()
+
+
+def _optional_overlay_string(*, payload: dict[str, Any], key: str, item_path: Path, warnings: list[str]) -> str | None:
+    try:
+        return require_optional_string(payload=payload, key=key, config_path=item_path)
+    except WorkspaceUsageError as exc:
+        warnings.append(str(exc))
+        return None
+
+
+def _optional_overlay_enum(
+    *, payload: dict[str, Any], key: str, item_path: Path, allowed: tuple[str, ...], default: str, warnings: list[str]
+) -> str:
+    try:
+        return require_optional_enum(payload=payload, key=key, config_path=item_path, allowed=allowed, default=default)
+    except WorkspaceUsageError as exc:
+        warnings.append(str(exc))
+        return default
+
+
+def _normalize_local_high_risk_overlay(
+    *,
+    raw_overlay: Any,
+    local_payload: dict[str, Any],
+    shared_payload: dict[str, Any] | None,
+    warnings: list[str],
+) -> dict[str, Any]:
+    if raw_overlay in (None, {}):
+        return {
+            "kind": "agentic-workspace/local-high-risk-overlay-config/v1",
+            "status": "absent",
+            "sections": {},
+            "warnings": [],
+        }
+    if not isinstance(raw_overlay, dict):
+        warnings.append(f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [high_risk_overlay] section must be a table.")
+        return {
+            "kind": "agentic-workspace/local-high-risk-overlay-config/v1",
+            "status": "invalid",
+            "sections": {},
+            "warnings": [f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [high_risk_overlay] section must be a table."],
+        }
+    section_fields = {
+        "source_maps": {
+            "applies_to_paths",
+            "applies_to_task_markers",
+            "authority_refs",
+            "required_sources",
+            "review_owner",
+            "review_aids",
+            "proof_profiles",
+            "required_commands",
+            "manual_evidence",
+            "claim_boundary",
+            "drift_state",
+            "impact",
+            "notes",
+        },
+        "validation_profiles": {
+            "category",
+            "applies_to_paths",
+            "applies_to_task_markers",
+            "required_commands",
+            "optional_commands",
+            "manual_checks",
+            "unavailable_routes",
+            "claim_boundary",
+            "proof_profiles",
+            "authority_refs",
+            "impact",
+            "notes",
+        },
+        "ci_validation": {
+            "applies_to_paths",
+            "applies_to_task_markers",
+            "validation_state",
+            "local_substitute_commands",
+            "local_substitute_policy",
+            "authority_refs",
+            "claim_boundary",
+            "impact",
+            "notes",
+        },
+        "templates": {
+            "applies_to_task_markers",
+            "host",
+            "kind",
+            "paths",
+            "headings",
+            "required_fields",
+            "state",
+            "impact",
+            "notes",
+        },
+        "guardrails": {
+            "applies_to_paths",
+            "applies_to_task_markers",
+            "sensitive_data",
+            "synthetic_fixture_guidance",
+            "safe_examples",
+            "authority_refs",
+            "claim_boundary",
+            "impact",
+            "notes",
+        },
+        "unresolved_questions": {
+            "applies_to_paths",
+            "applies_to_task_markers",
+            "category",
+            "question",
+            "owner",
+            "residue_route",
+            "reason",
+            "authority_refs",
+            "claim_boundary",
+            "impact",
+            "notes",
+        },
+    }
+    unknown_sections = sorted(set(raw_overlay) - set(section_fields))
+    if unknown_sections:
+        warnings.append(
+            f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [high_risk_overlay] contains unsupported section(s): {', '.join(unknown_sections)}."
+        )
+    overlay_warnings: list[str] = []
+    sections: dict[str, list[dict[str, Any]]] = {}
+    for section, allowed_fields in section_fields.items():
+        raw_section = raw_overlay.get(section, {})
+        if raw_section in (None, {}):
+            sections[section] = []
+            continue
+        if not isinstance(raw_section, dict):
+            message = f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} high_risk_overlay.{section} must be a table of named items."
+            warnings.append(message)
+            overlay_warnings.append(message)
+            sections[section] = []
+            continue
+        items: list[dict[str, Any]] = []
+        for item_id, raw_item in sorted(raw_section.items()):
+            item_path = Path(f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} high_risk_overlay.{section}.{item_id}")
+            if not isinstance(raw_item, dict):
+                message = f"{item_path.as_posix()} must be a table."
+                warnings.append(message)
+                overlay_warnings.append(message)
+                continue
+            raw_item = dict(raw_item)
+            unknown_fields = sorted(set(raw_item) - allowed_fields)
+            if unknown_fields:
+                message = f"{item_path.as_posix()} contains unsupported field(s): {', '.join(unknown_fields)}."
+                warnings.append(message)
+                overlay_warnings.append(message)
+            item: dict[str, Any] = {
+                "id": str(item_id).strip(),
+                "section": section,
+                "source_layer": _local_config_nested_source(
+                    local_payload=local_payload,
+                    shared_payload=shared_payload,
+                    section=section,
+                    item_id=str(item_id),
+                ),
+                "surface": f"{WORKSPACE_LOCAL_CONFIG_PATH.as_posix()} [high_risk_overlay.{section}.{item_id}]",
+                "applies_to_paths": list(
+                    _optional_overlay_string_list(payload=raw_item, key="applies_to_paths", item_path=item_path, warnings=overlay_warnings)
+                ),
+                "applies_to_task_markers": list(
+                    _optional_overlay_string_list(
+                        payload=raw_item, key="applies_to_task_markers", item_path=item_path, warnings=overlay_warnings
+                    )
+                ),
+                "authority_refs": list(
+                    _optional_overlay_string_list(payload=raw_item, key="authority_refs", item_path=item_path, warnings=overlay_warnings)
+                ),
+                "claim_boundary": _optional_overlay_string(
+                    payload=raw_item, key="claim_boundary", item_path=item_path, warnings=overlay_warnings
+                ),
+                "impact": _optional_overlay_enum(
+                    payload=raw_item,
+                    key="impact",
+                    item_path=item_path,
+                    allowed=SUPPORTED_LOCAL_HIGH_RISK_IMPACTS,
+                    default="advisory",
+                    warnings=overlay_warnings,
+                ),
+                "notes": _optional_overlay_string(payload=raw_item, key="notes", item_path=item_path, warnings=overlay_warnings),
+            }
+            for key in (
+                "required_sources",
+                "review_aids",
+                "proof_profiles",
+                "required_commands",
+                "manual_evidence",
+                "optional_commands",
+                "manual_checks",
+                "unavailable_routes",
+                "local_substitute_commands",
+                "paths",
+                "headings",
+                "required_fields",
+                "sensitive_data",
+                "synthetic_fixture_guidance",
+                "safe_examples",
+            ):
+                if key in allowed_fields:
+                    item[key] = list(
+                        _optional_overlay_string_list(payload=raw_item, key=key, item_path=item_path, warnings=overlay_warnings)
+                    )
+            for key in (
+                "review_owner",
+                "drift_state",
+                "category",
+                "validation_state",
+                "local_substitute_policy",
+                "host",
+                "kind",
+                "state",
+                "question",
+                "owner",
+                "residue_route",
+                "reason",
+            ):
+                if key in allowed_fields:
+                    item[key] = _optional_overlay_string(payload=raw_item, key=key, item_path=item_path, warnings=overlay_warnings)
+            if section == "ci_validation" and item.get("validation_state") not in (None, ""):
+                item["validation_state"] = _optional_overlay_enum(
+                    payload=raw_item,
+                    key="validation_state",
+                    item_path=item_path,
+                    allowed=SUPPORTED_LOCAL_HIGH_RISK_VALIDATION_STATES,
+                    default="ci_unavailable",
+                    warnings=overlay_warnings,
+                )
+            if section == "ci_validation" and item.get("local_substitute_policy") not in (None, ""):
+                item["local_substitute_policy"] = _optional_overlay_enum(
+                    payload=raw_item,
+                    key="local_substitute_policy",
+                    item_path=item_path,
+                    allowed=SUPPORTED_LOCAL_HIGH_RISK_SUBSTITUTE_POLICIES,
+                    default="insufficient",
+                    warnings=overlay_warnings,
+                )
+            if section == "unresolved_questions" and item.get("category") not in (None, ""):
+                item["category"] = _optional_overlay_enum(
+                    payload=raw_item,
+                    key="category",
+                    item_path=item_path,
+                    allowed=SUPPORTED_LOCAL_HIGH_RISK_UNRESOLVED_CLASSES,
+                    default="safe-follow-up",
+                    warnings=overlay_warnings,
+                )
+            items.append(item)
+        sections[section] = items
+    item_count = sum(len(items) for items in sections.values())
+    return {
+        "kind": "agentic-workspace/local-high-risk-overlay-config/v1",
+        "status": "configured" if item_count else "absent",
+        "item_count": item_count,
+        "sections": sections,
+        "warnings": overlay_warnings,
+        "authority_boundary": {
+            "source": "local-only-overlay",
+            "rule": "Local high-risk overlay guidance may shape the acting checkout workflow, but it is not checked-in host policy.",
+        },
+    }
 
 
 def _local_config_display_path(*, path: Path, target_root: Path) -> str:
@@ -1611,6 +1927,7 @@ def load_mixed_agent_local_override(*, target_root: Path) -> tuple[MixedAgentLoc
             "delegation",
             "clarification",
             "local_memory",
+            "high_risk_overlay",
             "delegation_targets",
         }
     )
@@ -1746,6 +2063,12 @@ def load_mixed_agent_local_override(*, target_root: Path) -> tuple[MixedAgentLoc
         config_path=WORKSPACE_LOCAL_CONFIG_PATH,
     )
     warnings.extend(delegation_target_warnings)
+    high_risk_overlay = _normalize_local_high_risk_overlay(
+        raw_overlay=payload.get("high_risk_overlay", {}),
+        local_payload=local_payload,
+        shared_payload=shared_payload,
+        warnings=warnings,
+    )
 
     return MixedAgentLocalOverride(
         path=local_path,
@@ -1800,6 +2123,7 @@ def load_mixed_agent_local_override(*, target_root: Path) -> tuple[MixedAgentLoc
             default=WORKSPACE_LOCAL_MEMORY_DEFAULT_PATH,
         ),
         delegation_targets=delegation_targets,
+        high_risk_overlay=high_risk_overlay,
         field_sources=field_sources
         | {
             field_path: _local_config_field_source(

--- a/src/agentic_workspace/contracts/schemas/workspace_local_override.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_local_override.schema.json
@@ -129,36 +129,47 @@
       "additionalProperties": false,
       "description": "Machine-local memory opt-in and path configuration."
     },
-    "high_risk_overlay": {
+    "local_overlay": {
       "type": "object",
       "properties": {
-        "source_maps": {
-          "$ref": "#/$defs/overlay_items",
-          "description": "Local-only path or task mappings to host-owned authority refs, sources, proof profiles, and review expectations."
+        "guidance": {
+          "$ref": "#/$defs/local_guidance_items",
+          "description": "General local guidance overlay items for ordinary checkout-local facts such as tool availability, validation commands, branch conventions, access constraints, and adoption-time hints."
         },
-        "validation_profiles": {
-          "$ref": "#/$defs/overlay_items",
-          "description": "Local-only validation profile mappings for changed paths or task markers."
-        },
-        "ci_validation": {
-          "$ref": "#/$defs/overlay_items",
-          "description": "Local-only CI availability and substitute-validation declarations."
-        },
-        "templates": {
-          "$ref": "#/$defs/overlay_items",
-          "description": "Local-only issue or PR template preservation requirements for API-created work items."
-        },
-        "guardrails": {
-          "$ref": "#/$defs/overlay_items",
-          "description": "Local-only sensitive-data and synthetic-fixture guardrails."
-        },
-        "unresolved_questions": {
-          "$ref": "#/$defs/overlay_items",
-          "description": "Local-only unresolved assumption/question classifications for high-risk closeout."
+        "high_risk": {
+          "type": "object",
+          "properties": {
+            "source_maps": {
+              "$ref": "#/$defs/overlay_items",
+              "description": "High-assurance profile path or task mappings to host-owned authority refs, sources, proof profiles, and review expectations."
+            },
+            "validation_profiles": {
+              "$ref": "#/$defs/overlay_items",
+              "description": "High-assurance profile validation mappings for changed paths or task markers."
+            },
+            "ci_validation": {
+              "$ref": "#/$defs/overlay_items",
+              "description": "High-assurance profile CI availability and substitute-validation declarations."
+            },
+            "templates": {
+              "$ref": "#/$defs/overlay_items",
+              "description": "High-assurance profile issue or PR template preservation requirements for API-created work items."
+            },
+            "guardrails": {
+              "$ref": "#/$defs/overlay_items",
+              "description": "High-assurance profile sensitive-data and synthetic-fixture guardrails."
+            },
+            "unresolved_questions": {
+              "$ref": "#/$defs/overlay_items",
+              "description": "High-assurance profile unresolved assumption/question classifications for closeout."
+            }
+          },
+          "additionalProperties": false,
+          "description": "High-assurance workflow profile that consumes the general local overlay substrate."
         }
       },
       "additionalProperties": false,
-      "description": "Machine-local high-risk workflow overlay. It may shape the acting checkout workflow but is not checked-in host policy."
+      "description": "Machine-local guidance overlay. It may shape the acting checkout workflow but is not checked-in host policy."
     },
     "delegation_targets": {
       "type": "object",
@@ -358,6 +369,84 @@
         "description": "One non-empty local overlay value."
       },
       "description": "List of non-empty strings used by local-only overlay records."
+    },
+    "local_guidance_items": {
+      "type": "object",
+      "patternProperties": {
+        "^.+$": {
+          "type": "object",
+          "properties": {
+            "applies_to_paths": {
+              "$ref": "#/$defs/string_list",
+              "description": "Repository-relative glob patterns that activate this local guidance item for changed paths."
+            },
+            "applies_to_task_markers": {
+              "$ref": "#/$defs/string_list",
+              "description": "Case-insensitive task text markers that activate this local guidance item."
+            },
+            "signal": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Short local guidance signal label, such as local-tool-availability or access-constraint."
+            },
+            "category": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Optional category for grouping ordinary local guidance."
+            },
+            "guidance": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Human-readable local guidance for the acting agent."
+            },
+            "authority_refs": {
+              "$ref": "#/$defs/string_list",
+              "description": "Local or host references that explain why this guidance exists."
+            },
+            "required_commands": {
+              "$ref": "#/$defs/string_list",
+              "description": "Local validation commands required when this guidance item matches."
+            },
+            "optional_commands": {
+              "$ref": "#/$defs/string_list",
+              "description": "Optional local commands that may improve confidence."
+            },
+            "unavailable_routes": {
+              "$ref": "#/$defs/string_list",
+              "description": "Named local tools, CI routes, or access paths that are unavailable in this checkout."
+            },
+            "review_owner": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Local review owner label for this guidance item."
+            },
+            "claim_boundary": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Claim boundary imposed by this local guidance item."
+            },
+            "impact": {
+              "type": "string",
+              "enum": [
+                "advisory",
+                "blocking",
+                "human-review-only",
+                "claim-limiting"
+              ],
+              "description": "How strongly this local guidance item affects routing and closeout claims."
+            },
+            "notes": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Optional local notes for reviewers or future agents."
+            }
+          },
+          "additionalProperties": false,
+          "description": "One named ordinary local guidance overlay item. It can shape this checkout's workflow but is not shared host policy."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Named ordinary local guidance overlay items."
     },
     "overlay_items": {
       "type": "object",

--- a/src/agentic_workspace/contracts/schemas/workspace_local_override.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_local_override.schema.json
@@ -129,6 +129,37 @@
       "additionalProperties": false,
       "description": "Machine-local memory opt-in and path configuration."
     },
+    "high_risk_overlay": {
+      "type": "object",
+      "properties": {
+        "source_maps": {
+          "$ref": "#/$defs/overlay_items",
+          "description": "Local-only path or task mappings to host-owned authority refs, sources, proof profiles, and review expectations."
+        },
+        "validation_profiles": {
+          "$ref": "#/$defs/overlay_items",
+          "description": "Local-only validation profile mappings for changed paths or task markers."
+        },
+        "ci_validation": {
+          "$ref": "#/$defs/overlay_items",
+          "description": "Local-only CI availability and substitute-validation declarations."
+        },
+        "templates": {
+          "$ref": "#/$defs/overlay_items",
+          "description": "Local-only issue or PR template preservation requirements for API-created work items."
+        },
+        "guardrails": {
+          "$ref": "#/$defs/overlay_items",
+          "description": "Local-only sensitive-data and synthetic-fixture guardrails."
+        },
+        "unresolved_questions": {
+          "$ref": "#/$defs/overlay_items",
+          "description": "Local-only unresolved assumption/question classifications for high-risk closeout."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Machine-local high-risk workflow overlay. It may shape the acting checkout workflow but is not checked-in host policy."
+    },
     "delegation_targets": {
       "type": "object",
       "patternProperties": {
@@ -316,6 +347,203 @@
       },
       "additionalProperties": false,
       "description": "Named local delegation targets available to this runtime."
+    }
+  },
+  "$defs": {
+    "string_list": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "One non-empty local overlay value."
+      },
+      "description": "List of non-empty strings used by local-only overlay records."
+    },
+    "overlay_items": {
+      "type": "object",
+      "patternProperties": {
+        "^.+$": {
+          "type": "object",
+          "properties": {
+            "applies_to_paths": {
+              "$ref": "#/$defs/string_list",
+              "description": "Repository-relative glob patterns that activate this local overlay item for changed paths."
+            },
+            "applies_to_task_markers": {
+              "$ref": "#/$defs/string_list",
+              "description": "Case-insensitive task text markers that activate this local overlay item."
+            },
+            "authority_refs": {
+              "$ref": "#/$defs/string_list",
+              "description": "Host-owned authority references that explain why this overlay exists."
+            },
+            "required_sources": {
+              "$ref": "#/$defs/string_list",
+              "description": "Local source-of-truth references that should be consulted before claims are made."
+            },
+            "review_owner": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Local review owner label for this overlay item."
+            },
+            "review_aids": {
+              "$ref": "#/$defs/string_list",
+              "description": "Optional local references, commands, or notes that help the reviewer evaluate the work."
+            },
+            "proof_profiles": {
+              "$ref": "#/$defs/string_list",
+              "description": "Proof profile labels this overlay item contributes when it matches current work."
+            },
+            "required_commands": {
+              "$ref": "#/$defs/string_list",
+              "description": "Validation commands required by this local overlay item when it matches."
+            },
+            "manual_evidence": {
+              "$ref": "#/$defs/string_list",
+              "description": "Manual evidence handles or records required before making bounded claims."
+            },
+            "optional_commands": {
+              "$ref": "#/$defs/string_list",
+              "description": "Optional validation commands that may improve confidence but are not required by this overlay item."
+            },
+            "manual_checks": {
+              "$ref": "#/$defs/string_list",
+              "description": "Manual checks the acting agent should record or route to a reviewer."
+            },
+            "unavailable_routes": {
+              "$ref": "#/$defs/string_list",
+              "description": "Named CI or validation routes that are unavailable for this checkout."
+            },
+            "validation_state": {
+              "type": "string",
+              "enum": [
+                "ci_failed",
+                "ci_pending",
+                "ci_skipped",
+                "ci_not_run",
+                "ci_unavailable",
+                "quota_exhausted",
+                "logs_unavailable",
+                "local_substitute"
+              ],
+              "description": "Current CI or validation availability state for this local overlay item."
+            },
+            "local_substitute_commands": {
+              "$ref": "#/$defs/string_list",
+              "description": "Local substitute commands available when host CI or another validation route is unavailable."
+            },
+            "local_substitute_policy": {
+              "type": "string",
+              "enum": [
+                "advisory",
+                "sufficient-for-bounded-claim",
+                "insufficient",
+                "human-review-only"
+              ],
+              "description": "How local substitute validation may support or limit completion claims."
+            },
+            "host": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Host system name for a template or work-item preservation rule."
+            },
+            "kind": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Host work-item or artifact kind affected by this overlay item."
+            },
+            "paths": {
+              "$ref": "#/$defs/string_list",
+              "description": "Repository-relative template or artifact paths that should be preserved."
+            },
+            "headings": {
+              "$ref": "#/$defs/string_list",
+              "description": "Template headings expected to remain available for API-created work items."
+            },
+            "required_fields": {
+              "$ref": "#/$defs/string_list",
+              "description": "Template fields expected to remain available for API-created work items."
+            },
+            "state": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Local state classification such as present, missing, or drifted."
+            },
+            "sensitive_data": {
+              "$ref": "#/$defs/string_list",
+              "description": "Sensitive data classes that must not be exposed in fixtures or examples."
+            },
+            "synthetic_fixture_guidance": {
+              "$ref": "#/$defs/string_list",
+              "description": "Guidance for acceptable synthetic fixtures or examples."
+            },
+            "safe_examples": {
+              "$ref": "#/$defs/string_list",
+              "description": "Known-safe example values that may be used instead of sensitive data."
+            },
+            "category": {
+              "type": "string",
+              "enum": [
+                "merge-blocker",
+                "release-blocker",
+                "human-review-required",
+                "safe-follow-up",
+                "intentionally-deferred"
+              ],
+              "description": "Unresolved assumption category used to decide whether closeout needs human review or can defer residue."
+            },
+            "question": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Unresolved question that must be answered, reviewed, or explicitly routed."
+            },
+            "owner": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Human or team owner for the unresolved question or overlay item."
+            },
+            "residue_route": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Where unresolved residue should be routed if it cannot be closed in the current work."
+            },
+            "reason": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Local explanation for why this overlay item applies."
+            },
+            "claim_boundary": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Claim boundary imposed by this overlay item."
+            },
+            "drift_state": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Local drift classification for source, template, or validation expectations."
+            },
+            "impact": {
+              "type": "string",
+              "enum": [
+                "advisory",
+                "blocking",
+                "human-review-only",
+                "claim-limiting"
+              ],
+              "description": "How strongly this overlay item affects routing and closeout claims."
+            },
+            "notes": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Optional local notes for reviewers or future agents."
+            }
+          },
+          "additionalProperties": false,
+          "description": "One named local-only high-risk overlay item. It can shape this checkout's workflow but is not shared host policy."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Named local-only high-risk overlay items for one overlay section."
     }
   },
   "additionalProperties": false,

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -9980,9 +9980,15 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "before adding external automation, bot, CI, ticket, or agent workflow integration",
     },
     {
+        "section": "local_overlay",
+        "kind": "agentic-workspace/local-overlay/v1",
+        "purpose": "general local guidance overlay contract, provenance, ordinary guidance, and high-risk profile summary",
+        "when_to_use": "when local config may shape this checkout's workflow without becoming checked-in host policy",
+    },
+    {
         "section": "local_high_risk_overlay",
         "kind": "agentic-workspace/local-high-risk-overlay/v1",
-        "purpose": "local-only high-risk overlay contract, provenance, matched source maps, validation profiles, CI states, templates, guardrails, and unresolved questions",
+        "purpose": "high-assurance local overlay profile: matched source maps, validation profiles, CI states, templates, guardrails, and unresolved questions",
         "when_to_use": "when local config may shape high-assurance implement/proof/closeout routing without becoming checked-in host policy",
     },
     {
@@ -10031,6 +10037,48 @@ def _report_section_catalog_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> 
             "listed section payloads must remain lazy unless an explicit selector or verbose report already has the needed inputs",
             "adding a section here should not require ordinary report callers to compute that section",
         ],
+    }
+
+
+def _local_overlay_report_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
+    overlay = config.local_override.local_overlay if isinstance(config.local_override.local_overlay, dict) else {}
+    if overlay.get("status") != "configured":
+        return {
+            "kind": "agentic-workspace/local-overlay/v1",
+            "status": "absent",
+            "configured_count": 0,
+            "ordinary_guidance_count": 0,
+            "high_risk_profile_count": 0,
+            "rule": "No local guidance overlay is configured; ordinary output remains quiet.",
+        }
+    sections = _as_dict(overlay.get("sections"))
+    ordinary_guidance = _list_payload(sections.get("guidance"))
+    return {
+        "kind": "agentic-workspace/local-overlay/v1",
+        "status": "configured",
+        "configured_count": int(overlay.get("item_count", 0) or 0),
+        "ordinary_guidance_count": int(overlay.get("ordinary_guidance_count", len(ordinary_guidance)) or 0),
+        "high_risk_profile_count": int(overlay.get("high_risk_profile_count", 0) or 0),
+        "ordinary_guidance": ordinary_guidance,
+        "high_risk_profile": {
+            "status": _as_dict(overlay.get("high_risk_profile")).get("status", "absent"),
+            "configured_count": int(_as_dict(overlay.get("high_risk_profile")).get("item_count", 0) or 0),
+            "detail_selector": "local_high_risk_overlay",
+        },
+        "warnings": _list_payload(overlay.get("warnings")),
+        "authority_boundary": overlay.get("authority_boundary", {}),
+        "ordinary_routes": {
+            "report": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section local_overlay --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+            "match_changed_paths": _command_with_cli_invoke(
+                command="agentic-workspace implement --target ./repo --changed <paths> --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+        },
+        "matching_rule": "Ordinary guidance and high-risk profile items match changed paths or task markers; no-match work stays quiet.",
+        "quiet_rule": "No-overlay and no-match ordinary work does not expand local-only detail.",
     }
 
 
@@ -12327,6 +12375,10 @@ def _run_lazy_report_section_command(
             config=config,
             cli_invoke=config.cli_invoke,
         )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "local_overlay":
+        payload["local_overlay"] = _local_overlay_report_payload(config=config)
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "local_high_risk_overlay":
@@ -30884,10 +30936,10 @@ def _config_field_enforcement_entries() -> list[dict[str, Any]]:
             "used_by": ["config.local_memory", "report.local_memory"],
         },
         {
-            "field": "high_risk_overlay.*",
+            "field": "local_overlay.*",
             "enforcement": "local-advisory",
             "scope": "local-config",
-            "used_by": ["config.local_high_risk_overlay", "implement.proof.high_risk_overlay", "proof.high_risk_overlay"],
+            "used_by": ["config.local_overlay", "report.local_overlay", "implement.proof.local_overlay", "proof.high_risk_overlay"],
         },
     ]
 
@@ -31038,13 +31090,20 @@ def _config_effect_audit_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
         elif field.startswith("local_memory"):
             concrete_commands = [command("agentic-workspace report --target ./repo --section local_memory --format json")]
             payload_fields = ["local_memory"]
-        elif field.startswith("high_risk_overlay"):
+        elif field.startswith("local_overlay"):
             concrete_commands = [
+                command("agentic-workspace report --target ./repo --section local_overlay --format json"),
                 command("agentic-workspace report --target ./repo --section local_high_risk_overlay --format json"),
                 command("agentic-workspace implement --target ./repo --changed <paths> --format json"),
                 command("agentic-workspace proof --target ./repo --changed <paths> --format json"),
             ]
-            payload_fields = ["local_high_risk_overlay", "proof.high_risk_overlay", "proof.proof_decision"]
+            payload_fields = [
+                "local_overlay",
+                "local_high_risk_overlay",
+                "proof.local_overlay",
+                "proof.high_risk_overlay",
+                "proof.proof_decision",
+            ]
         elif field.startswith("workspace.cli_invoke"):
             concrete_commands = [command("agentic-workspace config --target ./repo --select workspace.cli_invoke --format json")]
             payload_fields = ["copyable command strings"]
@@ -31404,23 +31463,30 @@ def _ambient_configuration_projection_rows(*, config: WorkspaceConfig) -> list[d
             authority_exception="local-only advisory; cannot become shared Planning, Memory, proof, or closeout authority",
         )
     )
-    high_risk_overlay = config.local_override.high_risk_overlay if isinstance(config.local_override.high_risk_overlay, dict) else {}
+    local_overlay = config.local_override.local_overlay if isinstance(config.local_override.local_overlay, dict) else {}
     rows.append(
         _configuration_projection_row(
-            row_id="local-high-risk-overlay:local-only-provenance",
+            row_id="local-overlay:local-only-provenance",
             source="local-config",
-            source_surface=".agentic-workspace/config.local.toml [high_risk_overlay]",
+            source_surface=".agentic-workspace/config.local.toml [local_overlay]",
             owner="local-human-owned",
-            field="high_risk_overlay.*",
-            configured_concern="local-only high-risk source maps, validation profiles, CI/substitute evidence, templates, guardrails, and unresolved questions",
-            status="selector-backed" if high_risk_overlay.get("status") == "configured" else "latent",
+            field="local_overlay.*",
+            configured_concern="local guidance overlay for ordinary local facts plus high-assurance profile guidance",
+            status="selector-backed" if local_overlay.get("status") == "configured" else "latent",
             ordinary_path_routes=[
+                "agentic-workspace report --target ./repo --section local_overlay --format json",
                 "agentic-workspace report --target ./repo --section local_high_risk_overlay --format json",
                 "agentic-workspace implement --target ./repo --changed <paths> --format json",
                 "agentic-workspace proof --target ./repo --changed <paths> --format json",
             ],
-            payload_fields=["local_high_risk_overlay", "proof.high_risk_overlay", "proof.proof_decision"],
-            trigger="a configured overlay item matches changed paths or task markers",
+            payload_fields=[
+                "local_overlay",
+                "local_high_risk_overlay",
+                "proof.local_overlay",
+                "proof.high_risk_overlay",
+                "proof.proof_decision",
+            ],
+            trigger="a configured local overlay item matches changed paths or task markers",
             suppression_rule="no overlay or no match stays quiet in ordinary output",
             proof_or_test_coverage=["tests/test_workspace_proof_cli.py", "tests/test_workspace_implement_cli.py"],
             authority_exception="local-only advisory/blocking guidance for this checkout; cannot become checked-in host policy or certify conformance",
@@ -31552,8 +31618,8 @@ def _configuration_projection_applicability(field: str) -> str:
         return "delegation or runtime posture is relevant to the current task shape and safety allows handoff"
     if field.startswith("local_memory"):
         return "local memory is enabled and a memory-backed route is requested"
-    if field.startswith("high_risk_overlay"):
-        return "a local overlay item matches changed paths or task markers for source, validation, guardrail, template, CI, or unresolved-question routing"
+    if field.startswith("local_overlay"):
+        return "a local overlay item matches changed paths or task markers for ordinary local guidance or high-assurance profile routing"
     if field.startswith("system_intent"):
         return "task, changed paths, or subsystem config intersects durable system intent"
     if field.startswith("update.modules"):
@@ -31572,7 +31638,7 @@ def _configuration_projection_suppression(field: str) -> str:
         return "hide target detail unless delegation posture changes the next action or config detail is requested"
     if field.startswith("local_memory"):
         return "hide local memory detail when disabled or when shared repo authority is being reported"
-    if field.startswith("high_risk_overlay"):
+    if field.startswith("local_overlay"):
         return "hide overlay detail when no overlay exists or no overlay item matches the current changed paths/task facts"
     if field.startswith("system_intent"):
         return "surface only compact applicable-intent facts unless system-intent detail is requested"
@@ -31580,7 +31646,7 @@ def _configuration_projection_suppression(field: str) -> str:
 
 
 def _configuration_projection_authority_exception(*, field: str, owner_boundary: str, dependency: str) -> str:
-    if field.startswith("high_risk_overlay"):
+    if field.startswith("local_overlay"):
         return "local-only guidance may shape this checkout's workflow but cannot become checked-in host policy or certify conformance"
     if owner_boundary == "local-human-owned":
         return "local-only advisory; cannot create shared repo obligations, proof gates, or closeout claims"
@@ -40722,6 +40788,14 @@ def _mixed_agent_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
         ),
         "agent_aid_storage": _agent_aid_storage_payload(target_root=config.target_root),
         "local_memory": _local_memory_payload(config=config),
+        "local_overlay": local_override.local_overlay
+        if isinstance(local_override.local_overlay, dict)
+        else {
+            "kind": "agentic-workspace/local-overlay-config/v1",
+            "status": "absent",
+            "sections": {},
+            "warnings": [],
+        },
         "high_risk_overlay": local_override.high_risk_overlay
         if isinstance(local_override.high_risk_overlay, dict)
         else {
@@ -40927,6 +41001,7 @@ def _compact_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
     effective_posture = mixed_agent["effective_posture"]
     runtime_resolution = mixed_agent["runtime_resolution"]
     assurance = payload["assurance"]
+    local_overlay = mixed_agent.get("local_overlay", {}) if isinstance(mixed_agent, dict) else {}
     local_high_risk_overlay = mixed_agent.get("high_risk_overlay", {}) if isinstance(mixed_agent, dict) else {}
     compact_obligations = [
         {"id": obligation["id"], "stage": obligation["stage"], "scope_tags": obligation["scope_tags"], "commands": obligation["commands"]}
@@ -41008,6 +41083,15 @@ def _compact_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "confidence": runtime_resolution["confidence"],
                 "reasons": runtime_resolution["reasons"],
             },
+        },
+        "local_overlay": {
+            "status": local_overlay.get("status", "absent") if isinstance(local_overlay, dict) else "absent",
+            "item_count": local_overlay.get("item_count", 0) if isinstance(local_overlay, dict) else 0,
+            "ordinary_guidance_count": local_overlay.get("ordinary_guidance_count", 0) if isinstance(local_overlay, dict) else 0,
+            "high_risk_profile_count": local_overlay.get("high_risk_profile_count", 0) if isinstance(local_overlay, dict) else 0,
+            "warning_count": len(local_overlay.get("warnings", [])) if isinstance(local_overlay, dict) else 0,
+            "authority_boundary": local_overlay.get("authority_boundary", {}) if isinstance(local_overlay, dict) else {},
+            "detail_command": f"{workspace['cli_invoke']} report --target ./repo --section local_overlay --format json",
         },
         "local_high_risk_overlay": {
             "status": local_high_risk_overlay.get("status", "absent") if isinstance(local_high_risk_overlay, dict) else "absent",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -9980,6 +9980,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "before adding external automation, bot, CI, ticket, or agent workflow integration",
     },
     {
+        "section": "local_high_risk_overlay",
+        "kind": "agentic-workspace/local-high-risk-overlay/v1",
+        "purpose": "local-only high-risk overlay contract, provenance, matched source maps, validation profiles, CI states, templates, guardrails, and unresolved questions",
+        "when_to_use": "when local config may shape high-assurance implement/proof/closeout routing without becoming checked-in host policy",
+    },
+    {
         "section": "release_recovery",
         "kind": "agentic-workspace/release-recovery/v1",
         "purpose": "source-checkout release recovery posture for semver PR action, failed release summaries, and payload drift repair",
@@ -10025,6 +10031,40 @@ def _report_section_catalog_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> 
             "listed section payloads must remain lazy unless an explicit selector or verbose report already has the needed inputs",
             "adding a section here should not require ordinary report callers to compute that section",
         ],
+    }
+
+
+def _local_high_risk_overlay_report_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
+    overlay = config.local_override.high_risk_overlay if isinstance(config.local_override.high_risk_overlay, dict) else {}
+    if overlay.get("status") != "configured":
+        return {
+            "kind": "agentic-workspace/local-high-risk-overlay/v1",
+            "status": "absent",
+            "configured_count": 0,
+            "active_count": 0,
+            "rule": "No local high-risk overlay is configured; ordinary output remains quiet.",
+        }
+    sections = _as_dict(overlay.get("sections"))
+    return {
+        "kind": "agentic-workspace/local-high-risk-overlay/v1",
+        "status": "configured",
+        "configured_count": int(overlay.get("item_count", 0) or 0),
+        "active_count": 0,
+        "sections": sections,
+        "warnings": _list_payload(overlay.get("warnings")),
+        "authority_boundary": overlay.get("authority_boundary", {}),
+        "ordinary_routes": {
+            "match_changed_paths": _command_with_cli_invoke(
+                command="agentic-workspace implement --target ./repo --changed <paths> --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+            "proof_decision": _command_with_cli_invoke(
+                command="agentic-workspace proof --target ./repo --changed <paths> --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+        },
+        "matching_rule": "This selector reports configured local overlay items; implement/proof report active matches from changed paths or task markers.",
+        "quiet_rule": "No-overlay and no-match ordinary work does not expand this local-only detail.",
     }
 
 
@@ -12287,6 +12327,10 @@ def _run_lazy_report_section_command(
             config=config,
             cli_invoke=config.cli_invoke,
         )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "local_high_risk_overlay":
+        payload["local_high_risk_overlay"] = _local_high_risk_overlay_report_payload(config=config)
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "architecture_principles":
@@ -21009,6 +21053,16 @@ def _compact_start_proof_payload(proof: dict[str, Any]) -> dict[str, Any]:
             "classifications": cli_authority_review.get("classifications", []),
             "detail_command": "agentic-workspace proof --verbose --changed <paths> --format json",
         }
+    high_risk_overlay = proof.get("high_risk_overlay", {})
+    if isinstance(high_risk_overlay, dict) and high_risk_overlay.get("status") == "active":
+        active = high_risk_overlay.get("active", {})
+        active = active if isinstance(active, dict) else {}
+        compact["high_risk_overlay"] = {
+            "status": high_risk_overlay.get("status"),
+            "active_count": high_risk_overlay.get("active_count", 0),
+            "sections": {str(section): len(items) for section, items in active.items() if isinstance(items, list) and items},
+            "detail_selector": "proof.high_risk_overlay",
+        }
     changed = proof.get("changed_paths", [])
     if isinstance(changed, list) and changed:
         compact["detail_command"] = "agentic-workspace proof --verbose --changed <paths> --format json"
@@ -28777,7 +28831,7 @@ def _compact_selector_next_safe_action(packet: dict[str, Any]) -> dict[str, Any]
             "human_owned_decisions": [
                 _compact_authority_text(str(item)) for item in _list_payload(authority.get("human_owned_decisions"))[:1]
             ],
-            "reporting_rule": "AW marks hard gates; recommendations guide agent-owned route and completion judgment.",
+            "reporting_rule": "AW marks hard gates; recommendations guide agent judgment.",
         }
         compact["authority_boundary"] = compact_authority
     return compact
@@ -30829,6 +30883,12 @@ def _config_field_enforcement_entries() -> list[dict[str, Any]]:
             "scope": "local-config",
             "used_by": ["config.local_memory", "report.local_memory"],
         },
+        {
+            "field": "high_risk_overlay.*",
+            "enforcement": "local-advisory",
+            "scope": "local-config",
+            "used_by": ["config.local_high_risk_overlay", "implement.proof.high_risk_overlay", "proof.high_risk_overlay"],
+        },
     ]
 
 
@@ -30978,6 +31038,13 @@ def _config_effect_audit_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
         elif field.startswith("local_memory"):
             concrete_commands = [command("agentic-workspace report --target ./repo --section local_memory --format json")]
             payload_fields = ["local_memory"]
+        elif field.startswith("high_risk_overlay"):
+            concrete_commands = [
+                command("agentic-workspace report --target ./repo --section local_high_risk_overlay --format json"),
+                command("agentic-workspace implement --target ./repo --changed <paths> --format json"),
+                command("agentic-workspace proof --target ./repo --changed <paths> --format json"),
+            ]
+            payload_fields = ["local_high_risk_overlay", "proof.high_risk_overlay", "proof.proof_decision"]
         elif field.startswith("workspace.cli_invoke"):
             concrete_commands = [command("agentic-workspace config --target ./repo --select workspace.cli_invoke --format json")]
             payload_fields = ["copyable command strings"]
@@ -31337,6 +31404,28 @@ def _ambient_configuration_projection_rows(*, config: WorkspaceConfig) -> list[d
             authority_exception="local-only advisory; cannot become shared Planning, Memory, proof, or closeout authority",
         )
     )
+    high_risk_overlay = config.local_override.high_risk_overlay if isinstance(config.local_override.high_risk_overlay, dict) else {}
+    rows.append(
+        _configuration_projection_row(
+            row_id="local-high-risk-overlay:local-only-provenance",
+            source="local-config",
+            source_surface=".agentic-workspace/config.local.toml [high_risk_overlay]",
+            owner="local-human-owned",
+            field="high_risk_overlay.*",
+            configured_concern="local-only high-risk source maps, validation profiles, CI/substitute evidence, templates, guardrails, and unresolved questions",
+            status="selector-backed" if high_risk_overlay.get("status") == "configured" else "latent",
+            ordinary_path_routes=[
+                "agentic-workspace report --target ./repo --section local_high_risk_overlay --format json",
+                "agentic-workspace implement --target ./repo --changed <paths> --format json",
+                "agentic-workspace proof --target ./repo --changed <paths> --format json",
+            ],
+            payload_fields=["local_high_risk_overlay", "proof.high_risk_overlay", "proof.proof_decision"],
+            trigger="a configured overlay item matches changed paths or task markers",
+            suppression_rule="no overlay or no match stays quiet in ordinary output",
+            proof_or_test_coverage=["tests/test_workspace_proof_cli.py", "tests/test_workspace_implement_cli.py"],
+            authority_exception="local-only advisory/blocking guidance for this checkout; cannot become checked-in host policy or certify conformance",
+        )
+    )
     return rows
 
 
@@ -31463,6 +31552,8 @@ def _configuration_projection_applicability(field: str) -> str:
         return "delegation or runtime posture is relevant to the current task shape and safety allows handoff"
     if field.startswith("local_memory"):
         return "local memory is enabled and a memory-backed route is requested"
+    if field.startswith("high_risk_overlay"):
+        return "a local overlay item matches changed paths or task markers for source, validation, guardrail, template, CI, or unresolved-question routing"
     if field.startswith("system_intent"):
         return "task, changed paths, or subsystem config intersects durable system intent"
     if field.startswith("update.modules"):
@@ -31481,12 +31572,16 @@ def _configuration_projection_suppression(field: str) -> str:
         return "hide target detail unless delegation posture changes the next action or config detail is requested"
     if field.startswith("local_memory"):
         return "hide local memory detail when disabled or when shared repo authority is being reported"
+    if field.startswith("high_risk_overlay"):
+        return "hide overlay detail when no overlay exists or no overlay item matches the current changed paths/task facts"
     if field.startswith("system_intent"):
         return "surface only compact applicable-intent facts unless system-intent detail is requested"
     return "keep detailed field data behind config/report selectors unless it changes the ordinary next action"
 
 
 def _configuration_projection_authority_exception(*, field: str, owner_boundary: str, dependency: str) -> str:
+    if field.startswith("high_risk_overlay"):
+        return "local-only guidance may shape this checkout's workflow but cannot become checked-in host policy or certify conformance"
     if owner_boundary == "local-human-owned":
         return "local-only advisory; cannot create shared repo obligations, proof gates, or closeout claims"
     if dependency in {"medium", "high"}:
@@ -37294,6 +37389,8 @@ def _proof_intent_for_lane(lane: dict[str, Any]) -> dict[str, Any]:
 def _proof_route_source_for_lane(*, lane: dict[str, Any], command: str, adjustments_by_replacement: dict[str, dict[str, str]]) -> str:
     if lane.get("domain_lane"):
         return "host-declared-domain-proof-lane"
+    if lane.get("local_overlay"):
+        return "local-only-high-risk-overlay"
     if lane.get("proof_profile"):
         return "host-configured-proof-profile"
     if lane.get("subsystem"):
@@ -40625,6 +40722,14 @@ def _mixed_agent_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
         ),
         "agent_aid_storage": _agent_aid_storage_payload(target_root=config.target_root),
         "local_memory": _local_memory_payload(config=config),
+        "high_risk_overlay": local_override.high_risk_overlay
+        if isinstance(local_override.high_risk_overlay, dict)
+        else {
+            "kind": "agentic-workspace/local-high-risk-overlay-config/v1",
+            "status": "absent",
+            "sections": {},
+            "warnings": [],
+        },
         "runtime_inference": {
             "tool_owned": defaults["runtime_inference"]["tool_owned"],
             "reported_here": False,
@@ -40822,6 +40927,7 @@ def _compact_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
     effective_posture = mixed_agent["effective_posture"]
     runtime_resolution = mixed_agent["runtime_resolution"]
     assurance = payload["assurance"]
+    local_high_risk_overlay = mixed_agent.get("high_risk_overlay", {}) if isinstance(mixed_agent, dict) else {}
     compact_obligations = [
         {"id": obligation["id"], "stage": obligation["stage"], "scope_tags": obligation["scope_tags"], "commands": obligation["commands"]}
         for obligation in workspace["workflow_obligations"]
@@ -40902,6 +41008,15 @@ def _compact_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 "confidence": runtime_resolution["confidence"],
                 "reasons": runtime_resolution["reasons"],
             },
+        },
+        "local_high_risk_overlay": {
+            "status": local_high_risk_overlay.get("status", "absent") if isinstance(local_high_risk_overlay, dict) else "absent",
+            "item_count": local_high_risk_overlay.get("item_count", 0) if isinstance(local_high_risk_overlay, dict) else 0,
+            "warning_count": len(local_high_risk_overlay.get("warnings", [])) if isinstance(local_high_risk_overlay, dict) else 0,
+            "authority_boundary": local_high_risk_overlay.get("authority_boundary", {})
+            if isinstance(local_high_risk_overlay, dict)
+            else {},
+            "detail_command": f"{workspace['cli_invoke']} report --target ./repo --section local_high_risk_overlay --format json",
         },
         "full_profile_command": f"{workspace['cli_invoke']} config --target . --verbose --format json",
     }

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -1144,6 +1144,13 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     and int(payload.get("architecture_principles", {}).get("matched_count", 0) or 0) > 0
                     else []
                 ),
+                *(
+                    [f"high_risk_overlay={payload.get('proof', {}).get('high_risk_overlay', {}).get('active_count')}"]
+                    if isinstance(payload.get("proof"), dict)
+                    and isinstance(payload.get("proof", {}).get("high_risk_overlay"), dict)
+                    and payload.get("proof", {}).get("high_risk_overlay", {}).get("status") == "active"
+                    else []
+                ),
             ],
             advisory_selectors=advisory_selectors,
             agent_judgment="Agent owns semantic work shape and completion judgment after proof and acceptance reconciliation.",
@@ -1190,6 +1197,15 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             if isinstance(payload.get("proof"), dict)
             and isinstance(payload.get("proof", {}).get("proof_route_maintenance"), dict)
             and payload.get("proof", {}).get("proof_route_maintenance", {}).get("status") == "attention"
+            else {},
+            "high_risk_overlay": {
+                "status": payload.get("proof", {}).get("high_risk_overlay", {}).get("status"),
+                "active_count": payload.get("proof", {}).get("high_risk_overlay", {}).get("active_count", 0),
+                "detail_selector": "proof.high_risk_overlay",
+            }
+            if isinstance(payload.get("proof"), dict)
+            and isinstance(payload.get("proof", {}).get("high_risk_overlay"), dict)
+            and payload.get("proof", {}).get("high_risk_overlay", {}).get("status") == "active"
             else {},
             "detail_command": _command_with_cli_invoke(
                 command="agentic-workspace proof --verbose --changed <paths> --format json", cli_invoke=config.cli_invoke

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -1145,6 +1145,13 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     else []
                 ),
                 *(
+                    [f"local_overlay={payload.get('proof', {}).get('local_overlay', {}).get('active_count')}"]
+                    if isinstance(payload.get("proof"), dict)
+                    and isinstance(payload.get("proof", {}).get("local_overlay"), dict)
+                    and payload.get("proof", {}).get("local_overlay", {}).get("status") == "active"
+                    else []
+                ),
+                *(
                     [f"high_risk_overlay={payload.get('proof', {}).get('high_risk_overlay', {}).get('active_count')}"]
                     if isinstance(payload.get("proof"), dict)
                     and isinstance(payload.get("proof", {}).get("high_risk_overlay"), dict)
@@ -1197,6 +1204,15 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             if isinstance(payload.get("proof"), dict)
             and isinstance(payload.get("proof", {}).get("proof_route_maintenance"), dict)
             and payload.get("proof", {}).get("proof_route_maintenance", {}).get("status") == "attention"
+            else {},
+            "local_overlay": {
+                "status": payload.get("proof", {}).get("local_overlay", {}).get("status"),
+                "active_count": payload.get("proof", {}).get("local_overlay", {}).get("active_count", 0),
+                "detail_selector": "proof.local_overlay",
+            }
+            if isinstance(payload.get("proof"), dict)
+            and isinstance(payload.get("proof", {}).get("local_overlay"), dict)
+            and payload.get("proof", {}).get("local_overlay", {}).get("status") == "active"
             else {},
             "high_risk_overlay": {
                 "status": payload.get("proof", {}).get("high_risk_overlay", {}).get("status"),

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -10115,9 +10115,15 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "before adding external automation, bot, CI, ticket, or agent workflow integration",
     },
     {
+        "section": "local_overlay",
+        "kind": "agentic-workspace/local-overlay/v1",
+        "purpose": "general local guidance overlay contract, provenance, ordinary guidance, and high-risk profile summary",
+        "when_to_use": "when local config may shape this checkout's workflow without becoming checked-in host policy",
+    },
+    {
         "section": "local_high_risk_overlay",
         "kind": "agentic-workspace/local-high-risk-overlay/v1",
-        "purpose": "local-only high-risk overlay contract, provenance, matched source maps, validation profiles, CI states, templates, guardrails, and unresolved questions",
+        "purpose": "high-assurance local overlay profile: matched source maps, validation profiles, CI states, templates, guardrails, and unresolved questions",
         "when_to_use": "when local config may shape high-assurance implement/proof/closeout routing without becoming checked-in host policy",
     },
     {
@@ -10166,6 +10172,48 @@ def _report_section_catalog_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> 
             "listed section payloads must remain lazy unless an explicit selector or verbose report already has the needed inputs",
             "adding a section here should not require ordinary report callers to compute that section",
         ],
+    }
+
+
+def _local_overlay_report_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
+    overlay = config.local_override.local_overlay if isinstance(config.local_override.local_overlay, dict) else {}
+    if overlay.get("status") != "configured":
+        return {
+            "kind": "agentic-workspace/local-overlay/v1",
+            "status": "absent",
+            "configured_count": 0,
+            "ordinary_guidance_count": 0,
+            "high_risk_profile_count": 0,
+            "rule": "No local guidance overlay is configured; ordinary output remains quiet.",
+        }
+    sections = _as_dict(overlay.get("sections"))
+    ordinary_guidance = _list_payload(sections.get("guidance"))
+    return {
+        "kind": "agentic-workspace/local-overlay/v1",
+        "status": "configured",
+        "configured_count": int(overlay.get("item_count", 0) or 0),
+        "ordinary_guidance_count": int(overlay.get("ordinary_guidance_count", len(ordinary_guidance)) or 0),
+        "high_risk_profile_count": int(overlay.get("high_risk_profile_count", 0) or 0),
+        "ordinary_guidance": ordinary_guidance,
+        "high_risk_profile": {
+            "status": _as_dict(overlay.get("high_risk_profile")).get("status", "absent"),
+            "configured_count": int(_as_dict(overlay.get("high_risk_profile")).get("item_count", 0) or 0),
+            "detail_selector": "local_high_risk_overlay",
+        },
+        "warnings": _list_payload(overlay.get("warnings")),
+        "authority_boundary": overlay.get("authority_boundary", {}),
+        "ordinary_routes": {
+            "report": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section local_overlay --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+            "match_changed_paths": _command_with_cli_invoke(
+                command="agentic-workspace implement --target ./repo --changed <paths> --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+        },
+        "matching_rule": "Ordinary guidance and high-risk profile items match changed paths or task markers; no-match work stays quiet.",
+        "quiet_rule": "No-overlay and no-match ordinary work does not expand local-only detail.",
     }
 
 
@@ -12462,6 +12510,10 @@ def _run_lazy_report_section_command(
             config=config,
             cli_invoke=config.cli_invoke,
         )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "local_overlay":
+        payload["local_overlay"] = _local_overlay_report_payload(config=config)
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "local_high_risk_overlay":
@@ -30739,10 +30791,10 @@ def _config_field_enforcement_entries() -> list[dict[str, Any]]:
             "used_by": ["config.local_memory", "report.local_memory"],
         },
         {
-            "field": "high_risk_overlay.*",
+            "field": "local_overlay.*",
             "enforcement": "local-advisory",
             "scope": "local-config",
-            "used_by": ["config.local_high_risk_overlay", "implement.proof.high_risk_overlay", "proof.high_risk_overlay"],
+            "used_by": ["config.local_overlay", "report.local_overlay", "implement.proof.local_overlay", "proof.high_risk_overlay"],
         },
     ]
 
@@ -30893,13 +30945,20 @@ def _config_effect_audit_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
         elif field.startswith("local_memory"):
             concrete_commands = [command("agentic-workspace report --target ./repo --section local_memory --format json")]
             payload_fields = ["local_memory"]
-        elif field.startswith("high_risk_overlay"):
+        elif field.startswith("local_overlay"):
             concrete_commands = [
+                command("agentic-workspace report --target ./repo --section local_overlay --format json"),
                 command("agentic-workspace report --target ./repo --section local_high_risk_overlay --format json"),
                 command("agentic-workspace implement --target ./repo --changed <paths> --format json"),
                 command("agentic-workspace proof --target ./repo --changed <paths> --format json"),
             ]
-            payload_fields = ["local_high_risk_overlay", "proof.high_risk_overlay", "proof.proof_decision"]
+            payload_fields = [
+                "local_overlay",
+                "local_high_risk_overlay",
+                "proof.local_overlay",
+                "proof.high_risk_overlay",
+                "proof.proof_decision",
+            ]
         elif field.startswith("workspace.cli_invoke"):
             concrete_commands = [command("agentic-workspace config --target ./repo --select workspace.cli_invoke --format json")]
             payload_fields = ["copyable command strings"]
@@ -31259,23 +31318,30 @@ def _ambient_configuration_projection_rows(*, config: WorkspaceConfig) -> list[d
             authority_exception="local-only advisory; cannot become shared Planning, Memory, proof, or closeout authority",
         )
     )
-    high_risk_overlay = config.local_override.high_risk_overlay if isinstance(config.local_override.high_risk_overlay, dict) else {}
+    local_overlay = config.local_override.local_overlay if isinstance(config.local_override.local_overlay, dict) else {}
     rows.append(
         _configuration_projection_row(
-            row_id="local-high-risk-overlay:local-only-provenance",
+            row_id="local-overlay:local-only-provenance",
             source="local-config",
-            source_surface=".agentic-workspace/config.local.toml [high_risk_overlay]",
+            source_surface=".agentic-workspace/config.local.toml [local_overlay]",
             owner="local-human-owned",
-            field="high_risk_overlay.*",
-            configured_concern="local-only high-risk source maps, validation profiles, CI/substitute evidence, templates, guardrails, and unresolved questions",
-            status="selector-backed" if high_risk_overlay.get("status") == "configured" else "latent",
+            field="local_overlay.*",
+            configured_concern="local guidance overlay for ordinary local facts plus high-assurance profile guidance",
+            status="selector-backed" if local_overlay.get("status") == "configured" else "latent",
             ordinary_path_routes=[
+                "agentic-workspace report --target ./repo --section local_overlay --format json",
                 "agentic-workspace report --target ./repo --section local_high_risk_overlay --format json",
                 "agentic-workspace implement --target ./repo --changed <paths> --format json",
                 "agentic-workspace proof --target ./repo --changed <paths> --format json",
             ],
-            payload_fields=["local_high_risk_overlay", "proof.high_risk_overlay", "proof.proof_decision"],
-            trigger="a configured overlay item matches changed paths or task markers",
+            payload_fields=[
+                "local_overlay",
+                "local_high_risk_overlay",
+                "proof.local_overlay",
+                "proof.high_risk_overlay",
+                "proof.proof_decision",
+            ],
+            trigger="a configured local overlay item matches changed paths or task markers",
             suppression_rule="no overlay or no match stays quiet in ordinary output",
             proof_or_test_coverage=["tests/test_workspace_proof_cli.py", "tests/test_workspace_implement_cli.py"],
             authority_exception="local-only advisory/blocking guidance for this checkout; cannot become checked-in host policy or certify conformance",
@@ -31407,6 +31473,8 @@ def _configuration_projection_applicability(field: str) -> str:
         return "delegation or runtime posture is relevant to the current task shape and safety allows handoff"
     if field.startswith("local_memory"):
         return "local memory is enabled and a memory-backed route is requested"
+    if field.startswith("local_overlay"):
+        return "a local overlay item matches changed paths or task markers for ordinary local guidance or high-assurance profile routing"
     if field.startswith("system_intent"):
         return "task, changed paths, or subsystem config intersects durable system intent"
     if field.startswith("update.modules"):
@@ -31425,12 +31493,16 @@ def _configuration_projection_suppression(field: str) -> str:
         return "hide target detail unless delegation posture changes the next action or config detail is requested"
     if field.startswith("local_memory"):
         return "hide local memory detail when disabled or when shared repo authority is being reported"
+    if field.startswith("local_overlay"):
+        return "hide overlay detail when no overlay exists or no overlay item matches the current changed paths/task facts"
     if field.startswith("system_intent"):
         return "surface only compact applicable-intent facts unless system-intent detail is requested"
     return "keep detailed field data behind config/report selectors unless it changes the ordinary next action"
 
 
 def _configuration_projection_authority_exception(*, field: str, owner_boundary: str, dependency: str) -> str:
+    if field.startswith("local_overlay"):
+        return "local-only guidance may shape this checkout's workflow but cannot become checked-in host policy or certify conformance"
     if owner_boundary == "local-human-owned":
         return "local-only advisory; cannot create shared repo obligations, proof gates, or closeout claims"
     if dependency in {"medium", "high"}:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -10115,6 +10115,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "before adding external automation, bot, CI, ticket, or agent workflow integration",
     },
     {
+        "section": "local_high_risk_overlay",
+        "kind": "agentic-workspace/local-high-risk-overlay/v1",
+        "purpose": "local-only high-risk overlay contract, provenance, matched source maps, validation profiles, CI states, templates, guardrails, and unresolved questions",
+        "when_to_use": "when local config may shape high-assurance implement/proof/closeout routing without becoming checked-in host policy",
+    },
+    {
         "section": "release_recovery",
         "kind": "agentic-workspace/release-recovery/v1",
         "purpose": "source-checkout release recovery posture for semver PR action, failed release summaries, and payload drift repair",
@@ -10160,6 +10166,40 @@ def _report_section_catalog_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> 
             "listed section payloads must remain lazy unless an explicit selector or verbose report already has the needed inputs",
             "adding a section here should not require ordinary report callers to compute that section",
         ],
+    }
+
+
+def _local_high_risk_overlay_report_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
+    overlay = config.local_override.high_risk_overlay if isinstance(config.local_override.high_risk_overlay, dict) else {}
+    if overlay.get("status") != "configured":
+        return {
+            "kind": "agentic-workspace/local-high-risk-overlay/v1",
+            "status": "absent",
+            "configured_count": 0,
+            "active_count": 0,
+            "rule": "No local high-risk overlay is configured; ordinary output remains quiet.",
+        }
+    sections = _as_dict(overlay.get("sections"))
+    return {
+        "kind": "agentic-workspace/local-high-risk-overlay/v1",
+        "status": "configured",
+        "configured_count": int(overlay.get("item_count", 0) or 0),
+        "active_count": 0,
+        "sections": sections,
+        "warnings": _list_payload(overlay.get("warnings")),
+        "authority_boundary": overlay.get("authority_boundary", {}),
+        "ordinary_routes": {
+            "match_changed_paths": _command_with_cli_invoke(
+                command="agentic-workspace implement --target ./repo --changed <paths> --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+            "proof_decision": _command_with_cli_invoke(
+                command="agentic-workspace proof --target ./repo --changed <paths> --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+        },
+        "matching_rule": "This selector reports configured local overlay items; implement/proof report active matches from changed paths or task markers.",
+        "quiet_rule": "No-overlay and no-match ordinary work does not expand this local-only detail.",
     }
 
 
@@ -12422,6 +12462,10 @@ def _run_lazy_report_section_command(
             config=config,
             cli_invoke=config.cli_invoke,
         )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "local_high_risk_overlay":
+        payload["local_high_risk_overlay"] = _local_high_risk_overlay_report_payload(config=config)
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "architecture_principles":
@@ -28642,7 +28686,7 @@ def _compact_selector_next_safe_action(packet: dict[str, Any]) -> dict[str, Any]
             "human_owned_decisions": [
                 _compact_authority_text(str(item)) for item in _list_payload(authority.get("human_owned_decisions"))[:1]
             ],
-            "reporting_rule": "AW marks hard gates; recommendations guide agent-owned route and completion judgment.",
+            "reporting_rule": "AW marks hard gates; recommendations guide agent judgment.",
         }
         compact["authority_boundary"] = compact_authority
     return compact
@@ -30694,6 +30738,12 @@ def _config_field_enforcement_entries() -> list[dict[str, Any]]:
             "scope": "local-config",
             "used_by": ["config.local_memory", "report.local_memory"],
         },
+        {
+            "field": "high_risk_overlay.*",
+            "enforcement": "local-advisory",
+            "scope": "local-config",
+            "used_by": ["config.local_high_risk_overlay", "implement.proof.high_risk_overlay", "proof.high_risk_overlay"],
+        },
     ]
 
 
@@ -30843,6 +30893,13 @@ def _config_effect_audit_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
         elif field.startswith("local_memory"):
             concrete_commands = [command("agentic-workspace report --target ./repo --section local_memory --format json")]
             payload_fields = ["local_memory"]
+        elif field.startswith("high_risk_overlay"):
+            concrete_commands = [
+                command("agentic-workspace report --target ./repo --section local_high_risk_overlay --format json"),
+                command("agentic-workspace implement --target ./repo --changed <paths> --format json"),
+                command("agentic-workspace proof --target ./repo --changed <paths> --format json"),
+            ]
+            payload_fields = ["local_high_risk_overlay", "proof.high_risk_overlay", "proof.proof_decision"]
         elif field.startswith("workspace.cli_invoke"):
             concrete_commands = [command("agentic-workspace config --target ./repo --select workspace.cli_invoke --format json")]
             payload_fields = ["copyable command strings"]
@@ -31200,6 +31257,28 @@ def _ambient_configuration_projection_rows(*, config: WorkspaceConfig) -> list[d
             suppression_rule="disabled or local-only memory stays out of shared authority and ordinary repo closeout",
             proof_or_test_coverage=["tests/test_workspace_config_cli.py"],
             authority_exception="local-only advisory; cannot become shared Planning, Memory, proof, or closeout authority",
+        )
+    )
+    high_risk_overlay = config.local_override.high_risk_overlay if isinstance(config.local_override.high_risk_overlay, dict) else {}
+    rows.append(
+        _configuration_projection_row(
+            row_id="local-high-risk-overlay:local-only-provenance",
+            source="local-config",
+            source_surface=".agentic-workspace/config.local.toml [high_risk_overlay]",
+            owner="local-human-owned",
+            field="high_risk_overlay.*",
+            configured_concern="local-only high-risk source maps, validation profiles, CI/substitute evidence, templates, guardrails, and unresolved questions",
+            status="selector-backed" if high_risk_overlay.get("status") == "configured" else "latent",
+            ordinary_path_routes=[
+                "agentic-workspace report --target ./repo --section local_high_risk_overlay --format json",
+                "agentic-workspace implement --target ./repo --changed <paths> --format json",
+                "agentic-workspace proof --target ./repo --changed <paths> --format json",
+            ],
+            payload_fields=["local_high_risk_overlay", "proof.high_risk_overlay", "proof.proof_decision"],
+            trigger="a configured overlay item matches changed paths or task markers",
+            suppression_rule="no overlay or no match stays quiet in ordinary output",
+            proof_or_test_coverage=["tests/test_workspace_proof_cli.py", "tests/test_workspace_implement_cli.py"],
+            authority_exception="local-only advisory/blocking guidance for this checkout; cannot become checked-in host policy or certify conformance",
         )
     )
     return rows

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -160,6 +160,19 @@ def _compact_tiny_intent_proof(intent_proof: Any) -> dict[str, Any]:
     return compact
 
 
+def _compact_tiny_high_risk_overlay(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or value.get("status") != "active":
+        return {}
+    active = _as_dict(value.get("active"))
+    return {
+        "status": value.get("status"),
+        "active_count": value.get("active_count", 0),
+        "sections": {section: len(_list_payload(items)) for section, items in active.items() if _list_payload(items)},
+        "authority_boundary": _as_dict(value.get("authority_boundary")).get("rule", ""),
+        "detail_selector": "high_risk_overlay",
+    }
+
+
 def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
     if payload.get("profile") == "compact-contract-answer/v1":
         answer = payload.get("answer", {})
@@ -194,6 +207,9 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
                 }
             if include_intent_proof:
                 next_decision["intent_proof"] = _compact_tiny_intent_proof(answer["intent_proof"])
+            high_risk_overlay = _compact_tiny_high_risk_overlay(answer.get("high_risk_overlay"))
+            if high_risk_overlay:
+                next_decision["high_risk_overlay"] = high_risk_overlay
             next_decision.setdefault(
                 "detail_command",
                 _command_with_cli_invoke(
@@ -217,6 +233,7 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
         warnings: list[dict[str, Any]] = []
         if isinstance(surface_value, dict) and surface_value.get("status") in {"blocked", "needs-review"}:
             warnings.append({"status": surface_value.get("status"), "summary": surface_value.get("summary") or surface_value.get("rule")})
+        high_risk_overlay = _compact_tiny_high_risk_overlay(answer.get("high_risk_overlay") if isinstance(answer, dict) else {})
         next_payload = {
             "kind": "proof-next-decision/v1",
             "target": payload.get("target"),
@@ -230,6 +247,7 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
             },
             "required_commands": required_commands,
             **({"intent_proof": _compact_tiny_intent_proof(answer["intent_proof"])} if include_intent_proof else {}),
+            **({"high_risk_overlay": high_risk_overlay} if high_risk_overlay else {}),
             **(
                 {"proof_command_adjustments": answer["proof_command_adjustments"]}
                 if isinstance(answer, dict) and answer.get("proof_command_adjustments")
@@ -974,6 +992,10 @@ def _proof_route_authority_for_lane(*, lane: dict[str, Any], route_source: str, 
         authority = "repo-owned-domain-proof-lane"
         fallback_status = "repo-confirmed"
         surface = ".agentic-workspace/config.toml [assurance.domain_proof_lanes]"
+    elif lane.get("local_overlay"):
+        authority = "local-only-high-risk-overlay"
+        fallback_status = "local-only"
+        surface = ".agentic-workspace/config.local.toml [high_risk_overlay]"
     elif lane.get("proof_profile") or lane.get("requirement_id") or lane.get("subsystem"):
         authority = "repo-owned-proof-policy"
         fallback_status = "repo-confirmed"
@@ -1018,6 +1040,7 @@ def _proof_route_precedence_payload(*, selected_commands: list[dict[str, Any]]) 
         "host-configured-subsystem": 95,
         "repo-learned-proof-route": 90,
         "verification-manual-protocol": 85,
+        "local-only-high-risk-overlay": 75,
         "live-adapted-target-capability": 60,
         "live-confirmed-proof-rule": 40,
         "manual-fallback": 20,
@@ -1081,6 +1104,203 @@ def _proof_route_precedence_payload(*, selected_commands: list[dict[str, Any]]) 
         ],
         "cases": competing,
         "rule": "When the same command is selected from multiple sources, repo-owned and learned authority should be visible and preferred over package defaults.",
+    }
+
+
+def _local_overlay_item_matches(*, item: dict[str, Any], changed_paths: list[str], task_text: str | None) -> tuple[bool, list[str]]:
+    reasons: list[str] = []
+    path_patterns = [str(pattern).strip() for pattern in _list_payload(item.get("applies_to_paths")) if str(pattern).strip()]
+    for changed_path in changed_paths:
+        for pattern in path_patterns:
+            if fnmatch.fnmatch(changed_path, pattern):
+                reasons.append(f"path:{changed_path} matches {pattern}")
+                break
+    normalized_task = (task_text or "").lower()
+    for marker in [str(marker).strip() for marker in _list_payload(item.get("applies_to_task_markers")) if str(marker).strip()]:
+        if marker.lower() in normalized_task:
+            reasons.append(f"task-marker:{marker}")
+    return (bool(reasons), reasons)
+
+
+def _local_high_risk_overlay_for_work(
+    *, config: WorkspaceConfig | None, changed_paths: list[str], task_text: str | None, cli_invoke: str = DEFAULT_CLI_INVOKE
+) -> dict[str, Any]:
+    overlay = config.local_override.high_risk_overlay if config is not None else {}
+    if not isinstance(overlay, dict) or overlay.get("status") != "configured":
+        return {
+            "kind": "agentic-workspace/local-high-risk-overlay/v1",
+            "status": "absent",
+            "active_count": 0,
+            "detail_command": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section local_high_risk_overlay --format json",
+                cli_invoke=cli_invoke,
+            ),
+        }
+    sections = _as_dict(overlay.get("sections"))
+    active_by_section: dict[str, list[dict[str, Any]]] = {}
+    for section, raw_items in sections.items():
+        active_items: list[dict[str, Any]] = []
+        for raw_item in _list_payload(raw_items):
+            if not isinstance(raw_item, dict):
+                continue
+            matched, reasons = _local_overlay_item_matches(item=raw_item, changed_paths=changed_paths, task_text=task_text)
+            if not matched:
+                continue
+            item = dict(raw_item)
+            item["matched_because"] = reasons
+            item["provenance"] = {
+                "source_layer": item.get("source_layer", "local-config"),
+                "surface": item.get("surface", ".agentic-workspace/config.local.toml [high_risk_overlay]"),
+                "authority": "local-only-overlay",
+                "shared_repo_policy": False,
+            }
+            active_items.append(item)
+        active_by_section[str(section)] = active_items
+    active_count = sum(len(items) for items in active_by_section.values())
+    return {
+        "kind": "agentic-workspace/local-high-risk-overlay/v1",
+        "status": "active" if active_count else "configured-no-match",
+        "configured_count": int(overlay.get("item_count", 0) or 0),
+        "active_count": active_count,
+        "changed_paths": changed_paths,
+        "active": active_by_section,
+        "warnings": _list_payload(overlay.get("warnings")),
+        "authority_boundary": {
+            "kind": "agentic-workspace/authority-boundary/v1",
+            "surface": "local_high_risk_overlay",
+            "authority_class": "local-advisory",
+            "observed_by_aw": ["local config overlay declarations", "changed-path/task-marker match facts"],
+            "recommended_by_aw": ["carry matched local guardrails into proof and closeout claims"],
+            "agent_owned_decisions": ["semantic applicability", "whether proof and review evidence satisfy the requested task"],
+            "human_owned_decisions": ["host policy acceptance", "security/legal review", "local override trust"],
+            "rule": "Local-only overlays may shape this checkout's workflow but never become checked-in host policy or certification.",
+        },
+        "detail_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section local_high_risk_overlay --format json",
+            cli_invoke=cli_invoke,
+        ),
+    }
+
+
+def _local_overlay_lanes(overlay: dict[str, Any]) -> list[dict[str, Any]]:
+    if overlay.get("status") != "active":
+        return []
+    active = _as_dict(overlay.get("active"))
+    lanes: list[dict[str, Any]] = []
+    for item in _list_payload(active.get("source_maps")):
+        if not isinstance(item, dict):
+            continue
+        item_id = str(item.get("id", "")).strip()
+        if not item_id:
+            continue
+        lanes.append(
+            {
+                "id": f"local-overlay-source:{item_id}",
+                "when": "local-only high-risk overlay source map matched changed paths or task markers",
+                "enough_proof": _list_payload(item.get("required_commands")),
+                "manual_evidence": _list_payload(item.get("manual_evidence")) or _list_payload(item.get("required_sources")),
+                "review_aids": _list_payload(item.get("review_aids")),
+                "proof_profile": next(iter(_list_payload(item.get("proof_profiles"))), ""),
+                "authority_refs": _list_payload(item.get("authority_refs")) or _list_payload(item.get("required_sources")),
+                "claim_boundary": str(item.get("claim_boundary") or ""),
+                "local_overlay": {
+                    "section": "source_maps",
+                    "id": item_id,
+                    "source_layer": item.get("source_layer"),
+                    "impact": item.get("impact"),
+                    "matched_because": _list_payload(item.get("matched_because")),
+                },
+                "proof_responsibility": "local-closeout",
+                "execution_mode": "serial-recommended",
+                "recovery_signal": "local source-of-truth mapping must be considered before high-risk closeout claims",
+            }
+        )
+    for item in _list_payload(active.get("validation_profiles")):
+        if not isinstance(item, dict):
+            continue
+        item_id = str(item.get("id", "")).strip()
+        if not item_id:
+            continue
+        lanes.append(
+            {
+                "id": f"local-overlay-validation:{item_id}",
+                "when": "local-only validation profile matched changed paths or task markers",
+                "enough_proof": _list_payload(item.get("required_commands")),
+                "manual_evidence": _list_payload(item.get("manual_checks")),
+                "optional_commands": _list_payload(item.get("optional_commands")),
+                "review_aids": _list_payload(item.get("manual_checks")),
+                "proof_profile": next(iter(_list_payload(item.get("proof_profiles"))), ""),
+                "authority_refs": _list_payload(item.get("authority_refs")),
+                "claim_boundary": str(item.get("claim_boundary") or ""),
+                "validation_profile": {
+                    "id": item_id,
+                    "category": item.get("category"),
+                    "unavailable_routes": _list_payload(item.get("unavailable_routes")),
+                    "source_layer": item.get("source_layer"),
+                    "impact": item.get("impact"),
+                    "matched_because": _list_payload(item.get("matched_because")),
+                },
+                "proof_responsibility": "local-closeout",
+                "execution_mode": "serial-recommended",
+                "recovery_signal": "matched local validation profile must be resolved or consciously substituted before closeout",
+            }
+        )
+    return lanes
+
+
+def _local_overlay_claim_effects(overlay: dict[str, Any]) -> dict[str, Any]:
+    if overlay.get("status") != "active":
+        return {"status": overlay.get("status", "absent"), "blockers": [], "warnings": []}
+    active = _as_dict(overlay.get("active"))
+    blockers: list[str] = []
+    warnings: list[str] = []
+    ci_items: list[dict[str, Any]] = []
+    unresolved_items: list[dict[str, Any]] = []
+    guardrail_items: list[dict[str, Any]] = []
+    template_items: list[dict[str, Any]] = []
+    for item in _list_payload(active.get("ci_validation")):
+        if not isinstance(item, dict):
+            continue
+        ci_items.append(item)
+        state = str(item.get("validation_state") or "ci_unavailable")
+        policy = str(item.get("local_substitute_policy") or "insufficient")
+        if state in {"ci_failed", "ci_pending", "ci_unavailable", "quota_exhausted", "logs_unavailable"}:
+            blockers.append(f"validation-state:{state}")
+        if policy in {"insufficient", "human-review-only"}:
+            blockers.append(f"local-substitute-policy:{policy}")
+        elif policy == "advisory":
+            warnings.append("local substitute validation is advisory only")
+    for item in _list_payload(active.get("unresolved_questions")):
+        if not isinstance(item, dict):
+            continue
+        unresolved_items.append(item)
+        category = str(item.get("category") or "safe-follow-up")
+        if category in {"merge-blocker", "release-blocker", "human-review-required"}:
+            blockers.append(f"unresolved-question:{category}")
+        elif category == "intentionally-deferred":
+            warnings.append("unresolved question intentionally deferred with owner")
+    for item in _list_payload(active.get("guardrails")):
+        if not isinstance(item, dict):
+            continue
+        guardrail_items.append(item)
+        impact = str(item.get("impact") or "advisory")
+        if impact in {"blocking", "human-review-only", "claim-limiting"}:
+            blockers.append(f"guardrail:{impact}")
+    for item in _list_payload(active.get("templates")):
+        if not isinstance(item, dict):
+            continue
+        template_items.append(item)
+        state = str(item.get("state") or "")
+        if state in {"missing", "ambiguous", "unsupported"}:
+            blockers.append(f"template-preservation:{state}")
+    return {
+        "status": "attention" if blockers else "advisory" if warnings else "clear",
+        "blockers": _dedupe(blockers),
+        "warnings": _dedupe(warnings),
+        "ci_validation": ci_items,
+        "unresolved_questions": unresolved_items,
+        "guardrails": guardrail_items,
+        "templates": template_items,
     }
 
 
@@ -1665,6 +1885,7 @@ def _proof_decision_packet(
     high_assurance_closeout_posture: dict[str, Any],
     test_strategy_check: dict[str, Any],
     proof_execution_evidence: dict[str, Any],
+    local_high_risk_overlay: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     lane_authority = {
         str(command.get("lane", "")): {
@@ -1685,6 +1906,8 @@ def _proof_decision_packet(
             lane=lane,
             route_source="host-declared-domain-proof-lane"
             if lane.get("domain_lane")
+            else "local-only-high-risk-overlay"
+            if lane.get("local_overlay")
             else "verification-manual-protocol"
             if lane_id.startswith("verification:")
             else "live-confirmed-proof-rule",
@@ -1705,6 +1928,8 @@ def _proof_decision_packet(
                 "claim_boundary": str(lane.get("claim_boundary", "")),
                 "route_authority": authority,
                 **({"domain_lane": lane["domain_lane"]} if lane.get("domain_lane") else {}),
+                **({"local_overlay": lane["local_overlay"]} if lane.get("local_overlay") else {}),
+                **({"validation_profile": lane["validation_profile"]} if lane.get("validation_profile") else {}),
             }
         )
     manual_required = bool(manual_verification) or any(item.get("required") for item in manual_proof_obligations)
@@ -1749,10 +1974,18 @@ def _proof_decision_packet(
         blockers.append("high-assurance closeout posture evidence is missing")
     if closeout_posture_waivers or closeout_posture_uncertainty:
         blockers.append("high-assurance closeout posture requires human waiver or uncertainty acknowledgement")
+    overlay_claim_effects = _local_overlay_claim_effects(local_high_risk_overlay or {})
+    overlay_blockers = _list_payload(overlay_claim_effects.get("blockers"))
+    if overlay_blockers:
+        blockers.append("local high-risk overlay constrains proof or closeout claims")
     if host_policy_blocked_commands:
         safe_claim_state = "human-waiver-required"
     elif closeout_posture_waivers or closeout_posture_uncertainty:
         safe_claim_state = "human-waiver-required"
+    elif any(str(item).startswith("unresolved-question:human-review-required") for item in overlay_blockers):
+        safe_claim_state = "human-waiver-required"
+    elif overlay_blockers:
+        safe_claim_state = "overlay-review-required"
     elif manual_required:
         safe_claim_state = "manual-review-required"
     elif required_commands or unavailable_commands or architecture_count or assurance_active or closeout_posture_missing:
@@ -1777,9 +2010,12 @@ def _proof_decision_packet(
             "verification_protocol_count": verification_active,
             "architecture_principle_match_count": architecture_count,
             "high_assurance_closeout_posture_status": closeout_posture_status,
+            "local_high_risk_overlay_status": str((local_high_risk_overlay or {}).get("status", "absent")),
+            "local_high_risk_overlay_active_count": int((local_high_risk_overlay or {}).get("active_count", 0) or 0),
             "test_strategy_status": str(test_strategy_check.get("status", "")) if isinstance(test_strategy_check, dict) else "",
         },
         "high_assurance_closeout_posture": high_assurance_closeout_posture,
+        "local_high_risk_overlay": local_high_risk_overlay or {"status": "absent", "active_count": 0},
         "missing_or_unresolved": {
             "blockers": blockers,
             "unavailable_commands": unavailable_commands,
@@ -1788,6 +2024,10 @@ def _proof_decision_packet(
             "closeout_posture_missing_evidence": closeout_posture_missing,
             "closeout_posture_human_waiver_refs": closeout_posture_waivers,
             "closeout_posture_uncertainty": closeout_posture_uncertainty,
+            "local_overlay_blockers": overlay_blockers,
+            "local_overlay_warnings": _list_payload(overlay_claim_effects.get("warnings")),
+            "local_overlay_ci_validation": _list_payload(overlay_claim_effects.get("ci_validation")),
+            "local_overlay_unresolved_questions": _list_payload(overlay_claim_effects.get("unresolved_questions")),
             "proof_execution_evidence_status": str(proof_execution_evidence.get("status", "")),
         },
         "safe_claim_now": {
@@ -1804,6 +2044,7 @@ def _proof_decision_packet(
             "assurance_requirements",
             "architecture_principles",
             "high_assurance_closeout_posture",
+            "high_risk_overlay",
             "test_strategy_check",
             "proof_route_explanation",
         ],
@@ -2086,6 +2327,14 @@ def _proof_selection_for_changed_paths(
     selected_lanes.extend(requirement_lanes)
     selected_lanes.extend(verification_lanes)
     selected_lanes.extend(domain_lanes)
+    local_high_risk_overlay = _local_high_risk_overlay_for_work(
+        config=config,
+        changed_paths=changed_paths,
+        task_text=task_text,
+        cli_invoke=cli_invoke,
+    )
+    local_overlay_lanes = _local_overlay_lanes(local_high_risk_overlay)
+    selected_lanes.extend(local_overlay_lanes)
     make_targets = _makefile_targets(target_root)
     package_scripts = _package_json_scripts(target_root)
     project_roots = _project_roots_for_changed_paths(target_root=target_root, changed_paths=changed_paths)
@@ -2476,6 +2725,7 @@ def _proof_selection_for_changed_paths(
         high_assurance_closeout_posture=high_assurance_closeout_posture,
         test_strategy_check=test_strategy_check,
         proof_execution_evidence=proof_execution_evidence,
+        local_high_risk_overlay=local_high_risk_overlay,
     )
     proof_selection = {
         "kind": "proof-selection/v1",
@@ -2565,6 +2815,8 @@ def _proof_selection_for_changed_paths(
                 ),
                 **({"proof_profile": lane["proof_profile"]} if lane.get("proof_profile") else {}),
                 **({"domain_lane": lane["domain_lane"]} if lane.get("domain_lane") else {}),
+                **({"local_overlay": lane["local_overlay"]} if lane.get("local_overlay") else {}),
+                **({"validation_profile": lane["validation_profile"]} if lane.get("validation_profile") else {}),
                 **({"manual_evidence": lane["manual_evidence"]} if lane.get("manual_evidence") else {}),
                 **({"evidence_concepts": lane["evidence_concepts"]} if lane.get("evidence_concepts") else {}),
                 **({"evidence_concept_usage": lane["evidence_concept_usage"]} if lane.get("evidence_concept_usage") else {}),
@@ -2636,6 +2888,8 @@ def _proof_selection_for_changed_paths(
         )
     if manual_verification is not None:
         proof_selection["manual_verification"] = manual_verification
+    if local_high_risk_overlay.get("status") == "active":
+        proof_selection["high_risk_overlay"] = local_high_risk_overlay
     if config is not None and target_root is not None and include_durable_intent:
         durable_intent = _intent_decision_projection(target_root=target_root, config=config, changed_paths=changed_paths, compact=True)
         proof_selection["durable_intent"] = durable_intent

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -173,6 +173,19 @@ def _compact_tiny_high_risk_overlay(value: Any) -> dict[str, Any]:
     }
 
 
+def _compact_tiny_local_overlay(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or value.get("status") != "active":
+        return {}
+    active = _as_dict(value.get("active"))
+    return {
+        "status": value.get("status"),
+        "active_count": value.get("active_count", 0),
+        "ordinary_guidance_count": len(_list_payload(active.get("guidance"))),
+        "authority_boundary": _as_dict(value.get("authority_boundary")).get("rule", ""),
+        "detail_selector": "local_overlay",
+    }
+
+
 def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
     if payload.get("profile") == "compact-contract-answer/v1":
         answer = payload.get("answer", {})
@@ -207,6 +220,9 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
                 }
             if include_intent_proof:
                 next_decision["intent_proof"] = _compact_tiny_intent_proof(answer["intent_proof"])
+            local_overlay = _compact_tiny_local_overlay(answer.get("local_overlay"))
+            if local_overlay:
+                next_decision["local_overlay"] = local_overlay
             high_risk_overlay = _compact_tiny_high_risk_overlay(answer.get("high_risk_overlay"))
             if high_risk_overlay:
                 next_decision["high_risk_overlay"] = high_risk_overlay
@@ -234,6 +250,7 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
         if isinstance(surface_value, dict) and surface_value.get("status") in {"blocked", "needs-review"}:
             warnings.append({"status": surface_value.get("status"), "summary": surface_value.get("summary") or surface_value.get("rule")})
         high_risk_overlay = _compact_tiny_high_risk_overlay(answer.get("high_risk_overlay") if isinstance(answer, dict) else {})
+        local_overlay = _compact_tiny_local_overlay(answer.get("local_overlay") if isinstance(answer, dict) else {})
         next_payload = {
             "kind": "proof-next-decision/v1",
             "target": payload.get("target"),
@@ -247,6 +264,7 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
             },
             "required_commands": required_commands,
             **({"intent_proof": _compact_tiny_intent_proof(answer["intent_proof"])} if include_intent_proof else {}),
+            **({"local_overlay": local_overlay} if local_overlay else {}),
             **({"high_risk_overlay": high_risk_overlay} if high_risk_overlay else {}),
             **(
                 {"proof_command_adjustments": answer["proof_command_adjustments"]}
@@ -993,9 +1011,9 @@ def _proof_route_authority_for_lane(*, lane: dict[str, Any], route_source: str, 
         fallback_status = "repo-confirmed"
         surface = ".agentic-workspace/config.toml [assurance.domain_proof_lanes]"
     elif lane.get("local_overlay"):
-        authority = "local-only-high-risk-overlay"
+        authority = "local-only-high-risk-profile"
         fallback_status = "local-only"
-        surface = ".agentic-workspace/config.local.toml [high_risk_overlay]"
+        surface = ".agentic-workspace/config.local.toml [local_overlay.high_risk]"
     elif lane.get("proof_profile") or lane.get("requirement_id") or lane.get("subsystem"):
         authority = "repo-owned-proof-policy"
         fallback_status = "repo-confirmed"
@@ -1150,7 +1168,7 @@ def _local_high_risk_overlay_for_work(
             item["matched_because"] = reasons
             item["provenance"] = {
                 "source_layer": item.get("source_layer", "local-config"),
-                "surface": item.get("surface", ".agentic-workspace/config.local.toml [high_risk_overlay]"),
+                "surface": item.get("surface", ".agentic-workspace/config.local.toml [local_overlay.high_risk]"),
                 "authority": "local-only-overlay",
                 "shared_repo_policy": False,
             }
@@ -1177,6 +1195,65 @@ def _local_high_risk_overlay_for_work(
         },
         "detail_command": _command_with_cli_invoke(
             command="agentic-workspace report --target ./repo --section local_high_risk_overlay --format json",
+            cli_invoke=cli_invoke,
+        ),
+    }
+
+
+def _local_overlay_for_work(
+    *, config: WorkspaceConfig | None, changed_paths: list[str], task_text: str | None, cli_invoke: str = DEFAULT_CLI_INVOKE
+) -> dict[str, Any]:
+    overlay = config.local_override.local_overlay if config is not None else {}
+    if not isinstance(overlay, dict) or overlay.get("status") != "configured":
+        return {
+            "kind": "agentic-workspace/local-overlay/v1",
+            "status": "absent",
+            "active_count": 0,
+            "detail_command": _command_with_cli_invoke(
+                command="agentic-workspace report --target ./repo --section local_overlay --format json",
+                cli_invoke=cli_invoke,
+            ),
+        }
+    sections = _as_dict(overlay.get("sections"))
+    active_guidance: list[dict[str, Any]] = []
+    for raw_item in _list_payload(sections.get("guidance")):
+        if not isinstance(raw_item, dict):
+            continue
+        matched, reasons = _local_overlay_item_matches(item=raw_item, changed_paths=changed_paths, task_text=task_text)
+        if not matched:
+            continue
+        item = dict(raw_item)
+        item["matched_because"] = reasons
+        item["provenance"] = {
+            "source_layer": item.get("source_layer", "local-config"),
+            "surface": item.get("surface", ".agentic-workspace/config.local.toml [local_overlay.guidance]"),
+            "authority": "local-only-overlay",
+            "shared_repo_policy": False,
+        }
+        active_guidance.append(item)
+    active_count = len(active_guidance)
+    return {
+        "kind": "agentic-workspace/local-overlay/v1",
+        "status": "active" if active_count else "configured-no-match",
+        "configured_count": int(overlay.get("item_count", 0) or 0),
+        "ordinary_guidance_count": int(overlay.get("ordinary_guidance_count", 0) or 0),
+        "high_risk_profile_count": int(overlay.get("high_risk_profile_count", 0) or 0),
+        "active_count": active_count,
+        "changed_paths": changed_paths,
+        "active": {"guidance": active_guidance},
+        "warnings": _list_payload(overlay.get("warnings")),
+        "authority_boundary": {
+            "kind": "agentic-workspace/authority-boundary/v1",
+            "surface": "local_overlay",
+            "authority_class": "local-advisory",
+            "observed_by_aw": ["local overlay declarations", "changed-path/task-marker match facts"],
+            "recommended_by_aw": ["carry matched local guidance into workflow choices"],
+            "agent_owned_decisions": ["semantic applicability", "whether local guidance is sufficient or only advisory"],
+            "human_owned_decisions": ["host policy acceptance", "local override trust"],
+            "rule": "Local overlays may shape this checkout's workflow but never become checked-in host policy or certification.",
+        },
+        "detail_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section local_overlay --format json",
             cli_invoke=cli_invoke,
         ),
     }
@@ -1885,6 +1962,7 @@ def _proof_decision_packet(
     high_assurance_closeout_posture: dict[str, Any],
     test_strategy_check: dict[str, Any],
     proof_execution_evidence: dict[str, Any],
+    local_overlay: dict[str, Any] | None = None,
     local_high_risk_overlay: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     lane_authority = {
@@ -2010,11 +2088,14 @@ def _proof_decision_packet(
             "verification_protocol_count": verification_active,
             "architecture_principle_match_count": architecture_count,
             "high_assurance_closeout_posture_status": closeout_posture_status,
+            "local_overlay_status": str((local_overlay or {}).get("status", "absent")),
+            "local_overlay_active_count": int((local_overlay or {}).get("active_count", 0) or 0),
             "local_high_risk_overlay_status": str((local_high_risk_overlay or {}).get("status", "absent")),
             "local_high_risk_overlay_active_count": int((local_high_risk_overlay or {}).get("active_count", 0) or 0),
             "test_strategy_status": str(test_strategy_check.get("status", "")) if isinstance(test_strategy_check, dict) else "",
         },
         "high_assurance_closeout_posture": high_assurance_closeout_posture,
+        "local_overlay": local_overlay or {"status": "absent", "active_count": 0},
         "local_high_risk_overlay": local_high_risk_overlay or {"status": "absent", "active_count": 0},
         "missing_or_unresolved": {
             "blockers": blockers,
@@ -2044,6 +2125,7 @@ def _proof_decision_packet(
             "assurance_requirements",
             "architecture_principles",
             "high_assurance_closeout_posture",
+            "local_overlay",
             "high_risk_overlay",
             "test_strategy_check",
             "proof_route_explanation",
@@ -2327,6 +2409,12 @@ def _proof_selection_for_changed_paths(
     selected_lanes.extend(requirement_lanes)
     selected_lanes.extend(verification_lanes)
     selected_lanes.extend(domain_lanes)
+    local_overlay = _local_overlay_for_work(
+        config=config,
+        changed_paths=changed_paths,
+        task_text=task_text,
+        cli_invoke=cli_invoke,
+    )
     local_high_risk_overlay = _local_high_risk_overlay_for_work(
         config=config,
         changed_paths=changed_paths,
@@ -2725,6 +2813,7 @@ def _proof_selection_for_changed_paths(
         high_assurance_closeout_posture=high_assurance_closeout_posture,
         test_strategy_check=test_strategy_check,
         proof_execution_evidence=proof_execution_evidence,
+        local_overlay=local_overlay,
         local_high_risk_overlay=local_high_risk_overlay,
     )
     proof_selection = {
@@ -2890,6 +2979,8 @@ def _proof_selection_for_changed_paths(
         proof_selection["manual_verification"] = manual_verification
     if local_high_risk_overlay.get("status") == "active":
         proof_selection["high_risk_overlay"] = local_high_risk_overlay
+    if local_overlay.get("status") == "active":
+        proof_selection["local_overlay"] = local_overlay
     if config is not None and target_root is not None and include_durable_intent:
         durable_intent = _intent_decision_projection(target_root=target_root, config=config, changed_paths=changed_paths, compact=True)
         proof_selection["durable_intent"] = durable_intent

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1402,6 +1402,9 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         startup_changed_signals.append(f"dogfooding_signal_status={dogfooding_signal_status.get('status')}")
     startup_proof = payload.get("proof", {})
     startup_proof_commands = _tiny_required_proof_commands(startup_proof) if isinstance(startup_proof, dict) else []
+    startup_local_overlay = startup_proof.get("local_overlay", {}) if isinstance(startup_proof, dict) else {}
+    if isinstance(startup_local_overlay, dict) and startup_local_overlay.get("status") == "active":
+        startup_changed_signals.append(f"local_overlay={startup_local_overlay.get('active_count', 0)}")
     startup_high_risk_overlay = startup_proof.get("high_risk_overlay", {}) if isinstance(startup_proof, dict) else {}
     if isinstance(startup_high_risk_overlay, dict) and startup_high_risk_overlay.get("status") == "active":
         startup_changed_signals.append(f"high_risk_overlay={startup_high_risk_overlay.get('active_count', 0)}")
@@ -1439,6 +1442,8 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         advisory_selectors.append("pr_comment_attention")
     if isinstance(dogfooding_signal_status, dict) and dogfooding_signal_status.get("status") not in {None, "", "not_applicable"}:
         advisory_selectors.append("dogfooding_signal_status")
+    if isinstance(startup_local_overlay, dict) and startup_local_overlay.get("status") == "active":
+        advisory_selectors.append("proof.local_overlay")
     if isinstance(startup_high_risk_overlay, dict) and startup_high_risk_overlay.get("status") == "active":
         advisory_selectors.append("proof.high_risk_overlay")
     selected: dict[str, Any] = {

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1402,6 +1402,9 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         startup_changed_signals.append(f"dogfooding_signal_status={dogfooding_signal_status.get('status')}")
     startup_proof = payload.get("proof", {})
     startup_proof_commands = _tiny_required_proof_commands(startup_proof) if isinstance(startup_proof, dict) else []
+    startup_high_risk_overlay = startup_proof.get("high_risk_overlay", {}) if isinstance(startup_proof, dict) else {}
+    if isinstance(startup_high_risk_overlay, dict) and startup_high_risk_overlay.get("status") == "active":
+        startup_changed_signals.append(f"high_risk_overlay={startup_high_risk_overlay.get('active_count', 0)}")
     available_selectors = _available_selectors_for_payload(payload)
     available_selectors = [selector for selector in available_selectors if not selector.startswith("workflow_participation")]
     if "routine_work_context" not in available_selectors:
@@ -1436,6 +1439,8 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         advisory_selectors.append("pr_comment_attention")
     if isinstance(dogfooding_signal_status, dict) and dogfooding_signal_status.get("status") not in {None, "", "not_applicable"}:
         advisory_selectors.append("dogfooding_signal_status")
+    if isinstance(startup_high_risk_overlay, dict) and startup_high_risk_overlay.get("status") == "active":
+        advisory_selectors.append("proof.high_risk_overlay")
     selected: dict[str, Any] = {
         "kind": payload["kind"],
         "target": ".",

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -2479,6 +2479,51 @@ def test_report_exposes_configuration_projection_without_expanding_config_detail
     assert selected_eval["answer"]["metrics"]["compact_json_size"] <= 1400
 
 
+def test_local_high_risk_overlay_report_section_and_projection(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        f"""
+schema_version = 1
+
+[workspace]
+cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
+""",
+    )
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "local_high_risk_overlay", "--format", "json"]) == 0
+    absent = json.loads(capsys.readouterr().out)["answer"]
+    assert absent["status"] == "absent"
+
+    _write(
+        tmp_path / ".agentic-workspace" / "config.local.toml",
+        """
+schema_version = 1
+
+[high_risk_overlay.guardrails.fixtures]
+applies_to_paths = ["tests/fixtures/**"]
+sensitive_data = ["real customer email"]
+synthetic_fixture_guidance = ["Use example.com addresses."]
+impact = "claim-limiting"
+unsupported_policy_override = true
+""",
+    )
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "local_high_risk_overlay", "--format", "json"]) == 0
+    configured = json.loads(capsys.readouterr().out)["answer"]
+    assert configured["status"] == "configured"
+    assert configured["configured_count"] == 1
+    assert configured["sections"]["guardrails"][0]["source_layer"] == "repo-local-override"
+    assert "unsupported_policy_override" in configured["warnings"][0]
+    assert "checked-in host policy" in configured["authority_boundary"]["rule"]
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "configuration_projection", "--format", "json"]) == 0
+    projection = json.loads(capsys.readouterr().out)["answer"]
+    overlay_row = next(row for row in projection["facts"] if row["field"] == "high_risk_overlay.*")
+    assert overlay_row["projection_status"] in {"active", "selector-backed"}
+    assert "local_high_risk_overlay" in overlay_row["ordinary_path_routes"][0]
+
+
 def test_report_ordinary_agent_path_is_phase_question_first(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -2479,7 +2479,7 @@ def test_report_exposes_configuration_projection_without_expanding_config_detail
     assert selected_eval["answer"]["metrics"]["compact_json_size"] <= 1400
 
 
-def test_local_high_risk_overlay_report_section_and_projection(tmp_path: Path, capsys) -> None:
+def test_local_overlay_report_section_and_projection(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(
         tmp_path / ".agentic-workspace" / "config.toml",
@@ -2491,7 +2491,7 @@ cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
 """,
     )
 
-    assert cli.main(["report", "--target", str(tmp_path), "--section", "local_high_risk_overlay", "--format", "json"]) == 0
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "local_overlay", "--format", "json"]) == 0
     absent = json.loads(capsys.readouterr().out)["answer"]
     assert absent["status"] == "absent"
 
@@ -2500,7 +2500,15 @@ cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
         """
 schema_version = 1
 
-[high_risk_overlay.guardrails.fixtures]
+[local_overlay.guidance.local_cli]
+signal = "local-tool-availability"
+category = "tooling"
+applies_to_paths = ["tools/**"]
+guidance = "Use the checkout-local CLI."
+required_commands = ["python -c \\"print('tool ok')\\""]
+impact = "advisory"
+
+[local_overlay.high_risk.guardrails.fixtures]
 applies_to_paths = ["tests/fixtures/**"]
 sensitive_data = ["real customer email"]
 synthetic_fixture_guidance = ["Use example.com addresses."]
@@ -2509,19 +2517,68 @@ unsupported_policy_override = true
 """,
     )
 
-    assert cli.main(["report", "--target", str(tmp_path), "--section", "local_high_risk_overlay", "--format", "json"]) == 0
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "local_overlay", "--format", "json"]) == 0
     configured = json.loads(capsys.readouterr().out)["answer"]
     assert configured["status"] == "configured"
-    assert configured["configured_count"] == 1
-    assert configured["sections"]["guardrails"][0]["source_layer"] == "repo-local-override"
+    assert configured["configured_count"] == 2
+    assert configured["ordinary_guidance_count"] == 1
+    assert configured["high_risk_profile_count"] == 1
+    assert configured["ordinary_guidance"][0]["source_layer"] == "repo-local-override"
+    assert configured["high_risk_profile"]["detail_selector"] == "local_high_risk_overlay"
     assert "unsupported_policy_override" in configured["warnings"][0]
     assert "checked-in host policy" in configured["authority_boundary"]["rule"]
 
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "local_high_risk_overlay", "--format", "json"]) == 0
+    high_risk = json.loads(capsys.readouterr().out)["answer"]
+    assert high_risk["configured_count"] == 1
+    assert high_risk["sections"]["guardrails"][0]["source_layer"] == "repo-local-override"
+
     assert cli.main(["report", "--target", str(tmp_path), "--section", "configuration_projection", "--format", "json"]) == 0
     projection = json.loads(capsys.readouterr().out)["answer"]
-    overlay_row = next(row for row in projection["facts"] if row["field"] == "high_risk_overlay.*")
+    overlay_row = next(row for row in projection["facts"] if row["field"] == "local_overlay.*")
     assert overlay_row["projection_status"] in {"active", "selector-backed"}
-    assert "local_high_risk_overlay" in overlay_row["ordinary_path_routes"][0]
+    assert "local_overlay" in overlay_row["ordinary_path_routes"][0]
+
+
+def test_local_overlay_ordinary_guidance_projects_without_high_risk(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        f"""
+schema_version = 1
+
+[workspace]
+cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "config.local.toml",
+        """
+schema_version = 1
+
+[local_overlay.guidance.local_cli]
+signal = "local-tool-availability"
+category = "tooling"
+applies_to_paths = ["tools/**"]
+guidance = "Use the checkout-local CLI."
+required_commands = ["python -c \\"print('tool ok')\\""]
+impact = "advisory"
+
+[local_overlay.guidance.stack]
+signal = "branch-stack-convention"
+category = "workflow"
+applies_to_task_markers = ["stacked pr"]
+guidance = "Keep local stack order when preparing PRs."
+impact = "claim-limiting"
+""",
+    )
+    _write(tmp_path / "tools" / "run.py", "print('ok')\n")
+
+    assert cli.main(["proof", "--target", str(tmp_path), "--changed", "tools/run.py", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["local_overlay"]["status"] == "active"
+    assert payload["local_overlay"]["ordinary_guidance_count"] == 1
+    assert payload.get("high_risk_overlay") is None
 
 
 def test_report_ordinary_agent_path_is_phase_question_first(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -61,7 +61,7 @@ cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
         """
 schema_version = 1
 
-[high_risk_overlay.validation_profiles.migration]
+[local_overlay.high_risk.validation_profiles.migration]
 category = "migration"
 applies_to_paths = ["db/migrations/**"]
 required_commands = ["python -c \\"print('migration validation')\\""]
@@ -90,6 +90,43 @@ impact = "blocking"
     assert payload["proof"]["high_risk_overlay"]["status"] == "active"
     assert payload["proof"]["high_risk_overlay"]["active_count"] == 1
     assert "high_risk_overlay=1" in payload["action_signals"]["changed_signals"]
+
+
+def test_implement_tiny_surfaces_ordinary_local_overlay_without_high_risk(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        f"""
+schema_version = 1
+
+[workspace]
+cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "config.local.toml",
+        """
+schema_version = 1
+
+[local_overlay.guidance.local_cli]
+signal = "local-tool-availability"
+category = "tooling"
+applies_to_paths = ["tools/**"]
+guidance = "Local CLI is available in this checkout."
+required_commands = ["python -c \\"print('tool ok')\\""]
+impact = "advisory"
+""",
+    )
+    _write(tmp_path / "tools" / "run.py", "print('ok')\n")
+
+    assert cli.main(["implement", "--target", str(tmp_path), "--changed", "tools/run.py", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["proof"]["local_overlay"]["status"] == "active"
+    assert payload["proof"]["local_overlay"]["active_count"] == 1
+    assert payload["proof"]["high_risk_overlay"] == {}
+    assert "local_overlay=1" in payload["action_signals"]["changed_signals"]
 
 
 def _write_architecture_principles(target_root: Path) -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -44,6 +44,54 @@ def test_implement_context_adapter_routes_through_implement_owner_facade() -> No
     assert workspace_runtime_primitives._run_implement_context_adapter is workspace_runtime_implement._run_implement_context_adapter
 
 
+def test_implement_tiny_surfaces_local_high_risk_overlay(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        f"""
+schema_version = 1
+
+[workspace]
+cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "config.local.toml",
+        """
+schema_version = 1
+
+[high_risk_overlay.validation_profiles.migration]
+category = "migration"
+applies_to_paths = ["db/migrations/**"]
+required_commands = ["python -c \\"print('migration validation')\\""]
+manual_checks = ["Confirm rollback note exists."]
+impact = "blocking"
+""",
+    )
+    _write(tmp_path / "db" / "migrations" / "001_init.sql", "select 1;\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "db/migrations/001_init.sql",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["proof"]["high_risk_overlay"]["status"] == "active"
+    assert payload["proof"]["high_risk_overlay"]["active_count"] == 1
+    assert "high_risk_overlay=1" in payload["action_signals"]["changed_signals"]
+
+
 def _write_architecture_principles(target_root: Path) -> None:
     _write(
         target_root / ".agentic-workspace" / "system-intent" / "intent.toml",

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -3120,6 +3120,141 @@ proof_profiles = ["runtime_contract"]
     assert "domain:runtime_contract" in lane_ids
 
 
+def test_local_high_risk_overlay_shapes_proof_decision_with_provenance(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_proof_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        f"""
+schema_version = 1
+
+[workspace]
+cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "config.local.toml",
+        """
+schema_version = 1
+
+[high_risk_overlay.source_maps.auth_docs]
+applies_to_paths = ["services/auth/**"]
+authority_refs = ["SECURITY.md#auth", "docs/adr/auth-boundary.md"]
+required_sources = ["docs/risk/auth-risk-register.md"]
+manual_evidence = ["host:auth-risk-review"]
+review_aids = ["Confirm auth ADR still matches changed code."]
+claim_boundary = "auth-source-map-review"
+impact = "human-review-only"
+
+[high_risk_overlay.validation_profiles.security_sensitive]
+category = "security-sensitive"
+applies_to_paths = ["services/auth/**"]
+required_commands = ["python -c \\"print('security validation')\\""]
+manual_checks = ["Review auth threat-model delta."]
+claim_boundary = "security-validation-profile"
+impact = "blocking"
+
+[high_risk_overlay.ci_validation.github_actions]
+applies_to_paths = ["services/auth/**"]
+validation_state = "ci_unavailable"
+local_substitute_commands = ["python -c \\"print('local substitute')\\""]
+local_substitute_policy = "human-review-only"
+claim_boundary = "local-substitute-is-not-ci"
+
+[high_risk_overlay.templates.security_issue]
+applies_to_paths = ["services/auth/**"]
+host = "github"
+kind = "issue"
+paths = [".github/ISSUE_TEMPLATE/security.yml"]
+headings = ["Risk", "Evidence", "Reviewer"]
+state = "missing"
+impact = "blocking"
+
+[high_risk_overlay.guardrails.synthetic_auth_data]
+applies_to_paths = ["services/auth/**"]
+sensitive_data = ["production tokens", "customer emails"]
+synthetic_fixture_guidance = ["Use example.com addresses.", "Use placeholder credentials."]
+impact = "claim-limiting"
+
+[high_risk_overlay.unresolved_questions.legal_review]
+applies_to_paths = ["services/auth/**"]
+category = "human-review-required"
+question = "Does this auth change require legal/security review before merge?"
+owner = "security"
+residue_route = "human-review"
+reason = "local high-risk overlay declares auth changes review-sensitive"
+""",
+    )
+    _write(tmp_path / "services" / "auth" / "policy.py", "ALLOW = True\n")
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "services/auth/policy.py",
+                "--select",
+                "proof_decision",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    packet = json.loads(capsys.readouterr().out)["values"]["proof_decision"]
+    overlay = packet["local_high_risk_overlay"]
+    assert overlay["status"] == "active"
+    assert overlay["active_count"] == 6
+    source_lane = next(lane for lane in packet["selected_lanes"] if lane["id"] == "local-overlay-source:auth_docs")
+    assert source_lane["route_authority"]["authority"] == "local-only-high-risk-overlay"
+    assert source_lane["local_overlay"]["source_layer"] == "repo-local-override"
+    assert "SECURITY.md#auth" in source_lane["commands"] or source_lane["manual_evidence"] == ["host:auth-risk-review"]
+    validation_lane = next(lane for lane in packet["selected_lanes"] if lane["id"] == "local-overlay-validation:security_sensitive")
+    assert validation_lane["validation_profile"]["category"] == "security-sensitive"
+    assert "python -c \"print('security validation')\"" in validation_lane["commands"]
+    unresolved = packet["missing_or_unresolved"]
+    assert "validation-state:ci_unavailable" in unresolved["local_overlay_blockers"]
+    assert "local-substitute-policy:human-review-only" in unresolved["local_overlay_blockers"]
+    assert "template-preservation:missing" in unresolved["local_overlay_blockers"]
+    assert "guardrail:claim-limiting" in unresolved["local_overlay_blockers"]
+    assert "unresolved-question:human-review-required" in unresolved["local_overlay_blockers"]
+    assert packet["safe_claim_now"]["state"] == "human-waiver-required"
+
+
+def test_local_high_risk_overlay_no_match_stays_out_of_tiny_proof(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_proof_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        f"""
+schema_version = 1
+
+[workspace]
+cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "config.local.toml",
+        """
+schema_version = 1
+
+[high_risk_overlay.guardrails.auth_data]
+applies_to_paths = ["services/auth/**"]
+sensitive_data = ["production token"]
+impact = "blocking"
+""",
+    )
+    _write(tmp_path / "docs" / "readme.md", "# Docs\n")
+
+    assert cli.main(["proof", "--target", str(tmp_path), "--changed", "docs/readme.md", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload.get("high_risk_overlay") is None
+
+
 def test_high_assurance_closeout_posture_projects_missing_and_non_applicable_states(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write_empty_proof_planning_state(tmp_path)

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -3137,7 +3137,7 @@ cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
         """
 schema_version = 1
 
-[high_risk_overlay.source_maps.auth_docs]
+[local_overlay.high_risk.source_maps.auth_docs]
 applies_to_paths = ["services/auth/**"]
 authority_refs = ["SECURITY.md#auth", "docs/adr/auth-boundary.md"]
 required_sources = ["docs/risk/auth-risk-register.md"]
@@ -3146,7 +3146,7 @@ review_aids = ["Confirm auth ADR still matches changed code."]
 claim_boundary = "auth-source-map-review"
 impact = "human-review-only"
 
-[high_risk_overlay.validation_profiles.security_sensitive]
+[local_overlay.high_risk.validation_profiles.security_sensitive]
 category = "security-sensitive"
 applies_to_paths = ["services/auth/**"]
 required_commands = ["python -c \\"print('security validation')\\""]
@@ -3154,14 +3154,14 @@ manual_checks = ["Review auth threat-model delta."]
 claim_boundary = "security-validation-profile"
 impact = "blocking"
 
-[high_risk_overlay.ci_validation.github_actions]
+[local_overlay.high_risk.ci_validation.github_actions]
 applies_to_paths = ["services/auth/**"]
 validation_state = "ci_unavailable"
 local_substitute_commands = ["python -c \\"print('local substitute')\\""]
 local_substitute_policy = "human-review-only"
 claim_boundary = "local-substitute-is-not-ci"
 
-[high_risk_overlay.templates.security_issue]
+[local_overlay.high_risk.templates.security_issue]
 applies_to_paths = ["services/auth/**"]
 host = "github"
 kind = "issue"
@@ -3170,13 +3170,13 @@ headings = ["Risk", "Evidence", "Reviewer"]
 state = "missing"
 impact = "blocking"
 
-[high_risk_overlay.guardrails.synthetic_auth_data]
+[local_overlay.high_risk.guardrails.synthetic_auth_data]
 applies_to_paths = ["services/auth/**"]
 sensitive_data = ["production tokens", "customer emails"]
 synthetic_fixture_guidance = ["Use example.com addresses.", "Use placeholder credentials."]
 impact = "claim-limiting"
 
-[high_risk_overlay.unresolved_questions.legal_review]
+[local_overlay.high_risk.unresolved_questions.legal_review]
 applies_to_paths = ["services/auth/**"]
 category = "human-review-required"
 question = "Does this auth change require legal/security review before merge?"
@@ -3206,10 +3206,11 @@ reason = "local high-risk overlay declares auth changes review-sensitive"
 
     packet = json.loads(capsys.readouterr().out)["values"]["proof_decision"]
     overlay = packet["local_high_risk_overlay"]
+    assert packet["local_overlay"]["status"] == "configured-no-match"
     assert overlay["status"] == "active"
     assert overlay["active_count"] == 6
     source_lane = next(lane for lane in packet["selected_lanes"] if lane["id"] == "local-overlay-source:auth_docs")
-    assert source_lane["route_authority"]["authority"] == "local-only-high-risk-overlay"
+    assert source_lane["route_authority"]["authority"] == "local-only-high-risk-profile"
     assert source_lane["local_overlay"]["source_layer"] == "repo-local-override"
     assert "SECURITY.md#auth" in source_lane["commands"] or source_lane["manual_evidence"] == ["host:auth-risk-review"]
     validation_lane = next(lane for lane in packet["selected_lanes"] if lane["id"] == "local-overlay-validation:security_sensitive")
@@ -3241,7 +3242,7 @@ cli_invoke = "{REPO_LOCAL_CLI_INVOKE}"
         """
 schema_version = 1
 
-[high_risk_overlay.guardrails.auth_data]
+[local_overlay.high_risk.guardrails.auth_data]
 applies_to_paths = ["services/auth/**"]
 sensitive_data = ["production token"]
 impact = "blocking"


### PR DESCRIPTION
## Summary

Reworks the #1873 substrate so local checkout guidance is modeled as a general `local_overlay` contract, with high-assurance workflow guidance as a child profile instead of the top-level abstraction:

- adds `local_overlay.guidance` for ordinary local guidance such as tool availability, validation commands, access constraints, branch/stack conventions, and adoption-time hints
- moves high-risk workflow guidance under `local_overlay.high_risk` while keeping the existing high-risk proof/report/implement behavior as the #1872 consumer profile
- exposes ordinary local overlay signals separately from high-risk matched signals in report/proof/start/implement compact outputs
- keeps no-match overlays quiet in ordinary proof output and preserves local-only provenance/authority boundaries
- updates the local override schema and generated reference docs so the checked-in surfaces stay current

A dogfooding follow-up was filed as #1880 for noisy `upgrade --dry-run --format json` local scratch preservation output.

Closes #1872.
Closes #1873.
Closes #1874.
Closes #1875.
Closes #1876.
Closes #1877.
Closes #1878.
Closes #1879.

## Validation

- `uv run pytest tests/test_workspace_cli.py::test_local_overlay_report_section_and_projection tests/test_workspace_cli.py::test_local_overlay_ordinary_guidance_projects_without_high_risk -q --tb=short`
- `uv run pytest tests/test_workspace_proof_cli.py::test_local_high_risk_overlay_shapes_proof_decision_with_provenance tests/test_workspace_proof_cli.py::test_local_high_risk_overlay_no_match_stays_out_of_tiny_proof -q --tb=short`
- `uv run pytest tests/test_workspace_implement_cli.py::test_implement_tiny_surfaces_local_high_risk_overlay tests/test_workspace_implement_cli.py::test_implement_tiny_surfaces_ordinary_local_overlay_without_high_risk -q --tb=short`
- `uv run pytest tests/test_workspace_proof_cli.py -q`
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --format json`
- `make maintainer-surfaces`
- `make test-workspace`
- `make lint-workspace`
- `make typecheck`
- `make schema-reference-docs`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run ruff check src/agentic_workspace/workspace_runtime_proof.py tests/test_workspace_proof_cli.py`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `make absolute-paths`
- `git diff --check`