### PR TITLE
[codex] Add PR comment addressing packet

### DIFF
--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -12,6 +12,16 @@ Use `pr_comment_delta.py` at the start of a review-response turn when a PR may h
 - ambiguous comments route to clarification instead of broad local edits;
 - resolved or outdated threads become informational.
 
+Each item also carries an `addressing_status` so AW report/startup can derive a closeout packet without rereading raw comments:
+
+- `unresolved_action` needs a code, docs, metadata, or checks action;
+- `reply_only` needs clarification or a human response before local edits;
+- `already_addressed` was resolved in the inspected thread evidence;
+- `outdated` was superseded by later diff state;
+- `informational` does not require local action.
+
+The packet includes `comment_surfaces` so closeout can distinguish complete GraphQL comment/thread reads from normalized fixtures or legacy caches with incomplete thread-surface proof.
+
 Live read-only use:
 
 ```powershell

--- a/scripts/github/pr_comment_delta.py
+++ b/scripts/github/pr_comment_delta.py
@@ -27,6 +27,11 @@ CATEGORIES = (
     "informational_no_local_change",
     "ambiguous_needs_human",
 )
+ACTIONABLE_CATEGORIES = (
+    "actionable_code_doc_body_change",
+    "pr_metadata_body_only_change",
+    "ci_label_only_issue",
+)
 
 
 def _parse_timestamp(value: str | None) -> datetime | None:
@@ -72,9 +77,13 @@ def _author_login(raw: Any) -> str:
 
 
 def _normalize_graphql(payload: dict[str, Any]) -> dict[str, Any]:
+    graphql_shape = False
     pr = payload.get("pull_request") if isinstance(payload.get("pull_request"), dict) else None
     if pr is None:
         pr = payload.get("data", {}).get("repository", {}).get("pullRequest", {})
+        graphql_shape = bool(pr)
+    else:
+        graphql_shape = True
     if not isinstance(pr, dict):
         pr = {}
 
@@ -160,6 +169,11 @@ def _normalize_graphql(payload: dict[str, Any]) -> dict[str, Any]:
             },
             "rule": "When truncated is true, do not treat this packet as a complete review-comment delta.",
         },
+        "comment_surfaces": {
+            "inspected": ["issue_comments", "reviews", "review_threads"] if graphql_shape else ["normalized_comments"],
+            "unavailable": [] if graphql_shape else ["thread_surface_completeness"],
+            "rule": "Use unavailable surfaces to bound review-readiness claims; normalized fixtures may not prove complete thread coverage.",
+        },
     }
 
 
@@ -225,6 +239,18 @@ def _classify(item: dict[str, Any]) -> tuple[str, str, str]:
     )
 
 
+def _addressing_status(item: dict[str, Any], category: str) -> str:
+    if item.get("is_outdated") is True:
+        return "outdated"
+    if item.get("is_resolved") is True:
+        return "already_addressed"
+    if category == "ambiguous_needs_human":
+        return "reply_only"
+    if category in ACTIONABLE_CATEGORIES:
+        return "unresolved_action"
+    return "informational"
+
+
 def _item_identity(item: dict[str, Any]) -> str:
     for key in ("url", "database_id", "databaseId", "id"):
         value = _text(item.get(key))
@@ -251,10 +277,13 @@ def build_packet(payload: dict[str, Any], *, since: datetime | None = None, seen
             skipped_seen += 1
             continue
         category, reason, proof_hint = _classify(raw)
+        addressing_status = _addressing_status(raw, category)
         item = {
             "id": _item_identity(raw),
             "kind": _text(raw.get("kind") or "comment"),
             "category": category,
+            "addressing_status": addressing_status,
+            "action_required": addressing_status in {"unresolved_action", "reply_only"},
             "reason": reason,
             "proof_hint": proof_hint,
             "url": url,
@@ -297,6 +326,7 @@ def build_packet(payload: dict[str, Any], *, since: datetime | None = None, seen
         "category_counts": counts,
         "items": items,
         "pagination": pagination,
+        "comment_surfaces": normalized.get("comment_surfaces", {}),
         "smallest_next_action": _smallest_next_action(counts, pagination=pagination),
         "write_safety": {
             "github_writes_performed": False,

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -24141,6 +24141,162 @@ def _installed_state_closeout_residue_payload(
     }
 
 
+_PR_COMMENT_ADDRESSING_BUCKETS = (
+    "unresolved_action",
+    "reply_only",
+    "already_addressed",
+    "outdated",
+    "informational",
+)
+
+
+def _pr_comment_item_addressing_status(item: dict[str, Any]) -> str:
+    explicit = str(item.get("addressing_status") or "").strip()
+    if explicit in _PR_COMMENT_ADDRESSING_BUCKETS:
+        return explicit
+    if item.get("is_outdated") is True:
+        return "outdated"
+    if item.get("is_resolved") is True:
+        return "already_addressed"
+    category = str(item.get("category") or "").strip()
+    if category == "ambiguous_needs_human":
+        return "reply_only"
+    if category in {"actionable_code_doc_body_change", "pr_metadata_body_only_change", "ci_label_only_issue"}:
+        return "unresolved_action"
+    return "informational"
+
+
+def _pr_comment_addressing_sample(item: dict[str, Any]) -> dict[str, Any]:
+    status = _pr_comment_item_addressing_status(item)
+    return {
+        key: item.get(key)
+        for key in (
+            "id",
+            "kind",
+            "category",
+            "path",
+            "line",
+            "url",
+            "author",
+            "created_at",
+            "proof_hint",
+            "reason",
+            "body_excerpt",
+        )
+        if item.get(key) not in (None, "")
+    } | {"addressing_status": status}
+
+
+def _pr_comment_addressing_unavailable_packet(
+    *, repo: str, pr_number: str, cache_path: str, reason: str, cli_invoke: str
+) -> dict[str, Any]:
+    return {
+        "kind": "agentic-workspace/pr-comment-addressing/v1",
+        "status": "review_comment_evidence_unavailable",
+        "repository": repo,
+        "pr_number": pr_number,
+        "source_availability": {
+            "cached_delta": "unavailable",
+            "thread_level_comments": "unverified",
+            "cache_path": cache_path,
+            "reason": reason,
+        },
+        "bucket_counts": {bucket: 0 for bucket in _PR_COMMENT_ADDRESSING_BUCKETS},
+        "buckets": {bucket: [] for bucket in _PR_COMMENT_ADDRESSING_BUCKETS},
+        "closeout": {
+            "status": "blocked_until_inspected",
+            "addressed_comments": [],
+            "intentionally_open_comments": [],
+            "rule": "Fetch or provide thread-aware PR comment evidence before claiming review feedback is fully handled.",
+        },
+        "thread_inspection": _pr_comment_thread_inspection_payload(repo=repo, pr_number=pr_number, cli_invoke=cli_invoke),
+        "write_safety": {
+            "github_writes_performed": False,
+            "rule": "Do not reply, resolve, or submit reviews from this packet without explicit user approval.",
+        },
+    }
+
+
+def _pr_comment_addressing_packet_from_delta(
+    *, cache: dict[str, Any], repo: str, pr_number: str, cache_path: str, cli_invoke: str
+) -> dict[str, Any]:
+    items = [item for item in _list_payload(cache.get("items")) if isinstance(item, dict)]
+    buckets: dict[str, list[dict[str, Any]]] = {bucket: [] for bucket in _PR_COMMENT_ADDRESSING_BUCKETS}
+    for item in items:
+        buckets[_pr_comment_item_addressing_status(item)].append(_pr_comment_addressing_sample(item))
+    bucket_counts = {bucket: len(entries) for bucket, entries in buckets.items()}
+    freshness = cache.get("freshness", {}) if isinstance(cache.get("freshness"), dict) else {}
+    pagination = cache.get("pagination", {}) if isinstance(cache.get("pagination"), dict) else {}
+    truncated = bool(pagination.get("truncated"))
+    comment_surfaces = cache.get("comment_surfaces", {}) if isinstance(cache.get("comment_surfaces"), dict) else {}
+    unavailable_surfaces = [str(item) for item in _list_payload(comment_surfaces.get("unavailable")) if str(item).strip()]
+    if not comment_surfaces:
+        unavailable_surfaces.append("thread_surface_completeness")
+    if truncated:
+        unavailable_surfaces.append("paginated_comment_tail")
+    fresh = freshness.get("status") == "current_at_observed_head" and bool(str(freshness.get("pr_head_sha") or "").strip())
+    open_count = bucket_counts["unresolved_action"] + bucket_counts["reply_only"]
+    status = (
+        "incomplete_review_comment_evidence"
+        if truncated
+        else "unresolved_review_feedback_present"
+        if open_count
+        else "stale_or_unverified"
+        if not fresh
+        else "review_feedback_closed"
+    )
+    changed_files = sorted(
+        {str(item.get("path") or "").strip() for item in buckets["unresolved_action"] if str(item.get("path") or "").strip()}
+    )
+    return {
+        "kind": "agentic-workspace/pr-comment-addressing/v1",
+        "status": status,
+        "repository": repo,
+        "pr_number": str(cache.get("pr_number") or pr_number),
+        "pr_url": str(cache.get("pr_url") or ""),
+        "source_availability": {
+            "cached_delta": "available",
+            "cache_path": cache_path,
+            "freshness": freshness or {"status": "missing"},
+            "pagination": pagination,
+            "inspected_surfaces": [str(item) for item in _list_payload(comment_surfaces.get("inspected")) if str(item).strip()]
+            or ["cached_delta_items"],
+            "unavailable_surfaces": unavailable_surfaces,
+            "surface_rule": str(
+                comment_surfaces.get("rule")
+                or "Use unavailable surfaces to bound review-readiness claims before claiming all comments are handled."
+            ),
+        },
+        "bucket_counts": bucket_counts,
+        "buckets": buckets,
+        "changed_files": changed_files,
+        "proof_linkage": {
+            "status": "path_anchored" if changed_files else "no_path_anchored_actions" if open_count else "no_open_local_actions",
+            "changed_paths": changed_files,
+            "proof_hints": [
+                str(item.get("proof_hint") or "") for item in buckets["unresolved_action"][:3] if str(item.get("proof_hint") or "").strip()
+            ],
+        },
+        "closeout": {
+            "status": "open_feedback_present" if open_count else "ready_if_fresh" if fresh else "blocked_until_refreshed",
+            "addressed_comments": buckets["already_addressed"],
+            "outdated_comments": buckets["outdated"],
+            "intentionally_open_comments": [*buckets["unresolved_action"], *buckets["reply_only"]],
+            "rule": (
+                "Before closeout, list each unresolved or reply-only comment as addressed or intentionally open; "
+                "do not treat stale or truncated comment evidence as full closure proof."
+            ),
+        },
+        "thread_inspection": _pr_comment_thread_inspection_payload(
+            repo=repo, pr_number=str(cache.get("pr_number") or pr_number), cli_invoke=cli_invoke, status="available"
+        ),
+        "write_safety": {
+            "github_writes_performed": False,
+            "rule": "Do not reply, resolve, or submit reviews from this packet without explicit user approval.",
+        },
+    }
+
+
 def _pr_stack_comment_cache_payload(*, target_root: Path, repo: str, branch: str, cli_invoke: str) -> dict[str, Any]:
     cache_path = ".agentic-workspace/local/cache/pr-comment-stack.json"
     cache = _read_local_cache_json(target_root, cache_path)
@@ -24192,6 +24348,13 @@ def _pr_stack_comment_cache_payload(*, target_root: Path, repo: str, branch: str
             unavailable_present = True
         refresh_command = _pr_comment_report_command(cli_invoke=cli_invoke)
         thread_inspection = _pr_comment_thread_inspection_payload(repo=command_repo, pr_number=pr_number, cli_invoke=cli_invoke)
+        comment_addressing = _pr_comment_addressing_packet_from_delta(
+            cache=member_cache,
+            repo=command_repo,
+            pr_number=pr_number,
+            cache_path=cache_path,
+            cli_invoke=cli_invoke,
+        )
         members.append(
             {
                 "pr_number": pr_number,
@@ -24214,6 +24377,7 @@ def _pr_stack_comment_cache_payload(*, target_root: Path, repo: str, branch: str
                     repo=command_repo, pr_number=pr_number, cli_invoke=cli_invoke
                 ),
                 "thread_inspection": thread_inspection,
+                "comment_addressing": comment_addressing,
             }
         )
     status = (
@@ -24249,6 +24413,25 @@ def _pr_stack_comment_cache_payload(*, target_root: Path, repo: str, branch: str
         else ["At least one stack member lacks PR-head freshness proof; refresh that member before readiness claims."],
         "claim_boundary": "A broad stack-ready claim is blocked while any stack member has actionable, stale, or unavailable comment status.",
         "degraded_because": "stale-or-missing-member-freshness" if unavailable_present else "",
+        "comment_addressing": {
+            "kind": "agentic-workspace/pr-comment-stack-addressing/v1",
+            "status": "open_feedback_present"
+            if actionable_present
+            else "stale_or_unverified"
+            if unavailable_present
+            else "review_feedback_closed",
+            "member_count": len(members),
+            "members": [
+                {
+                    "pr_number": member.get("pr_number"),
+                    "branch": member.get("branch"),
+                    "comment_status": member.get("comment_status"),
+                    "comment_addressing": member.get("comment_addressing", {}),
+                }
+                for member in members
+            ],
+            "closeout_rule": "List addressed and intentionally open comments per stack member before claiming the whole stack is ready.",
+        },
     }
 
 
@@ -24331,6 +24514,7 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
             "comment_state": stack.get("comment_state") or status,
             "thread_inspection": stack.get("thread_inspection")
             or _pr_comment_thread_inspection_payload(repo=repo, pr_number=pr_number, cli_invoke=cli_invoke),
+            "comment_addressing": stack.get("comment_addressing", {}),
             "unverified_context": stack.get("unverified_context", []),
             "recommended_command": str(stack.get("stack_members", [{}])[0].get("refresh_command", ""))
             if isinstance(stack.get("stack_members"), list) and stack.get("stack_members")
@@ -24353,6 +24537,13 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
             "cache_path": cache_path,
             "recommended_command": command,
             "thread_inspection": _pr_comment_thread_inspection_payload(repo=repo, pr_number=pr_number, cli_invoke=cli_invoke),
+            "comment_addressing": _pr_comment_addressing_unavailable_packet(
+                repo=repo,
+                pr_number=pr_number,
+                cache_path=cache_path,
+                reason=str(cache["_cache_error"]),
+                cli_invoke=cli_invoke,
+            ),
             "unverified_context": ["Cached PR comment delta could not be read; thread-level comment state is unverified."],
             "selector": "pr_comment_attention",
         }
@@ -24370,6 +24561,13 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
         status = "actionable_pr_comments_present" if actionable_count else "no_actionable_pr_comments_detected"
         freshness = cache.get("freshness", {}) if isinstance(cache.get("freshness"), dict) else {}
         cache_is_fresh = freshness.get("status") == "current_at_observed_head" and bool(str(freshness.get("pr_head_sha") or "").strip())
+        comment_addressing = _pr_comment_addressing_packet_from_delta(
+            cache=cache,
+            repo=repo,
+            pr_number=str(cache.get("pr_number") or pr_number),
+            cache_path=cache_path,
+            cli_invoke=cli_invoke,
+        )
         if actionable_count == 0 and not cache_is_fresh:
             return {
                 "kind": "agentic-workspace/pr-comment-attention/v1",
@@ -24389,6 +24587,7 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
                 "thread_inspection": _pr_comment_thread_inspection_payload(
                     repo=repo, pr_number=str(cache.get("pr_number") or pr_number), cli_invoke=cli_invoke
                 ),
+                "comment_addressing": comment_addressing,
                 "unverified_context": ["Current PR head is unverified.", "Thread-level comment state may be stale."],
                 "selector": "pr_comment_attention",
                 "degraded_explicitly": True,
@@ -24419,6 +24618,7 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
             "thread_inspection": _pr_comment_thread_inspection_payload(
                 repo=repo, pr_number=str(cache.get("pr_number") or pr_number), cli_invoke=cli_invoke, status="available"
             ),
+            "comment_addressing": comment_addressing,
             "unverified_context": [] if cache_is_fresh else ["Current PR head is unverified; refresh before readiness claims."],
             "selector": "pr_comment_attention",
             "claim_boundary": "Do not claim PR readiness while actionable PR comments are present unless they are addressed or explicitly deferred.",
@@ -24434,6 +24634,13 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
         "cache_path": cache_path,
         "recommended_command": command,
         "thread_inspection": _pr_comment_thread_inspection_payload(repo=repo, pr_number=pr_number, cli_invoke=cli_invoke),
+        "comment_addressing": _pr_comment_addressing_unavailable_packet(
+            repo=repo,
+            pr_number=pr_number,
+            cache_path=cache_path,
+            reason="No cached PR comment delta exists.",
+            cli_invoke=cli_invoke,
+        ),
         "unverified_context": ["No cached PR comment delta exists.", "Thread-level PR comment state is unverified."],
         "selector": "pr_comment_attention",
         "degraded_explicitly": True,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -22946,6 +22946,162 @@ def _compact_installed_state_drift_triage(triage: Any) -> dict[str, Any]:
     }
 
 
+_PR_COMMENT_ADDRESSING_BUCKETS = (
+    "unresolved_action",
+    "reply_only",
+    "already_addressed",
+    "outdated",
+    "informational",
+)
+
+
+def _pr_comment_item_addressing_status(item: dict[str, Any]) -> str:
+    explicit = str(item.get("addressing_status") or "").strip()
+    if explicit in _PR_COMMENT_ADDRESSING_BUCKETS:
+        return explicit
+    if item.get("is_outdated") is True:
+        return "outdated"
+    if item.get("is_resolved") is True:
+        return "already_addressed"
+    category = str(item.get("category") or "").strip()
+    if category == "ambiguous_needs_human":
+        return "reply_only"
+    if category in {"actionable_code_doc_body_change", "pr_metadata_body_only_change", "ci_label_only_issue"}:
+        return "unresolved_action"
+    return "informational"
+
+
+def _pr_comment_addressing_sample(item: dict[str, Any]) -> dict[str, Any]:
+    status = _pr_comment_item_addressing_status(item)
+    return {
+        key: item.get(key)
+        for key in (
+            "id",
+            "kind",
+            "category",
+            "path",
+            "line",
+            "url",
+            "author",
+            "created_at",
+            "proof_hint",
+            "reason",
+            "body_excerpt",
+        )
+        if item.get(key) not in (None, "")
+    } | {"addressing_status": status}
+
+
+def _pr_comment_addressing_unavailable_packet(
+    *, repo: str, pr_number: str, cache_path: str, reason: str, cli_invoke: str
+) -> dict[str, Any]:
+    return {
+        "kind": "agentic-workspace/pr-comment-addressing/v1",
+        "status": "review_comment_evidence_unavailable",
+        "repository": repo,
+        "pr_number": pr_number,
+        "source_availability": {
+            "cached_delta": "unavailable",
+            "thread_level_comments": "unverified",
+            "cache_path": cache_path,
+            "reason": reason,
+        },
+        "bucket_counts": {bucket: 0 for bucket in _PR_COMMENT_ADDRESSING_BUCKETS},
+        "buckets": {bucket: [] for bucket in _PR_COMMENT_ADDRESSING_BUCKETS},
+        "closeout": {
+            "status": "blocked_until_inspected",
+            "addressed_comments": [],
+            "intentionally_open_comments": [],
+            "rule": "Fetch or provide thread-aware PR comment evidence before claiming review feedback is fully handled.",
+        },
+        "thread_inspection": _pr_comment_thread_inspection_payload(repo=repo, pr_number=pr_number, cli_invoke=cli_invoke),
+        "write_safety": {
+            "github_writes_performed": False,
+            "rule": "Do not reply, resolve, or submit reviews from this packet without explicit user approval.",
+        },
+    }
+
+
+def _pr_comment_addressing_packet_from_delta(
+    *, cache: dict[str, Any], repo: str, pr_number: str, cache_path: str, cli_invoke: str
+) -> dict[str, Any]:
+    items = [item for item in _list_payload(cache.get("items")) if isinstance(item, dict)]
+    buckets: dict[str, list[dict[str, Any]]] = {bucket: [] for bucket in _PR_COMMENT_ADDRESSING_BUCKETS}
+    for item in items:
+        buckets[_pr_comment_item_addressing_status(item)].append(_pr_comment_addressing_sample(item))
+    bucket_counts = {bucket: len(entries) for bucket, entries in buckets.items()}
+    freshness = cache.get("freshness", {}) if isinstance(cache.get("freshness"), dict) else {}
+    pagination = cache.get("pagination", {}) if isinstance(cache.get("pagination"), dict) else {}
+    truncated = bool(pagination.get("truncated"))
+    comment_surfaces = cache.get("comment_surfaces", {}) if isinstance(cache.get("comment_surfaces"), dict) else {}
+    unavailable_surfaces = [str(item) for item in _list_payload(comment_surfaces.get("unavailable")) if str(item).strip()]
+    if not comment_surfaces:
+        unavailable_surfaces.append("thread_surface_completeness")
+    if truncated:
+        unavailable_surfaces.append("paginated_comment_tail")
+    fresh = freshness.get("status") == "current_at_observed_head" and bool(str(freshness.get("pr_head_sha") or "").strip())
+    open_count = bucket_counts["unresolved_action"] + bucket_counts["reply_only"]
+    status = (
+        "incomplete_review_comment_evidence"
+        if truncated
+        else "unresolved_review_feedback_present"
+        if open_count
+        else "stale_or_unverified"
+        if not fresh
+        else "review_feedback_closed"
+    )
+    changed_files = sorted(
+        {str(item.get("path") or "").strip() for item in buckets["unresolved_action"] if str(item.get("path") or "").strip()}
+    )
+    return {
+        "kind": "agentic-workspace/pr-comment-addressing/v1",
+        "status": status,
+        "repository": repo,
+        "pr_number": str(cache.get("pr_number") or pr_number),
+        "pr_url": str(cache.get("pr_url") or ""),
+        "source_availability": {
+            "cached_delta": "available",
+            "cache_path": cache_path,
+            "freshness": freshness or {"status": "missing"},
+            "pagination": pagination,
+            "inspected_surfaces": [str(item) for item in _list_payload(comment_surfaces.get("inspected")) if str(item).strip()]
+            or ["cached_delta_items"],
+            "unavailable_surfaces": unavailable_surfaces,
+            "surface_rule": str(
+                comment_surfaces.get("rule")
+                or "Use unavailable surfaces to bound review-readiness claims before claiming all comments are handled."
+            ),
+        },
+        "bucket_counts": bucket_counts,
+        "buckets": buckets,
+        "changed_files": changed_files,
+        "proof_linkage": {
+            "status": "path_anchored" if changed_files else "no_path_anchored_actions" if open_count else "no_open_local_actions",
+            "changed_paths": changed_files,
+            "proof_hints": [
+                str(item.get("proof_hint") or "") for item in buckets["unresolved_action"][:3] if str(item.get("proof_hint") or "").strip()
+            ],
+        },
+        "closeout": {
+            "status": "open_feedback_present" if open_count else "ready_if_fresh" if fresh else "blocked_until_refreshed",
+            "addressed_comments": buckets["already_addressed"],
+            "outdated_comments": buckets["outdated"],
+            "intentionally_open_comments": [*buckets["unresolved_action"], *buckets["reply_only"]],
+            "rule": (
+                "Before closeout, list each unresolved or reply-only comment as addressed or intentionally open; "
+                "do not treat stale or truncated comment evidence as full closure proof."
+            ),
+        },
+        "thread_inspection": _pr_comment_thread_inspection_payload(
+            repo=repo, pr_number=str(cache.get("pr_number") or pr_number), cli_invoke=cli_invoke, status="available"
+        ),
+        "write_safety": {
+            "github_writes_performed": False,
+            "rule": "Do not reply, resolve, or submit reviews from this packet without explicit user approval.",
+        },
+    }
+
+
 def _pr_stack_comment_cache_payload(*, target_root: Path, repo: str, branch: str, cli_invoke: str) -> dict[str, Any]:
     cache_path = ".agentic-workspace/local/cache/pr-comment-stack.json"
     cache = _read_local_cache_json(target_root, cache_path)
@@ -22997,6 +23153,13 @@ def _pr_stack_comment_cache_payload(*, target_root: Path, repo: str, branch: str
             unavailable_present = True
         refresh_command = _pr_comment_report_command(cli_invoke=cli_invoke)
         thread_inspection = _pr_comment_thread_inspection_payload(repo=command_repo, pr_number=pr_number, cli_invoke=cli_invoke)
+        comment_addressing = _pr_comment_addressing_packet_from_delta(
+            cache=member_cache,
+            repo=command_repo,
+            pr_number=pr_number,
+            cache_path=cache_path,
+            cli_invoke=cli_invoke,
+        )
         members.append(
             {
                 "pr_number": pr_number,
@@ -23019,6 +23182,7 @@ def _pr_stack_comment_cache_payload(*, target_root: Path, repo: str, branch: str
                     repo=command_repo, pr_number=pr_number, cli_invoke=cli_invoke
                 ),
                 "thread_inspection": thread_inspection,
+                "comment_addressing": comment_addressing,
             }
         )
     status = (
@@ -23054,6 +23218,25 @@ def _pr_stack_comment_cache_payload(*, target_root: Path, repo: str, branch: str
         else ["At least one stack member lacks PR-head freshness proof; refresh that member before readiness claims."],
         "claim_boundary": "A broad stack-ready claim is blocked while any stack member has actionable, stale, or unavailable comment status.",
         "degraded_because": "stale-or-missing-member-freshness" if unavailable_present else "",
+        "comment_addressing": {
+            "kind": "agentic-workspace/pr-comment-stack-addressing/v1",
+            "status": "open_feedback_present"
+            if actionable_present
+            else "stale_or_unverified"
+            if unavailable_present
+            else "review_feedback_closed",
+            "member_count": len(members),
+            "members": [
+                {
+                    "pr_number": member.get("pr_number"),
+                    "branch": member.get("branch"),
+                    "comment_status": member.get("comment_status"),
+                    "comment_addressing": member.get("comment_addressing", {}),
+                }
+                for member in members
+            ],
+            "closeout_rule": "List addressed and intentionally open comments per stack member before claiming the whole stack is ready.",
+        },
     }
 
 
@@ -23136,6 +23319,7 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
             "comment_state": stack.get("comment_state") or status,
             "thread_inspection": stack.get("thread_inspection")
             or _pr_comment_thread_inspection_payload(repo=repo, pr_number=pr_number, cli_invoke=cli_invoke),
+            "comment_addressing": stack.get("comment_addressing", {}),
             "unverified_context": stack.get("unverified_context", []),
             "recommended_command": str(stack.get("stack_members", [{}])[0].get("refresh_command", ""))
             if isinstance(stack.get("stack_members"), list) and stack.get("stack_members")
@@ -23158,6 +23342,13 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
             "cache_path": cache_path,
             "recommended_command": command,
             "thread_inspection": _pr_comment_thread_inspection_payload(repo=repo, pr_number=pr_number, cli_invoke=cli_invoke),
+            "comment_addressing": _pr_comment_addressing_unavailable_packet(
+                repo=repo,
+                pr_number=pr_number,
+                cache_path=cache_path,
+                reason=str(cache["_cache_error"]),
+                cli_invoke=cli_invoke,
+            ),
             "unverified_context": ["Cached PR comment delta could not be read; thread-level comment state is unverified."],
             "selector": "pr_comment_attention",
         }
@@ -23175,6 +23366,13 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
         status = "actionable_pr_comments_present" if actionable_count else "no_actionable_pr_comments_detected"
         freshness = cache.get("freshness", {}) if isinstance(cache.get("freshness"), dict) else {}
         cache_is_fresh = freshness.get("status") == "current_at_observed_head" and bool(str(freshness.get("pr_head_sha") or "").strip())
+        comment_addressing = _pr_comment_addressing_packet_from_delta(
+            cache=cache,
+            repo=repo,
+            pr_number=str(cache.get("pr_number") or pr_number),
+            cache_path=cache_path,
+            cli_invoke=cli_invoke,
+        )
         if actionable_count == 0 and not cache_is_fresh:
             return {
                 "kind": "agentic-workspace/pr-comment-attention/v1",
@@ -23194,6 +23392,7 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
                 "thread_inspection": _pr_comment_thread_inspection_payload(
                     repo=repo, pr_number=str(cache.get("pr_number") or pr_number), cli_invoke=cli_invoke
                 ),
+                "comment_addressing": comment_addressing,
                 "unverified_context": ["Current PR head is unverified.", "Thread-level comment state may be stale."],
                 "selector": "pr_comment_attention",
                 "degraded_explicitly": True,
@@ -23224,6 +23423,7 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
             "thread_inspection": _pr_comment_thread_inspection_payload(
                 repo=repo, pr_number=str(cache.get("pr_number") or pr_number), cli_invoke=cli_invoke, status="available"
             ),
+            "comment_addressing": comment_addressing,
             "unverified_context": [] if cache_is_fresh else ["Current PR head is unverified; refresh before readiness claims."],
             "selector": "pr_comment_attention",
             "claim_boundary": "Do not claim PR readiness while actionable PR comments are present unless they are addressed or explicitly deferred.",
@@ -23239,6 +23439,13 @@ def _pr_comment_attention_payload(*, target_root: Path, task_text: str | None, c
         "cache_path": cache_path,
         "recommended_command": command,
         "thread_inspection": _pr_comment_thread_inspection_payload(repo=repo, pr_number=pr_number, cli_invoke=cli_invoke),
+        "comment_addressing": _pr_comment_addressing_unavailable_packet(
+            repo=repo,
+            pr_number=pr_number,
+            cache_path=cache_path,
+            reason="No cached PR comment delta exists.",
+            cli_invoke=cli_invoke,
+        ),
         "unverified_context": ["No cached PR comment delta exists.", "Thread-level PR comment state is unverified."],
         "selector": "pr_comment_attention",
         "degraded_explicitly": True,

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1523,6 +1523,18 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             else "detail_omitted",
             "thread_level_comments": "hidden_behind_detail_route",
         }
+        comment_addressing = pr_comment_attention.get("comment_addressing", {})
+        if isinstance(comment_addressing, dict) and comment_addressing:
+            closeout = comment_addressing.get("closeout", {}) if isinstance(comment_addressing.get("closeout"), dict) else {}
+            context["pr_comment_attention"]["comment_addressing"] = {
+                key: comment_addressing.get(key)
+                for key in ("kind", "status", "bucket_counts", "changed_files")
+                if comment_addressing.get(key) not in (None, "", [], {})
+            }
+            if closeout:
+                context["pr_comment_attention"]["comment_addressing"]["closeout"] = {
+                    key: closeout.get(key) for key in ("status", "rule") if closeout.get(key) not in (None, "", [], {})
+                }
         context["pr_comment_attention"]["detail_route"] = pr_comment_attention.get(
             "recommended_command", "agentic-workspace report --target . --section pr_comment_attention --format json"
         )

--- a/tests/test_pr_comment_delta.py
+++ b/tests/test_pr_comment_delta.py
@@ -98,12 +98,20 @@ def test_pr_comment_delta_classifies_new_review_response_scope() -> None:
     assert packet["category_counts"]["ci_label_only_issue"] == 1
     assert packet["category_counts"]["ambiguous_needs_human"] == 1
     assert packet["category_counts"]["informational_no_local_change"] == 1
+    assert packet["comment_surfaces"]["inspected"] == ["normalized_comments"]
+    assert packet["comment_surfaces"]["unavailable"] == ["thread_surface_completeness"]
     closure = next(item for item in packet["items"] if item["url"].endswith("#closure"))
     assert closure["category"] == "pr_metadata_body_only_change"
     assert "no source proof" in closure["proof_hint"].lower()
     anchored = next(item for item in packet["items"] if item["url"].endswith("#code"))
     assert anchored["path"] == "tests/test_widget.py"
+    assert anchored["addressing_status"] == "unresolved_action"
+    assert anchored["action_required"] is True
     assert "focused tests" in anchored["proof_hint"]
+    question = next(item for item in packet["items"] if item["url"].endswith("#question"))
+    assert question["addressing_status"] == "reply_only"
+    resolved = next(item for item in packet["items"] if item["url"].endswith("#resolved"))
+    assert resolved["addressing_status"] == "already_addressed"
 
 
 def test_pr_comment_delta_filters_seen_comment_urls(tmp_path: Path) -> None:
@@ -167,11 +175,48 @@ def test_pr_comment_delta_normalizes_graphql_review_threads() -> None:
     assert packet["new_comment_count"] == 1
     assert packet["freshness"]["status"] == "current_at_observed_head"
     assert packet["freshness"]["pr_head_sha"] == "abc123"
+    assert packet["comment_surfaces"]["inspected"] == ["issue_comments", "reviews", "review_threads"]
+    assert packet["comment_surfaces"]["unavailable"] == []
     item = packet["items"][0]
     assert item["kind"] == "review_thread_comment"
     assert item["category"] == "actionable_code_doc_body_change"
+    assert item["addressing_status"] == "unresolved_action"
     assert item["path"] == "src/app.py"
     assert item["line"] == 12
+
+
+def test_pr_comment_delta_separates_outdated_threads_from_addressed_threads() -> None:
+    module = _load_module()
+    packet = module.build_packet(
+        {
+            "repository": "rickardvh/agentic-workspace",
+            "pr_number": 42,
+            "comments": [
+                {
+                    "kind": "review_thread_comment",
+                    "url": "https://example.test/pr#outdated",
+                    "body": "Old inline note",
+                    "created_at": "2026-06-23T11:00:00Z",
+                    "path": "src/app.py",
+                    "is_resolved": False,
+                    "is_outdated": True,
+                },
+                {
+                    "kind": "review_thread_comment",
+                    "url": "https://example.test/pr#resolved",
+                    "body": "Handled inline note",
+                    "created_at": "2026-06-23T11:01:00Z",
+                    "path": "src/app.py",
+                    "is_resolved": True,
+                    "is_outdated": False,
+                },
+            ],
+        }
+    )
+
+    statuses = {item["url"].split("#")[-1]: item["addressing_status"] for item in packet["items"]}
+    assert statuses == {"outdated": "outdated", "resolved": "already_addressed"}
+    assert all(item["action_required"] is False for item in packet["items"])
 
 
 def test_pr_comment_delta_reports_graphql_truncation_boundaries() -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -3508,8 +3508,8 @@ def test_report_pr_comment_attention_reads_cached_actionable_and_empty_deltas(tm
                     "actionable_code_doc_body_change": 1,
                     "pr_metadata_body_only_change": 0,
                     "ci_label_only_issue": 0,
-                    "ambiguous_needs_human": 0,
-                    "informational_no_local_change": 0,
+                    "ambiguous_needs_human": 1,
+                    "informational_no_local_change": 2,
                 },
                 "items": [
                     {
@@ -3519,7 +3519,30 @@ def test_report_pr_comment_attention_reads_cached_actionable_and_empty_deltas(tm
                         "line": 12,
                         "url": "https://example.test/pr#thread",
                         "proof_hint": "Run focused tests.",
-                    }
+                    },
+                    {
+                        "kind": "issue_comment",
+                        "category": "ambiguous_needs_human",
+                        "url": "https://example.test/pr#question",
+                        "body_excerpt": "Which behavior should win here?",
+                        "proof_hint": "Ask or draft a response before editing.",
+                    },
+                    {
+                        "kind": "review_thread_comment",
+                        "category": "informational_no_local_change",
+                        "path": "README.md",
+                        "url": "https://example.test/pr#resolved",
+                        "is_resolved": True,
+                        "proof_hint": "No local proof unless the thread is reopened.",
+                    },
+                    {
+                        "kind": "review_thread_comment",
+                        "category": "informational_no_local_change",
+                        "path": "docs/old.md",
+                        "url": "https://example.test/pr#outdated",
+                        "is_outdated": True,
+                        "proof_hint": "No local proof unless the thread is reopened.",
+                    },
                 ],
                 "baseline": {"since": "2026-06-28T00:00:00Z"},
             }
@@ -3531,11 +3554,32 @@ def test_report_pr_comment_attention_reads_cached_actionable_and_empty_deltas(tm
     actionable = json.loads(capsys.readouterr().out)["answer"]
     assert actionable["status"] == "actionable_pr_comments_present"
     assert actionable["comment_state"] == "comments_requiring_action"
-    assert actionable["actionable_count"] == 1
+    assert actionable["actionable_count"] == 2
     assert actionable["sample"][0]["path"] == "src/app.py"
     assert actionable["thread_inspection"]["status"] == "available"
     assert "report --target . --section pr_comment_attention --format json" in actionable["recommended_command"]
     assert "pr_comment_delta.py" in actionable["thread_inspection"]["source_checkout_helper"]["command"]
+    addressing = actionable["comment_addressing"]
+    assert addressing["kind"] == "agentic-workspace/pr-comment-addressing/v1"
+    assert addressing["status"] == "unresolved_review_feedback_present"
+    assert addressing["bucket_counts"] == {
+        "unresolved_action": 1,
+        "reply_only": 1,
+        "already_addressed": 1,
+        "outdated": 1,
+        "informational": 0,
+    }
+    assert addressing["buckets"]["unresolved_action"][0]["path"] == "src/app.py"
+    assert addressing["buckets"]["reply_only"][0]["url"].endswith("#question")
+    assert addressing["source_availability"]["inspected_surfaces"] == ["cached_delta_items"]
+    assert addressing["source_availability"]["unavailable_surfaces"] == ["thread_surface_completeness"]
+    assert addressing["closeout"]["addressed_comments"][0]["url"].endswith("#resolved")
+    assert addressing["closeout"]["outdated_comments"][0]["url"].endswith("#outdated")
+    assert [item["url"] for item in addressing["closeout"]["intentionally_open_comments"]] == [
+        "https://example.test/pr#thread",
+        "https://example.test/pr#question",
+    ]
+    assert addressing["write_safety"]["github_writes_performed"] is False
 
     # Legacy empty caches are not enough to support readiness claims because they
     # do not prove which PR head was observed.
@@ -3565,6 +3609,8 @@ def test_report_pr_comment_attention_reads_cached_actionable_and_empty_deltas(tm
     assert stale_empty["comment_state"] == "stale_or_unknown"
     assert stale_empty["cached_status"] == "no_actionable_pr_comments_detected"
     assert stale_empty["degraded_explicitly"] is True
+    assert stale_empty["comment_addressing"]["status"] == "stale_or_unverified"
+    assert stale_empty["comment_addressing"]["closeout"]["status"] == "blocked_until_refreshed"
     assert "Current PR head is unverified." in stale_empty["unverified_context"]
 
     cache_path.write_text(
@@ -3598,6 +3644,8 @@ def test_report_pr_comment_attention_reads_cached_actionable_and_empty_deltas(tm
     assert fresh_empty["comment_state"] == "no_comments_requiring_action"
     assert fresh_empty["actionable_count"] == 0
     assert fresh_empty["freshness"]["pr_head_sha"] == "abc123"
+    assert fresh_empty["comment_addressing"]["status"] == "review_feedback_closed"
+    assert fresh_empty["comment_addressing"]["closeout"]["status"] == "ready_if_fresh"
     assert fresh_empty["unverified_context"] == []
 
 
@@ -3726,6 +3774,8 @@ def test_start_pr_comment_attention_reads_stack_cache_with_concrete_refresh_comm
     assert attention["status"] == "actionable_stack_comments_present"
     assert attention["comment_state"] == "stack_comments_requiring_action"
     assert attention["stack_member_count"] == 2
+    assert attention["comment_addressing"]["kind"] == "agentic-workspace/pr-comment-stack-addressing/v1"
+    assert attention["comment_addressing"]["status"] == "open_feedback_present"
     assert "--section pr_comment_attention --format json" in attention["detail_route"]
     assert attention["absence_states"]["thread_level_comments"] == "hidden_behind_detail_route"
     assert "pr_comment_attention=actionable_stack_comments_present" in payload["action_signals"]["changed_signals"]


### PR DESCRIPTION
## Summary
- Adds item-level PR comment addressing statuses to the read-only PR comment delta helper.
- Derives an `agentic-workspace/pr-comment-addressing/v1` packet in `pr_comment_attention` for single PR and stacked PR follow-up.
- Separates unresolved action, reply-only, already-addressed, outdated, and informational comments, preserving source availability, path anchors, closeout lists, and the no-GitHub-write boundary.

Closes #1999.

## Validation
- `uv run pytest tests/test_pr_comment_delta.py -q`
- `uv run pytest tests/test_workspace_cli.py -q -k "pr_comment_attention"`
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`

## Notes
- This is stacked on #2013 / `codex/1993-docs-process-proof-route`.
- The host-agnostic runtime principle is preserved: routing comes from cached comment evidence and explicit packet statuses, not package-owned assumptions about repo workflow meaning.
- #1969 remains open; this lane adds more evidence for state-delta-first packets and closeout-ready residue summaries.