### PR TITLE
[codex] Explain proof command reason classes

### DIFF
--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -3194,6 +3194,14 @@ def _proof_selection_for_changed_paths(
         proof_confidence=proof_confidence,
         manual_verification=manual_verification,
     )
+    proof_command_explanations = _proof_command_explanations_payload(
+        selected_commands=selected_commands,
+        required_commands=required_commands,
+        optional_commands=optional_commands,
+        unavailable_commands=unavailable_commands,
+        host_policy_blocked_commands=host_policy_blocked_commands,
+        manual_verification=manual_verification,
+    )
     active_planning_record_for_requirement = (
         _active_planning_record_for_report_section(target_root=target_root) if target_root is not None else {}
     )
@@ -3300,6 +3308,7 @@ def _proof_selection_for_changed_paths(
         "intent_proof": intent_proof,
         "proof_confidence": proof_confidence,
         "proof_adequacy": proof_adequacy,
+        "proof_command_explanations": proof_command_explanations,
         "requirement_grounding": requirement_grounding,
         "test_strategy_check": test_strategy_check,
         "architecture_principles": architecture_principles,
@@ -3689,3 +3698,132 @@ def _markdown_path_reference_memory_note_entry() -> str:
         "learned_at": date.today().isoformat(),
     }
     return f"agentic-workspace-proof-route: {json.dumps(entry, sort_keys=True)}"
+
+
+def _proof_command_explanations_payload(
+    *,
+    selected_commands: list[dict[str, Any]],
+    required_commands: list[str],
+    optional_commands: list[str],
+    unavailable_commands: list[dict[str, Any]],
+    host_policy_blocked_commands: list[dict[str, str]],
+    manual_verification: dict[str, Any] | None,
+) -> dict[str, Any]:
+    selected_by_text = {str(command.get("command", "")): command for command in selected_commands}
+    required_items = [
+        _proof_command_explanation_item(command=str(command), selected=selected_by_text.get(str(command), {}), blocking=True)
+        for command in required_commands
+    ]
+    optional_items = [
+        {
+            "command": str(command),
+            "reason_classes": ["optional-confidence"],
+            "blocking": False,
+            "why": "Recommended confidence check; it may raise trust but does not replace required proof.",
+        }
+        for command in optional_commands
+        if str(command) not in set(required_commands)
+    ]
+    manual_items = (
+        [
+            {
+                "kind": "manual-verification/v1",
+                "status": str(manual_verification.get("status", "")),
+                "reason_classes": ["unavailable-manual"],
+                "blocking": True,
+                "why": str(manual_verification.get("reason", "")) or "Manual verification is required.",
+            }
+        ]
+        if manual_verification is not None
+        else []
+    )
+    unavailable_items = [
+        {
+            "command": str(command.get("command", "")),
+            "lane": str(command.get("lane", "")),
+            "reason": str(command.get("reason", "")),
+            "reason_classes": ["unavailable-manual"],
+            "blocking": True,
+            **({"missing_paths": command["missing_paths"]} if command.get("missing_paths") else {}),
+            **({"replacement": command["replacement"]} if command.get("replacement") else {}),
+        }
+        for command in unavailable_commands
+    ]
+    policy_blocked_items = [
+        {
+            "command": str(command.get("command", "")),
+            "lane": str(command.get("lane", "")),
+            "reason": str(command.get("reason", "")),
+            "reason_classes": ["explicit-config-policy"],
+            "blocking": True,
+            "configured_command": str(command.get("configured_command", "")),
+        }
+        for command in host_policy_blocked_commands
+    ]
+    return {
+        "kind": "agentic-workspace/proof-command-explanations/v1",
+        "status": "present" if required_items or optional_items or manual_items or unavailable_items else "empty",
+        "reason_class_model": {
+            "learned-repo-evidence": "selected from confirmed repo-local route evidence or Memory-backed learning",
+            "explicit-config-policy": "selected or blocked by host configuration, subsystem ownership, local overlay, or proof profile",
+            "changed-surface-risk": "selected because changed paths matched a proof rule or risk lane",
+            "conservative-fallback": "selected through package seed, broad fallback, or live-adapted target capability before route learning is mature",
+            "optional-confidence": "recommended confidence check that is not a hard closeout blocker",
+            "unavailable-manual": "manual verification or explanation is required because executable proof is missing, blocked, or unavailable",
+        },
+        "required": required_items,
+        "optional_confidence": optional_items,
+        "manual_or_unavailable": [*manual_items, *unavailable_items, *policy_blocked_items],
+        "blocking_rule": (
+            "Only required commands, host-policy blockers, unavailable required proof, and required manual verification block closeout; "
+            "optional confidence checks remain visible but non-blocking."
+        ),
+        "route_maturity_rule": "Commands with conservative-fallback should be refined by learned route evidence before treating them as route-specific.",
+    }
+
+
+def _proof_command_explanation_item(*, command: str, selected: dict[str, Any], blocking: bool) -> dict[str, Any]:
+    route_source = str(selected.get("selected_from", ""))
+    fallback_status = str(selected.get("fallback_status", ""))
+    reason_classes = _proof_command_reason_classes(route_source=route_source, fallback_status=fallback_status)
+    return {
+        "command": command,
+        "lane": str(selected.get("lane", "")),
+        "intent_type": str(selected.get("intent_type", "")),
+        "route_source": route_source,
+        "fallback_status": fallback_status,
+        "route_authority": str(selected.get("route_authority", "")),
+        "reason_classes": reason_classes,
+        "blocking": blocking,
+        "why": _proof_command_explanation_text(reason_classes=reason_classes, selected=selected),
+    }
+
+
+def _proof_command_reason_classes(*, route_source: str, fallback_status: str) -> list[str]:
+    classes: list[str] = []
+    if route_source == "repo-learned-proof-route":
+        classes.append("learned-repo-evidence")
+    if route_source in {
+        "host-configured-proof-profile",
+        "host-declared-domain-proof-lane",
+        "host-configured-subsystem",
+        "local-only-high-risk-overlay",
+        "verification-manual-protocol",
+    }:
+        classes.append("explicit-config-policy")
+    if route_source in {"live-confirmed-proof-rule", "live-adapted-target-capability"}:
+        classes.append("changed-surface-risk")
+    if fallback_status in {"seed-fallback", "fallback", "candidate-live-confirmed"}:
+        classes.append("conservative-fallback")
+    return classes or ["changed-surface-risk"]
+
+
+def _proof_command_explanation_text(*, reason_classes: list[str], selected: dict[str, Any]) -> str:
+    lane = str(selected.get("lane", ""))
+    if "learned-repo-evidence" in reason_classes:
+        return f"Required because learned repo evidence selected lane {lane}."
+    if "explicit-config-policy" in reason_classes:
+        return f"Required because host-owned policy or configuration selected lane {lane}."
+    if "conservative-fallback" in reason_classes:
+        return f"Required as conservative fallback for lane {lane}; refine with learned route evidence when possible."
+    return f"Required because changed-surface risk selected lane {lane}."

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -3762,7 +3762,7 @@ def _proof_command_explanations_payload(
     ]
     return {
         "kind": "agentic-workspace/proof-command-explanations/v1",
-        "status": "present" if required_items or optional_items or manual_items or unavailable_items else "empty",
+        "status": "present" if required_items or optional_items or manual_items or unavailable_items or policy_blocked_items else "empty",
         "reason_class_model": {
             "learned-repo-evidence": "selected from confirmed repo-local route evidence or Memory-backed learning",
             "explicit-config-policy": "selected or blocked by host configuration, subsystem ownership, local overlay, or proof profile",

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -799,6 +799,12 @@ def test_proof_verbose_exposes_manual_fallback_decision_layers(tmp_path: Path, c
     assert execution_evidence["missing_evidence_diagnostics"]["not-run-or-not-recorded"] == (
         "no trusted receipt exists for this selected command"
     )
+    explanations = answer["proof_command_explanations"]
+    assert explanations["status"] == "present"
+    assert explanations["required"] == []
+    assert explanations["manual_or_unavailable"][0]["reason_classes"] == ["unavailable-manual"]
+    assert explanations["manual_or_unavailable"][0]["blocking"] is True
+    assert "optional-confidence" in explanations["reason_class_model"]
 
 
 def test_proof_changed_uses_target_package_json_scripts_without_makefile(tmp_path: Path, capsys) -> None:
@@ -2706,6 +2712,13 @@ def test_proof_changed_selector_includes_planning_source_typecheck_ci_parity(tmp
     assert typecheck_step["lane_id"] == "planning_source_typecheck_ci_parity"
     typecheck_command = next(command for command in answer["selected_commands"] if command["command"] == "make typecheck-planning")
     assert typecheck_command["intent_type"] == "static-check"
+    explanations = answer["proof_command_explanations"]
+    typecheck_explanation = next(item for item in explanations["required"] if item["command"] == "make typecheck-planning")
+    assert typecheck_explanation["blocking"] is True
+    assert "changed-surface-risk" in typecheck_explanation["reason_classes"]
+    assert "conservative-fallback" in typecheck_explanation["reason_classes"]
+    assert all(item["blocking"] is False for item in explanations["optional_confidence"])
+    assert explanations["blocking_rule"].startswith("Only required commands")
 
 
 def test_proof_changed_selector_includes_workspace_runtime_typecheck_ci_parity(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -807,6 +807,38 @@ def test_proof_verbose_exposes_manual_fallback_decision_layers(tmp_path: Path, c
     assert "optional-confidence" in explanations["reason_class_model"]
 
 
+def test_proof_command_explanations_status_present_for_policy_blockers_only() -> None:
+    explanations = workspace_runtime_proof._proof_command_explanations_payload(
+        selected_commands=[],
+        required_commands=[],
+        optional_commands=[],
+        unavailable_commands=[],
+        host_policy_blocked_commands=[
+            {
+                "command": "npm test",
+                "lane": "concern:no_npm_test",
+                "reason": "host-configured proof profile disallows this command",
+                "configured_command": "npm test",
+            }
+        ],
+        manual_verification=None,
+    )
+
+    assert explanations["status"] == "present"
+    assert explanations["required"] == []
+    assert explanations["optional_confidence"] == []
+    assert explanations["manual_or_unavailable"] == [
+        {
+            "command": "npm test",
+            "lane": "concern:no_npm_test",
+            "reason": "host-configured proof profile disallows this command",
+            "reason_classes": ["explicit-config-policy"],
+            "blocking": True,
+            "configured_command": "npm test",
+        }
+    ]
+
+
 def test_proof_changed_uses_target_package_json_scripts_without_makefile(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(tmp_path / "package.json", json.dumps({"scripts": {"test": "vitest run", "lint": "eslint ."}}))


### PR DESCRIPTION
## Summary
- Add `proof_command_explanations` to proof selection output.
- Classify required commands with reason classes for learned repo evidence, explicit config/policy, changed-surface risk, conservative fallback, optional confidence, and manual/unavailable proof.
- Keep completion blocking tied only to required commands, host-policy blockers, unavailable required proof, and required manual verification.
- Preserve optional confidence checks as visible but non-blocking.

## Stack
- Base: `codex/1994-markdown-path-reference-checks`
- This PR stacks after #2008.

## Dogfooding evidence for #1969 and #2000
- This makes the proof state-delta more direct: maintainers can inspect why a command blocks closeout and whether fallback maturity is involved without inferring from broad command lists.
- The packet helps #2000 learned-route work by naming conservative fallback and learned-route classes, but it does not close #2000.

## Validation
- `uv run pytest tests/test_workspace_proof_cli.py -q -k "manual_fallback_decision_layers or planning_source_typecheck_ci_parity"`
- `uv run python scripts/run_agentic_workspace.py implement --changed src/agentic_workspace/workspace_runtime_proof.py tests/test_workspace_proof_cli.py --task "Implement #1995 proof command reason classes and fallback explanation" --format json`
- `uv run pytest tests/test_workspace_proof_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make typecheck`

Closes #1995