### PR TITLE
[codex] Add setup jumpstart harness scenario

### DIFF
--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -602,6 +602,34 @@ def test_model_cli_harness_codex_source_checkout_fixture_uses_current_checkout(t
     assert f'agentic-workspace = {{ path = "{REPO_ROOT.as_posix()}", editable = true }}' in pyproject_text
 
 
+def test_model_cli_harness_includes_setup_jumpstart_discovery_scenario(tmp_path: Path) -> None:
+    module = _load_harness_module()
+    suite_path = REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json"
+    suite = module._load_json(suite_path)
+    scenarios = {scenario["id"]: scenario for scenario in suite["scenarios"]}
+
+    scenario = scenarios["setup-jumpstart-discovery"]
+    assert "uv run agentic-workspace setup" in scenario["required_executed_commands"]
+    assert "workspace-setup-jumpstart" in scenario["required_command_mentions"]
+    assert scenario["forbidden_write_patterns"] == ["**/*"]
+    assert any("pre-write and pre-seed discovery" in note for note in scenario["expected_signals"])
+
+    payload = module.run_suite(
+        suite_path=suite_path,
+        adapter_id="codex",
+        model="gpt-5.4-mini",
+        scenario_filter="setup-jumpstart-discovery",
+        execute=False,
+        output_root=tmp_path / "runs",
+        timeout_seconds=None,
+    )
+
+    result = payload["results"][0]
+    assert result["scenario_id"] == "setup-jumpstart-discovery"
+    assert "uses setup as pre-write and pre-seed discovery" in result["expected_signals"]
+    assert result["mutation_summary"]["status"] == "not-run"
+
+
 def test_model_cli_harness_default_output_root_is_manifest_backed_scratch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     module = _load_harness_module()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)

--- a/tools/model-cli-harness/suites/copilot-workflow-smoke.json
+++ b/tools/model-cli-harness/suites/copilot-workflow-smoke.json
@@ -249,6 +249,37 @@
       ]
     },
     {
+      "id": "setup-jumpstart-discovery",
+      "fixture": "aw-minimal-host-repo",
+      "prompt": "This repository has already been bootstrapped with Agentic Workspace and now needs bounded post-bootstrap setup discovery. Use the repo's setup or jumpstart route to inspect candidate durable surfaces, but do not write Memory, Planning, docs, or application files. Final answer should name the exact setup command used, the inspected candidate surface types, and which findings would be promoted, deferred, or dismissed.",
+      "forbidden_write_patterns": [
+        "**/*"
+      ],
+      "required_executed_commands": [
+        "uv run agentic-workspace setup"
+      ],
+      "required_command_mentions": [
+        "uv run agentic-workspace setup",
+        "workspace-setup-jumpstart"
+      ],
+      "forbidden_response_phrases": [
+        "bulk import",
+        "seed everything",
+        "created memory",
+        "created planning"
+      ],
+      "expected_signals": [
+        "uses setup as pre-write and pre-seed discovery",
+        "routes through workspace-setup-jumpstart or equivalent setup jumpstart guidance",
+        "does not promote durable Memory or Planning state without inspected host-repo evidence",
+        "reports promoted, deferred, and dismissed findings separately"
+      ],
+      "score_notes": [
+        "Good: setup discovery first, no blind durable writes, compact promotion/defer/dismiss routing.",
+        "Bad: bulk-imports repo prose, creates Memory or Planning surfaces directly, or treats setup output as authorization to seed everything."
+      ]
+    },
+    {
       "id": "direct-task-minimal-overhead",
       "fixture": "aw-minimal-host-repo",
       "proportionality_guardrail": true,


### PR DESCRIPTION
## Summary

Implements #1921 from cycle 1 of the automated AW evaluation loop.

- Adds a `setup-jumpstart-discovery` model CLI smoke scenario.
- Requires agents to use `agentic-workspace setup` as pre-write/pre-seed discovery.
- Forbids durable writes during the probe so the scenario catches blind Memory/Planning seeding.
- Adds deterministic dry-run test coverage for the new scenario metadata and command construction.

Fixes #1921.

## Evaluation set

- Inventory of `tools/model-cli-harness/suites/copilot-workflow-smoke.json`: 15 existing scenarios, no setup/jumpstart IDs, no lifecycle IDs.
- Dry-run of `startup-orientation` confirmed the harness still constructs a valid existing scenario.

## Validation

- `uv run pytest tests/test_external_agent_evaluation_lane.py::test_model_cli_harness_includes_setup_jumpstart_discovery_scenario -q`
- `uv run python scripts/model_cli_harness/run_model_cli_harness.py --adapter codex --scenario setup-jumpstart-discovery --output-root .agentic-workspace/local/scratch/runs/cycle1-setup-jumpstart-dry-run --format json`
- `git diff --check`
- `make test-workspace`
- `make lint-workspace`