### PR TITLE
[codex] Keep report-target work-shape judgment out of runtime

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1951-github-comment-direct.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1951-github-comment-direct.plan.json
@@ -1,0 +1,355 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Treat bounded GitHub comment corrections as direct work",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Create a bounded plan for Treat bounded GitHub comment corrections as direct work.",
+    "hard_constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Fill in execution bounds, touched paths, and validation before implementation starts.",
+    "proof_expectations": [
+      "See proof_report.validation proof."
+    ],
+    "touched_scope": [
+      "closeout scope recorded in closure_check and generated_closeout."
+    ],
+    "completion_criteria": [
+      "Treat bounded GitHub comment corrections as direct work is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Treat bounded GitHub comment corrections as direct work."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Treat bounded GitHub comment corrections as direct work.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1951-github-comment-direct",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Treat bounded GitHub comment corrections as direct work.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Treat bounded GitHub comment corrections as direct work",
+    "inferred intended outcome": "Create a bounded plan for Treat bounded GitHub comment corrections as direct work.",
+    "chosen concrete what": "#1951 acceptance is satisfied: bounded comment/report target refs no longer escalate into checked-in Planning custody by themselves, broad/ambiguous/implementation refs still remain visible as issue scope, and focused coverage plus skill guidance describe the boundary.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Treat bounded GitHub comment corrections as direct work.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1951-github-comment-direct",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Treat bounded GitHub comment corrections as direct work is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented #1951 by removing multi-ref task text as Planning-escalation pressure and documenting the external reporting/comment target decision as workspace-work-shape skill judgment instead of runtime keyword classification. Added focused startup coverage that verifies report-target-shaped tasks do not force a Planning gate while leaving final work-shape judgment to the agent/skill.",
+    "scope touched": "src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_planning.py; tests/test_workspace_cli.py; .agentic-workspace/skills/workspace-work-shape/SKILL.md; src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-work-shape/SKILL.md",
+    "changed surfaces": "startup planning safety gate; task posture scope evidence; workspace-work-shape skill; source payload skill mirror; workspace CLI tests",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Runtime keeps neutral issue refs and explicit PR context facts, but no longer classifies reporting destinations from prompt prose. Tests assert workflow_sufficient remains true and no Planning-escalation gate is forced, not that runtime chooses a specific semantic work-shape.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "make test-workspace; make lint-workspace; uv run pytest tests/test_workspace_cli.py -q; make typecheck; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json; make maintainer-surfaces; uv run python scripts/generate/generate_command_packages.py --check; make absolute-paths; git diff --check",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Treat bounded GitHub comment corrections as direct work.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1951 acceptance is satisfied: bounded comment/report target refs no longer escalate into checked-in Planning custody by themselves, broad/ambiguous/implementation refs still remain visible as issue scope, and focused coverage plus skill guidance describe the boundary.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-02: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Treat bounded GitHub comment corrections as direct work.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: make test-workspace; make lint-workspace; uv run pytest tests/test_workspace_cli.py -q; make typecheck; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json; make maintainer-surfaces; uv run python scripts/generate/generate_command_packages.py --check; make absolute-paths; git diff --check\nChanged surfaces: startup planning safety gate; task posture scope evidence; workspace-work-shape skill; source payload skill mirror; workspace CLI tests\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/.agentic-workspace/skills/workspace-work-shape/SKILL.md
+++ b/.agentic-workspace/skills/workspace-work-shape/SKILL.md
@@ -17,6 +17,18 @@ This reference exists so compact output, reviews, or issue discussions can name 
 - `lane`: multi-slice or issue-lane work; checked-in Planning state owns sequencing before implementation.
 - `epic`: multiple lanes, high assurance, or unclear decomposition; shape before implementation.
 
+## External Reporting Targets
+
+Use this as an agent checklist, not as runtime keyword policy. Issue or PR references used only as comment, report, reply, evidence-hub, or follow-up destinations are context for the current communication task. Do not treat those refs as implementation issue scope or multi-issue lane evidence by themselves.
+
+When a task mixes an implementation issue with a reporting target, separate them before judging shape:
+
+- implementation refs may carry issue scope and proof obligations;
+- reporting target refs identify where to post, edit, or read a comment;
+- the agent still owns the final direct/bounded/lane judgment from action safety, source impact, proof burden, and closure claims.
+
+Do not implement this distinction with hardcoded prompt/prose keyword matching in AW runtime. Runtime may expose neutral refs, structured PR refs, changed paths, active Planning state, and proof facts; the semantic split belongs to this checklist and agent judgment.
+
 ## Reference Output
 
 When this reference is explicitly requested, report the inferred intended outcome, work shape, why that shape fits, the first repo-visible surface to inspect or update, satisfaction evidence, required next route, and whether Planning state is optional, recommended, or required.

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-work-shape/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-work-shape/SKILL.md
@@ -17,6 +17,18 @@ This reference exists so compact output, reviews, or issue discussions can name 
 - `lane`: multi-slice or issue-lane work; checked-in Planning state owns sequencing before implementation.
 - `epic`: multiple lanes, high assurance, or unclear decomposition; shape before implementation.
 
+## External Reporting Targets
+
+Use this as an agent checklist, not as runtime keyword policy. Issue or PR references used only as comment, report, reply, evidence-hub, or follow-up destinations are context for the current communication task. Do not treat those refs as implementation issue scope or multi-issue lane evidence by themselves.
+
+When a task mixes an implementation issue with a reporting target, separate them before judging shape:
+
+- implementation refs may carry issue scope and proof obligations;
+- reporting target refs identify where to post, edit, or read a comment;
+- the agent still owns the final direct/bounded/lane judgment from action safety, source impact, proof burden, and closure claims.
+
+Do not implement this distinction with hardcoded prompt/prose keyword matching in AW runtime. Runtime may expose neutral refs, structured PR refs, changed paths, active Planning state, and proof facts; the semantic split belongs to this checklist and agent judgment.
+
 ## Reference Output
 
 When this reference is explicitly requested, report the inferred intended outcome, work shape, why that shape fits, the first repo-visible surface to inspect or update, satisfaction evidence, required next route, and whether Planning state is optional, recommended, or required.

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -25319,6 +25319,9 @@ def _pr_context_refs_from_task(task_text: str | None) -> list[str]:
     refs = sorted(set(re.findall(r"#\d+\b", text)), key=lambda value: int(value.lstrip("#")))
     if not refs:
         return []
+    explicit_pr_refs = {f"#{match}" for match in re.findall(r"\b(?:pr|pull request)\s+#?(\d+)\b", text, flags=re.IGNORECASE)}
+    if explicit_pr_refs:
+        return sorted(explicit_pr_refs, key=lambda value: int(value.lstrip("#")))
     pr_terms = (
         " pr ",
         " pull request",
@@ -30979,7 +30982,6 @@ def _capability_posture_for_implementation(*, changed_paths: list[str], task_tex
             "posture": {},
             "reason": "No task text or changed paths were provided, so execution posture cannot infer task capability safely.",
         }
-    issue_refs = re.findall("#\\d+", task_text or "")
     judgment_terms = (
         "architecture",
         "contract",
@@ -31000,8 +31002,8 @@ def _capability_posture_for_implementation(*, changed_paths: list[str], task_tex
         risk_flags.append("many changed paths")
     if len(set((path.split("/")[0] for path in changed_paths if path))) >= 3:
         risk_flags.append("cross-surface breadth")
-    if len(issue_refs) > 1 or "epic" in combined:
-        scope_signal = "epic" if "epic" in combined else "lane"
+    if "epic" in combined:
+        scope_signal = "epic"
     elif "lane" in combined or len(changed_paths) >= 4:
         scope_signal = "lane"
     elif changed_paths or task_text:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1886,6 +1886,95 @@ def test_start_pr_reference_wording_does_not_route_as_unknown_issue_scope(tmp_pa
     assert payload.get("missing") == ["issue_reference_intent"]
 
 
+def test_start_github_comment_report_correction_does_not_force_planning(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Correct the #1942 follow-up report format after PR #1950 review fix",
+                "--select",
+                "planning_safety_gate,issue_reference_intent",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    gate = payload["values"]["planning_safety_gate"]
+
+    assert gate["workflow_sufficient"] is True
+    assert gate["decision"] != "planning-escalation-required"
+    assert gate["issue_refs"] == ["#1942"]
+    assert gate["pr_context"]["refs"] == ["#1950"]
+    assert payload["values"]["issue_reference_intent"]["issue_refs"] == ["#1942"]
+    assert "external_reporting_context" not in gate
+
+
+def test_start_mixed_issue_implementation_and_report_target_does_not_force_planning(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Implement issue #1951 and make a better report on #1942",
+                "--select",
+                "planning_safety_gate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    gate = json.loads(capsys.readouterr().out)["values"]["planning_safety_gate"]
+
+    assert gate["workflow_sufficient"] is True
+    assert gate["decision"] != "planning-escalation-required"
+    assert gate["issue_refs"] == ["#1942", "#1951"]
+    assert "external_reporting_context" not in gate
+
+
+@pytest.mark.parametrize("task", ["Work on #1951", "Fix bug in #1951", "Implement changes in #1951"])
+def test_start_bare_preposition_issue_refs_remain_implementation_scope(tmp_path: Path, capsys, task: str) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                task,
+                "--select",
+                "planning_safety_gate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    gate = json.loads(capsys.readouterr().out)["values"]["planning_safety_gate"]
+
+    assert gate["issue_refs"] == ["#1951"]
+    assert "external_reporting_context" not in gate
+
+
 def test_start_issue_reference_wording_keeps_issue_scope_warning(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0


### PR DESCRIPTION
## Summary

Implements #1951 according to the repo intent boundary.

- Removes the attempted runtime reporting-target prose classifier instead of narrowing it.
- Stops multiple numeric issue refs in task text from becoming lane/Planning-escalation pressure by themselves.
- Keeps explicit PR refs, such as `PR #1950`, out of unknown issue-scope inference as structured provider context.
- Moves the report/comment/evidence-destination distinction into the `workspace-work-shape` checklist, where agent judgment owns the semantic split.
- Adds startup coverage for the observed GitHub comment/report correction, mixed implementation/reporting wording, and ordinary implementation phrases such as `work on #1951`.

Closes #1951

## Proof

- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `make maintainer-surfaces`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `make absolute-paths`
- `git diff --check`

## Notes

Runtime now exposes neutral refs, explicit PR context, changed-path facts, active Planning state, and proof signals. It does not infer reporting destinations from arbitrary prompt prose. The reporting-target interpretation is skill/checklist guidance for agent judgment.