### PR TITLE
[chatgpt] Add repo-owned maintainer workflow skills

### DIFF
--- a/tools/skills/REGISTRY.json
+++ b/tools/skills/REGISTRY.json
@@ -43,13 +43,39 @@
       }
     },
     {
+      "id": "pr-review-recheck",
+      "path": "pr-review-recheck/SKILL.md",
+      "scope": "repo-owned",
+      "stability": "repo-managed",
+      "summary": "review, re-review, and assess merge readiness for this repo's pull requests using intent, proof, closure, CI, and semver boundaries",
+      "activation_hints": {
+        "verbs": ["review", "re-review", "recheck", "approve", "merge", "comment"],
+        "nouns": ["pull request", "PR", "merge readiness", "review comment", "CI", "semver label"],
+        "phrases": ["review PR", "review pull request", "recheck PR", "check again", "merge if ready", "mark ready", "post a comment"],
+        "when": ["reviewing or rechecking pull requests", "deciding whether a PR is ready", "checking whether review feedback was addressed"]
+      }
+    },
+    {
+      "id": "github-issue-shaping",
+      "path": "github-issue-shaping/SKILL.md",
+      "scope": "repo-owned",
+      "stability": "repo-managed",
+      "summary": "shape or refine repo GitHub issues before creation or update while preserving intent, scope, evidence, and closure boundaries",
+      "activation_hints": {
+        "verbs": ["shape", "refine", "split", "prune", "update", "create", "file"],
+        "nouns": ["github issue", "issue lane", "issue refinement", "child issue", "parent issue", "final satisfaction", "non-solutions"],
+        "phrases": ["refine issue", "shape issue", "split into child issues", "create an issue lane", "add concrete suggestions", "final satisfaction"],
+        "when": ["turning findings into durable issue shape", "refining existing issues", "deciding issue hierarchy or closure boundaries"]
+      }
+    },
+    {
       "id": "self-improvement-dogfooding",
       "path": "self-improvement-dogfooding/SKILL.md",
       "scope": "repo-owned",
       "stability": "repo-managed",
       "summary": "run bounded repo-local improvement cycles that dogfood package surfaces without becoming shipped workflow",
       "activation_hints": {
-        "verbs": ["continue", "repeat", "improve", "optimise", "optimize", "evaluate", "dogfood", "autopilot"],
+        "verbs": ["continue", "repeat", "improve", "optimise", "optimize", "evaluate", "dogfood", "autopilot", "triage", "route"],
         "nouns": [
           "self-improvement",
           "dogfooding",
@@ -61,7 +87,9 @@
           "evaluation scenario",
           "exploratory evaluation",
           "findings issue",
-          "model CLI evaluation"
+          "model CLI evaluation",
+          "dogfooding finding",
+          "friction signal"
         ],
         "phrases": [
           "run self-improvement",
@@ -74,14 +102,17 @@
           "skill optimization evaluation loop",
           "model cli optimisation loop",
           "dogfood the package",
-          "system-intent-driven dogfooding"
+          "system-intent-driven dogfooding",
+          "triage dogfooding finding",
+          "route friction signal"
         ],
         "when": [
           "repo-local improvement loop",
           "skill-routing optimisation",
           "model CLI dogfooding loop",
           "autonomous package dogfooding",
-          "system-intent follow-through"
+          "system-intent follow-through",
+          "single observed dogfooding finding needs routing"
         ]
       }
     },

--- a/tools/skills/github-issue-shaping/SKILL.md
+++ b/tools/skills/github-issue-shaping/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: github-issue-shaping
+description: Shape or refine Agentic Workspace GitHub issues before creation or update while preserving intent, scope, evidence, and honest closure boundaries.
+---
+
+# GitHub Issue Shaping
+
+Use this repo-owned skill when refining an existing issue, turning a finding into a lane or child issue, or deciding whether a new issue should be created for this repository. Use `github-issue-creation` after this skill only when a new issue must actually be created.
+
+## Procedure
+
+1. Identify the real problem before naming a solution:
+   - what is missing, mis-shaped, noisy, unsafe, or too costly today;
+   - why it matters beyond the local symptom;
+   - who owns the final intended outcome.
+2. Choose the issue shape:
+   - `bug` for correctness, reliability, regression, or broken behavior;
+   - `direction` for product direction, architecture, lanes, or bounded planning slices;
+   - `review` for dogfooding friction, trust gaps, continuation gaps, and review findings.
+3. Decide hierarchy:
+   - parent direction / lane;
+   - child slice / bounded follow-on;
+   - cross-cutting proposal;
+   - no new issue, only a comment or direct fix.
+4. Preserve closure boundaries:
+   - intended final outcome;
+   - observable acceptance criteria;
+   - non-solutions;
+   - evidence required for final completion;
+   - completion rule for whether a PR may close the issue.
+5. Keep useful slices honest:
+   - name a useful first slice only if it does not imply final closure;
+   - route residual intent to a clear owner;
+   - avoid creating follow-up issues as a substitute for completing the stated outcome.
+6. If creating the issue, hand off to `github-issue-creation` so the template, labels, and refresh/reconcile steps are preserved.
+7. If updating an issue, preserve the existing template headings unless a human asks to reshape the issue format.
+
+## Output
+
+Report the shaped issue in this form:
+
+- `recommended_action`: create issue / update issue / comment only / direct fix / dismiss
+- `issue_kind`: bug / direction / review
+- `hierarchy`: parent / child / cross-cutting / none
+- `parent_or_refs`: issue, PR, lane, file, or evidence refs
+- `problem_intent`: concise statement of the actual problem
+- `intended_outcome`: final state that must become true
+- `scope`: in scope and out of scope
+- `acceptance`: observable final-state criteria
+- `non_solutions`: what does not close the issue
+- `evidence_required`: proof or review evidence for final completion
+- `completion_rule`: when a PR may close it
+- `remaining_gap_owner`: where any residual intent lives
+
+## Rules
+
+- Do not create a new issue when a direct fix, PR comment, or existing issue update is the smaller durable owner.
+- Do not make a parent direction issue closable by a single useful slice unless final satisfaction is truly delivered.
+- Do not preserve history for its own sake; preserve only future-useful intent, proof, and continuation context.
+- Keep repo-specific maintainer expectations here, not in shipped installed AW skills.

--- a/tools/skills/pr-review-recheck/SKILL.md
+++ b/tools/skills/pr-review-recheck/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pr-review-recheck
+description: Review, re-review, or assess merge readiness for Agentic Workspace pull requests while preserving intent, proof, closure, CI, and semver boundaries.
+---
+
+# PR Review / Recheck
+
+Use this repo-owned skill when reviewing an Agentic Workspace PR, checking a fix after review feedback, or deciding whether a PR is ready to merge. This is maintainer workflow guidance for this repository only; do not ship it as an installed AW skill.
+
+## Procedure
+
+1. Identify the PR's claimed intent:
+   - PR title and body;
+   - linked issue(s) and closure claims;
+   - any review comments, evidence reports, or requested fixes.
+2. Inspect the current changed-file set before opening broad files.
+3. For first review, compare the diff against the linked issue's final intended outcome, non-solutions, and evidence requirements.
+4. For recheck, start from the previous blocker or requested change, then inspect only the follow-up delta unless new evidence points wider.
+5. Check proof separately from intent satisfaction:
+   - CI and reported validation;
+   - focused tests for changed behavior;
+   - generated/payload sync when shipped or mirrored surfaces changed;
+   - semver label when package behavior or shipped payload changes.
+6. Check closure honesty:
+   - what landed;
+   - what intent it serves;
+   - what remains unresolved;
+   - whether the PR may honestly close each linked issue.
+7. Decide the action:
+   - approve / ready when intent, proof, CI, labels, and closure all line up;
+   - comment with a blocker when the ordinary path would be wrong after merge;
+   - comment with non-blocking suggestions only when they should not delay merge;
+   - merge only when the user explicitly asks or the current instruction permits it.
+
+## Recheck Focus
+
+When rechecking after a fix, do not repeat the whole original review by default. Verify:
+
+- the specific blocker was removed;
+- no stale checked-in state or residue remains;
+- tests/evidence were updated if the blocker concerned behavior;
+- the PR body, labels, and closure claims still match the new state.
+
+## Blockers
+
+Treat these as blockers unless the human explicitly accepts the risk:
+
+- linked issue would close without final satisfaction being true;
+- proof is missing, stale, too narrow, or contradicted by the diff;
+- checked-in Planning, Memory, payload, or generated state is stale after the claimed closeout;
+- package-affecting changes lack exactly one semver label;
+- a shipped payload mirror is out of sync with the source surface;
+- a draft PR is treated as merge-ready without explicit direction.
+
+## Output
+
+Report in this shape:
+
+- `decision`: approve / ready / comment / block / merge-ready / not-ready
+- `what_landed`: concise summary of the actual change
+- `intent_served`: which issue or product intent is served
+- `proof`: CI, validation, focused checks, or missing proof
+- `unresolved`: blockers or remaining non-blocking risks
+- `closure_honest`: yes / no / partial, with issue refs
+- `next_action`: comment, approve, wait, request fix, label, or merge
+
+## Rules
+
+- Prefer evidence from the current PR head over stale prior comments.
+- Do not infer merge readiness from passing CI alone.
+- Keep comments focused on actionable blockers or durable suggestions.
+- If GitHub disallows a formal review action on an own-account PR, post the review as a top-level PR comment instead.

--- a/tools/skills/self-improvement-dogfooding/SKILL.md
+++ b/tools/skills/self-improvement-dogfooding/SKILL.md
@@ -136,6 +136,33 @@ Treat dogfooding friction as product input, but do not derail the active lane. P
 5. Record a review finding when evidence needs later prioritization.
 6. Promote durable repo knowledge to memory only when it will prevent rediscovery.
 
+## Single Finding Triage
+
+Use this compact triage when one dogfooding finding appears during unrelated work and does not justify a full self-improvement pass.
+
+1. State the friction in one sentence and name the observed evidence.
+2. Classify the owner:
+   - direct fix now;
+   - GitHub issue;
+   - Memory note;
+   - Planning state;
+   - docs/checks/contracts;
+   - PR or review comment;
+   - dismissed with reason.
+3. Check whether the finding is repo-local, package-generic, or agent-runtime-specific.
+4. Route only the future-useful residue; do not preserve the whole chat or transcript.
+5. If creating an issue, use the repo-owned issue shaping/creation skills.
+6. If dismissing, say why future agents do not need to act differently.
+
+Output:
+
+- `finding`: one sentence
+- `evidence`: issue, PR, command, file, or review ref
+- `owner`: direct fix / issue / Memory / Planning / docs-checks-contracts / review / dismissed
+- `portability`: repo-local / package-generic / agent-runtime-specific
+- `action`: what was done or where it was routed
+- `remaining_gap`: none or explicit owner
+
 ## Required Anti-Overfitting Review
 
 Before closing a self-improvement pass, record a compact anti-overfitting review in the execplan closeout, review artifact, or issue-close proof. Do not treat validation success alone as enough to close.


### PR DESCRIPTION
## Summary

Implements #1967.

- Adds a repo-owned `pr-review-recheck` skill for PR review, re-review, merge-readiness, closure honesty, proof, CI, and semver checks.
- Adds a repo-owned `github-issue-shaping` skill for issue refinement, lane/child shaping, final satisfaction, non-solutions, and evidence boundaries before issue creation or update.
- Extends `self-improvement-dogfooding` with a compact single-finding triage procedure for routing dogfooding friction without starting a full improvement pass.
- Registers the new repo-owned skills in `tools/skills/REGISTRY.json` and keeps all changes out of shipped `.agentic-workspace/skills` and payload mirrors.

Closes #1967

## Proof

- Not run here. Changes are limited to repo-owned skill Markdown and the repo-owned tool-skill registry JSON; CI should verify repository-level checks.

## Boundary

These are maintainer aids for this repository only. They are intentionally not added to installed AW skill payloads or shipped workspace defaults.