### PR TITLE
Add continuation capsules

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -246,6 +246,43 @@ def message_economy_payload(*, surface: str, communication_contract: dict[str, A
     }
 
 
+def continuation_capsule_payload(
+    *,
+    surface: str,
+    current_decision: dict[str, Any],
+    message_economy: dict[str, Any] | None = None,
+    preserved_intent: str | None = None,
+    stale_context: list[str] | None = None,
+) -> dict[str, Any]:
+    economy = message_economy if isinstance(message_economy, dict) else message_economy_payload(surface=surface)
+    proof_boundary = current_decision.get("proof_boundary", "not-evaluated")
+    residue_owner = current_decision.get("residue_owner", "none")
+    return {
+        "kind": "agentic-workspace/continuation-capsule/v1",
+        "surface": surface,
+        "status": "available",
+        "preserved_intent": preserved_intent or str(current_decision.get("decision_question", "")),
+        "current_decision": {
+            "question": current_decision.get("decision_question", ""),
+            "status": current_decision.get("status", "unknown"),
+            "next_action": current_decision.get("next_action", ""),
+        },
+        "known_evidence": list(current_decision.get("known_evidence", []))[:6],
+        "proof_boundary": proof_boundary,
+        "unresolved_residue": residue_owner,
+        "next_safe_action": current_decision.get("next_action", ""),
+        "do_not_repeat": stale_context
+        or [
+            "full task history",
+            "tool chronology already captured by proof or decision packets",
+            "raw selector-backed context unless expansion triggers require it",
+        ],
+        "expansion_triggers": list(economy.get("expand_when", []))[:8],
+        "detail_routes": current_decision.get("detail_routes", {}),
+        "rule": "Use this capsule for handoff, resume, or recheck before writing a prose recap.",
+    }
+
+
 def _load_reasoning_economy_evidence_ledger(*, target_root: Path | None) -> dict[str, Any]:
     if target_root is None:
         return {

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -17,6 +17,7 @@ from agentic_workspace.config import DEFAULT_CLI_INVOKE, WORKSPACE_CONFIG_PATH, 
 from agentic_workspace.reporting_support import (
     communication_contract_payload,
     compact_communication_contract_payload,
+    continuation_capsule_payload,
     current_decision_payload,
     message_economy_payload,
 )
@@ -1726,6 +1727,16 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                 next_safe_action.get("preferred_cli") or selected["decision_packet"].get("detail_routes", {}).get("active_plan") or ""
             ),
         )
+        continuation_answers = (
+            payload.get("continuation_view", {}).get("answers", {}) if isinstance(payload.get("continuation_view"), dict) else {}
+        )
+        if isinstance(payload.get("continuation_view"), dict):
+            selected["continuation_capsule"] = continuation_capsule_payload(
+                surface="startup",
+                current_decision=selected["current_decision"],
+                message_economy=selected["message_economy"],
+                preserved_intent=str(continuation_answers.get("preserved_intent", "")) if isinstance(continuation_answers, dict) else "",
+            )
     if isinstance(payload.get("continuation_view"), dict) or isinstance(payload.get("continuation_reorientation"), dict):
         drill_down: dict[str, Any] = selected["drill_down"]
         omitted_detail = drill_down.get("omitted_detail")

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -802,6 +802,42 @@ def test_start_exposes_communication_contract_in_ordinary_path(tmp_path: Path, c
     ]
     assert "repeated_context_reconstruction" in current_decision["avoid_repeat"]
     assert current_decision["state_backed"] is True
+    assert "continuation_capsule" not in payload
+
+
+def test_start_exposes_continuation_capsule_when_active_planning_exists(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    assert (
+        cli.main(
+            [
+                "planning",
+                "new-plan",
+                "--id",
+                "capsule-plan",
+                "--title",
+                "Capsule plan",
+                "--target",
+                str(tmp_path),
+                "--activate",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert cli.main(["start", "--target", str(tmp_path), "--task", "Capsule plan", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    capsule = payload["continuation_capsule"]
+    assert capsule["kind"] == "agentic-workspace/continuation-capsule/v1"
+    assert capsule["surface"] == "startup"
+    assert capsule["current_decision"]["question"] == "Startup posture?"
+    assert capsule["proof_boundary"] == payload["current_decision"]["proof_boundary"]
+    assert "full task history" in capsule["do_not_repeat"]
 
 
 def test_start_surfaces_configured_pre_test_guardrail_without_universal_bug_keyword(tmp_path: Path, capsys) -> None:
@@ -3634,6 +3670,7 @@ def test_report_exposes_communication_contract_in_router_and_output_contract(tmp
     assert "handoff_review" in contract["phase_ids"]
     assert "current_decision" not in router
     assert "message_economy" not in router
+    assert "continuation_capsule" not in router
     assert cli.main(["report", "--target", str(tmp_path), "--section", "output_contract", "--format", "json"]) == 0
 
     selected = json.loads(capsys.readouterr().out)["answer"]

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -149,6 +149,7 @@ def test_implement_exposes_communication_contract_for_changed_paths(tmp_path: Pa
     ]
     assert "current_decision" not in payload
     assert "message_economy" not in payload
+    assert "continuation_capsule" not in payload
 
 
 def _write_architecture_principles(target_root: Path) -> None:


### PR DESCRIPTION
Stack slice 3 for #1969 / #1972.

Stack base: #1977 (`codex/1969-02-message-economy`).

This adds `continuation_capsule` packets on the guarded startup path when active planning provides a continuation view. Routine startup, implement, and report defaults remain compact and packet-free where the capsule would not be action-changing.

Validation:
- `uv run pytest tests/test_workspace_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_skills_cli.py` on this branch: 271 passed
- `git diff --check` on this branch