### PR TITLE
Add evidence bundles

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -217,32 +217,26 @@ def message_economy_payload(*, surface: str, communication_contract: dict[str, A
         "speak_when": [
             "decision_changed",
             "proof_boundary_changed",
-            "residue_or_owner_changed",
             "next_safe_action_changed",
-            "safety_or_reversibility_changed",
         ],
         "stay_compact_when": [
             "state_unchanged",
-            "evidence_already_queryable",
             "detail_route_available",
             "chronology_not_trust_relevant",
         ],
-        "expand_when": list(contract.get("expand_when", []))
+        "expand_when": (list(contract.get("expand_when", [])) or ["stale_missing_or_failed_proof", "user_requests_detail"])[:3]
+        if "stale_missing_or_failed_proof" in (list(contract.get("expand_when", [])) or [])
+        else (["stale_missing_or_failed_proof", *(list(contract.get("expand_when", [])) or ["user_requests_detail"])])[:3]
         or [
-            "ambiguous_action_safety",
             "stale_missing_or_failed_proof",
             "user_requests_detail",
-            "unresolved_residue",
         ],
         "discourage": [
             "low_value_tool_chronology",
             "repeated_state_recaps",
-            "broad_process_narration_without_decision_delta",
         ],
-        "preserve": ["proof_boundary", "residue_or_claim_boundary", "next_safe_action", "uncertainty_when_action_changing"],
-        "density_rule": "Default visible updates should be compact state deltas; expand only when the triggers change trust, safety, proof, residue, or user value.",
-        "source_contract": contract.get("kind", "agentic-workspace/communication-contract/v1"),
-        "rule": "Message cadence is derived from structured communication state, not from prompt-prose keyword matching.",
+        "preserve": ["proof_boundary", "next_safe_action"],
+        "state_backed": True,
     }
 
 
@@ -267,19 +261,41 @@ def continuation_capsule_payload(
             "status": current_decision.get("status", "unknown"),
             "next_action": current_decision.get("next_action", ""),
         },
-        "known_evidence": list(current_decision.get("known_evidence", []))[:6],
         "proof_boundary": proof_boundary,
         "unresolved_residue": residue_owner,
         "next_safe_action": current_decision.get("next_action", ""),
         "do_not_repeat": stale_context
         or [
             "full task history",
-            "tool chronology already captured by proof or decision packets",
-            "raw selector-backed context unless expansion triggers require it",
+            "tool chronology already captured",
         ],
-        "expansion_triggers": list(economy.get("expand_when", []))[:8],
-        "detail_routes": current_decision.get("detail_routes", {}),
-        "rule": "Use this capsule for handoff, resume, or recheck before writing a prose recap.",
+        "expansion_triggers": list(economy.get("expand_when", []))[:3],
+        "state_backed": True,
+    }
+
+
+def evidence_bundle_payload(*, surface: str, current_decision: dict[str, Any]) -> dict[str, Any]:
+    route_ids = current_decision.get("detail_route_ids", [])
+    minimal_surfaces = [{"id": str(item)} for item in route_ids if str(item).strip()][:6]
+    missing_evidence = [str(item) for item in current_decision.get("missing_evidence", []) if str(item).strip()]
+    return {
+        "kind": "agentic-workspace/evidence-bundle/v1",
+        "surface": surface,
+        "status": "available" if minimal_surfaces or missing_evidence else "not-needed",
+        "supports_decision": current_decision.get("decision_question", ""),
+        "minimal_evidence_surfaces": minimal_surfaces,
+        **({"missing_evidence": missing_evidence[:2]} if missing_evidence else {}),
+        "decision_changes_when": [
+            {
+                "outcome": "proof or safe probe passes",
+                "decision_effect": "answer from the compact state delta",
+            },
+        ],
+        "escalate_when": [
+            "proof boundary is stale or missing for a hard claim",
+            "residue owner is unresolved",
+        ],
+        "state_backed": True,
     }
 
 

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -224,9 +224,7 @@ def message_economy_payload(*, surface: str, communication_contract: dict[str, A
             "detail_route_available",
             "chronology_not_trust_relevant",
         ],
-        "expand_when": (list(contract.get("expand_when", [])) or ["stale_missing_or_failed_proof", "user_requests_detail"])[:3]
-        if "stale_missing_or_failed_proof" in (list(contract.get("expand_when", [])) or [])
-        else (["stale_missing_or_failed_proof", *(list(contract.get("expand_when", [])) or ["user_requests_detail"])])[:3]
+        "expand_when": list(contract.get("expand_when", []))
         or [
             "stale_missing_or_failed_proof",
             "user_requests_detail",
@@ -235,7 +233,7 @@ def message_economy_payload(*, surface: str, communication_contract: dict[str, A
             "low_value_tool_chronology",
             "repeated_state_recaps",
         ],
-        "preserve": ["proof_boundary", "next_safe_action"],
+        "preserve": ["proof_boundary", "residue_or_claim_boundary", "next_safe_action"],
         "state_backed": True,
     }
 
@@ -262,6 +260,7 @@ def continuation_capsule_payload(
             "next_action": current_decision.get("next_action", ""),
         },
         "proof_boundary": proof_boundary,
+        "known_evidence": list(current_decision.get("known_evidence", []))[:2],
         "unresolved_residue": residue_owner,
         "next_safe_action": current_decision.get("next_action", ""),
         "do_not_repeat": stale_context

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -12,7 +12,10 @@ from pathlib import Path
 from typing import Any, cast
 
 from agentic_workspace.config import WorkspaceUsageError
-from agentic_workspace.reporting_support import communication_contract_payload, compact_communication_contract_payload
+from agentic_workspace.reporting_support import (
+    communication_contract_payload,
+    compact_communication_contract_payload,
+)
 from agentic_workspace.runtime_source_review import (
     tiny_generated_cli_freshness_payload,
     tiny_runtime_source_edit_review_payload,

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -19,6 +19,7 @@ from agentic_workspace.reporting_support import (
     compact_communication_contract_payload,
     continuation_capsule_payload,
     current_decision_payload,
+    evidence_bundle_payload,
     message_economy_payload,
 )
 from agentic_workspace.workspace_runtime_core import (
@@ -1708,10 +1709,10 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     task_posture_packet = payload.get("task_posture_packet", {})
     if isinstance(task_posture_packet, dict) and task_posture_packet:
         selected["task_posture_packet"] = _compact_task_posture_packet_projection(task_posture_packet)
-    show_current_decision = str(next_safe_action.get("next_safe_action", "")) != "choose-task-switch-route" and not isinstance(
+    show_state_delta_packets = str(next_safe_action.get("next_safe_action", "")) != "choose-task-switch-route" and not isinstance(
         payload.get("installed_state_compatibility"), dict
     )
-    if show_current_decision:
+    if show_state_delta_packets:
         selected["message_economy"] = message_economy_payload(
             surface="startup", communication_contract=compact_communication_contract_payload(surface="startup")
         )
@@ -1737,6 +1738,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                 message_economy=selected["message_economy"],
                 preserved_intent=str(continuation_answers.get("preserved_intent", "")) if isinstance(continuation_answers, dict) else "",
             )
+        selected["evidence_bundle"] = evidence_bundle_payload(surface="startup", current_decision=selected["current_decision"])
     if isinstance(payload.get("continuation_view"), dict) or isinstance(payload.get("continuation_reorientation"), dict):
         drill_down: dict[str, Any] = selected["drill_down"]
         omitted_detail = drill_down.get("omitted_detail")

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -790,6 +790,8 @@ def test_start_exposes_communication_contract_in_ordinary_path(tmp_path: Path, c
     assert "state_unchanged" in message_economy["stay_compact_when"]
     assert "stale_missing_or_failed_proof" in message_economy["expand_when"]
     assert "proof_boundary" in message_economy["preserve"]
+    assert "residue_or_claim_boundary" in message_economy["preserve"]
+    assert "user_requests_detail" in message_economy["expand_when"]
     current_decision = payload["current_decision"]
     assert current_decision["kind"] == "agentic-workspace/current-decision/v1"
     assert current_decision["surface"] == "startup"
@@ -843,6 +845,7 @@ def test_start_exposes_continuation_capsule_when_active_planning_exists(tmp_path
     assert capsule["surface"] == "startup"
     assert capsule["current_decision"]["question"] == "Startup posture?"
     assert capsule["proof_boundary"] == payload["current_decision"]["proof_boundary"]
+    assert capsule["known_evidence"] == payload["current_decision"]["known_evidence"][:2]
     assert "full task history" in capsule["do_not_repeat"]
 
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -803,6 +803,12 @@ def test_start_exposes_communication_contract_in_ordinary_path(tmp_path: Path, c
     assert "repeated_context_reconstruction" in current_decision["avoid_repeat"]
     assert current_decision["state_backed"] is True
     assert "continuation_capsule" not in payload
+    bundle = payload["evidence_bundle"]
+    assert bundle["kind"] == "agentic-workspace/evidence-bundle/v1"
+    assert bundle["surface"] == "startup"
+    assert bundle["supports_decision"] == "Startup posture?"
+    assert bundle["minimal_evidence_surfaces"][0]["id"] == "why_blocked"
+    assert "residue owner is unresolved" in bundle["escalate_when"]
 
 
 def test_start_exposes_continuation_capsule_when_active_planning_exists(tmp_path: Path, capsys) -> None:
@@ -3670,7 +3676,6 @@ def test_report_exposes_communication_contract_in_router_and_output_contract(tmp
     assert "handoff_review" in contract["phase_ids"]
     assert "current_decision" not in router
     assert "message_economy" not in router
-    assert "continuation_capsule" not in router
     assert cli.main(["report", "--target", str(tmp_path), "--section", "output_contract", "--format", "json"]) == 0
 
     selected = json.loads(capsys.readouterr().out)["answer"]

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -149,7 +149,6 @@ def test_implement_exposes_communication_contract_for_changed_paths(tmp_path: Pa
     ]
     assert "current_decision" not in payload
     assert "message_economy" not in payload
-    assert "continuation_capsule" not in payload
 
 
 def _write_architecture_principles(target_root: Path) -> None:


### PR DESCRIPTION
Stack slice 4 for #1969 / #1973.

Stack base: #1978 (`codex/1969-03-continuation-capsule`).

This adds startup `evidence_bundle` packets tied to the current decision. The bundle points to minimal selector-backed evidence and keeps escalation conditions explicit without expanding implement/report compact defaults.

Validation:
- `uv run pytest tests/test_workspace_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_skills_cli.py` on this branch: 271 passed
- `git diff --check` on this branch