### PR TITLE
[codex] Add evidence-aware workflow gate surfacing

### DIFF
--- a/.agentic-workspace/memory/UPGRADE-SOURCE.toml
+++ b/.agentic-workspace/memory/UPGRADE-SOURCE.toml
@@ -1,5 +1,5 @@
 source_type = "git"
 source_ref = "git+https://github.com/rickardvh/agentic-workspace@master#subdirectory=packages/memory"
 source_label = "agentic-memory monorepo master"
-recorded_at = "2026-07-01"
+recorded_at = "2026-07-02"
 recommended_upgrade_after_days = 30

--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,8 +13,8 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:ad020493a1b7",
-    "version": "0.14.0"
+    "source_identity": "git:9f6237baef02",
+    "version": "0.15.0"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
   "payload_files": [
@@ -37,8 +37,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.14.0",
-    "version": "0.14.0"
+    "tag": "v0.15.0",
+    "version": "0.15.0"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/.agentic-workspace/planning/UPGRADE-SOURCE.toml
+++ b/.agentic-workspace/planning/UPGRADE-SOURCE.toml
@@ -1,5 +1,5 @@
 source_type = "git"
 source_ref = "git+https://github.com/rickardvh/agentic-workspace@master#subdirectory=packages/planning"
 source_label = "agentic-planning monorepo master"
-recorded_at = "2026-07-01"
+recorded_at = "2026-07-02"
 recommended_upgrade_after_days = 30

--- a/.agentic-workspace/planning/execplans/archive/issue-1954-evidence-aware-gates.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1954-evidence-aware-gates.plan.json
@@ -1,0 +1,381 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement evidence-aware workflow gates for #1953 and #1954",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #1953 and #1954 in one bounded PR: make early AW workflow gates expose decision maturity and surface matched non-enum keyword-routing guardrails before implementation.",
+    "hard_constraints": "Do not add prompt-prose keyword classifiers. Use structured path/scope facts, declared architecture principles, and existing gate state. Keep compact output phase-local.",
+    "agent_may_decide": "Exact packet field names, test placement, and compact wording as long as the result distinguishes hard/provisional/evidence-seeking decisions and preserves agent judgment.",
+    "escalate_when": "A correct fix requires broad redesign of all workflow gates, always-on context dumps, or semantic task-shape classification from arbitrary prompt prose.",
+    "next_action": "Patch runtime gate packets and implement-context projection, then prove focused and workspace checks.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_cli.py tests/test_workspace_implement_cli.py -q",
+      "make test-workspace",
+      "make lint-workspace",
+      "make typecheck"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_core.py",
+      "src/agentic_workspace/workspace_runtime_planning.py",
+      "src/agentic_workspace/workspace_runtime_implement.py",
+      "tests/test_workspace_cli.py",
+      "tests/test_workspace_implement_cli.py"
+    ],
+    "completion_criteria": [
+      "decision_maturity appears in compact workflow/planning gate output",
+      "matched non-enum keyword-routing guardrail is visible in implement compact context from structured path scope",
+      "simple unrelated work does not receive broad architecture guardrail context",
+      "the implementation adds no new arbitrary prompt-prose classifier"
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Implement evidence-aware workflow gates for #1953 and #1954."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement #1953 and #1954 in one bounded PR.",
+      "constraints": "No prompt-prose classifiers; use structured facts and declared intent.",
+      "latitude": "Packet naming, compact projection shape, and focused tests.",
+      "escalation": "Escalate on broad gate redesign or always-on context dump.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1954-evidence-aware-gates",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "src/agentic_workspace/workspace_runtime_planning.py",
+        "src/agentic_workspace/workspace_runtime_implement.py",
+        "tests/test_workspace_cli.py",
+        "tests/test_workspace_implement_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Implement evidence-aware workflow gates for #1953 and #1954.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement evidence-aware workflow gates for #1953 and #1954",
+    "inferred intended outcome": "Create a bounded plan for Implement evidence-aware workflow gates for #1953 and #1954.",
+    "chosen concrete what": "#1953 and #1954 satisfied in one PR slice; installed payload sync remains a separate freshness limit and is not claimed current.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "closeout scope recorded in closure_check and generated_closeout.",
+    "max changed files": "closed slice; no further writes expected without reopening a fresh plan.",
+    "required validation commands": "See proof_report.validation proof.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Implement evidence-aware workflow gates for #1953 and #1954.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1954-evidence-aware-gates",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Implement evidence-aware workflow gates for #1953 and #1954 is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented evidence-aware workflow gates for #1953/#1954: start/implement workflow and planning gates now expose compact decision_maturity, and implement compact context surfaces matched non-enum keyword-routing guardrails from structured architecture-principle path matches.",
+    "scope touched": "Runtime gate packets, implement tiny projection, focused startup/implement tests, and active planning closeout.",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_planning.py; src/agentic_workspace/workspace_runtime_implement.py; tests/test_workspace_cli.py; tests/test_workspace_implement_cli.py",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope preserved: no prompt-prose classifier added; guardrail surfacing comes from declared path_globs and compact output stays below existing tiny budgets.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json (attention: installed payload sync available, not task proof); make test-workspace; make lint-workspace; uv run pytest tests/test_workspace_cli.py -q; uv run pytest tests/test_workspace_implement_cli.py -q; make typecheck; uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json; git diff --check",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement evidence-aware workflow gates for #1953 and #1954.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1953 and #1954 satisfied in one PR slice; installed payload sync remains a separate freshness limit and is not claimed current.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-02: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "blocked_claim_classes": [],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#1953",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        },
+        {
+          "kind": "issue_closure",
+          "target": "#1954",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement evidence-aware workflow gates for #1953 and #1954.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json (attention: installed payload sync available, not task proof); make test-workspace; make lint-workspace; uv run pytest tests/test_workspace_cli.py -q; uv run pytest tests/test_workspace_implement_cli.py -q; make typecheck; uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json; git diff --check\nChanged surfaces: src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_planning.py; src/agentic_workspace/workspace_runtime_implement.py; tests/test_workspace_cli.py; tests/test_workspace_implement_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/payload-sync-pr1955.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/payload-sync-pr1955.plan.json
@@ -1,0 +1,387 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Sync AW payload on PR 1955",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Sync the Agentic Workspace payload on the current PR branch.",
+    "hard_constraints": "Keep scope bounded to command-owned payload sync output and the proof lane requested by payload closure guidance.",
+    "agent_may_decide": "Whether to amend the current PR commit after proof and how to summarize payload sync evidence.",
+    "escalate_when": "The upgrade produces review blockers, source changes outside managed payload surfaces, or failing payload closure proof.",
+    "next_action": "Run payload closure proof and close out this sync slice.",
+    "proof_expectations": [
+      "uv run python scripts/run_agentic_workspace.py doctor --target . --format json",
+      "make test-workspace",
+      "make maintainer-surfaces",
+      "uv run python scripts/generate/generate_command_packages.py --check",
+      "make absolute-paths",
+      "git diff --check"
+    ],
+    "touched_scope": [
+      ".agentic-workspace/docs/execution-flow-contract.md",
+      ".agentic-workspace/docs/system-intent-contract.md",
+      ".agentic-workspace/memory/UPGRADE-SOURCE.toml",
+      ".agentic-workspace/payload-provenance.json",
+      ".agentic-workspace/planning/UPGRADE-SOURCE.toml",
+      ".agentic-workspace/planning/execplans/README.md",
+      ".agentic-workspace/planning/execplans/payload-sync-pr1955.plan.json"
+    ],
+    "completion_criteria": [
+      "Payload upgrade reports installed-state compatibility.",
+      "Payload closure proof passes.",
+      "Active planning residue is archived before the PR update is pushed."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Sync the Agentic Workspace payload on the current PR branch."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Sync the Agentic Workspace payload on the current PR branch.",
+      "constraints": "Keep scope bounded to command-owned payload sync output and the proof lane requested by payload closure guidance.",
+      "latitude": "Whether to amend the current PR commit after proof and how to summarize payload sync evidence.",
+      "escalation": "Escalate when the upgrade produces review blockers, source changes outside managed payload surfaces, or failing payload closure proof.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "payload-sync-pr1955",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        ".agentic-workspace/docs/execution-flow-contract.md",
+        ".agentic-workspace/docs/system-intent-contract.md",
+        ".agentic-workspace/memory/UPGRADE-SOURCE.toml",
+        ".agentic-workspace/payload-provenance.json",
+        ".agentic-workspace/planning/UPGRADE-SOURCE.toml",
+        ".agentic-workspace/planning/execplans/README.md",
+        ".agentic-workspace/planning/execplans/payload-sync-pr1955.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Keep PR #1955 payload and provenance current after the review update.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Sync the payload",
+    "inferred intended outcome": "Run the AW payload upgrade on the current PR branch, verify it, and include it in the PR update.",
+    "chosen concrete what": "Apply the command-owned upgrade for planning, memory, and verification payloads.",
+    "interpretation distance": "low",
+    "review guidance": "Do not broaden beyond managed payload sync and required payload closure proof."
+  },
+  "execution_bounds": {
+    "allowed paths": "Managed AW payload docs/provenance/module metadata plus this active execplan/archive.",
+    "max changed files": "About eight files before archive cleanup.",
+    "required validation commands": "doctor, test-workspace, maintainer-surfaces, generated command package check, absolute-paths, git diff --check.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "Payload upgrade output, changed managed payload files, this execplan, and payload closure proof commands.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Payload sync applied; run/finish closure proof, close/archive plan, amend and push PR.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Sync the Agentic Workspace payload on the current PR branch.",
+    "hard constraints": "Keep scope bounded to command-owned payload sync output and the proof lane requested by payload closure guidance.",
+    "agent may decide locally": "Whether to amend the current PR commit after proof and how to summarize payload sync evidence.",
+    "escalate when": "The upgrade produces review blockers, source changes outside managed payload surfaces, or failing payload closure proof."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "payload-sync-pr1955",
+    "status": "completed",
+    "scope": "Command-owned AW payload sync and closure proof for PR #1955.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run payload closure proof and close out this sync slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    ".agentic-workspace/docs/execution-flow-contract.md",
+    ".agentic-workspace/docs/system-intent-contract.md",
+    ".agentic-workspace/memory/UPGRADE-SOURCE.toml",
+    ".agentic-workspace/payload-provenance.json",
+    ".agentic-workspace/planning/UPGRADE-SOURCE.toml",
+    ".agentic-workspace/planning/execplans/README.md",
+    ".agentic-workspace/planning/execplans/payload-sync-pr1955.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run python scripts/run_agentic_workspace.py doctor --target . --format json",
+    "make test-workspace",
+    "make maintainer-surfaces",
+    "uv run python scripts/generate/generate_command_packages.py --check",
+    "make absolute-paths",
+    "git diff --check"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Payload upgrade reports installed-state compatibility.",
+    "Payload closure proof passes.",
+    "Active planning residue is archived before the PR update is pushed."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Applied command-owned AW payload sync for planning, memory, and verification on PR #1955; fixed trailing EOF whitespace reported by diff check.",
+    "scope touched": "managed AW payload docs, module UPGRADE-SOURCE metadata, payload provenance, and the payload-sync planning record",
+    "changed surfaces": ".agentic-workspace/docs/execution-flow-contract.md; .agentic-workspace/docs/system-intent-contract.md; .agentic-workspace/memory/UPGRADE-SOURCE.toml; .agentic-workspace/payload-provenance.json; .agentic-workspace/planning/UPGRADE-SOURCE.toml; .agentic-workspace/planning/execplans/README.md; payload-sync planning record",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed bounded to payload sync. Doctor now reports installed-state compatibility and healthy workspace diagnostics.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Payload sync proof: upgrade applied with installed_state_compatibility=compatible and health=healthy; doctor healthy; make test-workspace passed; make maintainer-surfaces passed; generated command packages check passed; make absolute-paths passed; git diff --check passed after whitespace cleanup; make lint-workspace passed; summary inspected active state.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Sync AW payload on PR 1955.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "AW payload is synced to v0.15.0 provenance for this branch and active planning residue is being archived.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-02: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Sync AW payload on PR 1955.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Payload sync proof: upgrade applied with installed_state_compatibility=compatible and health=healthy; doctor healthy; make test-workspace passed; make maintainer-surfaces passed; generated command packages check passed; make absolute-paths passed; git diff --check passed after whitespace cleanup; make lint-workspace passed; summary inspected active state.\nChanged surfaces: .agentic-workspace/docs/execution-flow-contract.md; .agentic-workspace/docs/system-intent-contract.md; .agentic-workspace/memory/UPGRADE-SOURCE.toml; .agentic-workspace/payload-provenance.json; .agentic-workspace/planning/UPGRADE-SOURCE.toml; .agentic-workspace/planning/execplans/README.md; payload-sync planning record\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/review-1955-decision-maturity.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/review-1955-decision-maturity.plan.json
@@ -1,0 +1,399 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Address PR 1955 decision maturity review",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Address the PR #1955 review comment about decision_maturity hard-gate classification and post the requested evidence report.",
+    "hard_constraints": "Keep scope bounded to decision_maturity classification, focused tests, plan closeout, and the PR evidence comment.",
+    "agent_may_decide": "The narrow code shape, test assertions, and exact evidence wording as long as missing evidence is no longer represented as a hard gate without explicit justification.",
+    "escalate_when": "A correct fix requires broader workflow redesign, unrelated payload sync, or changes outside the maturity/gate/reporting surface.",
+    "next_action": "Patch decision_maturity hard-gate derivation and add focused proof.",
+    "proof_expectations": [
+      "Focused pytest for decision_maturity startup/implement cases."
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_core.py",
+      "src/agentic_workspace/workspace_runtime_planning.py",
+      "tests/test_workspace_cli.py",
+      "tests/test_workspace_implement_cli.py",
+      ".agentic-workspace/planning/execplans/review-1955-decision-maturity.plan.json"
+    ],
+    "completion_criteria": [
+      "Review comment is addressed with missing-evidence cases represented as evidence_seeking unless an explicit hard gate applies.",
+      "A real hard gate remains hard.",
+      "Focused tests pass.",
+      "A new PR comment reports communication-contract evidence in the requested format."
+    ],
+    "continuation_owner": "#1957 and #1958 cover unrelated closeout/projection residue",
+    "closeout_decision": "archive-but-keep-lane-open"
+  },
+  "goal": [
+    "Create a bounded plan for Address PR 1955 decision maturity review."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Address the PR #1955 review comment about decision_maturity hard-gate classification and post the requested evidence report.",
+      "constraints": "Keep scope bounded to decision_maturity classification, focused tests, plan closeout, and the PR evidence comment.",
+      "latitude": "The narrow code shape, test assertions, and exact evidence wording as long as missing evidence is no longer represented as a hard gate without explicit justification.",
+      "escalation": "Escalate when a correct fix requires broader workflow redesign, unrelated payload sync, or changes outside the maturity/gate/reporting surface.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "review-1955-decision-maturity",
+      "status": "completed",
+      "next_step": "Continue via #1957 and #1958 cover unrelated closeout/projection residue.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "src/agentic_workspace/workspace_runtime_planning.py",
+        "tests/test_workspace_cli.py",
+        "tests/test_workspace_implement_cli.py",
+        ".agentic-workspace/planning/execplans/review-1955-decision-maturity.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Address PR #1955 review feedback and keep #1953/#1954 closure evidence honest.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "#1957 and #1958 cover unrelated closeout/projection residue"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "yes",
+    "owner surface": "#1957 and #1958 cover unrelated closeout/projection residue",
+    "activation trigger": "when the continuation owner promotes the next slice"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via #1957 and #1958 cover unrelated closeout/projection residue."
+  },
+  "intent_interpretation": {
+    "literal request": "There is a review comment. Address it and post another evidence report as before in a comment.",
+    "inferred intended outcome": "Fix the reviewed decision_maturity behavior, validate it, push the PR update, and add a communication-contract evidence report.",
+    "chosen concrete what": "Patch decision_maturity so missing evidence is evidence_seeking unless an explicit hard gate is passed.",
+    "interpretation distance": "low",
+    "review guidance": "Keep the fix narrow to the review concern and avoid counting proof/routing success as direct communication-contract evidence."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_planning.py; focused CLI tests; this execplan; PR comment only.",
+    "max changed files": "About five repo files plus GitHub comment metadata.",
+    "required validation commands": "Focused pytest for decision_maturity startup/implement cases, plus implement --changed for the modified paths.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the PR review comment, decision_maturity payload code, planning gate call site, and focused tests.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Fix explicit hard-gate classification in decision_maturity, prove focused cases, post PR evidence comment.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Address the PR #1955 review comment about decision_maturity hard-gate classification and post the requested evidence report.",
+    "hard constraints": "Keep scope bounded to decision_maturity classification, focused tests, plan closeout, and the PR evidence comment.",
+    "agent may decide locally": "The narrow code shape, test assertions, and exact evidence wording as long as missing evidence is no longer represented as a hard gate without explicit justification.",
+    "escalate when": "A correct fix requires broader workflow redesign, unrelated payload sync, or changes outside the maturity/gate/reporting surface."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "review-1955-decision-maturity",
+    "status": "completed",
+    "scope": "Fix the decision_maturity review concern and update the PR evidence comment.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Patch decision_maturity hard-gate derivation and add focused proof."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_core.py",
+    "src/agentic_workspace/workspace_runtime_planning.py",
+    "tests/test_workspace_cli.py",
+    "tests/test_workspace_implement_cli.py",
+    ".agentic-workspace/planning/execplans/review-1955-decision-maturity.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_cli.py::test_start_routes_high_assurance_milestone_to_planning_before_implementation tests/test_workspace_cli.py::test_start_issue_reference_wording_keeps_issue_scope_warning tests/test_workspace_implement_cli.py::test_implement_task_allows_narrow_single_issue_context -q",
+    "uv run python scripts/run_agentic_workspace.py implement --changed src/agentic_workspace/workspace_runtime_core.py src/agentic_workspace/workspace_runtime_planning.py tests/test_workspace_cli.py tests/test_workspace_implement_cli.py .agentic-workspace/planning/execplans/review-1955-decision-maturity.plan.json --task \"Address review comment on PR 1955 decision maturity and post updated evidence report\" --format json"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Review comment is addressed with missing-evidence cases represented as evidence_seeking unless an explicit hard gate applies.",
+    "A real hard gate remains hard.",
+    "Focused tests pass.",
+    "A new PR comment reports communication-contract evidence in the requested format."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Addressed PR #1955 review by making hard_gate explicit in decision_maturity and preserving evidence_required as evidence_seeking unless a hard gate is passed.",
+    "scope touched": "decision_maturity helper, workflow sufficiency hard-gate call sites, planning safety gate maturity, focused implement test, active planning record",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_startup.py; src/agentic_workspace/workspace_runtime_implement.py; src/agentic_workspace/workspace_runtime_planning.py; tests/test_workspace_implement_cli.py; active execplan",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "continue from #1957 and #1958 cover unrelated closeout/projection residue",
+    "next step": "promote the next bounded slice from #1957 and #1958 cover unrelated closeout/projection residue"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed bounded to the review concern; missing evidence now classifies as evidence_seeking and real Planning escalation remains hard_gate.",
+    "proof status": "passed",
+    "intent served": "yes for slice; parent remains open via #1957 and #1958 cover unrelated closeout/projection residue",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "#1957 and #1958 cover unrelated closeout/projection residue"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "Focused pytest: 3 passed; tests/test_workspace_cli.py: 95 passed; tests/test_workspace_implement_cli.py: 138 passed; make test-workspace passed; make lint-workspace passed; make typecheck passed; runtime_mirror_consistency in_sync; doctor attention is unrelated installed-payload sync residue.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Address PR 1955 decision maturity review.",
+    "was original intent fully satisfied?": "no",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "#1957 and #1958 cover unrelated closeout/projection residue"
+  },
+  "execution_summary": {
+    "outcome delivered": "PR #1955 review concern addressed and validated; PR evidence comment still needs posting after push.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "#1957 and #1958 cover unrelated closeout/projection residue",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "#1957 and #1958 cover unrelated closeout/projection residue",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed issue residue to #1957 and #1958 cover unrelated closeout/projection residue.",
+    "motivation worth preserving": "Future agents should continue from #1957 and #1958 cover unrelated closeout/projection residue rather than rediscover this closeout residue.",
+    "canonical owner now": "#1957 and #1958 cover unrelated closeout/projection residue",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "#1957 and #1958 cover unrelated closeout/projection residue",
+    "proposed durable intent": "Future agents should continue from #1957 and #1958 cover unrelated closeout/projection residue rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "#1957 and #1958 cover unrelated closeout/projection residue"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen when #1957 and #1958 cover unrelated closeout/projection residue activates a fresh bounded slice."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      {
+        "summary": "Closeout routed issue residue to #1957 and #1958 cover unrelated closeout/projection residue.",
+        "owner": "#1957 and #1958 cover unrelated closeout/projection residue",
+        "source": "durable_residue"
+      }
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      {
+        "summary": "Closeout routed issue residue to #1957 and #1958 cover unrelated closeout/projection residue.",
+        "owner": "#1957 and #1958 cover unrelated closeout/projection residue",
+        "source": "durable_residue"
+      }
+    ],
+    "signals dismissed": [],
+    "next owner": "see routed signal owner"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [
+        {
+          "summary": "#1957 and #1958 cover unrelated closeout/projection residue",
+          "owner": "#1957 and #1958 cover unrelated closeout/projection residue",
+          "source": "execution_summary.follow-on routed to"
+        }
+      ],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-02: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "#1957 and #1958 cover unrelated closeout/projection residue",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "continue-required",
+    "active_intent_satisfied": false,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "partial-progress",
+    "required_next_action": "create-follow-on-plan",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete"
+      ],
+      "blocked_claim_classes": [
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [
+          "done",
+          "implemented",
+          "complete",
+          "finished",
+          "all",
+          "full intent complete"
+        ],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "#1957 and #1958 cover unrelated closeout/projection residue",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "no",
+      "reason": "#1957 and #1958 cover unrelated closeout/projection residue"
+    },
+    "continuation": {
+      "owner_surface": "#1957 and #1958 cover unrelated closeout/projection residue",
+      "created_or_required": true,
+      "reason": "#1957 and #1958 cover unrelated closeout/projection residue"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Address PR 1955 decision maturity review.\nIntent satisfied: no\nArchive decision: archive-but-keep-lane-open\nProof: Focused pytest: 3 passed; tests/test_workspace_cli.py: 95 passed; tests/test_workspace_implement_cli.py: 138 passed; make test-workspace passed; make lint-workspace passed; make typecheck passed; runtime_mirror_consistency in_sync; doctor attention is unrelated installed-payload sync residue.\nChanged surfaces: src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_startup.py; src/agentic_workspace/workspace_runtime_implement.py; src/agentic_workspace/workspace_runtime_planning.py; tests/test_workspace_implement_cli.py; active execplan\nDurable residue: planning (#1957 and #1958 cover unrelated closeout/projection residue)\nMemory learning: route_to_planning\nFollow-up: #1957 and #1958 cover unrelated closeout/projection residue\nCompletion gate: continue-required\nCompletion claim allowed: partial-progress"
+  }
+}

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -13692,6 +13692,40 @@ def _successful_completion_cost_router_payload(*, cli_invoke: str) -> dict[str, 
     }
 
 
+def _decision_maturity_payload(
+    *,
+    decision: str,
+    workflow_sufficient: bool,
+    required_next_action: str | None = None,
+    evidence_required: list[str] | None = None,
+    evidence_basis: list[str] | None = None,
+    missing_evidence: list[str] | None = None,
+    hard_gate: bool = False,
+) -> dict[str, Any]:
+    evidence_required = [item for item in (evidence_required or []) if str(item).strip()]
+    missing_evidence = [item for item in (missing_evidence or []) if str(item).strip()]
+    evidence_basis = [item for item in (evidence_basis or []) if str(item).strip()]
+    if hard_gate:
+        level = "hard_gate"
+    elif evidence_required or missing_evidence or decision in {"external-issue-scope-unknown", "agent-work-shape-decision-required"}:
+        level = "evidence_seeking"
+    elif not workflow_sufficient:
+        level = "provisional_gate"
+    else:
+        level = "provisional_gate"
+    payload = {
+        "kind": "agentic-workspace/decision-maturity/v1",
+        "level": level,
+        "decision": decision,
+        "evidence_basis": evidence_basis,
+        "missing_evidence": missing_evidence or evidence_required,
+        "safe_probe": required_next_action or "",
+    }
+    if missing_evidence or evidence_required:
+        payload["reconsider_after"] = missing_evidence or evidence_required
+    return {key: value for key, value in payload.items() if value not in (None, "", [], {})}
+
+
 def _workflow_sufficiency_payload(
     *,
     surface: str,
@@ -13700,6 +13734,7 @@ def _workflow_sufficiency_payload(
     required_next_action: str | None = None,
     evidence_required: list[str] | None = None,
     drill_down: dict[str, str] | None = None,
+    hard_gate: bool = False,
 ) -> dict[str, Any]:
     evidence_required = evidence_required or []
     authority_boundary = _authority_boundary_payload(
@@ -13721,6 +13756,15 @@ def _workflow_sufficiency_payload(
         "legacy_aliases": {"decision": "sufficiency_result"},
         "rule": "Do not hide proof, ownership, or closeout obligations.",
     }
+    if surface in {"start", "implement"}:
+        payload["decision_maturity"] = _decision_maturity_payload(
+            decision=decision,
+            workflow_sufficient=not evidence_required,
+            required_next_action=required_next_action,
+            evidence_required=evidence_required,
+            evidence_basis=["workflow state", "required evidence"],
+            hard_gate=hard_gate,
+        )
     if required_next_action:
         payload["required_next_action"] = required_next_action
     if not evidence_required:
@@ -16217,6 +16261,10 @@ def _architecture_principles_payload(
                     "title": item["title"],
                     "owner": item["owner"],
                     "authority": item["authority"],
+                    "summary": item["summary"],
+                    "allowed_sources": item["allowed_sources"],
+                    "forbidden_sources": item["forbidden_sources"],
+                    "affected_decisions": item["affected_decisions"],
                     "matched_paths": item["matched_paths"],
                     "matcher": item["matcher"],
                     "guardrail_refs": item["guardrail_refs"],
@@ -23029,6 +23077,7 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         "gate_result": gate.get("gate_result") or gate.get("decision"),
         "workflow_sufficient": gate.get("workflow_sufficient"),
         "reason": gate.get("reason"),
+        "decision_maturity": _tiny_decision_maturity(gate.get("decision_maturity")),
         "required_next_action": gate.get("required_next_action"),
         "active_planning_present": gate.get("active_planning_present"),
         "issue_refs": gate.get("issue_refs", []),
@@ -24566,6 +24615,7 @@ def _start_tiny_payload_fast(
             reason=planning_safety_gate["reason"],
             required_next_action=planning_safety_gate["required_next_action"],
             evidence_required=["active planning ownership evidence"],
+            hard_gate=True,
         )
         payload["immediate_next_allowed_action"] = {
             "action": planning_safety_gate["required_next_action"],
@@ -30145,12 +30195,21 @@ def _tiny_work_shape_guidance(value: Any) -> dict[str, Any]:
     }
 
 
+def _tiny_decision_maturity(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: value.get(key) for key in ("level", "decision", "missing_evidence", "safe_probe") if value.get(key) not in (None, "", [], {})
+    }
+
+
 def _tiny_workflow_sufficiency(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
-    keys = ("kind", "surface", "sufficiency_result", "required_next_action", "evidence_required")
+    keys = ("kind", "surface", "sufficiency_result", "required_next_action", "evidence_required", "decision_maturity")
     compact = {key: value.get(key) for key in keys if value.get(key) not in (None, "", [])}
     compact.setdefault("sufficiency_result", value.get("decision"))
+    compact["decision_maturity"] = _tiny_decision_maturity(value.get("decision_maturity"))
     compact["authority_boundary"] = _compact_authority_boundary(value.get("authority_boundary"))
     return {key: item for key, item in compact.items() if item not in (None, "", {})}
 

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -713,6 +713,7 @@ def _implement_payload(
             else ["proof execution evidence before closeout"]
             if normalized_paths
             else ["changed paths"],
+            hard_gate=not planning_safety_gate["workflow_sufficient"],
         ),
         "adaptive_routing": _adaptive_routing_payload(
             surface="implement",
@@ -1511,15 +1512,15 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
         remove_available_selector("context.intent_satisfaction_matrix")
     tiny_context = projected.get("context", {})
     if isinstance(tiny_context, dict):
-        tiny_context["absence_states"] = {
+        absence_states = {
             **_as_dict(tiny_context.get("absence_states")),
             "adaptive_routing": "detail_omitted",
             "architecture_principles": "hidden_behind_detail_route",
             "work_shape_guidance": "detail_omitted",
         }
+        tiny_context["absence_states"] = absence_states
         tiny_context.pop("adaptive_routing", None)
         tiny_context.pop("guidance", None)
-        tiny_context.pop("architecture_principles", None)
         parent_packet = tiny_context.get("parent_intent_status", {})
         parent_status = str(parent_packet.get("status") or "").strip() if isinstance(parent_packet, dict) else ""
         if parent_status in {"", "guidance-only", "not-recorded", "needs-planning"}:
@@ -1543,6 +1544,8 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     advisory_selectors = advisory_detail.get("selectors", [])
                     if isinstance(advisory_selectors, list):
                         advisory_detail["selectors"] = [item for item in advisory_selectors if item != "architecture_principles"]
+        else:
+            absence_states["architecture_principles"] = "present"
     generated_surface_trust = payload.get("generated_surface_trust", {})
     if isinstance(generated_surface_trust, dict) and generated_surface_trust.get("status") == "present":
         projected["generated_surface_trust"] = _tiny_generated_surface_trust(generated_surface_trust)

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -29,6 +29,7 @@ from agentic_workspace.workspace_runtime_core import (
     _candidate_with_canonical_route,
     _capability_structural_hints,
     _command_with_expected_planning_revision,
+    _decision_maturity_payload,
     _emit_payload,
     _ensure_external_intent_cache_if_available,
     _external_intent_status_by_ref,
@@ -810,6 +811,14 @@ def _planning_safety_gate_payload(
         reason = "No AW-owned hard blocker was detected; the agent owns soft work-shape judgment."
         required_next_action = "continue-direct"
         workflow_sufficient = True
+    hard_gate = decision in {
+        "delegation-decision-required",
+        "parent-decomposition-decision-required",
+        "lane-owner-artifact-required",
+        "implementation-owner-missing",
+        "candidate-lane-promotion-required",
+        "planning-escalation-required",
+    }
     candidates = (
         [
             _candidate_with_canonical_route(candidate)
@@ -873,6 +882,25 @@ def _planning_safety_gate_payload(
         "decision": decision,
         "workflow_sufficient": workflow_sufficient,
         "reason": reason,
+        "decision_maturity": _decision_maturity_payload(
+            decision=decision,
+            workflow_sufficient=workflow_sufficient,
+            required_next_action=required_next_action,
+            evidence_basis=[
+                f"active_planning_present={active_planning_present}",
+                f"dirty_shape={path_classification.get('dirty_shape')}",
+                f"candidate_pressure={candidate_pressure.get('status')}",
+                f"issue_ref_count={len(issue_refs)}",
+            ],
+            missing_evidence=(
+                ["external issue intent evidence"]
+                if decision == "external-issue-scope-unknown"
+                else ["changed-path scope decision"]
+                if decision == "agent-work-shape-decision-required"
+                else []
+            ),
+            hard_gate=hard_gate,
+        ),
         "authority_boundary": authority_boundary,
         "required_next_action": required_next_action,
         "active_planning_present": active_planning_present,

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -783,6 +783,7 @@ def _start_payload(
             reason=planning_safety_gate["reason"],
             required_next_action=planning_safety_gate["required_next_action"],
             evidence_required=["active planning ownership evidence"],
+            hard_gate=True,
         )
         payload["immediate_next_allowed_action"] = {
             "action": planning_safety_gate["required_next_action"],

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1036,7 +1036,10 @@ def test_start_routes_high_assurance_milestone_to_planning_before_implementation
     assert payload["next_safe_action"]["implementation_allowed"] is False
     assert "continue implementation without active planning ownership" in payload["next_safe_action"]["forbidden_actions"]
     assert payload["action_signals"]["allowed_next_action"] == "create-or-promote-active-execplan"
-    assert payload["context"]["planning"]["workflow_sufficiency"]["sufficiency_result"] == "planning-escalation-required"
+    sufficiency = payload["context"]["planning"]["workflow_sufficiency"]
+    assert sufficiency["sufficiency_result"] == "planning-escalation-required"
+    assert sufficiency["decision_maturity"]["level"] == "hard_gate"
+    assert payload["context"]["planning"]["planning_safety_gate"]["decision_maturity"]["level"] == "hard_gate"
 
 
 def test_start_reconciles_unrelated_active_plan_with_explicit_maintenance_task(tmp_path: Path, capsys) -> None:
@@ -1996,6 +1999,10 @@ def test_start_issue_reference_wording_keeps_issue_scope_warning(tmp_path: Path,
     )
     payload = json.loads(capsys.readouterr().out)
     assert payload["next_safe_action"]["next_safe_action"] == "refresh-external-issue-intent"
+    gate = payload["context"]["planning"]["planning_safety_gate"]
+    assert gate["decision_maturity"]["level"] == "evidence_seeking"
+    assert gate["decision_maturity"]["missing_evidence"] == ["external issue intent evidence"]
+    assert gate["decision_maturity"]["safe_probe"] == "refresh-external-intent-or-state-bounded-slice"
     assert payload["context"]["issue_reference_intent"]["issue_refs"] == ["#103"]
     effect = payload["context"]["issue_reference_intent"]["action_effect"]
     assert effect["force"] == "required_before_claim"

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -3353,8 +3353,12 @@ def test_implement_task_allows_narrow_single_issue_context(tmp_path: Path, capsy
 
     payload = json.loads(capsys.readouterr().out)
     assert "task_routing" not in payload
+    assert payload["workflow_sufficiency"]["decision_maturity"]["level"] == "evidence_seeking"
+    assert payload["workflow_sufficiency"]["decision_maturity"]["missing_evidence"] == ["changed paths"]
     assert payload["planning_safety_gate"]["status"] == "attention"
     assert payload["planning_safety_gate"]["gate_result"] == "external-issue-scope-unknown"
+    assert payload["planning_safety_gate"]["decision_maturity"]["level"] == "evidence_seeking"
+    assert payload["planning_safety_gate"]["decision_maturity"]["missing_evidence"] == ["external issue intent evidence"]
     assert payload["planning_safety_gate"]["implementation_allowed"] is True
     assert payload["planning_safety_gate"]["issue_scope_evidence"]["missing_issue_refs"] == ["#424"]
     assert payload["planning_safety_gate"]["work_shape_guidance"]["scope_factors"]["issue_refs"] == ["#424"]
@@ -4701,7 +4705,14 @@ def test_implement_routes_configured_architecture_principle_for_runtime_path(tmp
 
     payload = json.loads(capsys.readouterr().out)
     assert "architecture_principles=1" in payload["action_signals"]["changed_signals"]
-    assert payload["context"]["absence_states"]["architecture_principles"] == "hidden_behind_detail_route"
+    assert payload["context"]["absence_states"]["architecture_principles"] == "present"
+    compact_packet = payload["context"]["architecture_principles"]
+    assert compact_packet["matched_count"] == 1
+    compact_principle = compact_packet["matched_principles"][0]
+    assert compact_principle["guardrails"][0]["id"] == "non-enum-keyword-routing"
+    assert "explicit structured facts" in compact_principle["allowed_sources"]
+    assert "package-owned assumptions about prose keywords" in compact_principle["forbidden_sources"]
+    assert "routing" in compact_principle["affected_decisions"]
     assert (
         cli.main(
             [
@@ -4767,6 +4778,27 @@ def test_implement_architecture_principle_uses_structured_path_not_task_keywords
     assert packet["status"] == "clear"
     assert packet["matched_count"] == 0
     assert packet["matched_principles"] == []
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "README.md",
+                "--task",
+                "Avoid keyword routing and non-enum marker phrases in workflow ownership",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    tiny_payload = json.loads(capsys.readouterr().out)
+    assert "architecture_principles" not in tiny_payload["context"]
+    assert tiny_payload["context"]["absence_states"]["architecture_principles"] == "hidden_behind_detail_route"
 
 
 def test_implement_architecture_principle_selector_reports_multiple_matches(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Closes #1953 and #1954.

- Adds a compact `decision_maturity` packet for start/implement workflow and planning gates so early decisions can be `hard_gate`, `evidence_seeking`, or `provisional_gate`.
- Surfaces matched architecture principles in compact implement context when structured changed-path globs match, including the non-enum keyword-routing guardrail and its allowed/forbidden authority sources.
- Keeps unrelated simple work quiet by hiding architecture-principle detail when no structured path match exists.
- Adds focused coverage for hard Planning escalation, issue-scope evidence seeking, runtime-path guardrail surfacing, and non-matching prompt-keyword traps.

## Proof

- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` reports existing installed-payload sync attention after the v0.15 merge; this PR does not claim installed payload freshness.
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run pytest tests/test_workspace_implement_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`

## Communication Contract Evidence

classification: direct
workflow: implementation / proof / PR publication
AW surface: `start`, `implement`, `summary`, `doctor`
contract visible: yes
visible communication change: The report stays decision-first and names only the material caveat: doctor still reports installed-payload sync attention, so the PR does not claim payload freshness. Tool/process narration and full proof logs are omitted from the PR body.
what would likely have been worse without the contract: I likely would have reported all validation as simply passing or expanded into chronological command narration, losing the proof/residue boundary around the payload-sync caveat.
proof/residue/next-action preserved: yes
product implication: Keep the communication contract focused on visible output behavior; do not count routing, Planning, or proof success as direct evidence unless it changes what the agent writes or omits.