### PR TITLE
[codex] Surface setup host orientation candidates

### DIFF
--- a/.agentic-workspace/verification/assurance-evidence-records.json
+++ b/.agentic-workspace/verification/assurance-evidence-records.json
@@ -24,6 +24,58 @@
       ],
       "recorded_by": "agent",
       "notes": "Owner is the root workspace lifecycle smoke suite because the trust question is front-door integration: dry-run upgrade and uninstall commands must report dry_run=true and leave installed planning and memory state intact."
+    },
+    {
+      "requirement_id": "subsystem:workspace-cli-runtime",
+      "evidence_label": "workspace_runtime_proof",
+      "status": "satisfied",
+      "source_kind": "command",
+      "command": "uv run pytest tests/test_workspace_cli.py::test_setup_surfaces_host_orientation_candidates_for_jumpstarted_repo -q; uv run pytest tests/test_workspace_cli.py -q; make test-workspace; make lint-workspace; make typecheck; uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json; git diff --check",
+      "changed_paths": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "tests/test_workspace_cli.py"
+      ],
+      "recorded_by": "agent",
+      "notes": "Issue #1925 changes the setup guidance payload owned by the workspace CLI runtime. The focused setup test installs AW into a mature-looking host repo and asserts read-only host orientation candidates are exposed without setup findings or durable seeding."
+    },
+    {
+      "requirement_id": "subsystem:workspace-cli-runtime",
+      "evidence_label": "tiny_surface_compatibility_review",
+      "status": "satisfied",
+      "source_kind": "manual-review",
+      "command": "uv run pytest tests/test_workspace_cli.py::test_setup_surfaces_host_orientation_candidates_for_jumpstarted_repo -q; git diff --check",
+      "changed_paths": [
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "tests/test_workspace_cli.py"
+      ],
+      "recorded_by": "agent",
+      "notes": "The new host_orientation field is scoped to the setup command payload and text output. It does not widen default start, implement, preflight, or summary payloads."
+    },
+    {
+      "requirement_id": "test_evidence_change_decision",
+      "evidence_label": "verification_proof_decision_review",
+      "status": "satisfied",
+      "source_kind": "manual-review",
+      "command": "uv run pytest tests/test_workspace_cli.py::test_setup_surfaces_host_orientation_candidates_for_jumpstarted_repo -q; uv run pytest tests/test_workspace_cli.py -q; make test-workspace; make lint-workspace; make typecheck; git diff --check",
+      "changed_paths": [
+        "tests/test_workspace_cli.py"
+      ],
+      "recorded_by": "agent",
+      "notes": "Issue #1925 adds permanent root workspace CLI coverage for setup guidance in jumpstarted repos. The test is additive behavior-class coverage and does not prune existing setup or lifecycle evidence."
+    },
+    {
+      "requirement_id": "test_evidence_change_decision",
+      "evidence_label": "test_evidence_owner_review",
+      "status": "satisfied",
+      "source_kind": "manual-review",
+      "command": "uv run pytest tests/test_workspace_cli.py::test_setup_surfaces_host_orientation_candidates_for_jumpstarted_repo -q; uv run pytest tests/test_workspace_cli.py -q; make test-workspace; make lint-workspace; make typecheck; git diff --check",
+      "changed_paths": [
+        "tests/test_workspace_cli.py"
+      ],
+      "recorded_by": "agent",
+      "notes": "Owner is the root workspace CLI test suite because the trust question is command-facing setup guidance, not package-local Planning or Memory state semantics."
     }
   ]
 }

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -36237,6 +36237,40 @@ def _repo_looks_setup_mature(*, target_root: Path) -> bool:
     return all((path.exists() for path in _setup_orientation_surfaces(target_root=target_root)))
 
 
+def _host_repo_orientation_payload(*, target_root: Path) -> dict[str, Any]:
+    candidates: list[dict[str, Any]] = []
+
+    def _add(path: str, *, reason: str, confidence: float) -> None:
+        surface = target_root / path
+        if not surface.exists():
+            return
+        candidates.append(
+            {
+                "surface": path,
+                "reason": reason,
+                "confidence": confidence,
+                "refs": [path],
+            }
+        )
+
+    _add("README.md", reason="host repo overview and setup context", confidence=0.94)
+    _add("docs/architecture.md", reason="host architecture and ownership context", confidence=0.9)
+    _add("docs", reason="host documentation directory", confidence=0.82)
+    _add("pyproject.toml", reason="Python project metadata and test or tooling hints", confidence=0.88)
+    _add("package.json", reason="Node project metadata and script hints", confidence=0.88)
+    _add("Cargo.toml", reason="Rust project metadata and test or tooling hints", confidence=0.88)
+    _add("go.mod", reason="Go module metadata and test or tooling hints", confidence=0.88)
+    _add("src", reason="host source tree", confidence=0.78)
+    _add("tests", reason="host test suite", confidence=0.78)
+
+    return {
+        "status": "present" if candidates else "absent",
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+        "rule": "Host orientation candidates are read-only setup hints; setup must not seed Memory, Planning, assurance, or verification state from them without agent judgment.",
+    }
+
+
 def _setup_payload(
     *,
     target_root: Path,
@@ -36273,6 +36307,7 @@ def _setup_payload(
     )
     proof_route_hints = _load_proof_route_hints(target_root=target_root)
     findings_input = _setup_findings_input_payload(target_root=target_root)
+    host_orientation = _host_repo_orientation_payload(target_root=target_root)
     assurance_onboarding = _assurance_onboarding_payload(assurance=config.assurance)
     verification_guidance = _verification_enablement_guidance(target_root=target_root, config=config)
     onboarding_routes = {
@@ -36359,6 +36394,7 @@ def _setup_payload(
             "rule": "Accept agent-produced setup findings as optional input, preserve only the classes that reduce rediscovery, and keep low-value or weakly grounded findings transient.",
         },
         "analysis_input": findings_input,
+        "host_orientation": host_orientation,
         "proof_route_hints": {
             "path": PROOF_ROUTE_HINTS_PATH.as_posix(),
             "status": proof_route_hints["status"],
@@ -36402,6 +36438,10 @@ def _emit_setup(
         print(f"- surface: {payload['orientation']['surface']}")
     if payload["orientation"].get("reason"):
         print(f"- reason: {payload['orientation']['reason']}")
+    if payload.get("host_orientation", {}).get("candidates"):
+        print("Host orientation candidates:")
+        for item in payload["host_orientation"]["candidates"]:
+            print(f"- {item['surface']}: {item['reason']}")
     print(f"- next action: {payload['next_action']['summary']}")
     for command in payload["next_action"]["commands"]:
         print(f"  - {command}")

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -35417,6 +35417,40 @@ def _repo_looks_setup_mature(*, target_root: Path) -> bool:
     return all((path.exists() for path in _setup_orientation_surfaces(target_root=target_root)))
 
 
+def _host_repo_orientation_payload(*, target_root: Path) -> dict[str, Any]:
+    candidates: list[dict[str, Any]] = []
+
+    def _add(path: str, *, reason: str, confidence: float) -> None:
+        surface = target_root / path
+        if not surface.exists():
+            return
+        candidates.append(
+            {
+                "surface": path,
+                "reason": reason,
+                "confidence": confidence,
+                "refs": [path],
+            }
+        )
+
+    _add("README.md", reason="host repo overview and setup context", confidence=0.94)
+    _add("docs/architecture.md", reason="host architecture and ownership context", confidence=0.9)
+    _add("docs", reason="host documentation directory", confidence=0.82)
+    _add("pyproject.toml", reason="Python project metadata and test or tooling hints", confidence=0.88)
+    _add("package.json", reason="Node project metadata and script hints", confidence=0.88)
+    _add("Cargo.toml", reason="Rust project metadata and test or tooling hints", confidence=0.88)
+    _add("go.mod", reason="Go module metadata and test or tooling hints", confidence=0.88)
+    _add("src", reason="host source tree", confidence=0.78)
+    _add("tests", reason="host test suite", confidence=0.78)
+
+    return {
+        "status": "present" if candidates else "absent",
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+        "rule": "Host orientation candidates are read-only setup hints; setup must not seed Memory, Planning, assurance, or verification state from them without agent judgment.",
+    }
+
+
 def _setup_payload(
     *,
     target_root: Path,
@@ -35453,6 +35487,7 @@ def _setup_payload(
     )
     proof_route_hints = _load_proof_route_hints(target_root=target_root)
     findings_input = _setup_findings_input_payload(target_root=target_root)
+    host_orientation = _host_repo_orientation_payload(target_root=target_root)
     assurance_onboarding = _assurance_onboarding_payload(assurance=config.assurance)
     verification_guidance = _verification_enablement_guidance(target_root=target_root, config=config)
     onboarding_routes = {
@@ -35539,6 +35574,7 @@ def _setup_payload(
             "rule": "Accept agent-produced setup findings as optional input, preserve only the classes that reduce rediscovery, and keep low-value or weakly grounded findings transient.",
         },
         "analysis_input": findings_input,
+        "host_orientation": host_orientation,
         "proof_route_hints": {
             "path": PROOF_ROUTE_HINTS_PATH.as_posix(),
             "status": proof_route_hints["status"],
@@ -35582,6 +35618,10 @@ def _emit_setup(
         print(f"- surface: {payload['orientation']['surface']}")
     if payload["orientation"].get("reason"):
         print(f"- reason: {payload['orientation']['reason']}")
+    if payload.get("host_orientation", {}).get("candidates"):
+        print("Host orientation candidates:")
+        for item in payload["host_orientation"]["candidates"]:
+            print(f"- {item['surface']}: {item['reason']}")
     print(f"- next action: {payload['next_action']['summary']}")
     for command in payload["next_action"]["commands"]:
         print(f"  - {command}")

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -68,6 +68,28 @@ def test_lifecycle_guidance_uses_canonical_modules_option(tmp_path: Path, capsys
     assert "--module planning --module memory" not in command_text
 
 
+def test_setup_surfaces_host_orientation_candidates_for_jumpstarted_repo(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "README.md", "# Host Repo\n")
+    _write(tmp_path / "docs" / "architecture.md", "# Architecture\n")
+    _write(tmp_path / "pyproject.toml", "[project]\nname = 'host-repo'\nversion = '0.1.0'\n")
+    _write(tmp_path / "src" / "app.py", "VALUE = 1\n")
+    _write(tmp_path / "tests" / "test_smoke.py", "def test_smoke():\n    assert True\n")
+
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--non-interactive", "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["setup", "--target", str(tmp_path), "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    host_orientation = payload["host_orientation"]
+    assert host_orientation["status"] == "present"
+    surfaces = {candidate["surface"] for candidate in host_orientation["candidates"]}
+    assert {"README.md", "docs/architecture.md", "docs", "pyproject.toml", "src", "tests"} <= surfaces
+    assert payload["analysis_input"]["status"] == "not-found"
+    assert "must not seed Memory, Planning, assurance, or verification state" in host_orientation["rule"]
+
+
 def test_start_context_adapter_routes_through_startup_owner_facade() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     start_command = (repo_root / "generated" / "workspace" / "python" / "commands" / "start_context.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- fixes #1925
- adds read-only `host_orientation` candidates to the setup guidance payload/text output
- covers a jumpstarted host repo with README, docs, package metadata, source, and tests
- extends AW verification evidence records for the runtime and test-evidence obligations

## Evaluation Set
Cycle 3 ran `agentic-workspace setup` before and after installing AW into a disposable mature-looking host repo under `.agentic-workspace/local/scratch/cycle3-jumpstarted-*`. After init, setup was healthy but only pointed orientation at AW planning state; it did not surface preexisting host repo orientation surfaces.

## Proof
- `uv run pytest tests/test_workspace_cli.py::test_setup_surfaces_host_orientation_candidates_for_jumpstarted_repo -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`
- `uv run python scripts/run_agentic_workspace.py implement --changed src/agentic_workspace/workspace_runtime_primitives.py src/agentic_workspace/workspace_runtime_core.py tests/test_workspace_cli.py .agentic-workspace/verification/assurance-evidence-records.json --task "Implement issue #1925: setup should surface host orientation candidates in jumpstarted repos" --select assurance_requirements,proof --format json`
