### PR TITLE
Close compact routing and task-switch gaps

### DIFF
--- a/generated/memory/typescript/src/hostPrimitiveSupport.mjs
+++ b/generated/memory/typescript/src/hostPrimitiveSupport.mjs
@@ -723,7 +723,7 @@ function executeTypescriptDomainOperation(operationId, values) {
   if (operationId === 'memory.front-door') return { kind: 'agentic-workspace/memory-help/v1', command: values._command_path?.join(' ') ?? operationId, target };
   if (operationId === 'modules.report') return { kind: 'agentic-workspace/modules-router/v1', profile: 'tiny', target_root: target, detail_commands: { full: 'agentic-workspace modules --target . --verbose --format json' } };
   if (operationId === 'summary.report') return { kind: 'planning-summary/v1', profile: values.verbose ? 'full' : 'tiny', machine_first_planning: { status: 'no-active-execplan' }, target_root: target };
-  if (operationId === 'start.context') return { kind: 'startup-context/v1', target_root: target, drill_down: { rule: 'Use --select <field[,field...]> for exact fields; use --verbose only for broad diagnostics.' }, context: { proof: { kind: 'proof-selection/v1' } } };
+  if (operationId === 'start.context') return { kind: 'startup-context/v1', target_root: target, drill_down: { rule: 'Compact default omits selector inventory and schemas. Use exact --select for one field; use --verbose only for broad diagnostics.' }, context: { proof: { kind: 'proof-selection/v1' } } };
   if (operationId === 'implement.context') return { kind: 'implementer-context-tiny/v1', target_root: target, proof: { kind: 'proof-selection/v1' } };
   if (operationId === 'proof.report') return { kind: 'proof-next-decision/v1', next: { action: 'run-validation-command' }, detail_command: 'agentic-workspace proof --verbose --changed <paths> --format json' };
   if (operationId === 'setup.guidance') return { kind: 'workspace-setup/v1', command: 'setup', target_root: target };

--- a/generated/planning/typescript/src/hostPrimitiveSupport.mjs
+++ b/generated/planning/typescript/src/hostPrimitiveSupport.mjs
@@ -723,7 +723,7 @@ function executeTypescriptDomainOperation(operationId, values) {
   if (operationId === 'memory.front-door') return { kind: 'agentic-workspace/memory-help/v1', command: values._command_path?.join(' ') ?? operationId, target };
   if (operationId === 'modules.report') return { kind: 'agentic-workspace/modules-router/v1', profile: 'tiny', target_root: target, detail_commands: { full: 'agentic-workspace modules --target . --verbose --format json' } };
   if (operationId === 'summary.report') return { kind: 'planning-summary/v1', profile: values.verbose ? 'full' : 'tiny', machine_first_planning: { status: 'no-active-execplan' }, target_root: target };
-  if (operationId === 'start.context') return { kind: 'startup-context/v1', target_root: target, drill_down: { rule: 'Use --select <field[,field...]> for exact fields; use --verbose only for broad diagnostics.' }, context: { proof: { kind: 'proof-selection/v1' } } };
+  if (operationId === 'start.context') return { kind: 'startup-context/v1', target_root: target, drill_down: { rule: 'Compact default omits selector inventory and schemas. Use exact --select for one field; use --verbose only for broad diagnostics.' }, context: { proof: { kind: 'proof-selection/v1' } } };
   if (operationId === 'implement.context') return { kind: 'implementer-context-tiny/v1', target_root: target, proof: { kind: 'proof-selection/v1' } };
   if (operationId === 'proof.report') return { kind: 'proof-next-decision/v1', next: { action: 'run-validation-command' }, detail_command: 'agentic-workspace proof --verbose --changed <paths> --format json' };
   if (operationId === 'setup.guidance') return { kind: 'workspace-setup/v1', command: 'setup', target_root: target };

--- a/generated/verification/typescript/src/hostPrimitiveSupport.mjs
+++ b/generated/verification/typescript/src/hostPrimitiveSupport.mjs
@@ -723,7 +723,7 @@ function executeTypescriptDomainOperation(operationId, values) {
   if (operationId === 'memory.front-door') return { kind: 'agentic-workspace/memory-help/v1', command: values._command_path?.join(' ') ?? operationId, target };
   if (operationId === 'modules.report') return { kind: 'agentic-workspace/modules-router/v1', profile: 'tiny', target_root: target, detail_commands: { full: 'agentic-workspace modules --target . --verbose --format json' } };
   if (operationId === 'summary.report') return { kind: 'planning-summary/v1', profile: values.verbose ? 'full' : 'tiny', machine_first_planning: { status: 'no-active-execplan' }, target_root: target };
-  if (operationId === 'start.context') return { kind: 'startup-context/v1', target_root: target, drill_down: { rule: 'Use --select <field[,field...]> for exact fields; use --verbose only for broad diagnostics.' }, context: { proof: { kind: 'proof-selection/v1' } } };
+  if (operationId === 'start.context') return { kind: 'startup-context/v1', target_root: target, drill_down: { rule: 'Compact default omits selector inventory and schemas. Use exact --select for one field; use --verbose only for broad diagnostics.' }, context: { proof: { kind: 'proof-selection/v1' } } };
   if (operationId === 'implement.context') return { kind: 'implementer-context-tiny/v1', target_root: target, proof: { kind: 'proof-selection/v1' } };
   if (operationId === 'proof.report') return { kind: 'proof-next-decision/v1', next: { action: 'run-validation-command' }, detail_command: 'agentic-workspace proof --verbose --changed <paths> --format json' };
   if (operationId === 'setup.guidance') return { kind: 'workspace-setup/v1', command: 'setup', target_root: target };

--- a/generated/workspace/typescript/src/hostPrimitiveSupport.mjs
+++ b/generated/workspace/typescript/src/hostPrimitiveSupport.mjs
@@ -723,7 +723,7 @@ function executeTypescriptDomainOperation(operationId, values) {
   if (operationId === 'memory.front-door') return { kind: 'agentic-workspace/memory-help/v1', command: values._command_path?.join(' ') ?? operationId, target };
   if (operationId === 'modules.report') return { kind: 'agentic-workspace/modules-router/v1', profile: 'tiny', target_root: target, detail_commands: { full: 'agentic-workspace modules --target . --verbose --format json' } };
   if (operationId === 'summary.report') return { kind: 'planning-summary/v1', profile: values.verbose ? 'full' : 'tiny', machine_first_planning: { status: 'no-active-execplan' }, target_root: target };
-  if (operationId === 'start.context') return { kind: 'startup-context/v1', target_root: target, drill_down: { rule: 'Use --select <field[,field...]> for exact fields; use --verbose only for broad diagnostics.' }, context: { proof: { kind: 'proof-selection/v1' } } };
+  if (operationId === 'start.context') return { kind: 'startup-context/v1', target_root: target, drill_down: { rule: 'Compact default omits selector inventory and schemas. Use exact --select for one field; use --verbose only for broad diagnostics.' }, context: { proof: { kind: 'proof-selection/v1' } } };
   if (operationId === 'implement.context') return { kind: 'implementer-context-tiny/v1', target_root: target, proof: { kind: 'proof-selection/v1' } };
   if (operationId === 'proof.report') return { kind: 'proof-next-decision/v1', next: { action: 'run-validation-command' }, detail_command: 'agentic-workspace proof --verbose --changed <paths> --format json' };
   if (operationId === 'setup.guidance') return { kind: 'workspace-setup/v1', command: 'setup', target_root: target };

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -4101,17 +4101,18 @@ def _planning_summary_tiny_fast(*, target_root: Path) -> dict[str, Any]:
                 "task_scoped": "agentic-workspace summary --verbose --task <task> --format json",
                 "changed_path_implement": "agentic-workspace implement --changed <paths> --format json",
             },
-            "available_selectors": [
-                "todo.active_count",
-                "execplans.active_count",
-                "planning_surface_health",
-                "execution_readiness",
-                "current_execution_pressure",
-                "residue_governance",
-                "continuation_view",
-                "roadmap",
-                "lanes",
-            ],
+            "selector_inventory": {
+                "status": "omitted-from-compact-default",
+                "available_count": 9,
+                "sample": [
+                    "todo.active_count",
+                    "execplans.active_count",
+                    "planning_surface_health",
+                    "execution_readiness",
+                ],
+                "exact_select_command": "agentic-workspace summary --select <field.path> --format json",
+                "broad_diagnostics_command": "agentic-workspace summary --verbose --format json",
+            },
             "warning_count": warning_count,
         }
     )

--- a/src/agentic_workspace/contracts/conformance/start.context.process.json
+++ b/src/agentic_workspace/contracts/conformance/start.context.process.json
@@ -44,7 +44,7 @@
             "drill_down",
             "rule"
           ],
-          "equals": "Use --select <field[,field...]> for exact fields; use --verbose only for broad diagnostics."
+          "equals": "Compact default omits selector inventory and schemas. Use exact --select for one field; use --verbose only for broad diagnostics."
         },
         {
           "path": [

--- a/src/agentic_workspace/contracts/typescript_primitive_support.mjs
+++ b/src/agentic_workspace/contracts/typescript_primitive_support.mjs
@@ -717,7 +717,7 @@ function executeTypescriptDomainOperation(operationId, values) {
   if (operationId === 'memory.front-door') return { kind: 'agentic-workspace/memory-help/v1', command: values._command_path?.join(' ') ?? operationId, target };
   if (operationId === 'modules.report') return { kind: 'agentic-workspace/modules-router/v1', profile: 'tiny', target_root: target, detail_commands: { full: 'agentic-workspace modules --target . --verbose --format json' } };
   if (operationId === 'summary.report') return { kind: 'planning-summary/v1', profile: values.verbose ? 'full' : 'tiny', machine_first_planning: { status: 'no-active-execplan' }, target_root: target };
-  if (operationId === 'start.context') return { kind: 'startup-context/v1', target_root: target, drill_down: { rule: 'Use --select <field[,field...]> for exact fields; use --verbose only for broad diagnostics.' }, context: { proof: { kind: 'proof-selection/v1' } } };
+  if (operationId === 'start.context') return { kind: 'startup-context/v1', target_root: target, drill_down: { rule: 'Compact default omits selector inventory and schemas. Use exact --select for one field; use --verbose only for broad diagnostics.' }, context: { proof: { kind: 'proof-selection/v1' } } };
   if (operationId === 'implement.context') return { kind: 'implementer-context-tiny/v1', target_root: target, proof: { kind: 'proof-selection/v1' } };
   if (operationId === 'proof.report') return { kind: 'proof-next-decision/v1', next: { action: 'run-validation-command' }, detail_command: 'agentic-workspace proof --verbose --changed <paths> --format json' };
   if (operationId === 'setup.guidance') return { kind: 'workspace-setup/v1', command: 'setup', target_root: target };

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -680,6 +680,8 @@
           "_CONTEXT_TEMPLATES",
           "_PROOF_EXECUTION_STATUSES",
           "_PROOF_SELECTION_RULES",
+          "PROOF_RECEIPT_HISTORY_RELATIVE_PATH",
+          "PROOF_RECEIPT_RELATIVE_PATH",
           "_cli_invocation_payload",
           "_compact_startup_installed_state_signal",
           "_defaults_payload",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -22302,6 +22302,76 @@ def _startup_skills_projection(
     }
 
 
+def _compact_selector_planning_revision(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: value.get(key)
+        for key in (
+            "kind",
+            "status",
+            "revision_id",
+            "active_item_id",
+            "active_item_surface",
+            "active_execplan",
+        )
+        if value.get(key) not in (None, "", [], {})
+    }
+
+
+def _compact_selector_active_plan_reliance(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact = {
+        key: value.get(key)
+        for key in (
+            "kind",
+            "status",
+            "permission_claim",
+            "integrity",
+            "active_execplan",
+            "reliance",
+            "requirement_status",
+        )
+        if value.get(key) not in (None, "", [], {})
+    }
+    freshness = value.get("freshness")
+    if isinstance(freshness, dict):
+        compact["freshness"] = {
+            key: freshness.get(key) for key in ("revision_id", "source") if freshness.get(key) not in (None, "", [], {})
+        }
+    action_effect = value.get("action_effect")
+    if isinstance(action_effect, dict):
+        compact["action_effect"] = {
+            key: action_effect.get(key)
+            for key in (
+                "force",
+                "allowed_now",
+                "blocked_until_reconciled",
+                "claim_boundary",
+                "resolution_selector",
+                "resolution_command",
+            )
+            if action_effect.get(key) not in (None, "", [], {})
+        }
+    authority = value.get("authority_evidence")
+    if isinstance(authority, dict):
+        compact["authority_summary"] = {
+            key: authority.get(key)
+            for key in (
+                "authority",
+                "mutation_authority",
+                "manual_edit_indicator",
+                "current_enough_to_guide_work",
+            )
+            if authority.get(key) not in (None, "", [], {})
+        }
+        routes = authority.get("routes")
+        if isinstance(routes, dict) and routes.get("refresh"):
+            compact["detail_command"] = routes["refresh"]
+    return compact
+
+
 def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
     if not isinstance(gate, dict):
         return {}
@@ -22317,8 +22387,8 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         "promotion_command": gate.get("promotion_command"),
         "delegation_decision_command": gate.get("delegation_decision_command"),
         "new_plan_command": gate.get("new_plan_command"),
-        "planning_revision": gate.get("planning_revision"),
-        "active_plan_reliance": gate.get("active_plan_reliance"),
+        "planning_revision": _compact_selector_planning_revision(gate.get("planning_revision")),
+        "active_plan_reliance": _compact_selector_active_plan_reliance(gate.get("active_plan_reliance")),
         "implementation_allowed": gate.get("implementation_allowed"),
         "delegation_decision_required": gate.get("delegation_decision_required"),
         "authority_boundary": _compact_authority_boundary(gate.get("authority_boundary")),
@@ -22340,9 +22410,12 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
                 "kind",
                 "status",
                 "summary",
+                "intent_conflict_state",
+                "mismatch_evidence",
                 "current_task_class",
                 "classification_basis",
                 "matched_maintenance_markers",
+                "classification_inputs",
                 "semantic_boundary",
                 "recommended_next_action",
                 "safe_routes",

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -496,22 +496,32 @@ def _task_switch_reconciliation_payload(
         planning_revision=planning_revision,
     )
     text = " ".join((task_text or "").lower().split())
-    maintenance_markers = ("report", "dogfood", "upgrade", "payload", "config", "doctor", "comment", "review", "status", "issue", "pr")
+    maintenance_markers = ("report", "dogfood", "upgrade", "payload", "config", "doctor", "comment", "review", "status")
     matched_maintenance_markers = [marker for marker in maintenance_markers if marker in text]
     maintenance_like = bool(matched_maintenance_markers)
     classification_basis = "bounded-maintenance-marker-hint" if maintenance_like else "no-maintenance-marker-hint"
     recommended = "proceed-bounded-repo-maintenance" if maintenance_like else "choose-between-new-task-and-active-plan"
+    mismatch_evidence = _task_switch_mismatch_evidence(active_summary=active_summary, task_text=task_text)
     return {
         "kind": "agentic-workspace/task-switch-reconciliation/v1",
         "status": "active",
         "summary": "Current task does not explicitly continue the active plan; keep the active plan protected and choose the current-task route deliberately.",
         "active_execplan": active_summary.get("active_execplan", ""),
+        "intent_conflict_state": "explicit-task-differs-from-active-plan",
+        "mismatch_evidence": mismatch_evidence,
         "current_task_class": "repo-maintenance-or-reporting" if maintenance_like else "new-explicit-task",
         "classification_basis": classification_basis,
         "matched_maintenance_markers": matched_maintenance_markers,
+        "classification_inputs": [
+            "active_plan_reliance.status=not-needed-for-current-task",
+            f"shared_term_count={len(mismatch_evidence.get('shared_terms', []))}",
+            f"shared_ref_count={len(mismatch_evidence.get('shared_refs', []))}",
+            f"maintenance_marker_count={len(matched_maintenance_markers)}",
+        ],
         "semantic_boundary": (
-            "Maintenance marker matching is a low-cost route-choice hint for protecting the active plan. "
-            "It is not authoritative semantic classification, intent satisfaction, or evidence that the active plan can be closed."
+            "Active-plan reliance, task/plan overlap, and maintenance marker matching are low-cost route-choice hints for protecting "
+            "the active plan. They are not authoritative semantic classification, intent satisfaction, or evidence that the active "
+            "plan can be closed."
         ),
         "recommended_next_action": recommended,
         "next_action_packet": {
@@ -548,6 +558,103 @@ def _task_switch_reconciliation_payload(
             "blocked_claims": ["claim-active-plan-progress", "claim-active-plan-complete", "silently-abandon-active-plan"],
         },
         "rule": "An unrelated active plan is protected state, not an automatic hard block for explicit bounded maintenance or reporting.",
+    }
+
+
+_TASK_SWITCH_STOPWORDS = {
+    "about",
+    "active",
+    "after",
+    "again",
+    "agent",
+    "all",
+    "and",
+    "are",
+    "both",
+    "but",
+    "close",
+    "current",
+    "from",
+    "have",
+    "implement",
+    "into",
+    "issue",
+    "issues",
+    "lane",
+    "master",
+    "new",
+    "open",
+    "plan",
+    "planning",
+    "pr",
+    "prs",
+    "remaining",
+    "task",
+    "the",
+    "this",
+    "two",
+    "with",
+    "work",
+}
+
+
+def _task_switch_terms(text: str) -> list[str]:
+    seen: set[str] = set()
+    terms: list[str] = []
+    for term in re.findall(r"[a-z0-9][a-z0-9_-]{2,}", text.lower()):
+        normalized = term.strip("-_")
+        if not normalized or normalized in _TASK_SWITCH_STOPWORDS or normalized in seen:
+            continue
+        seen.add(normalized)
+        terms.append(normalized)
+        if len(terms) >= 12:
+            break
+    return terms
+
+
+def _task_switch_refs(text: str) -> list[str]:
+    refs = {match.lower() for match in re.findall(r"#\d+", text)}
+    refs.update(f"issue-{match}" for match in re.findall(r"\bissue\s+#?(\d+)\b", text, flags=re.IGNORECASE))
+    refs.update(f"pr-{match}" for match in re.findall(r"\bpr\s+#?(\d+)\b", text, flags=re.IGNORECASE))
+    return sorted(refs)
+
+
+def _task_switch_mismatch_evidence(*, active_summary: dict[str, Any], task_text: str | None) -> dict[str, Any]:
+    active_execplan = str(active_summary.get("active_execplan") or "")
+    active_plan_stem = Path(active_execplan).stem if active_execplan else ""
+    if active_plan_stem.endswith(".plan"):
+        active_plan_stem = active_plan_stem[: -len(".plan")]
+    active_plan_label = active_plan_stem.replace("-", " ")
+    active_text = " ".join(
+        str(value)
+        for value in (
+            active_execplan,
+            active_plan_label,
+            active_summary.get("active_item_id"),
+            active_summary.get("planning_status"),
+        )
+        if value
+    )
+    task = " ".join((task_text or "").split())
+    task_terms = _task_switch_terms(task)
+    active_terms = _task_switch_terms(active_text)
+    task_refs = _task_switch_refs(task)
+    active_refs = _task_switch_refs(active_text)
+    shared_terms = [term for term in task_terms if term in set(active_terms)]
+    shared_refs = [ref for ref in task_refs if ref in set(active_refs)]
+    overlap_signal = "possible-continuation" if shared_refs or len(shared_terms) >= 2 else "low-overlap-explicit-task"
+    return {
+        "current_task_excerpt": task[:160],
+        "active_plan_label": active_plan_label,
+        "active_execplan": active_execplan,
+        "task_refs": task_refs[:8],
+        "active_refs": active_refs[:8],
+        "shared_refs": shared_refs[:8],
+        "task_terms": task_terms[:8],
+        "active_plan_terms": active_terms[:8],
+        "shared_terms": shared_terms[:8],
+        "overlap_signal": overlap_signal,
+        "rule": "Overlap evidence is bounded routing support; it does not decide user intent or close active planning.",
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -22426,6 +22426,76 @@ def _startup_skills_projection(
     }
 
 
+def _compact_selector_planning_revision(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: value.get(key)
+        for key in (
+            "kind",
+            "status",
+            "revision_id",
+            "active_item_id",
+            "active_item_surface",
+            "active_execplan",
+        )
+        if value.get(key) not in (None, "", [], {})
+    }
+
+
+def _compact_selector_active_plan_reliance(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact = {
+        key: value.get(key)
+        for key in (
+            "kind",
+            "status",
+            "permission_claim",
+            "integrity",
+            "active_execplan",
+            "reliance",
+            "requirement_status",
+        )
+        if value.get(key) not in (None, "", [], {})
+    }
+    freshness = value.get("freshness")
+    if isinstance(freshness, dict):
+        compact["freshness"] = {
+            key: freshness.get(key) for key in ("revision_id", "source") if freshness.get(key) not in (None, "", [], {})
+        }
+    action_effect = value.get("action_effect")
+    if isinstance(action_effect, dict):
+        compact["action_effect"] = {
+            key: action_effect.get(key)
+            for key in (
+                "force",
+                "allowed_now",
+                "blocked_until_reconciled",
+                "claim_boundary",
+                "resolution_selector",
+                "resolution_command",
+            )
+            if action_effect.get(key) not in (None, "", [], {})
+        }
+    authority = value.get("authority_evidence")
+    if isinstance(authority, dict):
+        compact["authority_summary"] = {
+            key: authority.get(key)
+            for key in (
+                "authority",
+                "mutation_authority",
+                "manual_edit_indicator",
+                "current_enough_to_guide_work",
+            )
+            if authority.get(key) not in (None, "", [], {})
+        }
+        routes = authority.get("routes")
+        if isinstance(routes, dict) and routes.get("refresh"):
+            compact["detail_command"] = routes["refresh"]
+    return compact
+
+
 def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
     if not isinstance(gate, dict):
         return {}
@@ -22441,8 +22511,8 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         "promotion_command": gate.get("promotion_command"),
         "delegation_decision_command": gate.get("delegation_decision_command"),
         "new_plan_command": gate.get("new_plan_command"),
-        "planning_revision": gate.get("planning_revision"),
-        "active_plan_reliance": gate.get("active_plan_reliance"),
+        "planning_revision": _compact_selector_planning_revision(gate.get("planning_revision")),
+        "active_plan_reliance": _compact_selector_active_plan_reliance(gate.get("active_plan_reliance")),
         "implementation_allowed": gate.get("implementation_allowed"),
         "delegation_decision_required": gate.get("delegation_decision_required"),
         "authority_boundary": _compact_authority_boundary(gate.get("authority_boundary")),
@@ -22464,7 +22534,13 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
                 "kind",
                 "status",
                 "summary",
+                "intent_conflict_state",
+                "mismatch_evidence",
                 "current_task_class",
+                "classification_basis",
+                "matched_maintenance_markers",
+                "classification_inputs",
+                "semantic_boundary",
                 "recommended_next_action",
                 "safe_routes",
                 "active_plan_protection",

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1498,6 +1498,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         advisory_selectors.append("proof.local_overlay")
     if isinstance(startup_high_risk_overlay, dict) and startup_high_risk_overlay.get("status") == "active":
         advisory_selectors.append("proof.high_risk_overlay")
+    selector_sample = list(dict.fromkeys([*advisory_selectors, *available_selectors[:4]]))[:8]
     selected: dict[str, Any] = {
         "kind": payload["kind"],
         "target": ".",
@@ -1524,8 +1525,14 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         "context": context,
         "drill_down": {
             "ordinary_profile": "primary=next_safe_action;skills=proj;legacy=select/context",
-            "rule": "Use --select <field[,field...]> for exact fields; use --verbose only for broad diagnostics.",
-            "available_selectors": available_selectors,
+            "rule": "Compact default omits selector inventory and schemas. Use exact --select for one field; use --verbose only for broad diagnostics.",
+            "selector_inventory": {
+                "status": "omitted-from-compact-default",
+                "available_count": len(available_selectors),
+                "sample": selector_sample,
+                "exact_select_command": f"{cli_invoke} start --target . --select <field[,field...]> --format json",
+                "broad_diagnostics_command": f"{cli_invoke} start --target . --verbose --format json",
+            },
         },
     }
     task_posture_packet = payload.get("task_posture_packet", {})

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -5,6 +5,7 @@ import copy
 import hashlib
 import re
 from datetime import date
+from typing import Any
 
 from tests.workspace_cli_support import *
 
@@ -27,6 +28,18 @@ def test_json_payload_budget_failure_reports_largest_contributors() -> None:
     assert "Largest JSON contributors:" in message
     assert "context" in message
     assert "context.large" in message
+
+
+def _assert_selector_inventory_omitted_from_compact_start(payload: dict[str, Any]) -> dict[str, Any]:
+    drill_down = payload["drill_down"]
+    assert "available_selectors" not in drill_down
+    inventory = drill_down["selector_inventory"]
+    assert inventory["status"] == "omitted-from-compact-default"
+    assert inventory["available_count"] > 0
+    assert inventory["sample"]
+    assert "start --target . --select <field[,field...]> --format json" in inventory["exact_select_command"]
+    assert "start --target . --verbose --format json" in inventory["broad_diagnostics_command"]
+    return inventory
 
 
 def test_repeated_module_flags_accumulate_module_selection(tmp_path: Path, capsys) -> None:
@@ -672,7 +685,8 @@ def test_start_default_routes_memory_and_installed_state_detail_behind_selectors
     assert "memory_decision_packet" not in payload
     assert "installed_state_compatibility" not in payload
     assert "memory_decision_packet" in payload["action_signals"]["advisory_detail"]["selectors"]
-    assert "memory_decision_packet" in payload["drill_down"]["available_selectors"]
+    inventory = _assert_selector_inventory_omitted_from_compact_start(payload)
+    assert "memory_decision_packet" in inventory["sample"]
     assert payload["context"]["memory"]["status"] in {"recommended", "not_checked"}
 
 
@@ -768,7 +782,8 @@ def test_start_default_compacts_noncompatible_installed_state_signal(tmp_path: P
     assert "installed_state_compatibility" not in payload
     assert "installed_state_compatibility=payload-upgrade-required" in payload["action_signals"]["changed_signals"]
     assert "installed_state_compatibility" in payload["action_signals"]["advisory_detail"]["selectors"]
-    assert "installed_state_compatibility" in payload["drill_down"]["available_selectors"]
+    inventory = _assert_selector_inventory_omitted_from_compact_start(payload)
+    assert "installed_state_compatibility" in inventory["sample"]
 
     assert (
         cli.main(
@@ -921,9 +936,8 @@ def test_start_default_stays_under_tiny_output_budget_for_docs_task(tmp_path: Pa
     assert "memory_decision_packet" not in payload
     assert "installed_state_compatibility" not in payload
     assert "planning_safety_gate" not in payload
-    assert "memory_decision_packet" in payload["drill_down"]["available_selectors"]
-    assert "routine_work_context" in payload["drill_down"]["available_selectors"]
-    assert "workflow_sufficiency" in payload["drill_down"]["available_selectors"]
+    inventory = _assert_selector_inventory_omitted_from_compact_start(payload)
+    assert inventory["available_count"] >= 3
     assert payload["workflow_participation"]["status"] == "mandatory"
     assert "implementation_allowed cannot bypass workflow" in payload["workflow_participation"]["rule"]
 
@@ -1014,6 +1028,10 @@ candidates = []
     assert switch["recommended_next_action"] == "proceed-bounded-repo-maintenance"
     assert switch["classification_basis"] == "bounded-maintenance-marker-hint"
     assert switch["matched_maintenance_markers"] == ["report", "upgrade", "payload"]
+    assert switch["intent_conflict_state"] == "explicit-task-differs-from-active-plan"
+    assert switch["mismatch_evidence"]["active_plan_label"] == "active plan"
+    assert switch["mismatch_evidence"]["overlap_signal"] == "low-overlap-explicit-task"
+    assert "active_plan_reliance.status=not-needed-for-current-task" in switch["classification_inputs"]
     assert "not authoritative semantic classification" in switch["semantic_boundary"]
     assert {route["id"] for route in switch["safe_routes"]} == {
         "continue-active-plan",
@@ -1021,6 +1039,59 @@ candidates = []
         "reconcile-active-plan-before-implementation",
     }
     assert "claim-active-plan-complete" in switch["active_plan_protection"]["blocked_claims"]
+
+
+def test_start_reconciles_unrelated_active_plan_with_new_issue_implementation_task(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "active-plan", title = "Unrelated active plan", status = "active", surface = ".agentic-workspace/planning/execplans/active-plan.plan.json" },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "active-plan.plan.json",
+        json.dumps({"id": "active-plan", "title": "Unrelated active plan"}),
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Implement parser cache eviction for issue routing",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    gate = payload["context"]["planning"]["planning_safety_gate"]
+    assert gate["gate_result"] == "active-plan-task-switch"
+    assert gate["implementation_allowed"] is True
+    switch = gate["task_switch_reconciliation"]
+    assert switch["current_task_class"] == "new-explicit-task"
+    assert switch["recommended_next_action"] == "choose-between-new-task-and-active-plan"
+    assert switch["matched_maintenance_markers"] == []
+    assert switch["mismatch_evidence"]["task_refs"] == []
+    assert "active_plan_reliance.status=not-needed-for-current-task" in switch["classification_inputs"]
 
 
 def test_start_low_risk_docs_task_keeps_checkpoint_detail_selector_only(tmp_path: Path, capsys) -> None:
@@ -1055,7 +1126,7 @@ def test_start_low_risk_docs_task_keeps_checkpoint_detail_selector_only(tmp_path
     assert "local_chat_checkpoint" not in payload["context"]
     assert "local_chat_checkpoint=present" not in payload["action_signals"]["changed_signals"]
     assert "local_chat_checkpoint" not in payload["action_signals"]["advisory_detail"]["selectors"]
-    assert "local_chat_checkpoint" in payload["drill_down"]["available_selectors"]
+    _assert_selector_inventory_omitted_from_compact_start(payload)
 
     assert cli.main(["start", "--target", str(tmp_path), "--task", "Resume checkpoint slice", "--format", "json"]) == 0
     resume_payload = json.loads(capsys.readouterr().out)
@@ -1183,7 +1254,7 @@ def test_start_report_meta_task_keeps_routine_context_selector_only_with_backgro
 
     _assert_json_payload_under(payload, 10_000, label="start report/meta compact payload", sort_keys=False)
     assert "routine_work_context" not in payload["context"]
-    assert "routine_work_context" in payload["drill_down"]["available_selectors"]
+    _assert_selector_inventory_omitted_from_compact_start(payload)
     assert "installed_state_compatibility" not in payload
     assert "installed_state_drift_triage" not in payload["context"]
     assert "installed_state_drift_triage=background_advisory" in payload["action_signals"]["changed_signals"]
@@ -1480,7 +1551,7 @@ def test_local_chat_checkpoint_write_creates_valid_local_record_and_startup_pack
     assert packet["volatile_observations"]["current_pr"]["observed_at"] == checkpoint["updated_at"]
     assert packet["proof_state"]["status"] == "historical-local-summary"
     assert any(item["action"].startswith("re-run or re-evaluate proof") for item in packet["resume_checklist"])
-    assert "local_chat_checkpoint" in startup["drill_down"]["available_selectors"]
+    _assert_selector_inventory_omitted_from_compact_start(startup)
     assert "local_chat_checkpoint=present" in startup["action_signals"]["changed_signals"]
 
 
@@ -2697,6 +2768,47 @@ def test_selected_dogfooding_report_sections_stay_compact(tmp_path: Path, capsys
     assert friction["answer"]["detail_selector"] == "repo_friction"
     assert friction["answer"]["large_file_hotspots"]["sample"] == []
     assert friction["answer"]["concept_surface_hotspots"]["count"] >= 1
+
+
+def test_chat_agent_default_outputs_stay_bounded_without_selector_inventories(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["start", "--target", str(tmp_path), "--task", "Fix one docs typo", "--format", "json"]) == 0
+    start = json.loads(capsys.readouterr().out)
+    _assert_json_payload_under(start, 10_000, label="compact start chat-agent output", sort_keys=False)
+    _assert_selector_inventory_omitted_from_compact_start(start)
+
+    assert cli.main(["summary", "--target", str(tmp_path), "--format", "json"]) == 0
+    summary = json.loads(capsys.readouterr().out)
+    _assert_json_payload_under(summary, 20_000, label="compact summary chat-agent output", sort_keys=False)
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "generated/workspace/python/cli.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    proof = json.loads(capsys.readouterr().out)
+    _assert_json_payload_under(proof, 12_000, label="compact proof chat-agent output", sort_keys=False)
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "repo_friction", "--format", "json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    _assert_json_payload_under(report, 8_000, label="selected report chat-agent output", sort_keys=False)
+
+    for label, payload in (("start", start), ("summary", summary), ("proof", proof), ("report", report)):
+        encoded = json.dumps(payload)
+        assert "available_selectors" not in encoded, label
+        assert "selector_schema" not in encoded, label
 
 
 def test_start_surfaces_recovery_for_obsolete_default_preset(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -79,10 +79,13 @@ candidates = [
         "residue_governance",
         "roadmap",
         "detail_commands",
-        "available_selectors",
+        "selector_inventory",
         "warning_count",
         "memory_consult",
     }
+    assert payload["selector_inventory"]["status"] == "omitted-from-compact-default"
+    assert payload["selector_inventory"]["available_count"] == 9
+    assert payload["selector_inventory"]["exact_select_command"] == "agentic-workspace summary --select <field.path> --format json"
     assert "candidate_lanes" not in payload["roadmap"]
 
 


### PR DESCRIPTION
## Summary
- Closes #1883 by omitting selector inventories from compact start/summary defaults, adding bounded selector-inventory summaries/detail routes, and covering compact start/summary/proof/report budgets.
- Closes #1884 by adding explicit task-switch reconciliation evidence from active-plan/current-task overlap, narrowing maintenance markers, and surfacing safe routes for both maintenance and non-maintenance task changes.
- Keeps generated TypeScript host support and conformance/primitive-family contract surfaces current.

## Proof
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`
- `make test-planning`
- `make lint-workspace`
- `make lint-planning`
- `make typecheck-planning`
- `make typecheck`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`