### PR TITLE
Make closeout trust honor task-switch residue

### DIFF
--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -2871,6 +2871,23 @@
           "name": "section"
         },
         {
+          "action": "extend",
+          "default": [],
+          "flags": [
+            "--changed"
+          ],
+          "help": "Optional repo-relative changed paths used by task-scoped report sections such as closeout_trust.",
+          "name": "changed",
+          "nargs": "*"
+        },
+        {
+          "flags": [
+            "--task"
+          ],
+          "help": "Optional task description used by task-scoped report sections such as closeout_trust.",
+          "name": "task"
+        },
+        {
           "flags": [
             "--select"
           ],

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -3735,6 +3735,23 @@
             "name": "section"
           },
           {
+            "action": "extend",
+            "default": [],
+            "flags": [
+              "--changed"
+            ],
+            "help": "Optional repo-relative changed paths used by task-scoped report sections such as closeout_trust.",
+            "name": "changed",
+            "nargs": "*"
+          },
+          {
+            "flags": [
+              "--task"
+            ],
+            "help": "Optional task description used by task-scoped report sections such as closeout_trust.",
+            "name": "task"
+          },
+          {
             "flags": [
               "--select"
             ],

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -3735,6 +3735,23 @@
             "name": "section"
           },
           {
+            "action": "extend",
+            "default": [],
+            "flags": [
+              "--changed"
+            ],
+            "help": "Optional repo-relative changed paths used by task-scoped report sections such as closeout_trust.",
+            "name": "changed",
+            "nargs": "*"
+          },
+          {
+            "flags": [
+              "--task"
+            ],
+            "help": "Optional task description used by task-scoped report sections such as closeout_trust.",
+            "name": "task"
+          },
+          {
             "flags": [
               "--select"
             ],

--- a/generated/workspace/typescript/resources/operations/report.combined.json
+++ b/generated/workspace/typescript/resources/operations/report.combined.json
@@ -15,6 +15,7 @@
     "The default profile should route to high-signal sections before exposing high-volume module detail.",
     "Operational-compression measures must remain descriptive and advisory, not a score, dashboard, workflow engine, or host-specific tracker policy.",
     "Unknown sections should be treated as usage errors.",
+    "Optional task text and changed paths may refine task-scoped section payloads, but must not change default repo-wide closeout trust semantics.",
     "Exact field selectors must operate on the selected report payload and must not force a lazy section to build the full report."
   ],
   "id": "report.combined",
@@ -46,6 +47,16 @@
     },
     {
       "name": "section",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "changed",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "task",
       "required": false,
       "source": "cli-option"
     },
@@ -100,6 +111,7 @@
   "proof": [
     "operation contract validates against operation.schema.json",
     "report command tests remain compatible",
+    "task-scoped closeout trust distinguishes bounded task-switch residue from repo-wide active-plan closure blockers",
     "operational-compression section selector returns compact advisory measures",
     "sectioned exact field selection returns selected-output JSON without full-report assembly"
   ],
@@ -127,6 +139,10 @@
     {
       "required": false,
       "surface": "section name and exact field selector for compact drill-down"
+    },
+    {
+      "required": false,
+      "surface": "optional task text and changed-path list for task-scoped closeout trust sections"
     }
   ],
   "schema_version": "agentic-workspace/operation/v1",

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -2914,6 +2914,23 @@ const commandDefinitions = [
           "name": "section"
         },
         {
+          "action": "extend",
+          "default": [],
+          "flags": [
+            "--changed"
+          ],
+          "help": "Optional repo-relative changed paths used by task-scoped report sections such as closeout_trust.",
+          "name": "changed",
+          "nargs": "*"
+        },
+        {
+          "flags": [
+            "--task"
+          ],
+          "help": "Optional task description used by task-scoped report sections such as closeout_trust.",
+          "name": "task"
+        },
+        {
           "flags": [
             "--select"
           ],

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -2308,6 +2308,23 @@
           "help": "Return one top-level full-report section in the compact contract profile."
         },
         {
+          "name": "changed",
+          "flags": [
+            "--changed"
+          ],
+          "action": "extend",
+          "nargs": "*",
+          "default": [],
+          "help": "Optional repo-relative changed paths used by task-scoped report sections such as closeout_trust."
+        },
+        {
+          "name": "task",
+          "flags": [
+            "--task"
+          ],
+          "help": "Optional task description used by task-scoped report sections such as closeout_trust."
+        },
+        {
           "name": "select",
           "flags": [
             "--select"

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -5080,6 +5080,23 @@
                 "help": "Return one top-level full-report section in the compact contract profile."
               },
               {
+                "name": "changed",
+                "flags": [
+                  "--changed"
+                ],
+                "action": "extend",
+                "nargs": "*",
+                "default": [],
+                "help": "Optional repo-relative changed paths used by task-scoped report sections such as closeout_trust."
+              },
+              {
+                "name": "task",
+                "flags": [
+                  "--task"
+                ],
+                "help": "Optional task description used by task-scoped report sections such as closeout_trust."
+              },
+              {
                 "name": "select",
                 "flags": [
                   "--select"

--- a/src/agentic_workspace/contracts/operations/report.combined.json
+++ b/src/agentic_workspace/contracts/operations/report.combined.json
@@ -38,6 +38,16 @@
       "required": false
     },
     {
+      "name": "changed",
+      "source": "cli-option",
+      "required": false
+    },
+    {
+      "name": "task",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "select",
       "source": "cli-option",
       "required": false
@@ -87,6 +97,10 @@
     {
       "surface": "section name and exact field selector for compact drill-down",
       "required": false
+    },
+    {
+      "surface": "optional task text and changed-path list for task-scoped closeout trust sections",
+      "required": false
     }
   ],
   "writes": [],
@@ -127,11 +141,13 @@
     "The default profile should route to high-signal sections before exposing high-volume module detail.",
     "Operational-compression measures must remain descriptive and advisory, not a score, dashboard, workflow engine, or host-specific tracker policy.",
     "Unknown sections should be treated as usage errors.",
+    "Optional task text and changed paths may refine task-scoped section payloads, but must not change default repo-wide closeout trust semantics.",
     "Exact field selectors must operate on the selected report payload and must not force a lazy section to build the full report."
   ],
   "proof": [
     "operation contract validates against operation.schema.json",
     "report command tests remain compatible",
+    "task-scoped closeout trust distinguishes bounded task-switch residue from repo-wide active-plan closure blockers",
     "operational-compression section selector returns compact advisory measures",
     "sectioned exact field selection returns selected-output JSON without full-report assembly"
   ],

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -1059,6 +1059,100 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
                 }
             return compact
 
+        def compact_current_task_closeout(value: dict[str, Any]) -> dict[str, Any]:
+            if value.get("status") != "active":
+                return {"status": value.get("status", "not-applicable")}
+            scope = value.get("scope", {})
+            scope = scope if isinstance(scope, dict) else {}
+            planning_gate = scope.get("planning_safety_gate", {})
+            planning_gate = planning_gate if isinstance(planning_gate, dict) else {}
+            task_switch = scope.get("task_switch_reconciliation", {})
+            task_switch = task_switch if isinstance(task_switch, dict) else {}
+            proof = value.get("proof", {})
+            proof = proof if isinstance(proof, dict) else {}
+            proof_commands = _support_list_payload(proof.get("required_commands"))
+            changed_paths = _support_list_payload(scope.get("changed_paths"))
+            repo_wide = value.get("repo_wide_residue", {})
+            repo_wide = repo_wide if isinstance(repo_wide, dict) else {}
+            repo_wide_gate = repo_wide.get("strict_closeout_gate", {})
+            repo_wide_gate = repo_wide_gate if isinstance(repo_wide_gate, dict) else {}
+            repo_wide_completion_gate = repo_wide.get("completion_gate", {})
+            repo_wide_completion_gate = repo_wide_completion_gate if isinstance(repo_wide_completion_gate, dict) else {}
+            return {
+                "kind": value.get("kind", "agentic-workspace/current-task-closeout/v1"),
+                "status": "active",
+                "scope": {
+                    "status": scope.get("status", ""),
+                    "relationship": scope.get("relationship", ""),
+                    "changed_path_count": len(changed_paths),
+                    "changed_paths": changed_paths[:12],
+                    "changed_paths_omitted_count": max(0, len(changed_paths) - 12),
+                    "planning_safety_gate": {
+                        key: planning_gate.get(key)
+                        for key in (
+                            "kind",
+                            "label",
+                            "provenance",
+                            "status",
+                            "gate_result",
+                            "workflow_sufficient",
+                            "reason",
+                            "required_next_action",
+                            "active_planning_present",
+                            "issue_refs",
+                            "implementation_allowed",
+                            "task_switch_reconciliation",
+                        )
+                        if key in planning_gate
+                    },
+                    "task_switch_reconciliation": {
+                        key: task_switch.get(key)
+                        for key in (
+                            "kind",
+                            "status",
+                            "summary",
+                            "current_task_class",
+                            "recommended_next_action",
+                            "safe_route_ids",
+                            "blocked_claims",
+                            "detail_selector",
+                            "rule",
+                        )
+                        if key in task_switch
+                    },
+                    "rule": scope.get("rule", ""),
+                },
+                "strict_closeout_gate": value.get("strict_closeout_gate", {}),
+                "completion_options": value.get("completion_options", []),
+                "operating_loop": value.get("operating_loop", {}),
+                "proof": {
+                    "status": proof.get("status", ""),
+                    "changed_path_count": len(_support_list_payload(proof.get("changed_paths"))),
+                    "required_commands": proof_commands,
+                    "required_command_count": len(proof_commands),
+                    "proof_strategy": proof.get("proof_strategy", {}),
+                    "detail_omitted": "full proof packet is available with report --section closeout_trust --verbose",
+                },
+                "repo_wide_residue": {
+                    "strict_closeout_gate": repo_wide_gate,
+                    "completion_gate": {
+                        key: repo_wide_completion_gate.get(key)
+                        for key in (
+                            "kind",
+                            "status",
+                            "active_intent_satisfied",
+                            "claim_level_allowed",
+                            "required_next_action",
+                            "claim_authorization",
+                        )
+                        if key in repo_wide_completion_gate
+                    },
+                    "trust": repo_wide.get("trust", ""),
+                    "lower_trust_closeout_count": repo_wide.get("lower_trust_closeout_count", 0),
+                },
+                "rule": value.get("rule", ""),
+            }
+
         historical_reviews = answer.get("historical_review_artifacts", {})
         historical_reviews = historical_reviews if isinstance(historical_reviews, dict) else {}
         retention_policy = historical_reviews.get("retention_policy", {})
@@ -1099,6 +1193,8 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
         memory_decision_packet = memory_decision_packet if isinstance(memory_decision_packet, dict) else {}
         operating_loop = answer.get("operating_loop", {})
         operating_loop = operating_loop if isinstance(operating_loop, dict) else {}
+        current_task_closeout = answer.get("current_task_closeout", {})
+        current_task_closeout = current_task_closeout if isinstance(current_task_closeout, dict) else {}
         detail_command = _command_with_cli_invoke(
             "agentic-workspace report --target ./repo --verbose --format json",
             cli_invoke=cli_invoke,
@@ -1158,6 +1254,7 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
             "completion_options": completion_options,
             "memory_decision_packet": memory_decision_packet,
             "operating_loop": operating_loop,
+            "current_task_closeout": compact_current_task_closeout(current_task_closeout),
             "closeout_protocol": {
                 key: closeout_protocol.get(key)
                 for key in (

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -8549,6 +8549,8 @@ def _run_report_command(
     resolved_preset: str | None,
     descriptors: dict[str, ModuleDescriptor],
     config: WorkspaceConfig,
+    task_text: str | None = None,
+    changed_paths: list[str] | None = None,
 ) -> dict[str, Any]:
     status_payload = _run_lifecycle_command(
         command_name="status",
@@ -8635,7 +8637,12 @@ def _run_report_command(
     local_footprint = _local_footprint_payload(target_root=target_root, cli_invoke=config.cli_invoke)
     local_memory = _local_memory_payload(config=config)
     closeout_trust = _report_closeout_trust_payload(
-        module_reports=module_reports, target_root=target_root, config=config, cli_invoke=config.cli_invoke
+        module_reports=module_reports,
+        target_root=target_root,
+        config=config,
+        cli_invoke=config.cli_invoke,
+        task_text=task_text,
+        changed_paths=changed_paths,
     )
     decision_pressure = _decision_pressure_payload(
         target_root=target_root, config=config, module_reports=module_reports, cli_invoke=config.cli_invoke
@@ -12957,6 +12964,8 @@ def _run_lazy_report_section_command(
     resolved_preset: str | None,
     config: WorkspaceConfig,
     section: str | None,
+    task_text: str | None = None,
+    changed_paths: list[str] | None = None,
 ) -> dict[str, Any] | None:
     if section is None:
         return None
@@ -13170,6 +13179,8 @@ def _run_lazy_report_section_command(
             target_root=target_root,
             config=config,
             cli_invoke=config.cli_invoke,
+            task_text=task_text,
+            changed_paths=changed_paths,
         )
         return _select_report_payload(payload, profile="router", section=normalized)
 
@@ -13215,6 +13226,8 @@ def _run_lazy_report_section_command(
                 target_root=target_root,
                 config=config,
                 cli_invoke=config.cli_invoke,
+                task_text=task_text,
+                changed_paths=changed_paths,
             )
             payload["closeout_trust"] = closeout_trust
         payload["external_work_delta"] = external_work_delta
@@ -17150,6 +17163,7 @@ def _closeout_completion_options(
     durable_residue_action: dict[str, Any],
     lower_trust_closeout_count: int,
     cli_invoke: str,
+    current_task_switch_scope: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     closure_scope = intent_check.get("closure_scope", {}) if isinstance(intent_check, dict) else {}
     closure_scope = closure_scope if isinstance(closure_scope, dict) else {}
@@ -17171,6 +17185,8 @@ def _closeout_completion_options(
     acceptance_trust = str(acceptance_reconciliation.get("trust", "")).strip().lower()
     intent_proof_check = intent_proof_check if isinstance(intent_proof_check, dict) else {}
     completion_gate = completion_gate if isinstance(completion_gate, dict) else {}
+    current_task_switch_scope = _as_dict(current_task_switch_scope)
+    current_task_switch_active = str(current_task_switch_scope.get("status") or "") == "active"
     completion_gate_status = str(completion_gate.get("status", "")).strip()
     claim_authorization = _as_dict(completion_gate.get("claim_authorization"))
     allowed_claim_classes = {
@@ -17178,6 +17194,8 @@ def _closeout_completion_options(
     }
 
     def structured_claim_authorized(claim_class: str) -> bool:
+        if current_task_switch_active and claim_class == "slice_complete":
+            return True
         return not claim_authorization or claim_class in allowed_claim_classes
 
     completion_gate_blocks_full = completion_gate_status in {
@@ -17260,18 +17278,21 @@ def _closeout_completion_options(
     slice_blockers = [
         field
         for field in completion_blockers
-        if not field.startswith("intent_satisfaction.")
+        if field == "intent_satisfaction.closure_scope.validation_proof"
+        or not field.startswith("intent_satisfaction.")
         and not field.endswith(".intent_proof.status")
         or intent_proof_status == "needs_review"
     ]
+    if current_task_switch_active:
+        slice_blockers = [field for field in slice_blockers if field not in {"strict_closeout_gate", "durable_residue", "completion_gate"}]
     slice_blockers.extend(assurance_claim_blockers.get("claim-slice-complete", []))
     work_blockers = [*completion_blockers, *assurance_claim_blockers.get("claim-work-complete", [])]
     parent_blockers = [*completion_blockers, *assurance_claim_blockers.get("close-parent-lane", [])]
     claim_slice_allowed = (
         proof_achieved
-        and (not strict_blocking)
+        and (current_task_switch_active or not strict_blocking)
         and acceptance_ok
-        and not residue_required
+        and (current_task_switch_active or not residue_required)
         and not intent_proof_needs_review
         and not unsupported_preservation
         and not assurance_claim_blockers.get("claim-slice-complete")
@@ -17922,8 +17943,11 @@ def _report_closeout_trust_payload(
     target_root: Path | None = None,
     config: WorkspaceConfig | None = None,
     cli_invoke: str = DEFAULT_CLI_INVOKE,
+    task_text: str | None = None,
+    changed_paths: list[str] | None = None,
 ) -> dict[str, Any]:
     strict_closeout = bool(config.assurance.strict_closeout) if config is not None else False
+    normalized_changed_paths = _normalize_changed_paths(changed_paths or [])
     knowledge_authority_review = _knowledge_authority_review_payload(
         target_root=target_root,
         source_payload={"module_reports": module_reports},
@@ -18003,6 +18027,43 @@ def _report_closeout_trust_payload(
         }
         action["run"] = action["command"]
         return action
+
+    def current_task_switch_scope() -> dict[str, Any]:
+        if target_root is None or config is None or not normalized_changed_paths or not str(task_text or "").strip():
+            return {"kind": "agentic-workspace/current-task-closeout-scope/v1", "status": "not-applicable"}
+        execution_posture = _execution_posture_payload(
+            config=config,
+            changed_paths=normalized_changed_paths,
+            task_text=task_text,
+            target_root=target_root,
+        )
+        planning_safety_gate = _planning_safety_gate_payload(
+            target_root=target_root,
+            config=config,
+            changed_paths=normalized_changed_paths,
+            task_text=task_text,
+            execution_posture=execution_posture,
+        )
+        task_switch = _as_dict(planning_safety_gate.get("task_switch_reconciliation"))
+        if (
+            str(planning_safety_gate.get("gate_result") or "") != "active-plan-task-switch"
+            or planning_safety_gate.get("workflow_sufficient") is not True
+            or str(task_switch.get("status") or "") != "active"
+        ):
+            return {
+                "kind": "agentic-workspace/current-task-closeout-scope/v1",
+                "status": "not-applicable",
+                "planning_safety_gate": _selector_first_planning_safety_gate(planning_safety_gate),
+            }
+        return {
+            "kind": "agentic-workspace/current-task-closeout-scope/v1",
+            "status": "active",
+            "relationship": "bounded-task-switch",
+            "changed_paths": normalized_changed_paths,
+            "planning_safety_gate": _selector_first_planning_safety_gate(planning_safety_gate),
+            "task_switch_reconciliation": task_switch,
+            "rule": "The active plan remains protected repo-wide residue; this scope only classifies current bounded-task closeout blockers.",
+        }
 
     def archived_slice_closeout_evidence() -> dict[str, Any]:
         archived_record = _closeout_planning_record_for_report(active_planning_record={}, target_root=target_root)
@@ -18097,6 +18158,7 @@ def _report_closeout_trust_payload(
             adjusted.append(updated)
         return adjusted
 
+    task_switch_scope = current_task_switch_scope()
     planning_report = next((report for report in module_reports if isinstance(report, dict) and report.get("module") == "planning"), None)
     if not isinstance(planning_report, dict):
         gate = strict_gate(trust="unavailable", reason="planning module is not installed", active_planning_record=False)
@@ -18407,6 +18469,61 @@ def _report_closeout_trust_payload(
         cli_invoke=cli_invoke,
     )
     completion_options = allow_archived_slice_claim(completion_options, slice_closeout_evidence)
+    current_task_closeout: dict[str, Any] = {"status": "not-applicable"}
+    if task_switch_scope.get("status") == "active":
+        current_task_gate = copy.deepcopy(gate)
+        current_task_gate.update(
+            {
+                "status": "unrelated-active-plan-residue",
+                "blocking": False,
+                "current_task_blocking": False,
+                "relationship": "bounded-task-switch",
+                "summary": "Strict closeout still protects the unrelated active plan, but it is not a current bounded-task slice blocker.",
+            }
+        )
+        proof_selection = _proof_selection_for_changed_paths(
+            changed_paths=normalized_changed_paths,
+            target_root=target_root,
+            task_text=task_text,
+            include_durable_intent=False,
+            include_assurance_requirements=False,
+            include_routine_work_context=False,
+        )
+        current_task_options = _closeout_completion_options(
+            status="present",
+            trust=trust,
+            strict_gate=current_task_gate,
+            completion_gate=completion_gate,
+            intent_check=intent_satisfaction_check,
+            acceptance_reconciliation=acceptance_reconciliation,
+            intent_proof_check=intent_proof_check,
+            assurance_requirements=assurance_requirements,
+            durable_residue_action=residue_action,
+            lower_trust_closeout_count=effective_lower_trust_count,
+            cli_invoke=cli_invoke,
+            current_task_switch_scope=task_switch_scope,
+        )
+        current_task_operating_loop = _operating_loop_decision_payload(
+            claim_context="closeout",
+            planning_safety_gate=_as_dict(task_switch_scope.get("planning_safety_gate")),
+            proof=proof_selection,
+        )
+        current_task_closeout = {
+            "kind": "agentic-workspace/current-task-closeout/v1",
+            "status": "active",
+            "scope": task_switch_scope,
+            "strict_closeout_gate": current_task_gate,
+            "completion_options": current_task_options,
+            "operating_loop": current_task_operating_loop,
+            "proof": proof_selection,
+            "repo_wide_residue": {
+                "strict_closeout_gate": gate,
+                "completion_gate": completion_gate,
+                "trust": trust,
+                "lower_trust_closeout_count": effective_lower_trust_count,
+            },
+            "rule": "Current-task closeout options do not authorize active-plan progress, parent closure, or issue closure for unrelated planning residue.",
+        }
     memory_consult = (
         _memory_consult_payload(target_root=target_root, compact=True, cli_invoke=cli_invoke)
         if target_root is not None
@@ -18462,6 +18579,7 @@ def _report_closeout_trust_payload(
         "memory_consult": memory_consult,
         "memory_decision_packet": memory_decision_packet,
         "operating_loop": operating_loop,
+        "current_task_closeout": current_task_closeout,
         "knowledge_authority_review": knowledge_authority_review,
         "architecture_decision_closeout": architecture_decision_closeout,
         "historical_review_artifacts": _historical_review_artifacts_policy(
@@ -38692,6 +38810,8 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
         profile = "router"
     section = getattr(args, "section", None)
     select = getattr(args, "select", None)
+    task_text = getattr(args, "task", None)
+    changed_paths = _normalize_changed_paths(getattr(args, "changed", []) or [])
     if section in {"external_work_reconciliation", "external_work_delta"}:
         _ensure_external_intent_cache_if_available(target_root=target_root)
     if profile == "router" and section is None and (args.format == "json"):
@@ -38714,6 +38834,8 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
             resolved_preset=resolved_preset,
             config=config,
             section=section,
+            task_text=task_text,
+            changed_paths=changed_paths,
         )
         if payload is not None:
             if select:
@@ -38722,7 +38844,13 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
             _emit_payload(payload=payload, format_name=args.format)
             return 0
     payload = _run_report_command(
-        target_root=target_root, selected_modules=selected_modules, resolved_preset=resolved_preset, descriptors=descriptors, config=config
+        target_root=target_root,
+        selected_modules=selected_modules,
+        resolved_preset=resolved_preset,
+        descriptors=descriptors,
+        config=config,
+        task_text=task_text,
+        changed_paths=changed_paths,
     )
     payload = _select_report_payload(payload, profile=profile, section=section)
     if select:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -8643,6 +8643,8 @@ def _run_report_command(
     resolved_preset: str | None,
     descriptors: dict[str, ModuleDescriptor],
     config: WorkspaceConfig,
+    task_text: str | None = None,
+    changed_paths: list[str] | None = None,
 ) -> dict[str, Any]:
     status_payload = _run_lifecycle_command(
         command_name="status",
@@ -8728,7 +8730,12 @@ def _run_report_command(
     local_aw_state = _local_aw_state_payload(target_root=target_root)
     local_memory = _local_memory_payload(config=config)
     closeout_trust = _report_closeout_trust_payload(
-        module_reports=module_reports, target_root=target_root, config=config, cli_invoke=config.cli_invoke
+        module_reports=module_reports,
+        target_root=target_root,
+        config=config,
+        cli_invoke=config.cli_invoke,
+        task_text=task_text,
+        changed_paths=changed_paths,
     )
     decision_pressure = _decision_pressure_payload(
         target_root=target_root, config=config, module_reports=module_reports, cli_invoke=config.cli_invoke
@@ -12472,6 +12479,8 @@ def _run_lazy_report_section_command(
     resolved_preset: str | None,
     config: WorkspaceConfig,
     section: str | None,
+    task_text: str | None = None,
+    changed_paths: list[str] | None = None,
 ) -> dict[str, Any] | None:
     if section is None:
         return None
@@ -12685,6 +12694,8 @@ def _run_lazy_report_section_command(
             target_root=target_root,
             config=config,
             cli_invoke=config.cli_invoke,
+            task_text=task_text,
+            changed_paths=changed_paths,
         )
         return _select_report_payload(payload, profile="router", section=normalized)
 
@@ -12730,6 +12741,8 @@ def _run_lazy_report_section_command(
                 target_root=target_root,
                 config=config,
                 cli_invoke=config.cli_invoke,
+                task_text=task_text,
+                changed_paths=changed_paths,
             )
             payload["closeout_trust"] = closeout_trust
         payload["external_work_delta"] = external_work_delta
@@ -16475,6 +16488,7 @@ def _closeout_completion_options(
     durable_residue_action: dict[str, Any],
     lower_trust_closeout_count: int,
     cli_invoke: str,
+    current_task_switch_scope: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     closure_scope = intent_check.get("closure_scope", {}) if isinstance(intent_check, dict) else {}
     closure_scope = closure_scope if isinstance(closure_scope, dict) else {}
@@ -16496,6 +16510,8 @@ def _closeout_completion_options(
     acceptance_trust = str(acceptance_reconciliation.get("trust", "")).strip().lower()
     intent_proof_check = intent_proof_check if isinstance(intent_proof_check, dict) else {}
     completion_gate = completion_gate if isinstance(completion_gate, dict) else {}
+    current_task_switch_scope = _as_dict(current_task_switch_scope)
+    current_task_switch_active = str(current_task_switch_scope.get("status") or "") == "active"
     completion_gate_status = str(completion_gate.get("status", "")).strip()
     claim_authorization = _as_dict(completion_gate.get("claim_authorization"))
     allowed_claim_classes = {
@@ -16503,6 +16519,8 @@ def _closeout_completion_options(
     }
 
     def structured_claim_authorized(claim_class: str) -> bool:
+        if current_task_switch_active and claim_class == "slice_complete":
+            return True
         return not claim_authorization or claim_class in allowed_claim_classes
 
     completion_gate_blocks_full = completion_gate_status in {
@@ -16578,16 +16596,20 @@ def _closeout_completion_options(
     slice_blockers = [
         field
         for field in completion_blockers
-        if field not in {"intent_satisfaction", "intent_proof"} or intent_proof_status == "needs_review"
+        if field == "intent_satisfaction.closure_scope.validation_proof"
+        or field not in {"intent_satisfaction", "intent_proof"}
+        or intent_proof_status == "needs_review"
     ]
+    if current_task_switch_active:
+        slice_blockers = [field for field in slice_blockers if field not in {"strict_closeout_gate", "durable_residue", "completion_gate"}]
     slice_blockers.extend(assurance_claim_blockers.get("claim-slice-complete", []))
     work_blockers = [*completion_blockers, *assurance_claim_blockers.get("claim-work-complete", [])]
     parent_blockers = [*completion_blockers, *assurance_claim_blockers.get("close-parent-lane", [])]
     claim_slice_allowed = (
         proof_achieved
-        and (not strict_blocking)
+        and (current_task_switch_active or not strict_blocking)
         and acceptance_ok
-        and not residue_required
+        and (current_task_switch_active or not residue_required)
         and not intent_proof_needs_review
         and not unsupported_preservation
         and not assurance_claim_blockers.get("claim-slice-complete")
@@ -17234,8 +17256,11 @@ def _report_closeout_trust_payload(
     target_root: Path | None = None,
     config: WorkspaceConfig | None = None,
     cli_invoke: str = DEFAULT_CLI_INVOKE,
+    task_text: str | None = None,
+    changed_paths: list[str] | None = None,
 ) -> dict[str, Any]:
     strict_closeout = bool(config.assurance.strict_closeout) if config is not None else False
+    normalized_changed_paths = _normalize_changed_paths(changed_paths or [])
     knowledge_authority_review = _knowledge_authority_review_payload(
         target_root=target_root,
         source_payload={"module_reports": module_reports},
@@ -17315,6 +17340,43 @@ def _report_closeout_trust_payload(
         }
         action["run"] = action["command"]
         return action
+
+    def current_task_switch_scope() -> dict[str, Any]:
+        if target_root is None or config is None or not normalized_changed_paths or not str(task_text or "").strip():
+            return {"kind": "agentic-workspace/current-task-closeout-scope/v1", "status": "not-applicable"}
+        execution_posture = _execution_posture_payload(
+            config=config,
+            changed_paths=normalized_changed_paths,
+            task_text=task_text,
+            target_root=target_root,
+        )
+        planning_safety_gate = _planning_safety_gate_payload(
+            target_root=target_root,
+            config=config,
+            changed_paths=normalized_changed_paths,
+            task_text=task_text,
+            execution_posture=execution_posture,
+        )
+        task_switch = _as_dict(planning_safety_gate.get("task_switch_reconciliation"))
+        if (
+            str(planning_safety_gate.get("gate_result") or "") != "active-plan-task-switch"
+            or planning_safety_gate.get("workflow_sufficient") is not True
+            or str(task_switch.get("status") or "") != "active"
+        ):
+            return {
+                "kind": "agentic-workspace/current-task-closeout-scope/v1",
+                "status": "not-applicable",
+                "planning_safety_gate": _selector_first_planning_safety_gate(planning_safety_gate),
+            }
+        return {
+            "kind": "agentic-workspace/current-task-closeout-scope/v1",
+            "status": "active",
+            "relationship": "bounded-task-switch",
+            "changed_paths": normalized_changed_paths,
+            "planning_safety_gate": _selector_first_planning_safety_gate(planning_safety_gate),
+            "task_switch_reconciliation": task_switch,
+            "rule": "The active plan remains protected repo-wide residue; this scope only classifies current bounded-task closeout blockers.",
+        }
 
     def archived_slice_closeout_evidence() -> dict[str, Any]:
         archived_record = _closeout_planning_record_for_report(active_planning_record={}, target_root=target_root)
@@ -17409,6 +17471,7 @@ def _report_closeout_trust_payload(
             adjusted.append(updated)
         return adjusted
 
+    task_switch_scope = current_task_switch_scope()
     planning_report = next((report for report in module_reports if isinstance(report, dict) and report.get("module") == "planning"), None)
     if not isinstance(planning_report, dict):
         gate = strict_gate(trust="unavailable", reason="planning module is not installed", active_planning_record=False)
@@ -17719,6 +17782,61 @@ def _report_closeout_trust_payload(
         cli_invoke=cli_invoke,
     )
     completion_options = allow_archived_slice_claim(completion_options, slice_closeout_evidence)
+    current_task_closeout: dict[str, Any] = {"status": "not-applicable"}
+    if task_switch_scope.get("status") == "active":
+        current_task_gate = copy.deepcopy(gate)
+        current_task_gate.update(
+            {
+                "status": "unrelated-active-plan-residue",
+                "blocking": False,
+                "current_task_blocking": False,
+                "relationship": "bounded-task-switch",
+                "summary": "Strict closeout still protects the unrelated active plan, but it is not a current bounded-task slice blocker.",
+            }
+        )
+        proof_selection = _proof_selection_for_changed_paths(
+            changed_paths=normalized_changed_paths,
+            target_root=target_root,
+            task_text=task_text,
+            include_durable_intent=False,
+            include_assurance_requirements=False,
+            include_routine_work_context=False,
+        )
+        current_task_options = _closeout_completion_options(
+            status="present",
+            trust=trust,
+            strict_gate=current_task_gate,
+            completion_gate=completion_gate,
+            intent_check=intent_satisfaction_check,
+            acceptance_reconciliation=acceptance_reconciliation,
+            intent_proof_check=intent_proof_check,
+            assurance_requirements=assurance_requirements,
+            durable_residue_action=residue_action,
+            lower_trust_closeout_count=effective_lower_trust_count,
+            cli_invoke=cli_invoke,
+            current_task_switch_scope=task_switch_scope,
+        )
+        current_task_operating_loop = _operating_loop_decision_payload(
+            claim_context="closeout",
+            planning_safety_gate=_as_dict(task_switch_scope.get("planning_safety_gate")),
+            proof=proof_selection,
+        )
+        current_task_closeout = {
+            "kind": "agentic-workspace/current-task-closeout/v1",
+            "status": "active",
+            "scope": task_switch_scope,
+            "strict_closeout_gate": current_task_gate,
+            "completion_options": current_task_options,
+            "operating_loop": current_task_operating_loop,
+            "proof": proof_selection,
+            "repo_wide_residue": {
+                "strict_closeout_gate": gate,
+                "completion_gate": completion_gate,
+                "trust": trust,
+                "lower_trust_closeout_count": effective_lower_trust_count,
+            },
+            "rule": "Current-task closeout options do not authorize active-plan progress, parent closure, or issue closure for unrelated planning residue.",
+        }
     memory_consult = (
         _memory_consult_payload(target_root=target_root, compact=True, cli_invoke=cli_invoke)
         if target_root is not None
@@ -17774,6 +17892,7 @@ def _report_closeout_trust_payload(
         "memory_consult": memory_consult,
         "memory_decision_packet": memory_decision_packet,
         "operating_loop": operating_loop,
+        "current_task_closeout": current_task_closeout,
         "knowledge_authority_review": knowledge_authority_review,
         "architecture_decision_closeout": architecture_decision_closeout,
         "historical_review_artifacts": _historical_review_artifacts_policy(
@@ -36631,6 +36750,8 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
         profile = "router"
     section = getattr(args, "section", None)
     select = getattr(args, "select", None)
+    task_text = getattr(args, "task", None)
+    changed_paths = _normalize_changed_paths(getattr(args, "changed", []) or [])
     if section in {"external_work_reconciliation", "external_work_delta"}:
         _ensure_external_intent_cache_if_available(target_root=target_root)
     if profile == "router" and section is None and (args.format == "json"):
@@ -36653,6 +36774,8 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
             resolved_preset=resolved_preset,
             config=config,
             section=section,
+            task_text=task_text,
+            changed_paths=changed_paths,
         )
         if payload is not None:
             if select:
@@ -36661,7 +36784,13 @@ def _run_report_combined_adapter(args: argparse.Namespace) -> int:
             _emit_payload(payload=payload, format_name=args.format)
             return 0
     payload = _run_report_command(
-        target_root=target_root, selected_modules=selected_modules, resolved_preset=resolved_preset, descriptors=descriptors, config=config
+        target_root=target_root,
+        selected_modules=selected_modules,
+        resolved_preset=resolved_preset,
+        descriptors=descriptors,
+        config=config,
+        task_text=task_text,
+        changed_paths=changed_paths,
     )
     payload = _select_report_payload(payload, profile=profile, section=section)
     if select:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -633,6 +633,91 @@ def test_closeout_trust_names_external_intent_evidence_blocker_for_open_issue(tm
     assert "intent_satisfaction.required_follow_on" not in claim_work["blocking_fields"]
 
 
+def test_closeout_trust_scopes_unrelated_active_plan_residue_to_repo_wide_closeout(tmp_path: Path, capsys) -> None:
+    from repo_planning_bootstrap import installer as planning_installer
+
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        """
+schema_version = 1
+
+[assurance]
+strict_closeout = true
+""",
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "active-plan", title = "Unrelated active plan", status = "active", surface = ".agentic-workspace/planning/execplans/active-plan.plan.json" },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    record = planning_installer._build_execplan_record_from_todo_item(
+        title="Unrelated active plan",
+        item_id="active-plan",
+        status="active",
+        why_now="regress task-scoped closeout trust with unrelated active planning residue.",
+        next_action="Continue unrelated active plan later.",
+        done_when="The unrelated active plan is complete.",
+    )
+    planning_installer._write_execplan_record(
+        record_path=tmp_path / ".agentic-workspace" / "planning" / "execplans" / "active-plan.plan.json",
+        record=record,
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(tmp_path),
+                "--section",
+                "closeout_trust",
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_primitives.py",
+                "--task",
+                "Implement issue #3000 parser cache cleanup",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)["answer"]
+
+    assert payload["strict_closeout_gate"]["blocking"] is True
+    current = payload["current_task_closeout"]
+    assert current["status"] == "active"
+    assert current["scope"]["relationship"] == "bounded-task-switch"
+    assert current["scope"]["planning_safety_gate"]["gate_result"] == "active-plan-task-switch"
+    assert current["strict_closeout_gate"]["blocking"] is False
+    assert current["strict_closeout_gate"]["current_task_blocking"] is False
+    assert current["operating_loop"]["planning"]["state"] == "unrelated_active_plan"
+    assert current["operating_loop"]["planning"]["blocks_full_closure"] is False
+    assert current["operating_loop"]["verification"]["state"] == "proof_missing"
+    assert current["operating_loop"]["required_before_full_closure"] == ["run_or_refresh_proof"]
+    claim_slice = next(option for option in current["completion_options"] if option["id"] == "claim-slice-complete")
+    assert claim_slice["allowed"] is False
+    assert "intent_satisfaction.closure_scope.validation_proof" in claim_slice["blocking_fields"]
+    assert "strict_closeout_gate" not in claim_slice["blocking_fields"]
+    assert "durable_residue" not in claim_slice["blocking_fields"]
+    assert "completion_gate" not in claim_slice["blocking_fields"]
+
+
 def test_verbose_aliases_full_diagnostic_output_for_major_workspace_commands(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     (tmp_path / "README.md").write_text("# Fixture\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Closes #2018.

This stacks on #2019 and makes `report --section closeout_trust` accept optional task context:

- adds `report --task` and repeatable `--changed` contract/generated command surfaces
- adds `current_task_closeout` for bounded task-switch closeout classification
- keeps repo-wide strict closeout residue visible while excluding unrelated active-plan residue from current-task slice blockers
- compacts the selected `closeout_trust` answer so the task-scoped packet is usable without verbose proof payloads

## Dogfood evidence

On this branch, `closeout_trust --task --changed` reports:

- current task scope: `bounded-task-switch`
- current-task strict gate: `blocking=false`, `current_task_blocking=false`
- current-task slice completion: allowed after proof evidence
- repo-wide residue: strict closeout still blocked for the unrelated active #1981 plan

## Proof

- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run pytest tests/test_workspace_cli.py -q -k "closeout_trust"`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `git diff --cached --check`