### PR TITLE
[codex] Separate task-switch planning residue from closure blockers

### DIFF
--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -58,7 +58,7 @@ Cheap implementer context for a bounded changed-path scope.
 | `operating_loop.memory.route_ref` | string \| null | yes |  | Selector or route reference for pulled Memory, when available. |  |  |
 | `operating_loop.memory.capture` | enum `"none"`, `"recommended"`, `"required"` | yes |  | Whether reusable learning capture is absent, recommended, or required. |  |  |
 | `operating_loop.planning` | object | yes |  | Planning state relevant to full closure safety. |  |  |
-| `operating_loop.planning.state` | enum `"none"`, `"active"`, `"continuation"`, `"closeout_required"` | yes |  | Active, continuation, closeout-required, or absent Planning state. |  |  |
+| `operating_loop.planning.state` | enum `"none"`, `"active"`, `"continuation"`, `"closeout_required"`, `"unrelated_active_plan"` | yes |  | Active, continuation, closeout-required, or absent Planning state. |  |  |
 | `operating_loop.planning.plan_ref` | string \| null | yes |  | Planning record or execplan reference, when available. |  |  |
 | `operating_loop.planning.blocks_full_closure` | boolean | yes |  | Whether the Planning state structurally blocks an unqualified full closure claim. |  |  |
 | `operating_loop.verification` | object | yes |  | Verification or proof state relevant to the current claim boundary. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -152,6 +152,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `architecture_principles` | object | yes |  | Structured architecture-principle routing packet derived from the normalized system-intent record and changed paths. |  |  |
 | `local_aw_state` | object | yes |  | Compact ownership-aware status for tracked, ignored, local-only, cache, payload, policy, and proof AW surfaces. |  |  |
 | `local_footprint` | object | yes |  | Tracked-vs-ignored AW footprint, local scratch retention budgets, largest offenders, and cleanup routing. |  |  |
+| `stale_cleanup` | object | no |  | Cleanup routing for stale local and checked-in planning surfaces. |  |  |
 | `workflow_obligations` | object | yes |  | Repo-configured workflow obligations surfaced for report consumers. |  |  |
 | `assurance_requirements` | object | yes |  | Repo-declared assurance requirements, active matches, and evidence status projection; task-marker matches cite explicit config while semantic acceptance remains agent/human owned. |  |  |
 | `verification` | object | yes |  | Repo-native verification protocols, scenarios, bounded evidence bundles, and soft verification routing projection; task-marker matches are configured protocol evidence, not AW-owned intent classification. |  |  |

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -904,7 +904,8 @@
                 "none",
                 "active",
                 "continuation",
-                "closeout_required"
+                "closeout_required",
+                "unrelated_active_plan"
               ]
             },
             "plan_ref": {

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -283,6 +283,11 @@
       "description": "Tracked-vs-ignored AW footprint, local scratch retention budgets, largest offenders, and cleanup routing.",
       "additionalProperties": true
     },
+    "stale_cleanup": {
+      "type": "object",
+      "description": "Cleanup routing for stale local and checked-in planning surfaces.",
+      "additionalProperties": true
+    },
     "workflow_obligations": {
       "type": "object",
       "description": "Repo-configured workflow obligations surfaced for report consumers."

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -389,6 +389,7 @@
         "source_symbols": [
           "_boundary_warning_for_path",
           "_change_impact_path_payload",
+          "_changed_path_exists",
           "_ownership_payload",
           "_project_roots_for_changed_paths",
           "_read_changed_surface_text",
@@ -504,6 +505,7 @@
           "_issue_reference_intent_payload",
           "_memory_consult_from_payload",
           "_memory_consult_payload",
+          "_open_issue_intake_payload",
           "_operating_loop_decision_payload",
           "_operating_posture_payload",
           "_parent_intent_status_payload",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -14924,7 +14924,7 @@ _OPERATING_LOOP_MEMORY_REASONS = {
     "explicitly_dismissed",
 }
 _OPERATING_LOOP_MEMORY_CAPTURE = {"none", "recommended", "required"}
-_OPERATING_LOOP_PLANNING_STATES = {"none", "active", "continuation", "closeout_required"}
+_OPERATING_LOOP_PLANNING_STATES = {"none", "active", "continuation", "closeout_required", "unrelated_active_plan"}
 _OPERATING_LOOP_VERIFICATION_STATES = {
     "proof_not_required",
     "proof_required",
@@ -15041,6 +15041,13 @@ def _operating_loop_planning_state(
             "blocks_full_closure": True,
             "custody": "recommended",
         }
+    task_switch = _as_dict(gate.get("task_switch_reconciliation"))
+    if (
+        str(gate.get("gate_result") or "") == "active-plan-task-switch"
+        and gate.get("workflow_sufficient") is True
+        and str(task_switch.get("status") or "") == "active"
+    ):
+        return {"state": "unrelated_active_plan", "plan_ref": plan_ref, "blocks_full_closure": False}
     if str(reliance.get("status") or "") not in {"", "no-active-plan", "not-applicable", "clear", "satisfied"}:
         return {"state": "continuation", "plan_ref": plan_ref, "blocks_full_closure": True}
     if active_record.get("status") == "present":

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -14387,7 +14387,7 @@ _OPERATING_LOOP_MEMORY_REASONS = {
     "explicitly_dismissed",
 }
 _OPERATING_LOOP_MEMORY_CAPTURE = {"none", "recommended", "required"}
-_OPERATING_LOOP_PLANNING_STATES = {"none", "active", "continuation", "closeout_required"}
+_OPERATING_LOOP_PLANNING_STATES = {"none", "active", "continuation", "closeout_required", "unrelated_active_plan"}
 _OPERATING_LOOP_VERIFICATION_STATES = {
     "proof_not_required",
     "proof_required",
@@ -14504,6 +14504,13 @@ def _operating_loop_planning_state(
             "blocks_full_closure": True,
             "custody": "recommended",
         }
+    task_switch = _as_dict(gate.get("task_switch_reconciliation"))
+    if (
+        str(gate.get("gate_result") or "") == "active-plan-task-switch"
+        and gate.get("workflow_sufficient") is True
+        and str(task_switch.get("status") or "") == "active"
+    ):
+        return {"state": "unrelated_active_plan", "plan_ref": plan_ref, "blocks_full_closure": False}
     if str(reliance.get("status") or "") not in {"", "no-active-plan", "not-applicable", "clear", "satisfied"}:
         return {"state": "continuation", "plan_ref": plan_ref, "blocks_full_closure": True}
     if active_record.get("status") == "present":

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -316,6 +316,63 @@ def test_implement_surfaces_operating_loop_with_proof_blocker(tmp_path: Path, ca
     assert packet["reasons"][0]["code"] == "proof_missing"
 
 
+def test_implement_task_switch_keeps_unrelated_active_plan_out_of_current_closure_blockers(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "active-plan", title = "Unrelated active plan", status = "active", surface = ".agentic-workspace/planning/execplans/active-plan.plan.json" },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "active-plan.plan.json",
+        {"kind": "planning-execplan/v1", "id": "active-plan", "title": "Unrelated active plan"},
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_primitives.py",
+                "--task",
+                "Implement issue #3000 parser cache cleanup",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["context"]["workflow_sufficiency"]["sufficiency_result"] == "enough-for-bounded-implementation"
+    assert payload["context"]["planning_safety_gate"]["gate_result"] == "active-plan-task-switch"
+    packet = payload["operating_loop"]
+    assert packet["verification"]["state"] == "proof_missing"
+    assert packet["closeout_state"] == "blocked_missing_proof"
+    assert packet["residue_owner"] == "verification"
+    assert packet["planning"]["state"] == "unrelated_active_plan"
+    assert packet["planning"]["plan_ref"] == ".agentic-workspace/planning/execplans/active-plan.plan.json"
+    assert packet["planning"]["blocks_full_closure"] is False
+    assert packet["required_before_full_closure"] == ["run_or_refresh_proof"]
+
+
 def test_implement_does_not_require_stale_deleted_test_inventory_sweep(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -707,6 +707,29 @@ def test_operating_loop_projection_blocks_active_planning() -> None:
     assert "continue_or_close_plan" in packet["required_before_full_closure"]
 
 
+def test_operating_loop_projection_keeps_unrelated_task_switch_plan_as_residue() -> None:
+    packet = _operating_loop_decision_payload(
+        claim_context="closeout",
+        planning_safety_gate={
+            "gate_result": "active-plan-task-switch",
+            "workflow_sufficient": True,
+            "task_switch_reconciliation": {"status": "active"},
+            "active_plan_reliance": {
+                "status": "active-plan-present",
+                "active_execplan": ".agentic-workspace/planning/execplans/current.md",
+            },
+        },
+        proof={"status": "passed"},
+    )
+
+    assert packet["planning"]["state"] == "unrelated_active_plan"
+    assert packet["planning"]["plan_ref"] == ".agentic-workspace/planning/execplans/current.md"
+    assert packet["planning"]["blocks_full_closure"] is False
+    assert packet["closeout_state"] == "ready_for_full_closure"
+    assert packet["safe_claim"] == "full"
+    assert "continue_or_close_plan" not in packet["required_before_full_closure"]
+
+
 def test_operating_loop_projection_maps_planning_continuation_to_partial_claim() -> None:
     packet = _operating_loop_decision_payload(
         claim_context="closeout",


### PR DESCRIPTION
## Summary
- classify active-plan task switches as `unrelated_active_plan` in the operating-loop planning packet when the current changed-path route is explicitly bounded
- keep the unrelated active plan reference visible while removing `continue_or_close_plan` from current-lane closure blockers
- update the implementer-context schema/reference docs and add focused unit + CLI regressions for the #2007 dogfood case
- repair narrow contract drift surfaced by the required proof lane: `stale_cleanup` report schema coverage and two shared-core import family entries

## Validation
- `uv run pytest tests/test_workspace_summary_cli.py -q -k "operating_loop_projection"`
- `uv run pytest tests/test_workspace_implement_cli.py -q -k "operating_loop"`
- `uv run python scripts/run_agentic_workspace.py implement --changed docs/reference/implementer-context.md docs/reference/workspace-report.md src/agentic_workspace/workspace_runtime_primitives.py src/agentic_workspace/workspace_runtime_core.py src/agentic_workspace/contracts/schemas/implementer_context.schema.json src/agentic_workspace/contracts/schemas/workspace_report.schema.json src/agentic_workspace/contracts/workspace_runtime_primitive_families.json tests/test_workspace_summary_cli.py tests/test_workspace_implement_cli.py --task "Implement #2007 separate unrelated active-plan residue from bounded task closure blockers, leaving #1969 last" --format json`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `make render-schema-reference`
- `make schema-reference-docs`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `make maintainer-surfaces`
- `git diff --check`

## Dogfood follow-up
- Filed #2018 for the remaining closeout-trust variant: after this PR, `implement --changed` separates current-lane blockers correctly, but `report --section closeout_trust` still treats the unrelated active plan as strict-closeout residue for bounded slice claims.

Closes #2007.