### PR TITLE
Reconcile proof receipts and closeout routing

### DIFF
--- a/.agentic-workspace/planning/execplans/open-issues-stacked-lanes.plan.json
+++ b/.agentic-workspace/planning/execplans/open-issues-stacked-lanes.plan.json
@@ -30,7 +30,7 @@
     "hard_constraints": "Start from merged master. Create stacked PRs, one coherent lane at a time, without merging them. Preserve AW mandatory workflow gates. Put the computer to sleep only after local proof, pushed PRs, and final status checks are complete.",
     "agent_may_decide": "Exact lane grouping, branch names, implementation details, test boundaries, and whether a lane can close multiple related issues.",
     "escalate_when": "An issue cannot be closed without redesign beyond the intended lane, destructive system action before PR publication, unavailable GitHub auth, or proof failures that cannot be fixed locally.",
-    "next_action": "Implement lane 1 (#1888 payload upgrade idempotence) on a branch from master, then stack subsequent branches for proof/closeout, startup/output routing, and PR comment attention.",
+    "next_action": "Publish lane 2 (#1885/#1887 proof and closeout route), then implement lane 3 (#1883/#1884 startup/output routing) stacked on lane 2.",
     "proof_expectations": [
       "Focused regression tests for each issue lane.",
       "AW implement proof selection after each lane's changed paths are known.",
@@ -75,7 +75,7 @@
     "execution": {
       "milestone": "open-issues-stacked-lanes",
       "status": "active",
-      "next_step": "Implement and publish lane 1 (#1888) from master, then stack later lanes.",
+      "next_step": "Publish lane 2 (#1885/#1887) stacked on lane 1, then implement lane 3 (#1883/#1884).",
       "proof": "Focused regression, AW implement proof selection, workspace lint/typecheck, and PR checks."
     },
     "scope": {
@@ -162,7 +162,7 @@
     "optional_deps": "none"
   },
   "immediate_next_action": [
-    "Implement lane 1 (#1888 payload upgrade idempotence) from current master."
+    "Publish lane 2 (#1885/#1887 proof receipts/templates and mandatory closeout route), then continue to lane 3."
   ],
   "blockers": [
     "None."
@@ -204,15 +204,15 @@
     "All PRs remain unmerged, final checks/status are reported, and the computer is put to sleep."
   ],
   "execution_run": {
-    "run status": "not-run-yet",
-    "executor": "",
+    "run status": "in-progress",
+    "executor": "Codex",
     "handoff source": "agentic-planning new-plan",
-    "what happened": "execution has not started",
-    "scope touched": "none yet",
-    "changed surfaces": "none yet; execution has not changed files",
-    "validations run": "pending",
-    "result for continuation": "continue from this scaffolded execplan",
-    "next step": "Fill in execution bounds, touched paths, and validation before implementation starts."
+    "what happened": "Lane 1 (#1888) was published as draft PR #1894. Lane 2 (#1885/#1887) now reconciles proof receipts, labels placeholder proof commands as templates, and exposes the mandatory closeout report route in ordinary startup guidance.",
+    "scope touched": "Lane 2 runtime proof/startup surfaces and focused workspace CLI/proof tests.",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_primitives.py; src/agentic_workspace/workspace_runtime_proof.py; src/agentic_workspace/workspace_runtime_startup.py; tests/test_workspace_cli.py; tests/test_workspace_proof_cli.py",
+    "validations run": "make test-workspace; make lint-workspace; uv run pytest tests/test_workspace_cli.py -q; make typecheck; uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json; git diff --check",
+    "result for continuation": "lane 2 ready to commit/push as the second stacked PR",
+    "next step": "Create lane 2 PR against codex/open-issues-lane1-upgrade-idempotence, then branch lane 3 from lane 2."
   },
   "finished_run_review": {
     "review status": "pending",
@@ -233,9 +233,9 @@
     "decomposition adjustment": "pending"
   },
   "proof_report": {
-    "validation proof": "pending",
-    "proof achieved now": "pending",
-    "evidence for \"proof achieved\" state": ""
+    "validation proof": "Lane 2 passed make test-workspace, make lint-workspace, focused tests/test_workspace_cli.py, make typecheck, runtime mirror consistency, and git diff --check.",
+    "proof achieved now": "yes for lane 2 local proof",
+    "evidence for \"proof achieved\" state": ".agentic-workspace/local/proof-receipts/last.json records the lane 2 proof receipt."
   },
   "intent_satisfaction": {
     "original intent": "Create a bounded plan for Implement current open issues by stacked PR lane.",
@@ -244,12 +244,12 @@
     "unsolved intent passed to": "none yet"
   },
   "execution_summary": {
-    "outcome delivered": "not completed yet",
-    "validation confirmed": "pending",
+    "outcome delivered": "lane 1 published; lane 2 implemented and locally proven",
+    "validation confirmed": "lane 2 local proof passed",
     "follow-on routed to": "none yet",
     "post-work posterity capture": "pending",
     "knowledge promoted (Memory/Docs/Config)": "none",
-    "resume from": "current milestone"
+    "resume from": "publish lane 2, then implement lane 3"
   },
   "durable_residue": {
     "status": "none",
@@ -309,6 +309,7 @@
     }
   },
   "drift_log": [
-    "2026-06-29: Scaffolded by agentic-planning new-plan."
+    "2026-06-29: Scaffolded by agentic-planning new-plan.",
+    "2026-06-29: Lane 1 (#1888) published as draft PR #1894; lane 2 (#1885/#1887) implemented with local proof passing."
   ]
 }

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -20789,6 +20789,7 @@ def _startup_closeout_report_route(closeout_inspection: dict[str, Any]) -> dict[
     closeout_report_command = detail_command.replace("--section closeout_trust", "--section closeout_report")
     if not closeout_report_command or closeout_report_command == detail_command:
         closeout_report_command = "agentic-workspace report --target ./repo --section closeout_report --format json"
+    closeout_trust_command = detail_command or closeout_report_command.replace("--section closeout_report", "--section closeout_trust")
     return {
         "kind": "agentic-workspace/closeout-report-route/v1",
         "status": "available",
@@ -20797,6 +20798,18 @@ def _startup_closeout_report_route(closeout_inspection: dict[str, Any]) -> dict[
         "escalation_source": "closeout_trust_inspection" if closeout_inspection.get("status") == "required" else "startup-route",
         "next_command": closeout_report_command,
         "selector": "closeout_report",
+        "ordinary_route": {
+            "status": "mandatory-before-completion-claim",
+            "first_inspection": closeout_trust_command,
+            "closeout_report": closeout_report_command,
+            "applies_to": ["implementation closeout", "read-only GitHub status", "repo-maintenance completion"],
+            "rule": "Run the closeout route and reconcile its result before claiming completion; startup/proof commands do not close work by themselves.",
+        },
+        "top_level_closeout_command": {
+            "status": "not-available",
+            "substitute_command": closeout_report_command,
+            "why": "Agentic Workspace exposes closeout through report sections and planning closeout/archive commands rather than a generic top-level closeout command.",
+        },
     }
 
 
@@ -21248,6 +21261,14 @@ def _compact_start_proof_payload(proof: dict[str, Any]) -> dict[str, Any]:
             "status": cli_authority_review.get("status", "unknown"),
             "classifications": cli_authority_review.get("classifications", []),
             "detail_command": "agentic-workspace proof --verbose --changed <paths> --format json",
+            "detail_command_template": {
+                "kind": "agentic-workspace/command-template/v1",
+                "template": "agentic-workspace proof --verbose --changed <paths> --format json",
+                "runnable": False,
+                "placeholders": {"paths": proof.get("changed_paths", [])},
+                "instantiation_required": [] if proof.get("changed_paths") else ["paths"],
+                "rule": "Do not run templates containing angle-bracket placeholders until all placeholders are substituted.",
+            },
         }
     high_risk_overlay = proof.get("high_risk_overlay", {})
     if isinstance(high_risk_overlay, dict) and high_risk_overlay.get("status") == "active":
@@ -21262,6 +21283,14 @@ def _compact_start_proof_payload(proof: dict[str, Any]) -> dict[str, Any]:
     changed = proof.get("changed_paths", [])
     if isinstance(changed, list) and changed:
         compact["detail_command"] = "agentic-workspace proof --verbose --changed <paths> --format json"
+        compact["detail_command_template"] = {
+            "kind": "agentic-workspace/command-template/v1",
+            "template": "agentic-workspace proof --verbose --changed <paths> --format json",
+            "runnable": False,
+            "placeholders": {"paths": changed},
+            "instantiation_required": [],
+            "rule": "Do not run templates containing angle-bracket placeholders until all placeholders are substituted.",
+        }
     return compact
 
 
@@ -23309,6 +23338,24 @@ def _start_tiny_payload_fast(
             "detail_command": _command_with_cli_invoke(
                 command="agentic-workspace report --target ./repo --section closeout_trust --format json", cli_invoke=config.cli_invoke
             ),
+            "ordinary_closeout_route": {
+                "status": "mandatory-before-completion-claim",
+                "first_inspection": _command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section closeout_trust --format json",
+                    cli_invoke=config.cli_invoke,
+                ),
+                "closeout_report": _command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section closeout_report --format json",
+                    cli_invoke=config.cli_invoke,
+                ),
+                "applies_to": ["implementation closeout", "read-only GitHub status", "repo-maintenance completion"],
+                "top_level_closeout_command": "not-available",
+                "substitute_command": _command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section closeout_report --format json",
+                    cli_invoke=config.cli_invoke,
+                ),
+                "rule": "Use this route before claiming completion; if Planning is active, satisfy planning closeout/archive requirements as well.",
+            },
         },
         "memory_consult": _tiny_memory_consult_payload(config=config),
         "local_chat_checkpoint": _local_chat_checkpoint_projection(target_root=target_root, cli_invoke=config.cli_invoke),
@@ -24490,15 +24537,29 @@ def _compact_start_closeout_obligations(
     if not isinstance(required, list):
         required = []
     target_arg = _command_target_arg(target_root)
+    closeout_trust_command = _command_with_cli_invoke(
+        command=f"agentic-workspace report --target {target_arg} --section closeout_trust --format json",
+        cli_invoke=cli_invoke,
+    )
+    closeout_report_command = _command_with_cli_invoke(
+        command=f"agentic-workspace report --target {target_arg} --section closeout_report --format json",
+        cli_invoke=cli_invoke,
+    )
     return {
         "status": value.get("status", "unknown"),
         "required_before_lane_closeout_count": len(required),
         "required_before_lane_closeout_ids": [str(item.get("id", "")) for item in required if isinstance(item, dict)],
         "activation_rule": "closeout obligations apply after implementation or lane closeout, not ordinary first-contact orientation",
-        "detail_command": _command_with_cli_invoke(
-            command=f"agentic-workspace report --target {target_arg} --section closeout_trust --format json",
-            cli_invoke=cli_invoke,
-        ),
+        "detail_command": closeout_trust_command,
+        "ordinary_closeout_route": {
+            "status": "mandatory-before-completion-claim",
+            "first_inspection": closeout_trust_command,
+            "closeout_report": closeout_report_command,
+            "applies_to": ["implementation closeout", "read-only GitHub status", "repo-maintenance completion"],
+            "top_level_closeout_command": "not-available",
+            "substitute_command": closeout_report_command,
+            "rule": "Use this route before claiming completion; if Planning is active, satisfy planning closeout/archive requirements as well.",
+        },
     }
 
 
@@ -38651,8 +38712,19 @@ def _proof_execution_evidence_summary(*, declared: Any, required_commands: list[
     lower_trust_count = sum((1 for item in command_states if item["trust"] == "lower-trust"))
     return {
         "status": "complete" if command_states and lower_trust_count == 0 else "absent" if not command_states else "attention",
-        "rule": "Selected proof is not executed proof; required commands need compact evidence or an explicit waiver reason.",
+        "rule": (
+            "Selected proof is not executed proof; required commands need compact evidence, a reconciled proof receipt, "
+            "or an explicit waiver reason."
+        ),
         "state_model": list(_PROOF_EXECUTION_STATUSES),
+        "missing_evidence_diagnostics": {
+            "missing": "not run or not recorded",
+            "run": "run but not recorded as passed evidence",
+            "failed": "run and recorded as failed",
+            "unavailable": "selected command unavailable in this target",
+            "waived": "accepted only with explicit reason or evidence reference",
+            "passed": "recorded as executed evidence",
+        },
         "required_command_count": len(command_states),
         "lower_trust_required_count": lower_trust_count,
         "counts": counts,

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -35506,6 +35506,7 @@ def _tiny_required_proof_commands(answer: dict[str, Any]) -> list[str]:
 
 
 PROOF_RECEIPT_RELATIVE_PATH = Path(".agentic-workspace") / "local" / "proof-receipts" / "last.json"
+PROOF_RECEIPT_HISTORY_RELATIVE_PATH = Path(".agentic-workspace") / "local" / "proof-receipts" / "history.jsonl"
 
 
 def _proof_receipt_result_failed(result: str) -> bool:
@@ -35774,10 +35775,14 @@ def _record_proof_receipt_payload(
     if not dry_run:
         receipt_path.parent.mkdir(parents=True, exist_ok=True)
         receipt_path.write_text(json.dumps(receipt, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        history_path = target_root / PROOF_RECEIPT_HISTORY_RELATIVE_PATH
+        with history_path.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(receipt, sort_keys=True, ensure_ascii=True) + "\n")
     payload = {
         "kind": "agentic-workspace/proof-receipt-write/v1",
         "status": "dry-run" if dry_run else "written",
         "path": PROOF_RECEIPT_RELATIVE_PATH.as_posix(),
+        "history_path": PROOF_RECEIPT_HISTORY_RELATIVE_PATH.as_posix(),
         "receipt": receipt,
         "closeout_command": "agentic-workspace planning closeout --target . --proof-from last --format json",
     }

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -35360,6 +35360,7 @@ def _tiny_required_proof_commands(answer: dict[str, Any]) -> list[str]:
 
 
 PROOF_RECEIPT_RELATIVE_PATH = Path(".agentic-workspace") / "local" / "proof-receipts" / "last.json"
+PROOF_RECEIPT_HISTORY_RELATIVE_PATH = Path(".agentic-workspace") / "local" / "proof-receipts" / "history.jsonl"
 
 
 def _proof_receipt_result_failed(result: str) -> bool:
@@ -35628,10 +35629,14 @@ def _record_proof_receipt_payload(
     if not dry_run:
         receipt_path.parent.mkdir(parents=True, exist_ok=True)
         receipt_path.write_text(json.dumps(receipt, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        history_path = target_root / PROOF_RECEIPT_HISTORY_RELATIVE_PATH
+        with history_path.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(receipt, sort_keys=True, ensure_ascii=True) + "\n")
     payload = {
         "kind": "agentic-workspace/proof-receipt-write/v1",
         "status": "dry-run" if dry_run else "written",
         "path": PROOF_RECEIPT_RELATIVE_PATH.as_posix(),
+        "history_path": PROOF_RECEIPT_HISTORY_RELATIVE_PATH.as_posix(),
         "receipt": receipt,
         "closeout_command": "agentic-workspace planning closeout --target . --proof-from last --format json",
     }

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -20923,6 +20923,7 @@ def _startup_closeout_report_route(closeout_inspection: dict[str, Any]) -> dict[
     closeout_report_command = detail_command.replace("--section closeout_trust", "--section closeout_report")
     if not closeout_report_command or closeout_report_command == detail_command:
         closeout_report_command = "agentic-workspace report --target ./repo --section closeout_report --format json"
+    closeout_trust_command = detail_command or closeout_report_command.replace("--section closeout_report", "--section closeout_trust")
     return {
         "kind": "agentic-workspace/closeout-report-route/v1",
         "status": "available",
@@ -20931,6 +20932,18 @@ def _startup_closeout_report_route(closeout_inspection: dict[str, Any]) -> dict[
         "escalation_source": "closeout_trust_inspection" if closeout_inspection.get("status") == "required" else "startup-route",
         "next_command": closeout_report_command,
         "selector": "closeout_report",
+        "ordinary_route": {
+            "status": "mandatory-before-completion-claim",
+            "first_inspection": closeout_trust_command,
+            "closeout_report": closeout_report_command,
+            "applies_to": ["implementation closeout", "read-only GitHub status", "repo-maintenance completion"],
+            "rule": "Run the closeout route and reconcile its result before claiming completion; startup/proof commands do not close work by themselves.",
+        },
+        "top_level_closeout_command": {
+            "status": "not-available",
+            "substitute_command": closeout_report_command,
+            "why": "Agentic Workspace exposes closeout through report sections and planning closeout/archive commands rather than a generic top-level closeout command.",
+        },
     }
 
 
@@ -21382,6 +21395,14 @@ def _compact_start_proof_payload(proof: dict[str, Any]) -> dict[str, Any]:
             "status": cli_authority_review.get("status", "unknown"),
             "classifications": cli_authority_review.get("classifications", []),
             "detail_command": "agentic-workspace proof --verbose --changed <paths> --format json",
+            "detail_command_template": {
+                "kind": "agentic-workspace/command-template/v1",
+                "template": "agentic-workspace proof --verbose --changed <paths> --format json",
+                "runnable": False,
+                "placeholders": {"paths": proof.get("changed_paths", [])},
+                "instantiation_required": [] if proof.get("changed_paths") else ["paths"],
+                "rule": "Do not run templates containing angle-bracket placeholders until all placeholders are substituted.",
+            },
         }
     runtime_symbol_working_set = proof.get("runtime_symbol_working_set", {})
     if isinstance(runtime_symbol_working_set, dict) and runtime_symbol_working_set.get("status") == "present":
@@ -21389,6 +21410,14 @@ def _compact_start_proof_payload(proof: dict[str, Any]) -> dict[str, Any]:
     changed = proof.get("changed_paths", [])
     if isinstance(changed, list) and changed:
         compact["detail_command"] = "agentic-workspace proof --verbose --changed <paths> --format json"
+        compact["detail_command_template"] = {
+            "kind": "agentic-workspace/command-template/v1",
+            "template": "agentic-workspace proof --verbose --changed <paths> --format json",
+            "runnable": False,
+            "placeholders": {"paths": changed},
+            "instantiation_required": [],
+            "rule": "Do not run templates containing angle-bracket placeholders until all placeholders are substituted.",
+        }
     return compact
 
 
@@ -23433,6 +23462,24 @@ def _start_tiny_payload_fast(
             "detail_command": _command_with_cli_invoke(
                 command="agentic-workspace report --target ./repo --section closeout_trust --format json", cli_invoke=config.cli_invoke
             ),
+            "ordinary_closeout_route": {
+                "status": "mandatory-before-completion-claim",
+                "first_inspection": _command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section closeout_trust --format json",
+                    cli_invoke=config.cli_invoke,
+                ),
+                "closeout_report": _command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section closeout_report --format json",
+                    cli_invoke=config.cli_invoke,
+                ),
+                "applies_to": ["implementation closeout", "read-only GitHub status", "repo-maintenance completion"],
+                "top_level_closeout_command": "not-available",
+                "substitute_command": _command_with_cli_invoke(
+                    command="agentic-workspace report --target ./repo --section closeout_report --format json",
+                    cli_invoke=config.cli_invoke,
+                ),
+                "rule": "Use this route before claiming completion; if Planning is active, satisfy planning closeout/archive requirements as well.",
+            },
         },
         "memory_consult": _tiny_memory_consult_payload(config=config),
         "local_chat_checkpoint": _local_chat_checkpoint_projection(target_root=target_root, cli_invoke=config.cli_invoke),
@@ -24597,15 +24644,29 @@ def _compact_start_closeout_obligations(
     if not isinstance(required, list):
         required = []
     target_arg = _command_target_arg(target_root)
+    closeout_trust_command = _command_with_cli_invoke(
+        command=f"agentic-workspace report --target {target_arg} --section closeout_trust --format json",
+        cli_invoke=cli_invoke,
+    )
+    closeout_report_command = _command_with_cli_invoke(
+        command=f"agentic-workspace report --target {target_arg} --section closeout_report --format json",
+        cli_invoke=cli_invoke,
+    )
     return {
         "status": value.get("status", "unknown"),
         "required_before_lane_closeout_count": len(required),
         "required_before_lane_closeout_ids": [str(item.get("id", "")) for item in required if isinstance(item, dict)],
         "activation_rule": "closeout obligations apply after implementation or lane closeout, not ordinary first-contact orientation",
-        "detail_command": _command_with_cli_invoke(
-            command=f"agentic-workspace report --target {target_arg} --section closeout_trust --format json",
-            cli_invoke=cli_invoke,
-        ),
+        "detail_command": closeout_trust_command,
+        "ordinary_closeout_route": {
+            "status": "mandatory-before-completion-claim",
+            "first_inspection": closeout_trust_command,
+            "closeout_report": closeout_report_command,
+            "applies_to": ["implementation closeout", "read-only GitHub status", "repo-maintenance completion"],
+            "top_level_closeout_command": "not-available",
+            "substitute_command": closeout_report_command,
+            "rule": "Use this route before claiming completion; if Planning is active, satisfy planning closeout/archive requirements as well.",
+        },
     }
 
 
@@ -38435,8 +38496,19 @@ def _proof_execution_evidence_summary(*, declared: Any, required_commands: list[
     lower_trust_count = sum((1 for item in command_states if item["trust"] == "lower-trust"))
     return {
         "status": "complete" if command_states and lower_trust_count == 0 else "absent" if not command_states else "attention",
-        "rule": "Selected proof is not executed proof; required commands need compact evidence or an explicit waiver reason.",
+        "rule": (
+            "Selected proof is not executed proof; required commands need compact evidence, a reconciled proof receipt, "
+            "or an explicit waiver reason."
+        ),
         "state_model": list(_PROOF_EXECUTION_STATUSES),
+        "missing_evidence_diagnostics": {
+            "missing": "not run or not recorded",
+            "run": "run but not recorded as passed evidence",
+            "failed": "run and recorded as failed",
+            "unavailable": "selected command unavailable in this target",
+            "waived": "accepted only with explicit reason or evidence reference",
+            "passed": "recorded as executed evidence",
+        },
         "required_command_count": len(command_states),
         "lower_trust_required_count": lower_trust_count,
         "counts": counts,

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -29,6 +29,7 @@ from agentic_workspace.runtime_symbol_working_set import runtime_symbol_working_
 from agentic_workspace.workspace_runtime_core import (
     _PROOF_EXECUTION_STATUSES,
     _PROOF_SELECTION_RULES,
+    PROOF_RECEIPT_RELATIVE_PATH,
     _active_planning_assurance_for_proof,
     _adapt_make_proof_command_for_target,
     _applicable_intent_status_payload,
@@ -218,6 +219,17 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
                     "kind": answer.get("proof_strategy", {}).get("kind"),
                     "selection_order": answer.get("proof_strategy", {}).get("selection_order", []),
                 }
+            next_decision["detail_command_template"] = _command_template_payload(
+                command=next_decision.get(
+                    "detail_command",
+                    _command_with_cli_invoke(
+                        command="agentic-workspace proof --verbose --changed <paths> --format json",
+                        cli_invoke=cli_invoke,
+                    ),
+                ),
+                placeholders={"paths": _list_payload(payload.get("selector", {}).get("changed"))},
+                purpose="verbose proof drill-down after substituting the actual changed paths",
+            )
             if include_intent_proof:
                 next_decision["intent_proof"] = _compact_tiny_intent_proof(answer["intent_proof"])
             local_overlay = _compact_tiny_local_overlay(answer.get("local_overlay"))
@@ -304,6 +316,14 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
             "detail_command": _command_with_cli_invoke(
                 command="agentic-workspace proof --verbose --changed <paths> --format json", cli_invoke=cli_invoke
             ),
+            "detail_command_template": _command_template_payload(
+                command=_command_with_cli_invoke(
+                    command="agentic-workspace proof --verbose --changed <paths> --format json",
+                    cli_invoke=cli_invoke,
+                ),
+                placeholders={"paths": _list_payload(payload.get("selector", {}).get("changed"))},
+                purpose="verbose proof drill-down after substituting the actual changed paths",
+            ),
         }
         return _guidance_with_cli_invoke(value=next_payload, cli_invoke=cli_invoke)
     return {
@@ -312,13 +332,146 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
         "selector": {},
         "next": {
             "action": "select-proof-scope",
-            "command": _command_with_cli_invoke(command="agentic-workspace proof --changed <paths> --format json", cli_invoke=cli_invoke),
+            "command": None,
             "run": None,
             "required": False,
         },
+        "command_template": _command_template_payload(
+            command=_command_with_cli_invoke(command="agentic-workspace proof --changed <paths> --format json", cli_invoke=cli_invoke),
+            placeholders={"paths": []},
+            purpose="proof selection after changed paths are known",
+        ),
         "required_commands": [],
         "warnings": [],
         "detail_command": _command_with_cli_invoke(command="agentic-workspace proof --verbose --format json", cli_invoke=cli_invoke),
+    }
+
+
+def _command_template_payload(*, command: Any, placeholders: dict[str, Any], purpose: str) -> dict[str, Any]:
+    template = str(command or "").strip()
+    return {
+        "kind": "agentic-workspace/command-template/v1",
+        "template": template,
+        "runnable": False,
+        "placeholders": placeholders,
+        "instantiation_required": [name for name, value in placeholders.items() if value in (None, "", [])],
+        "purpose": purpose,
+        "rule": "Substitute placeholders before running.",
+    }
+
+
+def _proof_receipt_passed(result: Any) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "-", str(result or "").strip().lower()).strip("-")
+    return normalized in {"pass", "passed", "success", "succeeded", "ok", "green"}
+
+
+def _proof_receipt_failed(result: Any) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "-", str(result or "").strip().lower()).strip("-")
+    if normalized in {"fail", "failed", "failure", "error", "errored", "timeout", "timed-out", "cancelled", "canceled"}:
+        return True
+    return bool(set(normalized.split("-")) & {"fail", "failed", "failure", "error", "errored", "timeout", "cancelled", "canceled"})
+
+
+def _proof_receipt_reconciliation_payload(
+    *, target_root: Path | None, required_commands: list[str], changed_paths: list[str]
+) -> dict[str, Any]:
+    command_states: list[dict[str, Any]] = []
+    base = {
+        "kind": "agentic-workspace/proof-receipt-reconciliation/v1",
+        "receipt_path": PROOF_RECEIPT_RELATIVE_PATH.as_posix(),
+        "required_command_count": len(required_commands),
+        "rule": (
+            "Receipts are accepted only for exact command matches, compatible changed-path scope, and passed results; "
+            "proof selection alone is never treated as execution evidence."
+        ),
+    }
+    if target_root is None:
+        return {
+            **base,
+            "status": "unavailable",
+            "reason": "target root unavailable",
+            "commands": [
+                {"command": command, "evidence_state": "not-run-or-not-recorded", "diagnostic": "not run or not recorded"}
+                for command in required_commands
+            ],
+        }
+    receipt_path = target_root / PROOF_RECEIPT_RELATIVE_PATH
+    if not receipt_path.is_file():
+        return {
+            **base,
+            "status": "not-recorded",
+            "commands": [
+                {"command": command, "evidence_state": "not-run-or-not-recorded", "diagnostic": "not run or not recorded"}
+                for command in required_commands
+            ],
+        }
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            **base,
+            "status": "untrusted-record",
+            "reason": f"latest receipt could not be read as JSON: {exc}",
+            "commands": [
+                {"command": command, "evidence_state": "record-stale-untrusted", "diagnostic": "record unreadable or untrusted"}
+                for command in required_commands
+            ],
+        }
+    if not isinstance(receipt, dict):
+        receipt = {}
+    receipt_command = str(receipt.get("command") or "").strip()
+    receipt_result = str(receipt.get("result") or "").strip()
+    receipt_paths = _list_payload(receipt.get("changed_paths"))
+    normalized_receipt_paths = [str(path).strip() for path in receipt_paths if str(path).strip()]
+    normalized_changed_paths = [str(path).strip() for path in changed_paths if str(path).strip()]
+    path_scope_matches = set(normalized_changed_paths).issubset(set(normalized_receipt_paths)) if normalized_changed_paths else True
+    for command in required_commands:
+        state: dict[str, Any]
+        if command != receipt_command:
+            state = {
+                "command": command,
+                "evidence_state": "run-but-not-recorded" if receipt_command else "not-run-or-not-recorded",
+                "diagnostic": "run but not recorded for this selected command" if receipt_command else "not run or not recorded",
+            }
+        elif not path_scope_matches:
+            state = {
+                "command": command,
+                "evidence_state": "record-stale-untrusted",
+                "diagnostic": "record stale or untrusted for this changed-path scope",
+            }
+        elif _proof_receipt_passed(receipt_result):
+            state = {
+                "command": command,
+                "evidence_state": "accepted",
+                "diagnostic": "passed receipt accepted",
+            }
+        elif _proof_receipt_failed(receipt_result):
+            state = {
+                "command": command,
+                "evidence_state": "recorded-failed",
+                "diagnostic": "run and recorded as failed",
+            }
+        else:
+            state = {
+                "command": command,
+                "evidence_state": "record-stale-untrusted",
+                "diagnostic": "receipt result is not a recognized pass/fail state",
+            }
+        state["required"] = True
+        command_states.append(state)
+    accepted_count = sum(1 for state in command_states if state.get("evidence_state") == "accepted")
+    return {
+        **base,
+        "status": "accepted" if command_states and accepted_count == len(command_states) else "attention",
+        "accepted_count": accepted_count,
+        "receipt": {
+            "command": receipt_command,
+            "result": receipt_result,
+            "changed_paths": normalized_receipt_paths,
+            "recorded_at": receipt.get("recorded_at", ""),
+            "plan_id": receipt.get("plan_id", ""),
+        },
+        "commands": command_states,
     }
 
 
@@ -2612,13 +2765,29 @@ def _proof_selection_for_changed_paths(
             "candidate_commands": target_capabilities.get("candidate_commands", []),
             "unavailable_commands": unavailable_commands,
         }
+    proof_receipt_reconciliation = _proof_receipt_reconciliation_payload(
+        target_root=target_root,
+        required_commands=required_commands,
+        changed_paths=changed_paths,
+    )
     proof_execution_evidence = {
         "kind": "proof-execution-evidence/v1",
-        "status": "not-run",
+        "status": "recorded-and-accepted" if proof_receipt_reconciliation.get("status") == "accepted" else "not-run-or-not-recorded",
         "state_model": list(_PROOF_EXECUTION_STATUSES),
         "expected_commands": required_commands,
         "manual_verification_expected": manual_verification is not None,
-        "rule": "Proof selection describes expected proof only; closeout must record what actually ran, failed, was skipped, or was manually verified.",
+        "receipt_reconciliation": proof_receipt_reconciliation,
+        "missing_evidence_diagnostics": {
+            "not-run-or-not-recorded": "no trusted receipt exists for this selected command",
+            "run-but-not-recorded": "a receipt exists, but not for this selected command",
+            "record-stale-untrusted": "a receipt exists, but command/path/result trust does not match the current proof selection",
+            "recorded-failed": "the selected command was recorded as failed",
+            "accepted": "the selected command has an exact matching passed receipt",
+        },
+        "rule": (
+            "Proof selection describes expected proof only; closeout must record what actually ran, failed, was skipped, "
+            "or was manually verified. Latest receipts are reconciled but do not bypass intent or closeout review."
+        ),
     }
     configured_policy = [
         {
@@ -2867,6 +3036,7 @@ def _proof_selection_for_changed_paths(
         "unavailable_commands": unavailable_commands,
         "host_policy_blocked_commands": host_policy_blocked_commands,
         "proof_execution_evidence": proof_execution_evidence,
+        "proof_receipt_reconciliation": proof_receipt_reconciliation,
         "proof_decision": proof_decision,
         "high_assurance_closeout_posture": high_assurance_closeout_posture,
         "intent_proof": intent_proof,

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -29,6 +29,7 @@ from agentic_workspace.runtime_symbol_working_set import runtime_symbol_working_
 from agentic_workspace.workspace_runtime_core import (
     _PROOF_EXECUTION_STATUSES,
     _PROOF_SELECTION_RULES,
+    PROOF_RECEIPT_HISTORY_RELATIVE_PATH,
     PROOF_RECEIPT_RELATIVE_PATH,
     _active_planning_assurance_for_proof,
     _adapt_make_proof_command_for_target,
@@ -372,6 +373,73 @@ def _proof_receipt_failed(result: Any) -> bool:
     return bool(set(normalized.split("-")) & {"fail", "failed", "failure", "error", "errored", "timeout", "cancelled", "canceled"})
 
 
+def _proof_receipt_summary(receipt: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "command": str(receipt.get("command") or "").strip(),
+        "result": str(receipt.get("result") or "").strip(),
+        "changed_paths": [str(path).strip() for path in _list_payload(receipt.get("changed_paths")) if str(path).strip()],
+        "recorded_at": receipt.get("recorded_at", ""),
+        "plan_id": receipt.get("plan_id", ""),
+    }
+
+
+def _proof_receipt_identity(receipt: dict[str, Any]) -> str:
+    return json.dumps(_proof_receipt_summary(receipt), sort_keys=True, ensure_ascii=True)
+
+
+def _read_proof_receipt_records(target_root: Path) -> tuple[list[dict[str, Any]] | None, dict[str, Any], str]:
+    receipt_path = target_root / PROOF_RECEIPT_RELATIVE_PATH
+    history_path = target_root / PROOF_RECEIPT_HISTORY_RELATIVE_PATH
+    records: list[dict[str, Any]] = []
+    latest_receipt: dict[str, Any] = {}
+    seen: set[str] = set()
+
+    def add_record(receipt: Any) -> None:
+        if not isinstance(receipt, dict):
+            return
+        identity = _proof_receipt_identity(receipt)
+        if identity in seen:
+            return
+        seen.add(identity)
+        records.append(receipt)
+
+    if receipt_path.is_file():
+        try:
+            loaded = json.loads(receipt_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return None, {}, f"latest receipt could not be read as JSON: {exc}"
+        if isinstance(loaded, dict):
+            latest_receipt = loaded
+            add_record(loaded)
+        else:
+            return None, {}, "latest receipt is not a JSON object"
+
+    if history_path.is_file():
+        try:
+            lines = history_path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            return None, latest_receipt, f"receipt history could not be read: {exc}"
+        for index, line in enumerate(lines, start=1):
+            if not line.strip():
+                continue
+            try:
+                loaded = json.loads(line)
+            except json.JSONDecodeError as exc:
+                return None, latest_receipt, f"receipt history line {index} could not be read as JSON: {exc}"
+            if not isinstance(loaded, dict):
+                return None, latest_receipt, f"receipt history line {index} is not a JSON object"
+            add_record(loaded)
+
+    records.sort(key=lambda item: str(item.get("recorded_at") or ""), reverse=True)
+    return records, latest_receipt, ""
+
+
+def _proof_receipt_path_scope_matches(*, receipt: dict[str, Any], changed_paths: list[str]) -> bool:
+    receipt_paths = [str(path).strip() for path in _list_payload(receipt.get("changed_paths")) if str(path).strip()]
+    normalized_changed_paths = [str(path).strip() for path in changed_paths if str(path).strip()]
+    return set(normalized_changed_paths).issubset(set(receipt_paths)) if normalized_changed_paths else True
+
+
 def _proof_receipt_reconciliation_payload(
     *, target_root: Path | None, required_commands: list[str], changed_paths: list[str]
 ) -> dict[str, Any]:
@@ -379,10 +447,12 @@ def _proof_receipt_reconciliation_payload(
     base = {
         "kind": "agentic-workspace/proof-receipt-reconciliation/v1",
         "receipt_path": PROOF_RECEIPT_RELATIVE_PATH.as_posix(),
+        "receipt_history_path": PROOF_RECEIPT_HISTORY_RELATIVE_PATH.as_posix(),
         "required_command_count": len(required_commands),
         "rule": (
             "Receipts are accepted only for exact command matches, compatible changed-path scope, and passed results; "
-            "proof selection alone is never treated as execution evidence."
+            "proof selection alone is never treated as execution evidence. Receipt history may satisfy multiple selected "
+            "commands for the current changed-path boundary without forcing duplicate validation runs."
         ),
     }
     if target_root is None:
@@ -395,8 +465,18 @@ def _proof_receipt_reconciliation_payload(
                 for command in required_commands
             ],
         }
-    receipt_path = target_root / PROOF_RECEIPT_RELATIVE_PATH
-    if not receipt_path.is_file():
+    receipt_records, latest_receipt, read_error = _read_proof_receipt_records(target_root)
+    if receipt_records is None:
+        return {
+            **base,
+            "status": "untrusted-record",
+            "reason": read_error,
+            "commands": [
+                {"command": command, "evidence_state": "record-stale-untrusted", "diagnostic": "record unreadable or untrusted"}
+                for command in required_commands
+            ],
+        }
+    if not receipt_records:
         return {
             **base,
             "status": "not-recorded",
@@ -405,57 +485,51 @@ def _proof_receipt_reconciliation_payload(
                 for command in required_commands
             ],
         }
-    try:
-        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        return {
-            **base,
-            "status": "untrusted-record",
-            "reason": f"latest receipt could not be read as JSON: {exc}",
-            "commands": [
-                {"command": command, "evidence_state": "record-stale-untrusted", "diagnostic": "record unreadable or untrusted"}
-                for command in required_commands
-            ],
-        }
-    if not isinstance(receipt, dict):
-        receipt = {}
-    receipt_command = str(receipt.get("command") or "").strip()
-    receipt_result = str(receipt.get("result") or "").strip()
-    receipt_paths = _list_payload(receipt.get("changed_paths"))
-    normalized_receipt_paths = [str(path).strip() for path in receipt_paths if str(path).strip()]
-    normalized_changed_paths = [str(path).strip() for path in changed_paths if str(path).strip()]
-    path_scope_matches = set(normalized_changed_paths).issubset(set(normalized_receipt_paths)) if normalized_changed_paths else True
     for command in required_commands:
         state: dict[str, Any]
-        if command != receipt_command:
+        command_receipts = [receipt for receipt in receipt_records if str(receipt.get("command") or "").strip() == command]
+        scoped_receipts = [
+            receipt for receipt in command_receipts if _proof_receipt_path_scope_matches(receipt=receipt, changed_paths=changed_paths)
+        ]
+        accepted_receipt = next(
+            (receipt for receipt in scoped_receipts if _proof_receipt_passed(str(receipt.get("result") or ""))),
+            None,
+        )
+        failed_receipt = next(
+            (receipt for receipt in scoped_receipts if _proof_receipt_failed(str(receipt.get("result") or ""))),
+            None,
+        )
+        if accepted_receipt is not None:
             state = {
                 "command": command,
-                "evidence_state": "run-but-not-recorded" if receipt_command else "not-run-or-not-recorded",
-                "diagnostic": "run but not recorded for this selected command" if receipt_command else "not run or not recorded",
+                "evidence_state": "accepted",
+                "diagnostic": "passed receipt accepted",
+                "receipt": _proof_receipt_summary(accepted_receipt),
             }
-        elif not path_scope_matches:
+        elif failed_receipt is not None:
+            state = {
+                "command": command,
+                "evidence_state": "recorded-failed",
+                "diagnostic": "run and recorded as failed",
+                "receipt": _proof_receipt_summary(failed_receipt),
+            }
+        elif command_receipts and not scoped_receipts:
             state = {
                 "command": command,
                 "evidence_state": "record-stale-untrusted",
                 "diagnostic": "record stale or untrusted for this changed-path scope",
             }
-        elif _proof_receipt_passed(receipt_result):
-            state = {
-                "command": command,
-                "evidence_state": "accepted",
-                "diagnostic": "passed receipt accepted",
-            }
-        elif _proof_receipt_failed(receipt_result):
-            state = {
-                "command": command,
-                "evidence_state": "recorded-failed",
-                "diagnostic": "run and recorded as failed",
-            }
-        else:
+        elif command_receipts:
             state = {
                 "command": command,
                 "evidence_state": "record-stale-untrusted",
                 "diagnostic": "receipt result is not a recognized pass/fail state",
+            }
+        else:
+            state = {
+                "command": command,
+                "evidence_state": "run-but-not-recorded",
+                "diagnostic": "run but not recorded for this selected command",
             }
         state["required"] = True
         command_states.append(state)
@@ -464,12 +538,12 @@ def _proof_receipt_reconciliation_payload(
         **base,
         "status": "accepted" if command_states and accepted_count == len(command_states) else "attention",
         "accepted_count": accepted_count,
-        "receipt": {
-            "command": receipt_command,
-            "result": receipt_result,
-            "changed_paths": normalized_receipt_paths,
-            "recorded_at": receipt.get("recorded_at", ""),
-            "plan_id": receipt.get("plan_id", ""),
+        "receipt": _proof_receipt_summary(latest_receipt),
+        "receipt_history": {
+            "path": PROOF_RECEIPT_HISTORY_RELATIVE_PATH.as_posix(),
+            "record_count": len(receipt_records),
+            "accepted_record_count": accepted_count,
+            "rule": "Each selected command may be reconciled against any trusted receipt in the current proof boundary.",
         },
         "commands": command_states,
     }

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -223,6 +223,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "detail_command": payload.get("closeout_obligations", {}).get(
                 "detail_command", "agentic-workspace report --target ./repo --section closeout_trust --format json"
             ),
+            "ordinary_closeout_route": payload.get("closeout_obligations", {}).get("ordinary_closeout_route", {}),
         },
         "memory_consult": {
             "status": payload.get("memory_consult", {}).get("status", "unknown"),
@@ -1188,6 +1189,39 @@ def _hydrate_selected_start_advisory_payloads(
         )
 
 
+def _selector_first_closeout_obligations(payload: dict[str, Any]) -> dict[str, Any]:
+    obligations = payload.get("closeout_obligations", {})
+    if not isinstance(obligations, dict):
+        return {}
+    task_intent = _as_dict(payload.get("task_intent"))
+    requested_text = " ".join(
+        [
+            *(str(item) for item in _list_payload(task_intent.get("requested_outcomes"))),
+            str(task_intent.get("implement_changed_command") or ""),
+        ]
+    ).lower()
+    route_relevant = bool(payload.get("closeout_report_route")) or any(
+        marker in requested_text
+        for marker in ("planned", "plan", "lane", "release", "status", "complete", "completion", "closeout", "merge", "issue", "pr")
+    )
+    if not route_relevant:
+        return {}
+    compact = {
+        key: obligations.get(key)
+        for key in ("status", "activation_rule", "detail_command")
+        if key in obligations and obligations.get(key) not in (None, "", [], {})
+    }
+    raw_route = _as_dict(obligations.get("ordinary_closeout_route"))
+    route = {
+        key: raw_route.get(key)
+        for key in ("status", "first_inspection", "substitute_command", "top_level_closeout_command")
+        if raw_route.get(key) not in (None, "", [], {})
+    }
+    if route:
+        compact["ordinary_closeout_route"] = route
+    return compact
+
+
 def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, target_root: Path | None = None) -> dict[str, Any]:
     skill_routing = payload.get("skill_routing", {}) if isinstance(payload.get("skill_routing"), dict) else {}
     read_only_response = payload.get("read_only_response", {})
@@ -1226,6 +1260,9 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         },
         "memory": payload.get("memory_consult", {}),
     }
+    compact_closeout_obligations = _selector_first_closeout_obligations(payload)
+    if compact_closeout_obligations:
+        context["closeout_obligations"] = compact_closeout_obligations
     local_checkpoint = payload.get("local_chat_checkpoint", {})
     if isinstance(local_checkpoint, dict) and _local_chat_checkpoint_default_visible(local_checkpoint, payload=payload):
         context["local_chat_checkpoint"] = {

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1028,6 +1028,11 @@ def test_start_keeps_planned_and_release_closeout_signals_visible(tmp_path: Path
     planned = json.loads(capsys.readouterr().out)
     assert planned["context"]["dogfooding_signal_status"]["status"] == "not_checked"
     assert "dogfooding_signal_status=not_checked" in planned["action_signals"]["changed_signals"]
+    ordinary_route = planned["context"]["closeout_obligations"]["ordinary_closeout_route"]
+    assert ordinary_route["status"] == "mandatory-before-completion-claim"
+    assert "--section closeout_trust" in ordinary_route["first_inspection"]
+    assert "--section closeout_report" in ordinary_route["substitute_command"]
+    assert ordinary_route["top_level_closeout_command"] == "not-available"
 
     assert (
         cli.main(
@@ -1046,6 +1051,9 @@ def test_start_keeps_planned_and_release_closeout_signals_visible(tmp_path: Path
     release = json.loads(capsys.readouterr().out)
     assert release["context"]["dogfooding_signal_status"]["status"] == "not_checked"
     assert "dogfooding_signal_status" in release["action_signals"]["advisory_detail"]["selectors"]
+    release_route = release["context"]["closeout_obligations"]["ordinary_closeout_route"]
+    assert release_route["status"] == "mandatory-before-completion-claim"
+    assert release_route["top_level_closeout_command"] == "not-available"
 
 
 def test_start_surfaces_unresolved_dogfooding_signal_outcome(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -2083,13 +2083,17 @@ def test_proof_record_receipt_writes_latest_execution_evidence(tmp_path: Path, c
 
     payload = json.loads(capsys.readouterr().out)
     receipt_path = target / ".agentic-workspace" / "local" / "proof-receipts" / "last.json"
+    history_path = target / ".agentic-workspace" / "local" / "proof-receipts" / "history.jsonl"
     receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    history = [json.loads(line) for line in history_path.read_text(encoding="utf-8").splitlines()]
     assert payload["status"] == "written"
     assert payload["path"] == ".agentic-workspace/local/proof-receipts/last.json"
+    assert payload["history_path"] == ".agentic-workspace/local/proof-receipts/history.jsonl"
     assert receipt["command"] == "uv run pytest tests/test_workspace_proof_cli.py -q"
     assert receipt["result"] == "passed"
     assert receipt["changed_paths"] == ["tests/test_workspace_proof_cli.py"]
     assert receipt["plan_id"] == "plan-alpha"
+    assert history == [receipt]
     assert "repair_retry_ladder" not in receipt
     assert "repair_retry_ladder" not in payload
 
@@ -2241,7 +2245,7 @@ def test_proof_failed_receipt_marks_excerpt_failure_summary_lower_trust(tmp_path
     }
 
 
-def test_proof_changed_reconciles_latest_passed_receipt_without_closing_claim(tmp_path: Path, capsys) -> None:
+def test_proof_changed_reconciles_receipt_history_without_duplicate_runs(tmp_path: Path, capsys) -> None:
     _write_repo_local_proof_target(tmp_path)
 
     assert (
@@ -2255,6 +2259,27 @@ def test_proof_changed_reconciles_latest_passed_receipt_without_closing_claim(tm
                 "--record-receipt",
                 "--receipt-command",
                 "make test-workspace",
+                "--receipt-result",
+                "passed",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_proof.py",
+                "--record-receipt",
+                "--receipt-command",
+                "make typecheck",
                 "--receipt-result",
                 "passed",
                 "--format",
@@ -2284,11 +2309,16 @@ def test_proof_changed_reconciles_latest_passed_receipt_without_closing_claim(tm
     answer = json.loads(capsys.readouterr().out)["answer"]
     reconciliation = answer["proof_receipt_reconciliation"]
     states = {item["command"]: item for item in reconciliation["commands"]}
-    assert reconciliation["status"] == "attention"
+    assert reconciliation["status"] == "accepted"
+    assert reconciliation["accepted_count"] == 2
+    assert reconciliation["receipt"]["command"] == "make typecheck"
+    assert reconciliation["receipt_history"]["record_count"] == 2
+    assert reconciliation["receipt_history"]["accepted_record_count"] == 2
     assert states["make test-workspace"]["evidence_state"] == "accepted"
     assert states["make test-workspace"]["diagnostic"] == "passed receipt accepted"
-    assert states["make typecheck"]["evidence_state"] == "run-but-not-recorded"
-    assert answer["proof_execution_evidence"]["status"] == "not-run-or-not-recorded"
+    assert states["make typecheck"]["evidence_state"] == "accepted"
+    assert states["make typecheck"]["diagnostic"] == "passed receipt accepted"
+    assert answer["proof_execution_evidence"]["status"] == "recorded-and-accepted"
     assert "closeout review" in answer["proof_execution_evidence"]["rule"]
 
 

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -621,6 +621,7 @@ def test_proof_tiny_profile_returns_next_validation_action(capsys) -> None:
         "warnings",
         "intent_proof",
         "detail_command",
+        "detail_command_template",
         "proof_route_selection",
     }
     assert payload["selector"] == {"changed": ["generated/workspace/python/cli.py"]}
@@ -631,7 +632,9 @@ def test_proof_tiny_profile_returns_next_validation_action(capsys) -> None:
     assert "answer" not in payload
     assert "selected_lanes" not in encoded
     assert "validation_plan" not in encoded
-    assert len(encoded) < 2900
+    assert payload["detail_command_template"]["runnable"] is False
+    assert payload["detail_command_template"]["placeholders"] == {"paths": ["generated/workspace/python/cli.py"]}
+    assert len(encoded) < 3400
 
 
 def test_proof_changed_uses_available_target_makefile_targets(tmp_path: Path, capsys) -> None:
@@ -742,14 +745,16 @@ def test_proof_verbose_exposes_manual_fallback_decision_layers(tmp_path: Path, c
     assert explanation["manual_verification"]["status"] == "required"
     assert explanation["manual_verification"]["templates"][0]["intent_type"] == "behavior-test"
     assert explanation["manual_verification"]["templates"][0]["trust"] == "lower-than-executable-proof"
-    assert explanation["proof_execution_evidence"] == {
-        "kind": "proof-execution-evidence/v1",
-        "status": "not-run",
-        "state_model": ["selected", "run", "passed", "failed", "skipped", "unavailable", "waived", "missing"],
-        "expected_commands": [],
-        "manual_verification_expected": True,
-        "rule": "Proof selection describes expected proof only; closeout must record what actually ran, failed, was skipped, or was manually verified.",
-    }
+    execution_evidence = explanation["proof_execution_evidence"]
+    assert execution_evidence["kind"] == "proof-execution-evidence/v1"
+    assert execution_evidence["status"] == "not-run-or-not-recorded"
+    assert execution_evidence["state_model"] == ["selected", "run", "passed", "failed", "skipped", "unavailable", "waived", "missing"]
+    assert execution_evidence["expected_commands"] == []
+    assert execution_evidence["manual_verification_expected"] is True
+    assert execution_evidence["receipt_reconciliation"]["commands"] == []
+    assert execution_evidence["missing_evidence_diagnostics"]["not-run-or-not-recorded"] == (
+        "no trusted receipt exists for this selected command"
+    )
 
 
 def test_proof_changed_uses_target_package_json_scripts_without_makefile(tmp_path: Path, capsys) -> None:
@@ -1127,7 +1132,7 @@ def test_proof_changed_reports_live_confirmed_learned_route_hints(tmp_path: Path
         },
     }
     assert explanation["selected_commands"][0]["kind"] == "proof-command/v1"
-    assert explanation["proof_execution_evidence"]["status"] == "not-run"
+    assert explanation["proof_execution_evidence"]["status"] == "not-run-or-not-recorded"
     assert answer["proof_next_decision"]["warnings"] == ["1 learned route hint(s) are stale or unavailable."]
     maintenance = answer["proof_route_maintenance"]
     assert maintenance["status"] == "attention"
@@ -2234,6 +2239,103 @@ def test_proof_failed_receipt_marks_excerpt_failure_summary_lower_trust(tmp_path
         "source_kind": "caller-supplied-excerpt",
         "rule": "Caller-supplied excerpts are useful repair hints but lower trust than repo-local logs.",
     }
+
+
+def test_proof_changed_reconciles_latest_passed_receipt_without_closing_claim(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_proof.py",
+                "--record-receipt",
+                "--receipt-command",
+                "make test-workspace",
+                "--receipt-result",
+                "passed",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--verbose",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_proof.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    reconciliation = answer["proof_receipt_reconciliation"]
+    states = {item["command"]: item for item in reconciliation["commands"]}
+    assert reconciliation["status"] == "attention"
+    assert states["make test-workspace"]["evidence_state"] == "accepted"
+    assert states["make test-workspace"]["diagnostic"] == "passed receipt accepted"
+    assert states["make typecheck"]["evidence_state"] == "run-but-not-recorded"
+    assert answer["proof_execution_evidence"]["status"] == "not-run-or-not-recorded"
+    assert "closeout review" in answer["proof_execution_evidence"]["rule"]
+
+
+def test_proof_changed_marks_receipt_stale_for_changed_path_mismatch(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "README.md",
+                "--record-receipt",
+                "--receipt-command",
+                "make test-workspace",
+                "--receipt-result",
+                "passed",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--verbose",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_proof.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    states = {item["command"]: item for item in answer["proof_receipt_reconciliation"]["commands"]}
+    assert states["make test-workspace"]["evidence_state"] == "record-stale-untrusted"
+    assert states["make test-workspace"]["diagnostic"] == "record stale or untrusted for this changed-path scope"
 
 
 def test_proof_changed_selector_routes_installed_docs_to_docs_review(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Reconciles the latest proof receipt back into proof selection output with accepted, stale/untrusted, failed, and not-recorded command states.
- Adds append-only proof receipt history (`history.jsonl`) so multiple selected proof commands can be reconciled for the same changed-path proof boundary without rerunning commands just because `last.json` moved on.
- Adds explicit non-runnable command-template metadata for placeholder proof commands so `<paths>` templates are not treated as executable proof.
- Exposes the mandatory closeout report route in ordinary startup guidance when lane/status/closeout routing is relevant, while preserving tiny output budgets.

Fixes #1885.
Fixes #1887.

## Stack
- Base: #1894 / `codex/open-issues-lane1-upgrade-idempotence`
- This PR: lane 2 (#1885/#1887)
- Next: lane 3 (#1883/#1884)

## Validation
- `uv run pytest tests/test_workspace_proof_cli.py::test_proof_record_receipt_writes_latest_execution_evidence tests/test_workspace_proof_cli.py::test_proof_changed_reconciles_receipt_history_without_duplicate_runs tests/test_workspace_proof_cli.py::test_proof_changed_marks_receipt_stale_for_changed_path_mismatch -q --tb=short`
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`
