### PR TITLE
Separate closeout drift and stale projections

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1957-1958-closeout-projection-signals.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1957-1958-closeout-projection-signals.plan.json
@@ -1,0 +1,393 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Issues 1957 and 1958 closeout/projection signals",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement issues #1957 and #1958: separate unrelated installed-payload drift from narrow closeout proof, and prevent compact planning projections from presenting stale scaffold text as live guidance.",
+    "hard_constraints": "Do not hide installed-state drift; do not weaken drift blocking when installed/generated payload freshness is in scope; preserve stale planning history behind freshness/supersession markers.",
+    "agent_may_decide": "Payload names, compact projection fields, and focused fixtures that prove unrelated drift, in-scope drift, and stale projection replacement.",
+    "escalate_when": "A correct fix requires broad planning UI redesign, automatic payload syncing, or changes outside closeout/report and planning summary projection surfaces.",
+    "next_action": "Finish implementation, run focused and selected proof, then close out and archive this plan.",
+    "proof_expectations": [
+      "Run focused tests for planning stale projection replacement and closeout installed-state residue classification.",
+      "Run AW-selected planning/workspace proof before completion."
+    ],
+    "touched_scope": [
+      "packages/planning/src/repo_planning_bootstrap/installer.py",
+      "packages/planning/tests/test_promote.py",
+      "src/agentic_workspace/workspace_runtime_core.py",
+      "src/agentic_workspace/workspace_runtime_proof.py",
+      "tests/test_workspace_summary_cli.py"
+    ],
+    "completion_criteria": [
+      "Closeout/report output separates narrow task proof from unrelated installed-payload drift residue.",
+      "Installed/generated payload owned work still treats installed-state drift as blocking.",
+      "Compact planning summary active items do not present stale scaffold next_action as live guidance when active execplan state has a fresher value.",
+      "Stale planning values remain visible as superseded/audit detail.",
+      "Issues #1957 and #1958 are represented in one PR with the requested evidence note under the PR."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for Issues 1957 and 1958 closeout/projection signals."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement issues #1957 and #1958: closeout installed-state residue separation and compact planning stale-projection replacement.",
+      "constraints": "Do not hide installed-state drift; keep in-scope installed/generated payload drift blocking; preserve stale planning history as superseded/audit detail.",
+      "latitude": "Payload names, compact projection fields, and focused fixtures that prove unrelated drift, in-scope drift, and stale projection replacement.",
+      "escalation": "Escalate when a correct fix requires broad planning UI redesign, automatic payload syncing, or changes outside closeout/report and planning summary projection surfaces.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-1957-1958-closeout-projection-signals",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "packages/planning/src/repo_planning_bootstrap/installer.py",
+        "packages/planning/tests/test_promote.py",
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "src/agentic_workspace/workspace_runtime_proof.py",
+        "tests/test_workspace_summary_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Issues 1957 and 1958 closeout/projection signals.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Issues 1957 and 1958 closeout/projection signals",
+    "inferred intended outcome": "Separate closeout proof from unrelated installed drift and make compact planning guidance prefer current execplan state over stale scaffold text.",
+    "chosen concrete what": "Add closeout installed-state residue classification, active-item stale projection replacement, and focused fixtures.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_promote.py; src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_proof.py; tests/test_workspace_summary_cli.py; this plan/state.",
+    "max changed files": "About 7 files including plan metadata.",
+    "required validation commands": "uv run pytest packages/planning/tests/test_promote.py -k stale -q; uv run pytest tests/test_workspace_summary_cli.py -k installed_state_drift -q; make test-planning; make lint-planning; make test-workspace; make lint-workspace; make typecheck-planning; make typecheck",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue the #1957/#1958 closeout/projection signal-quality implementation and proof.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement issues #1957 and #1958 closeout/projection signal quality.",
+    "hard constraints": "Do not hide installed-state drift; keep in-scope installed/generated payload drift blocking; mark stale planning values as superseded rather than live.",
+    "agent may decide locally": "Payload names, compact fields, and focused tests.",
+    "escalate when": "A correct fix requires broad planning UI redesign, automatic payload syncing, or unrelated module changes."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1957-1958-closeout-projection-signals",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Finish implementation, run focused and selected proof, then close out and archive this plan."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "packages/planning/src/repo_planning_bootstrap/installer.py",
+    "packages/planning/tests/test_promote.py",
+    "src/agentic_workspace/workspace_runtime_core.py",
+    "src/agentic_workspace/workspace_runtime_proof.py",
+    "tests/test_workspace_summary_cli.py",
+    ".agentic-workspace/planning/execplans/issue-1957-1958-closeout-projection-signals.plan.json",
+    ".agentic-workspace/planning/state.toml"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest packages/planning/tests/test_promote.py -k stale -q",
+    "uv run pytest tests/test_workspace_summary_cli.py -k installed_state_drift -q",
+    "make test-planning",
+    "make lint-planning",
+    "make test-workspace",
+    "make lint-workspace",
+    "make typecheck-planning",
+    "make typecheck"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Issues 1957 and 1958 closeout/projection signals is implemented, validated, and closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented #1957 and #1958. Closeout reports now classify installed-payload drift as current-task blocking only when the current claim touches owned payload/generated surfaces, otherwise preserving it as separate maintenance residue. Planning compact summaries now override stale active-item projection fields from fresher continuation answers while retaining stale values as superseded projection evidence.",
+    "scope touched": "Planning summary compact projection; workspace closeout report projection; installed-state closeout residue; focused report/projection tests.",
+    "changed surfaces": "packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_promote.py; src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_proof.py; tests/test_workspace_summary_cli.py",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Host-agnostic agent judgment principle preserved: the change uses structured planning continuation facts, changed-surface paths from the active record, AW-owned installed-state enum/status payloads, and existing configured CLI commands; it does not add package-owned prose keyword routing or repo-specific issue taxonomy. Runtime source edit reason: existing primitive/report bugfix for planning summary projection and closeout report derivation. Residue: installed payload sync remains open and must not be reported as fixed by this PR.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "uv run pytest packages/planning/tests/test_promote.py -k stale -q; uv run pytest tests/test_workspace_summary_cli.py -k 'installed_state_drift or installed_state_residue' -q; uv run pytest tests/test_workspace_summary_cli.py -q; make lint-planning; make typecheck-planning; make lint-workspace; make typecheck; make test-planning; uv run pytest tests/test_workspace_cli.py -q; uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json; git diff --check; make test-workspace; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json (attention-needed only for pre-existing installed payload sync/provenance drift).",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Issues 1957 and 1958 closeout/projection signals.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#1957 satisfied by closeout_report.installed_state_residue and gaps_and_residual_risk.installed_state_residue. #1958 satisfied by compact summary projection_overrides and fresh continuation guidance winning over stale active item scaffold text.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "planning",
+    "learned constraint": "Closeout routed issue residue to installed-payload-sync.",
+    "motivation worth preserving": "Future agents should continue from installed-payload-sync rather than rediscover this closeout residue.",
+    "canonical owner now": "installed-payload-sync",
+    "promotion trigger": "when the routed closeout residue is acted on",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "installed-payload-sync",
+    "proposed durable intent": "Future agents should continue from installed-payload-sync rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "installed-payload-sync"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a lane claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "signals_routed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      {
+        "summary": "Closeout routed issue residue to installed-payload-sync.",
+        "owner": "installed-payload-sync",
+        "source": "durable_residue"
+      }
+    ],
+    "signals fixed": [],
+    "signals routed": [
+      {
+        "summary": "Closeout routed issue residue to installed-payload-sync.",
+        "owner": "installed-payload-sync",
+        "source": "durable_residue"
+      }
+    ],
+    "signals dismissed": [],
+    "next owner": "see routed signal owner"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-02: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "route_to_planning",
+    "target": "installed-payload-sync",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Issues 1957 and 1958 closeout/projection signals.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: uv run pytest packages/planning/tests/test_promote.py -k stale -q; uv run pytest tests/test_workspace_summary_cli.py -k 'installed_state_drift or installed_state_residue' -q; uv run pytest tests/test_workspace_summary_cli.py -q; make lint-planning; make typecheck-planning; make lint-workspace; make typecheck; make test-planning; uv run pytest tests/test_workspace_cli.py -q; uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json; git diff --check; make test-workspace; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json (attention-needed only for pre-existing installed payload sync/provenance drift).\nChanged surfaces: packages/planning/src/repo_planning_bootstrap/installer.py; packages/planning/tests/test_promote.py; src/agentic_workspace/workspace_runtime_core.py; src/agentic_workspace/workspace_runtime_proof.py; tests/test_workspace_summary_cli.py\nDurable residue: planning (installed-payload-sync)\nMemory learning: route_to_planning\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -4054,6 +4054,11 @@ def _planning_summary_tiny_fast(*, target_root: Path) -> dict[str, Any]:
             summary_profile="tiny",
         )
     )
+    continuation_answers = continuation_view.get("answers", {}) if isinstance(continuation_view.get("answers"), dict) else {}
+    continuation_next_action = str(continuation_answers.get("next_safe_action") or "").strip()
+    if continuation_next_action:
+        recommendation = continuation_next_action
+    projected_active_items = _active_items_with_projection_overrides(active_items, continuation_view)
     return _drop_empty_compact_fields(
         {
             "kind": "planning-summary/v1",
@@ -4063,7 +4068,7 @@ def _planning_summary_tiny_fast(*, target_root: Path) -> dict[str, Any]:
             "todo": {
                 "active_count": len(active_items),
                 "queued_count": len(queued_items),
-                "active_items": _compact_active_items(active_items),
+                "active_items": _compact_active_items(projected_active_items),
             },
             "execplans": {
                 "active_count": len(active_execplans),
@@ -4202,6 +4207,52 @@ def _drop_empty_compact_fields(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _active_items_with_projection_overrides(items: Any, continuation_view: Any) -> list[dict[str, Any]]:
+    if not isinstance(items, list):
+        return []
+    projected = [dict(item) if isinstance(item, dict) else item for item in items]
+    if not isinstance(continuation_view, dict):
+        return [item for item in projected if isinstance(item, dict)]
+    stale_projections = continuation_view.get("stale_projections", [])
+    if not isinstance(stale_projections, list):
+        return [item for item in projected if isinstance(item, dict)]
+    for projection in stale_projections:
+        if not isinstance(projection, dict):
+            continue
+        field = str(projection.get("field", "")).strip()
+        match = re.fullmatch(r"todo\.active_items\[(\d+)\]\.([A-Za-z0-9_ -]+)", field)
+        if match is None:
+            continue
+        index = int(match.group(1))
+        key = match.group(2).strip().replace(" ", "_")
+        if index < 0 or index >= len(projected) or not isinstance(projected[index], dict):
+            continue
+        chosen_value = str(projection.get("chosen_value", "")).strip()
+        if not chosen_value:
+            continue
+        item = dict(projected[index])
+        item[key] = chosen_value
+        raw_overrides = item.get("projection_overrides", [])
+        overrides: list[dict[str, Any]] = (
+            [dict(override) for override in raw_overrides if isinstance(override, dict)] if isinstance(raw_overrides, list) else []
+        )
+        overrides.append(
+            {
+                "field": key,
+                "stale_value": str(projection.get("stale_value", "")).strip(),
+                "chosen_value": chosen_value,
+                "chosen_source": str(projection.get("chosen_source", "")).strip(),
+                "reason": str(projection.get("reason", "")).strip(),
+            }
+        )
+        item["projection_freshness"] = "superseded-state-field"
+        item["projection_overrides"] = [
+            {key: value for key, value in override.items() if value not in ("", [], {}, None)} for override in overrides
+        ]
+        projected[index] = item
+    return [item for item in projected if isinstance(item, dict)]
+
+
 def _compact_active_items(items: Any, *, max_items: int = 3) -> list[dict[str, Any]]:
     if not isinstance(items, list):
         return []
@@ -4224,6 +4275,8 @@ def _compact_active_items(items: Any, *, max_items: int = 3) -> list[dict[str, A
                     "next_action",
                     "done_when",
                     "suggested_first_slice",
+                    "projection_freshness",
+                    "projection_overrides",
                 )
                 if key in item and item[key] not in ("", [], {}, None)
             }
@@ -4736,6 +4789,12 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
     ordered_batch = execution_readiness.get("ordered_batch")
     if isinstance(ordered_batch, dict) and ordered_batch.get("status") == "present":
         compact_execution_readiness["ordered_batch"] = ordered_batch
+    continuation_answers = continuation_view.get("answers", {}) if isinstance(continuation_view.get("answers"), dict) else {}
+    continuation_next_action = str(continuation_answers.get("next_safe_action") or "").strip()
+    if continuation_next_action:
+        compact_execution_readiness["recommendation"] = {"summary": continuation_next_action}
+        planning_surface_health = dict(planning_surface_health)
+        planning_surface_health["recommended_next_action"] = continuation_next_action
 
     compact_summary: dict[str, Any] = {
         "kind": summary.get("kind", "planning-summary/v1"),
@@ -4748,7 +4807,7 @@ def _planning_summary_compact_projection(summary: dict[str, Any]) -> dict[str, A
             "line_count": todo.get("line_count", 0),
             "item_count": todo.get("item_count", 0),
             "active_count": todo.get("active_count", 0),
-            "active_items": _compact_active_items(todo.get("active_items", [])),
+            "active_items": _compact_active_items(_active_items_with_projection_overrides(todo.get("active_items", []), continuation_view)),
             "queued_count": todo.get("queued_count", 0),
             "queued_items": _compact_active_items(todo.get("queued_items", [])),
         },

--- a/packages/planning/tests/test_promote.py
+++ b/packages/planning/tests/test_promote.py
@@ -1393,8 +1393,17 @@ candidates = []
     )
 
     summary = planning_summary(target=tmp_path, profile="tiny")
+    active_item = summary["todo"]["active_items"][0]
     view = summary["continuation_view"]
 
+    assert active_item["next_action"] == "Use the fresher execplan action."
+    assert active_item["projection_freshness"] == "superseded-state-field"
+    assert active_item["projection_overrides"][0]["field"] == "next_action"
+    assert active_item["projection_overrides"][0]["stale_value"] == "Stale todo action."
+    assert summary["planning_surface_health"]["recommended_next_action"] == "Use the fresher execplan action."
+    assert summary["execution_readiness"]["recommendation"]["summary"] == "Use the fresher execplan action."
+    assert summary["current_execution_pressure"]["recommended_next_action"] == "Use the fresher execplan action."
+    assert summary["decision_packet"]["next_action"] == "Use the fresher execplan action."
     assert view["answers"]["preserved_intent"] == "Preserve the active intent."
     assert view["answers"]["next_safe_action"] == "Use the fresher execplan action."
     assert view["resume_predicate"]["status"] == "pass"

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -12901,6 +12901,11 @@ def _derived_continuation_projection_payloads(
         target_root=target_root,
     )
     architecture_principles = _as_dict(source_payload.get("architecture_principles"))
+    installed_state_closeout_residue = _installed_state_closeout_residue_payload(
+        installed_state=_as_dict(source_payload.get("installed_state_compatibility")),
+        active_planning_record=closeout_planning_record,
+        cli_invoke=config.cli_invoke,
+    )
     closeout_report = _closeout_report_payload(
         active_planning_record=closeout_planning_record,
         closeout_trust=source_payload.get("closeout_trust", {}),
@@ -12908,6 +12913,7 @@ def _derived_continuation_projection_payloads(
         workflow_compliance_summary=workflow_compliance_summary,
         verification=verification,
         architecture_principles=architecture_principles,
+        installed_state_closeout_residue=installed_state_closeout_residue,
         config=config,
     )
     return {
@@ -13187,6 +13193,14 @@ def _run_lazy_report_section_command(
             payload["closeout_trust"] = closeout_trust
         payload["external_work_delta"] = external_work_delta
         payload["external_work_reconciliation"] = external_work_reconciliation
+        cli_compatibility = _cli_compatibility_payload(config=config, compact=True)
+        payload["installed_state_compatibility"] = _installed_state_compatibility_payload(
+            config=config,
+            selected_modules=selected_modules,
+            installed_modules=[str(module_name) for module_name in payload.get("installed_modules", [])],
+            cli_compatibility=cli_compatibility,
+            compact=True,
+        )
         payload["architecture_principles"] = _architecture_principles_payload(
             target_root=target_root,
             changed_paths=[],
@@ -23512,6 +23526,72 @@ def _compact_installed_state_drift_triage(triage: Any) -> dict[str, Any]:
             "detail_visibility",
         )
         if key in triage and triage.get(key) not in (None, "", [], {})
+    }
+
+
+def _closeout_changed_surface_paths(active_planning_record: Any) -> list[str]:
+    execution = _as_dict(_as_dict(active_planning_record).get("execution_run"))
+    raw_values = [
+        execution.get("changed surfaces"),
+        execution.get("changed_surfaces"),
+        execution.get("scope touched"),
+        execution.get("scope_touched"),
+    ]
+    paths: list[str] = []
+    for raw in raw_values:
+        if isinstance(raw, list):
+            candidates = raw
+        else:
+            candidates = re.split(r"[;\n,]+", str(raw or ""))
+        for candidate in candidates:
+            text = str(candidate).strip()
+            if not text or text.lower() in {"none", "none yet", "pending", "not recorded"}:
+                continue
+            paths.append(text)
+    return _normalize_changed_paths(paths)
+
+
+def _installed_state_closeout_residue_payload(
+    *,
+    installed_state: dict[str, Any],
+    active_planning_record: dict[str, Any],
+    cli_invoke: str,
+) -> dict[str, Any]:
+    status = str(installed_state.get("status") or "compatible")
+    if status == "compatible":
+        return {
+            "kind": "agentic-workspace/installed-state-closeout-residue/v1",
+            "status": "not_applicable",
+            "current_task_proof_effect": "none",
+        }
+    delegated = _as_dict(active_planning_record.get("delegated_judgment"))
+    requested_outcome = str(delegated.get("requested outcome") or delegated.get("requested_outcome") or "").strip()
+    changed_paths = _closeout_changed_surface_paths(active_planning_record)
+    triage = _installed_state_drift_triage_payload(
+        installed_state=installed_state,
+        task_text=requested_outcome,
+        changed_paths=changed_paths,
+        cli_invoke=cli_invoke,
+    )
+    triage_status = str(triage.get("status") or "")
+    current_task_blocking = triage_status in {"claim_blocking", "actionable_now"}
+    return {
+        "kind": "agentic-workspace/installed-state-closeout-residue/v1",
+        "status": "current_task_blocking" if current_task_blocking else "separate_maintenance_residue",
+        "installed_state_status": status,
+        "triage_status": triage_status,
+        "current_task_proof_effect": "blocking" if current_task_blocking else "not_blocking_narrow_task_proof",
+        "proof_claim_rule": (
+            "Installed payload drift blocks this closeout only when the task changes or claims installed/generated payload freshness."
+        ),
+        "residue": {
+            "status": "open",
+            "owner": "installed-payload-sync",
+            "next_action": triage.get("repair_command") or triage.get("selector") or "inspect installed_state_compatibility",
+            "claim_boundary": triage.get("claim_boundary", ""),
+        },
+        "triage": _compact_installed_state_drift_triage(triage),
+        "changed_paths_considered": changed_paths,
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -645,6 +645,7 @@ def _closeout_report_payload(
     workflow_compliance_summary: dict[str, Any],
     verification: dict[str, Any],
     architecture_principles: dict[str, Any] | None = None,
+    installed_state_closeout_residue: dict[str, Any] | None = None,
     config: WorkspaceConfig,
 ) -> dict[str, Any]:
     active_planning_record = active_planning_record if isinstance(active_planning_record, dict) else {}
@@ -652,6 +653,7 @@ def _closeout_report_payload(
     completion_contract = completion_contract if isinstance(completion_contract, dict) else {}
     verification = verification if isinstance(verification, dict) else {}
     architecture_principles = architecture_principles if isinstance(architecture_principles, dict) else {}
+    installed_state_closeout_residue = installed_state_closeout_residue if isinstance(installed_state_closeout_residue, dict) else {}
     execution = _as_dict(active_planning_record.get("execution_run"))
     proof_report = _as_dict(active_planning_record.get("proof_report"))
     closure_check = _as_dict(active_planning_record.get("closure_check"))
@@ -922,6 +924,7 @@ def _closeout_report_payload(
         "parent_intent_status": parent_intent_status,
         "applicable_intent_status": applicable_intent_status,
         "architecture_principles_status": architecture_principles,
+        "installed_state_residue": installed_state_closeout_residue,
         "changes": {
             "changed_surfaces": changed_surfaces,
             "scope_touched": str(execution.get("scope touched") or "").strip(),
@@ -944,6 +947,7 @@ def _closeout_report_payload(
             "task_posture_followthrough": task_posture_followthrough,
             "residual_risk": residual_risk,
             "durable_residue_action": closeout_trust.get("durable_residue_action", {}),
+            "installed_state_residue": installed_state_closeout_residue,
             "workflow_trust_impact": workflow_compliance_summary.get("trust_impact", "unknown")
             if isinstance(workflow_compliance_summary, dict)
             else "unknown",

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -127,6 +127,111 @@ candidates = []
     assert loop["safe_claim"] in {"full", "partial", "blocked", "none"}
 
 
+def _closeout_report_with_installed_state(tmp_path: Path, *, changed_surfaces: str, requested_outcome: str) -> dict[str, object]:
+    config = workspace_runtime_core._load_workspace_config(target_root=tmp_path)
+    installed_state = {
+        "status": "payload-upgrade-required",
+        "action_effect": {
+            "force": "required_before_claim",
+            "resolution_command": "agentic-workspace upgrade --target . --dry-run --format json",
+            "claim_boundary": "do not claim installed payload freshness",
+        },
+    }
+    active_record = {
+        "execution_run": {
+            "what happened": "Finished the slice.",
+            "changed surfaces": changed_surfaces,
+        },
+        "delegated_judgment": {"requested outcome": requested_outcome},
+        "proof_report": {
+            "validation proof": "uv run pytest tests/test_workspace_summary_cli.py",
+            "proof achieved now": "yes",
+        },
+        "closure_check": {"closure decision": "archive-and-close"},
+    }
+    return workspace_runtime_core._derived_continuation_projection_payloads(
+        target_root=tmp_path,
+        config=config,
+        source_payload={
+            "closeout_trust": {},
+            "installed_state_compatibility": installed_state,
+            "architecture_principles": {},
+        },
+        active_planning_record=active_record,
+        assurance_requirements={},
+        verification={},
+        external_work_delta={"status": "not-evaluated"},
+        external_work_reconciliation={"status": "not-evaluated"},
+    )["closeout_report"]
+
+
+def test_closeout_report_routes_unrelated_installed_state_drift_as_residue(tmp_path: Path) -> None:
+    report = _closeout_report_with_installed_state(
+        tmp_path,
+        changed_surfaces="docs/typo.md",
+        requested_outcome="Fix one docs typo.",
+    )
+
+    residue = report["installed_state_residue"]
+    assert residue["status"] == "separate_maintenance_residue"
+    assert residue["current_task_proof_effect"] == "not_blocking_narrow_task_proof"
+    assert residue["residue"]["owner"] == "installed-payload-sync"
+    assert residue["triage"]["status"] == "waived_for_narrow_work"
+    assert report["gaps_and_residual_risk"]["installed_state_residue"]["status"] == "separate_maintenance_residue"
+
+
+def test_closeout_report_keeps_installed_state_drift_blocking_for_owned_surfaces(tmp_path: Path) -> None:
+    report = _closeout_report_with_installed_state(
+        tmp_path,
+        changed_surfaces="src/agentic_workspace/workspace_runtime_core.py",
+        requested_outcome="Verify payload freshness before release.",
+    )
+
+    residue = report["installed_state_residue"]
+    assert residue["status"] == "current_task_blocking"
+    assert residue["current_task_proof_effect"] == "blocking"
+    assert residue["triage"]["claim_relevant"] is True
+    assert residue["changed_paths_considered"] == ["src/agentic_workspace/workspace_runtime_core.py"]
+
+
+def test_closeout_report_section_reads_installed_state_residue(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_bootstrap(target=tmp_path)
+
+    def fake_installed_state_compatibility(**_: object) -> dict[str, object]:
+        return {
+            "status": "payload-upgrade-required",
+            "action_effect": {
+                "force": "required_before_claim",
+                "resolution_command": "agentic-workspace upgrade --target . --dry-run --format json",
+                "claim_boundary": "do not claim installed payload freshness",
+            },
+        }
+
+    monkeypatch.setattr(workspace_runtime_core, "_installed_state_compatibility_payload", fake_installed_state_compatibility)
+    monkeypatch.setattr(
+        workspace_runtime_core,
+        "_active_planning_record_for_report_section",
+        lambda target_root: {
+            "execution_run": {
+                "what happened": "Finished the docs slice.",
+                "changed surfaces": "docs/typo.md",
+            },
+            "delegated_judgment": {"requested outcome": "Fix one docs typo."},
+            "proof_report": {"validation proof": "uv run pytest tests/test_workspace_summary_cli.py"},
+        },
+    )
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "closeout_report", "--format", "json"]) == 0
+
+    report = json.loads(capsys.readouterr().out)["answer"]
+    residue = report["installed_state_residue"]
+    assert residue["status"] == "separate_maintenance_residue"
+    assert residue["current_task_proof_effect"] == "not_blocking_narrow_task_proof"
+    assert residue["residue"]["owner"] == "installed-payload-sync"
+
+
 def test_report_local_aw_state_classifies_ignored_policy_and_cache(tmp_path: Path, capsys) -> None:
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
     _write(tmp_path / ".gitignore", ".agentic-workspace/local/\n.agentic-workspace/verification/\n")


### PR DESCRIPTION
## Summary
- Separates installed-payload sync drift from narrow closeout proof in `closeout_report`.
- Keeps stale planning scaffold fields out of live compact summary guidance by projecting fresher continuation answers while retaining superseded values as audit evidence.
- Archives the #1957/#1958 execution plan with proof and residue boundaries.

Closes #1957.
Closes #1958.

## Proof
- `uv run pytest packages/planning/tests/test_promote.py -k stale -q`
- `uv run pytest tests/test_workspace_summary_cli.py -k 'installed_state_drift or installed_state_residue' -q`
- `uv run pytest tests/test_workspace_summary_cli.py -q`
- `make lint-planning`
- `make typecheck-planning`
- `make lint-workspace`
- `make typecheck`
- `make test-planning`
- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`
- `make test-workspace`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`

## Residue
`doctor --modules planning` still reports pre-existing installed payload sync/provenance drift. This PR does not sync installed payloads and must not be read as proof of installed payload freshness.

## Architecture Principle
Host-agnostic agent judgment is preserved. The change uses structured planning continuation facts, changed-surface paths from the active record, AW-owned installed-state enum/status payloads, and configured CLI commands. It does not add package-owned prose keyword routing or repo-specific issue taxonomy.