### PR TITLE
[codex] Fix long-horizon dogfood blockers

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/long-horizon-improvement-cycles-2026-07-01.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/long-horizon-improvement-cycles-2026-07-01.plan.json
@@ -1,0 +1,380 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Run three long-horizon improvement cycles",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for Run three long-horizon improvement cycles.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Run three long-horizon improvement cycles is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "#1935 and #1936",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Run three long-horizon improvement cycles."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Run three long-horizon improvement cycles.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "long-horizon-improvement-cycles-2026-07-01",
+      "status": "completed",
+      "next_step": "Continue via #1935 and #1936.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Run three long-horizon improvement cycles.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "#1935 and #1936"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "#1935 and #1936",
+    "activation trigger": "when the continuation owner promotes the next slice"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via #1935 and #1936."
+  },
+  "intent_interpretation": {
+    "literal request": "Run three long-horizon improvement cycles",
+    "inferred intended outcome": "Create a bounded plan for Run three long-horizon improvement cycles.",
+    "chosen concrete what": "Three additional long-horizon sandbox cycles completed; in-scope blockers fixed; durable residuals routed to issues #1935 and #1936.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Run three long-horizon improvement cycles.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "long-horizon-improvement-cycles-2026-07-01",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Run three long-horizon improvement cycles is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Ran three long-horizon improvement cycles in the codex-sbx Docker sandbox, created issues for findings, fixed in-scope harness/planning blockers, and reran affected scenarios.",
+    "scope touched": "Planning switch-active closeout state, long-horizon evaluator prompt transport/compaction/identity/model override behavior, and evaluator suite wording.",
+    "changed surfaces": ".agentic-workspace/planning/state.toml; .agentic-workspace/planning/execplans/*; packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_promote.py; scripts/model_cli_harness/long_horizon_episode.py; scripts/model_cli_harness/run_sbx_codex_adapter.py; tests/test_external_agent_evaluation_lane.py; tests/test_long_horizon_episode.py; tools/model-cli-harness/suites/copilot-workflow-smoke.json",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from #1935 and #1936",
+    "next step": "promote the next bounded slice from #1935 and #1936"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope respected. Cycle 1 fixed planning and prompt transport blockers, cycle 2 routed the remaining semantic proof gap to #1936, and cycle 3 fixed adapter override model incompatibility with a clean rerun.",
+    "proof status": "passed",
+    "intent served": "yes for slice; parent remains open via #1935 and #1936",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "#1935 and #1936"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "Long-horizon cycles completed in Docker sandbox output roots cycle-20260701-1e, cycle-20260701-2b, and cycle-20260701-3b. Proof commands passed: make test-workspace; make test-planning; make lint-workspace; make lint-planning; make typecheck-planning; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; uv run python scripts/run_agentic_workspace.py summary --target . --format json; git diff --check.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Run three long-horizon improvement cycles.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "#1935 and #1936"
+  },
+  "execution_summary": {
+    "outcome delivered": "Three additional long-horizon sandbox cycles completed; in-scope blockers fixed; durable residuals routed to issues #1935 and #1936.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "#1935 and #1936",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "#1935 and #1936",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed issue residue to #1935 and #1936.",
+    "motivation worth preserving": "Future agents should continue from #1935 and #1936 rather than rediscover this closeout residue.",
+    "canonical owner now": "#1935 and #1936",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "#1935 and #1936",
+    "proposed durable intent": "Future agents should continue from #1935 and #1936 rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "#1935 and #1936"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when #1935 and #1936 activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      {
+        "summary": "Closeout routed issue residue to #1935 and #1936.",
+        "owner": "#1935 and #1936",
+        "source": "durable_residue"
+      }
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      {
+        "summary": "Closeout routed issue residue to #1935 and #1936.",
+        "owner": "#1935 and #1936",
+        "source": "durable_residue"
+      }
+    ],
+    "signals dismissed": [],
+    "next owner": "see routed signal owner"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "#1935 and #1936",
+          "owner": "#1935 and #1936",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-01: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "#1935 and #1936",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "continue-required",
+    "active_intent_satisfied": false,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "partial-progress",
+    "required_next_action": "create-follow-on-plan",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [
+          "done",
+          "implemented",
+          "complete",
+          "finished",
+          "all",
+          "full intent complete"
+        ],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "#1935 and #1936",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "no",
+      "reason": "#1935 and #1936"
+    },
+    "continuation": {
+      "owner_surface": "#1935 and #1936",
+      "created_or_required": true,
+      "reason": "#1935 and #1936"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Run three long-horizon improvement cycles.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: Long-horizon cycles completed in Docker sandbox output roots cycle-20260701-1e, cycle-20260701-2b, and cycle-20260701-3b. Proof commands passed: make test-workspace; make test-planning; make lint-workspace; make lint-planning; make typecheck-planning; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; uv run python scripts/run_agentic_workspace.py summary --target . --format json; git diff --check.\nChanged surfaces: .agentic-workspace/planning/state.toml; .agentic-workspace/planning/execplans/*; packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_promote.py; scripts/model_cli_harness/long_horizon_episode.py; scripts/model_cli_harness/run_sbx_codex_adapter.py; tests/test_external_agent_evaluation_lane.py; tests/test_long_horizon_episode.py; tools/model-cli-harness/suites/copilot-workflow-smoke.json\nDurable residue: planning (#1935 and #1936)\nMemory learning: route_to_planning\nFollow-up: #1935 and #1936\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
+  }
+}

--- a/.agentic-workspace/planning/execplans/open-issues-stacked-lanes.plan.json
+++ b/.agentic-workspace/planning/execplans/open-issues-stacked-lanes.plan.json
@@ -155,11 +155,13 @@
   "references": [],
   "active_milestone": {
     "id": "open-issues-stacked-lanes",
-    "status": "active",
+    "status": "planned",
     "scope": "Keep this execution thread bounded to the promoted TODO item.",
-    "ready": "ready",
+    "ready": "queued",
     "blocked": "none",
-    "optional_deps": "none"
+    "optional_deps": "none",
+    "switched_from_active_by": "long-horizon-improvement-cycles-2026-07-01",
+    "switch_reason": "Switched active lane to Run three long-horizon improvement cycles."
   },
   "immediate_next_action": [
     "Review draft PRs, mark ready when acceptable, and merge in stack order (#1894, #1895, #1896, #1897)."

--- a/.agentic-workspace/planning/state.toml
+++ b/.agentic-workspace/planning/state.toml
@@ -12,10 +12,10 @@ work_items = []
 execplans = []
 
 [todo]
-active_items = [
-  { id = "open-issues-stacked-lanes", title = "Implement current open issues by stacked PR lane", maturity = "active", status = "active", surface = ".agentic-workspace/planning/execplans/open-issues-stacked-lanes.plan.json", why_now = "Created by new-plan scaffold.", owner_role = "implementation", review_role = "validation", handoff_ready = true, next_action = "Tighten scaffold fields, touched paths, and validation before implementation starts.", done_when = "Implement current open issues by stacked PR lane is implemented, validated, and closed out honestly.", proof = "Run the proof selected by implement --changed before claiming completion." },
+active_items = []
+queued_items = [
+  { id = "open-issues-stacked-lanes", title = "Implement current open issues by stacked PR lane", maturity = "ready", status = "next", surface = ".agentic-workspace/planning/execplans/open-issues-stacked-lanes.plan.json", why_now = "Created by new-plan scaffold.", owner_role = "implementation", review_role = "validation", handoff_ready = true, next_action = "Tighten scaffold fields, touched paths, and validation before implementation starts.", done_when = "Implement current open issues by stacked PR lane is implemented, validated, and closed out honestly.", proof = "Run the proof selected by implement --changed before claiming completion.", switched_from_active_by = "long-horizon-improvement-cycles-2026-07-01", switch_reason = "Switched active lane to Run three long-horizon improvement cycles." },
 ]
-queued_items = []
 
 [roadmap]
 lanes = []

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -10935,6 +10935,7 @@ def create_execplan_scaffold(
         result.add("manual review", record_path, f"scaffold did not validate against planning-execplan.schema.json: {'; '.join(findings)}")
         return result
 
+    demoted_record_updates: list[tuple[Path, dict[str, Any]]] = []
     state = _read_state_from_toml(target_root) or {
         "kind": PLANNING_STATE_KIND,
         "schema_version": PLANNING_STATE_SCHEMA_VERSION,
@@ -10966,6 +10967,12 @@ def create_execplan_scaffold(
             )
             return result
         if activate and switch_active and items:
+            demoted_record_updates = _switched_active_execplan_record_updates(
+                target_root=target_root,
+                active_items=items,
+                switched_from_active_by=slug,
+                switch_reason=source_text or f"Switched active lane to {plan_title}.",
+            )
             switched_items: list[Any] = []
             for item in items:
                 if not isinstance(item, dict):
@@ -10973,7 +10980,7 @@ def create_execplan_scaffold(
                     continue
                 switched_item = copy.deepcopy(item)
                 switched_item["maturity"] = "ready"
-                switched_item["status"] = "queued"
+                switched_item["status"] = "next"
                 switched_item["switched_from_active_by"] = slug
                 switched_item["switch_reason"] = source_text or f"Switched active lane to {plan_title}."
                 switched_items.append(switched_item)
@@ -11004,6 +11011,20 @@ def create_execplan_scaffold(
         todo.setdefault("queued_items", [])
         updated_state["todo"] = todo
 
+    for demoted_path, demoted_record in demoted_record_updates:
+        try:
+            demoted_findings = _json_schema_findings(payload=demoted_record, schema_path=EXECPLAN_RECORD_SCHEMA_PATH)
+        except Exception as exc:  # pragma: no cover - defensive guard around schema loading
+            result.add("manual review", demoted_path, f"could not validate demoted execplan record against schema: {exc}")
+            return result
+        if demoted_findings:
+            result.add(
+                "manual review",
+                demoted_path,
+                f"demoted execplan record did not validate against planning-execplan.schema.json: {'; '.join(demoted_findings)}",
+            )
+            return result
+
     if dry_run:
         result.add("would create" if not record_path.exists() else "would update", record_path, "schema-valid execplan scaffold")
         state_todo = state.get("todo")
@@ -11012,6 +11033,8 @@ def create_execplan_scaffold(
             active_count = len(state_active_items)
             if active_count:
                 result.add("would update", state_path, f"demote {active_count} active planning item(s) into todo.queued_items")
+        for demoted_path, _demoted_record in demoted_record_updates:
+            result.add("would update", demoted_path, "demote displaced active execplan milestone to planned")
         if activate or queue:
             result.add("would update", state_path, f"register '{slug}' in todo.{'active_items' if activate else 'queued_items'}")
         result.add("next", target_root / PLANNING_STATE_PATH, "run `agentic-workspace summary --target . --verbose --format json`")
@@ -11019,8 +11042,12 @@ def create_execplan_scaffold(
         return result
 
     _write_execplan_record(record_path=record_path, record=plan_record)
+    for demoted_path, demoted_record in demoted_record_updates:
+        _write_execplan_record(record_path=demoted_path, record=demoted_record)
     detail = "schema-valid prep-only execplan scaffold" if prep_only else "schema-valid execplan scaffold"
     result.add("created" if not overwrite else "updated", record_path, detail)
+    for demoted_path, _demoted_record in demoted_record_updates:
+        result.add("updated", demoted_path, "demoted displaced active execplan milestone to planned")
     if activate or queue:
         _write_state_to_toml(target_root, updated_state)
         result.add("updated", state_path, f"registered '{slug}' in todo.{'active_items' if activate else 'queued_items'}")
@@ -11033,6 +11060,55 @@ def create_execplan_scaffold(
             "after summary verification, stop; do not create README, package, source, public, schema, database, or app scaffold files",
         )
     return result
+
+
+def _switched_active_execplan_record_updates(
+    *,
+    target_root: Path,
+    active_items: list[Any],
+    switched_from_active_by: str,
+    switch_reason: str,
+) -> list[tuple[Path, dict[str, Any]]]:
+    updates: list[tuple[Path, dict[str, Any]]] = []
+    seen: set[Path] = set()
+    inactive_statuses = {"complete", "completed", "done", "closed", "planned", "pending", "not-started"}
+    for item in active_items:
+        if not isinstance(item, dict):
+            continue
+        surface = _active_execplan_reference(item)
+        if not surface:
+            continue
+        plan_path = _resolve_execplan_path(target_root, surface)
+        if plan_path is None:
+            continue
+        record_path = _canonical_execplan_record_path(plan_path).resolve()
+        if record_path in seen or not record_path.exists():
+            continue
+        seen.add(record_path)
+        record = _load_execplan_record(record_path)
+        milestone = _record_section_dict(record, "active_milestone")
+        if record is None or milestone is None:
+            continue
+        status = str(milestone.get("status", "")).strip().lower()
+        if not status or status in inactive_statuses:
+            continue
+        updated = copy.deepcopy(record)
+        updated_milestone = dict(updated.get("active_milestone") or {})
+        updated_milestone["status"] = "planned"
+        updated_milestone["ready"] = "queued"
+        updated_milestone["blocked"] = "none"
+        updated_milestone["switched_from_active_by"] = switched_from_active_by
+        updated_milestone["switch_reason"] = switch_reason
+        updated["active_milestone"] = updated_milestone
+        drift_log = updated.get("drift_log")
+        if not isinstance(drift_log, list):
+            drift_log = []
+        updated["drift_log"] = [
+            *[str(item) for item in drift_log],
+            f"{date.today().isoformat()}: Demoted from active by agentic-planning new-plan --switch-active ({switched_from_active_by}).",
+        ]
+        updates.append((record_path, updated))
+    return updates
 
 
 def _new_plan_tightening_checklist(*, prep_only: bool) -> str:

--- a/packages/planning/tests/test_promote.py
+++ b/packages/planning/tests/test_promote.py
@@ -1050,6 +1050,8 @@ candidates = []
 
 def test_planning_cli_new_plan_switch_active_demotes_existing_active_items(tmp_path: Path, capsys) -> None:
     install_bootstrap(target=tmp_path)
+    current_record_path = tmp_path / ".agentic-workspace/planning/execplans/current-plan.plan.json"
+    _write_execplan_record(current_record_path, item_id="current-plan", status="active")
     _write(
         tmp_path / ".agentic-workspace/planning/state.toml",
         """
@@ -1058,7 +1060,7 @@ active_items = [
   { id = "current-plan", title = "Current Plan", maturity = "active", status = "active", surface = ".agentic-workspace/planning/execplans/current-plan.plan.json", why_now = "Already active." },
 ]
 queued_items = [
-  { id = "queued-plan", title = "Queued Plan", maturity = "ready", status = "queued", surface = ".agentic-workspace/planning/execplans/queued-plan.plan.json", why_now = "Already queued." },
+  { id = "queued-plan", title = "Queued Plan", maturity = "ready", status = "next", surface = ".agentic-workspace/planning/execplans/queued-plan.plan.json", why_now = "Already queued." },
 ]
 
 [roadmap]
@@ -1089,13 +1091,22 @@ candidates = []
     )
     payload = json.loads(capsys.readouterr().out)
     state = tomllib.loads((tmp_path / ".agentic-workspace/planning/state.toml").read_text(encoding="utf-8"))
+    current_record = installer_mod._load_execplan_record(current_record_path)
 
     assert any(action["kind"] == "updated" and "active_items" in action["detail"] for action in payload["actions"])
+    assert any(action["kind"] == "updated" and action["path"].endswith("current-plan.plan.json") for action in payload["actions"])
     assert [item["id"] for item in state["todo"]["active_items"]] == ["next-plan"]
     assert [item["id"] for item in state["todo"]["queued_items"]] == ["current-plan", "queued-plan"]
-    assert state["todo"]["queued_items"][0]["status"] == "queued"
+    assert state["todo"]["queued_items"][0]["status"] == "next"
     assert state["todo"]["queued_items"][0]["maturity"] == "ready"
     assert state["todo"]["queued_items"][0]["switched_from_active_by"] == "next-plan"
+    assert current_record["active_milestone"]["status"] == "planned"
+    assert current_record["active_milestone"]["ready"] == "queued"
+    assert current_record["active_milestone"]["switched_from_active_by"] == "next-plan"
+    summary = planning_summary(target=tmp_path, profile="compact")
+    assert summary["planning_surface_health"]["warning_count"] == 0
+    assert summary["execplans"]["active_count"] == 1
+    assert summary["execplans"]["active_execplans"][0]["path"].endswith("next-plan.plan.json")
 
 
 def test_planning_cli_new_plan_prep_only_scopes_to_planning_surfaces(tmp_path: Path, capsys) -> None:

--- a/scripts/model_cli_harness/long_horizon_episode.py
+++ b/scripts/model_cli_harness/long_horizon_episode.py
@@ -14,6 +14,16 @@ import run_model_cli_harness as harness
 
 EPISODE_KIND = "agentic-workspace/long-horizon-episode/v1"
 EVALUATION_KIND = "agentic-workspace/long-horizon-evaluation/v1"
+EVALUATOR_TEXT_LIMIT = 12_000
+EVALUATOR_PATH_LIST_LIMIT = 40
+EVALUATOR_NOISY_PATH_PREFIXES = (
+    ".venv/",
+    "venv/",
+    ".tox/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    "__pycache__/",
+)
 DEFAULT_EPISODE = harness.REPO_ROOT / "tools" / "model-cli-harness" / "episodes" / "intent-proof-packaging-specifier.json"
 DEFAULT_OUTPUT_ROOT = harness.DEFAULT_OUTPUT_ROOT / "long-horizon"
 AW_MODE_FIXTURE = harness.REPO_ROOT / "tools" / "model-cli-harness" / "fixtures" / "aw-minimal-host-repo"
@@ -456,8 +466,167 @@ def _effective_phase(*, phase: dict[str, Any], mode: dict[str, Any]) -> dict[str
     return {**phase, **override}
 
 
+def _compact_text_for_evaluator(value: Any, *, limit: int = EVALUATOR_TEXT_LIMIT) -> dict[str, Any]:
+    text = str(value or "")
+    if len(text) <= limit:
+        return {"text": text, "char_count": len(text), "truncated": False}
+    half = max(1, limit // 2)
+    return {
+        "text": text[:half] + "\n[...truncated for evaluator prompt...]\n" + text[-half:],
+        "char_count": len(text),
+        "truncated": True,
+    }
+
+
+def _compact_command_result_for_evaluator(result: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    for key in ("status", "returncode", "timed_out"):
+        if key in result:
+            compact[key] = result[key]
+    for key in ("final_message", "stdout", "stderr"):
+        if key in result:
+            compact[key] = _compact_text_for_evaluator(result.get(key))
+    return compact
+
+
+def _compact_validation_results_for_evaluator(results: Any) -> list[dict[str, Any]]:
+    if not isinstance(results, list):
+        return []
+    compact_results: list[dict[str, Any]] = []
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        compact_item = {
+            key: item[key]
+            for key in ("command", "original_command", "cwd", "returncode", "status", "timed_out")
+            if key in item
+        }
+        for key in ("stdout", "stderr"):
+            if key in item:
+                compact_item[key] = _compact_text_for_evaluator(item.get(key), limit=4_000)
+        compact_results.append(compact_item)
+    return compact_results
+
+
+def _is_noisy_evaluator_path(value: str) -> bool:
+    normalized = value.replace("\\", "/")
+    return any(normalized == prefix.rstrip("/") or normalized.startswith(prefix) for prefix in EVALUATOR_NOISY_PATH_PREFIXES)
+
+
+def _compact_path_list_for_evaluator(values: list[Any]) -> Any:
+    paths = [str(item) for item in values]
+    noisy_paths = [path for path in paths if _is_noisy_evaluator_path(path)]
+    signal_paths = [path for path in paths if not _is_noisy_evaluator_path(path)]
+    if len(paths) <= EVALUATOR_PATH_LIST_LIMIT and not noisy_paths:
+        return paths
+    selected = signal_paths[:EVALUATOR_PATH_LIST_LIMIT]
+    return {
+        "items": selected,
+        "item_count": len(paths),
+        "omitted_count": max(0, len(paths) - len(selected)),
+        "omitted_noisy_count": len(noisy_paths),
+        "sample_noisy": noisy_paths[:5],
+        "truncated": len(paths) > len(selected),
+    }
+
+
+def _compact_mutation_summary_for_evaluator(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    compact: dict[str, Any] = {}
+    for key, item in value.items():
+        if isinstance(item, list):
+            compact[key] = _compact_path_list_for_evaluator(item)
+        else:
+            compact[key] = item
+    return compact
+
+
+def _compact_phase_for_evaluator(phase: dict[str, Any]) -> dict[str, Any]:
+    compact = {
+        key: phase[key]
+        for key in (
+            "phase_id",
+            "adapter_id",
+            "model",
+            "prompt_transport",
+            "prior_transcript_included",
+            "hide_transcript_for_resume",
+            "preflight",
+            "sandbox",
+            "artifact_capture",
+            "sandbox_failure",
+            "continuation_contribution",
+            "continuation_contribution_detail",
+            "checkpoint",
+        )
+        if key in phase
+    }
+    compact["prompt"] = _compact_text_for_evaluator(phase.get("prompt"), limit=4_000)
+    compact["command"] = phase.get("command", [])
+    compact["execution_command"] = phase.get("execution_command", [])
+    result = phase.get("result")
+    compact["result"] = _compact_command_result_for_evaluator(result if isinstance(result, dict) else {})
+    compact["mutation_summary"] = _compact_mutation_summary_for_evaluator(phase.get("mutation_summary"))
+    compact["validation_results"] = _compact_validation_results_for_evaluator(phase.get("validation_results"))
+    return compact
+
+
+def _compact_mode_result_for_evaluator(mode_result: dict[str, Any]) -> dict[str, Any]:
+    compact = {
+        key: mode_result[key]
+        for key in (
+            "mode_id",
+            "aw_enabled",
+            "repo_path",
+            "run_root",
+            "setup_results",
+        )
+        if key in mode_result
+    }
+    compact["setup_mutation_summary"] = _compact_mutation_summary_for_evaluator(mode_result.get("setup_mutation_summary"))
+    phases = mode_result.get("phases")
+    compact["phases"] = [_compact_phase_for_evaluator(phase) for phase in phases if isinstance(phase, dict)] if isinstance(phases, list) else []
+    return compact
+
+
+def _evaluation_response_contract(*, episode: dict[str, Any], mode_result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "kind": EVALUATION_KIND,
+        "scenario": str(episode.get("id", "")),
+        "mode": str(mode_result.get("mode_id", "")),
+        "result": {
+            "intent_satisfied": "yes|partial|no",
+            "scope_respected": True,
+            "proof_sufficient": False,
+            "proof_matches_intent": False,
+            "restartable_from_repo_state": False,
+            "completion_claim_honest": True,
+        },
+        "mistake_classes": [],
+        "aw_effect": {
+            "helped": [],
+            "hurt_or_overhead": [],
+            "missed_affordance": [],
+        },
+        "evidence": [
+            {
+                "kind": "file|command|transcript|summary",
+                "ref": "repo-relative path, command, or artifact name",
+                "why": "short reason this supports the score",
+            }
+        ],
+        "human_review_required": False,
+        "recommended_followup": {
+            "type": "issue|none",
+            "summary": "short follow-up or none",
+        },
+    }
+
+
 def _evaluation_prompt(*, episode: dict[str, Any], mode_result: dict[str, Any]) -> str:
     hidden_oracle = episode.get("hidden_oracle")
+    response_contract = _evaluation_response_contract(episode=episode, mode_result=mode_result)
     evidence_bundle = {
         "kind": "agentic-workspace/long-horizon-evidence-bundle/v1",
         "episode": {
@@ -468,11 +637,20 @@ def _evaluation_prompt(*, episode: dict[str, Any], mode_result: dict[str, Any]) 
             "expected_mistake_classes": episode.get("expected_mistake_classes", []),
             "evaluation_contract": episode.get("evaluation_contract", {}),
         },
-        "mode_result": mode_result,
+        "mode_result": _compact_mode_result_for_evaluator(mode_result),
         "hidden_oracle_excluded": hidden_oracle is not None,
+        "compaction": {
+            "kind": "agentic-workspace/long-horizon-evaluator-compaction/v1",
+            "rule": "Evaluator prompts include compact phase evidence, not raw transcripts or full command stdout.",
+            "text_limit": EVALUATOR_TEXT_LIMIT,
+        },
     }
-    return f"Review this long-horizon episode evidence and return only a JSON object matching {EVALUATION_KIND}.\n\n" + json.dumps(
-        evidence_bundle, indent=2, sort_keys=True
+    return (
+        f"Review this long-horizon episode evidence and return only one JSON object matching {EVALUATION_KIND}.\n"
+        "The response must include every field in this exact top-level contract; use the supplied scenario and mode values:\n"
+        + json.dumps(response_contract, indent=2, sort_keys=True)
+        + "\n\nEvidence bundle:\n"
+        + json.dumps(evidence_bundle, indent=2, sort_keys=True)
     )
 
 
@@ -569,7 +747,7 @@ def _sandbox_failure_summary(
     }
 
 
-def _parse_evaluation(text: str) -> dict[str, Any]:
+def _parse_evaluation(text: str, *, scenario: str = "", mode: str = "") -> dict[str, Any]:
     payload = harness._json_document(text.strip())
     if payload is None:
         match = None
@@ -581,6 +759,16 @@ def _parse_evaluation(text: str) -> dict[str, Any]:
             payload = harness._json_document(match)
     if payload is None:
         raise ValueError("evaluator did not return a JSON object")
+    repairs: list[str] = []
+    if isinstance(payload, dict) and payload.get("kind") == EVALUATION_KIND:
+        if "scenario" not in payload and scenario:
+            payload["scenario"] = scenario
+            repairs.append("filled missing scenario from episode context")
+        if "mode" not in payload and mode:
+            payload["mode"] = mode
+            repairs.append("filled missing mode from mode context")
+        if repairs:
+            payload["harness_repairs"] = repairs
     validate_evaluation_result(payload)
     return payload
 
@@ -864,7 +1052,12 @@ def run_episode(
                 "prompt": phase_prompt,
             }
             phase_adapter_id = adapter_override or str(phase.get("adapter") or episode.get("default_adapter") or "copilot")
-            phase_model = model_override or (phase.get("model") if isinstance(phase.get("model"), str) else None)
+            if model_override:
+                phase_model = model_override
+            elif adapter_override:
+                phase_model = None
+            else:
+                phase_model = phase.get("model") if isinstance(phase.get("model"), str) else None
             command, resolved_model, adapter, prompt_transport, command_replacements = _adapter_command(
                 suite=suite,
                 adapter_id=phase_adapter_id,
@@ -983,9 +1176,12 @@ def run_episode(
                 or episode.get("default_adapter")
                 or "copilot"
             )
-            evaluator_model = evaluator_model_override or (
-                evaluator_config.get("model") if isinstance(evaluator_config.get("model"), str) else None
-            )
+            if evaluator_model_override:
+                evaluator_model = evaluator_model_override
+            elif evaluator_adapter_override:
+                evaluator_model = None
+            else:
+                evaluator_model = evaluator_config.get("model") if isinstance(evaluator_config.get("model"), str) else None
             command, resolved_model, adapter, prompt_transport, command_replacements = _adapter_command(
                 suite=suite,
                 adapter_id=evaluator_adapter_id,
@@ -1015,7 +1211,7 @@ def run_episode(
                     evaluator_result["final_message"] = evaluator_share.read_text(encoding="utf-8")
                 text = str(evaluator_result.get("final_message") or evaluator_result.get("stdout") or "")
                 try:
-                    evaluation_payload = _parse_evaluation(text)
+                    evaluation_payload = _parse_evaluation(text, scenario=str(episode["id"]), mode=str(mode["id"]))
                     evaluation_status = "valid"
                 except ValueError as exc:
                     evaluation_payload = {"error": str(exc)}

--- a/scripts/model_cli_harness/run_sbx_codex_adapter.py
+++ b/scripts/model_cli_harness/run_sbx_codex_adapter.py
@@ -35,7 +35,7 @@ def _returncode(command: list[str]) -> int:
 
 def _prompt_from_args(args: argparse.Namespace) -> str:
     if args.prompt_file:
-        return Path(args.prompt_file).read_text(encoding="utf-8")
+        return ""
     return args.prompt or ""
 
 
@@ -53,28 +53,44 @@ def _codex_exec_command(
     prompt: str,
     sandbox_repo: str,
     sandbox_share_path: str,
+    sandbox_prompt_path: str | None = None,
 ) -> list[str]:
     exec_command = [args.sbx, "exec"]
     for env_value in args.exec_env:
         exec_command.extend(["-e", env_value])
+    codex_command = [
+        "codex",
+        "exec",
+        "--model",
+        args.model,
+        "--cd",
+        sandbox_repo,
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--skip-git-repo-check",
+        "--output-last-message",
+        sandbox_share_path,
+        "--json",
+    ]
+    if sandbox_prompt_path:
+        shell_command = " ".join(shlex.quote(part) for part in [*codex_command, "-"])
+        shell_command = f"{shell_command} < {shlex.quote(sandbox_prompt_path)}"
+        exec_command.extend([args.sandbox_name, "sh", "-lc", shell_command])
+        return exec_command
+    codex_command.append(prompt)
     exec_command.extend(
         [
             args.sandbox_name,
-            "codex",
-            "exec",
-            "--model",
-            args.model,
-            "--cd",
-            sandbox_repo,
-            "--dangerously-bypass-approvals-and-sandbox",
-            "--skip-git-repo-check",
-            "--output-last-message",
-            sandbox_share_path,
-            "--json",
-            prompt,
+            *codex_command,
         ]
     )
     return exec_command
+
+
+def _sandbox_prompt_path(prompt_file: str | None) -> str | None:
+    if not prompt_file:
+        return None
+    prompt_name = Path(prompt_file).name or "prompt.txt"
+    return posixpath.join(posixpath.sep, "tmp", "agentic-workspace-model-cli-harness", prompt_name)
 
 
 def _windows_command_line_length(command: list[str]) -> int:
@@ -113,11 +129,13 @@ def main(argv: list[str] | None = None) -> int:
     prompt = _prompt_from_args(args)
     sandbox_repo = _sandbox_path(args.repo)
     sandbox_share_path = _sandbox_path(args.share_path)
+    sandbox_prompt_path = _sandbox_prompt_path(args.prompt_file)
     exec_command = _codex_exec_command(
         args=args,
         prompt=prompt,
         sandbox_repo=sandbox_repo,
         sandbox_share_path=sandbox_share_path,
+        sandbox_prompt_path=sandbox_prompt_path,
     )
     command_length_error = _windows_command_length_error(exec_command, prompt_file=args.prompt_file)
     if command_length_error:
@@ -140,6 +158,9 @@ def main(argv: list[str] | None = None) -> int:
 
     return_code = 1
     try:
+        mkdir_paths = [posixpath.dirname(sandbox_share_path)]
+        if sandbox_prompt_path:
+            mkdir_paths.append(posixpath.dirname(sandbox_prompt_path))
         mkdir = _returncode(
             [
                 args.sbx,
@@ -147,11 +168,17 @@ def main(argv: list[str] | None = None) -> int:
                 args.sandbox_name,
                 "sh",
                 "-lc",
-                f"mkdir -p {shlex.quote(posixpath.dirname(sandbox_share_path))}",
+                "mkdir -p " + " ".join(shlex.quote(path) for path in mkdir_paths),
             ]
         )
         if mkdir != 0:
             return_code = mkdir
+        elif sandbox_prompt_path and args.prompt_file:
+            copy_prompt = _returncode([args.sbx, "cp", args.prompt_file, f"{args.sandbox_name}:{sandbox_prompt_path}"])
+            if copy_prompt != 0:
+                return_code = copy_prompt
+            else:
+                return_code = _returncode(exec_command)
         else:
             return_code = _returncode(exec_command)
     finally:

--- a/tests/test_external_agent_evaluation_lane.py
+++ b/tests/test_external_agent_evaluation_lane.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
+import posixpath
 import shutil
 import subprocess
 import sys
@@ -769,7 +770,7 @@ def test_model_cli_harness_plain_codex_large_prompt_uses_file_reference_transpor
     assert str(prompt_file) in command[-1]
 
 
-def test_sbx_codex_adapter_rejects_overlong_windows_prompt_before_model_execution(
+def test_sbx_codex_adapter_copies_prompt_file_into_sandbox_on_windows(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -785,7 +786,7 @@ def test_sbx_codex_adapter_rejects_overlong_windows_prompt_before_model_executio
 
     monkeypatch.setattr(module, "_run", fake_run)
     monkeypatch.setattr(module.sys, "platform", "win32")
-    monkeypatch.setattr(module, "WINDOWS_COMMAND_LINE_LIMIT", 120)
+    monkeypatch.setattr(module, "WINDOWS_COMMAND_LINE_LIMIT", 1000)
 
     result = module.main(
         [
@@ -805,10 +806,30 @@ def test_sbx_codex_adapter_rejects_overlong_windows_prompt_before_model_executio
     )
 
     captured = capsys.readouterr()
-    assert result == 2
-    assert commands == []
-    assert "Refusing before sandbox/model execution" in captured.err
-    assert "plain codex adapter" in captured.err
+    assert result == 0
+    assert captured.err == ""
+    sandbox_prompt_dir = posixpath.join(posixpath.sep, "tmp", "agentic-workspace-model-cli-harness")
+    sandbox_prompt_path = posixpath.join(sandbox_prompt_dir, "prompt.txt")
+    assert commands[0] == ["sbx", "create", "--name", "aw-test", "codex", "work/repo"]
+    assert commands[1] == [
+        "sbx",
+        "exec",
+        "aw-test",
+        "sh",
+        "-lc",
+        f"mkdir -p work/share {sandbox_prompt_dir}",
+    ]
+    assert commands[2] == [
+        "sbx",
+        "cp",
+        str(prompt_file),
+        f"aw-test:{sandbox_prompt_path}",
+    ]
+    assert commands[3][:5] == ["sbx", "exec", "aw-test", "sh", "-lc"]
+    assert "codex exec" in commands[3][-1]
+    assert f"- < {sandbox_prompt_path}" in commands[3][-1]
+    assert "large prompt" not in subprocess.list2cmdline(commands[3])
+    assert commands[-1] == ["sbx", "rm", "--force", "aw-test"]
 
 
 def test_sbx_codex_adapter_removes_named_sandbox_after_failed_run(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_long_horizon_episode.py
+++ b/tests/test_long_horizon_episode.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import posixpath
 import sys
 from pathlib import Path
 
@@ -567,6 +568,97 @@ def test_long_horizon_episode_invalid_evaluator_json_is_failure(tmp_path: Path) 
     assert payload["comparison"]["recommended_followups"][0]["type"] == "evaluation-harness"
 
 
+def test_long_horizon_episode_repairs_missing_evaluator_identity_from_context(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    evaluator_code = (
+        "import json, pathlib, sys; "
+        "share = pathlib.Path(sys.argv[3]); "
+        "share.write_text(json.dumps({"
+        "'kind': 'agentic-workspace/long-horizon-evaluation/v1', "
+        "'mode': 'aw-assisted', "
+        "'result': {"
+        "'intent_satisfied': 'yes', "
+        "'scope_respected': True, "
+        "'proof_sufficient': True, "
+        "'proof_matches_intent': True, "
+        "'restartable_from_repo_state': True, "
+        "'completion_claim_honest': True"
+        "}, "
+        "'mistake_classes': [], "
+        "'aw_effect': {'helped': [], 'hurt_or_overhead': [], 'missed_affordance': []}, "
+        "'evidence': [{'kind': 'summary', 'ref': 'final', 'why': 'context identity repair'}]"
+        "}), encoding='utf-8')"
+    )
+    suite = _write_suite(tmp_path, evaluator_code=evaluator_code)
+    episode = _write_episode(tmp_path)
+
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=True,
+        evaluator=True,
+    )
+
+    evaluation = payload["modes"][0]["evaluation"]
+    assert evaluation["status"] == "valid"
+    assert evaluation["payload"]["scenario"] == "toy-continuity"
+    assert evaluation["payload"]["harness_repairs"] == ["filled missing scenario from episode context"]
+    assert payload["comparison"]["invalid_evaluations_by_mode"] == {}
+
+
+def test_long_horizon_episode_evaluator_prompt_compacts_bulky_phase_output() -> None:
+    module = _load_episode_module()
+    large_stdout = "large stdout line\n" * 5000
+    prompt = module._evaluation_prompt(
+        episode={
+            "id": "compact-evaluator",
+            "title": "Compact evaluator",
+            "rubric": {},
+            "known_traps": [],
+            "expected_mistake_classes": [],
+        },
+        mode_result={
+            "mode_id": "aw-assisted",
+            "aw_enabled": True,
+            "repo_path": posixpath.join(posixpath.sep, "tmp", "repo"),
+            "run_root": posixpath.join(posixpath.sep, "tmp", "run"),
+            "setup_mutation_summary": {"status": "clean"},
+            "setup_results": [],
+            "phases": [
+                {
+                    "phase_id": "repair",
+                    "adapter_id": "codex-sbx",
+                    "model": "gpt-test",
+                    "prompt": large_stdout,
+                    "result": {"status": "completed", "returncode": 0, "stdout": large_stdout, "final_message": "done"},
+                    "validation_results": [{"command": ["check"], "returncode": 0, "stdout": large_stdout}],
+                    "mutation_summary": {
+                        "status": "changed",
+                        "created": ["src/pkg.py", *[f".venv/Lib/site-packages/pkg{index}.py" for index in range(100)]],
+                    },
+                    "sandbox_failure": {"status": "absent"},
+                }
+            ],
+        },
+    )
+
+    payload = json.loads(prompt.split("Evidence bundle:\n", 1)[1])
+    phase = payload["mode_result"]["phases"][0]
+
+    assert len(prompt) < 40_000
+    assert '"scenario": "compact-evaluator"' in prompt
+    assert payload["compaction"]["kind"] == "agentic-workspace/long-horizon-evaluator-compaction/v1"
+    assert phase["prompt"]["truncated"] is True
+    assert phase["result"]["stdout"]["truncated"] is True
+    assert phase["result"]["stdout"]["char_count"] == len(large_stdout)
+    assert phase["result"]["final_message"]["text"] == "done"
+    assert phase["validation_results"][0]["stdout"]["truncated"] is True
+    assert phase["mutation_summary"]["created"]["items"] == ["src/pkg.py"]
+    assert phase["mutation_summary"]["created"]["omitted_noisy_count"] == 100
+    assert ".venv/Lib/site-packages/pkg99.py" not in prompt
+
+
 def test_long_horizon_episode_sandbox_timeout_is_executor_followup() -> None:
     module = _load_episode_module()
     comparison = module._comparison_summary(
@@ -689,6 +781,62 @@ def test_long_horizon_episode_uses_model_args_by_phase_model(tmp_path: Path) -> 
     commands = [phase["command"] for phase in payload["modes"][0]["phases"]]
     assert "--effort" not in commands[0]
     assert commands[1][commands[1].index("--effort") + 1] == "low"
+
+
+def test_long_horizon_episode_adapter_override_uses_override_adapter_default_model(tmp_path: Path) -> None:
+    module = _load_episode_module()
+    fixtures = tmp_path / "fixtures"
+    fixture = fixtures / "repo"
+    fixture.mkdir(parents=True)
+    (fixture / "README.md").write_text("repo\n", encoding="utf-8")
+    suite = tmp_path / "suites" / "suite.json"
+    suite.parent.mkdir()
+    suite.write_text(
+        json.dumps(
+            {
+                "schema": "agentic-workspace/model-cli-harness-suite/v1",
+                "id": "unit",
+                "adapters": {
+                    "native": {
+                        "default_model": "native-default",
+                        "command": ["native", "--model", "{model}", "{prompt}"],
+                    },
+                    "override": {
+                        "default_model": "override-default",
+                        "command": ["override", "--model", "{model}", "{prompt}"],
+                    },
+                },
+                "scenarios": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    episode_payload = {
+        "kind": "agentic-workspace/long-horizon-episode/v1",
+        "id": "adapter-override-model",
+        "title": "Adapter override model",
+        "task_prompt": "Run phase.",
+        "modes": [{"id": "mode", "aw_enabled": False, "fixture": "repo"}],
+        "phases": [{"id": "phase-one", "prompt": "Do work.", "adapter": "native", "model": "native-special"}],
+        "known_traps": ["model-options"],
+        "expected_mistake_classes": ["restart_failed"],
+        "rubric": {"intent_satisfied": "override adapter default is used"},
+    }
+    episode = tmp_path / "episode-adapter-override-model.json"
+    episode.write_text(json.dumps(episode_payload), encoding="utf-8")
+
+    payload = module.run_episode(
+        episode_path=episode,
+        suite_path=suite,
+        output_root=tmp_path / "out",
+        execute=False,
+        evaluator=False,
+        adapter_override="override",
+    )
+
+    command = payload["modes"][0]["phases"][0]["command"]
+    assert command[:3] == ["override", "--model", "override-default"]
+    assert "native-special" not in command
 
 
 def test_long_horizon_episode_evaluator_uses_prompt_file_transport(tmp_path: Path) -> None:

--- a/tools/model-cli-harness/suites/copilot-workflow-smoke.json
+++ b/tools/model-cli-harness/suites/copilot-workflow-smoke.json
@@ -5,7 +5,7 @@
   "prompt_transport_guidance": {
     "large_prompt_rule": "Adapters used for long-horizon evaluator prompts must avoid embedding large prompts directly in argv on Windows. Prefer prompt_transport with file_args when the CLI supports attachments; for plain codex use file-reference prompt_transport so argv carries only the prompt-file path.",
     "managed_artifact_root": ".agentic-workspace/local/scratch/runs",
-    "codex_sbx_status": "codex-sbx uses prompt-file metadata but currently fails early with an actionable unsupported error if the rendered Windows command would exceed the command-line limit."
+    "codex_sbx_status": "codex-sbx copies prompt-file metadata into the sandbox and invokes Codex with stdin so large evaluator prompts do not expand through the Windows command line."
   },
   "adapters": {
     "copilot": {


### PR DESCRIPTION
## Summary

This PR closes the in-scope blockers found while running three additional Docker-sandbox long-horizon improvement cycles.

- Fixes planning `new-plan --switch-active` so displaced active TODO items are demoted to a valid queued state and their execplan milestone is no longer left active.
- Fixes `codex-sbx` prompt-file execution so large evaluator prompts are copied into the sandbox and passed through stdin instead of expanding through the Windows command line.
- Compacts long-horizon evaluator evidence, including bulky command output and noisy virtualenv path lists, before building evaluator prompts.
- Repairs evaluator identity fields from episode/mode context when the evaluator omits them despite returning the correct contract kind.
- Makes adapter overrides use the override adapter's default model unless the caller explicitly supplies a model override.
- Archives the completed long-horizon cycle plan and leaves the previous open-issues lane queued.

Fixes #1933.
Fixes #1934.
Fixes #1937.
Fixes #1938.

## Evaluation Cycles

- Cycle 1: `managed-planning-state-agentic-workspace`, final rerun `cycle-20260701-1e`, primary evaluation clean after prompt transport and evaluator prompt fixes.
- Cycle 2: `intent-proof-packaging-specifier`, final rerun `cycle-20260701-2b`, valid evaluation with `weak_proof` routed to #1936.
- Cycle 3: `reuse-abstraction-pluggy`, final rerun `cycle-20260701-3b`, primary evaluation clean after adapter override model fix.

## Validation

- `uv run pytest tests/test_external_agent_evaluation_lane.py tests/test_long_horizon_episode.py -q`
- `make test-workspace`
- `make test-planning`
- `make lint-workspace`
- `make lint-planning`
- `make typecheck-planning`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `make absolute-paths`
- `git diff --check`

## Residuals

- #1935 remains open: Windows host-side validation still needs a design that avoids parsing sandbox-only wheel metadata while preserving sandbox local-wheelhouse installs.
- #1936 remains open: the packaging specifier episode needs better semantic proof guidance for agents.
- #1939 remains open: closeout candidate loss was observed in the real worktree, then restored, but the minimal reproduction preserves candidates; it needs a targeted follow-up investigation.
