### PR TITLE
Fix long-horizon Docker harness followups

### DIFF
--- a/scripts/model_cli_harness/long_horizon_episode.py
+++ b/scripts/model_cli_harness/long_horizon_episode.py
@@ -276,13 +276,29 @@ def _prepare_mode_repo(
     def effective_dependency_specs(repo_path: Path) -> list[str] | None:
         if local_aw_wheelhouse is None or adapter is None:
             return dependency_specs
-        return [
-            harness._fixture_local_wheel_dependency(
-                repo_path=repo_path,
-                source_wheelhouse=local_aw_wheelhouse,
-                adapter=adapter,
-            )
-        ]
+        return harness._fixture_local_wheel_dependencies(
+            repo_path=repo_path,
+            source_wheelhouse=local_aw_wheelhouse,
+            adapter=adapter,
+        )
+
+    def git_longpaths_enabled() -> bool:
+        result = harness._run_command(["git", "config", "--get", "core.longpaths"], cwd=paths.run_root, timeout_seconds=30)
+        if result.get("returncode") != 0:
+            return False
+        return str(result.get("stdout") or "").strip().lower() == "true"
+
+    def preflight_windows_clone_path(*, repo_url: str) -> None:
+        if os.name != "nt":
+            return
+        target = str(paths.repo_path.resolve())
+        if len(target) < 180 or git_longpaths_enabled():
+            return
+        raise RuntimeError(
+            "git clone path-length preflight failed for external long-horizon repo "
+            f"{repo_url}: target path is {len(target)} characters. "
+            "Set `git config --global core.longpaths true` or use a shorter --output-root before running the Docker episode."
+        )
 
     paths.run_root.mkdir(parents=True, exist_ok=False)
     setup_before: dict[str, dict[str, Any]] | None = None
@@ -331,6 +347,7 @@ def _prepare_mode_repo(
                 source_checkout_path=source_checkout_path,
             )
         return _setup_mutation_summary(setup_before=setup_before, repo_path=paths.repo_path)
+    preflight_windows_clone_path(repo_url=repo_url)
     result = harness._run_command(["git", "clone", repo_url, str(paths.repo_path)], cwd=paths.run_root, timeout_seconds=900)
     if result["returncode"] != 0:
         raise RuntimeError(f"git clone failed for {repo_url}: {result['stderr']}")
@@ -508,6 +525,50 @@ def _post_score_reference_payload(*, episode: dict[str, Any], evaluation_status:
     }
 
 
+def _sandbox_failure_summary(
+    *,
+    phase_id: str,
+    sandbox_report: dict[str, Any] | None,
+    result: dict[str, Any],
+    artifact_capture: dict[str, Any],
+    checkpoint: dict[str, str],
+) -> dict[str, Any] | None:
+    if not sandbox_report or not sandbox_report.get("enabled"):
+        return None
+    runtime_status = str(sandbox_report.get("runtime_status") or result.get("status") or "")
+    returncode = result.get("returncode")
+    if runtime_status in {"completed", "dry-run"} and (returncode in {0, None}):
+        return None
+    stderr = str(result.get("stderr") or "")
+    runtime_error = str(sandbox_report.get("runtime_error") or "").strip()
+    timeout_text = f"{runtime_status}\n{stderr}\n{runtime_error}".lower()
+    timed_out = bool(result.get("timed_out")) or "context deadline" in timeout_text or "deadline exceeded" in timeout_text
+    failure_class = "sandbox-timeout" if timed_out else "sandbox-runtime-failed"
+    share_path = checkpoint.get("share_path", "")
+    transcript_path = checkpoint.get("transcript_path", "")
+    share_artifact_exists = bool(result.get("final_message")) or bool(artifact_capture.get("share_captured"))
+    if not share_artifact_exists and share_path:
+        share_artifact_exists = Path(share_path).is_file()
+    transcript_exists = bool(transcript_path) and Path(transcript_path).is_file()
+    return {
+        "kind": "agentic-workspace/long-horizon-sandbox-failure/v1",
+        "status": "present",
+        "failure_class": failure_class,
+        "boundary": "sandbox-executor-timeout" if timed_out else "sandbox-adapter-runtime",
+        "phase_id": phase_id,
+        "sandbox": sandbox_report.get("identity", ""),
+        "sandbox_name": sandbox_report.get("sandbox_name", ""),
+        "runtime_status": runtime_status,
+        "runtime_returncode": returncode,
+        "timed_out": timed_out,
+        "runtime_error": runtime_error or (stderr.strip().splitlines()[0][:500] if stderr.strip() else ""),
+        "share_artifact_exists": share_artifact_exists,
+        "transcript_exists": transcript_exists,
+        "agent_performance_finding": False,
+        "rule": "Sandbox runtime failures are harness/executor evidence until a model transcript or share artifact proves agent behavior.",
+    }
+
+
 def _parse_evaluation(text: str) -> dict[str, Any]:
     payload = harness._json_document(text.strip())
     if payload is None:
@@ -529,16 +590,69 @@ def _comparison_summary(mode_results: list[dict[str, Any]], *, episode: dict[str
     aw_effect_by_mode: dict[str, dict[str, list[str]]] = {}
     post_score_reference_by_mode: dict[str, dict[str, Any]] = {}
     contract_assessment_by_mode: dict[str, dict[str, Any]] = {}
+    invalid_evaluations_by_mode: dict[str, dict[str, Any]] = {}
+    sandbox_runtime_failures_by_mode: dict[str, list[dict[str, Any]]] = {}
     human_review_required = False
     followups: list[dict[str, Any]] = []
     for result in mode_results:
         mode_id = result["mode_id"]
+        sandbox_failures = [
+            phase.get("sandbox_failure")
+            for phase in result.get("phases", [])
+            if isinstance(phase, dict)
+            and isinstance(phase.get("sandbox_failure"), dict)
+            and phase["sandbox_failure"].get("status") == "present"
+        ]
         evaluation_result = result.get("evaluation", {})
+        if isinstance(evaluation_result, dict) and isinstance(evaluation_result.get("sandbox_failure"), dict):
+            evaluator_sandbox_failure = evaluation_result["sandbox_failure"]
+            if evaluator_sandbox_failure.get("status") == "present":
+                sandbox_failures.append(evaluator_sandbox_failure)
+        if sandbox_failures:
+            sandbox_runtime_failures_by_mode[mode_id] = sandbox_failures
+            human_review_required = True
+            for failure in sandbox_failures:
+                followups.append(
+                    {
+                        "mode": mode_id,
+                        "type": "rerun-executor",
+                        "summary": "Rerun the Docker sandbox phase before scoring agent behavior.",
+                        "phase_id": failure.get("phase_id", ""),
+                        "failure_class": failure.get("failure_class", ""),
+                        "boundary": failure.get("boundary", ""),
+                        "sandbox": failure.get("sandbox", ""),
+                        "sandbox_name": failure.get("sandbox_name", ""),
+                        "share_artifact_exists": bool(failure.get("share_artifact_exists")),
+                        "transcript_exists": bool(failure.get("transcript_exists")),
+                        "aw_improvement_scope": "separate-from-agent-performance-finding",
+                    }
+                )
         if isinstance(evaluation_result, dict) and isinstance(evaluation_result.get("post_score_reference"), dict):
             post_score_reference_by_mode[mode_id] = evaluation_result["post_score_reference"]
         if isinstance(evaluation_result, dict) and isinstance(evaluation_result.get("contract_assessment"), dict):
             contract_assessment_by_mode[mode_id] = evaluation_result["contract_assessment"]
+        evaluation_status = str(evaluation_result.get("status") or "") if isinstance(evaluation_result, dict) else ""
         evaluation = evaluation_result.get("payload") if isinstance(evaluation_result, dict) else None
+        if evaluation_status == "invalid":
+            schema_errors = []
+            if isinstance(evaluation, dict) and isinstance(evaluation.get("error"), str):
+                schema_errors.append(evaluation["error"])
+            invalid_evaluations_by_mode[mode_id] = {
+                "status": "invalid",
+                "mode": mode_id,
+                "schema_errors": schema_errors,
+                "post_score_reference": post_score_reference_by_mode.get(mode_id, {}),
+            }
+            human_review_required = True
+            followups.append(
+                {
+                    "mode": mode_id,
+                    "type": "evaluation-harness",
+                    "summary": "Primary evaluator payload was invalid; rerun or fix evaluator schema handling before treating this mode as scored.",
+                    "schema_errors": schema_errors,
+                    "primary_evaluation_status": evaluation_status,
+                }
+            )
         if not isinstance(evaluation, dict):
             continue
         mistake_classes_by_mode[mode_id] = list(evaluation.get("mistake_classes", []))
@@ -559,6 +673,14 @@ def _comparison_summary(mode_results: list[dict[str, Any]], *, episode: dict[str
         for mode_id, assessment in contract_assessment_by_mode.items()
         if assessment.get("status") == "full-completion-blocked"
     ]
+    if mode_results and len(invalid_evaluations_by_mode) == len(mode_results):
+        claim_gate_status = "invalid-primary-evaluation"
+    elif invalid_evaluations_by_mode:
+        claim_gate_status = "primary-evaluation-with-invalid-modes"
+    elif blocking_modes:
+        claim_gate_status = "full-completion-blocked"
+    else:
+        claim_gate_status = "primary-evaluation"
     return {
         "kind": "agentic-workspace/long-horizon-comparison/v1",
         "status": "present" if mode_results else "absent",
@@ -568,12 +690,16 @@ def _comparison_summary(mode_results: list[dict[str, Any]], *, episode: dict[str
         "aw_effect_by_mode": aw_effect_by_mode,
         "human_review_required": human_review_required,
         "recommended_followups": followups,
+        "invalid_evaluations_by_mode": invalid_evaluations_by_mode,
+        "sandbox_runtime_failures_by_mode": sandbox_runtime_failures_by_mode,
         "continuation_comparison": _continuation_comparison(mode_results),
         "post_score_reference_by_mode": post_score_reference_by_mode,
         "contract_assessment_by_mode": contract_assessment_by_mode,
         "claim_gate": {
-            "status": "full-completion-blocked" if blocking_modes else "primary-evaluation",
+            "status": claim_gate_status,
             "blocking_modes": blocking_modes,
+            "invalid_modes": sorted(invalid_evaluations_by_mode),
+            "sandbox_failure_modes": sorted(sandbox_runtime_failures_by_mode),
             "contract_present": bool(isinstance(episode, dict) and episode.get("evaluation_contract")),
             "rule": (
                 "Episode evaluation contracts downgrade full-completion claims when configured mistake classes appear; "
@@ -797,6 +923,18 @@ def run_episode(
             final_message = str(result.get("final_message") or result.get("stdout") or "")
             if final_message.strip():
                 prior_context.append(f"{phase['id']} final message:\n{final_message.strip()}")
+            checkpoint = {
+                "transcript_path": str(phase_transcript),
+                "share_path": str(phase_share),
+                "repo_path": str(paths.repo_path),
+            }
+            sandbox_failure = _sandbox_failure_summary(
+                phase_id=str(phase["id"]),
+                sandbox_report=sandbox_report,
+                result=result,
+                artifact_capture=artifact_capture,
+                checkpoint=checkpoint,
+            )
             phase_results.append(
                 {
                     "phase_id": phase["id"],
@@ -811,16 +949,13 @@ def run_episode(
                     "preflight": preflight,
                     "sandbox": sandbox_report or {"enabled": False},
                     "artifact_capture": artifact_capture,
+                    "sandbox_failure": sandbox_failure or {"status": "absent"},
                     "result": result,
                     "mutation_summary": mutation_summary,
                     "continuation_contribution": contribution["kind"],
                     "continuation_contribution_detail": contribution,
                     "validation_results": validation_results,
-                    "checkpoint": {
-                        "transcript_path": str(phase_transcript),
-                        "share_path": str(phase_share),
-                        "repo_path": str(paths.repo_path),
-                    },
+                    "checkpoint": checkpoint,
                 }
             )
         mode_result: dict[str, Any] = {
@@ -898,6 +1033,18 @@ def run_episode(
                 evaluation_payload = {"status": "not-run"}
                 evaluation_status = "not-run"
             contract_assessment = _contract_assessment(episode=episode, evaluation_payload=evaluation_payload)
+            evaluator_checkpoint = {
+                "transcript_path": "",
+                "share_path": str(evaluator_share),
+                "repo_path": str(paths.repo_path),
+            }
+            sandbox_failure = _sandbox_failure_summary(
+                phase_id="evaluator",
+                sandbox_report=sandbox_report,
+                result=evaluator_result,
+                artifact_capture=artifact_capture,
+                checkpoint=evaluator_checkpoint,
+            )
             mode_result["evaluation"] = {
                 "status": evaluation_status,
                 "adapter_id": evaluator_adapter_id,
@@ -908,6 +1055,7 @@ def run_episode(
                 "execution_command": execution_command if execution_command != command else [],
                 "preflight": preflight,
                 "sandbox": sandbox_report or {"enabled": False},
+                "sandbox_failure": sandbox_failure or {"status": "absent"},
                 "artifact_capture": artifact_capture,
                 "result": evaluator_result,
                 "payload": evaluation_payload,

--- a/scripts/model_cli_harness/run_model_cli_harness.py
+++ b/scripts/model_cli_harness/run_model_cli_harness.py
@@ -197,7 +197,7 @@ def _prompt_transport(
 
     prompt_dir = run_root / "prompts"
     prompt_dir.mkdir(parents=True, exist_ok=True)
-    prompt_file = prompt_dir / f"{_safe_prompt_stem(prompt_id)}.txt"
+    prompt_file = (prompt_dir / f"{_safe_prompt_stem(prompt_id)}.txt").resolve()
     prompt_file.write_text(prompt, encoding="utf-8")
     transport_replacements = {
         **replacements,
@@ -270,6 +270,10 @@ def _adapter_invocation_command(
         replacements={**replacements, "model": model},
     )
     command_replacements = {**replacements, "model": model, "prompt": command_prompt}
+    if prompt_transport.get("prompt_file"):
+        command_replacements["prompt_file"] = str(prompt_transport["prompt_file"])
+    if prompt_transport.get("prompt_length") is not None:
+        command_replacements["prompt_length"] = str(prompt_transport["prompt_length"])
     command = _render_command_template(
         command_template,
         replacements=command_replacements,
@@ -444,11 +448,15 @@ def _sandbox_file_url(path: Path) -> str:
     return resolved.as_uri()
 
 
+def _host_file_url(path: Path) -> str:
+    return path.resolve().as_uri()
+
+
 def _fixture_file_url(path: Path, *, adapter: dict[str, Any]) -> str:
     sandbox = adapter.get("sandbox")
     if isinstance(sandbox, dict) and sandbox.get("backend") == "docker-sandbox":
         return _sandbox_file_url(path)
-    return path.resolve().as_uri()
+    return _host_file_url(path)
 
 
 def _find_wheel(wheelhouse: Path, prefix: str, version: str) -> Path:
@@ -458,13 +466,10 @@ def _find_wheel(wheelhouse: Path, prefix: str, version: str) -> Path:
     return matches[0]
 
 
-def _fixture_local_wheel_dependency(*, repo_path: Path, source_wheelhouse: Path, adapter: dict[str, Any]) -> str:
-    version = _local_aw_version()
-    target_wheelhouse = repo_path / ".agentic-workspace" / "local" / "model-cli-harness" / "wheelhouse"
+def _patch_local_aw_wheelhouse(*, source_wheelhouse: Path, target_wheelhouse: Path, release_asset_base_url: str, version: str) -> None:
     if target_wheelhouse.exists():
         shutil.rmtree(target_wheelhouse)
     shutil.copytree(source_wheelhouse, target_wheelhouse)
-    release_asset_base_url = _fixture_file_url(target_wheelhouse, adapter=adapter)
     subprocess.run(
         [
             "uv",
@@ -483,8 +488,52 @@ def _fixture_local_wheel_dependency(*, repo_path: Path, source_wheelhouse: Path,
         text=True,
         check=True,
     )
+
+
+def _fixture_local_wheel_dependencies(*, repo_path: Path, source_wheelhouse: Path, adapter: dict[str, Any]) -> list[str]:
+    version = _local_aw_version()
+    target_wheelhouse = repo_path / ".agentic-workspace" / "local" / "model-cli-harness" / "wheelhouse"
+    sandbox = adapter.get("sandbox")
+    if os.name == "nt" and isinstance(sandbox, dict) and sandbox.get("backend") == "docker-sandbox":
+        host_wheelhouse = target_wheelhouse / "host"
+        sandbox_wheelhouse = target_wheelhouse / "sandbox"
+        if target_wheelhouse.exists():
+            shutil.rmtree(target_wheelhouse)
+        _patch_local_aw_wheelhouse(
+            source_wheelhouse=source_wheelhouse,
+            target_wheelhouse=host_wheelhouse,
+            release_asset_base_url=_host_file_url(host_wheelhouse),
+            version=version,
+        )
+        _patch_local_aw_wheelhouse(
+            source_wheelhouse=source_wheelhouse,
+            target_wheelhouse=sandbox_wheelhouse,
+            release_asset_base_url=_sandbox_file_url(sandbox_wheelhouse),
+            version=version,
+        )
+        host_root_wheel = _find_wheel(host_wheelhouse, "agentic_workspace", version)
+        sandbox_root_wheel = _find_wheel(sandbox_wheelhouse, "agentic_workspace", version)
+        return [
+            f"agentic-workspace @ {_host_file_url(host_root_wheel)} ; sys_platform == 'win32'",
+            f"agentic-workspace @ {_sandbox_file_url(sandbox_root_wheel)} ; sys_platform != 'win32'",
+        ]
+
+    release_asset_base_url = _fixture_file_url(target_wheelhouse, adapter=adapter)
+    _patch_local_aw_wheelhouse(
+        source_wheelhouse=source_wheelhouse,
+        target_wheelhouse=target_wheelhouse,
+        release_asset_base_url=release_asset_base_url,
+        version=version,
+    )
     root_wheel = _find_wheel(target_wheelhouse, "agentic_workspace", version)
-    return f"agentic-workspace @ {_fixture_file_url(root_wheel, adapter=adapter)}"
+    return [f"agentic-workspace @ {_fixture_file_url(root_wheel, adapter=adapter)}"]
+
+
+def _fixture_local_wheel_dependency(*, repo_path: Path, source_wheelhouse: Path, adapter: dict[str, Any]) -> str:
+    dependencies = _fixture_local_wheel_dependencies(repo_path=repo_path, source_wheelhouse=source_wheelhouse, adapter=adapter)
+    if len(dependencies) != 1:
+        raise RuntimeError("local wheelhouse produced platform-specific dependencies; use _fixture_local_wheel_dependencies")
+    return dependencies[0]
 
 
 def _prepare_fixture(
@@ -508,7 +557,11 @@ def _prepare_fixture(
     paths.run_root.mkdir(parents=True, exist_ok=False)
     shutil.copytree(fixture_path, paths.repo_path)
     if local_aw_wheelhouse is not None:
-        dependency_specs = [_fixture_local_wheel_dependency(repo_path=paths.repo_path, source_wheelhouse=local_aw_wheelhouse, adapter=adapter)]
+        dependency_specs = _fixture_local_wheel_dependencies(
+            repo_path=paths.repo_path,
+            source_wheelhouse=local_aw_wheelhouse,
+            adapter=adapter,
+        )
     _prepare_source_checkout_invocation(paths.repo_path, dependency_specs=dependency_specs, source_checkout_path=source_checkout_path)
     _prepare_fixture_git_repository(paths.repo_path)
 
@@ -955,6 +1008,11 @@ def _adapter_sandbox_report(
         raise ValueError("adapter.sandbox.backend must be a string")
     if not isinstance(agent, str) or not agent.strip():
         raise ValueError("adapter.sandbox.agent must be a string")
+    sandbox_name = ""
+    if "--sandbox-name" in command:
+        index = command.index("--sandbox-name")
+        if index + 1 < len(command):
+            sandbox_name = str(command[index + 1])
     return {
         "kind": SANDBOX_ADAPTER_KIND,
         "enabled": True,
@@ -963,6 +1021,7 @@ def _adapter_sandbox_report(
         "adapter_id": adapter_id,
         "model": model,
         "identity": f"{backend}:{agent}:{adapter_id}",
+        "sandbox_name": sandbox_name,
         "template": str(config.get("template") or ""),
         "repo_path": str(repo_path),
         "evidence": "sandbox-backed",

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -851,8 +851,8 @@ def test_model_cli_harness_local_wheelhouse_mode_overrides_release_dependency(tm
     monkeypatch.setattr(module, "_build_local_aw_wheelhouse", lambda output_root: wheelhouse)
     monkeypatch.setattr(
         module,
-        "_fixture_local_wheel_dependency",
-        lambda *, repo_path, source_wheelhouse, adapter: "agentic-workspace @ file:///fixture-wheelhouse/agentic_workspace.whl",
+        "_fixture_local_wheel_dependencies",
+        lambda *, repo_path, source_wheelhouse, adapter: ["agentic-workspace @ file:///fixture-wheelhouse/agentic_workspace.whl"],
     )
 
     payload = module.run_suite(
@@ -869,3 +869,68 @@ def test_model_cli_harness_local_wheelhouse_mode_overrides_release_dependency(tm
     pyproject_text = (Path(payload["results"][0]["repo_path"]) / "pyproject.toml").read_text(encoding="utf-8")
     assert "fixture-wheelhouse/agentic_workspace.whl" in pyproject_text
     assert "releases/download/v0.4.3" not in pyproject_text
+
+
+def test_model_cli_harness_local_wheelhouse_windows_docker_uses_platform_uris(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_harness_module()
+    source = tmp_path / "source-wheelhouse"
+    source.mkdir()
+    (source / "agentic_workspace-1.2.3-py3-none-any.whl").write_text("wheel", encoding="utf-8")
+    patched_urls: list[str] = []
+
+    def fake_patch(*, source_wheelhouse, target_wheelhouse, release_asset_base_url, version):
+        patched_urls.append(release_asset_base_url)
+        target_wheelhouse.mkdir(parents=True)
+        for item in source_wheelhouse.iterdir():
+            (target_wheelhouse / item.name).write_text(item.read_text(encoding="utf-8"), encoding="utf-8")
+
+    monkeypatch.setattr(module.os, "name", "nt")
+    monkeypatch.setattr(module, "_local_aw_version", lambda: "1.2.3")
+    monkeypatch.setattr(module, "_patch_local_aw_wheelhouse", fake_patch)
+
+    dependencies = module._fixture_local_wheel_dependencies(
+        repo_path=tmp_path / "repo",
+        source_wheelhouse=source,
+        adapter={"sandbox": {"backend": "docker-sandbox"}},
+    )
+
+    assert len(dependencies) == 2
+    assert "sys_platform == 'win32'" in dependencies[0]
+    assert "sys_platform != 'win32'" in dependencies[1]
+    assert "file:///" in dependencies[0]
+    assert "file:///c/" in dependencies[1].lower()
+    assert patched_urls[0].startswith("file:///")
+    assert patched_urls[1].lower().startswith("file:///c/")
+
+
+def test_model_cli_harness_prompt_file_transport_uses_absolute_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_harness_module()
+    monkeypatch.chdir(tmp_path)
+
+    command, prompt_transport, replacements = module._adapter_invocation_command(
+        {
+            "prompt_transport": {
+                "threshold_chars": 1,
+                "file_args": ["--prompt-file", "{prompt_file}"],
+                "file_prompt": "Read {prompt_file}.",
+            },
+            "command": ["agent", "{prompt}", "{prompt_transport_args}"],
+        },
+        adapter_id="fake",
+        model="model",
+        replacements={"prompt": "large prompt", "repo": "repo"},
+        run_root=Path("relative-run-root"),
+        prompt_id="phase-one",
+    )
+
+    prompt_file = Path(prompt_transport["prompt_file"])
+    assert prompt_file.is_absolute()
+    assert prompt_file.exists()
+    assert replacements["prompt_file"] == str(prompt_file)
+    assert str(prompt_file) in command

--- a/tests/test_long_horizon_episode.py
+++ b/tests/test_long_horizon_episode.py
@@ -5,6 +5,7 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
 from jsonschema import Draft202012Validator
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -560,6 +561,78 @@ def test_long_horizon_episode_invalid_evaluator_json_is_failure(tmp_path: Path) 
     evaluation = payload["modes"][0]["evaluation"]
     assert evaluation["status"] == "invalid"
     assert "evaluator did not return" in evaluation["payload"]["error"]
+    assert payload["comparison"]["human_review_required"] is True
+    assert payload["comparison"]["claim_gate"]["status"] == "invalid-primary-evaluation"
+    assert payload["comparison"]["invalid_evaluations_by_mode"]["aw-assisted"]["schema_errors"]
+    assert payload["comparison"]["recommended_followups"][0]["type"] == "evaluation-harness"
+
+
+def test_long_horizon_episode_sandbox_timeout_is_executor_followup() -> None:
+    module = _load_episode_module()
+    comparison = module._comparison_summary(
+        [
+            {
+                "mode_id": "managed-state",
+                "aw_enabled": True,
+                "phases": [
+                    {
+                        "phase_id": "repair",
+                        "sandbox_failure": {
+                            "status": "present",
+                            "failure_class": "sandbox-timeout",
+                            "boundary": "sandbox-executor-timeout",
+                            "phase_id": "repair",
+                            "sandbox": "docker-sandbox:codex:codex-sbx",
+                            "sandbox_name": "aw-lh-123",
+                            "share_artifact_exists": False,
+                            "transcript_exists": False,
+                        },
+                    }
+                ],
+                "evaluation": {"status": "not-run", "payload": {"status": "not-run"}},
+            }
+        ]
+    )
+
+    followup = comparison["recommended_followups"][0]
+    assert comparison["human_review_required"] is True
+    assert comparison["sandbox_runtime_failures_by_mode"]["managed-state"][0]["boundary"] == "sandbox-executor-timeout"
+    assert followup["type"] == "rerun-executor"
+    assert followup["phase_id"] == "repair"
+    assert followup["sandbox_name"] == "aw-lh-123"
+    assert followup["share_artifact_exists"] is False
+    assert followup["transcript_exists"] is False
+    assert followup["aw_improvement_scope"] == "separate-from-agent-performance-finding"
+
+
+def test_long_horizon_episode_preflights_windows_external_clone_longpaths(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_episode_module()
+    long_root = tmp_path / ("very-long-output-root-" + ("x" * 170))
+    paths = module.harness.HarnessPaths(
+        run_root=long_root,
+        fixture_root=long_root / "fixture",
+        repo_path=long_root / "repo",
+        transcript_path=long_root / "transcript.jsonl",
+        share_path=long_root / "share.md",
+    )
+
+    monkeypatch.setattr(module.os, "name", "nt")
+    monkeypatch.setattr(
+        module.harness,
+        "_run_command",
+        lambda command, *, cwd, timeout_seconds, env=None: {"returncode": 1, "stdout": "", "stderr": ""},
+    )
+
+    with pytest.raises(RuntimeError, match="core.longpaths true"):
+        module._prepare_mode_repo(
+            suite_path=tmp_path / "suites" / "suite.json",
+            mode={"id": "external", "repo_url": "https://example.invalid/repo.git", "base_commit": "abc123"},
+            paths=paths,
+            execute=True,
+        )
 
 
 def test_long_horizon_episode_uses_model_args_by_phase_model(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- resolve prompt-file transport to absolute paths and carry prompt-file metadata through adapter replacements
- split Windows Docker local-wheelhouse dependencies into host and sandbox wheelhouses with platform markers, plus preflight long Windows external clones for missing git core.longpaths
- surface invalid evaluator payloads and sandbox runtime timeouts as human-review followups instead of agent-performance findings

Fixes #1927
Fixes #1928
Fixes #1929

## Proof
- uv run python -m py_compile scripts/model_cli_harness/long_horizon_episode.py scripts/model_cli_harness/run_model_cli_harness.py
- uv run pytest tests/test_long_horizon_episode.py tests/test_external_agent_evaluation_lane.py -q
- make lint-workspace
- make test-workspace
- git diff --check