### PR TITLE
[codex] Restore open issue intake selector

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -26060,8 +26060,11 @@ def _planning_state_roadmap_candidates(*, target_root: Path) -> list[dict[str, A
     return [candidate for candidate in candidates if isinstance(candidate, dict)]
 
 
-def _open_issue_intake_payload(*, target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
-    if not _is_open_issue_intake_task(task_text):
+def _open_issue_intake_payload(
+    *, target_root: Path, task_text: str | None, cli_invoke: str, explicit_request: bool = False
+) -> dict[str, Any]:
+    is_intake_task = _is_open_issue_intake_task(task_text)
+    if not is_intake_task and not explicit_request:
         return {"kind": "agentic-workspace/open-issue-intake/v1", "status": "not-applicable"}
     path, relative_path, storage = _external_intent_evidence_read_location(target_root)
     evidence: dict[str, Any] = {}
@@ -26073,20 +26076,29 @@ def _open_issue_intake_payload(*, target_root: Path, task_text: str | None, cli_
     items = [item for item in _list_payload(evidence.get("items")) if isinstance(item, dict)]
     candidates = _planning_state_roadmap_candidates(target_root=target_root)
     refreshed_at = str(evidence.get("refreshed_at") or _as_dict(evidence.get("refresh_metadata")).get("refreshed_at") or "").strip()
-    freshness_status = "fresh-enough" if path.exists() and refreshed_at else "needs-refresh"
+    refreshed_at_datetime = _parse_external_intent_timestamp(refreshed_at)
+    cache_age = datetime.now(timezone.utc) - refreshed_at_datetime if refreshed_at_datetime is not None else None
+    freshness_status = (
+        "fresh-enough"
+        if path.exists() and refreshed_at_datetime is not None and cache_age is not None and cache_age <= timedelta(hours=24)
+        else "stale-refresh-recommended"
+        if path.exists() and refreshed_at
+        else "needs-refresh"
+    )
     grouping = _external_issue_grouping_hints(items=items, candidates=candidates)
     refresh_command = _command_with_cli_invoke(
         command="agentic-workspace external-intent refresh-github --target . --state all --storage cache --apply-planning-candidates --format json",
         cli_invoke=cli_invoke,
     )
     status = "ready-to-review" if items or candidates else "refresh-needed"
-    recommended = "refresh-apply-intake" if freshness_status == "needs-refresh" else "inspect-candidate-grouping"
+    recommended = "refresh-apply-intake" if freshness_status != "fresh-enough" else "inspect-candidate-grouping"
     if candidates and freshness_status == "fresh-enough":
         recommended = "promote-or-review-first-lane"
+    trigger = "open-issue-intake-task" if is_intake_task else "explicit-selector"
     return {
         "kind": "agentic-workspace/open-issue-intake/v1",
         "status": status,
-        "trigger": "open-issue-intake-task",
+        "trigger": trigger,
         "command_owned_intake": refresh_command,
         "recommended_next_action": recommended,
         "freshness": {
@@ -26094,6 +26106,8 @@ def _open_issue_intake_payload(*, target_root: Path, task_text: str | None, cli_
             "source_path": relative_path if path.exists() else "",
             "storage": storage if path.exists() else "none",
             "refreshed_at": refreshed_at,
+            "max_age_hours": 24,
+            "age_hours": round(cache_age.total_seconds() / 3600, 2) if cache_age is not None else None,
             "refresh_before_relying_on_grouping": freshness_status != "fresh-enough",
         },
         "counts": {
@@ -26110,7 +26124,7 @@ def _open_issue_intake_payload(*, target_root: Path, task_text: str | None, cli_
         "authority_boundary": _authority_boundary_payload(
             surface="open_issue_intake",
             observed_by_aw=[
-                "task requests open issue intake",
+                "task requests open issue intake" if is_intake_task else "explicit open_issue_intake selector requested",
                 f"cached_evidence={path.exists()}",
                 f"planning_candidate_count={len(candidates)}",
             ],

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -24816,8 +24816,11 @@ def _planning_state_roadmap_candidates(*, target_root: Path) -> list[dict[str, A
     return [candidate for candidate in candidates if isinstance(candidate, dict)]
 
 
-def _open_issue_intake_payload(*, target_root: Path, task_text: str | None, cli_invoke: str) -> dict[str, Any]:
-    if not _is_open_issue_intake_task(task_text):
+def _open_issue_intake_payload(
+    *, target_root: Path, task_text: str | None, cli_invoke: str, explicit_request: bool = False
+) -> dict[str, Any]:
+    is_intake_task = _is_open_issue_intake_task(task_text)
+    if not is_intake_task and not explicit_request:
         return {"kind": "agentic-workspace/open-issue-intake/v1", "status": "not-applicable"}
     path, relative_path, storage = _external_intent_evidence_read_location(target_root)
     evidence: dict[str, Any] = {}
@@ -24829,20 +24832,29 @@ def _open_issue_intake_payload(*, target_root: Path, task_text: str | None, cli_
     items = [item for item in _list_payload(evidence.get("items")) if isinstance(item, dict)]
     candidates = _planning_state_roadmap_candidates(target_root=target_root)
     refreshed_at = str(evidence.get("refreshed_at") or _as_dict(evidence.get("refresh_metadata")).get("refreshed_at") or "").strip()
-    freshness_status = "fresh-enough" if path.exists() and refreshed_at else "needs-refresh"
+    refreshed_at_datetime = _parse_external_intent_timestamp(refreshed_at)
+    cache_age = datetime.now(timezone.utc) - refreshed_at_datetime if refreshed_at_datetime is not None else None
+    freshness_status = (
+        "fresh-enough"
+        if path.exists() and refreshed_at_datetime is not None and cache_age is not None and cache_age <= timedelta(hours=24)
+        else "stale-refresh-recommended"
+        if path.exists() and refreshed_at
+        else "needs-refresh"
+    )
     grouping = _external_issue_grouping_hints(items=items, candidates=candidates)
     refresh_command = _command_with_cli_invoke(
         command="agentic-workspace external-intent refresh-github --target . --state all --storage cache --apply-planning-candidates --format json",
         cli_invoke=cli_invoke,
     )
     status = "ready-to-review" if items or candidates else "refresh-needed"
-    recommended = "refresh-apply-intake" if freshness_status == "needs-refresh" else "inspect-candidate-grouping"
+    recommended = "refresh-apply-intake" if freshness_status != "fresh-enough" else "inspect-candidate-grouping"
     if candidates and freshness_status == "fresh-enough":
         recommended = "promote-or-review-first-lane"
+    trigger = "open-issue-intake-task" if is_intake_task else "explicit-selector"
     return {
         "kind": "agentic-workspace/open-issue-intake/v1",
         "status": status,
-        "trigger": "open-issue-intake-task",
+        "trigger": trigger,
         "command_owned_intake": refresh_command,
         "recommended_next_action": recommended,
         "freshness": {
@@ -24850,6 +24862,8 @@ def _open_issue_intake_payload(*, target_root: Path, task_text: str | None, cli_
             "source_path": relative_path if path.exists() else "",
             "storage": storage if path.exists() else "none",
             "refreshed_at": refreshed_at,
+            "max_age_hours": 24,
+            "age_hours": round(cache_age.total_seconds() / 3600, 2) if cache_age is not None else None,
             "refresh_before_relying_on_grouping": freshness_status != "fresh-enough",
         },
         "counts": {
@@ -24866,7 +24880,7 @@ def _open_issue_intake_payload(*, target_root: Path, task_text: str | None, cli_
         "authority_boundary": _authority_boundary_payload(
             surface="open_issue_intake",
             observed_by_aw=[
-                "task requests open issue intake",
+                "task requests open issue intake" if is_intake_task else "explicit open_issue_intake selector requested",
                 f"cached_evidence={path.exists()}",
                 f"planning_candidate_count={len(candidates)}",
             ],

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -86,6 +86,7 @@ from agentic_workspace.workspace_runtime_core import (
     _module_operations,
     _module_registry,
     _next_safe_action_packet,
+    _open_issue_intake_payload,
     _operating_posture_payload,
     _ordinary_decision_packet,
     _package_boundary_payload,
@@ -1206,6 +1207,13 @@ def _hydrate_selected_start_advisory_payloads(
             payload["issue_reference_intent"] = _issue_reference_intent_payload(
                 issue_scope_evidence=gate.get("issue_scope_evidence", {}), cli_invoke=config.cli_invoke
             )
+    if _selector_requests(select, "open_issue_intake"):
+        payload["open_issue_intake"] = _open_issue_intake_payload(
+            target_root=target_root,
+            task_text=task_text,
+            cli_invoke=config.cli_invoke,
+            explicit_request=True,
+        )
     if _selector_requests(select, "local_chat_checkpoint"):
         payload["local_chat_checkpoint"] = _local_chat_checkpoint_projection(target_root=target_root, cli_invoke=config.cli_invoke)
     if _selector_requests(select, "work_threads"):

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import re
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 from tests.workspace_cli_support import *
@@ -3090,7 +3090,7 @@ def test_start_open_issue_intake_routes_refresh_and_grouping(tmp_path: Path, cap
         json.dumps(
             {
                 "kind": "planning-external-intent-evidence/v1",
-                "refreshed_at": "2026-06-26T08:00:00+00:00",
+                "refreshed_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
                 "refresh_metadata": {"adapter": "fixture", "open_count": 4, "closed_count": 0},
                 "items": [
                     {"id": "#1739", "system": "github", "status": "open", "kind": "lane", "title": "Dogfooding friction lane"},
@@ -3162,6 +3162,25 @@ candidates = [
     assert grouping["child_issue_clusters"][0]["child_count"] == 2
     assert grouping["standalone_candidates"][0]["id"] == "#1802"
     assert intake["detailed_issue_list_rule"]
+
+    assert cli.main(["start", "--target", str(tmp_path), "--select", "open_issue_intake", "--format", "json"]) == 0
+    selected = json.loads(capsys.readouterr().out)
+    selected_intake = selected["values"]["open_issue_intake"]
+    assert selected.get("missing", []) == []
+    assert selected_intake["trigger"] == "explicit-selector"
+    assert selected_intake["status"] == "ready-to-review"
+    assert "external-intent refresh-github" in selected_intake["command_owned_intake"]
+    assert selected_intake["counts"]["open_issue_count"] == 4
+    assert selected_intake["grouping_hints"]["parent_lanes"][0]["id"] == "#1739"
+    assert "explicit open_issue_intake selector requested" in selected_intake["authority_boundary"]["observed_by_aw"]
+
+    stale_payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+    stale_payload["refreshed_at"] = (datetime.now(timezone.utc) - timedelta(hours=25)).replace(microsecond=0).isoformat()
+    evidence_path.write_text(json.dumps(stale_payload), encoding="utf-8")
+    assert cli.main(["start", "--target", str(tmp_path), "--select", "open_issue_intake", "--format", "json"]) == 0
+    stale_intake = json.loads(capsys.readouterr().out)["values"]["open_issue_intake"]
+    assert stale_intake["freshness"]["status"] == "stale-refresh-recommended"
+    assert stale_intake["recommended_next_action"] == "refresh-apply-intake"
 
 
 def test_start_cached_issue_reference_intent_is_advisory(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Hydrates `open_issue_intake` for explicit `start --select open_issue_intake` requests, so the old selector returns a usable packet instead of only `missing`.
- Preserves the ordinary quiet path: open issue intake is still task-triggered unless the selector is explicitly requested.
- Mirrors the intake helper change into `workspace_runtime_primitives.py` and tightens cache freshness so stale external issue evidence routes agents back to command-owned refresh/apply.
- Extends the existing open-issue intake fixture to cover direct selector output and stale-cache refresh guidance.

Closes #2002.

## Stacking
Stacked on #2004 / `codex/1982-closeout-trust-alignment`.

## Dogfooding / #1969 evidence
- Before this lane, `start --select open_issue_intake` could return only a missing selector, forcing direct `gh issue list/view` reconstruction.
- After this lane, the exact command returns `values.open_issue_intake` with command-owned intake, grouping hints, authority boundary, and stale-cache guidance.
- Live repo dogfood now reports the local cache as `stale-refresh-recommended` with `recommended_next_action=refresh-apply-intake`, which is useful state-delta evidence for #1969 but does not close #1969.

## Proof
- `uv run pytest tests/test_workspace_cli.py -q -k "open_issue_intake"` -> passed
- `uv run pytest tests/test_workspace_summary_cli.py -q -k "external_intent_refresh_applies_stale_candidate_reconciliation"` -> passed
- `uv run pytest tests/test_workspace_cli.py -q` -> 121 passed
- `make lint-workspace` -> ok
- `make test-workspace` -> ok
- `make typecheck` -> ok
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json` -> `status=in_sync`
- `uv run python scripts/run_agentic_workspace.py start --target . --select open_issue_intake --format json` -> returned `values.open_issue_intake`, not `missing`

## Architecture principle
Preserved `host-agnostic-agent-judgment`: the route exposes provider-agnostic cached external-intent evidence and command-owned refresh guidance without importing tracker state into Planning or hard-coding repo issue taxonomy.