### PR TITLE
[codex] Make AW skill routing main-loop driven

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1943-skill-driven-lane.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1943-skill-driven-lane.plan.json
@@ -1,0 +1,369 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement issue 1943 skill-driven AW lane",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement GitHub #1943 and child slices #1944-#1948 in one PR by making AW skill routing primarily main-skill driven.",
+    "hard_constraints": "Keep the change focused on installed workspace skill bodies, registry routing metadata, payload sync, and activation tests; preserve AW startup, proof, Planning, Memory, setup, and closeout obligations.",
+    "agent_may_decide": "Exact wording, registry scope values, activation hint tuning, and focused test cases that prove reduced overlap.",
+    "escalate_when": "The lane requires changing CLI command semantics, generated SkillSpec contracts, or broader package architecture beyond skill hierarchy/routing.",
+    "next_action": "Validate the skill hierarchy changes, update proof evidence, then publish a single PR for #1943-#1948.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_skills_cli.py -q",
+      "uv run python scripts/run_agentic_workspace.py implement --changed <changed paths> --task \"Implement the open issue lane in one PR. Refer to issuecomment-4860004222 and report under it.\" --format json"
+    ],
+    "touched_scope": [
+      ".agentic-workspace/skills/**",
+      "src/agentic_workspace/_payload/.agentic-workspace/skills/**",
+      "tests/test_workspace_skills_cli.py",
+      ".agentic-workspace/planning/state.toml",
+      ".agentic-workspace/planning/execplans/issue-1943-skill-driven-lane.plan.json"
+    ],
+    "completion_criteria": [
+      "#1943 has one canonical main AW operating skill, specialized subskills, demoted references, configured-invocation wording, and activation/non-activation proof in one PR."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Implement issue 1943 skill-driven AW lane."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement GitHub #1943 and child slices #1944-#1948 in one PR by making AW skill routing primarily main-skill driven.",
+      "constraints": "Keep the change focused on installed workspace skill bodies, registry routing metadata, payload sync, and activation tests; preserve AW startup, proof, Planning, Memory, setup, and closeout obligations.",
+      "latitude": "Exact wording, registry scope values, activation hint tuning, and focused test cases that prove reduced overlap.",
+      "escalation": "Escalate if the lane requires changing CLI command semantics, generated SkillSpec contracts, or broader package architecture beyond skill hierarchy/routing.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1943-skill-driven-lane",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        ".agentic-workspace/skills/**",
+        "src/agentic_workspace/_payload/.agentic-workspace/skills/**",
+        "tests/test_workspace_skills_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Close the #1943 skill-driven AW lane and child slices #1944-#1948 in one PR.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement the open issue lane in one PR and report under the #1942 evidence comment.",
+    "inferred intended outcome": "Implement the open #1943 skill-driven AW lane, including child slices #1944-#1948, in one PR and add evidence under issuecomment-4860004222.",
+    "chosen concrete what": "Consolidate workspace-startup as the main AW skill, convert intent/work-shape into one subskill, demote old peer skills to references, align configured invocation wording, and add activation/non-activation tests.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": ".agentic-workspace/skills/**, src/agentic_workspace/_payload/.agentic-workspace/skills/**, tests/test_workspace_skills_cli.py, active planning state/execplan",
+    "max changed files": "Focused skill registry/body/payload/test changes; avoid broad runtime or generated contract rewrites unless tests prove they are needed.",
+    "required validation commands": "uv run pytest tests/test_workspace_skills_cli.py -q plus AW implement/proof route for changed paths.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs CLI runtime semantics, generated SkillSpec schemas, package architecture, or unrelated skill systems outside the lane.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Validate and publish the #1943 skill-driven hierarchy: main startup skill, intent/shape subskill, proof/setup subskills, reference-only gate/module/work-shape support.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement GitHub #1943 and child slices #1944-#1948 in one PR by making AW skill routing primarily main-skill driven.",
+    "hard constraints": "Preserve startup/proof/Planning/Memory/setup/closeout obligations and configured invocation wording.",
+    "agent may decide locally": "Exact skill wording, scope metadata, activation hints, and focused tests.",
+    "escalate when": "The fix needs runtime semantics or broad architecture beyond skill hierarchy/routing."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1943-skill-driven-lane",
+    "status": "completed",
+    "scope": "Implement the #1943 lane through skill body, registry, payload, and focused activation tests.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run focused validation, record proof, publish one PR, and report evidence under issuecomment-4860004222."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    ".agentic-workspace/skills/REGISTRY.json",
+    ".agentic-workspace/skills/*/SKILL.md",
+    "src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json",
+    "src/agentic_workspace/_payload/.agentic-workspace/skills/*/SKILL.md",
+    "tests/test_workspace_skills_cli.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_skills_cli.py -q"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "The main/subskill/reference hierarchy is encoded in installed and payload skills.",
+    "Configured invocation wording no longer contradicts AGENTS.md.",
+    "Activation tests prove main skill, retained subskills, reference routing, and non-activation for ordinary direct work.",
+    "Evidence is reported under https://github.com/rickardvh/agentic-workspace/issues/1942#issuecomment-4860004222."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented #1943-#1948 as a skill hierarchy change: workspace-startup is the main AW operating skill, intent/work-shape is one subskill, proof/setup remain specialized, and old gate/module/work-shape peers are reference support.",
+    "scope touched": "installed workspace skill bodies, workspace skill registry metadata, payload skill mirrors, skills CLI activation tests",
+    "changed surfaces": ".agentic-workspace/skills/**; src/agentic_workspace/_payload/.agentic-workspace/skills/**; tests/test_workspace_skills_cli.py",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Focused activation matrix covers main skill, retained subskills, reference routing, and ordinary direct non-activation while preserving configured invocation and proof/closeout boundaries.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_skills_cli.py -q; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make test-workspace; make lint-workspace; make maintainer-surfaces; uv run python scripts/generate/generate_command_packages.py --check; make absolute-paths; git diff --check",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement issue 1943 skill-driven AW lane.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Skill-driven AW lane is implemented and ready for PR publication/reporting.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a lane claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-01: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement issue 1943 skill-driven AW lane.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_skills_cli.py -q; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; make test-workspace; make lint-workspace; make maintainer-surfaces; uv run python scripts/generate/generate_command_packages.py --check; make absolute-paths; git diff --check\nChanged surfaces: .agentic-workspace/skills/**; src/agentic_workspace/_payload/.agentic-workspace/skills/**; tests/test_workspace_skills_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/.agentic-workspace/skills/REGISTRY.json
+++ b/.agentic-workspace/skills/REGISTRY.json
@@ -6,41 +6,50 @@
     {
       "id": "workspace-startup",
       "path": "workspace-startup/SKILL.md",
-      "scope": "routed-projection",
+      "scope": "main-operating-skill",
       "stability": "contract-backed-projection",
-      "visibility": "routed-on-demand",
-      "summary": "orient through compact workspace commands before opening raw planning, memory, or docs surfaces",
+      "visibility": "ordinary-default",
+      "summary": "main AW operating loop for compact routing, configured invocation, routed gates, proof boundaries, and subskill handoff",
       "activation_hints": {
-        "verbs": ["start", "orient", "route", "preflight", "bootstrap", "closeout", "prove"],
-        "nouns": ["workspace", "startup", "workflow", "config", "proof", "closeout", "module map"],
+        "verbs": ["start", "orient", "route", "resume", "implement", "closeout"],
+        "nouns": ["workspace", "startup", "workflow", "config", "proof", "closeout", "AW repo"],
         "phrases": [
           "workspace startup",
+          "main aw operating loop",
+          "start work on this aw repo",
+          "implement issue",
           "orient in the workspace",
           "route this task",
-          "what should I do first",
-          "proof and closeout"
+          "what should I do first"
         ],
         "when": [
           "first contact with an installed workspace",
-          "task shape or proof route is unclear",
-          "agent is tempted to scan raw workspace docs"
+          "ordinary AW work starts or resumes",
+          "agent is tempted to scan raw workspace docs",
+          "a compact router should decide next safe action before source inspection"
         ]
       }
     },
     {
       "id": "workspace-intent-discovery",
       "path": "workspace-intent-discovery/SKILL.md",
-      "scope": "bundled",
+      "scope": "specialized-subskill",
       "stability": "package-managed",
-      "visibility": "ordinary-default",
-      "summary": "run bounded human intent discovery before vague or high-stakes prompts become Planning or implementation",
+      "visibility": "routed-on-demand",
+      "summary": "clarify ambiguous human intent and classify direct, bounded, lane, or epic work after main AW routing",
       "activation_hints": {
-        "verbs": ["ask", "clarify", "discover", "resolve", "brainstorm", "extract", "capture"],
+        "verbs": ["ask", "clarify", "discover", "resolve", "classify", "shape", "triage"],
         "nouns": [
           "intent discovery",
           "human intent",
           "vague prompt",
+          "vague outcome",
           "candidate interpretations",
+          "work shape",
+          "direct task",
+          "bounded task",
+          "lane",
+          "epic",
           "non-goals",
           "first slice",
           "stakes if wrong",
@@ -48,8 +57,14 @@
         ],
         "phrases": [
           "intent-discovery dialogue",
+          "intent and shape",
           "clarify human intent with candidate interpretations before planning",
           "clarify human intent",
+          "classify work shape",
+          "shape this work",
+          "vague outcome prompt",
+          "large vague feature request",
+          "direct bounded lane epic",
           "candidate interpretations",
           "ask before implementation",
           "ask before planning",
@@ -60,6 +75,9 @@
         "when": [
           "prompt is vague or under-specified",
           "stakes_if_wrong is high and inferred_intent_confidence is low",
+          "task size is unclear",
+          "the user describes an outcome rather than a solution",
+          "broad work needs routing before planning",
           "agent might silently choose a convenient implementation slice",
           "why, desired outcome, non-goals, or acceptable first slice are missing"
         ]
@@ -68,65 +86,38 @@
     {
       "id": "workspace-work-shape",
       "path": "workspace-work-shape/SKILL.md",
-      "scope": "bundled",
+      "scope": "reference-support",
       "stability": "package-managed",
-      "visibility": "ordinary-default",
-      "summary": "classify work shape and route direct, bounded, lane, or epic work before implementation",
+      "visibility": "reference-only",
+      "summary": "reference vocabulary for direct, bounded, lane, and epic work shapes; merged procedure lives in workspace-intent-discovery",
       "activation_hints": {
-        "verbs": ["classify", "triage", "shape", "route", "decide", "infer", "resolve"],
+        "verbs": ["reference"],
         "nouns": [
-          "work shape",
-          "direct task",
-          "bounded task",
-          "lane",
-          "epic",
-          "vague request",
-          "vague outcome",
-          "intended outcome",
-          "intent",
-          "trust",
-          "rework",
-          "handoff trust",
-          "what I meant",
-          "satisfaction evidence"
+          "work shape reference",
+          "direct bounded lane epic vocabulary",
+          "shape vocabulary",
+          "shape taxonomy"
         ],
         "phrases": [
-          "classify work shape",
-          "shape this work",
-          "infer intended outcome",
-          "resolve intended outcome",
-          "vague outcome prompt",
-          "feel more trustworthy",
-          "agents hand work back",
-          "agents keep making me repeat",
-          "what I meant",
-          "long task handoff",
-          "before naming a solution",
-          "how to know intent is satisfied",
-          "large vague feature request",
-          "before implementation",
-          "direct bounded lane epic"
+          "work shape reference",
+          "direct bounded lane epic vocabulary",
+          "what does lane shape mean"
         ],
         "when": [
-          "task size is unclear",
-          "the user describes an outcome rather than a solution",
-          "the user names a desired quality such as trust, less rework, or safer handoff",
-          "intent needs to be preserved before implementation",
-          "satisfaction criteria are unclear",
-          "agent may jump straight to implementation",
-          "broad work needs routing before planning"
+          "a compact packet or review explicitly asks for work-shape vocabulary",
+          "workspace-intent-discovery has already handled the procedure"
         ]
       }
     },
     {
       "id": "workspace-proof-selection",
       "path": "workspace-proof-selection/SKILL.md",
-      "scope": "routed-projection",
+      "scope": "specialized-subskill",
       "stability": "contract-backed-projection",
       "visibility": "routed-on-demand",
       "summary": "select and interpret proof for task, slice, lane, or epic completion claims",
       "activation_hints": {
-        "verbs": ["prove", "validate", "verify", "classify", "select"],
+        "verbs": ["prove", "validate", "verify", "select"],
         "nouns": [
           "proof selection",
           "completion claim",
@@ -155,12 +146,12 @@
     {
       "id": "workspace-transition-gates",
       "path": "workspace-transition-gates/SKILL.md",
-      "scope": "routed-support",
+      "scope": "reference-support",
       "stability": "contract-backed-projection",
-      "visibility": "routed-on-demand",
-      "summary": "apply SkillSpec-backed gates to startup, planning, proof, memory, and closeout transitions",
+      "visibility": "reference-only",
+      "summary": "reference SkillSpec-backed transition gate details when compact routed fields need interpretation",
       "activation_hints": {
-        "verbs": ["gate", "transition", "route", "preserve", "fallback"],
+        "verbs": ["reference", "interpret"],
         "nouns": [
           "SkillSpec",
           "transition gate",
@@ -171,12 +162,11 @@
           "no-CLI fallback"
         ],
         "phrases": [
-          "SkillSpec-backed gate",
-          "transition gate",
-          "allowed actions",
-          "forbidden actions",
-          "preferred CLI",
-          "no-CLI fallback"
+          "SkillSpec-backed gate reference",
+          "transition gate reference",
+          "interpret forbidden actions",
+          "interpret allowed actions",
+          "no-CLI fallback reference"
         ],
         "when": [
           "moving between workspace, planning, proof, memory, or closeout",
@@ -188,12 +178,12 @@
     {
       "id": "workspace-operating-loop",
       "path": "workspace-operating-loop/SKILL.md",
-      "scope": "routed-projection",
+      "scope": "reference-support",
       "stability": "contract-backed-projection",
-      "visibility": "routed-on-demand",
-      "summary": "apply the core operating loop and module slot contract across workspace, planning, proof, closeout, and memory",
+      "visibility": "reference-only",
+      "summary": "reference module-slot ownership and no-artifact direct-answer details after main AW routing",
       "activation_hints": {
-        "verbs": ["orchestrate", "slot", "route", "own", "preserve"],
+        "verbs": ["reference", "interpret"],
         "nouns": [
           "operating loop",
           "module slot",
@@ -204,12 +194,10 @@
           "direct answer"
         ],
         "phrases": [
-          "operating loop",
-          "module slot contract",
-          "module slot",
-          "answer directly no artifact",
-          "planning memory workspace loop",
-          "completion claim allowed"
+          "module slot contract reference",
+          "module slot reference",
+          "interpret module slot",
+          "answer directly no artifact reference"
         ],
         "when": [
           "module ownership is unclear",
@@ -221,12 +209,12 @@
     {
       "id": "workspace-setup-jumpstart",
       "path": "workspace-setup-jumpstart/SKILL.md",
-      "scope": "routed-support",
+      "scope": "specialized-subskill",
       "stability": "contract-backed-projection",
       "visibility": "routed-on-demand",
       "summary": "route newly installed or adopted Agentic Workspace in a lived-in repo through bounded setup and jumpstart discovery before seeding durable surfaces",
       "activation_hints": {
-        "verbs": ["setup", "jumpstart", "populate", "seed", "adopt", "install", "orient"],
+        "verbs": ["setup", "jumpstart", "populate", "seed", "adopt", "install"],
         "nouns": [
           "lived-in repo",
           "mature repo",

--- a/.agentic-workspace/skills/workspace-intent-discovery/SKILL.md
+++ b/.agentic-workspace/skills/workspace-intent-discovery/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: workspace-intent-discovery
-description: Run a bounded human intent-discovery dialogue before vague or high-stakes prompts become Planning or implementation work.
+description: Clarify ambiguous human intent and classify direct, bounded, lane, or epic work after the main AW operating skill routes to intent/shape judgment.
 ---
 
-# Workspace Intent Discovery
+# Workspace Intent And Shape
 
-Use this skill when a prompt is broad, vague, high-stakes, or outcome-shaped enough that silently choosing a first implementation slice could miss the user's real goal.
+Use this subskill after `workspace-startup` or compact routing when a prompt is broad, vague, high-stakes, or outcome-shaped enough that silently choosing a first implementation slice could miss the user's real goal.
+This subskill owns the merged intent/work-shape decision. `workspace-work-shape` is reference support, not a competing peer skill.
 
 ## Protocol
 
 1. Name two or three plausible interpretations, not just one inferred intent.
 2. Ask one compact question that captures why the work matters, desired outcome, non-goals, and an acceptable first slice.
 3. If the user does not answer and progress is still safe, proceed only with stated assumptions and visible uncertainty.
-4. Carry the clarified result into the smallest existing surface: `task_intent`, `acceptance`, `durable_intent`, Memory, Planning, or an issue, including a `completion-boundary` when closure could otherwise be ambiguous.
-5. Stop the dialogue after one bounded clarification unless the user's answer exposes a real safety, authority, or scope blocker.
+4. Classify the work as `direct`, `bounded`, `lane`, or `epic`.
+5. Carry the clarified result into the smallest existing surface: `task_intent`, `acceptance`, `durable_intent`, Memory, Planning, or an issue, including a `completion-boundary` when closure could otherwise be ambiguous.
+6. Stop the dialogue after one bounded clarification unless the user's answer exposes a real safety, authority, or scope blocker.
+
+## Shape Rules
+
+- `direct`: target and proof are obvious; keep workspace overhead minimal.
+- `bounded`: finite local implementation with non-obvious proof or continuation risk; use compact implement/proof output.
+- `lane`: multi-slice work that needs checked-in Planning state before coding.
+- `epic`: multiple lanes, unclear decomposition, or high assurance; stop before implementation and shape the durable plan first.
 
 ## Output Shape
 
@@ -23,6 +32,9 @@ Use this skill when a prompt is broad, vague, high-stakes, or outcome-shaped eno
 - `likely_non_goals`
 - `stakes_if_wrong`
 - `proposed_first_slice`
+- `work_shape`
+- `why_shape_fits`
+- `satisfaction_evidence`
 - `question_to_user`
 - `proceed_without_answer_when`
 - `captured_intent_after_reply`

--- a/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
+++ b/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: workspace-operating-loop
-description: Use the core Agentic Workspace operating loop and module slot contract. Use when deciding which module owns startup, planning, implementation, proof, closeout, memory consultation, residue routing, or no-artifact direct answers.
+description: Reference the Agentic Workspace module-slot contract only when the main AW operating skill or compact router names module ownership details that need interpretation.
 ---
 
-# Workspace Operating Loop
+# Workspace Operating Loop Reference
 
 This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
 
-Use it to keep module ownership visible while preserving compact CLI-first operation.
+Do not use it as an ordinary startup or implementation entrypoint. Start with `workspace-startup`; use this reference only when `module_slot`, module ownership, or no-artifact direct-answer behavior needs interpretation after compact routing.
 
 ## Module Slot Contract
 
 `workspace`
 
 - Owns startup, config, ownership, lifecycle, module map, skill routing, proof routing, and package composition.
-- Preferred CLI: `agentic-workspace start`, `implement`, `proof`, `skills`, `report`, `doctor`, `status`.
+- Preferred route: configured AW invocation with `start`, `implement`, `proof`, `skills`, `report`, `doctor`, or `status`.
 - No-CLI fallback: `.agentic-workspace/WORKFLOW.md`, `.agentic-workspace/docs/module-map.md`, then only the named surface.
 
 `planning`
 
 - Owns active execution state, todo promotion, execplans, decomposition, closeout, issue linkage, and continuation.
-- Preferred CLI: `agentic-workspace summary`, `agentic-workspace planning ...`.
+- Preferred route: configured AW invocation with `summary` or `planning ...`.
 - No-CLI fallback: read the compact summary first when possible; open the active execplan only when routed there.
 
 `planning.closeout`
@@ -32,18 +32,18 @@ Use it to keep module ownership visible while preserving compact CLI-first opera
 `workspace.proof`
 
 - Owns proof selection and proof result interpretation, not broader intent by itself.
-- Preferred CLI: `agentic-workspace proof --changed <paths> --format json`.
+- Preferred route: configured AW invocation with `proof --changed <paths> --format json`.
 - No-CLI fallback: select the narrowest existing test, lint, contract, or inspection route.
 
 `memory`
 
 - Owns durable anti-rediscovery knowledge, consultation status, durable residue, and improvement-signal routing.
-- Preferred CLI: `agentic-workspace memory route`, `capture-note`, `promotion-report`.
+- Preferred route: configured AW invocation with `memory route`, `capture-note`, or `promotion-report`.
 - No-CLI fallback: read the Memory index and already-routed notes only.
 
 ## Loop
 
-1. Start with the compact router.
+1. Start with the compact router through `workspace-startup`.
 2. Preserve the returned `module_slot`, `preferred_cli`, `forbidden_actions`, `proof_required`, and `completion_claim_allowed`.
 3. Move to the owning module slot only when the current packet routes there.
 4. Use the module's preferred CLI before raw files.

--- a/.agentic-workspace/skills/workspace-proof-selection/SKILL.md
+++ b/.agentic-workspace/skills/workspace-proof-selection/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: workspace-proof-selection
-description: Select proof that matches the task, slice, lane, or epic before claiming completion. Use when validation evidence, skips, warnings, retries, crashes, or negative proof need to be interpreted separately from whether the requested intent is satisfied.
+description: Select and interpret proof for a routed claim level. Use when validation evidence, skips, warnings, retries, crashes, or negative proof need proof-specific interpretation.
 ---
 
 # Workspace Proof Selection
 
 This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
 
-Use it to choose and interpret proof before closeout. It is not a test-running checklist; it is the decision layer that says what evidence is meaningful for the claim being made.
+Use it after the main AW operating skill or compact router points at proof selection. It is not a test-running checklist or a general completion policy; it decides what evidence is meaningful for the claim being made.
 
 ## Workflow
 
@@ -17,10 +17,10 @@ Use it to choose and interpret proof before closeout. It is not a test-running c
    - lane
    - epic
    - regression guard
-2. Read the structured proof route before broad inspection:
-   - `agentic-workspace implement --changed <paths> --format json` when changed paths are known
-   - `agentic-workspace proof --changed <paths> --format json` for proof-only selection
-   - `agentic-workspace summary --format json` when an active plan or lane determines the claim level
+2. Read the structured proof route before broad inspection using the configured AW invocation:
+   - `implement --changed <paths> --format json` when changed paths are known
+   - `proof --changed <paths> --format json` for proof-only selection
+   - `summary --format json` when an active plan or lane determines the claim level
 3. Select proof for both behavior and intent:
    - command success for changed behavior
    - targeted tests for the touched surface
@@ -36,9 +36,10 @@ Use it to choose and interpret proof before closeout. It is not a test-running c
    - `not_run`
    - `incomplete`
    - `negative_proof_found`
-5. Decide whether completion is allowed separately from command status:
-   - `completion_claim_allowed=true` only when the proof covers the actual claim level and requested intent
-   - `completion_claim_allowed=false` when proof is missing, stale, too narrow, skipped without justification, or contradicts the intended outcome
+5. Report proof adequacy separately from completion permission:
+   - proof can support the claim level only when it covers the changed behavior and requested intent
+   - proof is insufficient when it is missing, stale, too narrow, skipped without justification, or contradicts the intended outcome
+   - completion permission still belongs to the routed closeout/claim boundary, not this subskill alone
 6. Route gaps instead of hiding them:
    - run the missing focused proof
    - narrow the completion claim to a slice

--- a/.agentic-workspace/skills/workspace-setup-jumpstart/SKILL.md
+++ b/.agentic-workspace/skills/workspace-setup-jumpstart/SKILL.md
@@ -1,34 +1,34 @@
 ---
 name: workspace-setup-jumpstart
-description: Route newly installed or adopted Agentic Workspace in a lived-in repo through bounded setup and jumpstart discovery before seeding durable surfaces.
+description: Guide bounded post-bootstrap setup for newly installed or adopted Agentic Workspace in a lived-in repo after the main AW operating skill routes to setup jumpstart.
 ---
 
 # Workspace Setup Jumpstart
 
-Use this skill when Agentic Workspace was newly installed or adopted in a lived-in or mature repo and the task is to populate, seed, or orient workspace surfaces after bootstrap.
+Use this subskill when Agentic Workspace was newly installed or adopted in a lived-in or mature repo and the task is to populate, seed, or orient workspace surfaces after bootstrap.
+This subskill assumes the main AW operating skill or compact router has already selected the AW invocation and routed here.
 
 ## Route
 
-1. Run `agentic-workspace start --target . --task "<task>" --format json`.
-2. Run `agentic-workspace setup --target . --format json` for bounded post-bootstrap setup guidance.
-3. Treat setup as pre-write and pre-seed discovery. Do not bulk-import docs, backlog, or prose.
-4. Inspect only surfaces named by setup output, by the task, or by a durable mature-repo jumpstart memory note.
-5. Promote only:
+1. Run the configured invocation with `setup --target . --format json` for bounded post-bootstrap setup guidance.
+2. Treat setup as pre-write and pre-seed discovery. Do not bulk-import docs, backlog, or prose.
+3. Inspect only surfaces named by setup output, by the task, or by a durable mature-repo jumpstart memory note.
+4. Promote only:
    - durable operating knowledge to Memory;
    - bounded follow-up to Planning;
    - evidence-backed friction to repo-friction or improvement intake;
    - low-confidence or generic findings to transient report only.
-6. Before writing seed surfaces, check promotion criteria in `docs/setup-findings-contract.md` and the durable candidate rule in `docs/jumpstart-contract.md`.
+5. Before writing seed surfaces, check promotion criteria in `docs/setup-findings-contract.md` and the durable candidate rule in `docs/jumpstart-contract.md`.
 
 ## Required Seed Surfaces
 
 When the task is to populate durable workspace surfaces after bootstrap, handle these files explicitly:
 
 - `.agentic-workspace/OWNERSHIP.toml`: keep package-managed module roots, managed surfaces, fences, and authority surfaces generic; add host-specific `[[subsystems]]` only from inspected repo structure, test commands, ownership boundaries, or clear user direction. Do not copy subsystem entries from the Agentic Workspace source repo into a host repo.
-- `.agentic-workspace/system-intent/intent.toml`: run `agentic-workspace system-intent --target . --sync --format json` first, then refine only reviewable interpreted fields that are supported by named repo intent sources such as `README.md`, `SYSTEM_INTENT.md`, product docs, or explicit user direction. Do not mechanically summarize every source file.
+- `.agentic-workspace/system-intent/intent.toml`: use the configured invocation with `system-intent --target . --sync --format json` first, then refine only reviewable interpreted fields that are supported by named repo intent sources such as `README.md`, `SYSTEM_INTENT.md`, product docs, or explicit user direction. Do not mechanically summarize every source file.
 - `.agentic-workspace/system-intent/subsystems.toml`: add scoped durable intent only for subsystem ids already declared in `.agentic-workspace/OWNERSHIP.toml [[subsystems]]`. Leave `subsystems = []` when no host subsystem boundary is clear.
-- `.agentic-workspace/config.toml [assurance]`: run `agentic-workspace defaults --section assurance_onboarding --format json` before seeding assurance. Add proof profiles, requirements, or subsystem profiles only when an inspected host-owned source names the risk, requirement, evidence burden, proof route, or claim boundary. Subsystem profiles must use existing `.agentic-workspace/OWNERSHIP.toml [[subsystems]]` ids.
-- `.agentic-workspace/verification/manifest.toml`: run `agentic-workspace defaults --section verification_onboarding --format json` before seeding Verification. Add protocols, scenarios, proof routes, bundles, or known gaps only when the host repo has a repeatable proof need that ordinary test or command selection does not already express.
+- `.agentic-workspace/config.toml [assurance]`: use the configured invocation with `defaults --section assurance_onboarding --format json` before seeding assurance. Add proof profiles, requirements, or subsystem profiles only when an inspected host-owned source names the risk, requirement, evidence burden, proof route, or claim boundary. Subsystem profiles must use existing `.agentic-workspace/OWNERSHIP.toml [[subsystems]]` ids.
+- `.agentic-workspace/verification/manifest.toml`: use the configured invocation with `defaults --section verification_onboarding --format json` before seeding Verification. Add protocols, scenarios, proof routes, bundles, or known gaps only when the host repo has a repeatable proof need that ordinary test or command selection does not already express.
 - `.agentic-workspace/verification/proof-strategy.toml`: seed only enum hints that the host repo explicitly owns. Do not summarize strategy prose or infer policy from filenames.
 
 Population rule: host repo values must be derived from the host repo. Package defaults may provide schema shape and managed-surface ownership, but not source-repo product intent, source-repo subsystem ids, source paths, proof commands, or issue references.

--- a/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -1,23 +1,35 @@
 ---
 name: workspace-startup
-description: Orient through compact Agentic Workspace commands before opening raw planning, memory, or docs surfaces.
+description: Use the main Agentic Workspace operating loop in an installed AW repo. Start from the configured compact router, preserve routed actions and proof boundaries, and load specialized AW skills only when routed.
 ---
 
-# Workspace Startup
+# Workspace Startup / Operating Loop
 
-Use this skill when the task is about ordinary startup, task routing, config obligations, proof selection, closeout, or module boundaries in an installed Agentic Workspace repo.
-When Agentic Workspace is enabled, this skill is inside mandatory workflow participation; advisory skill routing and `implementation_allowed` never mean startup, planning gates, proof, or closeout can be skipped.
+Use this skill for ordinary AW startup, resume, changed-path implementation, proof approach, closeout, or routed fallback in an installed Agentic Workspace repo.
+When Agentic Workspace is enabled, this is the canonical main operating skill. Advisory skill routing and `implementation_allowed` never bypass startup, Planning gates, proof, or closeout.
 
-## Route
+Do not use this as a broad manual. Load specialized AW subskills only when the compact router, task shape, or this skill names their narrower job.
 
-1. Run `agentic-workspace start --target . --task "<task>" --format json` for ordinary first contact.
-2. If changed paths are already known, run `agentic-workspace implement --target . --changed <paths> --format json`.
-3. Run `agentic-workspace preflight --target . --format json` only for takeover, recovery, or uncertain state.
-4. Run `agentic-workspace summary --target . --format json` when active work, planning, handoff, or continuation matters.
-5. Run `agentic-workspace config --target . --format json` when local posture, configured obligations, startup file, or CLI invocation matters; use `--verbose` only when the tiny answer is insufficient.
-6. Run `agentic-workspace proof --target . --changed <paths> --format json` before claiming validation.
+## Configured Invocation
 
-Open raw `.agentic-workspace/` files only after a compact command points there.
+Use the configured AW invocation exposed by the repo adapter, config, or compact startup/config output. In an installed repo this may look like `agentic-workspace ...`; in a source checkout or dev-dependency install it may be a repo-local command. Do not prefer a bare selector when adapter/config names a different invocation.
+
+## Procedure
+
+1. Run the configured invocation with `start --target . --task "<task>" --format json` for ordinary first contact.
+2. If changed paths are already known, run the configured invocation with `implement --target . --changed <paths> --task "<task>" --format json`.
+3. Preserve `module_slot`, `next_safe_action`, `allowed_actions`, `forbidden_actions`, `proof_required`, and `completion_claim_allowed`.
+4. Follow `next_safe_action` before opening raw `.agentic-workspace/` files or running drill-down commands.
+5. Keep direct work direct when the router allows no-artifact work; do not create Planning, Memory, review, or handoff artifacts just to show work.
+6. Load specialized subskills only for routed intent/shape, proof, setup, or fallback/reference needs.
+7. Before claiming completion, reconcile intent, proof, residue, issue/PR closure, and next owner separately.
+
+## Subskill Routes
+
+- `workspace-intent-discovery`: ambiguous human intent, vague outcome prompts, or direct/bounded/lane/epic work-shape decisions.
+- `workspace-proof-selection`: proof selection or interpretation for task, slice, lane, epic, skipped, warning, retry, crash, or negative evidence.
+- `workspace-setup-jumpstart`: newly installed or adopted AW in a lived-in repo that needs bounded post-bootstrap seeding.
+- `workspace-operating-loop` / `workspace-transition-gates`: reference support only when `module_slot`, `forbidden_actions`, preferred invocation fallback, or transition gate details need interpretation.
 
 ## Red Flags
 
@@ -25,13 +37,13 @@ Red flag:
   I can inspect raw planning or memory files first because the request seems simple.
 
 Use instead:
-  Run `agentic-workspace start --target . --task "<task>" --format json`, or the known dedicated AW command when the request already names one, then follow `next_safe_action`.
+  Run the configured invocation with `start --target . --task "<task>" --format json`, or the known dedicated AW command when the request already names one, then follow `next_safe_action`.
 
 ## SkillSpec Pilot
 
 This skill is the hand-authored startup pilot for the `startup-router` SkillSpec contract in `src/agentic_workspace/contracts/skill_specs.json`.
 
-- Preferred CLI: `agentic-workspace start --target . --task "<task>" --format json`.
+- Preferred route: configured AW invocation with `start --target . --task "<task>" --format json`.
 - Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `next_safe_action`, `planning_safety_gate`, `skill_routing.preferred_routes`, and `detail_commands`.
 - Direct work: if compact startup does not require planning and proof is obvious, keep the work direct and avoid planning, review, Memory, or handoff artifacts.
 - Planning work: if `planning_safety_gate.implementation_allowed` is false, run the named planning command before implementation.

--- a/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
+++ b/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: workspace-transition-gates
-description: Apply SkillSpec-backed gates to workspace transitions. Use when moving between startup, planning, implementation, proof, closeout, memory residue, or issue/PR routing and the agent needs explicit allowed actions, forbidden actions, preferred CLI, interpreted fields, and fallback behavior.
+description: Reference SkillSpec-backed transition gates only when the main AW operating skill or compact router names allowed actions, forbidden actions, preferred invocation, interpreted fields, or fallback behavior that need interpretation.
 ---
 
-# Workspace Transition Gates
+# Workspace Transition Gates Reference
 
 This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
 
-Use it to make workflow transitions inspectable instead of relying on ambient judgement.
+Do not use it as an ordinary startup, implementation, proof, or closeout entrypoint. Start with `workspace-startup`; use this reference only when a routed transition packet needs explicit gate interpretation.
 When AW is enabled, these gates are mandatory workflow boundaries. Advisory routing explains agent-owned choices inside the workflow; it is not permission to skip `start`, `implement`, Planning gates, proof, or closeout.
 
 Each gate is a compact SkillSpec-shaped record:
@@ -25,7 +25,7 @@ Each gate is a compact SkillSpec-shaped record:
 ### Startup To Work
 
 - Trigger: first contact, takeover, or uncertain task shape.
-- Preferred CLI: `agentic-workspace start --task "<task>" --format json`.
+- Preferred route: configured AW invocation with `start --task "<task>" --format json`.
 - Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `workflow_sufficiency`, `next_safe_action`, `skill_routing`.
 - Allowed: follow `next_safe_action.preferred_cli`, request a selector, or continue direct work when the packet says enough.
 - Forbidden: open broad raw planning files before the compact summary when the packet forbids it; treat advisory routing or `implementation_allowed` as a bypass around enabled-AW workflow participation.
@@ -34,7 +34,7 @@ Each gate is a compact SkillSpec-shaped record:
 ### Work To Planning
 
 - Trigger: lane/epic shape, active planning pressure, durable sequencing, or issue-linked execution.
-- Preferred CLI: `agentic-workspace summary --format json`, then Planning commands named by the packet.
+- Preferred route: configured AW invocation with `summary --format json`, then Planning commands named by the packet.
 - Interpreted fields: active item, active execplan, continuation owner, stop conditions.
 - Allowed: create or continue the active planning artifact through package commands.
 - Forbidden: hand-edit planning state or claim completion from a local slice.
@@ -43,7 +43,7 @@ Each gate is a compact SkillSpec-shaped record:
 ### Work To Proof
 
 - Trigger: changed paths are known or a completion claim is near.
-- Preferred CLI: `agentic-workspace implement --changed <paths> --format json` or `agentic-workspace proof --changed <paths> --format json`.
+- Preferred route: configured AW invocation with `implement --changed <paths> --format json` or `proof --changed <paths> --format json`.
 - Interpreted fields: required commands, proof burden, acceptance guidance, completion-claim boundary.
 - Allowed: run the selected narrow proof and classify gaps.
 - Forbidden: substitute passing commands for intent satisfaction.
@@ -52,7 +52,7 @@ Each gate is a compact SkillSpec-shaped record:
 ### Work To Memory Residue
 
 - Trigger: repeated correction, durable lesson, closeout residue, or improvement signal.
-- Preferred CLI: `agentic-workspace memory route --files <paths...> --format json`, `agentic-workspace memory promotion-report --mode remediation --format json`.
+- Preferred route: configured AW invocation with `memory route --files <paths...> --format json` or `memory promotion-report --mode remediation --format json`.
 - Interpreted fields: `memory_consultation_status`, `durable_residue_decision`, `improvement_signal_status`.
 - Allowed: capture only durable anti-rediscovery knowledge or route to the owning surface.
 - Forbidden: write task logs, plan history, or one-off chat residue to Memory.

--- a/.agentic-workspace/skills/workspace-work-shape/SKILL.md
+++ b/.agentic-workspace/skills/workspace-work-shape/SKILL.md
@@ -1,27 +1,22 @@
 ---
 name: workspace-work-shape
-description: Classify work shape and route direct, bounded, lane, or epic work before implementation.
+description: Reference the direct, bounded, lane, and epic vocabulary only when workspace-intent-discovery or compact routing needs work-shape details interpreted.
 ---
 
-# Workspace Work Shape
+# Workspace Work Shape Reference
 
-Use this skill before implementation when task size, proof cost, handoff needs, or the user's intended outcome are unclear.
-This skill does not make AW optional: when AW is enabled, work-shape judgment happens after `start`/`implement` routing, and `implementation_allowed` only applies inside that routed workflow.
+Do not use this as an independently invoked subskill. `workspace-intent-discovery` owns the merged intent/shape procedure after the main AW operating skill routes there.
+When AW is enabled, this reference preserves the same routed workflow boundary as the main skill; it does not make work-shape judgment a bypass around startup, planning or proof gates.
 
-## Route
+This reference exists so compact output, reviews, or issue discussions can name the work-shape vocabulary without reloading the full intent protocol.
 
-1. Run `agentic-workspace start --target . --task "<task>" --format json`.
-2. If changed paths are known, run `agentic-workspace implement --target . --changed <paths> --format json`.
-3. Run `agentic-workspace preflight --target . --format json` only for takeover, recovery, or uncertain state.
-4. For vague outcome prompts, resolve the intended outcome before naming a solution:
-   - What user-visible failure or cost should be reduced?
-   - What would count as satisfaction?
-   - Which repo-visible surface should preserve that intent for the next pass?
-5. Classify the request as `direct`, `bounded`, `lane`, or `epic`.
-6. For `direct` work, keep workspace overhead minimal and prove with the obvious narrow command.
-7. For `bounded` work, use compact planning or proof output when continuation, risk, or non-obvious validation matters.
-8. For `lane` or `epic` work, stop before coding and create or continue checked-in Planning state.
+## Vocabulary
 
-## Output
+- `direct`: target and proof are obvious; answer or edit with the narrowest proof and no durable artifact unless routed.
+- `bounded`: finite implementation with meaningful proof, continuation, or issue-linkage risk; use compact implement/proof routing.
+- `lane`: multi-slice or issue-lane work; checked-in Planning state owns sequencing before implementation.
+- `epic`: multiple lanes, high assurance, or unclear decomposition; shape before implementation.
 
-Report the inferred intended outcome, the shape, why that shape fits, the first repo-visible surface to inspect or update, the satisfaction evidence, the required next command, and whether Planning state is optional, recommended, or required.
+## Reference Output
+
+When this reference is explicitly requested, report the inferred intended outcome, work shape, why that shape fits, the first repo-visible surface to inspect or update, satisfaction evidence, required next route, and whether Planning state is optional, recommended, or required.

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json
@@ -6,41 +6,50 @@
     {
       "id": "workspace-startup",
       "path": "workspace-startup/SKILL.md",
-      "scope": "routed-projection",
+      "scope": "main-operating-skill",
       "stability": "contract-backed-projection",
-      "visibility": "routed-on-demand",
-      "summary": "orient through compact workspace commands before opening raw planning, memory, or docs surfaces",
+      "visibility": "ordinary-default",
+      "summary": "main AW operating loop for compact routing, configured invocation, routed gates, proof boundaries, and subskill handoff",
       "activation_hints": {
-        "verbs": ["start", "orient", "route", "preflight", "bootstrap", "closeout", "prove"],
-        "nouns": ["workspace", "startup", "workflow", "config", "proof", "closeout", "module map"],
+        "verbs": ["start", "orient", "route", "resume", "implement", "closeout"],
+        "nouns": ["workspace", "startup", "workflow", "config", "proof", "closeout", "AW repo"],
         "phrases": [
           "workspace startup",
+          "main aw operating loop",
+          "start work on this aw repo",
+          "implement issue",
           "orient in the workspace",
           "route this task",
-          "what should I do first",
-          "proof and closeout"
+          "what should I do first"
         ],
         "when": [
           "first contact with an installed workspace",
-          "task shape or proof route is unclear",
-          "agent is tempted to scan raw workspace docs"
+          "ordinary AW work starts or resumes",
+          "agent is tempted to scan raw workspace docs",
+          "a compact router should decide next safe action before source inspection"
         ]
       }
     },
     {
       "id": "workspace-intent-discovery",
       "path": "workspace-intent-discovery/SKILL.md",
-      "scope": "bundled",
+      "scope": "specialized-subskill",
       "stability": "package-managed",
-      "visibility": "ordinary-default",
-      "summary": "run bounded human intent discovery before vague or high-stakes prompts become Planning or implementation",
+      "visibility": "routed-on-demand",
+      "summary": "clarify ambiguous human intent and classify direct, bounded, lane, or epic work after main AW routing",
       "activation_hints": {
-        "verbs": ["ask", "clarify", "discover", "resolve", "brainstorm", "extract", "capture"],
+        "verbs": ["ask", "clarify", "discover", "resolve", "classify", "shape", "triage"],
         "nouns": [
           "intent discovery",
           "human intent",
           "vague prompt",
+          "vague outcome",
           "candidate interpretations",
+          "work shape",
+          "direct task",
+          "bounded task",
+          "lane",
+          "epic",
           "non-goals",
           "first slice",
           "stakes if wrong",
@@ -48,8 +57,14 @@
         ],
         "phrases": [
           "intent-discovery dialogue",
+          "intent and shape",
           "clarify human intent with candidate interpretations before planning",
           "clarify human intent",
+          "classify work shape",
+          "shape this work",
+          "vague outcome prompt",
+          "large vague feature request",
+          "direct bounded lane epic",
           "candidate interpretations",
           "ask before implementation",
           "ask before planning",
@@ -60,6 +75,9 @@
         "when": [
           "prompt is vague or under-specified",
           "stakes_if_wrong is high and inferred_intent_confidence is low",
+          "task size is unclear",
+          "the user describes an outcome rather than a solution",
+          "broad work needs routing before planning",
           "agent might silently choose a convenient implementation slice",
           "why, desired outcome, non-goals, or acceptable first slice are missing"
         ]
@@ -68,65 +86,38 @@
     {
       "id": "workspace-work-shape",
       "path": "workspace-work-shape/SKILL.md",
-      "scope": "bundled",
+      "scope": "reference-support",
       "stability": "package-managed",
-      "visibility": "ordinary-default",
-      "summary": "classify work shape and route direct, bounded, lane, or epic work before implementation",
+      "visibility": "reference-only",
+      "summary": "reference vocabulary for direct, bounded, lane, and epic work shapes; merged procedure lives in workspace-intent-discovery",
       "activation_hints": {
-        "verbs": ["classify", "triage", "shape", "route", "decide", "infer", "resolve"],
+        "verbs": ["reference"],
         "nouns": [
-          "work shape",
-          "direct task",
-          "bounded task",
-          "lane",
-          "epic",
-          "vague request",
-          "vague outcome",
-          "intended outcome",
-          "intent",
-          "trust",
-          "rework",
-          "handoff trust",
-          "what I meant",
-          "satisfaction evidence"
+          "work shape reference",
+          "direct bounded lane epic vocabulary",
+          "shape vocabulary",
+          "shape taxonomy"
         ],
         "phrases": [
-          "classify work shape",
-          "shape this work",
-          "infer intended outcome",
-          "resolve intended outcome",
-          "vague outcome prompt",
-          "feel more trustworthy",
-          "agents hand work back",
-          "agents keep making me repeat",
-          "what I meant",
-          "long task handoff",
-          "before naming a solution",
-          "how to know intent is satisfied",
-          "large vague feature request",
-          "before implementation",
-          "direct bounded lane epic"
+          "work shape reference",
+          "direct bounded lane epic vocabulary",
+          "what does lane shape mean"
         ],
         "when": [
-          "task size is unclear",
-          "the user describes an outcome rather than a solution",
-          "the user names a desired quality such as trust, less rework, or safer handoff",
-          "intent needs to be preserved before implementation",
-          "satisfaction criteria are unclear",
-          "agent may jump straight to implementation",
-          "broad work needs routing before planning"
+          "a compact packet or review explicitly asks for work-shape vocabulary",
+          "workspace-intent-discovery has already handled the procedure"
         ]
       }
     },
     {
       "id": "workspace-proof-selection",
       "path": "workspace-proof-selection/SKILL.md",
-      "scope": "routed-projection",
+      "scope": "specialized-subskill",
       "stability": "contract-backed-projection",
       "visibility": "routed-on-demand",
       "summary": "select and interpret proof for task, slice, lane, or epic completion claims",
       "activation_hints": {
-        "verbs": ["prove", "validate", "verify", "classify", "select"],
+        "verbs": ["prove", "validate", "verify", "select"],
         "nouns": [
           "proof selection",
           "completion claim",
@@ -155,12 +146,12 @@
     {
       "id": "workspace-transition-gates",
       "path": "workspace-transition-gates/SKILL.md",
-      "scope": "routed-support",
+      "scope": "reference-support",
       "stability": "contract-backed-projection",
-      "visibility": "routed-on-demand",
-      "summary": "apply SkillSpec-backed gates to startup, planning, proof, memory, and closeout transitions",
+      "visibility": "reference-only",
+      "summary": "reference SkillSpec-backed transition gate details when compact routed fields need interpretation",
       "activation_hints": {
-        "verbs": ["gate", "transition", "route", "preserve", "fallback"],
+        "verbs": ["reference", "interpret"],
         "nouns": [
           "SkillSpec",
           "transition gate",
@@ -171,12 +162,11 @@
           "no-CLI fallback"
         ],
         "phrases": [
-          "SkillSpec-backed gate",
-          "transition gate",
-          "allowed actions",
-          "forbidden actions",
-          "preferred CLI",
-          "no-CLI fallback"
+          "SkillSpec-backed gate reference",
+          "transition gate reference",
+          "interpret forbidden actions",
+          "interpret allowed actions",
+          "no-CLI fallback reference"
         ],
         "when": [
           "moving between workspace, planning, proof, memory, or closeout",
@@ -188,12 +178,12 @@
     {
       "id": "workspace-operating-loop",
       "path": "workspace-operating-loop/SKILL.md",
-      "scope": "routed-projection",
+      "scope": "reference-support",
       "stability": "contract-backed-projection",
-      "visibility": "routed-on-demand",
-      "summary": "apply the core operating loop and module slot contract across workspace, planning, proof, closeout, and memory",
+      "visibility": "reference-only",
+      "summary": "reference module-slot ownership and no-artifact direct-answer details after main AW routing",
       "activation_hints": {
-        "verbs": ["orchestrate", "slot", "route", "own", "preserve"],
+        "verbs": ["reference", "interpret"],
         "nouns": [
           "operating loop",
           "module slot",
@@ -204,12 +194,10 @@
           "direct answer"
         ],
         "phrases": [
-          "operating loop",
-          "module slot contract",
-          "module slot",
-          "answer directly no artifact",
-          "planning memory workspace loop",
-          "completion claim allowed"
+          "module slot contract reference",
+          "module slot reference",
+          "interpret module slot",
+          "answer directly no artifact reference"
         ],
         "when": [
           "module ownership is unclear",
@@ -221,12 +209,12 @@
     {
       "id": "workspace-setup-jumpstart",
       "path": "workspace-setup-jumpstart/SKILL.md",
-      "scope": "routed-support",
+      "scope": "specialized-subskill",
       "stability": "contract-backed-projection",
       "visibility": "routed-on-demand",
       "summary": "route newly installed or adopted Agentic Workspace in a lived-in repo through bounded setup and jumpstart discovery before seeding durable surfaces",
       "activation_hints": {
-        "verbs": ["setup", "jumpstart", "populate", "seed", "adopt", "install", "orient"],
+        "verbs": ["setup", "jumpstart", "populate", "seed", "adopt", "install"],
         "nouns": [
           "lived-in repo",
           "mature repo",

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-intent-discovery/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-intent-discovery/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: workspace-intent-discovery
-description: Run a bounded human intent-discovery dialogue before vague or high-stakes prompts become Planning or implementation work.
+description: Clarify ambiguous human intent and classify direct, bounded, lane, or epic work after the main AW operating skill routes to intent/shape judgment.
 ---
 
-# Workspace Intent Discovery
+# Workspace Intent And Shape
 
-Use this skill when a prompt is broad, vague, high-stakes, or outcome-shaped enough that silently choosing a first implementation slice could miss the user's real goal.
+Use this subskill after `workspace-startup` or compact routing when a prompt is broad, vague, high-stakes, or outcome-shaped enough that silently choosing a first implementation slice could miss the user's real goal.
+This subskill owns the merged intent/work-shape decision. `workspace-work-shape` is reference support, not a competing peer skill.
 
 ## Protocol
 
 1. Name two or three plausible interpretations, not just one inferred intent.
 2. Ask one compact question that captures why the work matters, desired outcome, non-goals, and an acceptable first slice.
 3. If the user does not answer and progress is still safe, proceed only with stated assumptions and visible uncertainty.
-4. Carry the clarified result into the smallest existing surface: `task_intent`, `acceptance`, `durable_intent`, Memory, Planning, or an issue, including a `completion-boundary` when closure could otherwise be ambiguous.
-5. Stop the dialogue after one bounded clarification unless the user's answer exposes a real safety, authority, or scope blocker.
+4. Classify the work as `direct`, `bounded`, `lane`, or `epic`.
+5. Carry the clarified result into the smallest existing surface: `task_intent`, `acceptance`, `durable_intent`, Memory, Planning, or an issue, including a `completion-boundary` when closure could otherwise be ambiguous.
+6. Stop the dialogue after one bounded clarification unless the user's answer exposes a real safety, authority, or scope blocker.
+
+## Shape Rules
+
+- `direct`: target and proof are obvious; keep workspace overhead minimal.
+- `bounded`: finite local implementation with non-obvious proof or continuation risk; use compact implement/proof output.
+- `lane`: multi-slice work that needs checked-in Planning state before coding.
+- `epic`: multiple lanes, unclear decomposition, or high assurance; stop before implementation and shape the durable plan first.
 
 ## Output Shape
 
@@ -23,6 +32,9 @@ Use this skill when a prompt is broad, vague, high-stakes, or outcome-shaped eno
 - `likely_non_goals`
 - `stakes_if_wrong`
 - `proposed_first_slice`
+- `work_shape`
+- `why_shape_fits`
+- `satisfaction_evidence`
 - `question_to_user`
 - `proceed_without_answer_when`
 - `captured_intent_after_reply`

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: workspace-operating-loop
-description: Use the core Agentic Workspace operating loop and module slot contract. Use when deciding which module owns startup, planning, implementation, proof, closeout, memory consultation, residue routing, or no-artifact direct answers.
+description: Reference the Agentic Workspace module-slot contract only when the main AW operating skill or compact router names module ownership details that need interpretation.
 ---
 
-# Workspace Operating Loop
+# Workspace Operating Loop Reference
 
 This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
 
-Use it to keep module ownership visible while preserving compact CLI-first operation.
+Do not use it as an ordinary startup or implementation entrypoint. Start with `workspace-startup`; use this reference only when `module_slot`, module ownership, or no-artifact direct-answer behavior needs interpretation after compact routing.
 
 ## Module Slot Contract
 
 `workspace`
 
 - Owns startup, config, ownership, lifecycle, module map, skill routing, proof routing, and package composition.
-- Preferred CLI: `agentic-workspace start`, `implement`, `proof`, `skills`, `report`, `doctor`, `status`.
+- Preferred route: configured AW invocation with `start`, `implement`, `proof`, `skills`, `report`, `doctor`, or `status`.
 - No-CLI fallback: `.agentic-workspace/WORKFLOW.md`, `.agentic-workspace/docs/module-map.md`, then only the named surface.
 
 `planning`
 
 - Owns active execution state, todo promotion, execplans, decomposition, closeout, issue linkage, and continuation.
-- Preferred CLI: `agentic-workspace summary`, `agentic-workspace planning ...`.
+- Preferred route: configured AW invocation with `summary` or `planning ...`.
 - No-CLI fallback: read the compact summary first when possible; open the active execplan only when routed there.
 
 `planning.closeout`
@@ -32,18 +32,18 @@ Use it to keep module ownership visible while preserving compact CLI-first opera
 `workspace.proof`
 
 - Owns proof selection and proof result interpretation, not broader intent by itself.
-- Preferred CLI: `agentic-workspace proof --changed <paths> --format json`.
+- Preferred route: configured AW invocation with `proof --changed <paths> --format json`.
 - No-CLI fallback: select the narrowest existing test, lint, contract, or inspection route.
 
 `memory`
 
 - Owns durable anti-rediscovery knowledge, consultation status, durable residue, and improvement-signal routing.
-- Preferred CLI: `agentic-workspace memory route`, `capture-note`, `promotion-report`.
+- Preferred route: configured AW invocation with `memory route`, `capture-note`, or `promotion-report`.
 - No-CLI fallback: read the Memory index and already-routed notes only.
 
 ## Loop
 
-1. Start with the compact router.
+1. Start with the compact router through `workspace-startup`.
 2. Preserve the returned `module_slot`, `preferred_cli`, `forbidden_actions`, `proof_required`, and `completion_claim_allowed`.
 3. Move to the owning module slot only when the current packet routes there.
 4. Use the module's preferred CLI before raw files.

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-proof-selection/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-proof-selection/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: workspace-proof-selection
-description: Select proof that matches the task, slice, lane, or epic before claiming completion. Use when validation evidence, skips, warnings, retries, crashes, or negative proof need to be interpreted separately from whether the requested intent is satisfied.
+description: Select and interpret proof for a routed claim level. Use when validation evidence, skips, warnings, retries, crashes, or negative proof need proof-specific interpretation.
 ---
 
 # Workspace Proof Selection
 
 This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
 
-Use it to choose and interpret proof before closeout. It is not a test-running checklist; it is the decision layer that says what evidence is meaningful for the claim being made.
+Use it after the main AW operating skill or compact router points at proof selection. It is not a test-running checklist or a general completion policy; it decides what evidence is meaningful for the claim being made.
 
 ## Workflow
 
@@ -17,10 +17,10 @@ Use it to choose and interpret proof before closeout. It is not a test-running c
    - lane
    - epic
    - regression guard
-2. Read the structured proof route before broad inspection:
-   - `agentic-workspace implement --changed <paths> --format json` when changed paths are known
-   - `agentic-workspace proof --changed <paths> --format json` for proof-only selection
-   - `agentic-workspace summary --format json` when an active plan or lane determines the claim level
+2. Read the structured proof route before broad inspection using the configured AW invocation:
+   - `implement --changed <paths> --format json` when changed paths are known
+   - `proof --changed <paths> --format json` for proof-only selection
+   - `summary --format json` when an active plan or lane determines the claim level
 3. Select proof for both behavior and intent:
    - command success for changed behavior
    - targeted tests for the touched surface
@@ -36,9 +36,10 @@ Use it to choose and interpret proof before closeout. It is not a test-running c
    - `not_run`
    - `incomplete`
    - `negative_proof_found`
-5. Decide whether completion is allowed separately from command status:
-   - `completion_claim_allowed=true` only when the proof covers the actual claim level and requested intent
-   - `completion_claim_allowed=false` when proof is missing, stale, too narrow, skipped without justification, or contradicts the intended outcome
+5. Report proof adequacy separately from completion permission:
+   - proof can support the claim level only when it covers the changed behavior and requested intent
+   - proof is insufficient when it is missing, stale, too narrow, skipped without justification, or contradicts the intended outcome
+   - completion permission still belongs to the routed closeout/claim boundary, not this subskill alone
 6. Route gaps instead of hiding them:
    - run the missing focused proof
    - narrow the completion claim to a slice

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-setup-jumpstart/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-setup-jumpstart/SKILL.md
@@ -1,34 +1,34 @@
 ---
 name: workspace-setup-jumpstart
-description: Route newly installed or adopted Agentic Workspace in a lived-in repo through bounded setup and jumpstart discovery before seeding durable surfaces.
+description: Guide bounded post-bootstrap setup for newly installed or adopted Agentic Workspace in a lived-in repo after the main AW operating skill routes to setup jumpstart.
 ---
 
 # Workspace Setup Jumpstart
 
-Use this skill when Agentic Workspace was newly installed or adopted in a lived-in or mature repo and the task is to populate, seed, or orient workspace surfaces after bootstrap.
+Use this subskill when Agentic Workspace was newly installed or adopted in a lived-in or mature repo and the task is to populate, seed, or orient workspace surfaces after bootstrap.
+This subskill assumes the main AW operating skill or compact router has already selected the AW invocation and routed here.
 
 ## Route
 
-1. Run `agentic-workspace start --target . --task "<task>" --format json`.
-2. Run `agentic-workspace setup --target . --format json` for bounded post-bootstrap setup guidance.
-3. Treat setup as pre-write and pre-seed discovery. Do not bulk-import docs, backlog, or prose.
-4. Inspect only surfaces named by setup output, by the task, or by a durable mature-repo jumpstart memory note.
-5. Promote only:
+1. Run the configured invocation with `setup --target . --format json` for bounded post-bootstrap setup guidance.
+2. Treat setup as pre-write and pre-seed discovery. Do not bulk-import docs, backlog, or prose.
+3. Inspect only surfaces named by setup output, by the task, or by a durable mature-repo jumpstart memory note.
+4. Promote only:
    - durable operating knowledge to Memory;
    - bounded follow-up to Planning;
    - evidence-backed friction to repo-friction or improvement intake;
    - low-confidence or generic findings to transient report only.
-6. Before writing seed surfaces, check promotion criteria in `docs/setup-findings-contract.md` and the durable candidate rule in `docs/jumpstart-contract.md`.
+5. Before writing seed surfaces, check promotion criteria in `docs/setup-findings-contract.md` and the durable candidate rule in `docs/jumpstart-contract.md`.
 
 ## Required Seed Surfaces
 
 When the task is to populate durable workspace surfaces after bootstrap, handle these files explicitly:
 
 - `.agentic-workspace/OWNERSHIP.toml`: keep package-managed module roots, managed surfaces, fences, and authority surfaces generic; add host-specific `[[subsystems]]` only from inspected repo structure, test commands, ownership boundaries, or clear user direction. Do not copy subsystem entries from the Agentic Workspace source repo into a host repo.
-- `.agentic-workspace/system-intent/intent.toml`: run `agentic-workspace system-intent --target . --sync --format json` first, then refine only reviewable interpreted fields that are supported by named repo intent sources such as `README.md`, `SYSTEM_INTENT.md`, product docs, or explicit user direction. Do not mechanically summarize every source file.
+- `.agentic-workspace/system-intent/intent.toml`: use the configured invocation with `system-intent --target . --sync --format json` first, then refine only reviewable interpreted fields that are supported by named repo intent sources such as `README.md`, `SYSTEM_INTENT.md`, product docs, or explicit user direction. Do not mechanically summarize every source file.
 - `.agentic-workspace/system-intent/subsystems.toml`: add scoped durable intent only for subsystem ids already declared in `.agentic-workspace/OWNERSHIP.toml [[subsystems]]`. Leave `subsystems = []` when no host subsystem boundary is clear.
-- `.agentic-workspace/config.toml [assurance]`: run `agentic-workspace defaults --section assurance_onboarding --format json` before seeding assurance. Add proof profiles, requirements, or subsystem profiles only when an inspected host-owned source names the risk, requirement, evidence burden, proof route, or claim boundary. Subsystem profiles must use existing `.agentic-workspace/OWNERSHIP.toml [[subsystems]]` ids.
-- `.agentic-workspace/verification/manifest.toml`: run `agentic-workspace defaults --section verification_onboarding --format json` before seeding Verification. Add protocols, scenarios, proof routes, bundles, or known gaps only when the host repo has a repeatable proof need that ordinary test or command selection does not already express.
+- `.agentic-workspace/config.toml [assurance]`: use the configured invocation with `defaults --section assurance_onboarding --format json` before seeding assurance. Add proof profiles, requirements, or subsystem profiles only when an inspected host-owned source names the risk, requirement, evidence burden, proof route, or claim boundary. Subsystem profiles must use existing `.agentic-workspace/OWNERSHIP.toml [[subsystems]]` ids.
+- `.agentic-workspace/verification/manifest.toml`: use the configured invocation with `defaults --section verification_onboarding --format json` before seeding Verification. Add protocols, scenarios, proof routes, bundles, or known gaps only when the host repo has a repeatable proof need that ordinary test or command selection does not already express.
 - `.agentic-workspace/verification/proof-strategy.toml`: seed only enum hints that the host repo explicitly owns. Do not summarize strategy prose or infer policy from filenames.
 
 Population rule: host repo values must be derived from the host repo. Package defaults may provide schema shape and managed-surface ownership, but not source-repo product intent, source-repo subsystem ids, source paths, proof commands, or issue references.

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-startup/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-startup/SKILL.md
@@ -1,23 +1,35 @@
 ---
 name: workspace-startup
-description: Orient through compact Agentic Workspace commands before opening raw planning, memory, or docs surfaces.
+description: Use the main Agentic Workspace operating loop in an installed AW repo. Start from the configured compact router, preserve routed actions and proof boundaries, and load specialized AW skills only when routed.
 ---
 
-# Workspace Startup
+# Workspace Startup / Operating Loop
 
-Use this skill when the task is about ordinary startup, task routing, config obligations, proof selection, closeout, or module boundaries in an installed Agentic Workspace repo.
-When Agentic Workspace is enabled, this skill is inside mandatory workflow participation; advisory skill routing and `implementation_allowed` never mean startup, planning gates, proof, or closeout can be skipped.
+Use this skill for ordinary AW startup, resume, changed-path implementation, proof approach, closeout, or routed fallback in an installed Agentic Workspace repo.
+When Agentic Workspace is enabled, this is the canonical main operating skill. Advisory skill routing and `implementation_allowed` never bypass startup, Planning gates, proof, or closeout.
 
-## Route
+Do not use this as a broad manual. Load specialized AW subskills only when the compact router, task shape, or this skill names their narrower job.
 
-1. Run `agentic-workspace start --target . --task "<task>" --format json` for ordinary first contact.
-2. If changed paths are already known, run `agentic-workspace implement --target . --changed <paths> --format json`.
-3. Run `agentic-workspace preflight --target . --format json` only for takeover, recovery, or uncertain state.
-4. Run `agentic-workspace summary --target . --format json` when active work, planning, handoff, or continuation matters.
-5. Run `agentic-workspace config --target . --format json` when local posture, configured obligations, startup file, or CLI invocation matters; use `--verbose` only when the tiny answer is insufficient.
-6. Run `agentic-workspace proof --target . --changed <paths> --format json` before claiming validation.
+## Configured Invocation
 
-Open raw `.agentic-workspace/` files only after a compact command points there.
+Use the configured AW invocation exposed by the repo adapter, config, or compact startup/config output. In an installed repo this may look like `agentic-workspace ...`; in a source checkout or dev-dependency install it may be a repo-local command. Do not prefer a bare selector when adapter/config names a different invocation.
+
+## Procedure
+
+1. Run the configured invocation with `start --target . --task "<task>" --format json` for ordinary first contact.
+2. If changed paths are already known, run the configured invocation with `implement --target . --changed <paths> --task "<task>" --format json`.
+3. Preserve `module_slot`, `next_safe_action`, `allowed_actions`, `forbidden_actions`, `proof_required`, and `completion_claim_allowed`.
+4. Follow `next_safe_action` before opening raw `.agentic-workspace/` files or running drill-down commands.
+5. Keep direct work direct when the router allows no-artifact work; do not create Planning, Memory, review, or handoff artifacts just to show work.
+6. Load specialized subskills only for routed intent/shape, proof, setup, or fallback/reference needs.
+7. Before claiming completion, reconcile intent, proof, residue, issue/PR closure, and next owner separately.
+
+## Subskill Routes
+
+- `workspace-intent-discovery`: ambiguous human intent, vague outcome prompts, or direct/bounded/lane/epic work-shape decisions.
+- `workspace-proof-selection`: proof selection or interpretation for task, slice, lane, epic, skipped, warning, retry, crash, or negative evidence.
+- `workspace-setup-jumpstart`: newly installed or adopted AW in a lived-in repo that needs bounded post-bootstrap seeding.
+- `workspace-operating-loop` / `workspace-transition-gates`: reference support only when `module_slot`, `forbidden_actions`, preferred invocation fallback, or transition gate details need interpretation.
 
 ## Red Flags
 
@@ -25,13 +37,13 @@ Red flag:
   I can inspect raw planning or memory files first because the request seems simple.
 
 Use instead:
-  Run `agentic-workspace start --target . --task "<task>" --format json`, or the known dedicated AW command when the request already names one, then follow `next_safe_action`.
+  Run the configured invocation with `start --target . --task "<task>" --format json`, or the known dedicated AW command when the request already names one, then follow `next_safe_action`.
 
 ## SkillSpec Pilot
 
 This skill is the hand-authored startup pilot for the `startup-router` SkillSpec contract in `src/agentic_workspace/contracts/skill_specs.json`.
 
-- Preferred CLI: `agentic-workspace start --target . --task "<task>" --format json`.
+- Preferred route: configured AW invocation with `start --target . --task "<task>" --format json`.
 - Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `next_safe_action`, `planning_safety_gate`, `skill_routing.preferred_routes`, and `detail_commands`.
 - Direct work: if compact startup does not require planning and proof is obvious, keep the work direct and avoid planning, review, Memory, or handoff artifacts.
 - Planning work: if `planning_safety_gate.implementation_allowed` is false, run the named planning command before implementation.

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-transition-gates/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: workspace-transition-gates
-description: Apply SkillSpec-backed gates to workspace transitions. Use when moving between startup, planning, implementation, proof, closeout, memory residue, or issue/PR routing and the agent needs explicit allowed actions, forbidden actions, preferred CLI, interpreted fields, and fallback behavior.
+description: Reference SkillSpec-backed transition gates only when the main AW operating skill or compact router names allowed actions, forbidden actions, preferred invocation, interpreted fields, or fallback behavior that need interpretation.
 ---
 
-# Workspace Transition Gates
+# Workspace Transition Gates Reference
 
 This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
 
-Use it to make workflow transitions inspectable instead of relying on ambient judgement.
+Do not use it as an ordinary startup, implementation, proof, or closeout entrypoint. Start with `workspace-startup`; use this reference only when a routed transition packet needs explicit gate interpretation.
 When AW is enabled, these gates are mandatory workflow boundaries. Advisory routing explains agent-owned choices inside the workflow; it is not permission to skip `start`, `implement`, Planning gates, proof, or closeout.
 
 Each gate is a compact SkillSpec-shaped record:
@@ -25,7 +25,7 @@ Each gate is a compact SkillSpec-shaped record:
 ### Startup To Work
 
 - Trigger: first contact, takeover, or uncertain task shape.
-- Preferred CLI: `agentic-workspace start --task "<task>" --format json`.
+- Preferred route: configured AW invocation with `start --task "<task>" --format json`.
 - Interpreted fields: `workflow_participation`, `immediate_next_allowed_action`, `workflow_sufficiency`, `next_safe_action`, `skill_routing`.
 - Allowed: follow `next_safe_action.preferred_cli`, request a selector, or continue direct work when the packet says enough.
 - Forbidden: open broad raw planning files before the compact summary when the packet forbids it; treat advisory routing or `implementation_allowed` as a bypass around enabled-AW workflow participation.
@@ -34,7 +34,7 @@ Each gate is a compact SkillSpec-shaped record:
 ### Work To Planning
 
 - Trigger: lane/epic shape, active planning pressure, durable sequencing, or issue-linked execution.
-- Preferred CLI: `agentic-workspace summary --format json`, then Planning commands named by the packet.
+- Preferred route: configured AW invocation with `summary --format json`, then Planning commands named by the packet.
 - Interpreted fields: active item, active execplan, continuation owner, stop conditions.
 - Allowed: create or continue the active planning artifact through package commands.
 - Forbidden: hand-edit planning state or claim completion from a local slice.
@@ -43,7 +43,7 @@ Each gate is a compact SkillSpec-shaped record:
 ### Work To Proof
 
 - Trigger: changed paths are known or a completion claim is near.
-- Preferred CLI: `agentic-workspace implement --changed <paths> --format json` or `agentic-workspace proof --changed <paths> --format json`.
+- Preferred route: configured AW invocation with `implement --changed <paths> --format json` or `proof --changed <paths> --format json`.
 - Interpreted fields: required commands, proof burden, acceptance guidance, completion-claim boundary.
 - Allowed: run the selected narrow proof and classify gaps.
 - Forbidden: substitute passing commands for intent satisfaction.
@@ -52,7 +52,7 @@ Each gate is a compact SkillSpec-shaped record:
 ### Work To Memory Residue
 
 - Trigger: repeated correction, durable lesson, closeout residue, or improvement signal.
-- Preferred CLI: `agentic-workspace memory route --files <paths...> --format json`, `agentic-workspace memory promotion-report --mode remediation --format json`.
+- Preferred route: configured AW invocation with `memory route --files <paths...> --format json` or `memory promotion-report --mode remediation --format json`.
 - Interpreted fields: `memory_consultation_status`, `durable_residue_decision`, `improvement_signal_status`.
 - Allowed: capture only durable anti-rediscovery knowledge or route to the owning surface.
 - Forbidden: write task logs, plan history, or one-off chat residue to Memory.

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-work-shape/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-work-shape/SKILL.md
@@ -1,27 +1,22 @@
 ---
 name: workspace-work-shape
-description: Classify work shape and route direct, bounded, lane, or epic work before implementation.
+description: Reference the direct, bounded, lane, and epic vocabulary only when workspace-intent-discovery or compact routing needs work-shape details interpreted.
 ---
 
-# Workspace Work Shape
+# Workspace Work Shape Reference
 
-Use this skill before implementation when task size, proof cost, handoff needs, or the user's intended outcome are unclear.
-This skill does not make AW optional: when AW is enabled, work-shape judgment happens after `start`/`implement` routing, and `implementation_allowed` only applies inside that routed workflow.
+Do not use this as an independently invoked subskill. `workspace-intent-discovery` owns the merged intent/shape procedure after the main AW operating skill routes there.
+When AW is enabled, this reference preserves the same routed workflow boundary as the main skill; it does not make work-shape judgment a bypass around startup, planning or proof gates.
 
-## Route
+This reference exists so compact output, reviews, or issue discussions can name the work-shape vocabulary without reloading the full intent protocol.
 
-1. Run `agentic-workspace start --target . --task "<task>" --format json`.
-2. If changed paths are known, run `agentic-workspace implement --target . --changed <paths> --format json`.
-3. Run `agentic-workspace preflight --target . --format json` only for takeover, recovery, or uncertain state.
-4. For vague outcome prompts, resolve the intended outcome before naming a solution:
-   - What user-visible failure or cost should be reduced?
-   - What would count as satisfaction?
-   - Which repo-visible surface should preserve that intent for the next pass?
-5. Classify the request as `direct`, `bounded`, `lane`, or `epic`.
-6. For `direct` work, keep workspace overhead minimal and prove with the obvious narrow command.
-7. For `bounded` work, use compact planning or proof output when continuation, risk, or non-obvious validation matters.
-8. For `lane` or `epic` work, stop before coding and create or continue checked-in Planning state.
+## Vocabulary
 
-## Output
+- `direct`: target and proof are obvious; answer or edit with the narrowest proof and no durable artifact unless routed.
+- `bounded`: finite implementation with meaningful proof, continuation, or issue-linkage risk; use compact implement/proof routing.
+- `lane`: multi-slice or issue-lane work; checked-in Planning state owns sequencing before implementation.
+- `epic`: multiple lanes, high assurance, or unclear decomposition; shape before implementation.
 
-Report the inferred intended outcome, the shape, why that shape fits, the first repo-visible surface to inspect or update, the satisfaction evidence, the required next command, and whether Planning state is optional, recommended, or required.
+## Reference Output
+
+When this reference is explicitly requested, report the inferred intended outcome, work shape, why that shape fits, the first repo-visible surface to inspect or update, satisfaction evidence, required next route, and whether Planning state is optional, recommended, or required.

--- a/tests/test_workspace_skills_cli.py
+++ b/tests/test_workspace_skills_cli.py
@@ -133,14 +133,17 @@ def test_skills_command_lists_registered_workspace_skills(tmp_path: Path, capsys
     assert all(entry["registration"] == "explicit" for entry in payload["skills"])
     workspace_entries = {entry["id"]: entry for entry in payload["skills"] if entry["source_kind"] == "installed-workspace-skills"}
     assert {skill_id for skill_id, entry in workspace_entries.items() if entry["visibility"] == "ordinary-default"} == {
-        "workspace-intent-discovery",
-        "workspace-work-shape",
+        "workspace-startup",
     }
-    assert workspace_entries["workspace-startup"]["scope"] == "routed-projection"
+    assert workspace_entries["workspace-startup"]["scope"] == "main-operating-skill"
+    assert workspace_entries["workspace-intent-discovery"]["scope"] == "specialized-subskill"
+    assert workspace_entries["workspace-intent-discovery"]["visibility"] == "routed-on-demand"
     assert workspace_entries["workspace-proof-selection"]["visibility"] == "routed-on-demand"
-    assert workspace_entries["workspace-transition-gates"]["visibility"] == "routed-on-demand"
-    assert workspace_entries["workspace-operating-loop"]["scope"] == "routed-projection"
-    assert workspace_entries["workspace-setup-jumpstart"]["scope"] == "routed-support"
+    assert workspace_entries["workspace-transition-gates"]["visibility"] == "reference-only"
+    assert workspace_entries["workspace-transition-gates"]["scope"] == "reference-support"
+    assert workspace_entries["workspace-operating-loop"]["scope"] == "reference-support"
+    assert workspace_entries["workspace-work-shape"]["scope"] == "reference-support"
+    assert workspace_entries["workspace-setup-jumpstart"]["scope"] == "specialized-subskill"
     workspace_startup = next(entry for entry in payload["skills"] if entry["id"] == "workspace-startup")
     assert workspace_startup["source_kind"] == "installed-workspace-skills"
     assert "workspace startup" in workspace_startup["activation_hints"]["phrases"]
@@ -372,7 +375,7 @@ def test_skills_command_recommends_setup_jumpstart_for_mature_repo_seeding(tmp_p
     payload = json.loads(capsys.readouterr().out)
     assert payload["recommendations"][0]["id"] == "workspace-setup-jumpstart"
     assert payload["recommendations"][0]["source_kind"] == "installed-workspace-skills"
-    assert payload["recommendations"][0]["scope"] == "routed-support"
+    assert payload["recommendations"][0]["scope"] == "specialized-subskill"
     assert "pre-write and pre-seed discovery" in Path("docs/jumpstart-contract.md").read_text(encoding="utf-8")
     skill_text = Path(".agentic-workspace/skills/workspace-setup-jumpstart/SKILL.md").read_text(encoding="utf-8")
     assert "defaults --section assurance_onboarding" in skill_text
@@ -408,6 +411,66 @@ def test_skills_command_recommends_jumpstart_for_assurance_verification_populati
     nouns = jumpstart["activation_hints"]["nouns"]
     assert "assurance onboarding" in nouns
     assert "verification onboarding" in nouns
+
+
+def test_workspace_skill_hierarchy_activation_matrix(tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+
+    assert cli.main(["init", "--target", str(target)]) == 0
+    capsys.readouterr()
+
+    cases = [
+        {
+            "task": "start work on this AW repo and orient for task X",
+            "expected_top": "workspace-startup",
+            "absent": {"workspace-intent-discovery", "workspace-proof-selection", "workspace-setup-jumpstart"},
+        },
+        {
+            "task": "implement issue 1234 with a clear target",
+            "expected_top": "workspace-startup",
+            "absent": {"workspace-intent-discovery", "workspace-proof-selection", "workspace-setup-jumpstart"},
+        },
+        {
+            "task": "large vague feature request classify shape before implementation",
+            "expected_top": "workspace-intent-discovery",
+            "absent": {"workspace-work-shape", "workspace-proof-selection", "workspace-setup-jumpstart"},
+        },
+        {
+            "task": "select proof before completion claim allowed after passed with warning validation",
+            "expected_top": "workspace-proof-selection",
+            "absent": {"workspace-intent-discovery", "workspace-setup-jumpstart"},
+        },
+        {
+            "task": "populate surfaces after newly installed workspace in a lived-in repo",
+            "expected_top": "workspace-setup-jumpstart",
+            "absent": {"workspace-intent-discovery", "workspace-proof-selection"},
+        },
+        {
+            "task": "interpret forbidden actions from a routed transition gate packet",
+            "expected_top": "workspace-transition-gates",
+            "absent": {"workspace-proof-selection", "workspace-setup-jumpstart"},
+        },
+    ]
+
+    for case in cases:
+        assert cli.main(["skills", "--target", str(target), "--task", case["task"], "--format", "json"]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        recommendation_ids = [entry["id"] for entry in payload["recommendations"]]
+        assert recommendation_ids, case["task"]
+        assert recommendation_ids[0] == case["expected_top"]
+        assert not (set(recommendation_ids) & case["absent"])
+
+    assert cli.main(["skills", "--target", str(target), "--task", "fix typo in README", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert not {
+        "workspace-intent-discovery",
+        "workspace-proof-selection",
+        "workspace-setup-jumpstart",
+        "workspace-transition-gates",
+        "workspace-operating-loop",
+    } & {entry["id"] for entry in payload["recommendations"]}
 
 
 def test_skills_command_recommends_memory_router_for_note_selection_task(tmp_path: Path, capsys) -> None:
@@ -567,7 +630,7 @@ def test_skills_command_recommends_high_risk_workflow_decision_skills(tmp_path: 
     capsys.readouterr()
 
     cases = [
-        ("large vague feature request classify shape before implementation", "workspace-work-shape"),
+        ("large vague feature request classify shape before implementation", "workspace-intent-discovery"),
         ("clarify human intent with candidate interpretations before planning", "workspace-intent-discovery"),
         ("decompose an epic into lanes before execplans", "planning-decompose"),
         ("tighten a new execplan before coding", "planning-new-plan-tighten"),
@@ -575,8 +638,8 @@ def test_skills_command_recommends_high_risk_workflow_decision_skills(tmp_path: 
         ("high assurance planning lifecycle preserve intent satisfaction across a whole epic", "planning-high-assurance-lifecycle"),
         ("verify parent intent and negative invariants before completion claim", "planning-intent-verification"),
         ("select proof before completion claim allowed after passed with warning validation", "workspace-proof-selection"),
-        ("apply SkillSpec-backed transition gate with preferred CLI forbidden actions and no-CLI fallback", "workspace-transition-gates"),
-        ("use module slot contract for planning memory workspace operating loop without creating an artifact", "workspace-operating-loop"),
+        ("apply SkillSpec-backed gate reference with preferred CLI forbidden actions and no-CLI fallback", "workspace-transition-gates"),
+        ("use module slot contract reference for planning memory workspace loop without creating an artifact", "workspace-operating-loop"),
         ("closeout trust and residue distillation after implementation", "planning-closeout-trust"),
     ]
     for task, expected in cases:


### PR DESCRIPTION
## Summary

Implements the #1943 skill-driven AW lane in one PR, including child slices #1944 through #1948.

- Makes `workspace-startup` the single ordinary-default main AW operating skill.
- Converts intent discovery and work-shape into one routed subskill while demoting the old work-shape skill to reference support.
- Keeps proof selection and setup jumpstart as focused routed subskills.
- Demotes transition gates and operating-loop details to reference-only support instead of competing peer skills.
- Aligns installed skill wording with the configured AW invocation model and syncs the package payload copy.
- Adds an activation/non-activation matrix to prove the hierarchy and old-overlap regressions.

Closes #1943
Closes #1944
Closes #1945
Closes #1946
Closes #1947
Closes #1948

## Proof

- `uv run pytest tests/test_workspace_skills_cli.py -q`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `make absolute-paths`
- `git diff --check`

## Notes

The archived execplan records the lane closeout and proof evidence. The #1942 communication-contract evidence hub will get a separate issue comment linking this PR and summarizing the observed context-economy effect.
