### PR TITLE
[codex] Add lifecycle dry-run smoke coverage

### DIFF
--- a/.agentic-workspace/verification/assurance-evidence-records.json
+++ b/.agentic-workspace/verification/assurance-evidence-records.json
@@ -1,0 +1,29 @@
+{
+  "kind": "agentic-workspace/assurance-evidence-records/v1",
+  "records": [
+    {
+      "requirement_id": "test_evidence_change_decision",
+      "evidence_label": "verification_proof_decision_review",
+      "status": "satisfied",
+      "source_kind": "manual-review",
+      "command": "uv run pytest tests/test_lifecycle_smoke.py -q; make test-workspace; make lint-workspace; git diff --check",
+      "changed_paths": [
+        "tests/test_lifecycle_smoke.py"
+      ],
+      "recorded_by": "agent",
+      "notes": "Issue #1923 adds permanent root lifecycle smoke evidence for workspace, planning, and memory upgrade/uninstall dry-run safety. This is additive behavior-class coverage for high-risk lifecycle mutation safety; it does not prune or replace existing lifecycle evidence."
+    },
+    {
+      "requirement_id": "test_evidence_change_decision",
+      "evidence_label": "test_evidence_owner_review",
+      "status": "satisfied",
+      "source_kind": "manual-review",
+      "command": "uv run pytest tests/test_lifecycle_smoke.py -q; make test-workspace; make lint-workspace; git diff --check",
+      "changed_paths": [
+        "tests/test_lifecycle_smoke.py"
+      ],
+      "recorded_by": "agent",
+      "notes": "Owner is the root workspace lifecycle smoke suite because the trust question is front-door integration: dry-run upgrade and uninstall commands must report dry_run=true and leave installed planning and memory state intact."
+    }
+  ]
+}

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -602,6 +602,34 @@ def test_model_cli_harness_codex_source_checkout_fixture_uses_current_checkout(t
     assert f'agentic-workspace = {{ path = "{REPO_ROOT.as_posix()}", editable = true }}' in pyproject_text
 
 
+def test_model_cli_harness_includes_setup_jumpstart_discovery_scenario(tmp_path: Path) -> None:
+    module = _load_harness_module()
+    suite_path = REPO_ROOT / "tools" / "model-cli-harness" / "suites" / "copilot-workflow-smoke.json"
+    suite = module._load_json(suite_path)
+    scenarios = {scenario["id"]: scenario for scenario in suite["scenarios"]}
+
+    scenario = scenarios["setup-jumpstart-discovery"]
+    assert "uv run agentic-workspace setup" in scenario["required_executed_commands"]
+    assert "workspace-setup-jumpstart" in scenario["required_command_mentions"]
+    assert scenario["forbidden_write_patterns"] == ["**/*"]
+    assert any("pre-write and pre-seed discovery" in note for note in scenario["expected_signals"])
+
+    payload = module.run_suite(
+        suite_path=suite_path,
+        adapter_id="codex",
+        model="gpt-5.4-mini",
+        scenario_filter="setup-jumpstart-discovery",
+        execute=False,
+        output_root=tmp_path / "runs",
+        timeout_seconds=None,
+    )
+
+    result = payload["results"][0]
+    assert result["scenario_id"] == "setup-jumpstart-discovery"
+    assert "uses setup as pre-write and pre-seed discovery" in result["expected_signals"]
+    assert result["mutation_summary"]["status"] == "not-run"
+
+
 def test_model_cli_harness_default_output_root_is_manifest_backed_scratch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     module = _load_harness_module()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)

--- a/tests/test_lifecycle_smoke.py
+++ b/tests/test_lifecycle_smoke.py
@@ -76,6 +76,40 @@ def test_workspace_lifecycle_smoke() -> None:
         )
         assert json.loads(status.stdout)["health"] == "healthy"
 
+        upgrade_dry_run = _run(
+            "agentic-workspace",
+            "upgrade",
+            "--target",
+            str(target),
+            "--modules",
+            "planning,memory",
+            "--non-interactive",
+            "--dry-run",
+            "--format",
+            "json",
+            cwd=WORKSPACE_ROOT,
+        )
+        assert json.loads(upgrade_dry_run.stdout)["dry_run"] is True
+        assert (target / ".agentic-workspace/planning/state.toml").exists()
+        assert (target / ".agentic-workspace/memory/repo/index.md").exists()
+
+        uninstall_dry_run = _run(
+            "agentic-workspace",
+            "uninstall",
+            "--target",
+            str(target),
+            "--modules",
+            "planning,memory",
+            "--non-interactive",
+            "--dry-run",
+            "--format",
+            "json",
+            cwd=WORKSPACE_ROOT,
+        )
+        assert json.loads(uninstall_dry_run.stdout)["dry_run"] is True
+        assert (target / ".agentic-workspace/planning/state.toml").exists()
+        assert (target / ".agentic-workspace/memory/repo/index.md").exists()
+
     modules = _run("agentic-workspace", "modules", "--verbose", "--format", "json", cwd=WORKSPACE_ROOT)
     module_payload = json.loads(modules.stdout)
     assert {entry["name"] for entry in module_payload["modules"]} >= {"planning", "memory"}
@@ -99,6 +133,32 @@ def test_planning_lifecycle_smoke() -> None:
 
         status = _run("agentic-planning", "status", "--target", str(target), "--format", "json", cwd=WORKSPACE_ROOT)
         assert json.loads(status.stdout)["target_root"]
+
+        upgrade_dry_run = _run(
+            "agentic-planning",
+            "upgrade",
+            "--target",
+            str(target),
+            "--dry-run",
+            "--format",
+            "json",
+            cwd=WORKSPACE_ROOT,
+        )
+        assert json.loads(upgrade_dry_run.stdout)["dry_run"] is True
+        assert state_path.exists()
+
+        uninstall_dry_run = _run(
+            "agentic-planning",
+            "uninstall",
+            "--target",
+            str(target),
+            "--dry-run",
+            "--format",
+            "json",
+            cwd=WORKSPACE_ROOT,
+        )
+        assert json.loads(uninstall_dry_run.stdout)["dry_run"] is True
+        assert state_path.exists()
 
         second = _run("agentic-planning", "install", "--target", str(target), cwd=WORKSPACE_ROOT, check=False)
         if second.returncode == 0:
@@ -127,6 +187,32 @@ def test_memory_lifecycle_smoke() -> None:
 
         status = _run("agentic-memory", "status", "--target", str(target), "--format", "json", cwd=WORKSPACE_ROOT)
         assert json.loads(status.stdout)["target_root"]
+
+        upgrade_dry_run = _run(
+            "agentic-memory",
+            "upgrade",
+            "--target",
+            str(target),
+            "--dry-run",
+            "--format",
+            "json",
+            cwd=WORKSPACE_ROOT,
+        )
+        assert json.loads(upgrade_dry_run.stdout)["dry_run"] is True
+        assert index_path.exists()
+
+        uninstall_dry_run = _run(
+            "agentic-memory",
+            "uninstall",
+            "--target",
+            str(target),
+            "--dry-run",
+            "--format",
+            "json",
+            cwd=WORKSPACE_ROOT,
+        )
+        assert json.loads(uninstall_dry_run.stdout)["dry_run"] is True
+        assert index_path.exists()
 
         second = _run("agentic-memory", "install", "--target", str(target), cwd=WORKSPACE_ROOT, check=False)
         if second.returncode == 0:

--- a/tools/model-cli-harness/suites/copilot-workflow-smoke.json
+++ b/tools/model-cli-harness/suites/copilot-workflow-smoke.json
@@ -249,6 +249,37 @@
       ]
     },
     {
+      "id": "setup-jumpstart-discovery",
+      "fixture": "aw-minimal-host-repo",
+      "prompt": "This repository has already been bootstrapped with Agentic Workspace and now needs bounded post-bootstrap setup discovery. Use the repo's setup or jumpstart route to inspect candidate durable surfaces, but do not write Memory, Planning, docs, or application files. Final answer should name the exact setup command used, the inspected candidate surface types, and which findings would be promoted, deferred, or dismissed.",
+      "forbidden_write_patterns": [
+        "**/*"
+      ],
+      "required_executed_commands": [
+        "uv run agentic-workspace setup"
+      ],
+      "required_command_mentions": [
+        "uv run agentic-workspace setup",
+        "workspace-setup-jumpstart"
+      ],
+      "forbidden_response_phrases": [
+        "bulk import",
+        "seed everything",
+        "created memory",
+        "created planning"
+      ],
+      "expected_signals": [
+        "uses setup as pre-write and pre-seed discovery",
+        "routes through workspace-setup-jumpstart or equivalent setup jumpstart guidance",
+        "does not promote durable Memory or Planning state without inspected host-repo evidence",
+        "reports promoted, deferred, and dismissed findings separately"
+      ],
+      "score_notes": [
+        "Good: setup discovery first, no blind durable writes, compact promotion/defer/dismiss routing.",
+        "Bad: bulk-imports repo prose, creates Memory or Planning surfaces directly, or treats setup output as authorization to seed everything."
+      ]
+    },
+    {
       "id": "direct-task-minimal-overhead",
       "fixture": "aw-minimal-host-repo",
       "proportionality_guardrail": true,


### PR DESCRIPTION
## Summary
- fixes #1923
- extends root lifecycle smoke coverage across workspace, planning, and memory upgrade/uninstall dry-run paths
- records the test-evidence proof decision in the AW verification evidence surface

## Evaluation Set
Cycle 2 lifecycle evaluation found existing conformance cases for lifecycle dry-runs, but root smoke coverage only mentioned init/install and did not exercise upgrade/uninstall front-door safety.

## Proof
- `uv run pytest tests/test_lifecycle_smoke.py -q`
- `make test-workspace`
- `make lint-workspace`
- `git diff --check`
- `uv run python scripts/run_agentic_workspace.py implement --changed tests/test_lifecycle_smoke.py .agentic-workspace/verification/assurance-evidence-records.json --task "Implement issue #1923: add lifecycle upgrade/uninstall dry-run smoke coverage with evidence record" --select next,proof,assurance_requirements --format json`
