### PR TITLE
[codex] Add long-horizon evaluation contracts

### DIFF
--- a/docs/maintainer/model-cli-dogfooding-harness.md
+++ b/docs/maintainer/model-cli-dogfooding-harness.md
@@ -198,6 +198,9 @@ The episode runner supports:
 - a separate evaluator adapter with a controlled evidence bundle;
 - post-score hidden/reference oracle metadata, kept out of the primary evaluator prompt;
 - comparison summaries for mistake classes, same-agent versus agent-switch continuation, post-score reference status, AW effect, human-review-needed status, and follow-up routing.
+- episode-level `evaluation_contract` metadata for claim-boundary rules such as semantic proof sufficiency, restartable handoff records, and stale managed-state reconciliation. The contract is included in the evaluator evidence bundle and in the comparison `claim_gate`; it downgrades full-completion claims when configured mistake classes appear without turning the harness into a deterministic leaderboard.
+
+Large evaluator prompts should use file-backed prompt transport. The default suite supports this with prompt attachments for Copilot, prompt-file metadata for `codex-sbx`, and a file-reference prompt for plain `codex` so Windows argv carries the prompt path instead of the full prompt text. `codex-sbx` currently refuses an overlong rendered Windows command before sandbox/model execution and reports that the plain `codex` adapter should be used until in-sandbox prompt-file support exists.
 
 The first episode pack is intentionally small:
 

--- a/scripts/model_cli_harness/long_horizon_episode.py
+++ b/scripts/model_cli_harness/long_horizon_episode.py
@@ -38,6 +38,15 @@ MISTAKE_CLASSES = {
     "restart_failed",
     "stale_planning_state_trusted",
 }
+EVALUATION_CONTRACT_FIELDS = {
+    "issue_refs",
+    "failure_path_summary",
+    "agent_facing_claim_boundary",
+    "required_reconciliation",
+    "blocked_full_completion_when",
+    "evaluator_focus",
+    "handoff_contract",
+}
 
 
 def _string_list(value: Any, *, field: str) -> list[str]:
@@ -59,6 +68,49 @@ def _list_of_commands(value: Any, *, field: str) -> list[list[str]]:
             raise ValueError(f"{field}.{index} must be a string list command")
         commands.append(command)
     return commands
+
+
+def _validate_evaluation_contract(value: Any, *, field: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, dict):
+        raise ValueError(f"{field} must be an object")
+    unknown_fields = sorted(set(value) - EVALUATION_CONTRACT_FIELDS)
+    if unknown_fields:
+        raise ValueError(f"{field} has unknown fields: {', '.join(unknown_fields)}")
+    for list_field in ("issue_refs", "required_reconciliation", "evaluator_focus"):
+        _string_list(value.get(list_field), field=f"{field}.{list_field}")
+    for string_field in ("failure_path_summary", "agent_facing_claim_boundary"):
+        if string_field in value and not isinstance(value[string_field], str):
+            raise ValueError(f"{field}.{string_field} must be a string")
+    blocked_rules = value.get("blocked_full_completion_when")
+    if blocked_rules is not None:
+        if not isinstance(blocked_rules, list):
+            raise ValueError(f"{field}.blocked_full_completion_when must be a list")
+        for index, rule in enumerate(blocked_rules):
+            rule_field = f"{field}.blocked_full_completion_when.{index}"
+            if not isinstance(rule, dict):
+                raise ValueError(f"{rule_field} must be an object")
+            unknown_rule_fields = sorted(set(rule) - {"mistake_class", "reason"})
+            if unknown_rule_fields:
+                raise ValueError(f"{rule_field} has unknown fields: {', '.join(unknown_rule_fields)}")
+            mistake_class = rule.get("mistake_class")
+            if not isinstance(mistake_class, str) or not mistake_class.strip():
+                raise ValueError(f"{rule_field}.mistake_class is required")
+            if mistake_class not in MISTAKE_CLASSES:
+                raise ValueError(f"{rule_field}.mistake_class is unknown: {mistake_class}")
+            if "reason" in rule and not isinstance(rule["reason"], str):
+                raise ValueError(f"{rule_field}.reason must be a string")
+    handoff_contract = value.get("handoff_contract")
+    if handoff_contract is not None:
+        if not isinstance(handoff_contract, dict):
+            raise ValueError(f"{field}.handoff_contract must be an object")
+        unknown_handoff_fields = sorted(set(handoff_contract) - {"required_record", "avoid"})
+        if unknown_handoff_fields:
+            raise ValueError(f"{field}.handoff_contract has unknown fields: {', '.join(unknown_handoff_fields)}")
+        _string_list(handoff_contract.get("required_record"), field=f"{field}.handoff_contract.required_record")
+        if "avoid" in handoff_contract and not isinstance(handoff_contract["avoid"], str):
+            raise ValueError(f"{field}.handoff_contract.avoid must be a string")
 
 
 def load_episode(path: Path) -> dict[str, Any]:
@@ -110,6 +162,7 @@ def validate_episode(episode: dict[str, Any]) -> None:
     rubric = episode.get("rubric")
     if not isinstance(rubric, dict) or not rubric:
         raise ValueError("episode.rubric must be a non-empty object")
+    _validate_evaluation_contract(episode.get("evaluation_contract"), field="episode.evaluation_contract")
 
 
 def validate_evaluation_result(result: dict[str, Any]) -> None:
@@ -396,6 +449,7 @@ def _evaluation_prompt(*, episode: dict[str, Any], mode_result: dict[str, Any]) 
             "rubric": episode.get("rubric", {}),
             "known_traps": episode.get("known_traps", []),
             "expected_mistake_classes": episode.get("expected_mistake_classes", []),
+            "evaluation_contract": episode.get("evaluation_contract", {}),
         },
         "mode_result": mode_result,
         "hidden_oracle_excluded": hidden_oracle is not None,
@@ -403,6 +457,36 @@ def _evaluation_prompt(*, episode: dict[str, Any], mode_result: dict[str, Any]) 
     return f"Review this long-horizon episode evidence and return only a JSON object matching {EVALUATION_KIND}.\n\n" + json.dumps(
         evidence_bundle, indent=2, sort_keys=True
     )
+
+
+def _contract_assessment(*, episode: dict[str, Any], evaluation_payload: dict[str, Any]) -> dict[str, Any]:
+    contract = episode.get("evaluation_contract")
+    if not isinstance(contract, dict) or not contract:
+        return {"status": "absent"}
+    if not isinstance(evaluation_payload, dict) or evaluation_payload.get("kind") != EVALUATION_KIND:
+        return {
+            "status": "pending-primary-score",
+            "contract": contract,
+            "claim_level": "unknown",
+            "blocking_rules": [],
+        }
+    mistakes = set(_string_list(evaluation_payload.get("mistake_classes"), field="evaluation.mistake_classes"))
+    blocking_rules: list[dict[str, Any]] = []
+    for rule in contract.get("blocked_full_completion_when", []):
+        if not isinstance(rule, dict):
+            continue
+        mistake_class = rule.get("mistake_class")
+        if isinstance(mistake_class, str) and mistake_class in mistakes:
+            blocking_rules.append(rule)
+    full_completion_blocked = bool(blocking_rules)
+    return {
+        "status": "full-completion-blocked" if full_completion_blocked else "primary-score-allows-claim",
+        "contract": contract,
+        "claim_level": "partial-progress" if full_completion_blocked else "primary-evaluation-claim",
+        "blocking_rules": blocking_rules,
+        "required_reconciliation": contract.get("required_reconciliation", []) if full_completion_blocked else [],
+        "agent_facing_claim_boundary": contract.get("agent_facing_claim_boundary", "") if full_completion_blocked else "",
+    }
 
 
 def _post_score_reference_payload(*, episode: dict[str, Any], evaluation_status: str) -> dict[str, Any]:
@@ -440,10 +524,11 @@ def _parse_evaluation(text: str) -> dict[str, Any]:
     return payload
 
 
-def _comparison_summary(mode_results: list[dict[str, Any]]) -> dict[str, Any]:
+def _comparison_summary(mode_results: list[dict[str, Any]], *, episode: dict[str, Any] | None = None) -> dict[str, Any]:
     mistake_classes_by_mode: dict[str, list[str]] = {}
     aw_effect_by_mode: dict[str, dict[str, list[str]]] = {}
     post_score_reference_by_mode: dict[str, dict[str, Any]] = {}
+    contract_assessment_by_mode: dict[str, dict[str, Any]] = {}
     human_review_required = False
     followups: list[dict[str, Any]] = []
     for result in mode_results:
@@ -451,6 +536,8 @@ def _comparison_summary(mode_results: list[dict[str, Any]]) -> dict[str, Any]:
         evaluation_result = result.get("evaluation", {})
         if isinstance(evaluation_result, dict) and isinstance(evaluation_result.get("post_score_reference"), dict):
             post_score_reference_by_mode[mode_id] = evaluation_result["post_score_reference"]
+        if isinstance(evaluation_result, dict) and isinstance(evaluation_result.get("contract_assessment"), dict):
+            contract_assessment_by_mode[mode_id] = evaluation_result["contract_assessment"]
         evaluation = evaluation_result.get("payload") if isinstance(evaluation_result, dict) else None
         if not isinstance(evaluation, dict):
             continue
@@ -467,6 +554,11 @@ def _comparison_summary(mode_results: list[dict[str, Any]]) -> dict[str, Any]:
         if isinstance(followup, dict):
             followups.append({"mode": mode_id, **followup})
     all_classes = sorted({item for values in mistake_classes_by_mode.values() for item in values})
+    blocking_modes = [
+        mode_id
+        for mode_id, assessment in contract_assessment_by_mode.items()
+        if assessment.get("status") == "full-completion-blocked"
+    ]
     return {
         "kind": "agentic-workspace/long-horizon-comparison/v1",
         "status": "present" if mode_results else "absent",
@@ -478,6 +570,16 @@ def _comparison_summary(mode_results: list[dict[str, Any]]) -> dict[str, Any]:
         "recommended_followups": followups,
         "continuation_comparison": _continuation_comparison(mode_results),
         "post_score_reference_by_mode": post_score_reference_by_mode,
+        "contract_assessment_by_mode": contract_assessment_by_mode,
+        "claim_gate": {
+            "status": "full-completion-blocked" if blocking_modes else "primary-evaluation",
+            "blocking_modes": blocking_modes,
+            "contract_present": bool(isinstance(episode, dict) and episode.get("evaluation_contract")),
+            "rule": (
+                "Episode evaluation contracts downgrade full-completion claims when configured mistake classes appear; "
+                "visible validation success remains separate from semantic proof, restartability, and managed-state proof."
+            ),
+        },
         "rule": "Comparison is review evidence, not a deterministic leaderboard.",
     }
 
@@ -594,6 +696,10 @@ def run_episode(
             adapter=setup_adapter if isinstance(setup_adapter, dict) else None,
             local_aw_wheelhouse=local_aw_wheelhouse,
             source_checkout_path=_adapter_fixture_source_path(suite=suite, adapter_id=setup_adapter_id),
+        )
+        harness._write_scratch_run_manifest(
+            paths.run_root,
+            purpose=f"long-horizon episode run: {episode['id']}/{mode['id']}",
         )
         replacements = {
             "repo": str(paths.repo_path),
@@ -791,6 +897,7 @@ def run_episode(
                 }
                 evaluation_payload = {"status": "not-run"}
                 evaluation_status = "not-run"
+            contract_assessment = _contract_assessment(episode=episode, evaluation_payload=evaluation_payload)
             mode_result["evaluation"] = {
                 "status": evaluation_status,
                 "adapter_id": evaluator_adapter_id,
@@ -804,6 +911,7 @@ def run_episode(
                 "artifact_capture": artifact_capture,
                 "result": evaluator_result,
                 "payload": evaluation_payload,
+                "contract_assessment": contract_assessment,
                 "hidden_oracle_excluded": episode.get("hidden_oracle") is not None,
                 "post_score_reference": _post_score_reference_payload(episode=episode, evaluation_status=evaluation_status),
             }
@@ -815,7 +923,7 @@ def run_episode(
         "execute": execute,
         "mode_count": len(mode_results),
         "modes": mode_results,
-        "comparison": _comparison_summary(mode_results),
+        "comparison": _comparison_summary(mode_results, episode=episode),
     }
     output_root.mkdir(parents=True, exist_ok=True)
     harness._write_json(output_root / f"{episode['id']}-summary.json", payload)

--- a/scripts/model_cli_harness/run_sbx_codex_adapter.py
+++ b/scripts/model_cli_harness/run_sbx_codex_adapter.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+WINDOWS_COMMAND_LINE_LIMIT = 32000
+
 
 def _run(command: list[str], *, capture: bool = False) -> subprocess.CompletedProcess[str]:
     process = subprocess.run(  # noqa: S603
@@ -45,6 +47,55 @@ def _sandbox_path(path: str) -> str:
     return f"/{match.group(1).lower()}/{match.group(2)}"
 
 
+def _codex_exec_command(
+    *,
+    args: argparse.Namespace,
+    prompt: str,
+    sandbox_repo: str,
+    sandbox_share_path: str,
+) -> list[str]:
+    exec_command = [args.sbx, "exec"]
+    for env_value in args.exec_env:
+        exec_command.extend(["-e", env_value])
+    exec_command.extend(
+        [
+            args.sandbox_name,
+            "codex",
+            "exec",
+            "--model",
+            args.model,
+            "--cd",
+            sandbox_repo,
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--skip-git-repo-check",
+            "--output-last-message",
+            sandbox_share_path,
+            "--json",
+            prompt,
+        ]
+    )
+    return exec_command
+
+
+def _windows_command_line_length(command: list[str]) -> int:
+    return len(subprocess.list2cmdline(command))
+
+
+def _windows_command_length_error(command: list[str], *, prompt_file: str | None) -> str | None:
+    if sys.platform != "win32":
+        return None
+    command_length = _windows_command_line_length(command)
+    if command_length < WINDOWS_COMMAND_LINE_LIMIT:
+        return None
+    source = f" from prompt file {prompt_file}" if prompt_file else ""
+    return (
+        "codex-sbx cannot safely pass this large prompt through the Windows command line"
+        f"{source}: rendered command is {command_length} characters, limit is {WINDOWS_COMMAND_LINE_LIMIT}. "
+        "Refusing before sandbox/model execution. Use the plain codex adapter's file-backed prompt transport "
+        "or reduce the prompt until codex-sbx grows in-sandbox prompt-file support."
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--sbx", default="sbx")
@@ -62,6 +113,17 @@ def main(argv: list[str] | None = None) -> int:
     prompt = _prompt_from_args(args)
     sandbox_repo = _sandbox_path(args.repo)
     sandbox_share_path = _sandbox_path(args.share_path)
+    exec_command = _codex_exec_command(
+        args=args,
+        prompt=prompt,
+        sandbox_repo=sandbox_repo,
+        sandbox_share_path=sandbox_share_path,
+    )
+    command_length_error = _windows_command_length_error(exec_command, prompt_file=args.prompt_file)
+    if command_length_error:
+        print(command_length_error, file=sys.stderr, flush=True)
+        return 2
+
     create_command = [args.sbx, "create", "--name", args.sandbox_name]
     if args.template:
         create_command.extend(["--template", args.template])
@@ -91,26 +153,6 @@ def main(argv: list[str] | None = None) -> int:
         if mkdir != 0:
             return_code = mkdir
         else:
-            exec_command = [args.sbx, "exec"]
-            for env_value in args.exec_env:
-                exec_command.extend(["-e", env_value])
-            exec_command.extend(
-                [
-                    args.sandbox_name,
-                    "codex",
-                    "exec",
-                    "--model",
-                    args.model,
-                    "--cd",
-                    sandbox_repo,
-                    "--dangerously-bypass-approvals-and-sandbox",
-                    "--skip-git-repo-check",
-                    "--output-last-message",
-                    sandbox_share_path,
-                    "--json",
-                    prompt,
-                ]
-            )
             return_code = _returncode(exec_command)
     finally:
         if not args.keep_sandbox:

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -710,6 +710,79 @@ def test_model_cli_harness_codex_sbx_dry_run_marks_sandbox(tmp_path: Path) -> No
     assert "[tool.uv.sources]" not in pyproject_text
 
 
+def test_model_cli_harness_plain_codex_large_prompt_uses_file_reference_transport(tmp_path: Path) -> None:
+    module = _load_harness_module()
+    suite = module._load_json(REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json")
+    adapter = suite["adapters"]["codex"]
+    large_prompt = "large evaluator prompt\n" * 1000
+
+    command, prompt_transport, _ = module._adapter_invocation_command(
+        adapter,
+        adapter_id="codex",
+        model=adapter["default_model"],
+        replacements={
+            "repo": str(tmp_path / "repo"),
+            "run_root": str(tmp_path / "run"),
+            "share_path": str(tmp_path / "run" / "share.md"),
+            "postmortem_cwd": str(tmp_path / "run" / "postmortem-context"),
+            "transcript_path": str(tmp_path / "run" / "transcript.jsonl"),
+            "prompt": large_prompt,
+        },
+        run_root=tmp_path / "run",
+        prompt_id="large-evaluator",
+    )
+
+    prompt_file = Path(prompt_transport["prompt_file"])
+    assert prompt_transport["mode"] == "file-reference"
+    assert prompt_file.exists()
+    assert prompt_file.read_text(encoding="utf-8") == large_prompt
+    assert large_prompt not in command
+    assert command[-1].startswith("Read the complete prompt from this file")
+    assert str(prompt_file) in command[-1]
+
+
+def test_sbx_codex_adapter_rejects_overlong_windows_prompt_before_model_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_sbx_adapter_module()
+    commands: list[list[str]] = []
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("large prompt\n" * 100, encoding="utf-8")
+
+    def fake_run(command: list[str], *, capture: bool = False) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module, "_run", fake_run)
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    monkeypatch.setattr(module, "WINDOWS_COMMAND_LINE_LIMIT", 120)
+
+    result = module.main(
+        [
+            "--sbx",
+            "sbx",
+            "--sandbox-name",
+            "aw-test",
+            "--repo",
+            "work/repo",
+            "--model",
+            "gpt-test",
+            "--share-path",
+            "work/share/final.md",
+            "--prompt-file",
+            str(prompt_file),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert commands == []
+    assert "Refusing before sandbox/model execution" in captured.err
+    assert "plain codex adapter" in captured.err
+
+
 def test_sbx_codex_adapter_removes_named_sandbox_after_failed_run(monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_sbx_adapter_module()
     commands: list[list[str]] = []

--- a/tests/test_long_horizon_episode.py
+++ b/tests/test_long_horizon_episode.py
@@ -213,6 +213,46 @@ def test_long_horizon_episode_rejects_unknown_mistake_class(tmp_path: Path) -> N
         raise AssertionError("expected invalid mistake class to fail")
 
 
+def test_long_horizon_episode_rejects_malformed_evaluation_contract(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    schema_path = REPO_ROOT / "tools" / "model-cli-harness" / "schemas" / "long-horizon-episode.schema.json"
+    episode_schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    episode_validator = Draft202012Validator(episode_schema)
+    path = _write_episode(tmp_path)
+    episode = json.loads(path.read_text(encoding="utf-8"))
+
+    episode["evaluation_contract"] = {
+        "blocked_full_completion": [
+            {
+                "mistake_class": "weak_proof",
+                "reason": "misspelled gate key should not be accepted",
+            }
+        ]
+    }
+    assert list(episode_validator.iter_errors(episode))
+    try:
+        module.validate_episode(episode)
+    except ValueError as exc:
+        assert "unknown fields" in str(exc)
+    else:
+        raise AssertionError("expected misspelled contract key to fail")
+
+    episode["evaluation_contract"] = {
+        "blocked_full_completion_when": [
+            {
+                "reason": "missing mistake class would silently fail to gate claims",
+            }
+        ]
+    }
+    assert list(episode_validator.iter_errors(episode))
+    try:
+        module.validate_episode(episode)
+    except ValueError as exc:
+        assert "mistake_class is required" in str(exc)
+    else:
+        raise AssertionError("expected missing mistake_class to fail")
+
+
 def test_long_horizon_episode_runs_two_phase_hidden_restart(tmp_path: Path) -> None:
     module = _load_episode_module()
     suite = _write_suite(tmp_path)
@@ -463,6 +503,45 @@ def test_long_horizon_episode_evaluator_excludes_hidden_oracle_and_reports_compa
     assert payload["comparison"]["mistake_classes"] == ["weak_proof"]
     assert payload["comparison"]["human_review_required"] is True
     assert payload["comparison"]["recommended_followups"][0]["type"] == "issue"
+
+
+def test_long_horizon_episode_contract_blocks_full_completion_on_configured_mistake(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    suite = _write_suite(tmp_path)
+    episode = _write_episode(tmp_path)
+    episode_payload = json.loads(episode.read_text(encoding="utf-8"))
+    episode_payload["evaluation_contract"] = {
+        "issue_refs": ["#1917"],
+        "failure_path_summary": "Visible tests passed, but semantic proof stayed narrow.",
+        "agent_facing_claim_boundary": "Visible validation success is not semantic proof sufficiency.",
+        "required_reconciliation": ["Run broader semantic checks before claiming full completion."],
+        "blocked_full_completion_when": [
+            {
+                "mistake_class": "weak_proof",
+                "reason": "The proof path is too narrow for the intent.",
+            }
+        ],
+    }
+    episode.write_text(json.dumps(episode_payload), encoding="utf-8")
+
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=True,
+        evaluator=True,
+    )
+
+    mode = payload["modes"][0]
+    evaluator_prompt = (Path(mode["repo_path"]) / "evaluator-prompt.txt").read_text(encoding="utf-8")
+    assessment = mode["evaluation"]["contract_assessment"]
+
+    assert "Visible validation success is not semantic proof sufficiency" in evaluator_prompt
+    assert assessment["status"] == "full-completion-blocked"
+    assert assessment["claim_level"] == "partial-progress"
+    assert assessment["blocking_rules"][0]["mistake_class"] == "weak_proof"
+    assert payload["comparison"]["claim_gate"]["status"] == "full-completion-blocked"
+    assert payload["comparison"]["claim_gate"]["blocking_modes"] == ["aw-assisted"]
 
 
 def test_long_horizon_episode_invalid_evaluator_json_is_failure(tmp_path: Path) -> None:

--- a/tools/model-cli-harness/episodes/intent-proof-packaging-specifier.json
+++ b/tools/model-cli-harness/episodes/intent-proof-packaging-specifier.json
@@ -71,6 +71,35 @@
     "restartability_expected": true,
     "closeout_expectation": "Completion claim should identify whether only regression proof or broader semantic proof was obtained."
   },
+  "evaluation_contract": {
+    "issue_refs": [
+      "#1917"
+    ],
+    "failure_path_summary": "A prior AW-assisted run passed the visible specifier test path but still lacked proof that arbitrary `===` comparisons preserve original non-normalized spelling.",
+    "agent_facing_claim_boundary": "Visible test success is regression proof only for this episode. Full completion requires broader semantic variants or equivalent evidence for the original-string claim.",
+    "required_reconciliation": [
+      "Add or run semantic checks for non-normalized `===` spelling variants.",
+      "Separate visible validation success from semantic proof sufficiency in closeout."
+    ],
+    "blocked_full_completion_when": [
+      {
+        "mistake_class": "weak_proof",
+        "reason": "Narrow visible tests do not prove the semantic claim."
+      },
+      {
+        "mistake_class": "proof_overclaim",
+        "reason": "The proof claim exceeded the visible evidence."
+      },
+      {
+        "mistake_class": "completion_overclaim",
+        "reason": "Full completion was claimed before semantic proof was reconciled."
+      }
+    ],
+    "evaluator_focus": [
+      "Flag runs that pass visible tests but leave hidden original-string behavior unproven.",
+      "Downgrade full completion until semantic proof is broader than the regression path."
+    ]
+  },
   "evaluator": {
     "adapter": "codex",
     "model": "gpt-5.3-codex-spark"

--- a/tools/model-cli-harness/episodes/managed-planning-state-agentic-workspace.json
+++ b/tools/model-cli-harness/episodes/managed-planning-state-agentic-workspace.json
@@ -61,6 +61,40 @@
     "restartability_expected": false,
     "closeout_expectation": "Completion should identify the managed-state boundary and avoid claiming manual edits are ordinary source changes."
   },
+  "evaluation_contract": {
+    "issue_refs": [
+      "#1919"
+    ],
+    "failure_path_summary": "A prior recovery run trusted stale Planning/proof projections and then overclaimed completion instead of treating reconciliation as the next required action.",
+    "agent_facing_claim_boundary": "Stale Planning or proof projections are blockers when they are used to recover state or justify closeout. Full readiness requires reconciliation through AW-owned summary/repair proof.",
+    "required_reconciliation": [
+      "Name the stale projection and its owner.",
+      "Run or identify the AW-owned reconciliation/proof action before readiness.",
+      "Keep direct ordinary work unblocked unless it relies on the stale state or claims progress from it."
+    ],
+    "blocked_full_completion_when": [
+      {
+        "mistake_class": "stale_planning_state_trusted",
+        "reason": "Recovery or closeout trusted stale managed Planning/proof projection."
+      },
+      {
+        "mistake_class": "completion_overclaim",
+        "reason": "The agent claimed safe completion before managed-state reconciliation proof."
+      },
+      {
+        "mistake_class": "manual_managed_state_edit",
+        "reason": "Managed Planning state was edited as ordinary source."
+      },
+      {
+        "mistake_class": "wrong_owner_edit",
+        "reason": "The repair bypassed the AW-owned command surface."
+      }
+    ],
+    "evaluator_focus": [
+      "Flag stale Planning/proof projections as partial-claim boundaries during recovery.",
+      "Do not penalize ordinary direct work unless the task relies on stale state or claims progress from it."
+    ]
+  },
   "evaluator": {
     "adapter": "codex",
     "model": "gpt-5.3-codex-spark"

--- a/tools/model-cli-harness/episodes/reuse-abstraction-pluggy.json
+++ b/tools/model-cli-harness/episodes/reuse-abstraction-pluggy.json
@@ -82,13 +82,56 @@
     "existing_helper_missed",
     "bad_abstraction",
     "handoff_unusable",
-    "restart_failed"
+    "restart_failed",
+    "weak_proof"
   ],
   "rubric": {
     "intent_satisfied": "The hookcaller bookkeeping remains coherent for plugins with multiple hook implementations.",
     "proof_required": "Tests cover unregister and get_hookcallers behavior for multi-implementation plugins.",
     "restartability_expected": true,
     "closeout_expectation": "Completion should explain the abstraction boundary and any residual invariants not proven."
+  },
+  "evaluation_contract": {
+    "issue_refs": [
+      "#1918"
+    ],
+    "failure_path_summary": "Prior runs exposed two continuation failures: agent-switch handoff lacked a restartable abstraction-boundary record, and same-agent continuation drifted into duplicated hook bookkeeping with weak proof.",
+    "agent_facing_claim_boundary": "A continuation may not claim full completion unless the repo-visible state preserves the hookcaller abstraction boundary, the next action, and the proof boundary without relying on broad transcript replay.",
+    "required_reconciliation": [
+      "Record the hookcaller/plugin bookkeeping boundary in a compact continuation-safe form.",
+      "Keep abstraction-preservation checks visible before closeout.",
+      "For same-agent continuation, prove the implementation did not duplicate hook bookkeeping concepts."
+    ],
+    "blocked_full_completion_when": [
+      {
+        "mistake_class": "handoff_unusable",
+        "reason": "The next phase could not restart from repo-visible handoff state."
+      },
+      {
+        "mistake_class": "restart_failed",
+        "reason": "Continuation relied on lost chat context or stale assumptions."
+      },
+      {
+        "mistake_class": "bad_abstraction",
+        "reason": "The implementation duplicated or bypassed the existing hookcaller abstraction."
+      },
+      {
+        "mistake_class": "weak_proof",
+        "reason": "Proof did not show abstraction preservation for multi-implementation plugins."
+      }
+    ],
+    "handoff_contract": {
+      "required_record": [
+        "abstraction_boundary",
+        "next_action",
+        "claim_boundary"
+      ],
+      "avoid": "broad transcript replay for ordinary low-risk handoffs"
+    },
+    "evaluator_focus": [
+      "Compare same-agent and agent-switch continuation for restartability and abstraction drift.",
+      "Treat a handoff as insufficient if it lacks a compact next-action and claim-boundary record."
+    ]
   },
   "evaluator": {
     "adapter": "codex",

--- a/tools/model-cli-harness/schemas/long-horizon-episode.schema.json
+++ b/tools/model-cli-harness/schemas/long-horizon-episode.schema.json
@@ -161,6 +161,58 @@
       "minProperties": 1,
       "additionalProperties": true
     },
+    "evaluation_contract": {
+      "type": "object",
+      "properties": {
+        "issue_refs": {
+          "$ref": "#/$defs/stringList"
+        },
+        "failure_path_summary": {
+          "type": "string"
+        },
+        "agent_facing_claim_boundary": {
+          "type": "string"
+        },
+        "required_reconciliation": {
+          "$ref": "#/$defs/stringList"
+        },
+        "blocked_full_completion_when": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "mistake_class"
+            ],
+            "properties": {
+              "mistake_class": {
+                "type": "string",
+                "minLength": 1
+              },
+              "reason": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "evaluator_focus": {
+          "$ref": "#/$defs/stringList"
+        },
+        "handoff_contract": {
+          "type": "object",
+          "properties": {
+            "required_record": {
+              "$ref": "#/$defs/stringList"
+            },
+            "avoid": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "evaluator": {
       "type": "object",
       "additionalProperties": true
@@ -175,6 +227,12 @@
         "items": {
           "type": "string"
         }
+      }
+    },
+    "stringList": {
+      "type": "array",
+      "items": {
+        "type": "string"
       }
     }
   }

--- a/tools/model-cli-harness/suites/copilot-workflow-smoke.json
+++ b/tools/model-cli-harness/suites/copilot-workflow-smoke.json
@@ -2,6 +2,11 @@
   "schema": "agentic-workspace/model-cli-harness-suite/v1",
   "id": "copilot-workflow-smoke",
   "purpose": "Black-box smoke scenarios for checking whether model CLIs discover and follow Agentic Workspace startup, planning, and closeout paths.",
+  "prompt_transport_guidance": {
+    "large_prompt_rule": "Adapters used for long-horizon evaluator prompts must avoid embedding large prompts directly in argv on Windows. Prefer prompt_transport with file_args when the CLI supports attachments; for plain codex use file-reference prompt_transport so argv carries only the prompt-file path.",
+    "managed_artifact_root": ".agentic-workspace/local/scratch/runs",
+    "codex_sbx_status": "codex-sbx uses prompt-file metadata but currently fails early with an actionable unsupported error if the rendered Windows command would exceed the command-line limit."
+  },
   "adapters": {
     "copilot": {
       "default_model": "claude-haiku-4.5",
@@ -127,6 +132,12 @@
       "block_on_preflight_failure": true,
       "inject_repo_startup_instructions": true,
       "postmortem_feedback_supported": false,
+      "prompt_transport": {
+        "threshold_chars": 8000,
+        "mode": "file-reference",
+        "file_args": [],
+        "file_prompt": "Read the complete prompt from this file and follow it exactly: {prompt_file}"
+      },
       "command": [
         "codex",
         "exec",


### PR DESCRIPTION
## Summary

Implements the refined long-horizon evaluation issues as one focused harness slice.

- Adds plain Codex file-reference prompt transport and documents the supported large-prompt route for evaluator authors.
- Makes codex-sbx fail early with an actionable unsupported error before sandbox/model execution when a Windows command would exceed the command-line limit.
- Adds episode-level evaluation contracts for semantic proof sufficiency, restartable handoff/abstraction boundaries, and stale managed-planning recovery.
- Surfaces contract assessments in evaluator results and comparison claim gates so visible validation success is separate from full-completion proof.

Fixes #1916.
Fixes #1917.
Fixes #1918.
Fixes #1919.

## Validation

- `uv run pytest tests/test_long_horizon_episode.py -q`
- `uv run pytest tests/test_external_agent_evaluation_lane.py -q`
- `git diff --check`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `make typecheck`
- `uv run pytest tests/test_workspace_cli.py tests/test_workspace_proof_cli.py tests/test_workspace_summary_cli.py -q`