### PR TITLE
Route state delta loop through skill

### DIFF
--- a/.agentic-workspace/planning/execplans/issue-1969-lane-stack.plan.json
+++ b/.agentic-workspace/planning/execplans/issue-1969-lane-stack.plan.json
@@ -30,7 +30,7 @@
     "hard_constraints": "Preserve proof, residue, next action, uncertainty, and honest closure; avoid prompt-prose classifiers, hidden reasoning scoring, terse persona changes, and broad always-on context dumps.",
     "agent_may_decide": "Exact packet helper names, compact projection placement, branch boundaries, and focused test shape, while preserving child issue acceptance criteria.",
     "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
-    "next_action": "Implement shared state-delta packet builders and expose them through ordinary start, implement, report, and skill surfaces.",
+    "next_action": "Review the draft PR stack #1976-#1980, keep #1969 open until review/merge, and handle installed payload freshness as a separate follow-up.",
     "proof_expectations": [
       "uv run pytest tests/test_workspace_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_skills_cli.py",
       "uv run python scripts/run_agentic_workspace.py implement --changed <paths> --task \"Implement the full #1969 lane in stacked PRs. Switch to master and pull origin before starting work.\" --format json",
@@ -209,24 +209,24 @@
     "Parent #1969 acceptance evidence is recorded without over-claiming before proof."
   ],
   "execution_run": {
-    "run status": "not-run-yet",
-    "executor": "",
+    "run status": "completed",
+    "executor": "Codex",
     "handoff source": "agentic-planning new-plan",
-    "what happened": "execution has not started",
-    "scope touched": "none yet",
-    "changed surfaces": "none yet; execution has not changed files",
-    "validations run": "pending",
-    "result for continuation": "continue from this scaffolded execplan",
-    "next step": "Implement #1970 current_decision packet first, then layer #1971-#1974."
+    "what happened": "Implemented the #1969 stack as five local branches: current decision packets, message economy, continuation capsules, evidence bundles, and operating-loop skill adoption.",
+    "scope touched": "Planning/lane records, reporting support packet builders, startup compact projection, skill payload mirrors, and focused CLI tests.",
+    "changed surfaces": "reporting_support.py; workspace_runtime_startup.py; workspace_runtime_implement.py; workspace-operating-loop skill and registries; workspace CLI tests; planning records.",
+    "validations run": "uv run pytest tests/test_workspace_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_skills_cli.py; uv run python scripts/run_agentic_workspace.py summary --target . --format json; uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json; uv run python scripts/run_agentic_workspace.py memory route --target . --stage closeout --format json; uv run python scripts/run_agentic_workspace.py upgrade --target . --dry-run --format json.",
+    "result for continuation": "Draft PR stack opened: #1976 current decision, #1977 message economy, #1978 continuation capsule, #1979 evidence bundles, #1980 operating-loop skill and closeout. Installed payload freshness remains unclaimed because upgrade dry-run found broader managed-payload/provenance drift and scratch review items.",
+    "next step": "Review and merge the stacked PRs in order (#1976 -> #1977 -> #1978 -> #1979 -> #1980), then reassess #1969 closure and the installed payload freshness follow-up."
   },
   "finished_run_review": {
-    "review status": "pending",
-    "scope respected": "pending",
-    "proof status": "pending",
-    "intent served": "pending",
-    "config compliance": "pending",
-    "misinterpretation risk": "pending",
-    "follow-on decision": "pending"
+    "review status": "self-reviewed",
+    "scope respected": "yes; the work stayed within planned runtime packet, skill payload, test, and planning surfaces.",
+    "proof status": "passed for source behavior; doctor reports payload provenance drift, so installed payload freshness is not claimed.",
+    "intent served": "yes for source implementation of #1970-#1974; final issue closure should wait for PR review/merge.",
+    "config compliance": "AW start, summary, implement, closeout_trust, and memory route were used; upgrade apply was not run because dry-run reported review-required broader payload work.",
+    "misinterpretation risk": "low; packet defaults were tightened after budget tests showed early output bloat.",
+    "follow-on decision": "review stacked PRs #1976-#1980; keep parent issue open until review/merge confirms the lane."
   },
   "delegation_outcome_feedback": {
     "route chosen": "keep-local",
@@ -238,28 +238,28 @@
     "decomposition adjustment": "none"
   },
   "proof_report": {
-    "validation proof": "pending",
-    "proof achieved now": "pending",
-    "evidence for \"proof achieved\" state": ""
+    "validation proof": "uv run pytest tests/test_workspace_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_skills_cli.py passed: 271 passed in 41.29s. AW summary passed with planning_surface_health.status=active and warning_count=0. AW memory route closeout found only baseline memory routing and no task-specific durable note. AW upgrade dry-run showed payload/provenance drift and review-required scratch state, so payload freshness is intentionally not claimed.",
+    "proof achieved now": "source-behavior-valid; installed-payload-freshness-unproven",
+    "evidence for \"proof achieved\" state": "Focused CLI suite passed, summary clean, memory route completed, and upgrade dry-run reviewed."
   },
   "intent_satisfaction": {
-    "original intent": "Create a bounded plan for Issue 1969 lane stack.",
-    "was original intent fully satisfied?": "pending",
-    "evidence of intent satisfaction": "",
-    "unsolved intent passed to": "none yet"
+    "original intent": "Implement the full #1969 lane in stacked PRs.",
+    "was original intent fully satisfied?": "yes for local source implementation; external PR creation/review remains the delivery vehicle.",
+    "evidence of intent satisfaction": "The stack implements #1970 current_decision, #1971 message_economy, #1972 continuation_capsule for active continuation, #1973 evidence_bundle, and #1974 shipped operating-loop skill guidance with registry/payload mirror coverage.",
+    "unsolved intent passed to": "GitHub stacked PR review and merge (#1976-#1980); installed payload freshness follow-up if the broader upgrade review is accepted."
   },
   "execution_summary": {
-    "outcome delivered": "not completed yet",
-    "validation confirmed": "pending",
-    "follow-on routed to": "none yet",
-    "post-work posterity capture": "pending",
+    "outcome delivered": "draft PR stack opened for #1969: #1976, #1977, #1978, #1979, and #1980",
+    "validation confirmed": "focused CLI suite passed; planning summary clean",
+    "follow-on routed to": "stacked PR review and payload upgrade/provenance review if needed",
+    "post-work posterity capture": "planning record updated; no Memory note captured because closeout route found no task-specific durable knowledge",
     "knowledge promoted (Memory/Docs/Config)": "none",
     "resume from": "current milestone"
   },
   "durable_residue": {
     "status": "none",
-    "learned constraint": "none yet",
-    "motivation worth preserving": "none yet",
+    "learned constraint": "State-delta packets must remain visibility-gated and compact; default startup budget tests caught packet bloat.",
+    "motivation worth preserving": "The constraint is preserved in tests that keep simple start/implement/report outputs under existing budgets.",
     "canonical owner now": "none",
     "promotion trigger": "none",
     "retention after promotion": "retain"
@@ -275,16 +275,16 @@
     "owner surface": ""
   },
   "closure_check": {
-    "slice status": "pending",
-    "larger-intent status": "pending",
-    "closure decision": "pending",
+    "slice status": "complete",
+    "larger-intent status": "open",
+    "closure decision": "archive-but-keep-lane-open",
     "accepted values": "Accepted values: slice status = complete|completed|bounded slice complete; larger-intent status = closed|complete|completed for archive-and-close or open|partial|unfinished for archive-but-keep-lane-open; closure decision = archive-and-close|archive-but-keep-lane-open. Prefer `agentic-planning archive-plan <plan> --prepare-closeout` before hand-editing closeout fields.",
-    "why this decision is honest": "",
-    "evidence carried forward": "",
-    "reopen trigger": ""
+    "why this decision is honest": "Local source implementation and focused proof are complete, but PR review/merge and installed payload freshness are separate claims.",
+    "evidence carried forward": "271 focused tests passed; summary clean; doctor planning shows payload drift not claimed fresh; upgrade dry-run requires broader review before payload sync.",
+    "reopen trigger": "PR review finds packet semantics, budget behavior, skill discoverability, or payload mirror coverage insufficient."
   },
   "improvement_signal_review": {
-    "status": "not_checked",
+    "status": "signals_routed",
     "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
     "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
     "source": "operating_posture",
@@ -297,11 +297,15 @@
       "dismissed with reason"
     ],
     "ordinary output cap": 3,
-    "signals found": [],
+    "signals found": [
+      "implement --changed accepted a comma-separated path list as one path, yielding changed_path_count=1 for many intended paths."
+    ],
     "signals fixed": [],
-    "signals routed": [],
+    "signals routed": [
+      "GitHub #1975"
+    ],
     "signals dismissed": [],
-    "next owner": ""
+    "next owner": "GitHub #1975"
   },
   "closeout_distillation": {
     "buckets": {

--- a/.agentic-workspace/skills/REGISTRY.json
+++ b/.agentic-workspace/skills/REGISTRY.json
@@ -178,14 +178,21 @@
     {
       "id": "workspace-operating-loop",
       "path": "workspace-operating-loop/SKILL.md",
-      "scope": "reference-support",
+      "scope": "specialized-subskill",
       "stability": "contract-backed-projection",
-      "visibility": "reference-only",
-      "summary": "reference module-slot ownership and no-artifact direct-answer details after main AW routing",
+      "visibility": "routed-on-demand",
+      "summary": "use compact AW state for state-delta visible updates while preserving module-slot ownership and direct-answer boundaries",
       "activation_hints": {
-        "verbs": ["reference", "interpret"],
+        "verbs": ["reference", "interpret", "answer", "respond", "update", "resume", "recheck"],
         "nouns": [
           "operating loop",
+          "state-delta",
+          "current decision",
+          "message economy",
+          "continuation capsule",
+          "evidence bundle",
+          "decision packet",
+          "visible update",
           "module slot",
           "module slot contract",
           "workspace slot",
@@ -194,12 +201,23 @@
           "direct answer"
         ],
         "phrases": [
+          "state-delta-first",
+          "state delta first",
+          "current decision packet",
+          "message economy",
+          "continuation capsule",
+          "evidence bundle",
+          "visible update delta",
+          "answer from compact state",
           "module slot contract reference",
           "module slot reference",
           "interpret module slot",
           "answer directly no artifact reference"
         ],
         "when": [
+          "current_decision, message_economy, continuation_capsule, or evidence_bundle packets are present",
+          "the agent needs to write a compact visible update from AW state",
+          "a resume, recheck, handoff, proof, or closeout message should avoid prose recap",
           "module ownership is unclear",
           "a next-safe-action packet names a module slot",
           "the agent may create an unnecessary artifact instead of answering directly"

--- a/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
+++ b/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
@@ -1,13 +1,44 @@
 ---
 name: workspace-operating-loop
-description: Reference the Agentic Workspace module-slot contract only when the main AW operating skill or compact router names module ownership details that need interpretation.
+description: Use AW compact state to write visible updates as decision, proof, residue, and next-action deltas while preserving module-slot ownership.
 ---
 
-# Workspace Operating Loop Reference
+# Workspace Operating Loop
 
 This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
 
-Do not use it as an ordinary startup or implementation entrypoint. Start with `workspace-startup`; use this reference only when `module_slot`, module ownership, or no-artifact direct-answer behavior needs interpretation after compact routing.
+Start with `workspace-startup`; use this skill when compact routing, `current_decision`, `message_economy`, `continuation_capsule`, `evidence_bundle`, module ownership, or no-artifact direct-answer behavior needs interpretation before a visible update.
+
+## State-Delta Procedure
+
+1. Read the compact decision frame when present:
+   - `current_decision`
+   - `message_economy` or `communication_contract`
+   - `continuation_capsule`
+   - `evidence_bundle`
+   - `decision_packet`
+   - `proof_narrowness`
+   - `reasoning_economy`
+2. If the frame is sufficient, answer only the decision-relevant delta:
+   - decision or finding;
+   - evidence or proof boundary;
+   - residue or claim boundary;
+   - next safe action or closure status.
+3. Do not repeat context already captured in AW state unless it changes the current decision.
+4. Do not narrate tool chronology unless the chronology itself is proof-relevant or trust-relevant.
+5. If the frame is insufficient, use the smallest `evidence_bundle` or safe probe before making a hard claim.
+6. Expand only for proof gaps, safety or ownership ambiguity, unresolved residue, stale evidence, or explicit user request.
+
+## Output Rule
+
+Default visible output is a compact delta, not a recap:
+
+- `Decision:` or `Finding:`
+- `Evidence:`
+- `Residue:`
+- `Next action:`
+
+Omit a field only when it is genuinely irrelevant. Do not omit proof, residue, uncertainty, or owner boundaries when they change the safe claim.
 
 ## Module Slot Contract
 
@@ -56,6 +87,8 @@ When the router or task shape supports an answer-directly/no-artifact outcome, d
 
 ## Guardrails
 
+- Do not replace structured packets with prompt-prose keyword matching.
+- Do not make all messages short when proof or residue requires detail.
 - Do not let one module absorb another module's ownership.
 - Do not put active sequencing in Memory.
 - Do not put durable repo facts only in a plan closeout.

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/REGISTRY.json
@@ -178,14 +178,21 @@
     {
       "id": "workspace-operating-loop",
       "path": "workspace-operating-loop/SKILL.md",
-      "scope": "reference-support",
+      "scope": "specialized-subskill",
       "stability": "contract-backed-projection",
-      "visibility": "reference-only",
-      "summary": "reference module-slot ownership and no-artifact direct-answer details after main AW routing",
+      "visibility": "routed-on-demand",
+      "summary": "use compact AW state for state-delta visible updates while preserving module-slot ownership and direct-answer boundaries",
       "activation_hints": {
-        "verbs": ["reference", "interpret"],
+        "verbs": ["reference", "interpret", "answer", "respond", "update", "resume", "recheck"],
         "nouns": [
           "operating loop",
+          "state-delta",
+          "current decision",
+          "message economy",
+          "continuation capsule",
+          "evidence bundle",
+          "decision packet",
+          "visible update",
           "module slot",
           "module slot contract",
           "workspace slot",
@@ -194,12 +201,23 @@
           "direct answer"
         ],
         "phrases": [
+          "state-delta-first",
+          "state delta first",
+          "current decision packet",
+          "message economy",
+          "continuation capsule",
+          "evidence bundle",
+          "visible update delta",
+          "answer from compact state",
           "module slot contract reference",
           "module slot reference",
           "interpret module slot",
           "answer directly no artifact reference"
         ],
         "when": [
+          "current_decision, message_economy, continuation_capsule, or evidence_bundle packets are present",
+          "the agent needs to write a compact visible update from AW state",
+          "a resume, recheck, handoff, proof, or closeout message should avoid prose recap",
           "module ownership is unclear",
           "a next-safe-action packet names a module slot",
           "the agent may create an unnecessary artifact instead of answering directly"

--- a/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
+++ b/src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-operating-loop/SKILL.md
@@ -1,13 +1,44 @@
 ---
 name: workspace-operating-loop
-description: Reference the Agentic Workspace module-slot contract only when the main AW operating skill or compact router names module ownership details that need interpretation.
+description: Use AW compact state to write visible updates as decision, proof, residue, and next-action deltas while preserving module-slot ownership.
 ---
 
-# Workspace Operating Loop Reference
+# Workspace Operating Loop
 
 This is a package-managed workspace skill installed under `.agentic-workspace/skills/`.
 
-Do not use it as an ordinary startup or implementation entrypoint. Start with `workspace-startup`; use this reference only when `module_slot`, module ownership, or no-artifact direct-answer behavior needs interpretation after compact routing.
+Start with `workspace-startup`; use this skill when compact routing, `current_decision`, `message_economy`, `continuation_capsule`, `evidence_bundle`, module ownership, or no-artifact direct-answer behavior needs interpretation before a visible update.
+
+## State-Delta Procedure
+
+1. Read the compact decision frame when present:
+   - `current_decision`
+   - `message_economy` or `communication_contract`
+   - `continuation_capsule`
+   - `evidence_bundle`
+   - `decision_packet`
+   - `proof_narrowness`
+   - `reasoning_economy`
+2. If the frame is sufficient, answer only the decision-relevant delta:
+   - decision or finding;
+   - evidence or proof boundary;
+   - residue or claim boundary;
+   - next safe action or closure status.
+3. Do not repeat context already captured in AW state unless it changes the current decision.
+4. Do not narrate tool chronology unless the chronology itself is proof-relevant or trust-relevant.
+5. If the frame is insufficient, use the smallest `evidence_bundle` or safe probe before making a hard claim.
+6. Expand only for proof gaps, safety or ownership ambiguity, unresolved residue, stale evidence, or explicit user request.
+
+## Output Rule
+
+Default visible output is a compact delta, not a recap:
+
+- `Decision:` or `Finding:`
+- `Evidence:`
+- `Residue:`
+- `Next action:`
+
+Omit a field only when it is genuinely irrelevant. Do not omit proof, residue, uncertainty, or owner boundaries when they change the safe claim.
 
 ## Module Slot Contract
 
@@ -56,6 +87,8 @@ When the router or task shape supports an answer-directly/no-artifact outcome, d
 
 ## Guardrails
 
+- Do not replace structured packets with prompt-prose keyword matching.
+- Do not make all messages short when proof or residue requires detail.
 - Do not let one module absorb another module's ownership.
 - Do not put active sequencing in Memory.
 - Do not put durable repo facts only in a plan closeout.

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -23136,6 +23136,10 @@ def _startup_skills_projection(
     )
     if state_delta_packets_visible and "workspace-operating-loop" in skills_by_id:
         skill = skills_by_id.get("workspace-operating-loop", {})
+        state_delta_packets = ["current_decision", "message_economy"]
+        if isinstance(payload.get("continuation_view"), dict):
+            state_delta_packets.append("continuation_capsule")
+        state_delta_packets.append("evidence_bundle")
         recommended.append(
             {
                 "id": "workspace-operating-loop",
@@ -23143,7 +23147,7 @@ def _startup_skills_projection(
                 **({"summary": skill.get("summary")} if skill.get("summary") else {}),
                 "reason": "state-delta packets are visible in startup output",
                 "source": "startup_state_delta_packets",
-                "packets": ["current_decision", "message_economy", "evidence_bundle"],
+                "packets": state_delta_packets,
             }
         )
 

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -23131,6 +23131,21 @@ def _startup_skills_projection(
         )
 
     recommended: list[dict[str, Any]] = []
+    state_delta_packets_visible = str(next_safe_action.get("next_safe_action", "")) != "choose-task-switch-route" and not isinstance(
+        payload.get("installed_state_compatibility"), dict
+    )
+    if state_delta_packets_visible and "workspace-operating-loop" in skills_by_id:
+        skill = skills_by_id.get("workspace-operating-loop", {})
+        recommended.append(
+            {
+                "id": "workspace-operating-loop",
+                **({"path": skill.get("path")} if skill.get("path") else {}),
+                **({"summary": skill.get("summary")} if skill.get("summary") else {}),
+                "reason": "state-delta packets are visible in startup output",
+                "source": "startup_state_delta_packets",
+                "packets": ["current_decision", "message_economy", "evidence_bundle"],
+            }
+        )
 
     catalog_command = _proof_command_for_target(
         command='agentic-workspace skills --target ./repo --task "<task>" --format json',
@@ -23140,7 +23155,7 @@ def _startup_skills_projection(
 
     return {
         "kind": "agentic-workspace/startup-skills-projection/v1",
-        "status": "recommended" if required else "available",
+        "status": "recommended" if required or recommended else "available",
         "rule": "Use catalog.command only for task-specific skill search.",
         "required": required,
         "recommended": recommended,

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -851,6 +851,15 @@ def test_start_exposes_continuation_capsule_when_active_planning_exists(tmp_path
     assert capsule["proof_boundary"] == payload["current_decision"]["proof_boundary"]
     assert capsule["known_evidence"] == payload["current_decision"]["known_evidence"][:2]
     assert "full task history" in capsule["do_not_repeat"]
+    operating_loop_skill = next(entry for entry in payload["skills"]["recommended"] if entry["id"] == "workspace-operating-loop")
+    assert operating_loop_skill["reason"] == "state-delta packets are visible in startup output"
+    assert operating_loop_skill["source"] == "startup_state_delta_packets"
+    assert operating_loop_skill["packets"] == [
+        "current_decision",
+        "message_economy",
+        "continuation_capsule",
+        "evidence_bundle",
+    ]
 
 
 def test_start_surfaces_configured_pre_test_guardrail_without_universal_bug_keyword(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -811,6 +811,10 @@ def test_start_exposes_communication_contract_in_ordinary_path(tmp_path: Path, c
     assert bundle["supports_decision"] == "Startup posture?"
     assert bundle["minimal_evidence_surfaces"][0]["id"] == "why_blocked"
     assert "residue owner is unresolved" in bundle["escalate_when"]
+    operating_loop_skill = next(entry for entry in payload["skills"]["recommended"] if entry["id"] == "workspace-operating-loop")
+    assert operating_loop_skill["reason"] == "state-delta packets are visible in startup output"
+    assert operating_loop_skill["source"] == "startup_state_delta_packets"
+    assert operating_loop_skill["packets"] == ["current_decision", "message_economy", "evidence_bundle"]
 
 
 def test_start_exposes_continuation_capsule_when_active_planning_exists(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_skills_cli.py
+++ b/tests/test_workspace_skills_cli.py
@@ -141,7 +141,8 @@ def test_skills_command_lists_registered_workspace_skills(tmp_path: Path, capsys
     assert workspace_entries["workspace-proof-selection"]["visibility"] == "routed-on-demand"
     assert workspace_entries["workspace-transition-gates"]["visibility"] == "reference-only"
     assert workspace_entries["workspace-transition-gates"]["scope"] == "reference-support"
-    assert workspace_entries["workspace-operating-loop"]["scope"] == "reference-support"
+    assert workspace_entries["workspace-operating-loop"]["scope"] == "specialized-subskill"
+    assert workspace_entries["workspace-operating-loop"]["visibility"] == "routed-on-demand"
     assert workspace_entries["workspace-work-shape"]["scope"] == "reference-support"
     assert workspace_entries["workspace-setup-jumpstart"]["scope"] == "specialized-subskill"
     workspace_startup = next(entry for entry in payload["skills"] if entry["id"] == "workspace-startup")
@@ -452,6 +453,11 @@ def test_workspace_skill_hierarchy_activation_matrix(tmp_path: Path, capsys) -> 
             "expected_top": "workspace-transition-gates",
             "absent": {"workspace-proof-selection", "workspace-setup-jumpstart"},
         },
+        {
+            "task": "answer from state-delta-first current decision message economy continuation capsule evidence bundle",
+            "expected_top": "workspace-operating-loop",
+            "absent": {"workspace-proof-selection", "workspace-setup-jumpstart"},
+        },
     ]
 
     for case in cases:
@@ -471,6 +477,17 @@ def test_workspace_skill_hierarchy_activation_matrix(tmp_path: Path, capsys) -> 
         "workspace-transition-gates",
         "workspace-operating-loop",
     } & {entry["id"] for entry in payload["recommendations"]}
+
+    installed_skill_text = Path(".agentic-workspace/skills/workspace-operating-loop/SKILL.md").read_text(encoding="utf-8")
+    payload_skill_text = Path("src/agentic_workspace/_payload/.agentic-workspace/skills/workspace-operating-loop/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    for skill_text in (installed_skill_text, payload_skill_text):
+        assert "current_decision" in skill_text
+        assert "message_economy" in skill_text
+        assert "continuation_capsule" in skill_text
+        assert "evidence_bundle" in skill_text
+        assert "Default visible output is a compact delta" in skill_text
 
 
 def test_skills_command_recommends_memory_router_for_note_selection_task(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
Stack slice 5 for #1969 / #1974.

Stack base: #1979 (`codex/1969-04-evidence-bundles`).

This updates the shipped `workspace-operating-loop` skill and registry/payload mirrors so ordinary AW guidance routes agents through the new state-delta packets: `current_decision`, `message_economy`, `continuation_capsule`, and `evidence_bundle`. It also records the lane closeout state for review without claiming installed payload freshness or closing #1969.

Validation:
- `uv run pytest tests/test_workspace_cli.py tests/test_workspace_implement_cli.py tests/test_workspace_skills_cli.py` on this branch: 271 passed
- `git diff --check` on this branch
- AW summary after closeout: planning surface active, warning_count=0

Known boundary:
- `doctor --modules planning` still reports installed payload/provenance sync required; this stack validates source behavior and does not claim installed payload freshness.
- Dogfooding finding filed separately as #1975 for `implement --changed` comma-separated path handling.