### PR TITLE
Forecast architecture principles before edits

### DIFF
--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,8 +13,8 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:9f6237baef02",
-    "version": "0.15.0"
+    "source_identity": "git:346cd4f34bc1",
+    "version": "0.15.2"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
   "payload_files": [
@@ -37,8 +37,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.15.0",
-    "version": "0.15.0"
+    "tag": "v0.15.2",
+    "version": "0.15.2"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/.agentic-workspace/planning/execplans/archive/issue-1956-architecture-principle-forecast.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1956-architecture-principle-forecast.plan.json
@@ -1,0 +1,366 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Issue 1956 architecture-principle forecast",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement issue #1956: expose provisional architecture-principle forecasts before edits when structured planned path scope is available, without prompt-prose keyword matching.",
+    "hard_constraints": "Use structured path scope and configured architecture_principles.path_globs only; keep implement --changed as the verification surface; keep unrelated startup quiet.",
+    "agent_may_decide": "Exact payload shape, compact projection fields, and focused tests that prove pre-edit surfacing plus unrelated-work quietness.",
+    "escalate_when": "A correct fix requires natural-language semantic classification, broad planning redesign, or changes outside startup/architecture-principle projection.",
+    "next_action": "Implement the startup forecast payload and focused tests, then run the narrow CLI test set.",
+    "proof_expectations": [
+      "Run focused CLI tests covering startup forecast and implement verification."
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_startup.py",
+      "src/agentic_workspace/workspace_runtime_core.py",
+      "tests/test_workspace_cli.py"
+    ],
+    "completion_criteria": [
+      "Startup can surface provisional architecture-principle matches from explicit path-scoped planned work before edits.",
+      "The forecast states its evidence basis and implement --changed verification route.",
+      "Unrelated path-scoped startup work remains quiet.",
+      "Issue #1956 is represented in a PR with the requested evidence note under the PR."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Issue 1956 architecture-principle forecast."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement issue #1956: expose provisional architecture-principle forecasts before edits when structured planned path scope is available, without prompt-prose keyword matching.",
+      "constraints": "Use structured path scope and configured architecture_principles.path_globs only; keep implement --changed as the verification surface; keep unrelated startup quiet.",
+      "latitude": "Exact payload shape, compact projection fields, and focused tests that prove pre-edit surfacing plus unrelated-work quietness.",
+      "escalation": "Escalate when a correct fix requires natural-language semantic classification, broad planning redesign, or changes outside startup/architecture-principle projection.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1956-architecture-principle-forecast",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_startup.py",
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "tests/test_workspace_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Issue 1956 architecture-principle forecast.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Issue 1956 architecture-principle forecast",
+    "inferred intended outcome": "Expose architecture-principle forecasts before edits from structured planned path scope.",
+    "chosen concrete what": "Add a compact startup forecast payload backed by path-glob matches, plus focused tests.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace/workspace_runtime_startup.py; src/agentic_workspace/workspace_runtime_core.py; tests/test_workspace_cli.py; plan metadata for this active plan.",
+    "max changed files": "About 4 files, excluding generated caches.",
+    "required validation commands": "uv run pytest tests/test_workspace_cli.py -k architecture_principle_forecast; uv run pytest tests/test_workspace_implement_cli.py -k architecture_principle",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue implementing the #1956 startup architecture-principle forecast and focused tests.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement issue #1956: startup architecture-principle forecast from structured planned scope.",
+    "hard constraints": "No prompt-prose keyword classifier; forecast must be provisional and verified by implement --changed.",
+    "agent may decide locally": "Payload shape, compact projection fields, and focused regression tests.",
+    "escalate when": "A correct fix requires broad planning redesign or semantic task classification."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1956-architecture-principle-forecast",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Implement the startup forecast payload and focused tests, then run the narrow CLI test set."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_startup.py",
+    "src/agentic_workspace/workspace_runtime_core.py",
+    "tests/test_workspace_cli.py",
+    ".agentic-workspace/planning/execplans/issue-1956-architecture-principle-forecast.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_cli.py -k architecture_principle_forecast",
+    "uv run pytest tests/test_workspace_implement_cli.py -k architecture_principle"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Issue 1956 architecture-principle forecast is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented startup architecture-principle forecast from structured path-scoped planned work before edits.",
+    "scope touched": "Startup runtime projection, shared architecture-principle forecast helper, and focused CLI tests.",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_startup.py; tests/test_workspace_cli.py",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope respected. Host-agnostic agent-judgment principle preserved: the forecast uses explicit task path scope or active plan touched scope and configured path_globs only, labels matches provisional/evidence-seeking, and keeps implement --changed as verification. No prompt-prose keyword classifier was added.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest tests/test_workspace_cli.py -k 'architecture_principle or unmatched_path or active_plan_scope' -q (3 passed); uv run pytest tests/test_workspace_implement_cli.py -k architecture_principle -q (5 passed); uv run pytest tests/test_workspace_cli.py -q (98 passed); make lint-workspace (ok); make typecheck (ok); make test-workspace (ok); uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json (in_sync); git diff --check (ok)",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Issue 1956 architecture-principle forecast.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Issue #1956 is satisfied for the startup forecast lane; no durable residue identified beyond this PR.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-02: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Issue 1956 architecture-principle forecast.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest tests/test_workspace_cli.py -k 'architecture_principle or unmatched_path or active_plan_scope' -q (3 passed); uv run pytest tests/test_workspace_implement_cli.py -k architecture_principle -q (5 passed); uv run pytest tests/test_workspace_cli.py -q (98 passed); make lint-workspace (ok); make typecheck (ok); make test-workspace (ok); uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json (in_sync); git diff --check (ok)\nChanged surfaces: src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_startup.py; tests/test_workspace_cli.py\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -16130,6 +16130,25 @@ def _note_glob_matches(*, changed_paths: list[str], patterns: Any) -> list[dict[
     return matches
 
 
+def _active_plan_touched_scope_paths(active_planning_record: Any) -> list[str]:
+    record = _as_dict(active_planning_record)
+    candidate_values: list[Any] = [
+        _as_dict(record.get("canonical_core")).get("touched_scope"),
+        _as_dict(_as_dict(record.get("machine_readable_contract")).get("scope")).get("touched"),
+        record.get("touched_paths"),
+    ]
+    paths: list[str] = []
+    seen: set[str] = set()
+    for values in candidate_values:
+        for value in _list_payload(values):
+            path = str(value).strip()
+            if not path or path in seen or path.lower().startswith("fill in ") or path.lower() in {"none", "none yet", "not recorded"}:
+                continue
+            paths.append(path)
+            seen.add(path)
+    return _normalize_changed_paths(paths)
+
+
 def _architecture_principles_payload(
     *,
     target_root: Path | None,
@@ -16279,6 +16298,90 @@ def _architecture_principles_payload(
             ],
             "closeout": payload["closeout"],
         }
+    return payload
+
+
+def _architecture_principles_forecast_payload(
+    *,
+    target_root: Path | None,
+    planned_paths: list[str] | None,
+    scope_source: str,
+    cli_invoke: str,
+) -> dict[str, Any]:
+    normalized_paths = _normalize_changed_paths(planned_paths or [])
+    if not normalized_paths:
+        command = _command_with_cli_invoke(
+            command="agentic-workspace implement --changed <paths> --select architecture_principles --format json",
+            cli_invoke=cli_invoke,
+        )
+        return {
+            "kind": "agentic-workspace/architecture-principles-forecast/v1",
+            "status": "needs-planned-scope",
+            "matched_count": 0,
+            "planned_scope": {"source": scope_source, "paths": []},
+            "decision_maturity": {
+                "level": "evidence_seeking",
+                "decision": "architecture-principle-forecast",
+                "missing_evidence": ["planned paths or changed paths"],
+                "safe_probe": command,
+            },
+        }
+    architecture_principles = _architecture_principles_payload(
+        target_root=target_root,
+        changed_paths=normalized_paths,
+        cli_invoke=cli_invoke,
+        compact=True,
+    )
+    matched_count = int(architecture_principles.get("matched_count", 0) or 0)
+    status = "provisional-match" if matched_count else "clear"
+    command = _command_with_cli_invoke(
+        command=f"agentic-workspace implement --changed {' '.join(normalized_paths)} --select architecture_principles --format json",
+        cli_invoke=cli_invoke,
+    )
+    payload: dict[str, Any] = {
+        "kind": "agentic-workspace/architecture-principles-forecast/v1",
+        "status": status,
+        "matched_count": matched_count,
+        "forecast_state": "provisional",
+        "planned_scope": {
+            "source": scope_source,
+            "paths": normalized_paths,
+        },
+        "evidence_basis": [
+            "explicit existing repo path in task scope",
+            "declared architecture_principles.path_globs",
+        ],
+        "rule": ("Forecast uses structured planned paths and configured path_globs only; it does not classify arbitrary task prose."),
+        "decision_maturity": {
+            "level": "evidence_seeking",
+            "decision": "architecture-principle-forecast",
+            "evidence_basis": ["planned path scope", "configured path_globs"],
+            "missing_evidence": ["actual changed paths"],
+            "safe_probe": command,
+        },
+        "verification": {
+            "required": True,
+            "command": command,
+            "rule": "Re-run implement --changed once actual changed paths are known to confirm or correct the forecast.",
+        },
+    }
+    if matched_count:
+        payload["architecture_principles"] = architecture_principles
+        payload["authority_boundary"] = _authority_boundary_payload(
+            surface="architecture_principles_forecast",
+            observed_by_aw=[
+                f"planned_scope_source={scope_source}",
+                f"planned_path_count={len(normalized_paths)}",
+                f"matched_count={matched_count}",
+            ],
+            recommended_by_aw=["consider matched architecture principles before edits"],
+            proof_hints=["verify forecast against actual changed paths with implement --changed"],
+            agent_owned_decisions=[
+                "whether the forecasted principle is semantically relevant to the intended edit",
+                "whether implementation preserves, re-scopes, or leaves the principle unresolved",
+            ],
+            rule="AW forecasts only from structured path evidence; agent judgment owns semantic application.",
+        )
     return payload
 
 
@@ -24403,6 +24506,23 @@ def _start_tiny_payload_fast(
     task_path_references = _task_path_reference_payload(task_text=task_text, detected_paths=task_mentioned_paths)
     if task_path_references["status"] == "present":
         payload["task_path_references"] = task_path_references
+    forecast_paths = []
+    forecast_scope_source = ""
+    if task_path_references.get("path_reference_kind") == "path-scoped-work":
+        forecast_paths = _list_payload(task_path_references.get("path_scoped_paths")) or task_mentioned_paths
+        forecast_scope_source = "task_path_references.path_scoped_paths"
+    elif active_planning_present:
+        forecast_paths = _active_plan_touched_scope_paths(active_parent_record)
+        forecast_scope_source = "active_planning_record.touched_scope"
+    if forecast_paths and not changed_paths and not _is_config_posture_task(task_text):
+        architecture_forecast = _architecture_principles_forecast_payload(
+            target_root=target_root,
+            planned_paths=forecast_paths,
+            scope_source=forecast_scope_source,
+            cli_invoke=config.cli_invoke,
+        )
+        if architecture_forecast.get("status") == "provisional-match":
+            payload["architecture_principles_forecast"] = architecture_forecast
     vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
     if vague_orientation["applies_to_current_task"]:
         payload["vague_outcome_orientation"] = vague_orientation

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -16301,6 +16301,22 @@ def _architecture_principles_payload(
     return payload
 
 
+def _architecture_principles_configured(target_root: Path | None) -> bool:
+    if target_root is None:
+        return False
+    path = target_root / ".agentic-workspace/system-intent/intent.toml"
+    if not path.is_file():
+        return False
+    try:
+        document = tomllib.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError):
+        return False
+    return any(
+        isinstance(principle, dict) and str(principle.get("id", "")).strip()
+        for principle in _list_payload(document.get("architecture_principles"))
+    )
+
+
 def _architecture_principles_forecast_payload(
     *,
     target_root: Path | None,
@@ -16310,6 +16326,12 @@ def _architecture_principles_forecast_payload(
 ) -> dict[str, Any]:
     normalized_paths = _normalize_changed_paths(planned_paths or [])
     if not normalized_paths:
+        if not _architecture_principles_configured(target_root):
+            return {
+                "kind": "agentic-workspace/architecture-principles-forecast/v1",
+                "status": "not-configured",
+                "matched_count": 0,
+            }
         command = _command_with_cli_invoke(
             command="agentic-workspace implement --changed <paths> --select architecture_principles --format json",
             cli_invoke=cli_invoke,
@@ -16319,6 +16341,10 @@ def _architecture_principles_forecast_payload(
             "status": "needs-planned-scope",
             "matched_count": 0,
             "planned_scope": {"source": scope_source, "paths": []},
+            "rule": (
+                "Forecast cannot decide architecture-principle relevance until planned paths or changed paths are known; "
+                "it does not classify arbitrary task prose."
+            ),
             "decision_maturity": {
                 "level": "evidence_seeking",
                 "decision": "architecture-principle-forecast",
@@ -24514,14 +24540,22 @@ def _start_tiny_payload_fast(
     elif active_planning_present:
         forecast_paths = _active_plan_touched_scope_paths(active_parent_record)
         forecast_scope_source = "active_planning_record.touched_scope"
-    if forecast_paths and not changed_paths and not _is_config_posture_task(task_text):
+    forecast_missing_scope = (
+        bool(task_intent.get("status") == "present")
+        and not forecast_paths
+        and not changed_paths
+        and not _is_config_posture_task(task_text)
+        and read_only_response.get("status") != "read-only-reporting"
+        and not _is_prep_only_handoff_task(task_text)
+    )
+    if (forecast_paths or forecast_missing_scope) and not changed_paths and not _is_config_posture_task(task_text):
         architecture_forecast = _architecture_principles_forecast_payload(
             target_root=target_root,
             planned_paths=forecast_paths,
-            scope_source=forecast_scope_source,
+            scope_source=forecast_scope_source or "missing_planned_scope",
             cli_invoke=config.cli_invoke,
         )
-        if architecture_forecast.get("status") == "provisional-match":
+        if architecture_forecast.get("status") in {"provisional-match", "needs-planned-scope"}:
             payload["architecture_principles_forecast"] = architecture_forecast
     vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
     if vague_orientation["applies_to_current_task"]:

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -739,14 +739,22 @@ def _start_payload(
     elif active_planning_present:
         forecast_paths = _active_plan_touched_scope_paths(active_parent_record)
         forecast_scope_source = "active_planning_record.touched_scope"
-    if forecast_paths and not changed_paths and not _is_config_posture_task(task_text):
+    forecast_missing_scope = (
+        bool(task_intent.get("status") == "present")
+        and not forecast_paths
+        and not changed_paths
+        and not _is_config_posture_task(task_text)
+        and read_only_response.get("status") != "read-only-reporting"
+        and not _is_prep_only_handoff_task(task_text)
+    )
+    if (forecast_paths or forecast_missing_scope) and not changed_paths and not _is_config_posture_task(task_text):
         architecture_forecast = _architecture_principles_forecast_payload(
             target_root=target_root,
             planned_paths=forecast_paths,
-            scope_source=forecast_scope_source,
+            scope_source=forecast_scope_source or "missing_planned_scope",
             cli_invoke=config.cli_invoke,
         )
-        if architecture_forecast.get("status") == "provisional-match":
+        if architecture_forecast.get("status") in {"provisional-match", "needs-planned-scope"}:
             payload["architecture_principles_forecast"] = architecture_forecast
     vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
     if vague_orientation["applies_to_current_task"]:
@@ -1442,7 +1450,10 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     if isinstance(task_path_references, dict) and task_path_references.get("status") == "present":
         context["task_path_references"] = task_path_references
     architecture_forecast = payload.get("architecture_principles_forecast", {})
-    if isinstance(architecture_forecast, dict) and architecture_forecast.get("status") == "provisional-match":
+    if isinstance(architecture_forecast, dict) and architecture_forecast.get("status") in {
+        "provisional-match",
+        "needs-planned-scope",
+    }:
         context["architecture_principles_forecast"] = architecture_forecast
     pr_comment_attention = payload.get("pr_comment_attention", {})
     if isinstance(pr_comment_attention, dict) and pr_comment_attention.get("status") not in {None, "", "not_applicable"}:

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -18,8 +18,10 @@ from agentic_workspace.reporting_support import communication_contract_payload, 
 from agentic_workspace.workspace_runtime_core import (
     _CONTEXT_TEMPLATES,
     _active_intent_contract_payload,
+    _active_plan_touched_scope_paths,
     _applicable_intent_status_payload,
     _apply_lane_shaping_gate_to_start_payload,
+    _architecture_principles_forecast_payload,
     _assurance_requirements_report_payload,
     _attach_start_router_fields,
     _authority_markers_for_startup,
@@ -257,6 +259,11 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "repo_posture": _compact_repo_posture_projection(payload.get("repo_posture", {})),
         "delegation_decision": _compact_start_delegation_decision(payload.get("delegation_decision", {})),
         **({"task_path_references": payload["task_path_references"]} if isinstance(payload.get("task_path_references"), dict) else {}),
+        **(
+            {"architecture_principles_forecast": payload["architecture_principles_forecast"]}
+            if isinstance(payload.get("architecture_principles_forecast"), dict)
+            else {}
+        ),
         **({"pre_test_evidence_guardrail": payload["pre_test_evidence_guardrail"]} if "pre_test_evidence_guardrail" in payload else {}),
         **({"pr_comment_attention": payload["pr_comment_attention"]} if isinstance(payload.get("pr_comment_attention"), dict) else {}),
         **(
@@ -724,6 +731,23 @@ def _start_payload(
     task_path_references = _task_path_reference_payload(task_text=task_text, detected_paths=task_mentioned_paths)
     if task_path_references["status"] == "present":
         payload["task_path_references"] = task_path_references
+    forecast_paths = []
+    forecast_scope_source = ""
+    if task_path_references.get("path_reference_kind") == "path-scoped-work":
+        forecast_paths = _list_payload(task_path_references.get("path_scoped_paths")) or task_mentioned_paths
+        forecast_scope_source = "task_path_references.path_scoped_paths"
+    elif active_planning_present:
+        forecast_paths = _active_plan_touched_scope_paths(active_parent_record)
+        forecast_scope_source = "active_planning_record.touched_scope"
+    if forecast_paths and not changed_paths and not _is_config_posture_task(task_text):
+        architecture_forecast = _architecture_principles_forecast_payload(
+            target_root=target_root,
+            planned_paths=forecast_paths,
+            scope_source=forecast_scope_source,
+            cli_invoke=config.cli_invoke,
+        )
+        if architecture_forecast.get("status") == "provisional-match":
+            payload["architecture_principles_forecast"] = architecture_forecast
     vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)
     if vague_orientation["applies_to_current_task"]:
         payload["vague_outcome_orientation"] = vague_orientation
@@ -1417,6 +1441,9 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     task_path_references = payload.get("task_path_references", {})
     if isinstance(task_path_references, dict) and task_path_references.get("status") == "present":
         context["task_path_references"] = task_path_references
+    architecture_forecast = payload.get("architecture_principles_forecast", {})
+    if isinstance(architecture_forecast, dict) and architecture_forecast.get("status") == "provisional-match":
+        context["architecture_principles_forecast"] = architecture_forecast
     pr_comment_attention = payload.get("pr_comment_attention", {})
     if isinstance(pr_comment_attention, dict) and pr_comment_attention.get("status") not in {None, "", "not_applicable"}:
         context["pr_comment_attention"] = {

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1574,6 +1574,62 @@ def test_start_forecasts_architecture_principle_for_path_scoped_task_before_edit
     assert forecast["decision_maturity"]["level"] == "evidence_seeking"
 
 
+def test_start_surfaces_architecture_principle_scope_probe_when_planned_scope_missing(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_cli_architecture_principles(tmp_path)
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Implement the architecture principle forecast update",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    forecast = payload["context"]["architecture_principles_forecast"]
+    assert forecast["status"] == "needs-planned-scope"
+    assert forecast["planned_scope"] == {"source": "missing_planned_scope", "paths": []}
+    assert forecast["decision_maturity"]["level"] == "evidence_seeking"
+    assert forecast["decision_maturity"]["missing_evidence"] == ["planned paths or changed paths"]
+    assert "implement --changed <paths>" in forecast["decision_maturity"]["safe_probe"]
+    assert "--select architecture_principles" in forecast["decision_maturity"]["safe_probe"]
+    assert "does not classify arbitrary task prose" in forecast["rule"]
+
+
+def test_start_keeps_architecture_principle_scope_probe_quiet_when_not_configured(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Implement the architecture principle forecast update",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert "architecture_principles_forecast" not in payload["context"]
+
+
 def test_start_forecasts_architecture_principle_from_active_plan_scope_before_edits(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning", "--format", "json"]) == 0

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -42,6 +42,33 @@ def _assert_selector_inventory_omitted_from_compact_start(payload: dict[str, Any
     return inventory
 
 
+def _write_cli_architecture_principles(target_root: Path) -> None:
+    _write(
+        target_root / ".agentic-workspace" / "system-intent" / "intent.toml",
+        """
+kind = "agentic-workspace/system-intent/v1"
+summary = "Portable host-neutral operating intent."
+governing_intents = ["Keep package contracts portable across host repos."]
+anti_intents = ["Do not let this repo's current language, tooling, structure, or agent preferences become hidden universal product assumptions."]
+decision_tests = ["Favor work that improves portability by reducing accidental repo assumptions."]
+confidence = "high"
+needs_review = false
+
+[[architecture_principles]]
+id = "host-agnostic-agent-judgment"
+title = "Preserve host-agnostic agent judgment"
+authority = "repo-system-intent"
+owner = "workspace-runtime"
+summary = "AW provides infrastructure for agent judgment instead of package-owned host assumptions."
+allowed_sources = ["explicit structured facts", "AW-owned enum labels", "configuration"]
+forbidden_sources = ["package-owned assumptions about prose keywords", "package-owned assumptions about file names"]
+affected_decisions = ["routing", "ownership", "proof-selection"]
+path_globs = ["src/agentic_workspace/workspace_runtime*.py"]
+proof_expectation = "Closeout must state whether the principle was preserved or re-scoped."
+""",
+    )
+
+
 def test_repeated_module_flags_accumulate_module_selection(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--modules", "memory", "--modules", "planning", "--target", str(tmp_path), "--format", "json"]) == 0
@@ -1507,6 +1534,130 @@ def test_start_path_scoped_task_text_uses_known_path_inspection(tmp_path: Path, 
     assert path_refs["path_reference_kind"] == "path-scoped-work"
     assert path_refs["path_scoped_paths"] == ["AGENTS.md"]
     assert path_refs["matched_action_terms"] == ["review"]
+
+
+def test_start_forecasts_architecture_principle_for_path_scoped_task_before_edits(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_cli_architecture_principles(tmp_path)
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_startup.py", "VALUE = 1\n")
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Update src/agentic_workspace/workspace_runtime_startup.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    forecast = payload["context"]["architecture_principles_forecast"]
+    assert forecast["status"] == "provisional-match"
+    assert forecast["forecast_state"] == "provisional"
+    assert forecast["planned_scope"] == {
+        "source": "task_path_references.path_scoped_paths",
+        "paths": ["src/agentic_workspace/workspace_runtime_startup.py"],
+    }
+    assert forecast["architecture_principles"]["matched_principles"][0]["id"] == "host-agnostic-agent-judgment"
+    assert forecast["architecture_principles"]["matched_principles"][0]["matcher"]["kind"] == "path_glob"
+    assert "does not classify arbitrary task prose" in forecast["rule"]
+    assert "implement --changed src/agentic_workspace/workspace_runtime_startup.py" in forecast["verification"]["command"]
+    assert "--select architecture_principles" in forecast["verification"]["command"]
+    assert forecast["decision_maturity"]["level"] == "evidence_seeking"
+
+
+def test_start_forecasts_architecture_principle_from_active_plan_scope_before_edits(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning", "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_cli_architecture_principles(tmp_path)
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_startup.py", "VALUE = 1\n")
+    assert (
+        cli.main(
+            [
+                "planning",
+                "new-plan",
+                "--target",
+                str(tmp_path),
+                "--id",
+                "runtime-forecast-plan",
+                "--title",
+                "Runtime forecast plan",
+                "--activate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    plan_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "runtime-forecast-plan.plan.json"
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    planned_paths = ["src/agentic_workspace/workspace_runtime_startup.py"]
+    plan["canonical_core"]["touched_scope"] = planned_paths
+    plan["machine_readable_contract"]["scope"]["touched"] = planned_paths
+    plan["touched_paths"] = planned_paths
+    _write(plan_path, json.dumps(plan, indent=2) + "\n")
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue the active plan",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    forecast = payload["context"]["architecture_principles_forecast"]
+    assert forecast["status"] == "provisional-match"
+    assert forecast["planned_scope"] == {
+        "source": "active_planning_record.touched_scope",
+        "paths": planned_paths,
+    }
+    assert forecast["architecture_principles"]["matched_principles"][0]["matcher"]["kind"] == "path_glob"
+
+
+def test_start_keeps_architecture_principle_forecast_quiet_for_unmatched_path(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_cli_architecture_principles(tmp_path)
+    _write(tmp_path / "README.md", "# Notes\n")
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Review README.md",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["context"]["task_path_references"]["path_reference_kind"] == "path-scoped-work"
+    assert "architecture_principles_forecast" not in payload["context"]
+    assert "architecture_principles_forecast" not in payload
 
 
 def test_start_explicit_changed_path_still_uses_changed_path_startup(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Adds a startup architecture-principle forecast packet for explicit planned paths before code edits.
- Surfaces a compact `needs-planned-scope` forecast when architecture principles are configured but planned paths or changed paths are still missing.
- Uses structured task path references, active plan touched scope, and configured `architecture_principles.path_globs`; no task-prose keyword classifier.
- Keeps unmatched paths and unconfigured repos quiet, and keeps forecasts provisional/evidence-seeking with an `implement --changed <paths> --select architecture_principles` safe probe.
- Syncs checked-in AW payload provenance to the current coordinated release identity.

Closes #1956.

## Proof
- `uv run pytest tests/test_workspace_cli.py -k architecture_principle -q`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make lint-workspace`
- `make typecheck`
- `make test-workspace`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `make maintainer-surfaces`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `make absolute-paths`
- `uv run python scripts/run_agentic_workspace.py start --target . --select installed_state_compatibility --format json`
- `git diff --check`

## Review Fix
The missing planned-scope branch is now reachable from ordinary startup when the task has intent, no changed paths, no discovered path scope, is not read-only/config/prep-only, and architecture principles are configured. The packet reports `status = needs-planned-scope`, `missing_evidence = ["planned paths or changed paths"]`, and the safe probe command.

## Boundaries
- Architecture-principle forecasting remains path/config driven; the new missing-scope packet does not decide semantic relevance from arbitrary prose.
- Planning summary is clean after closing the temporary review plan.
- Payload compatibility is synced: `installed_state_compatibility.status = compatible`.