### PR TITLE
Expose message economy contract

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -208,6 +208,44 @@ def current_decision_payload(
     }
 
 
+def message_economy_payload(*, surface: str, communication_contract: dict[str, Any] | None = None) -> dict[str, Any]:
+    contract = communication_contract if isinstance(communication_contract, dict) else communication_contract_payload(surface=surface)
+    return {
+        "kind": "agentic-workspace/message-economy/v1",
+        "surface": surface,
+        "status": "active",
+        "speak_when": [
+            "decision_changed",
+            "proof_boundary_changed",
+            "residue_or_owner_changed",
+            "next_safe_action_changed",
+            "safety_or_reversibility_changed",
+        ],
+        "stay_compact_when": [
+            "state_unchanged",
+            "evidence_already_queryable",
+            "detail_route_available",
+            "chronology_not_trust_relevant",
+        ],
+        "expand_when": list(contract.get("expand_when", []))
+        or [
+            "ambiguous_action_safety",
+            "stale_missing_or_failed_proof",
+            "user_requests_detail",
+            "unresolved_residue",
+        ],
+        "discourage": [
+            "low_value_tool_chronology",
+            "repeated_state_recaps",
+            "broad_process_narration_without_decision_delta",
+        ],
+        "preserve": ["proof_boundary", "residue_or_claim_boundary", "next_safe_action", "uncertainty_when_action_changing"],
+        "density_rule": "Default visible updates should be compact state deltas; expand only when the triggers change trust, safety, proof, residue, or user value.",
+        "source_contract": contract.get("kind", "agentic-workspace/communication-contract/v1"),
+        "rule": "Message cadence is derived from structured communication state, not from prompt-prose keyword matching.",
+    }
+
+
 def _load_reasoning_economy_evidence_ledger(*, target_root: Path | None) -> dict[str, Any]:
     if target_root is None:
         return {

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -18,6 +18,7 @@ from agentic_workspace.reporting_support import (
     communication_contract_payload,
     compact_communication_contract_payload,
     current_decision_payload,
+    message_economy_payload,
 )
 from agentic_workspace.workspace_runtime_core import (
     _CONTEXT_TEMPLATES,
@@ -1710,6 +1711,9 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         payload.get("installed_state_compatibility"), dict
     )
     if show_current_decision:
+        selected["message_economy"] = message_economy_payload(
+            surface="startup", communication_contract=compact_communication_contract_payload(surface="startup")
+        )
         selected["current_decision"] = current_decision_payload(
             surface="startup",
             decision_packet=selected["decision_packet"],

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -783,6 +783,13 @@ def test_start_exposes_communication_contract_in_ordinary_path(tmp_path: Path, c
         "unresolved_residue",
         "next_safe_action",
     ]
+    message_economy = payload["message_economy"]
+    assert message_economy["kind"] == "agentic-workspace/message-economy/v1"
+    assert message_economy["surface"] == "startup"
+    assert "decision_changed" in message_economy["speak_when"]
+    assert "state_unchanged" in message_economy["stay_compact_when"]
+    assert "stale_missing_or_failed_proof" in message_economy["expand_when"]
+    assert "proof_boundary" in message_economy["preserve"]
     current_decision = payload["current_decision"]
     assert current_decision["kind"] == "agentic-workspace/current-decision/v1"
     assert current_decision["surface"] == "startup"
@@ -3626,6 +3633,7 @@ def test_report_exposes_communication_contract_in_router_and_output_contract(tmp
     assert contract["default_posture"] == "decision_first_state_backed"
     assert "handoff_review" in contract["phase_ids"]
     assert "current_decision" not in router
+    assert "message_economy" not in router
     assert cli.main(["report", "--target", str(tmp_path), "--section", "output_contract", "--format", "json"]) == 0
 
     selected = json.loads(capsys.readouterr().out)["answer"]

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -148,6 +148,7 @@ def test_implement_exposes_communication_contract_for_changed_paths(tmp_path: Pa
         "context_reconstruction",
     ]
     assert "current_decision" not in payload
+    assert "message_economy" not in payload
 
 
 def _write_architecture_principles(target_root: Path) -> None:


### PR DESCRIPTION
Stack slice 2 for #1969 / #1971.

Stack base: #1976 (`codex/1969-01-current-decision`).

This adds a structured `message_economy` packet for the guarded startup path. The packet describes when to speak, stay compact, or expand, while preserving the compact implement/report defaults and existing output budgets.

Validation:
- `uv run pytest tests/test_workspace_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_skills_cli.py` on this branch: 270 passed
- `git diff --check` on this branch