### PR TITLE
[codex] Handle comma-separated changed paths

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -39200,22 +39200,23 @@ def _emit_workspace_operation_system_intent_payload_text(payload: dict[str, Any]
 def _normalize_changed_paths(paths: Sequence[str]) -> list[str]:
     normalized: list[str] = []
     for path_text in paths:
-        stripped = str(path_text).strip()
-        if not stripped:
-            continue
-        path = Path(stripped)
-        try:
-            if path.is_absolute():
-                stripped = path.resolve().as_posix()
-            else:
+        for raw_part in str(path_text).split(","):
+            stripped = raw_part.strip()
+            if not stripped:
+                continue
+            path = Path(stripped)
+            try:
+                if path.is_absolute():
+                    stripped = path.resolve().as_posix()
+                else:
+                    stripped = path.as_posix()
+            except OSError:
                 stripped = path.as_posix()
-        except OSError:
-            stripped = path.as_posix()
-        while stripped.startswith("./"):
-            stripped = stripped[2:]
-        stripped = stripped.rstrip("/")
-        if stripped and stripped not in normalized:
-            normalized.append(stripped)
+            while stripped.startswith("./"):
+                stripped = stripped[2:]
+            stripped = stripped.rstrip("/")
+            if stripped and stripped not in normalized:
+                normalized.append(stripped)
     return normalized
 
 

--- a/src/agentic_workspace/workspace_runtime_generated_surface.py
+++ b/src/agentic_workspace/workspace_runtime_generated_surface.py
@@ -41,22 +41,23 @@ def _selector_tokens(select: str | None) -> list[str]:
 def _normalize_changed_paths(paths: list[str]) -> list[str]:
     normalized: list[str] = []
     for path_text in paths:
-        stripped = str(path_text).strip()
-        if not stripped:
-            continue
-        path = Path(stripped)
-        try:
-            if path.is_absolute():
-                stripped = path.resolve().as_posix()
-            else:
+        for raw_part in str(path_text).split(","):
+            stripped = raw_part.strip()
+            if not stripped:
+                continue
+            path = Path(stripped)
+            try:
+                if path.is_absolute():
+                    stripped = path.resolve().as_posix()
+                else:
+                    stripped = path.as_posix()
+            except OSError:
                 stripped = path.as_posix()
-        except OSError:
-            stripped = path.as_posix()
-        while stripped.startswith("./"):
-            stripped = stripped[2:]
-        stripped = stripped.rstrip("/")
-        if stripped and stripped not in normalized:
-            normalized.append(stripped)
+            while stripped.startswith("./"):
+                stripped = stripped[2:]
+            stripped = stripped.rstrip("/")
+            if stripped and stripped not in normalized:
+                normalized.append(stripped)
     return normalized
 
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -37091,22 +37091,23 @@ def _emit_workspace_operation_system_intent_payload_text(payload: dict[str, Any]
 def _normalize_changed_paths(paths: Sequence[str]) -> list[str]:
     normalized: list[str] = []
     for path_text in paths:
-        stripped = str(path_text).strip()
-        if not stripped:
-            continue
-        path = Path(stripped)
-        try:
-            if path.is_absolute():
-                stripped = path.resolve().as_posix()
-            else:
+        for raw_part in str(path_text).split(","):
+            stripped = raw_part.strip()
+            if not stripped:
+                continue
+            path = Path(stripped)
+            try:
+                if path.is_absolute():
+                    stripped = path.resolve().as_posix()
+                else:
+                    stripped = path.as_posix()
+            except OSError:
                 stripped = path.as_posix()
-        except OSError:
-            stripped = path.as_posix()
-        while stripped.startswith("./"):
-            stripped = stripped[2:]
-        stripped = stripped.rstrip("/")
-        if stripped and stripped not in normalized:
-            normalized.append(stripped)
+            while stripped.startswith("./"):
+                stripped = stripped[2:]
+            stripped = stripped.rstrip("/")
+            if stripped and stripped not in normalized:
+                normalized.append(stripped)
     return normalized
 
 

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -3200,6 +3200,30 @@ def test_implement_accumulates_repeated_changed_flags(tmp_path: Path, capsys) ->
     assert "focused tiny/default payload shape tests" in compatibility_review["expected_proof"]
 
 
+def test_implement_splits_comma_separated_changed_paths(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "./src/app.py, tests/test_app.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["context"]["scope"]["changed_paths"] == ["src/app.py", "tests/test_app.py"]
+    assert "changed_path_count=2" in payload["decision_packet"]["reasons"]
+
+
 def test_implement_package_cli_edits_select_generated_command_package_gate(capsys) -> None:
     assert (
         cli.main(


### PR DESCRIPTION
## Summary
- Split comma-separated `--changed` values before path normalization so `implement --changed "a,b"` no longer produces one synthetic path.
- Keep existing normalization behavior for repeated flags, relative `./` prefixes, absolute paths, empty values, and dedupe.
- Add focused CLI regression coverage for the comma-separated implement input.

## Stack
- Base: `codex/2002-open-issue-intake`
- This PR stacks after #2005.

## Dogfooding evidence for #1969
- Before this lane, #1975 showed a misleading state-delta: a comma bundle could report `changed_path_count=1` and route proof from a synthetic path.
- After this change, `uv run python scripts/run_agentic_workspace.py implement --changed "./src/app.py, tests/test_app.py" --format json` reports `changed_path_count=2` and `context.scope.changed_paths=["src/app.py", "tests/test_app.py"]`.
- This is evidence that state-delta-first closeout improves when path scope is normalized before routing, but it does not close #1969.

## Validation
- `uv run pytest tests/test_workspace_implement_cli.py -q -k "changed_paths or comma_separated"`
- `uv run python scripts/run_agentic_workspace.py implement --changed "./src/app.py, tests/test_app.py" --format json`
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json` -> `status=in_sync`

Closes #1975