### PR TITLE
[codex] Align closeout trust with active intent proof

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -17125,6 +17125,11 @@ def _completion_option(
     return item
 
 
+def _archive_and_close_decision(value: Any, *, allow_blank: bool = False) -> bool:
+    decision = str(value or "").strip().lower()
+    return (allow_blank and not decision) or decision == "archive-and-close" or decision.startswith("archive-and-close-")
+
+
 def _closeout_completion_options(
     *,
     status: str,
@@ -17184,6 +17189,7 @@ def _closeout_completion_options(
     larger_closure = larger_closure if isinstance(larger_closure, dict) else {}
     larger_status = str(larger_closure.get("status", "")).strip().lower()
     closure_decision = str(larger_closure.get("closure_decision", "")).strip().lower()
+    external_intent_evidence = _as_dict(closure_scope.get("external_intent_evidence"))
     continuation_owner = str(intent_check.get("continuation_surface", "")).strip()
     package_continuation = intent_check.get("package_owned_continuation", {})
     if not continuation_owner and isinstance(package_continuation, dict):
@@ -17195,6 +17201,16 @@ def _closeout_completion_options(
         or larger_status in {"open", "follow-up-required"}
         or required_follow_on in {"yes", "true"}
     )
+    larger_intent_blockers: list[str] = []
+    if intent_trust in {"follow-up-required", "needs-review"}:
+        if external_intent_evidence and str(external_intent_evidence.get("trust") or "").strip().lower() != "normal":
+            larger_intent_blockers.append("intent_satisfaction.closure_scope.external_intent_evidence")
+        else:
+            larger_intent_blockers.append("intent_satisfaction.trust")
+    if larger_status in {"open", "follow-up-required"}:
+        larger_intent_blockers.append("intent_satisfaction.closure_scope.larger_intent_closure.status")
+    if required_follow_on in {"yes", "true"}:
+        larger_intent_blockers.append("intent_satisfaction.required_follow_on")
     residue_required = (
         lower_trust_closeout_count > 0
         or trust in {"lower-trust", "unavailable"}
@@ -17208,12 +17224,8 @@ def _closeout_completion_options(
     intent_satisfied = intent_trust in {"satisfied", "normal"} or (intent_trust in {"", "not-applicable"} and intent_proof_supports_work)
     close_evidence = (
         larger_status in {"closed", "complete", "completed", "done"}
-        or closure_decision
-        in {
-            "archive-and-close",
-            "close",
-            "closed",
-        }
+        or _archive_and_close_decision(closure_decision)
+        or closure_decision in {"close", "closed"}
         or (intent_trust in {"", "not-applicable"} and intent_proof_supports_work)
     )
     proof_achieved = proof_achieved or intent_proof_records_execution
@@ -17227,11 +17239,11 @@ def _closeout_completion_options(
     if residue_required:
         completion_blockers.append("durable_residue")
     if larger_intent_open:
-        completion_blockers.append("intent_satisfaction")
+        completion_blockers.extend(_dedupe(larger_intent_blockers) or ["intent_satisfaction.trust"])
     if larger_intent_open and not continuation_owner:
-        completion_blockers.append("continuation_owner")
+        completion_blockers.append("intent_satisfaction.continuation_surface")
     if not intent_proof_supports_work:
-        completion_blockers.append("intent_proof")
+        completion_blockers.append("planning.active.planning_record.proof_report.intent_proof.status")
     if unsupported_preservation:
         completion_blockers.append("behavior_preservation")
     if completion_gate_blocks_full:
@@ -17241,7 +17253,9 @@ def _closeout_completion_options(
     slice_blockers = [
         field
         for field in completion_blockers
-        if field not in {"intent_satisfaction", "intent_proof"} or intent_proof_status == "needs_review"
+        if not field.startswith("intent_satisfaction.")
+        and not field.endswith(".intent_proof.status")
+        or intent_proof_status == "needs_review"
     ]
     slice_blockers.extend(assurance_claim_blockers.get("claim-slice-complete", []))
     work_blockers = [*completion_blockers, *assurance_claim_blockers.get("claim-work-complete", [])]
@@ -17327,7 +17341,11 @@ def _closeout_completion_options(
             if close_parent_allowed
             else "parent lane closure requires satisfied larger intent and explicit closure evidence",
             owner=continuation_owner if larger_intent_open else None,
-            blocking_fields=parent_blockers if parent_blockers else ["intent_satisfaction.closure_scope.larger_intent_closure"],
+            blocking_fields=None
+            if close_parent_allowed
+            else parent_blockers
+            if parent_blockers
+            else ["intent_satisfaction.closure_scope.larger_intent_closure"],
             required_claim_class="parent_complete",
         ),
         _completion_option(
@@ -19250,6 +19268,9 @@ def _acceptance_criteria_reconciliation_payload(*, planning_report: dict[str, An
             str(proof_report.get("acceptance reconciliation", "")),
             str(closure_check.get("acceptance reconciliation", "")),
             str(closure_check.get("criteria satisfied", "")),
+            str(closure_check.get("why this decision is honest", "")),
+            str(closure_check.get("evidence carried forward", "")),
+            str(_as_dict(planning_record.get("intent_satisfaction")).get("evidence of intent satisfaction", "")),
         ]
     ).lower()
     evidence_present = any(
@@ -19526,6 +19547,14 @@ def _intent_proof_check_payload(*, planning_report: dict[str, Any], target_root:
     proof_report = proof_report if isinstance(proof_report, dict) else {}
     raw_proof_report = raw_planning_record.get("proof_report", {}) if isinstance(raw_planning_record, dict) else {}
     raw_proof_report = raw_proof_report if isinstance(raw_proof_report, dict) else {}
+    intent_satisfaction = planning_record.get("intent_satisfaction", {})
+    intent_satisfaction = intent_satisfaction if isinstance(intent_satisfaction, dict) else {}
+    raw_intent_satisfaction = raw_planning_record.get("intent_satisfaction", {}) if isinstance(raw_planning_record, dict) else {}
+    raw_intent_satisfaction = raw_intent_satisfaction if isinstance(raw_intent_satisfaction, dict) else {}
+    closure_check = planning_record.get("closure_check", {})
+    closure_check = closure_check if isinstance(closure_check, dict) else {}
+    raw_closure_check = raw_planning_record.get("closure_check", {}) if isinstance(raw_planning_record, dict) else {}
+    raw_closure_check = raw_closure_check if isinstance(raw_closure_check, dict) else {}
     raw_intent_proof = planning_record.get(
         "intent_proof",
         proof_report.get(
@@ -19549,6 +19578,66 @@ def _intent_proof_check_payload(*, planning_report: dict[str, Any], target_root:
                 parsed = {"status": raw_intent_proof}
         raw_intent_proof = parsed
     raw_intent_proof = raw_intent_proof if isinstance(raw_intent_proof, dict) else {}
+
+    def truthy_yes(value: Any) -> bool:
+        return str(value or "").strip().lower() in {"yes", "true", "satisfied", "complete", "completed", "closed"}
+
+    def proof_text(*records: dict[str, Any]) -> str:
+        values: list[str] = []
+        for record in records:
+            values.extend(
+                str(record.get(key) or "").strip()
+                for key in (
+                    "validation proof",
+                    "proof achieved now",
+                    'evidence for "proof achieved" state',
+                    "proof execution evidence",
+                    "proof_execution_evidence",
+                )
+                if str(record.get(key) or "").strip()
+            )
+        return "\n".join(values)
+
+    def proof_recorded(text: str) -> bool:
+        normalized = text.lower()
+        return bool(normalized) and any(marker in normalized for marker in ("passed", "yes", "satisfied", "complete", "proof"))
+
+    def closure_complete(*records: dict[str, Any]) -> bool:
+        for record in records:
+            slice_status = str(record.get("slice status") or record.get("slice_status") or "").strip().lower()
+            larger_status = str(record.get("larger-intent status") or record.get("larger_intent_status") or "").strip().lower()
+            decision = str(record.get("closure decision") or record.get("closure_decision") or "").strip().lower()
+            if (
+                slice_status in {"complete", "completed", "closed", "done", "bounded slice complete"}
+                and larger_status in {"closed", "complete", "completed", "done", ""}
+                and (_archive_and_close_decision(decision, allow_blank=True) or decision in {"close", "closed"})
+            ):
+                return True
+        return False
+
+    if not raw_intent_proof:
+        recorded_proof_text = proof_text(proof_report, raw_proof_report)
+        satisfied = truthy_yes(
+            intent_satisfaction.get("was original intent fully satisfied?")
+            or raw_intent_satisfaction.get("was original intent fully satisfied?")
+        )
+        if satisfied and proof_recorded(recorded_proof_text) and closure_complete(closure_check, raw_closure_check):
+            raw_intent_proof = {
+                "status": "sufficient_for_claim",
+                "claim_boundary": "full-intent",
+                "intended_behavior": [
+                    str(
+                        intent_satisfaction.get("original intent")
+                        or raw_intent_satisfaction.get("original intent")
+                        or planning_record.get("requested_outcome")
+                        or ""
+                    ).strip()
+                ],
+                "proof_dimensions": ["recorded intent satisfaction", "recorded closeout proof"],
+                "proof_classes": ["closeout-evidence"],
+                "preservation_evidence": [recorded_proof_text],
+                "evidence": "Derived from active execplan proof_report, intent_satisfaction, and closure_check.",
+            }
     raw_status = str(raw_intent_proof.get("status", "")).strip().lower().replace("-", "_")
     status = (
         raw_status
@@ -19594,6 +19683,8 @@ def _intent_proof_check_payload(*, planning_report: dict[str, Any], target_root:
             "planning.active.planning_record.proof_report.intent_proof",
             "planning.active.task.surface.raw_execplan.intent_proof",
             "planning.active.task.surface.raw_execplan.proof_report.intent_proof",
+            "planning.active.planning_record.proof_report + intent_satisfaction + closure_check",
+            "planning.active.task.surface.raw_execplan.proof_report + intent_satisfaction + closure_check",
         ],
     }
 
@@ -27409,7 +27500,7 @@ def _parent_intent_status_payload(
     parent_closed = (
         intent_satisfied
         and closure_status in {"closed", "complete", "completed", "done", ""}
-        and closure_decision in {"archive-and-close", "close", "closed", ""}
+        and (_archive_and_close_decision(closure_decision, allow_blank=True) or closure_decision in {"close", "closed"})
         and required_follow_on not in {"yes", "true"}
         and intent_trust not in {"follow-up-required", "needs-review"}
         and not lane_blocks_parent_close
@@ -31563,7 +31654,7 @@ def _archive_record_closeout_state(*, target_root: Path, relative_path: str) -> 
     larger_intent_status = str(closure_check.get("larger-intent status") or "").strip().lower()
     intent_satisfied = str(intent_satisfaction.get("was original intent fully satisfied?") or "").strip().lower()
     completed = status in {"completed", "complete", "closed", "done"}
-    closed = closure_decision == "archive-and-close"
+    closed = _archive_and_close_decision(closure_decision)
     continuation_owner_present = any(
         value not in {"", "none", "no", "false", "n/a", "na"}
         for value in [

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -474,6 +474,165 @@ def test_closeout_trust_prefers_relevant_closeout_evidence_over_newer_unrelated_
     assert evidence["freshness"]["sort_mtime"] == 1000
 
 
+def _write_issue_1981_closeout_fixture(target: Path, *, include_proof: bool, external_status: str = "closed") -> None:
+    from repo_planning_bootstrap import installer as planning_installer
+
+    issue_ref = "#1981"
+    _write(
+        target / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "issue-1981", title = "Issue 1981 state-delta shared core", status = "active", surface = ".agentic-workspace/planning/execplans/issue-1981.plan.json", next_action = "Close complete.", done_when = "Issue 1981 can honestly be closed." },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    record = planning_installer._build_execplan_record_from_todo_item(
+        title="Issue 1981 state-delta shared core",
+        item_id="issue-1981",
+        status="active",
+        why_now="regress closeout trust alignment.",
+        next_action="Close complete.",
+        done_when="Issue 1981 can honestly be closed.",
+    )
+    record["references"] = [issue_ref]
+    record["completion_criteria"] = ["summary and closeout trust agree on active execplan intent satisfaction"]
+    record["proof_expectations"] = [
+        "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
+        "uv run python scripts/run_agentic_workspace.py report --target . --section closeout_trust --format json",
+        "uv run pytest tests/test_workspace_cli.py -q",
+    ]
+    record["execution_run"] = {
+        "handoff source": "synthetic regression fixture",
+        "what happened": "The shared state-delta core was implemented.",
+        "validations run": [
+            "agentic-workspace summary passed",
+            "agentic-workspace report --section closeout_trust passed",
+            "pytest passed",
+        ],
+    }
+    if include_proof:
+        record["proof_report"] = {
+            "validation proof": "uv run pytest tests/test_workspace_cli.py -q passed",
+            "proof achieved now": "yes, proof passed for the requested behavior",
+            'evidence for "proof achieved" state': "summary and closeout trust fixture covered the shared core closeout.",
+        }
+    else:
+        record["proof_report"] = {}
+    record["intent_satisfaction"] = {
+        "original intent": "Implement #1981 by making state-delta packet views derive from one shared compact core.",
+        "was original intent fully satisfied?": "yes",
+        "evidence of intent satisfaction": "Summary payloads and closeout trust agree the requested behavior is complete.",
+        "unsolved intent passed to": "none",
+    }
+    record["intent_continuity"] = {
+        "larger intended outcome": "Implement #1981 by making state-delta packet views derive from one shared compact core.",
+        "this slice completes the larger intended outcome": "yes",
+        "continuation surface": "none",
+    }
+    record["required_continuation"] = {
+        "required follow-on for the larger intended outcome": "no",
+        "owner surface": "none",
+    }
+    record["closure_check"] = {
+        "slice status": "complete",
+        "larger-intent status": "closed",
+        "closure decision": "archive-and-close-after-pr-merge",
+        "why this decision is honest": "#1981 acceptance criteria are satisfied by the fixture proof.",
+        "evidence carried forward": "summary, closeout_trust, and pytest proof",
+        "reopen trigger": "closeout_trust stops accepting active execplan closeout evidence",
+    }
+    record["durable_residue"] = {
+        "status": "none",
+        "learned constraint": "No reusable product constraint in this synthetic fixture.",
+        "motivation worth preserving": "Only the closeout trust alignment behavior matters.",
+        "canonical owner now": "none",
+        "promotion trigger": "none",
+        "retention after promotion": "retain",
+    }
+    planning_installer._write_execplan_record(
+        record_path=target / ".agentic-workspace" / "planning" / "execplans" / "issue-1981.plan.json",
+        record=record,
+    )
+    _write_json(
+        target / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json",
+        {
+            "kind": "planning-external-intent-evidence/v1",
+            "refreshed_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            "items": [
+                {
+                    "system": "fixture",
+                    "id": issue_ref,
+                    "title": "Issue 1981 state-delta shared core",
+                    "status": external_status,
+                    "kind": "issue",
+                },
+            ],
+        },
+    )
+
+
+def test_closeout_trust_derives_intent_proof_from_satisfied_active_execplan(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_issue_1981_closeout_fixture(tmp_path, include_proof=True)
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "closeout_trust", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)["answer"]
+
+    assert payload["completion_gate"]["status"] == "allowed"
+    assert payload["completion_gate"]["active_intent_satisfied"] is True
+    assert payload["completion_gate"]["claim_level_allowed"] == "full-intent-complete"
+    assert payload["checks"]["intent_proof"]["status"] == "sufficient_for_claim"
+    claim_work = next(option for option in payload["completion_options"] if option["id"] == "claim-work-complete")
+    assert claim_work["allowed"] is False
+    assert claim_work["blocking_fields"] == ["durable_residue"]
+    assert "planning.active.planning_record.proof_report.intent_proof.status" not in claim_work.get("blocking_fields", [])
+
+
+def test_closeout_trust_blocks_full_closeout_when_active_execplan_proof_is_missing(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_issue_1981_closeout_fixture(tmp_path, include_proof=False)
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "closeout_trust", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)["answer"]
+
+    assert payload["completion_gate"]["status"] in {"blocked", "continue-required"}
+    assert payload["completion_gate"]["active_intent_satisfied"] is False
+    assert payload["checks"]["intent_proof"]["status"] == "not_recorded"
+    claim_work = next(option for option in payload["completion_options"] if option["id"] == "claim-work-complete")
+    assert claim_work["allowed"] is False
+    assert "planning.active.planning_record.proof_report.intent_proof.status" in claim_work["blocking_fields"]
+    assert "intent_proof" not in claim_work["blocking_fields"]
+
+
+def test_closeout_trust_names_external_intent_evidence_blocker_for_open_issue(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_issue_1981_closeout_fixture(tmp_path, include_proof=True, external_status="open")
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "closeout_trust", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)["answer"]
+
+    assert payload["checks"]["intent_proof"]["status"] == "sufficient_for_claim"
+    claim_work = next(option for option in payload["completion_options"] if option["id"] == "claim-work-complete")
+    assert claim_work["allowed"] is False
+    assert "intent_satisfaction.closure_scope.external_intent_evidence" in claim_work["blocking_fields"]
+    assert "intent_satisfaction.required_follow_on" not in claim_work["blocking_fields"]
+
+
 def test_verbose_aliases_full_diagnostic_output_for_major_workspace_commands(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     (tmp_path / "README.md").write_text("# Fixture\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Derive closeout intent proof from active execplan `proof_report`, `intent_satisfaction`, and `closure_check` when explicit `intent_proof` is absent but the active owner fields prove full-intent completion.
- Preserve conservative closeout by keeping stricter blockers visible, with exact field paths for proof, external intent evidence, continuation, and residue instead of broad `intent_proof` / `intent_satisfaction` labels.
- Accept `archive-and-close-*` closeout decisions consistently across closeout options, parent intent status, and archive eligibility.
- Add #1981-style active execplan regressions for satisfied proof, missing proof, and open external issue evidence.

Closes #1982.

## Dogfooding / #1969 evidence
- Live `closeout_trust` on the stale active #1981 plan now reports `checks.intent_proof.status=sufficient_for_claim` and no longer blames broad proof failure.
- The remaining live blockers are state-delta useful and specific: `strict_closeout_gate`, `durable_residue`, `intent_satisfaction.closure_scope.external_intent_evidence`, and `completion_gate`.
- This is evidence toward #1969 closeout, but #1969 remains open because closeout still requires broader ordinary-loop evidence across more workflow classes.

## Proof
- `uv run pytest tests/test_workspace_cli.py -q` -> 121 passed
- `make lint-workspace` -> ok
- `make test-workspace` -> ok
- `make typecheck` -> ok
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json` -> `status=in_sync`
- `uv run python scripts/run_agentic_workspace.py report --target . --section closeout_trust --format json` -> live dogfood confirmed exact remaining blockers and derived intent proof

## Architecture principle
Preserved `host-agnostic-agent-judgment`: the implementation reads structured active planning and external-evidence fields, not repo-specific prose classifiers or issue taxonomy.