### PR TITLE
Add learned proof route model

### DIFF
--- a/src/agentic_workspace/contracts/schemas/proof_route_hints.schema.json
+++ b/src/agentic_workspace/contracts/schemas/proof_route_hints.schema.json
@@ -136,6 +136,11 @@
               "general-check"
             ]
           },
+          "route_class": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Repo-local route class for explaining why this learned route applies. Examples may include docs-process, access-audit, migration-storage, or any host-owned class; AW treats the value as evidence, not a global taxonomy."
+          },
           "candidate_command": {
             "type": "string",
             "minLength": 1,
@@ -200,6 +205,135 @@
             "type": "string",
             "minLength": 1,
             "description": "ISO date or timestamp when this lesson was learned or last confirmed."
+          },
+          "risk_markers": {
+            "type": "array",
+            "description": "Repo-owned risk signals that make this route relevant.",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "evidence": {
+            "type": "array",
+            "description": "Compact evidence records that justify the learned route.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source_path": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "summary": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "receipt": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "review_ref": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "memory_ref": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "proof_classes": {
+            "type": "object",
+            "description": "Proof buckets for this route. Required commands affect closeout; other classes explain recommended, optional, manual, or not-applicable evidence.",
+            "properties": {
+              "required": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "recommended": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "optional_confidence": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "unavailable_manual": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "not_applicable": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "override_semantics": {
+            "type": "object",
+            "description": "Escalation and override semantics that prevent learned routes from weakening proof under higher-risk conditions.",
+            "properties": {
+              "escalate_when": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "blocked_when": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "requires_human_review_when": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "fallback_when": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "repo_policy_overrides": {
+                "type": "boolean"
+              },
+              "user_instruction_overrides": {
+                "type": "boolean"
+              },
+              "rule": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "additionalProperties": false
           },
           "superseded_by": {
             "type": "string",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -39783,6 +39783,7 @@ def _learned_proof_lanes_for_changed_paths(*, changed_paths: list[str], learned_
             continue
         hint_id = str(hint.get("id") or _decision_slug(command)).strip()
         intent_type = str(hint.get("intent_type", "behavior-test")).strip() or "behavior-test"
+        override_semantics = _as_dict(hint.get("override_semantics"))
         lanes.append(
             {
                 "id": f"learned_route:{hint_id}",
@@ -39792,15 +39793,21 @@ def _learned_proof_lanes_for_changed_paths(*, changed_paths: list[str], learned_
                 "proof_responsibility": "local-closeout",
                 "execution_mode": "serial-recommended",
                 "matched_paths": matched_paths or list(changed_paths),
+                "escalate_when": _string_list_payload(override_semantics.get("escalate_when")),
                 "learned_route": {
                     "id": hint_id,
+                    "route_class": str(hint.get("route_class", "")),
                     "scope": scope,
+                    "matched_paths": matched_paths or list(changed_paths),
                     "source": str(hint.get("source", "")),
                     "source_path": str(hint.get("source_path", "")),
                     "owner": str(hint.get("owner", "")),
                     "provenance": str(hint.get("provenance", "")),
                     "learned_at": str(hint.get("learned_at", "")),
                     "confirmation": str(hint.get("confirmation", "")),
+                    "risk_markers": _list_payload(hint.get("risk_markers")),
+                    "proof_classes": _as_dict(hint.get("proof_classes")),
+                    "override_semantics": override_semantics,
                 },
                 "ci_relationship": str(hint.get("ci_relationship", "")),
                 "recovery_signal": "stale, failing, or missing learned route evidence should update the repo route table instead of forcing rediscovery",
@@ -40021,6 +40028,13 @@ def _proof_route_hints_payload(*, target_root: Path) -> dict[str, Any]:
 _PROOF_ROUTE_MEMORY_PREFIX = "agentic-workspace-proof-route:"
 _PROOF_ROUTE_STATES = {"candidate", "confirmed", "stale", "negative", "superseded", "invalid-authority"}
 _PROOF_ROUTE_INTENT_TYPES = {"behavior-test", "static-check", "type-check", "general-check"}
+_PROOF_ROUTE_PROOF_CLASS_KEYS = (
+    "required",
+    "recommended",
+    "optional_confidence",
+    "unavailable_manual",
+    "not_applicable",
+)
 _AUTHORITATIVE_PROOF_ROUTE_REQUIRED_FIELDS = (
     "candidate_command",
     "state",
@@ -40030,6 +40044,69 @@ _AUTHORITATIVE_PROOF_ROUTE_REQUIRED_FIELDS = (
     "provenance",
     "learned_at",
 )
+
+
+def _learned_route_class_for_intent_type(intent_type: str) -> str:
+    if intent_type == "static-check":
+        return "static-check"
+    if intent_type == "type-check":
+        return "type-check"
+    if intent_type == "general-check":
+        return "general-check"
+    return "behavior-test"
+
+
+def _string_list_payload(value: Any) -> list[str]:
+    return [str(item).strip() for item in _list_payload(value) if str(item).strip()]
+
+
+def _normalize_learned_route_proof_classes(value: Any, *, command: str, state: str = "candidate") -> dict[str, list[str]]:
+    raw = _as_dict(value)
+    proof_classes: dict[str, list[str]] = {}
+    for key in _PROOF_ROUTE_PROOF_CLASS_KEYS:
+        items = _string_list_payload(raw.get(key))
+        if items:
+            proof_classes[key] = items
+    if not proof_classes and command:
+        if state == "negative":
+            proof_classes["not_applicable"] = [command]
+        elif state in {"stale", "superseded", "invalid-authority"}:
+            proof_classes["unavailable_manual"] = [command]
+        else:
+            proof_classes["required"] = [command]
+    return proof_classes
+
+
+def _normalize_learned_route_override_semantics(value: Any) -> dict[str, Any]:
+    raw = _as_dict(value)
+    result: dict[str, Any] = {}
+    for key in ("escalate_when", "blocked_when", "requires_human_review_when", "fallback_when"):
+        items = _string_list_payload(raw.get(key))
+        if items:
+            result[key] = items
+    if "repo_policy_overrides" in raw:
+        result["repo_policy_overrides"] = bool(raw.get("repo_policy_overrides"))
+    if "user_instruction_overrides" in raw:
+        result["user_instruction_overrides"] = bool(raw.get("user_instruction_overrides"))
+    if "rule" in raw and str(raw.get("rule", "")).strip():
+        result["rule"] = str(raw["rule"]).strip()
+    return result
+
+
+def _normalize_learned_route_evidence(value: Any) -> list[dict[str, str]]:
+    evidence_items: list[dict[str, str]] = []
+    raw_items = value if isinstance(value, list) else [value] if isinstance(value, dict) else []
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        compact = {
+            key: str(item.get(key, "")).strip()
+            for key in ("source", "source_path", "summary", "receipt", "review_ref", "memory_ref")
+            if str(item.get(key, "")).strip()
+        }
+        if compact:
+            evidence_items.append(compact)
+    return evidence_items
 
 
 def _proof_route_hints_path(*, target_root: Path) -> Path:
@@ -40060,6 +40137,8 @@ def _normalize_proof_route_hint(
     intent_type = str(hint.get("intent_type") or "behavior-test").strip()
     if intent_type not in _PROOF_ROUTE_INTENT_TYPES:
         intent_type = "behavior-test"
+    route_class = str(hint.get("route_class") or _learned_route_class_for_intent_type(intent_type)).strip()
+    route_class = route_class or _learned_route_class_for_intent_type(intent_type)
     source = str(hint.get("source") or default_source).strip() or default_source
     source_path = str(hint.get("source_path") or default_source_path).strip()
     owner = str(hint.get("owner") or default_owner).strip()
@@ -40084,6 +40163,7 @@ def _normalize_proof_route_hint(
     record: dict[str, Any] = {
         "id": str(hint.get("id") or f"{source}:{_decision_slug(command)}"),
         "state": state,
+        "route_class": route_class,
         "intent_type": intent_type,
         "candidate_command": command,
         "source": source,
@@ -40094,6 +40174,10 @@ def _normalize_proof_route_hint(
         "owner": owner or ("Memory" if source == "memory" else ""),
         "provenance": str(hint.get("provenance") or hint.get("observed") or source_path or source).strip(),
         "learned_at": str(hint.get("learned_at") or hint.get("last_confirmed") or "").strip(),
+        "risk_markers": _string_list_payload(hint.get("risk_markers")),
+        "evidence": _normalize_learned_route_evidence(hint.get("evidence")),
+        "proof_classes": _normalize_learned_route_proof_classes(hint.get("proof_classes"), command=command, state=state),
+        "override_semantics": _normalize_learned_route_override_semantics(hint.get("override_semantics")),
     }
     superseded_by = str(hint.get("superseded_by") or hint.get("replacement_command") or "").strip()
     if superseded_by:
@@ -40276,6 +40360,7 @@ def _confirm_learned_route_hints(*, learned_hints: dict[str, Any], target_capabi
         record = {
             "id": str(hint.get("id", "")),
             "state": str(hint.get("state", "candidate")),
+            "route_class": str(hint.get("route_class", "")),
             "intent_type": str(hint.get("intent_type", "")),
             "candidate_command": command,
             "source": str(hint.get("source", "")),
@@ -40291,6 +40376,10 @@ def _confirm_learned_route_hints(*, learned_hints: dict[str, Any], target_capabi
             "original_state": str(hint.get("original_state", "")),
             "missing_fields": list(hint.get("missing_fields", [])) if isinstance(hint.get("missing_fields"), list) else [],
             "recovery": str(hint.get("recovery", "")),
+            "risk_markers": _list_payload(hint.get("risk_markers")),
+            "evidence": _list_payload(hint.get("evidence")),
+            "proof_classes": _as_dict(hint.get("proof_classes")),
+            "override_semantics": _as_dict(hint.get("override_semantics")),
         }
         record = {key: value for key, value in record.items() if value != "" and value != []}
         state = str(record.get("state", "candidate"))

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -37857,6 +37857,13 @@ def _proof_route_hints_payload(*, target_root: Path) -> dict[str, Any]:
 _PROOF_ROUTE_MEMORY_PREFIX = "agentic-workspace-proof-route:"
 _PROOF_ROUTE_STATES = {"candidate", "confirmed", "stale", "negative", "superseded", "invalid-authority"}
 _PROOF_ROUTE_INTENT_TYPES = {"behavior-test", "static-check", "type-check", "general-check"}
+_PROOF_ROUTE_PROOF_CLASS_KEYS = (
+    "required",
+    "recommended",
+    "optional_confidence",
+    "unavailable_manual",
+    "not_applicable",
+)
 _AUTHORITATIVE_PROOF_ROUTE_REQUIRED_FIELDS = (
     "candidate_command",
     "state",
@@ -37866,6 +37873,69 @@ _AUTHORITATIVE_PROOF_ROUTE_REQUIRED_FIELDS = (
     "provenance",
     "learned_at",
 )
+
+
+def _learned_route_class_for_intent_type(intent_type: str) -> str:
+    if intent_type == "static-check":
+        return "static-check"
+    if intent_type == "type-check":
+        return "type-check"
+    if intent_type == "general-check":
+        return "general-check"
+    return "behavior-test"
+
+
+def _string_list_payload(value: Any) -> list[str]:
+    return [str(item).strip() for item in _list_payload(value) if str(item).strip()]
+
+
+def _normalize_learned_route_proof_classes(value: Any, *, command: str, state: str = "candidate") -> dict[str, list[str]]:
+    raw = _as_dict(value)
+    proof_classes: dict[str, list[str]] = {}
+    for key in _PROOF_ROUTE_PROOF_CLASS_KEYS:
+        items = _string_list_payload(raw.get(key))
+        if items:
+            proof_classes[key] = items
+    if not proof_classes and command:
+        if state == "negative":
+            proof_classes["not_applicable"] = [command]
+        elif state in {"stale", "superseded", "invalid-authority"}:
+            proof_classes["unavailable_manual"] = [command]
+        else:
+            proof_classes["required"] = [command]
+    return proof_classes
+
+
+def _normalize_learned_route_override_semantics(value: Any) -> dict[str, Any]:
+    raw = _as_dict(value)
+    result: dict[str, Any] = {}
+    for key in ("escalate_when", "blocked_when", "requires_human_review_when", "fallback_when"):
+        items = _string_list_payload(raw.get(key))
+        if items:
+            result[key] = items
+    if "repo_policy_overrides" in raw:
+        result["repo_policy_overrides"] = bool(raw.get("repo_policy_overrides"))
+    if "user_instruction_overrides" in raw:
+        result["user_instruction_overrides"] = bool(raw.get("user_instruction_overrides"))
+    if "rule" in raw and str(raw.get("rule", "")).strip():
+        result["rule"] = str(raw["rule"]).strip()
+    return result
+
+
+def _normalize_learned_route_evidence(value: Any) -> list[dict[str, str]]:
+    evidence_items: list[dict[str, str]] = []
+    raw_items = value if isinstance(value, list) else [value] if isinstance(value, dict) else []
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        compact = {
+            key: str(item.get(key, "")).strip()
+            for key in ("source", "source_path", "summary", "receipt", "review_ref", "memory_ref")
+            if str(item.get(key, "")).strip()
+        }
+        if compact:
+            evidence_items.append(compact)
+    return evidence_items
 
 
 def _proof_route_hints_path(*, target_root: Path) -> Path:
@@ -37896,6 +37966,8 @@ def _normalize_proof_route_hint(
     intent_type = str(hint.get("intent_type") or "behavior-test").strip()
     if intent_type not in _PROOF_ROUTE_INTENT_TYPES:
         intent_type = "behavior-test"
+    route_class = str(hint.get("route_class") or _learned_route_class_for_intent_type(intent_type)).strip()
+    route_class = route_class or _learned_route_class_for_intent_type(intent_type)
     source = str(hint.get("source") or default_source).strip() or default_source
     source_path = str(hint.get("source_path") or default_source_path).strip()
     owner = str(hint.get("owner") or default_owner).strip()
@@ -37920,6 +37992,7 @@ def _normalize_proof_route_hint(
     record: dict[str, Any] = {
         "id": str(hint.get("id") or f"{source}:{_decision_slug(command)}"),
         "state": state,
+        "route_class": route_class,
         "intent_type": intent_type,
         "candidate_command": command,
         "source": source,
@@ -37930,6 +38003,10 @@ def _normalize_proof_route_hint(
         "owner": owner or ("Memory" if source == "memory" else ""),
         "provenance": str(hint.get("provenance") or hint.get("observed") or source_path or source).strip(),
         "learned_at": str(hint.get("learned_at") or hint.get("last_confirmed") or "").strip(),
+        "risk_markers": _string_list_payload(hint.get("risk_markers")),
+        "evidence": _normalize_learned_route_evidence(hint.get("evidence")),
+        "proof_classes": _normalize_learned_route_proof_classes(hint.get("proof_classes"), command=command, state=state),
+        "override_semantics": _normalize_learned_route_override_semantics(hint.get("override_semantics")),
     }
     superseded_by = str(hint.get("superseded_by") or hint.get("replacement_command") or "").strip()
     if superseded_by:
@@ -38112,6 +38189,7 @@ def _confirm_learned_route_hints(*, learned_hints: dict[str, Any], target_capabi
         record = {
             "id": str(hint.get("id", "")),
             "state": str(hint.get("state", "candidate")),
+            "route_class": str(hint.get("route_class", "")),
             "intent_type": str(hint.get("intent_type", "")),
             "candidate_command": command,
             "source": str(hint.get("source", "")),
@@ -38127,6 +38205,10 @@ def _confirm_learned_route_hints(*, learned_hints: dict[str, Any], target_capabi
             "original_state": str(hint.get("original_state", "")),
             "missing_fields": list(hint.get("missing_fields", [])) if isinstance(hint.get("missing_fields"), list) else [],
             "recovery": str(hint.get("recovery", "")),
+            "risk_markers": _list_payload(hint.get("risk_markers")),
+            "evidence": _list_payload(hint.get("evidence")),
+            "proof_classes": _as_dict(hint.get("proof_classes")),
+            "override_semantics": _as_dict(hint.get("override_semantics")),
         }
         record = {key: value for key, value in record.items() if value != "" and value != []}
         state = str(record.get("state", "candidate"))

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -251,6 +251,33 @@ def _compact_tiny_proof_closeout_summary(value: Any) -> dict[str, Any]:
     }
 
 
+def _compact_tiny_learned_proof_route_model(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    selected_routes = [
+        {
+            key: route.get(key)
+            for key in ("id", "route_class", "maturity", "selected", "scope", "proof_classes", "override_semantics")
+            if key in route
+        }
+        for route in _list_payload(value.get("selected_routes"))[:4]
+        if isinstance(route, dict)
+    ]
+    fallback = _as_dict(value.get("fallback"))
+    return {
+        "kind": value.get("kind", "learned-proof-route-model/v1"),
+        "status": value.get("status", "absent"),
+        "route_classes": _list_payload(value.get("route_classes")),
+        "selected_route_count": value.get("selected_route_count", 0),
+        "selected_routes": selected_routes,
+        "fallback": {key: fallback.get(key) for key in ("status", "reason", "manual_verification_required") if key in fallback},
+        "proof_class_vocabulary": _list_payload(value.get("proof_class_vocabulary")),
+        "override_rule": value.get("override_rule", ""),
+        "repo_neutrality_rule": value.get("repo_neutrality_rule", ""),
+        "detail_selector": "learned_proof_route_model",
+    }
+
+
 def _short_tiny_text(value: str, *, limit: int) -> str:
     text = re.sub(r"\s+", " ", value).strip()
     if len(text) <= limit:
@@ -281,6 +308,10 @@ def _tiny_proof_payload(payload: dict[str, Any], *, cli_invoke: str = DEFAULT_CL
                 next_decision["proof_command_adjustments"] = answer["proof_command_adjustments"]
             if answer.get("proof_closeout_summary"):
                 next_decision["proof_closeout_summary"] = _compact_tiny_proof_closeout_summary(answer["proof_closeout_summary"])
+            if answer.get("learned_proof_route_model"):
+                learned_route_model = _compact_tiny_learned_proof_route_model(answer["learned_proof_route_model"])
+                if learned_route_model.get("status") != "absent":
+                    next_decision["learned_proof_route_model"] = learned_route_model
             if answer.get("unavailable_proof_commands"):
                 next_decision["unavailable_proof_commands"] = answer["unavailable_proof_commands"]
             if answer.get("target_proof_capabilities") and (
@@ -2574,6 +2605,133 @@ def _proof_decision_packet(
     }
 
 
+def _learned_route_maturity(hint: dict[str, Any]) -> str:
+    confirmation = str(hint.get("confirmation", "")).strip()
+    state = str(hint.get("state", "candidate")).strip()
+    if confirmation == "learned-confirmed":
+        return "confirmed-learned"
+    if confirmation == "live-confirmed":
+        return "confirmed-live"
+    if state in {"stale", "negative", "superseded", "invalid-authority"}:
+        return state
+    if state == "confirmed":
+        return "confirmed"
+    return "candidate"
+
+
+def _default_proof_classes_for_hint(hint: dict[str, Any]) -> dict[str, list[str]]:
+    command = str(hint.get("candidate_command", "")).strip()
+    state = str(hint.get("state", "candidate")).strip()
+    if not command:
+        return {}
+    if state == "negative":
+        return {"not_applicable": [command]}
+    if state in {"stale", "superseded", "invalid-authority"}:
+        return {"unavailable_manual": [command]}
+    return {"required": [command]}
+
+
+def _learned_proof_route_model_payload(
+    *,
+    changed_paths: list[str],
+    learned_route_hints: dict[str, Any],
+    selected_lanes: list[dict[str, Any]],
+    selected_commands: list[dict[str, Any]],
+    manual_verification: dict[str, Any] | None,
+) -> dict[str, Any]:
+    selected_lane_ids = {str(command.get("lane", "")) for command in selected_commands if isinstance(command, dict)}
+    selected_commands_by_lane = {
+        str(command.get("lane", "")): str(command.get("command", ""))
+        for command in selected_commands
+        if isinstance(command, dict) and str(command.get("lane", ""))
+    }
+    selected_learned_lanes = {
+        str(lane.get("id", "")): _as_dict(lane.get("learned_route"))
+        for lane in selected_lanes
+        if isinstance(lane, dict) and isinstance(lane.get("learned_route"), dict)
+    }
+    route_records: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for bucket in ("confirmed", "stale", "negative", "superseded", "invalid"):
+        for raw_hint in _list_payload(learned_route_hints.get(bucket)):
+            if not isinstance(raw_hint, dict):
+                continue
+            hint = raw_hint
+            command = str(hint.get("candidate_command", "")).strip()
+            route_id = str(hint.get("id") or command or bucket).strip()
+            key = (route_id, command)
+            if key in seen:
+                continue
+            seen.add(key)
+            lane_id = next(
+                (
+                    candidate_lane_id
+                    for candidate_lane_id, lane in selected_learned_lanes.items()
+                    if str(lane.get("id", "")) == route_id or selected_commands_by_lane.get(candidate_lane_id) == command
+                ),
+                "",
+            )
+            selected = lane_id in selected_lane_ids
+            proof_classes = _as_dict(hint.get("proof_classes")) or _default_proof_classes_for_hint(hint)
+            route_records.append(
+                {
+                    "kind": "learned-proof-route/v1",
+                    "id": route_id,
+                    "route_class": str(hint.get("route_class") or hint.get("intent_type") or "behavior-test"),
+                    "state": str(hint.get("state", "candidate")),
+                    "maturity": _learned_route_maturity(hint),
+                    "selected": selected,
+                    "selected_lane": lane_id,
+                    "scope": str(hint.get("scope", "repo")),
+                    "matched_changed_paths": _list_payload(selected_learned_lanes.get(lane_id, {}).get("matched_paths")) if lane_id else [],
+                    "risk_markers": _list_payload(hint.get("risk_markers")),
+                    "evidence": _list_payload(hint.get("evidence")),
+                    "proof_classes": proof_classes,
+                    "override_semantics": _as_dict(hint.get("override_semantics")),
+                    "source": {
+                        "source": str(hint.get("source", "")),
+                        "source_path": str(hint.get("source_path", "")),
+                        "owner": str(hint.get("owner", "")),
+                        "provenance": str(hint.get("provenance", "")),
+                        "learned_at": str(hint.get("learned_at", "")),
+                    },
+                }
+            )
+    selected_routes = [route for route in route_records if route["selected"]]
+    fallback_reason = ""
+    if not selected_routes:
+        fallback_reason = "no learned route matched changed paths and live target capabilities"
+        if isinstance(manual_verification, dict):
+            fallback_reason = str(manual_verification.get("summary") or manual_verification.get("reason") or fallback_reason)
+    route_classes = sorted({str(route.get("route_class", "")) for route in route_records if route.get("route_class")})
+    return {
+        "kind": "learned-proof-route-model/v1",
+        "status": "selected" if selected_routes else "available" if route_records else "absent",
+        "changed_paths": changed_paths,
+        "route_class_count": len(route_classes),
+        "route_classes": route_classes,
+        "selected_route_count": len(selected_routes),
+        "selected_routes": selected_routes,
+        "routes": route_records,
+        "fallback": {
+            "status": "not-needed" if selected_routes else "used",
+            "reason": fallback_reason,
+            "manual_verification_required": isinstance(manual_verification, dict),
+        },
+        "proof_class_vocabulary": ["required", "recommended", "optional_confidence", "unavailable_manual", "not_applicable"],
+        "override_rule": (
+            "Learned routes can narrow or explain proof only within their evidence scope; repo policy, user instruction, "
+            "high-risk signals, stale evidence, unavailable commands, or explicit override semantics must escalate instead."
+        ),
+        "repo_neutrality_rule": "Route class names are host-owned evidence fields; AW does not treat them as global domains or universal requirements.",
+        "closeout_semantics": {
+            "selected_route_required": bool(selected_routes),
+            "report_maturity": "name selected route class, maturity, evidence source, and fallback/override state",
+            "issue_closure": "learned proof route selection alone never authorizes issue or parent closure",
+        },
+    }
+
+
 def _proof_selection_for_changed_paths(
     *,
     changed_paths: list[str],
@@ -3131,6 +3289,13 @@ def _proof_selection_for_changed_paths(
         selected_commands=selected_commands,
         learned_route_hints=learned_route_hints,
     )
+    learned_proof_route_model = _learned_proof_route_model_payload(
+        changed_paths=changed_paths,
+        learned_route_hints=learned_route_hints,
+        selected_lanes=selected_lanes,
+        selected_commands=selected_commands,
+        manual_verification=manual_verification,
+    )
     proof_next_decision = _proof_next_decision_payload(
         required_commands=required_commands,
         selected_commands=selected_commands,
@@ -3355,6 +3520,7 @@ def _proof_selection_for_changed_paths(
         "host_repo_learning": host_repo_learning,
         "learned_route_hints": learned_route_hints,
         "learned_route_reliance": learned_route_reliance,
+        "learned_proof_route_model": learned_proof_route_model,
         "proof_route_maintenance": proof_route_maintenance,
         "proof_route_precedence": proof_route_precedence,
         "proof_intents": proof_intents,

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -1306,6 +1306,140 @@ agentic-workspace-proof-route: {"state":"confirmed","intent_type":"behavior-test
     assert any(line == "Remaining gaps: none known." for line in summary["pr_validation_lines"])
 
 
+def test_proof_changed_projects_learned_route_model_for_two_route_classes(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "docs" / "runbook.md", "# Runbook\n")
+    _write(tmp_path / "src" / "security" / "policy.py", "ALLOW = True\n")
+    _write(tmp_path / "scripts" / "check_docs.py", "print('docs ok')\n")
+    _write(tmp_path / "scripts" / "check_access.py", "print('access ok')\n")
+    docs_route = {
+        "state": "confirmed",
+        "route_class": "docs-process",
+        "intent_type": "static-check",
+        "candidate_command": "python scripts/check_docs.py",
+        "source": "memory",
+        "confidence": "high",
+        "requires_live_confirmation": False,
+        "scope": "docs",
+        "owner": "Memory",
+        "provenance": "review feedback showed docs/process changes need path-reference checks",
+        "learned_at": "2026-07-06",
+        "risk_markers": ["docs-link-drift"],
+        "evidence": [{"source": "review", "review_ref": "#1993", "summary": "docs path-reference misses recurred"}],
+        "proof_classes": {
+            "required": ["python scripts/check_docs.py"],
+            "recommended": ["manual changed-link spot check"],
+            "not_applicable": ["full workspace typecheck"],
+        },
+        "override_semantics": {
+            "escalate_when": ["docs generator or published output changes"],
+            "repo_policy_overrides": True,
+            "rule": "Docs-process learned routes may not weaken generated documentation proof.",
+        },
+    }
+    access_route = {
+        "state": "confirmed",
+        "route_class": "access-audit",
+        "intent_type": "behavior-test",
+        "candidate_command": "python scripts/check_access.py",
+        "source": "memory",
+        "confidence": "high",
+        "requires_live_confirmation": False,
+        "scope": "src/security",
+        "owner": "Memory",
+        "provenance": "access-control closeout required stronger route than generic test",
+        "learned_at": "2026-07-06",
+        "risk_markers": ["authorization", "audit"],
+        "evidence": [{"source": "dogfood", "source_path": "tests/test_access_control.py", "summary": "access paths need focused checks"}],
+        "proof_classes": {
+            "required": ["python scripts/check_access.py"],
+            "optional_confidence": ["manual policy-diff review"],
+            "unavailable_manual": ["record unavailable audit harness evidence"],
+        },
+        "override_semantics": {
+            "escalate_when": ["auth boundary changes", "user requests high assurance"],
+            "requires_human_review_when": ["legal/compliance certification is claimed"],
+        },
+    }
+    _write(
+        tmp_path / ".agentic-workspace" / "memory" / "repo" / "runbooks" / "proof-routes.md",
+        "\n".join(
+            [
+                "# Proof routes",
+                "",
+                f"agentic-workspace-proof-route: {json.dumps(docs_route, sort_keys=True)}",
+                f"agentic-workspace-proof-route: {json.dumps(access_route, sort_keys=True)}",
+            ]
+        ),
+    )
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "docs/runbook.md",
+                "src/security/policy.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    compact = json.loads(capsys.readouterr().out)["learned_proof_route_model"]
+    assert compact["status"] == "selected"
+    assert set(compact["route_classes"]) >= {"docs-process", "access-audit"}
+    assert compact["selected_route_count"] == 2
+    assert compact["fallback"]["status"] == "not-needed"
+    assert "Route class names are host-owned evidence fields" in compact["repo_neutrality_rule"]
+    assert compact["proof_class_vocabulary"] == [
+        "required",
+        "recommended",
+        "optional_confidence",
+        "unavailable_manual",
+        "not_applicable",
+    ]
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--verbose",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "docs/runbook.md",
+                "src/security/policy.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    model = answer["learned_proof_route_model"]
+    assert model["status"] == "selected"
+    selected = {route["route_class"]: route for route in model["selected_routes"]}
+    assert selected["docs-process"]["proof_classes"]["required"] == ["python scripts/check_docs.py"]
+    assert selected["docs-process"]["proof_classes"]["recommended"] == ["manual changed-link spot check"]
+    assert selected["docs-process"]["proof_classes"]["not_applicable"] == ["full workspace typecheck"]
+    assert selected["access-audit"]["proof_classes"]["required"] == ["python scripts/check_access.py"]
+    assert selected["access-audit"]["proof_classes"]["optional_confidence"] == ["manual policy-diff review"]
+    assert selected["access-audit"]["proof_classes"]["unavailable_manual"] == ["record unavailable audit harness evidence"]
+    assert selected["access-audit"]["override_semantics"]["escalate_when"] == [
+        "auth boundary changes",
+        "user requests high assurance",
+    ]
+    assert selected["docs-process"]["source"]["provenance"] == "review feedback showed docs/process changes need path-reference checks"
+    assert "python scripts/check_docs.py" in answer["required_commands"]
+    assert "python scripts/check_access.py" in answer["required_commands"]
+    assert model["closeout_semantics"]["issue_closure"] == "learned proof route selection alone never authorizes issue or parent closure"
+
+
 def test_proof_tiny_includes_closeout_summary_for_pr_validation(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(tmp_path / "Makefile", "test:\n\tpytest\n\nlint:\n\truff check .\n")
@@ -1338,6 +1472,10 @@ agentic-workspace-proof-route: {"state":"negative","intent_type":"behavior-test"
     assert answer["learned_route_hints"]["negative"][0]["candidate_command"] == "npm test"
     assert "npm test" not in answer["target_proof_capabilities"]["candidate_commands"]
     assert answer["required_commands"] == []
+    model = answer["learned_proof_route_model"]
+    assert model["fallback"]["status"] == "used"
+    assert model["routes"][0]["proof_classes"]["not_applicable"] == ["npm test"]
+    assert model["routes"][0]["state"] == "negative"
     assert answer["proof_route_selection"]["selected_command"] is None
     assert answer["proof_route_selection"]["critical_warnings"] == ["1 learned negative route(s) suppressed candidate proof commands."]
     learning = answer["host_repo_learning"]


### PR DESCRIPTION
## Summary

Closes #2000.

Adds a learned proof route model to proof selection so AW can explain repo-local learned proof routes by route class, evidence, scope, maturity, proof class, override semantics, and fallback state without making route names package-owned policy.

## Changes

- Extends proof route hints with repo-owned `route_class`, `risk_markers`, compact `evidence`, `proof_classes`, and `override_semantics` fields.
- Preserves those learned-route fields through runtime normalization, live confirmation, selected proof lanes, and learned-route metadata.
- Adds `learned_proof_route_model` to verbose proof output and compact tiny proof output when learned route evidence exists.
- Keeps compact tiny proof output quiet for the ordinary absent-route case after dogfooding found the absent model bloated tiny output.
- Adds focused tests for two learned route classes with different proof classes and closeout semantics, plus negative-route fallback behavior.

## Proof

Required by `uv run python scripts/run_agentic_workspace.py implement --changed ... --task "Implement #2000 support agent-learned risk-based proof routes, leaving #1969 last" --format json`:

- `make test-workspace` passed.
- `make lint-workspace` passed.
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success` passed.
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success` passed.
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py` passed.
- `uv run pytest tests/test_workspace_cli.py -q` passed: 122 passed.
- `make schema-reference-docs` passed.
- `make typecheck` passed.
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json` passed with `status=in_sync`.
- `git diff --check` passed.

Additional focused proof:

- `uv run pytest tests/test_workspace_proof_cli.py -q -k "tiny_profile_returns_next_validation_action or tiny_readme_profile_keeps_docs_only_validation_light or learned_route_model or memory_negative_route_suppresses_candidate"` passed.

## Dogfooding

- `proof --verbose --select answer.learned_proof_route_model,...` on this branch reports `status=absent`, `fallback.status=used`, and explicitly states learned route selection alone never authorizes issue closure when no learned route matches.
- The first broad test run caught compact-output bloat from always emitting the absent learned-route model. This PR fixes that by keeping absent-route detail in verbose proof while omitting it from tiny proof unless learned route evidence exists.
- Filed #2021 for the separate closeout receipt bridge gap found while dogfooding: executed proof commands still show as `run-but-not-recorded` until explicit receipts are available.
- Added #1969 evidence comment linking this lane and #2021; #1969 remains open by design.