### PR TITLE
[codex] Make compact state drive communication contracts

### DIFF
--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -13,6 +13,7 @@ Cheap implementer context for a bounded changed-path scope.
 | (root) | object | yes |  | Cheap implementer context for a bounded changed-path scope. |  | x-agentic-workspace-doc-role: "contract-reference" |
 | `kind` | const `"implementer-context/v1"` | yes |  | Discriminator for the implementer context payload shape. |  |  |
 | `target` | string | yes |  | Resolved target repository for the implementation context. |  |  |
+| `communication_contract` | object | no |  | Compact communication and reasoning-economy contract for decision-first, state-backed implementer output. |  |  |
 | `action_signals` | object | no |  | Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment. |  |  |
 | `task_posture_packet` | ref `#/$defs/task_posture_packet` | no |  | Optional dynamic instruction packet emitted when changed paths, task facts, config posture, workflow obligations, or module contributions affect implementation routing. |  |  |
 | `task_posture_packet.kind` | const `"agentic-workspace/task-posture-packet/v1"` | yes |  | Discriminator for dynamic task posture. |  |  |

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -13,6 +13,7 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | (root) | object | yes |  | Startup routing payload returned when an agent needs the minimum safe context for entering or resuming work in a repository. |  | x-agentic-workspace-doc-role: "contract-reference" |
 | `kind` | const `"startup-context/v1"` | yes |  | Discriminator for the startup context payload shape. |  |  |
 | `target` | string | yes |  | Resolved target repository for the startup decision. |  |  |
+| `communication_contract` | object | no |  | Compact communication and reasoning-economy contract for decision-first, state-backed agent output. |  |  |
 | `workflow_participation` | object | no |  | Compact reminder that enabled Agentic Workspace workflow participation is mandatory; advisory fields only guide choices inside that workflow. |  |  |
 | `action_signals` | object | no |  | Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment. |  |  |
 | `decision_packet` | object | no |  | Compact ordinary decision packet that names the startup phase question, next action, claim boundary, detail routes, and omitted detail states. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -74,6 +74,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `health` | string | yes |  | Overall workspace health signal for quick routing. |  |  |
 | `report_profile` | object | yes |  | Report profile metadata, including which sections are decision-grade. |  |  |
 | `output_contract` | object | yes |  | Output contract details used by this contract. |  |  |
+| `communication_contract` | object | yes |  | Compact communication and reasoning-economy contract for decision-first, state-backed report output. |  |  |
 | `operating_posture` | object | yes |  | Current operating posture for agent work in this repository. |  |  |
 | `repo_posture` | object | yes |  | Effective repo posture ref, digest, provenance route, reorientation triggers, and closeout/report adherence visibility. |  |  |
 | `task_posture_packet` | ref `#/$defs/task_posture_packet` | no |  | Optional report-visible dynamic instruction packet with selected posture, module contributions, and provenance. |  |  |

--- a/generated/workspace/python/_contracts/payload.json
+++ b/generated/workspace/python/_contracts/payload.json
@@ -783,6 +783,167 @@
       "proof_route": "agentic-workspace proof --target ./repo --route <id> --format json"
     }
   },
+  "communication_contract": {
+    "canonical_doc": ".agentic-workspace/docs/compact-contract-profile.md",
+    "command": "agentic-workspace defaults --section communication_contract --format json",
+    "kind": "agentic-workspace/communication-contract/defaults/v1",
+    "rule": "Use compact AW state to produce decision-first, evidence-backed, phase-appropriate output; expand only when safety, proof, user request, or continuation value requires it.",
+    "default_posture": "decision_first_state_backed",
+    "narration_budget": "minimal",
+    "required_order": [
+      "decision_or_finding",
+      "why_it_matters",
+      "evidence_or_proof_route",
+      "residue_or_boundary",
+      "next_safe_action"
+    ],
+    "include": [
+      "decision_or_finding",
+      "current_intent_relevance",
+      "evidence_or_proof_route",
+      "unresolved_residue_or_safety_boundary",
+      "next_safe_action"
+    ],
+    "suppress_by_default": [
+      "chronological_tool_call_narration",
+      "repeated_context_reconstruction",
+      "generic_caveats_that_do_not_change_action_safety",
+      "broad_rationale_when_decisive_state_and_boundary_are_enough"
+    ],
+    "expand_when": [
+      "ambiguous_action_safety",
+      "irreversible_or_destructive_change",
+      "stale_missing_or_failed_proof",
+      "user_requests_detail",
+      "rejected_alternative_prevents_rediscovery",
+      "handoff_or_review_needs_continuation_context"
+    ],
+    "phase_expectations": {
+      "startup": {
+        "primary_question": "What is the next safe action?",
+        "include": [
+          "decision",
+          "blocking_or_allowed_action",
+          "required_skill_or_command",
+          "state_boundary"
+        ],
+        "default_detail": "action-first routing plus selector-backed detail routes"
+      },
+      "shaping": {
+        "primary_question": "What is the smallest safe workflow shape?",
+        "include": [
+          "scope_decision",
+          "why_it_matters",
+          "promotion_or_planning_boundary",
+          "next_safe_action"
+        ],
+        "default_detail": "state the bounded slice and non-goals when needed"
+      },
+      "implementation": {
+        "primary_question": "What narrow working set is safe to touch now?",
+        "include": [
+          "changed_paths",
+          "proof_route",
+          "acceptance_boundary",
+          "residue_owner"
+        ],
+        "default_detail": "name only action-changing warnings and selected proof"
+      },
+      "proof": {
+        "primary_question": "What evidence is required before the claim?",
+        "include": [
+          "required_commands",
+          "proof_gap_or_pass",
+          "claim_boundary",
+          "rerun_or_record_route"
+        ],
+        "default_detail": "summarize proof state without raw logs unless failure lines are needed"
+      },
+      "closeout": {
+        "primary_question": "Can this completion claim be trusted?",
+        "include": [
+          "intent_satisfaction",
+          "proof_receipts",
+          "residue",
+          "safe_claim_level"
+        ],
+        "default_detail": "compact claim, evidence, residue, and closure boundary"
+      },
+      "handoff_review": {
+        "primary_question": "What must the next agent or reviewer know without replaying chat?",
+        "include": [
+          "finding_or_change",
+          "evidence_ref",
+          "risk_or_residue",
+          "next_owner"
+        ],
+        "default_detail": "findings first for reviews; handoff facts only when continuation matters"
+      }
+    },
+    "state_usage_rule": "Use compact AW fields as the evidence source first; cite or expand raw docs only when selectors, proof gaps, or safety boundaries require it.",
+    "adapter_route": {
+      "startup": "agentic-workspace start --task \"<task>\" --format json exposes communication_contract",
+      "known_paths": "agentic-workspace implement --changed <paths> --task \"<task>\" --format json exposes communication_contract",
+      "diagnostics": "agentic-workspace report --target ./repo --format json exposes communication_contract and report.output_contract.communication_contract"
+    },
+    "cost_evaluation": {
+      "question": "Did structured state reduce rereads, narration, or reconstruction without weakening proof, residue, or action clarity?",
+      "preserve": [
+        "evidence",
+        "proof_boundary",
+        "unresolved_residue",
+        "next_safe_action"
+      ],
+      "reduce": [
+        "low_value_narration",
+        "repeated_rereads",
+        "context_reconstruction"
+      ],
+      "dogfooding_comparison": [
+        {
+          "workflow": "startup for issue #1942",
+          "compact_state_already_exposed": [
+            "next_safe_action",
+            "action_signals",
+            "decision_packet",
+            "skills",
+            "memory_consult"
+          ],
+          "observed_overhead": "The agent still had to infer concise output rules from scattered prose and output-contract density fields.",
+          "ideal_output": "Decision, issue-scope boundary, evidence route, unresolved proof requirement, and next safe action.",
+          "classified_failure": "field exists indirectly but is not routed prominently as a communication contract",
+          "product_change": "Expose communication_contract through defaults, start, implement, and report."
+        },
+        {
+          "workflow": "known changed-path implementation",
+          "compact_state_already_exposed": [
+            "action_signals",
+            "next",
+            "decision_packet",
+            "proof",
+            "context.scope"
+          ],
+          "observed_overhead": "Without an explicit contract, implement output could still invite retelling inspect/proof context rather than using the packet order.",
+          "ideal_output": "Changed-path decision, selected proof, acceptance boundary, residue owner, next action.",
+          "classified_failure": "model may ignore existing state without a stronger contract",
+          "product_change": "Add communication_contract to implementer full and tiny payloads."
+        },
+        {
+          "workflow": "report/router diagnostics",
+          "compact_state_already_exposed": [
+            "report_profile",
+            "output_contract",
+            "decision_packet",
+            "section_hints"
+          ],
+          "observed_overhead": "Rendering density was visible, but reasoning-economy expectations were not a first-class queryable contract.",
+          "ideal_output": "Finding or diagnostic first, source compact section, residue boundary, next action.",
+          "classified_failure": "missing compact field",
+          "product_change": "Embed communication_contract in output_contract and mirror a compact report-level field."
+        }
+      ]
+    }
+  },
   "completion": {
     "prefer_surfaces": [
       ".agentic-workspace/planning/state.toml",

--- a/generated/workspace/python/_contracts/payload.json
+++ b/generated/workspace/python/_contracts/payload.json
@@ -898,49 +898,6 @@
         "low_value_narration",
         "repeated_rereads",
         "context_reconstruction"
-      ],
-      "dogfooding_comparison": [
-        {
-          "workflow": "startup for issue #1942",
-          "compact_state_already_exposed": [
-            "next_safe_action",
-            "action_signals",
-            "decision_packet",
-            "skills",
-            "memory_consult"
-          ],
-          "observed_overhead": "The agent still had to infer concise output rules from scattered prose and output-contract density fields.",
-          "ideal_output": "Decision, issue-scope boundary, evidence route, unresolved proof requirement, and next safe action.",
-          "classified_failure": "field exists indirectly but is not routed prominently as a communication contract",
-          "product_change": "Expose communication_contract through defaults, start, implement, and report."
-        },
-        {
-          "workflow": "known changed-path implementation",
-          "compact_state_already_exposed": [
-            "action_signals",
-            "next",
-            "decision_packet",
-            "proof",
-            "context.scope"
-          ],
-          "observed_overhead": "Without an explicit contract, implement output could still invite retelling inspect/proof context rather than using the packet order.",
-          "ideal_output": "Changed-path decision, selected proof, acceptance boundary, residue owner, next action.",
-          "classified_failure": "model may ignore existing state without a stronger contract",
-          "product_change": "Add communication_contract to implementer full and tiny payloads."
-        },
-        {
-          "workflow": "report/router diagnostics",
-          "compact_state_already_exposed": [
-            "report_profile",
-            "output_contract",
-            "decision_packet",
-            "section_hints"
-          ],
-          "observed_overhead": "Rendering density was visible, but reasoning-economy expectations were not a first-class queryable contract.",
-          "ideal_output": "Finding or diagnostic first, source compact section, residue boundary, next action.",
-          "classified_failure": "missing compact field",
-          "product_change": "Embed communication_contract in output_contract and mirror a compact report-level field."
-        }
       ]
     }
   },

--- a/generated/workspace/typescript/resources/_contracts/payload.json
+++ b/generated/workspace/typescript/resources/_contracts/payload.json
@@ -783,6 +783,167 @@
       "proof_route": "agentic-workspace proof --target ./repo --route <id> --format json"
     }
   },
+  "communication_contract": {
+    "canonical_doc": ".agentic-workspace/docs/compact-contract-profile.md",
+    "command": "agentic-workspace defaults --section communication_contract --format json",
+    "kind": "agentic-workspace/communication-contract/defaults/v1",
+    "rule": "Use compact AW state to produce decision-first, evidence-backed, phase-appropriate output; expand only when safety, proof, user request, or continuation value requires it.",
+    "default_posture": "decision_first_state_backed",
+    "narration_budget": "minimal",
+    "required_order": [
+      "decision_or_finding",
+      "why_it_matters",
+      "evidence_or_proof_route",
+      "residue_or_boundary",
+      "next_safe_action"
+    ],
+    "include": [
+      "decision_or_finding",
+      "current_intent_relevance",
+      "evidence_or_proof_route",
+      "unresolved_residue_or_safety_boundary",
+      "next_safe_action"
+    ],
+    "suppress_by_default": [
+      "chronological_tool_call_narration",
+      "repeated_context_reconstruction",
+      "generic_caveats_that_do_not_change_action_safety",
+      "broad_rationale_when_decisive_state_and_boundary_are_enough"
+    ],
+    "expand_when": [
+      "ambiguous_action_safety",
+      "irreversible_or_destructive_change",
+      "stale_missing_or_failed_proof",
+      "user_requests_detail",
+      "rejected_alternative_prevents_rediscovery",
+      "handoff_or_review_needs_continuation_context"
+    ],
+    "phase_expectations": {
+      "startup": {
+        "primary_question": "What is the next safe action?",
+        "include": [
+          "decision",
+          "blocking_or_allowed_action",
+          "required_skill_or_command",
+          "state_boundary"
+        ],
+        "default_detail": "action-first routing plus selector-backed detail routes"
+      },
+      "shaping": {
+        "primary_question": "What is the smallest safe workflow shape?",
+        "include": [
+          "scope_decision",
+          "why_it_matters",
+          "promotion_or_planning_boundary",
+          "next_safe_action"
+        ],
+        "default_detail": "state the bounded slice and non-goals when needed"
+      },
+      "implementation": {
+        "primary_question": "What narrow working set is safe to touch now?",
+        "include": [
+          "changed_paths",
+          "proof_route",
+          "acceptance_boundary",
+          "residue_owner"
+        ],
+        "default_detail": "name only action-changing warnings and selected proof"
+      },
+      "proof": {
+        "primary_question": "What evidence is required before the claim?",
+        "include": [
+          "required_commands",
+          "proof_gap_or_pass",
+          "claim_boundary",
+          "rerun_or_record_route"
+        ],
+        "default_detail": "summarize proof state without raw logs unless failure lines are needed"
+      },
+      "closeout": {
+        "primary_question": "Can this completion claim be trusted?",
+        "include": [
+          "intent_satisfaction",
+          "proof_receipts",
+          "residue",
+          "safe_claim_level"
+        ],
+        "default_detail": "compact claim, evidence, residue, and closure boundary"
+      },
+      "handoff_review": {
+        "primary_question": "What must the next agent or reviewer know without replaying chat?",
+        "include": [
+          "finding_or_change",
+          "evidence_ref",
+          "risk_or_residue",
+          "next_owner"
+        ],
+        "default_detail": "findings first for reviews; handoff facts only when continuation matters"
+      }
+    },
+    "state_usage_rule": "Use compact AW fields as the evidence source first; cite or expand raw docs only when selectors, proof gaps, or safety boundaries require it.",
+    "adapter_route": {
+      "startup": "agentic-workspace start --task \"<task>\" --format json exposes communication_contract",
+      "known_paths": "agentic-workspace implement --changed <paths> --task \"<task>\" --format json exposes communication_contract",
+      "diagnostics": "agentic-workspace report --target ./repo --format json exposes communication_contract and report.output_contract.communication_contract"
+    },
+    "cost_evaluation": {
+      "question": "Did structured state reduce rereads, narration, or reconstruction without weakening proof, residue, or action clarity?",
+      "preserve": [
+        "evidence",
+        "proof_boundary",
+        "unresolved_residue",
+        "next_safe_action"
+      ],
+      "reduce": [
+        "low_value_narration",
+        "repeated_rereads",
+        "context_reconstruction"
+      ],
+      "dogfooding_comparison": [
+        {
+          "workflow": "startup for issue #1942",
+          "compact_state_already_exposed": [
+            "next_safe_action",
+            "action_signals",
+            "decision_packet",
+            "skills",
+            "memory_consult"
+          ],
+          "observed_overhead": "The agent still had to infer concise output rules from scattered prose and output-contract density fields.",
+          "ideal_output": "Decision, issue-scope boundary, evidence route, unresolved proof requirement, and next safe action.",
+          "classified_failure": "field exists indirectly but is not routed prominently as a communication contract",
+          "product_change": "Expose communication_contract through defaults, start, implement, and report."
+        },
+        {
+          "workflow": "known changed-path implementation",
+          "compact_state_already_exposed": [
+            "action_signals",
+            "next",
+            "decision_packet",
+            "proof",
+            "context.scope"
+          ],
+          "observed_overhead": "Without an explicit contract, implement output could still invite retelling inspect/proof context rather than using the packet order.",
+          "ideal_output": "Changed-path decision, selected proof, acceptance boundary, residue owner, next action.",
+          "classified_failure": "model may ignore existing state without a stronger contract",
+          "product_change": "Add communication_contract to implementer full and tiny payloads."
+        },
+        {
+          "workflow": "report/router diagnostics",
+          "compact_state_already_exposed": [
+            "report_profile",
+            "output_contract",
+            "decision_packet",
+            "section_hints"
+          ],
+          "observed_overhead": "Rendering density was visible, but reasoning-economy expectations were not a first-class queryable contract.",
+          "ideal_output": "Finding or diagnostic first, source compact section, residue boundary, next action.",
+          "classified_failure": "missing compact field",
+          "product_change": "Embed communication_contract in output_contract and mirror a compact report-level field."
+        }
+      ]
+    }
+  },
   "completion": {
     "prefer_surfaces": [
       ".agentic-workspace/planning/state.toml",

--- a/generated/workspace/typescript/resources/_contracts/payload.json
+++ b/generated/workspace/typescript/resources/_contracts/payload.json
@@ -898,49 +898,6 @@
         "low_value_narration",
         "repeated_rereads",
         "context_reconstruction"
-      ],
-      "dogfooding_comparison": [
-        {
-          "workflow": "startup for issue #1942",
-          "compact_state_already_exposed": [
-            "next_safe_action",
-            "action_signals",
-            "decision_packet",
-            "skills",
-            "memory_consult"
-          ],
-          "observed_overhead": "The agent still had to infer concise output rules from scattered prose and output-contract density fields.",
-          "ideal_output": "Decision, issue-scope boundary, evidence route, unresolved proof requirement, and next safe action.",
-          "classified_failure": "field exists indirectly but is not routed prominently as a communication contract",
-          "product_change": "Expose communication_contract through defaults, start, implement, and report."
-        },
-        {
-          "workflow": "known changed-path implementation",
-          "compact_state_already_exposed": [
-            "action_signals",
-            "next",
-            "decision_packet",
-            "proof",
-            "context.scope"
-          ],
-          "observed_overhead": "Without an explicit contract, implement output could still invite retelling inspect/proof context rather than using the packet order.",
-          "ideal_output": "Changed-path decision, selected proof, acceptance boundary, residue owner, next action.",
-          "classified_failure": "model may ignore existing state without a stronger contract",
-          "product_change": "Add communication_contract to implementer full and tiny payloads."
-        },
-        {
-          "workflow": "report/router diagnostics",
-          "compact_state_already_exposed": [
-            "report_profile",
-            "output_contract",
-            "decision_packet",
-            "section_hints"
-          ],
-          "observed_overhead": "Rendering density was visible, but reasoning-economy expectations were not a first-class queryable contract.",
-          "ideal_output": "Finding or diagnostic first, source compact section, residue boundary, next action.",
-          "classified_failure": "missing compact field",
-          "product_change": "Embed communication_contract in output_contract and mirror a compact report-level field."
-        }
       ]
     }
   },

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -180,7 +180,8 @@ def workspace_pointer_block(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> str:
         f'1. Use `{effective_cli} start --task "<task>" --format json` before non-trivial answers, edits, read-only workflow, config, delegation, or action-safety decisions.\n'
         f'2. Use `{effective_cli} implement --changed <paths> --task "<task>" --format json` when changed paths are already known.\n'
         "3. Follow `next_safe_action`, `action_signals`, and `skills` before opening raw `.agentic-workspace` files or running drill-down commands.\n"
-        "4. When implementing an issue, satisfy the intended end state in the ordinary path; ask for clarification instead of closing with a partial path when the full outcome appears larger than the issue safely permits.\n"
+        "4. Use the returned `communication_contract` for decision-first, evidence-backed, compact output; expand only for its safety/proof/detail triggers.\n"
+        "5. When implementing an issue, satisfy the intended end state in the ordinary path; ask for clarification instead of closing with a partial path when the full outcome appears larger than the issue safely permits.\n"
         "\n"
         "Boundaries:\n"
         "- The effective invocation comes from `.agentic-workspace/config.toml` `[workspace].cli_invoke`; `.agentic-workspace/config.local.toml` may override it.\n"

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -48,6 +48,11 @@
       "type": "string",
       "description": "Resolved target repository for the implementation context."
     },
+    "communication_contract": {
+      "type": "object",
+      "description": "Compact communication and reasoning-economy contract for decision-first, state-backed implementer output.",
+      "additionalProperties": true
+    },
     "action_signals": {
       "type": "object",
       "description": "Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment.",

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -17,6 +17,11 @@
       "type": "string",
       "description": "Resolved target repository for the startup decision."
     },
+    "communication_contract": {
+      "type": "object",
+      "description": "Compact communication and reasoning-economy contract for decision-first, state-backed agent output.",
+      "additionalProperties": true
+    },
     "workflow_participation": {
       "type": "object",
       "description": "Compact reminder that enabled Agentic Workspace workflow participation is mandatory; advisory fields only guide choices inside that workflow.",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -18,6 +18,7 @@
     "health",
     "report_profile",
     "output_contract",
+    "communication_contract",
     "operating_posture",
     "repo_posture",
     "maintainer_mode",
@@ -174,6 +175,11 @@
     "output_contract": {
       "type": "object",
       "description": "Output contract details used by this contract."
+    },
+    "communication_contract": {
+      "type": "object",
+      "description": "Compact communication and reasoning-economy contract for decision-first, state-backed report output.",
+      "additionalProperties": true
     },
     "operating_posture": {
       "type": "object",

--- a/src/agentic_workspace/contracts/workspace_defaults/payload.json
+++ b/src/agentic_workspace/contracts/workspace_defaults/payload.json
@@ -783,6 +783,167 @@
       "proof_route": "agentic-workspace proof --target ./repo --route <id> --format json"
     }
   },
+  "communication_contract": {
+    "canonical_doc": ".agentic-workspace/docs/compact-contract-profile.md",
+    "command": "agentic-workspace defaults --section communication_contract --format json",
+    "kind": "agentic-workspace/communication-contract/defaults/v1",
+    "rule": "Use compact AW state to produce decision-first, evidence-backed, phase-appropriate output; expand only when safety, proof, user request, or continuation value requires it.",
+    "default_posture": "decision_first_state_backed",
+    "narration_budget": "minimal",
+    "required_order": [
+      "decision_or_finding",
+      "why_it_matters",
+      "evidence_or_proof_route",
+      "residue_or_boundary",
+      "next_safe_action"
+    ],
+    "include": [
+      "decision_or_finding",
+      "current_intent_relevance",
+      "evidence_or_proof_route",
+      "unresolved_residue_or_safety_boundary",
+      "next_safe_action"
+    ],
+    "suppress_by_default": [
+      "chronological_tool_call_narration",
+      "repeated_context_reconstruction",
+      "generic_caveats_that_do_not_change_action_safety",
+      "broad_rationale_when_decisive_state_and_boundary_are_enough"
+    ],
+    "expand_when": [
+      "ambiguous_action_safety",
+      "irreversible_or_destructive_change",
+      "stale_missing_or_failed_proof",
+      "user_requests_detail",
+      "rejected_alternative_prevents_rediscovery",
+      "handoff_or_review_needs_continuation_context"
+    ],
+    "phase_expectations": {
+      "startup": {
+        "primary_question": "What is the next safe action?",
+        "include": [
+          "decision",
+          "blocking_or_allowed_action",
+          "required_skill_or_command",
+          "state_boundary"
+        ],
+        "default_detail": "action-first routing plus selector-backed detail routes"
+      },
+      "shaping": {
+        "primary_question": "What is the smallest safe workflow shape?",
+        "include": [
+          "scope_decision",
+          "why_it_matters",
+          "promotion_or_planning_boundary",
+          "next_safe_action"
+        ],
+        "default_detail": "state the bounded slice and non-goals when needed"
+      },
+      "implementation": {
+        "primary_question": "What narrow working set is safe to touch now?",
+        "include": [
+          "changed_paths",
+          "proof_route",
+          "acceptance_boundary",
+          "residue_owner"
+        ],
+        "default_detail": "name only action-changing warnings and selected proof"
+      },
+      "proof": {
+        "primary_question": "What evidence is required before the claim?",
+        "include": [
+          "required_commands",
+          "proof_gap_or_pass",
+          "claim_boundary",
+          "rerun_or_record_route"
+        ],
+        "default_detail": "summarize proof state without raw logs unless failure lines are needed"
+      },
+      "closeout": {
+        "primary_question": "Can this completion claim be trusted?",
+        "include": [
+          "intent_satisfaction",
+          "proof_receipts",
+          "residue",
+          "safe_claim_level"
+        ],
+        "default_detail": "compact claim, evidence, residue, and closure boundary"
+      },
+      "handoff_review": {
+        "primary_question": "What must the next agent or reviewer know without replaying chat?",
+        "include": [
+          "finding_or_change",
+          "evidence_ref",
+          "risk_or_residue",
+          "next_owner"
+        ],
+        "default_detail": "findings first for reviews; handoff facts only when continuation matters"
+      }
+    },
+    "state_usage_rule": "Use compact AW fields as the evidence source first; cite or expand raw docs only when selectors, proof gaps, or safety boundaries require it.",
+    "adapter_route": {
+      "startup": "agentic-workspace start --task \"<task>\" --format json exposes communication_contract",
+      "known_paths": "agentic-workspace implement --changed <paths> --task \"<task>\" --format json exposes communication_contract",
+      "diagnostics": "agentic-workspace report --target ./repo --format json exposes communication_contract and report.output_contract.communication_contract"
+    },
+    "cost_evaluation": {
+      "question": "Did structured state reduce rereads, narration, or reconstruction without weakening proof, residue, or action clarity?",
+      "preserve": [
+        "evidence",
+        "proof_boundary",
+        "unresolved_residue",
+        "next_safe_action"
+      ],
+      "reduce": [
+        "low_value_narration",
+        "repeated_rereads",
+        "context_reconstruction"
+      ],
+      "dogfooding_comparison": [
+        {
+          "workflow": "startup for issue #1942",
+          "compact_state_already_exposed": [
+            "next_safe_action",
+            "action_signals",
+            "decision_packet",
+            "skills",
+            "memory_consult"
+          ],
+          "observed_overhead": "The agent still had to infer concise output rules from scattered prose and output-contract density fields.",
+          "ideal_output": "Decision, issue-scope boundary, evidence route, unresolved proof requirement, and next safe action.",
+          "classified_failure": "field exists indirectly but is not routed prominently as a communication contract",
+          "product_change": "Expose communication_contract through defaults, start, implement, and report."
+        },
+        {
+          "workflow": "known changed-path implementation",
+          "compact_state_already_exposed": [
+            "action_signals",
+            "next",
+            "decision_packet",
+            "proof",
+            "context.scope"
+          ],
+          "observed_overhead": "Without an explicit contract, implement output could still invite retelling inspect/proof context rather than using the packet order.",
+          "ideal_output": "Changed-path decision, selected proof, acceptance boundary, residue owner, next action.",
+          "classified_failure": "model may ignore existing state without a stronger contract",
+          "product_change": "Add communication_contract to implementer full and tiny payloads."
+        },
+        {
+          "workflow": "report/router diagnostics",
+          "compact_state_already_exposed": [
+            "report_profile",
+            "output_contract",
+            "decision_packet",
+            "section_hints"
+          ],
+          "observed_overhead": "Rendering density was visible, but reasoning-economy expectations were not a first-class queryable contract.",
+          "ideal_output": "Finding or diagnostic first, source compact section, residue boundary, next action.",
+          "classified_failure": "missing compact field",
+          "product_change": "Embed communication_contract in output_contract and mirror a compact report-level field."
+        }
+      ]
+    }
+  },
   "completion": {
     "prefer_surfaces": [
       ".agentic-workspace/planning/state.toml",

--- a/src/agentic_workspace/contracts/workspace_defaults/payload.json
+++ b/src/agentic_workspace/contracts/workspace_defaults/payload.json
@@ -898,49 +898,6 @@
         "low_value_narration",
         "repeated_rereads",
         "context_reconstruction"
-      ],
-      "dogfooding_comparison": [
-        {
-          "workflow": "startup for issue #1942",
-          "compact_state_already_exposed": [
-            "next_safe_action",
-            "action_signals",
-            "decision_packet",
-            "skills",
-            "memory_consult"
-          ],
-          "observed_overhead": "The agent still had to infer concise output rules from scattered prose and output-contract density fields.",
-          "ideal_output": "Decision, issue-scope boundary, evidence route, unresolved proof requirement, and next safe action.",
-          "classified_failure": "field exists indirectly but is not routed prominently as a communication contract",
-          "product_change": "Expose communication_contract through defaults, start, implement, and report."
-        },
-        {
-          "workflow": "known changed-path implementation",
-          "compact_state_already_exposed": [
-            "action_signals",
-            "next",
-            "decision_packet",
-            "proof",
-            "context.scope"
-          ],
-          "observed_overhead": "Without an explicit contract, implement output could still invite retelling inspect/proof context rather than using the packet order.",
-          "ideal_output": "Changed-path decision, selected proof, acceptance boundary, residue owner, next action.",
-          "classified_failure": "model may ignore existing state without a stronger contract",
-          "product_change": "Add communication_contract to implementer full and tiny payloads."
-        },
-        {
-          "workflow": "report/router diagnostics",
-          "compact_state_already_exposed": [
-            "report_profile",
-            "output_contract",
-            "decision_packet",
-            "section_hints"
-          ],
-          "observed_overhead": "Rendering density was visible, but reasoning-economy expectations were not a first-class queryable contract.",
-          "ideal_output": "Finding or diagnostic first, source compact section, residue boundary, next action.",
-          "classified_failure": "missing compact field",
-          "product_change": "Embed communication_contract in output_contract and mirror a compact report-level field."
-        }
       ]
     }
   },

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -37,6 +37,98 @@ REPORT_SECTION_ALIASES = {
 }
 
 
+def communication_contract_payload(*, surface: str) -> dict[str, Any]:
+    phase_expectations = {
+        "startup": {
+            "primary_question": "What is the next safe action?",
+            "include": ["decision", "blocking_or_allowed_action", "required_skill_or_command", "state_boundary"],
+            "default_detail": "action-first routing plus selector-backed detail routes",
+        },
+        "shaping": {
+            "primary_question": "What is the smallest safe workflow shape?",
+            "include": ["scope_decision", "why_it_matters", "promotion_or_planning_boundary", "next_safe_action"],
+            "default_detail": "state the bounded slice and non-goals when needed",
+        },
+        "implementation": {
+            "primary_question": "What narrow working set is safe to touch now?",
+            "include": ["changed_paths", "proof_route", "acceptance_boundary", "residue_owner"],
+            "default_detail": "name only action-changing warnings and selected proof",
+        },
+        "proof": {
+            "primary_question": "What evidence is required before the claim?",
+            "include": ["required_commands", "proof_gap_or_pass", "claim_boundary", "rerun_or_record_route"],
+            "default_detail": "summarize proof state without raw logs unless failure lines are needed",
+        },
+        "closeout": {
+            "primary_question": "Can this completion claim be trusted?",
+            "include": ["intent_satisfaction", "proof_receipts", "residue", "safe_claim_level"],
+            "default_detail": "compact claim, evidence, residue, and closure boundary",
+        },
+        "handoff_review": {
+            "primary_question": "What must the next agent or reviewer know without replaying chat?",
+            "include": ["finding_or_change", "evidence_ref", "risk_or_residue", "next_owner"],
+            "default_detail": "findings first for reviews; handoff facts only when continuation matters",
+        },
+    }
+    return {
+        "kind": "agentic-workspace/communication-contract/v1",
+        "surface": surface,
+        "status": "active",
+        "default_posture": "decision_first_state_backed",
+        "narration_budget": "minimal",
+        "required_order": ["decision_or_finding", "why_it_matters", "evidence_or_proof_route", "residue_or_boundary", "next_safe_action"],
+        "include": [
+            "decision_or_finding",
+            "current_intent_relevance",
+            "evidence_or_proof_route",
+            "unresolved_residue_or_safety_boundary",
+            "next_safe_action",
+        ],
+        "suppress_by_default": [
+            "chronological_tool_call_narration",
+            "repeated_context_reconstruction",
+            "generic_caveats_that_do_not_change_action_safety",
+            "broad_rationale_when_decisive_state_and_boundary_are_enough",
+        ],
+        "expand_when": [
+            "ambiguous_action_safety",
+            "irreversible_or_destructive_change",
+            "stale_missing_or_failed_proof",
+            "user_requests_detail",
+            "rejected_alternative_prevents_rediscovery",
+            "handoff_or_review_needs_continuation_context",
+        ],
+        "phase_expectations": phase_expectations,
+        "state_usage_rule": (
+            "Use compact AW fields as the evidence source first; cite or expand raw docs only when selectors, proof gaps, "
+            "or safety boundaries require it."
+        ),
+        "cost_evaluation": {
+            "question": "Did structured state reduce rereads, narration, or reconstruction without weakening proof, residue, or action clarity?",
+            "preserve": ["evidence", "proof_boundary", "unresolved_residue", "next_safe_action"],
+            "reduce": ["low_value_narration", "repeated_rereads", "context_reconstruction"],
+        },
+        "detail_command": "agentic-workspace defaults --section communication_contract --format json",
+    }
+
+
+def compact_communication_contract_payload(*, surface: str) -> dict[str, Any]:
+    full = communication_contract_payload(surface=surface)
+    return {
+        "kind": full["kind"],
+        "surface": full["surface"],
+        "status": full["status"],
+        "default_posture": full["default_posture"],
+        "narration_budget": full["narration_budget"],
+        "phase_ids": list(full["phase_expectations"].keys()),
+        "expand_when": full["expand_when"],
+        "cost_evaluation": {
+            "preserve": full["cost_evaluation"]["preserve"],
+            "reduce": full["cost_evaluation"]["reduce"],
+        },
+    }
+
+
 def output_contract_payload(
     *,
     optimization_bias: str,
@@ -79,6 +171,7 @@ def output_contract_payload(
         "surface_boundary": bias_payload["surface_boundary"],
         "report_density": bias_payload["report_density"],
         "verbosity_budget": verbosity_budget,
+        "communication_contract": communication_contract_payload(surface=surface),
         "residue_density": bias_payload["residue_density"],
         "rendered_view_style": bias_payload["rendered_view_style"],
         "must_not_change": list(bias_payload["does_not_affect"]),
@@ -834,6 +927,10 @@ def report_router_payload(
         "installed_modules": payload.get("installed_modules", []),
         "health": payload.get("health", "unknown"),
         "output_contract": _report_router_output_contract(payload.get("output_contract", {})),
+        "communication_contract": payload.get(
+            "communication_contract",
+            _report_router_output_contract(payload.get("output_contract", {})).get("communication_contract", {}),
+        ),
         "operating_posture": _report_router_operating_posture(payload.get("operating_posture", {})),
         "maintainer_mode": payload.get("maintainer_mode", {}),
         "report_profile": profile_payload,
@@ -902,6 +999,7 @@ def report_router_payload(
         "target": router_payload["target"],
         "health": router_payload["health"],
         "next_action": router_payload["next_action"],
+        "communication_contract": _compact_communication_contract(router_payload.get("communication_contract")),
         "decision_packet": {
             "kind": "agentic-workspace/ordinary-decision-packet/v1",
             "surface": "report",
@@ -974,6 +1072,7 @@ def report_router_payload(
                     "context.current_work",
                     "context.memory_consult",
                     "context.routine_work_context",
+                    "communication_contract",
                     "context.warning_summary",
                     "context.execution_shape",
                     "context.configuration_projection",
@@ -1070,6 +1169,7 @@ def _report_router_output_contract(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {"status": "unavailable"}
     budget = value.get("verbosity_budget", {})
+    communication_contract = value.get("communication_contract", {})
     return {
         "optimization_bias": value.get("optimization_bias", ""),
         "optimization_bias_source": value.get("optimization_bias_source", ""),
@@ -1077,7 +1177,26 @@ def _report_router_output_contract(value: Any) -> dict[str, Any]:
         "rendered_view_style": value.get("rendered_view_style", ""),
         "default_detail": budget.get("default_detail", "") if isinstance(budget, dict) else "",
         "deep_detail": budget.get("deep_detail", "") if isinstance(budget, dict) else "",
+        "communication_contract": _compact_communication_contract(communication_contract),
         "detail_section": "output_contract",
+    }
+
+
+def _compact_communication_contract(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"status": "unavailable"}
+    phase_expectations = value.get("phase_expectations", {})
+    phase_ids = list(phase_expectations.keys()) if isinstance(phase_expectations, dict) else []
+    return {
+        key: value.get(key)
+        for key in (
+            "kind",
+            "surface",
+            "default_posture",
+        )
+        if key in value
+    } | {
+        "phase_ids": phase_ids,
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -113,6 +113,7 @@ from agentic_workspace.contract_tooling import (
     workspace_surfaces_manifest,
 )
 from agentic_workspace.reporting_support import (
+    communication_contract_payload,
     output_contract_payload,
     repo_friction_payload,
     report_profile_payload,
@@ -8736,6 +8737,7 @@ def _run_report_command(
             bias_payload=_optimization_bias_payload(config.optimization_bias),
             surface="report",
         ),
+        "communication_contract": communication_contract_payload(surface="report"),
         "operating_posture": _operating_posture_payload(config=config, surface="report"),
         "repo_posture": repo_posture,
         "maintainer_mode": _maintainer_mode_payload(config=config, target_root=target_root),
@@ -13583,6 +13585,7 @@ def _run_report_router_command(
             bias_payload=_optimization_bias_payload(config.optimization_bias),
             surface="report",
         ),
+        "communication_contract": communication_contract_payload(surface="report"),
         "operating_posture": _operating_posture_payload(config=config, surface="report"),
         "maintainer_mode": _maintainer_mode_payload(config=config, target_root=target_root, compact=True),
         "report_profile": _report_profile_payload(cli_invoke=config.cli_invoke),

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from agentic_workspace.config import WorkspaceUsageError
+from agentic_workspace.reporting_support import communication_contract_payload, compact_communication_contract_payload
 from agentic_workspace.runtime_source_review import (
     tiny_generated_cli_freshness_payload,
     tiny_runtime_source_edit_review_payload,
@@ -689,6 +690,7 @@ def _implement_payload(
     payload = {
         "kind": "implementer-context/v1",
         "target": target_root.as_posix(),
+        "communication_contract": communication_contract_payload(surface="implementation"),
         "workflow_sufficiency": _workflow_sufficiency_payload(
             surface="implement",
             decision=planning_safety_gate["decision"]
@@ -1085,6 +1087,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     projected = {
         "kind": "implementer-context-tiny/v1",
         "target": payload.get("target"),
+        "communication_contract": compact_communication_contract_payload(surface="implementation"),
         "action_signals": _compact_action_signals_payload(
             surface="implement",
             allowed_next_action=str(next_action),

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -114,6 +114,7 @@ from agentic_workspace.contract_tooling import (
     workspace_surfaces_manifest,
 )
 from agentic_workspace.reporting_support import (
+    communication_contract_payload,
     output_contract_payload,
     repo_friction_payload,
     report_profile_payload,
@@ -8841,6 +8842,7 @@ def _run_report_command(
             bias_payload=_optimization_bias_payload(config.optimization_bias),
             surface="report",
         ),
+        "communication_contract": communication_contract_payload(surface="report"),
         "operating_posture": _operating_posture_payload(config=config, surface="report"),
         "repo_posture": repo_posture,
         "maintainer_mode": _maintainer_mode_payload(config=config, target_root=target_root),
@@ -13112,6 +13114,7 @@ def _run_report_router_command(
             bias_payload=_optimization_bias_payload(config.optimization_bias),
             surface="report",
         ),
+        "communication_contract": communication_contract_payload(surface="report"),
         "operating_posture": _operating_posture_payload(config=config, surface="report"),
         "maintainer_mode": _maintainer_mode_payload(config=config, target_root=target_root, compact=True),
         "report_profile": _report_profile_payload(cli_invoke=config.cli_invoke),

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from agentic_workspace.config import DEFAULT_CLI_INVOKE, WORKSPACE_CONFIG_PATH, WORKSPACE_LOCAL_CONFIG_PATH, WorkspaceConfig
+from agentic_workspace.reporting_support import communication_contract_payload, compact_communication_contract_payload
 from agentic_workspace.workspace_runtime_core import (
     _CONTEXT_TEMPLATES,
     _active_intent_contract_payload,
@@ -197,6 +198,7 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "rule": "This tiny profile is the first-contact answer; run detail commands only when the next action says why.",
             "detail_commands": detail_commands,
         },
+        "communication_contract": compact_communication_contract_payload(surface="startup"),
         "feature_tier": {
             "active": compact_active_tier,
             "detail_command": feature_tier.get("detail_command", "agentic-workspace modules --target ./repo --format json")
@@ -648,6 +650,7 @@ def _start_payload(
             cli_invoke=config.cli_invoke,
             target_root=target_root,
         ),
+        "communication_contract": communication_contract_payload(surface="startup"),
         "memory_consult": _memory_consult_payload(
             target_root=target_root, changed_paths=changed_paths, compact=True, cli_invoke=config.cli_invoke
         ),
@@ -1637,6 +1640,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                 "verbose_planning_detail": "detail_omitted",
             },
         ),
+        "communication_contract": compact_communication_contract_payload(surface="startup"),
         "skills": _startup_skills_projection(
             payload=payload,
             next_safe_action=next_safe_action,

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -736,6 +736,28 @@ def test_start_flags_over_budget_local_footprint_as_advisory_selector(tmp_path: 
     assert selected["detail_command"].endswith("report --target ./repo --section local_footprint --format json")
 
 
+def test_start_exposes_communication_contract_in_ordinary_path(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["start", "--target", str(tmp_path), "--task", "Fix one docs typo", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    contract = payload["communication_contract"]
+    assert contract["kind"] == "agentic-workspace/communication-contract/v1"
+    assert contract["default_posture"] == "decision_first_state_backed"
+    assert contract["narration_budget"] == "minimal"
+    assert "startup" in contract["phase_ids"]
+    assert "stale_missing_or_failed_proof" in contract["expand_when"]
+    assert contract["cost_evaluation"]["preserve"] == [
+        "evidence",
+        "proof_boundary",
+        "unresolved_residue",
+        "next_safe_action",
+    ]
+
+
 def test_start_surfaces_configured_pre_test_guardrail_without_universal_bug_keyword(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
@@ -3137,6 +3159,35 @@ def test_report_ordinary_agent_path_is_phase_question_first(tmp_path: Path, caps
     assert ordinary_path["phase_questions"][3]["phase"] == "implementation_context"
     assert ordinary_path["phase_questions"][6]["question"] == "How can a future agent resume without replaying chat?"
     assert ordinary_path["lane_completion_model"]["detail_section"] == "report_profile"
+
+
+def test_report_exposes_communication_contract_in_router_and_output_contract(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    assert cli.main(["report", "--target", str(tmp_path), "--format", "json"]) == 0
+
+    router = json.loads(capsys.readouterr().out)
+    contract = router["communication_contract"]
+    assert contract["kind"] == "agentic-workspace/communication-contract/v1"
+    assert contract["surface"] == "report"
+    assert contract["default_posture"] == "decision_first_state_backed"
+    assert "handoff_review" in contract["phase_ids"]
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "output_contract", "--format", "json"]) == 0
+
+    selected = json.loads(capsys.readouterr().out)["answer"]
+    assert selected["communication_contract"]["phase_expectations"]["handoff_review"]["include"] == [
+        "finding_or_change",
+        "evidence_ref",
+        "risk_or_residue",
+        "next_owner",
+    ]
+    assert selected["communication_contract"]["required_order"] == [
+        "decision_or_finding",
+        "why_it_matters",
+        "evidence_or_proof_route",
+        "residue_or_boundary",
+        "next_safe_action",
+    ]
 
 
 def test_report_ordinary_agent_path_carries_lane_completion_model(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_defaults_cli.py
+++ b/tests/test_workspace_defaults_cli.py
@@ -1019,6 +1019,41 @@ def test_defaults_section_selector_returns_optimization_bias_answer(capsys) -> N
     assert "agentic-workspace defaults --format json" in payload["refs"]
 
 
+def test_defaults_section_selector_returns_communication_contract(capsys) -> None:
+    assert cli.main(["defaults", "--verbose", "--section", "communication_contract", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["profile"] == "compact-contract-answer/v1"
+    assert payload["surface"] == "defaults"
+    assert payload["selector"] == {"section": "communication_contract"}
+    answer = payload["answer"]
+    assert answer["kind"] == "agentic-workspace/communication-contract/defaults/v1"
+    assert answer["default_posture"] == "decision_first_state_backed"
+    assert answer["narration_budget"] == "minimal"
+    assert answer["required_order"] == [
+        "decision_or_finding",
+        "why_it_matters",
+        "evidence_or_proof_route",
+        "residue_or_boundary",
+        "next_safe_action",
+    ]
+    assert "stale_missing_or_failed_proof" in answer["expand_when"]
+    assert set(answer["phase_expectations"]) >= {"startup", "implementation", "proof", "closeout", "handoff_review"}
+    assert answer["cost_evaluation"]["preserve"] == [
+        "evidence",
+        "proof_boundary",
+        "unresolved_residue",
+        "next_safe_action",
+    ]
+    comparisons = answer["cost_evaluation"]["dogfooding_comparison"]
+    assert {item["workflow"] for item in comparisons} == {
+        "startup for issue #1942",
+        "known changed-path implementation",
+        "report/router diagnostics",
+    }
+    assert all(item["product_change"] for item in comparisons)
+
+
 def test_defaults_setup_section_selector_returns_compact_contract_answer(capsys) -> None:
     assert cli.main(["defaults", "--verbose", "--section", "setup", "--format", "json"]) == 0
 

--- a/tests/test_workspace_defaults_cli.py
+++ b/tests/test_workspace_defaults_cli.py
@@ -1045,13 +1045,14 @@ def test_defaults_section_selector_returns_communication_contract(capsys) -> Non
         "unresolved_residue",
         "next_safe_action",
     ]
-    comparisons = answer["cost_evaluation"]["dogfooding_comparison"]
-    assert {item["workflow"] for item in comparisons} == {
-        "startup for issue #1942",
-        "known changed-path implementation",
-        "report/router diagnostics",
-    }
-    assert all(item["product_change"] for item in comparisons)
+    assert answer["cost_evaluation"]["reduce"] == [
+        "low_value_narration",
+        "repeated_rereads",
+        "context_reconstruction",
+    ]
+    assert answer["cost_evaluation"]["question"].startswith("Did structured state reduce")
+    assert "dogfooding_comparison" not in answer["cost_evaluation"]
+    assert "#1942" not in json.dumps(answer)
 
 
 def test_defaults_setup_section_selector_returns_compact_contract_answer(capsys) -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -129,6 +129,26 @@ impact = "advisory"
     assert "local_overlay=1" in payload["action_signals"]["changed_signals"]
 
 
+def test_implement_exposes_communication_contract_for_changed_paths(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "README.md", "# Project\n")
+
+    assert cli.main(["implement", "--target", str(tmp_path), "--changed", "README.md", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    contract = payload["communication_contract"]
+    assert contract["kind"] == "agentic-workspace/communication-contract/v1"
+    assert contract["surface"] == "implementation"
+    assert contract["default_posture"] == "decision_first_state_backed"
+    assert "implementation" in contract["phase_ids"]
+    assert contract["cost_evaluation"]["reduce"] == [
+        "low_value_narration",
+        "repeated_rereads",
+        "context_reconstruction",
+    ]
+
+
 def _write_architecture_principles(target_root: Path) -> None:
     _write(
         target_root / ".agentic-workspace" / "system-intent" / "intent.toml",
@@ -2386,6 +2406,7 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert set(payload) <= {
         "kind",
         "target",
+        "communication_contract",
         "action_signals",
         "decision_packet",
         "next",


### PR DESCRIPTION
## Summary

Closes #1942.

- Adds a queryable `communication_contract` for reasoning-economy behavior across defaults, start, implement, and report surfaces.
- Splits full contract detail from compact ordinary payloads so weak-agent/default routes get decision-first guidance without payload budget regressions.
- Updates schemas, generated command-package payloads, reference docs, AGENTS pointer text, and focused tests for the new contract surface.

## Dogfooding Evidence

The shaping experiment is intentionally kept here in PR evidence instead of the shipped defaults contract payload.

| Workflow | Existing compact state | Observed overhead | Product change |
| --- | --- | --- | --- |
| Startup for issue #1942 | `next_safe_action`, `action_signals`, `decision_packet`, `skills`, memory consultation guidance | The agent still had to infer concise output rules from scattered prose and output-contract density fields. | Expose `communication_contract` through defaults, start, implement, and report. |
| Known changed-path implementation | `action_signals`, `next`, `decision_packet`, `proof`, `context.scope` | Without an explicit contract, implement output could still invite retelling inspect/proof context rather than using the packet order. | Add `communication_contract` to implementer full and tiny payloads. |
| Report/router diagnostics | `report_profile`, `output_contract`, `decision_packet`, `section_hints` | Rendering density was visible, but reasoning-economy expectations were not a first-class queryable contract. | Embed `communication_contract` in `output_contract` and mirror a compact report-level field. |

Closure rationale: no further child issues are needed for #1942 because this PR lands the product seam, compact ordinary projections, selector-backed full contract, adapter guidance, schemas, generated payloads, and tests. Review feedback moved local experiment evidence out of the product contract while preserving it here for auditability.

## Validation

- `git diff --check`
- `uv run python scripts/check/check_generated_command_packages.py`
- `make lint-workspace`
- `make typecheck`
- `make schema-reference-docs`
- `uv run pytest tests/test_workspace_cli.py tests/test_workspace_defaults_cli.py tests/test_workspace_implement_cli.py -q`
- `make test-workspace`
- `make maintainer-surfaces`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`

Review fix validation:

- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`

## Notes

The branch was created fresh from updated `master`, and the #1942 implementation diff was migrated there before validation and commit. The review fix removes repo-specific experiment evidence from `workspace_defaults/payload.json` and generated payloads; defaults now ship only stable operating guidance and generic cost-evaluation criteria.