### PR TITLE
Expose proof narrowness before broad validation

### DIFF
--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,8 +13,8 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:9f6237baef02",
-    "version": "0.15.0"
+    "source_identity": "git:0bfa5f527eb5",
+    "version": "0.15.2"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
   "payload_files": [
@@ -37,8 +37,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.15.0",
-    "version": "0.15.0"
+    "tag": "v0.15.2",
+    "version": "0.15.2"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/docs/reference/proof-selection-rules.md
+++ b/docs/reference/proof-selection-rules.md
@@ -15,6 +15,7 @@ Rules for selecting validation lanes from changed paths and task scope.
 | `rules` | array of object | yes |  | Policy rules that explain this contract behavior. |  |  |
 | `lane_proof_kinds` | object | no |  | Optional proof-kind classifications keyed by validation lane id. |  |  |
 | `lane_proof_kinds.<name>` | enum `"diff-review"`, `"surface-check"`, `"targeted-test"`, `"full-test"` | no |  | Proof kind for one validation lane. |  |  |
+| `broad_acceptance_lanes` | array of string | no |  | Lanes where broad proof is required when selected, even if the lane remains a targeted-test kind. |  |  |
 | `docs_only_reducer` | object | no |  | Second-stage classifier that can downgrade docs-only path-prefix matches to review proof. |  |  |
 | `docs_only_reducer.lane` | string | yes |  | Lane to use after reducing an eligible docs-only match. |  |  |
 | `docs_only_reducer.source_lanes` | array of string | yes |  | Matched lanes that may be reduced when the changed path is docs-only. |  |  |

--- a/src/agentic_workspace/contracts/proof_selection_rules.json
+++ b/src/agentic_workspace/contracts/proof_selection_rules.json
@@ -12,6 +12,10 @@
     "planning_surfaces": "surface-check",
     "maintainer_surfaces": "surface-check"
   },
+  "broad_acceptance_lanes": [
+    "generated_command_packages",
+    "workspace_cli"
+  ],
   "docs_only_reducer": {
     "lane": "repo_docs_review",
     "source_lanes": [

--- a/src/agentic_workspace/contracts/schemas/proof_selection_rules.schema.json
+++ b/src/agentic_workspace/contracts/schemas/proof_selection_rules.schema.json
@@ -75,6 +75,14 @@
       },
       "description": "Optional proof-kind classifications keyed by validation lane id."
     },
+    "broad_acceptance_lanes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Validation lane whose selected commands are broad proof for the current acceptance boundary."
+      },
+      "description": "Lanes where broad proof is required when selected, even if the lane remains a targeted-test kind."
+    },
     "docs_only_reducer": {
       "type": "object",
       "required": [

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -478,6 +478,7 @@
           "_architecture_principles_payload",
           "_closeout_intent_evidence_payload",
           "_compact_continuation_state_contract",
+          "_decision_maturity_payload",
           "_compact_intent_evidence",
           "_compact_start_delegation_decision",
           "_compact_start_prep_only_handoff",

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -1006,7 +1006,7 @@ def _tiny_proof_route_maintenance_payload(value: dict[str, Any]) -> dict[str, An
         }
         for item in value.get("suggested_updates", [])
         if isinstance(item, dict)
-    ][:3]
+    ][:1]
     return {
         "kind": value.get("kind", "proof-route-maintenance/v1"),
         "status": value.get("status", "unknown"),
@@ -1024,11 +1024,19 @@ def _implement_tiny_proof_narrowness_payload(value: Any) -> dict[str, Any]:
     packet = value if isinstance(value, dict) else {}
     if not _include_tiny_proof_narrowness(packet):
         return {}
+    compact = {"status": packet.get("status", "unknown")}
     if packet.get("status") == "broad_required":
-        return {}
-    return {
-        "status": packet.get("status", "unknown"),
-    }
+        raw_triggers = packet.get("expansion_triggers")
+        expansion_triggers: list[Any] = raw_triggers if isinstance(raw_triggers, list) else []
+        first_trigger = next((item for item in expansion_triggers if isinstance(item, dict) and item.get("lane")), {})
+        boundary = _as_dict(packet.get("broad_suite_boundary"))
+        compact.update(
+            {
+                "expansion_trigger_lane": str(first_trigger.get("lane", "")) if first_trigger else "",
+                "broad_suite_boundary_status": str(boundary.get("status", "")),
+            }
+        )
+    return {key: payload for key, payload in compact.items() if payload not in ("", [], {}, None)}
 
 
 def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -118,6 +118,7 @@ from agentic_workspace.workspace_runtime_planning import (
     _planning_safety_gate_payload,
 )
 from agentic_workspace.workspace_runtime_proof import (
+    _include_tiny_proof_narrowness,
     _proof_selection_for_changed_paths,
     _tiny_proof_obligations_payload,
     _verification_report_payload,
@@ -1019,6 +1020,17 @@ def _tiny_proof_route_maintenance_payload(value: dict[str, Any]) -> dict[str, An
     }
 
 
+def _implement_tiny_proof_narrowness_payload(value: Any) -> dict[str, Any]:
+    packet = value if isinstance(value, dict) else {}
+    if not _include_tiny_proof_narrowness(packet):
+        return {}
+    if packet.get("status") == "broad_required":
+        return {}
+    return {
+        "status": packet.get("status", "unknown"),
+    }
+
+
 def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     target_root = Path(str(payload.get("target", ".")))
     config = _load_workspace_config(target_root=target_root)
@@ -1242,6 +1254,9 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 payload.get("proof", {}).get("proof_obligations", {}), required_commands=proof_commands
             )
             if isinstance(payload.get("proof"), dict) and isinstance(payload.get("proof", {}).get("proof_obligations"), dict)
+            else {},
+            "proof_narrowness": _implement_tiny_proof_narrowness_payload(payload.get("proof", {}).get("proof_narrowness", {}))
+            if isinstance(payload.get("proof"), dict)
             else {},
             "proof_route_maintenance": _tiny_proof_route_maintenance_payload(payload.get("proof", {}).get("proof_route_maintenance", {}))
             if isinstance(payload.get("proof"), dict)
@@ -1558,6 +1573,9 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
     generated_cli_freshness = projected["proof"].get("generated_cli_freshness", {})
     if not (isinstance(generated_cli_freshness, dict) and generated_cli_freshness.get("kind")):
         projected["proof"].pop("generated_cli_freshness", None)
+    proof_narrowness = projected["proof"].get("proof_narrowness", {})
+    if not (isinstance(proof_narrowness, dict) and proof_narrowness.get("status")):
+        projected["proof"].pop("proof_narrowness", None)
     runtime_source_review = projected["proof"].get("runtime_source_edit_review", {})
     if not (
         isinstance(runtime_source_review, dict)

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -162,6 +162,39 @@ def _compact_tiny_intent_proof(intent_proof: Any) -> dict[str, Any]:
     return compact
 
 
+def _compact_tiny_proof_narrowness(value: Any) -> dict[str, Any]:
+    packet = value if isinstance(value, dict) else {}
+    if not packet:
+        return {}
+    required_items = [item for item in _list_payload(packet.get("required")) if isinstance(item, dict)]
+    trigger_items = [item for item in _list_payload(packet.get("expansion_triggers")) if isinstance(item, dict)]
+    first_required = required_items[0] if required_items else {}
+    first_trigger = trigger_items[0] if trigger_items else {}
+    compact = {
+        "status": packet.get("status", "unknown"),
+        "expansion_trigger_lane": str(first_trigger.get("lane", "")) if first_trigger.get("lane") else "",
+        "broad_suite_boundary_status": _as_dict(packet.get("broad_suite_boundary")).get("status", ""),
+    }
+    if first_required and packet.get("status") != "broad_required":
+        compact["required_reason_sample"] = {
+            "why_required": str(first_required.get("why_required", "")),
+            "acceptance_boundary": first_required.get("acceptance_boundary", True),
+        }
+    return {key: payload for key, payload in compact.items() if payload not in ("", [], {}, None)}
+
+
+def _include_tiny_proof_narrowness(value: Any) -> bool:
+    packet = value if isinstance(value, dict) else {}
+    status = str(packet.get("status", ""))
+    if status == "broad_required":
+        return True
+    if status != "narrow_required":
+        return False
+    return any(
+        isinstance(item, dict) and str(item.get("proof_kind", "")) != "diff-review" for item in _list_payload(packet.get("required"))
+    )
+
+
 def _compact_tiny_high_risk_overlay(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict) or value.get("status") != "active":
         return {}
@@ -233,6 +266,12 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
             )
             if include_intent_proof:
                 next_decision["intent_proof"] = _compact_tiny_intent_proof(answer["intent_proof"])
+            raw_proof_narrowness = answer.get("proof_narrowness")
+            proof_narrowness = (
+                _compact_tiny_proof_narrowness(raw_proof_narrowness) if _include_tiny_proof_narrowness(raw_proof_narrowness) else {}
+            )
+            if proof_narrowness:
+                next_decision["proof_narrowness"] = proof_narrowness
             local_overlay = _compact_tiny_local_overlay(answer.get("local_overlay"))
             if local_overlay:
                 next_decision["local_overlay"] = local_overlay
@@ -277,6 +316,13 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
             },
             "required_commands": required_commands,
             **({"intent_proof": _compact_tiny_intent_proof(answer["intent_proof"])} if include_intent_proof else {}),
+            **(
+                {"proof_narrowness": _compact_tiny_proof_narrowness(answer.get("proof_narrowness"))}
+                if isinstance(answer, dict)
+                and answer.get("proof_narrowness")
+                and _include_tiny_proof_narrowness(answer.get("proof_narrowness"))
+                else {}
+            ),
             **({"local_overlay": local_overlay} if local_overlay else {}),
             **({"high_risk_overlay": high_risk_overlay} if high_risk_overlay else {}),
             **(
@@ -1885,6 +1931,120 @@ def _proof_obligations_payload(
     }
 
 
+def _lane_activation_summary(lane: dict[str, Any]) -> str:
+    applies_because = _list_payload(lane.get("applies_because"))
+    if applies_because:
+        return str(applies_because[0])
+    when = _list_payload(lane.get("when"))
+    if when:
+        return str(when[0])
+    matched_paths = _list_payload(lane.get("matched_paths"))
+    if matched_paths:
+        return "changed path matched " + ", ".join(str(path) for path in matched_paths[:3])
+    return "selected by changed-path proof routing"
+
+
+def _proof_narrowness_payload(
+    *,
+    selected_lanes: list[dict[str, Any]],
+    selected_commands: list[dict[str, Any]],
+    required_commands: list[str],
+    optional_commands: list[str],
+    broaden_when: list[str],
+    escalate_when: list[str],
+    manual_verification: dict[str, Any] | None,
+) -> dict[str, Any]:
+    lane_by_id = {str(lane.get("id", "")): lane for lane in selected_lanes}
+    broad_acceptance_lanes = {str(lane_id) for lane_id in _list_payload(_PROOF_SELECTION_RULES.get("broad_acceptance_lanes"))}
+    command_tiers = _proof_command_tiers(selected_commands=selected_commands, required_commands=required_commands)
+    tier_by_command = {
+        str(item.get("command", "")): str(tier.get("id", ""))
+        for tier in _list_payload(command_tiers.get("tiers"))
+        if isinstance(tier, dict)
+        for item in _list_payload(tier.get("commands"))
+        if isinstance(item, dict)
+    }
+    required: list[dict[str, Any]] = []
+    for command in selected_commands:
+        command_text = str(command.get("command", ""))
+        if command_text not in required_commands:
+            continue
+        lane_id = str(command.get("lane", ""))
+        lane = lane_by_id.get(lane_id, {})
+        proof_kind = str(lane.get("proof_kind") or command.get("proof_kind") or "")
+        command_tier = tier_by_command.get(command_text, "")
+        required.append(
+            {
+                "command": command_text,
+                "lane": lane_id,
+                "proof_kind": proof_kind,
+                "command_tier": command_tier,
+                "why_required": _lane_activation_summary(lane),
+                "authority": str(command.get("route_authority") or command.get("selected_from") or "proof-route-selection"),
+                "acceptance_boundary": True,
+                "claim_boundary": "Required proof must pass or be explicitly reconciled before completion is claimed.",
+            }
+        )
+    optional = [
+        {
+            "command": str(command),
+            "why_optional": "Confidence or orientation check; not selected as the completion proof gate for these changed paths.",
+            "acceptance_boundary": False,
+        }
+        for command in optional_commands
+    ]
+    expansion_triggers: list[dict[str, Any]] = []
+    for lane in selected_lanes:
+        lane_id = str(lane.get("id", ""))
+        proof_kind = str(lane.get("proof_kind", ""))
+        if proof_kind == "full-test" or lane_id in broad_acceptance_lanes:
+            expansion_triggers.append(
+                {
+                    "trigger": "selected lane requires broad proof",
+                    "lane": lane_id,
+                    "why": _lane_activation_summary(lane),
+                    "effect": "broad proof is part of required_commands, not optional confidence",
+                }
+            )
+    for condition in broaden_when:
+        expansion_triggers.append({"trigger": "broaden_when", "why": str(condition), "effect": "broaden proof before closeout"})
+    for condition in escalate_when:
+        expansion_triggers.append({"trigger": "escalate_when", "why": str(condition), "effect": "escalate proof or review before closeout"})
+    broad_required = (
+        any(item.get("proof_kind") == "full-test" for item in required)
+        or any(item.get("command_tier") in {"generated_contract", "environmental"} for item in required)
+        or any(item.get("lane") in broad_acceptance_lanes for item in required)
+    )
+    if manual_verification is not None and not required_commands:
+        status = "manual_required"
+    elif broad_required:
+        status = "broad_required"
+    elif required_commands:
+        status = "narrow_required"
+    else:
+        status = "no_required_proof"
+    return {
+        "kind": "agentic-workspace/proof-narrowness/v1",
+        "status": status,
+        "required_command_count": len(required_commands),
+        "required": required,
+        "optional_confidence_check_count": len(optional_commands),
+        "optional_confidence_checks": optional,
+        "expansion_triggers": expansion_triggers,
+        "broad_suite_boundary": {
+            "status": "required_acceptance_boundary" if broad_required else "not_required_acceptance_boundary",
+            "rule": (
+                "Broad suite results are part of the acceptance boundary only when selected as required proof before validation runs; "
+                "otherwise they are confidence evidence the final report may mention without treating them as required."
+            ),
+        },
+        "final_report_rule": (
+            "Report required proof as the acceptance boundary. Report optional checks as confidence or residue unless a visible trigger "
+            "promoted them to required proof before they ran."
+        ),
+    }
+
+
 def _host_domain_proof_lanes_for_changed_paths(
     *,
     config: WorkspaceConfig | None,
@@ -2998,6 +3158,15 @@ def _proof_selection_for_changed_paths(
         )
         for command in optional_commands
     ]
+    proof_narrowness = _proof_narrowness_payload(
+        selected_lanes=selected_lanes,
+        selected_commands=selected_commands,
+        required_commands=required_commands,
+        optional_commands=optional_commands,
+        broaden_when=broaden_when,
+        escalate_when=escalate_when,
+        manual_verification=manual_verification,
+    )
     proof_obligations = _proof_obligations_payload(
         required_commands=required_commands,
         optional_commands=optional_commands,
@@ -3134,6 +3303,7 @@ def _proof_selection_for_changed_paths(
         "legacy_aliases": {"proof_route_decision": "proof_route_selection"},
         "proof_next_decision": proof_next_decision,
         "proof_command_tiers": _proof_command_tiers(selected_commands=selected_commands, required_commands=required_commands),
+        "proof_narrowness": proof_narrowness,
         "proof_obligations": proof_obligations,
         "transient_validation_retry": _transient_validation_retry_guidance(required_commands=required_commands),
         "tiny_surface_compatibility_review": _tiny_surface_compatibility_review(changed_paths),

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -676,7 +676,7 @@ def _tiny_proof_obligations_payload(value: dict[str, Any], *, required_commands:
         },
         "recommended_confidence_checks": {
             "status": recommended.get("status", "unknown"),
-            "commands": recommended.get("commands", []),
+            **({"commands": recommended.get("commands", [])} if required_commands is None else {}),
             "rule": recommended.get("rule", ""),
         },
         "completion_claim_rule": value.get("completion_claim_rule", ""),

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -3072,6 +3072,74 @@ def test_proof_supports_exact_field_selectors_for_sufficiency(tmp_path: Path, ca
     assert "missing" not in payload
 
 
+def test_proof_compact_surfaces_narrowness_for_bounded_package_change(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(
+        tmp_path / "Makefile",
+        "test-planning:\n\t@echo ok\nlint-planning:\n\t@echo ok\ntypecheck-planning:\n\t@echo ok\n",
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "packages/planning/src/repo_planning_bootstrap/installer.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    narrowness = payload["proof_narrowness"]
+    assert narrowness["status"] == "narrow_required"
+    assert narrowness["required_reason_sample"]["acceptance_boundary"] is True
+    assert "package-local planning source" in narrowness["required_reason_sample"]["why_required"]
+    assert narrowness["broad_suite_boundary_status"] == "not_required_acceptance_boundary"
+
+
+def test_proof_narrowness_marks_generated_surface_broad_proof_required(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(tmp_path / "Makefile", "test-workspace:\n\t@echo ok\nlint-workspace:\n\t@echo ok\n")
+    _write(tmp_path / "scripts" / "run_agentic_workspace.py", "print('ok')\n")
+    _write(tmp_path / "scripts" / "check" / "check_generated_command_packages.py", "print('ok')\n")
+    _write(tmp_path / "scripts" / "check" / "run_operation_conformance_tests.py", "print('ok')\n")
+    _write(tmp_path / "tests" / "test_workspace_cli.py", "def test_ok():\n    assert True\n")
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "generated/workspace/python/cli.py",
+                "--select",
+                "proof_narrowness",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    narrowness = payload["values"]["proof_narrowness"]
+    assert narrowness["status"] == "broad_required"
+    assert narrowness["broad_suite_boundary"]["status"] == "required_acceptance_boundary"
+    assert any(trigger["trigger"] == "selected lane requires broad proof" for trigger in narrowness["expansion_triggers"])
+    assert all(item["acceptance_boundary"] is False for item in narrowness["optional_confidence_checks"])
+    assert "optional checks as confidence" in narrowness["final_report_rule"]
+
+
 def test_report_sections_expose_authority_and_compliance_boundaries(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -381,6 +381,37 @@ proof = [
     )
 
 
+def test_implement_compact_surfaces_proof_narrowness_before_validation(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(
+        tmp_path / "Makefile",
+        "test-planning:\n\t@echo ok\nlint-planning:\n\t@echo ok\ntypecheck-planning:\n\t@echo ok\n",
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "packages/planning/src/repo_planning_bootstrap/installer.py",
+                "--task",
+                "Update planning package installer",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    narrowness = payload["proof"]["proof_narrowness"]
+    assert narrowness["status"] == "narrow_required"
+
+
 def test_operating_loop_schema_rejects_unknown_enum_values() -> None:
     schema_path = Path("src/agentic_workspace/contracts/schemas/implementer_context.schema.json")
     schema = json.loads(schema_path.read_text(encoding="utf-8"))

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -412,6 +412,40 @@ def test_implement_compact_surfaces_proof_narrowness_before_validation(tmp_path:
     assert narrowness["status"] == "narrow_required"
 
 
+def test_implement_compact_surfaces_broad_proof_narrowness_before_validation(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(tmp_path / "Makefile", "test-workspace:\n\t@echo ok\nlint-workspace:\n\t@echo ok\n")
+    _write(tmp_path / "scripts" / "run_agentic_workspace.py", "print('ok')\n")
+    _write(tmp_path / "scripts" / "check" / "check_generated_command_packages.py", "print('ok')\n")
+    _write(tmp_path / "scripts" / "check" / "run_operation_conformance_tests.py", "print('ok')\n")
+    _write(tmp_path / "tests" / "test_workspace_cli.py", "def test_ok():\n    assert True\n")
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "generated/workspace/python/cli.py",
+                "--task",
+                "Update generated workspace CLI projection",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    narrowness = payload["proof"]["proof_narrowness"]
+    assert narrowness["status"] == "broad_required"
+    assert narrowness["broad_suite_boundary_status"] == "required_acceptance_boundary"
+    assert narrowness["expansion_trigger_lane"] in {"workspace_cli", "generated_command_packages"}
+
+
 def test_operating_loop_schema_rejects_unknown_enum_values() -> None:
     schema_path = Path("src/agentic_workspace/contracts/schemas/implementer_context.schema.json")
     schema = json.loads(schema_path.read_text(encoding="utf-8"))

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -661,11 +661,14 @@ def test_proof_tiny_profile_returns_next_validation_action(capsys) -> None:
         "manual_verification",
         "warnings",
         "intent_proof",
+        "proof_narrowness",
         "detail_command",
         "detail_command_template",
         "proof_route_selection",
     }
     assert payload["selector"] == {"changed": ["generated/workspace/python/cli.py"]}
+    assert payload["proof_narrowness"]["status"] == "broad_required"
+    assert payload["proof_narrowness"]["broad_suite_boundary_status"] == "required_acceptance_boundary"
     assert payload["next"]["action"] == "run-validation-command"
     assert payload["next"]["command"] == "make test-workspace"
     assert "make lint-workspace" in payload["required_commands"]


### PR DESCRIPTION
## Summary
- add `proof_narrowness` so AW states whether selected proof is narrow, broad-required, manual, or absent before validation runs
- mark broad acceptance lanes from structured proof-selection config instead of package-owned prose or filename heuristics
- surface compact proof narrowness on `proof` and `implement` where it changes the current proof decision, including broad-required implement output
- sync the checked-in AW payload provenance to the current coordinated release identity

Closes #1959

## Evidence
- `uv run pytest tests/test_workspace_cli.py -k 'proof_narrowness or proof_compact_surfaces_narrowness or exact_field_selectors_for_sufficiency' -q`
- `uv run pytest tests/test_workspace_implement_cli.py -k 'proof_narrowness_before_validation or broad_proof_narrowness_before_validation or default_stays_under_tiny_output_budget or tiny_profile_returns_next_decision_without_diagnostics' -q`
- `uv run pytest tests/test_workspace_proof_cli.py -k 'tiny_profile_returns_next_validation_action or tiny_readme_profile_keeps_docs_only_validation_light' -q`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make lint-workspace`
- `make typecheck`
- `make test-workspace`
- `make maintainer-surfaces`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `make absolute-paths`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --format json`
- `uv run python scripts/run_agentic_workspace.py start --target . --select installed_state_compatibility --format json`
- `git diff --check`

## AW proof checks
- Bounded planning package change reports `proof_narrowness.status = narrow_required` and `broad_suite_boundary_status = not_required_acceptance_boundary`.
- Generated workspace CLI proof reports `proof_narrowness.status = broad_required` and `broad_suite_boundary.status = required_acceptance_boundary`.
- Generated workspace CLI implement output reports `proof.proof_narrowness.status = broad_required`, `broad_suite_boundary_status = required_acceptance_boundary`, and an expansion-trigger lane before validation runs.

## Architecture principle
Preserved. Broad proof lanes are declared in `proof_selection_rules.json` as structured contract data. The runtime does not infer proof narrowness from arbitrary prose keywords, issue taxonomy, or package-owned filename heuristics.

## Payload
Synced. `start --select installed_state_compatibility` and `doctor --target .` report installed-state compatibility as `compatible` with payload release identity `v0.15.2`.