### PR TITLE
Reconcile stale closeout residue

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -1244,6 +1244,7 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
                     "residual_intent",
                     "self_review",
                     "continuation",
+                    "task_posture_followthrough",
                     "authority_boundary",
                 )
                 if key in completion_gate

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -17680,7 +17680,25 @@ def _completion_gate_payload(
     intent_satisfied_field = truthy(intent_satisfaction.get("was original intent fully satisfied?")) or truthy(
         intent_continuity.get("this slice completes the larger intended outcome")
     )
-    task_posture_residue = _planned_task_posture_residue(active_planning_record)
+    closure_status = str(closure_check.get("larger-intent status") or closure_check.get("larger_intent_status") or "").strip().lower()
+    closure_decision = str(closure_check.get("closure decision") or closure_check.get("closure_decision") or "").strip().lower()
+    explicit_closeout_satisfied = closure_status in {"closed", "complete", "completed", "done", ""} and (
+        closure_decision in {"archive-and-close", "close", "closed", ""} or closure_decision.startswith("archive-and-close-")
+    )
+    no_required_follow_on = required_follow_on.lower() in {"", "no", "false", "none"}
+    active_closeout_evidence_satisfied = bool(
+        active_planning_record
+        and (intent_satisfied_field or intent_trust in {"satisfied", "normal"})
+        and no_required_follow_on
+        and (parent_satisfied or explicit_closeout_satisfied)
+        and acceptance_trust in {"", "normal", "not-applicable"}
+        and proof_supports_full
+        and not applicable_intent_status.get("closeout_blocked")
+    )
+    task_posture_residue = _planned_task_posture_residue(
+        active_planning_record,
+        active_closeout_evidence_satisfied=active_closeout_evidence_satisfied,
+    )
     task_posture_residue_open = task_posture_residue.get("status") == "open"
     if task_posture_residue_open:
         posture_titles = [
@@ -17694,12 +17712,12 @@ def _completion_gate_payload(
             "Task posture follow-through remains unresolved: " + "; ".join(posture_titles[:4]),
         )
         required_follow_on = "yes"
-    no_required_follow_on = required_follow_on.lower() in {"", "no", "false", "none"}
+        no_required_follow_on = False
     active_intent_satisfied = bool(
         active_planning_record
         and (intent_satisfied_field or intent_trust in {"satisfied", "normal"})
         and no_required_follow_on
-        and parent_satisfied
+        and (parent_satisfied or explicit_closeout_satisfied)
         and acceptance_trust in {"", "normal", "not-applicable"}
         and proof_supports_full
         and not applicable_intent_status.get("closeout_blocked")
@@ -17829,7 +17847,11 @@ def _completion_gate_payload(
     }
 
 
-def _planned_task_posture_residue(active_planning_record: dict[str, Any]) -> dict[str, Any]:
+def _planned_task_posture_residue(
+    active_planning_record: dict[str, Any],
+    *,
+    active_closeout_evidence_satisfied: bool = False,
+) -> dict[str, Any]:
     active_planning_record = _as_dict(active_planning_record)
     records = [active_planning_record]
     target_root = _target_root_from_record(active_planning_record)
@@ -17893,12 +17915,76 @@ def _planned_task_posture_residue(active_planning_record: dict[str, Any]) -> dic
             owner = ".agentic-workspace/planning/lanes/" + str(record.get("id", "")).strip() + ".lane.json"
         if owner:
             break
+    status = "stale-satisfied" if active_closeout_evidence_satisfied else "open"
     return {
-        "status": "open",
+        "status": status,
         "planned": planned,
         "owner_surface": owner or ".agentic-workspace/planning/lanes/lane-1392-open-module-participation.lane.json",
-        "rule": "Full closeout is blocked while task-posture slices remain planned, active, or blocked.",
+        "blocking": not active_closeout_evidence_satisfied,
+        "rule": (
+            "Task-posture slice residue remains visible as stale satisfied evidence because the active execplan records "
+            "full intent, proof, no required continuation, and closeout satisfaction."
+            if active_closeout_evidence_satisfied
+            else "Full closeout is blocked while task-posture slices remain planned, active, or blocked."
+        ),
     }
+
+
+def _active_closeout_evidence_satisfied(
+    *,
+    active_planning_record: dict[str, Any],
+    intent_satisfaction_check: dict[str, Any],
+    acceptance_reconciliation: dict[str, Any],
+    intent_proof_check: dict[str, Any],
+    parent_intent_status: dict[str, Any],
+    applicable_intent_status: dict[str, Any],
+) -> bool:
+    active_planning_record = _as_dict(active_planning_record)
+    if not active_planning_record:
+        return False
+    intent_satisfaction = _as_dict(active_planning_record.get("intent_satisfaction"))
+    intent_continuity = _as_dict(active_planning_record.get("intent_continuity"))
+    required_continuation = _as_dict(active_planning_record.get("required_continuation"))
+    closure_check = _as_dict(active_planning_record.get("closure_check"))
+    intent_trust = str(intent_satisfaction_check.get("trust") or "").strip().lower()
+    acceptance_trust = str(acceptance_reconciliation.get("trust") or "").strip().lower()
+    proof_status = str(intent_proof_check.get("status") or "").strip().lower().replace("-", "_")
+    parent_status = str(parent_intent_status.get("status") or "").strip().lower()
+    closure_status = str(closure_check.get("larger-intent status") or closure_check.get("larger_intent_status") or "").strip().lower()
+    closure_decision = str(closure_check.get("closure decision") or closure_check.get("closure_decision") or "").strip().lower()
+    intent_satisfied = str(intent_satisfaction.get("was original intent fully satisfied?") or "").strip().lower() in {
+        "yes",
+        "true",
+        "satisfied",
+        "complete",
+        "completed",
+    } or str(intent_continuity.get("this slice completes the larger intended outcome") or "").strip().lower() in {
+        "yes",
+        "true",
+        "satisfied",
+        "complete",
+        "completed",
+    }
+    required_follow_on = (
+        str(
+            required_continuation.get("required follow-on for the larger intended outcome")
+            or intent_satisfaction_check.get("required_follow_on")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
+    explicit_closeout_satisfied = closure_status in {"closed", "complete", "completed", "done", ""} and (
+        closure_decision in {"archive-and-close", "close", "closed", ""} or closure_decision.startswith("archive-and-close-")
+    )
+    return bool(
+        (intent_satisfied or intent_trust in {"satisfied", "normal"})
+        and required_follow_on in {"", "no", "false", "none"}
+        and (parent_status in {"satisfied", "guidance-only", ""} or explicit_closeout_satisfied)
+        and acceptance_trust in {"", "normal", "not-applicable"}
+        and proof_status in {"representative", "sufficient_for_claim"}
+        and not applicable_intent_status.get("closeout_blocked")
+    )
 
 
 def _assurance_claim_blockers(assurance_requirements: dict[str, Any] | None) -> dict[str, list[str]]:
@@ -18402,9 +18488,26 @@ def _report_closeout_trust_payload(
         assurance_requirements=assurance_requirements,
     )
     assurance_requirements = _assurance_requirements_with_verification(assurance_requirements, verification)
+    applicable_intent_status = _applicable_intent_status_payload(
+        active_planning_record=raw_active_planning_record,
+        verification=verification,
+        assurance_requirements=assurance_requirements,
+    )
+    active_closeout_satisfied = _active_closeout_evidence_satisfied(
+        active_planning_record=raw_active_planning_record,
+        intent_satisfaction_check=intent_satisfaction_check,
+        acceptance_reconciliation=acceptance_reconciliation,
+        intent_proof_check=intent_proof_check,
+        parent_intent_status=parent_intent_status,
+        applicable_intent_status=applicable_intent_status,
+    )
     active_planning_record = package_workflow_evidence.get("status") == "present"
     package_absence_signals: list[str] = []
-    if package_workflow_evidence.get("status") == "present" and package_workflow_evidence.get("trust") == "lower-trust":
+    if (
+        package_workflow_evidence.get("status") == "present"
+        and package_workflow_evidence.get("trust") == "lower-trust"
+        and not active_closeout_satisfied
+    ):
         missing = ", ".join((str(item) for item in package_workflow_evidence.get("missing_expected_surfaces", [])))
         missing = missing or "package workflow evidence"
         package_absence_signals.append(
@@ -18439,11 +18542,6 @@ def _report_closeout_trust_payload(
         active_planning_record=active_planning_record,
     )
     residue_action = durable_residue_action(trust=trust)
-    applicable_intent_status = _applicable_intent_status_payload(
-        active_planning_record=raw_active_planning_record,
-        verification=verification,
-        assurance_requirements=assurance_requirements,
-    )
     completion_gate = _completion_gate_payload(
         active_planning_record=raw_active_planning_record,
         intent_check=intent_satisfaction_check,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -16993,7 +16993,25 @@ def _completion_gate_payload(
     intent_satisfied_field = truthy(intent_satisfaction.get("was original intent fully satisfied?")) or truthy(
         intent_continuity.get("this slice completes the larger intended outcome")
     )
-    task_posture_residue = _planned_task_posture_residue(active_planning_record)
+    closure_status = str(closure_check.get("larger-intent status") or closure_check.get("larger_intent_status") or "").strip().lower()
+    closure_decision = str(closure_check.get("closure decision") or closure_check.get("closure_decision") or "").strip().lower()
+    explicit_closeout_satisfied = closure_status in {"closed", "complete", "completed", "done", ""} and (
+        closure_decision in {"archive-and-close", "close", "closed", ""} or closure_decision.startswith("archive-and-close-")
+    )
+    no_required_follow_on = required_follow_on.lower() in {"", "no", "false", "none"}
+    active_closeout_evidence_satisfied = bool(
+        active_planning_record
+        and (intent_satisfied_field or intent_trust in {"satisfied", "normal"})
+        and no_required_follow_on
+        and (parent_satisfied or explicit_closeout_satisfied)
+        and acceptance_trust in {"", "normal", "not-applicable"}
+        and proof_supports_full
+        and not applicable_intent_status.get("closeout_blocked")
+    )
+    task_posture_residue = _planned_task_posture_residue(
+        active_planning_record,
+        active_closeout_evidence_satisfied=active_closeout_evidence_satisfied,
+    )
     task_posture_residue_open = task_posture_residue.get("status") == "open"
     if task_posture_residue_open:
         posture_titles = [
@@ -17007,12 +17025,12 @@ def _completion_gate_payload(
             "Task posture follow-through remains unresolved: " + "; ".join(posture_titles[:4]),
         )
         required_follow_on = "yes"
-    no_required_follow_on = required_follow_on.lower() in {"", "no", "false", "none"}
+        no_required_follow_on = False
     active_intent_satisfied = bool(
         active_planning_record
         and (intent_satisfied_field or intent_trust in {"satisfied", "normal"})
         and no_required_follow_on
-        and parent_satisfied
+        and (parent_satisfied or explicit_closeout_satisfied)
         and acceptance_trust in {"", "normal", "not-applicable"}
         and proof_supports_full
         and not applicable_intent_status.get("closeout_blocked")
@@ -17142,7 +17160,11 @@ def _completion_gate_payload(
     }
 
 
-def _planned_task_posture_residue(active_planning_record: dict[str, Any]) -> dict[str, Any]:
+def _planned_task_posture_residue(
+    active_planning_record: dict[str, Any],
+    *,
+    active_closeout_evidence_satisfied: bool = False,
+) -> dict[str, Any]:
     active_planning_record = _as_dict(active_planning_record)
     records = [active_planning_record]
     target_root = _target_root_from_record(active_planning_record)
@@ -17206,12 +17228,76 @@ def _planned_task_posture_residue(active_planning_record: dict[str, Any]) -> dic
             owner = ".agentic-workspace/planning/lanes/" + str(record.get("id", "")).strip() + ".lane.json"
         if owner:
             break
+    status = "stale-satisfied" if active_closeout_evidence_satisfied else "open"
     return {
-        "status": "open",
+        "status": status,
         "planned": planned,
         "owner_surface": owner or ".agentic-workspace/planning/lanes/lane-1392-open-module-participation.lane.json",
-        "rule": "Full closeout is blocked while task-posture slices remain planned, active, or blocked.",
+        "blocking": not active_closeout_evidence_satisfied,
+        "rule": (
+            "Task-posture slice residue remains visible as stale satisfied evidence because the active execplan records "
+            "full intent, proof, no required continuation, and closeout satisfaction."
+            if active_closeout_evidence_satisfied
+            else "Full closeout is blocked while task-posture slices remain planned, active, or blocked."
+        ),
     }
+
+
+def _active_closeout_evidence_satisfied(
+    *,
+    active_planning_record: dict[str, Any],
+    intent_satisfaction_check: dict[str, Any],
+    acceptance_reconciliation: dict[str, Any],
+    intent_proof_check: dict[str, Any],
+    parent_intent_status: dict[str, Any],
+    applicable_intent_status: dict[str, Any],
+) -> bool:
+    active_planning_record = _as_dict(active_planning_record)
+    if not active_planning_record:
+        return False
+    intent_satisfaction = _as_dict(active_planning_record.get("intent_satisfaction"))
+    intent_continuity = _as_dict(active_planning_record.get("intent_continuity"))
+    required_continuation = _as_dict(active_planning_record.get("required_continuation"))
+    closure_check = _as_dict(active_planning_record.get("closure_check"))
+    intent_trust = str(intent_satisfaction_check.get("trust") or "").strip().lower()
+    acceptance_trust = str(acceptance_reconciliation.get("trust") or "").strip().lower()
+    proof_status = str(intent_proof_check.get("status") or "").strip().lower().replace("-", "_")
+    parent_status = str(parent_intent_status.get("status") or "").strip().lower()
+    closure_status = str(closure_check.get("larger-intent status") or closure_check.get("larger_intent_status") or "").strip().lower()
+    closure_decision = str(closure_check.get("closure decision") or closure_check.get("closure_decision") or "").strip().lower()
+    intent_satisfied = str(intent_satisfaction.get("was original intent fully satisfied?") or "").strip().lower() in {
+        "yes",
+        "true",
+        "satisfied",
+        "complete",
+        "completed",
+    } or str(intent_continuity.get("this slice completes the larger intended outcome") or "").strip().lower() in {
+        "yes",
+        "true",
+        "satisfied",
+        "complete",
+        "completed",
+    }
+    required_follow_on = (
+        str(
+            required_continuation.get("required follow-on for the larger intended outcome")
+            or intent_satisfaction_check.get("required_follow_on")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
+    explicit_closeout_satisfied = closure_status in {"closed", "complete", "completed", "done", ""} and (
+        closure_decision in {"archive-and-close", "close", "closed", ""} or closure_decision.startswith("archive-and-close-")
+    )
+    return bool(
+        (intent_satisfied or intent_trust in {"satisfied", "normal"})
+        and required_follow_on in {"", "no", "false", "none"}
+        and (parent_status in {"satisfied", "guidance-only", ""} or explicit_closeout_satisfied)
+        and acceptance_trust in {"", "normal", "not-applicable"}
+        and proof_status in {"representative", "sufficient_for_claim"}
+        and not applicable_intent_status.get("closeout_blocked")
+    )
 
 
 def _assurance_claim_blockers(assurance_requirements: dict[str, Any] | None) -> dict[str, list[str]]:
@@ -17715,9 +17801,26 @@ def _report_closeout_trust_payload(
         assurance_requirements=assurance_requirements,
     )
     assurance_requirements = _assurance_requirements_with_verification(assurance_requirements, verification)
+    applicable_intent_status = _applicable_intent_status_payload(
+        active_planning_record=raw_active_planning_record,
+        verification=verification,
+        assurance_requirements=assurance_requirements,
+    )
+    active_closeout_satisfied = _active_closeout_evidence_satisfied(
+        active_planning_record=raw_active_planning_record,
+        intent_satisfaction_check=intent_satisfaction_check,
+        acceptance_reconciliation=acceptance_reconciliation,
+        intent_proof_check=intent_proof_check,
+        parent_intent_status=parent_intent_status,
+        applicable_intent_status=applicable_intent_status,
+    )
     active_planning_record = package_workflow_evidence.get("status") == "present"
     package_absence_signals: list[str] = []
-    if package_workflow_evidence.get("status") == "present" and package_workflow_evidence.get("trust") == "lower-trust":
+    if (
+        package_workflow_evidence.get("status") == "present"
+        and package_workflow_evidence.get("trust") == "lower-trust"
+        and not active_closeout_satisfied
+    ):
         missing = ", ".join((str(item) for item in package_workflow_evidence.get("missing_expected_surfaces", [])))
         missing = missing or "package workflow evidence"
         package_absence_signals.append(
@@ -17752,11 +17855,6 @@ def _report_closeout_trust_payload(
         active_planning_record=active_planning_record,
     )
     residue_action = durable_residue_action(trust=trust)
-    applicable_intent_status = _applicable_intent_status_payload(
-        active_planning_record=raw_active_planning_record,
-        verification=verification,
-        assurance_requirements=assurance_requirements,
-    )
     completion_gate = _completion_gate_payload(
         active_planning_record=raw_active_planning_record,
         intent_check=intent_satisfaction_check,

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -474,7 +474,13 @@ def test_closeout_trust_prefers_relevant_closeout_evidence_over_newer_unrelated_
     assert evidence["freshness"]["sort_mtime"] == 1000
 
 
-def _write_issue_1981_closeout_fixture(target: Path, *, include_proof: bool, external_status: str = "closed") -> None:
+def _write_issue_1981_closeout_fixture(
+    target: Path,
+    *,
+    include_proof: bool,
+    external_status: str = "closed",
+    include_stale_task_posture_residue: bool = False,
+) -> None:
     from repo_planning_bootstrap import installer as planning_installer
 
     issue_ref = "#1981"
@@ -505,6 +511,8 @@ candidates = []
     )
     record["references"] = [issue_ref]
     record["completion_criteria"] = ["summary and closeout trust agree on active execplan intent satisfaction"]
+    if include_stale_task_posture_residue:
+        record["active_milestone"]["id"] = "task-posture-fixture"
     record["proof_expectations"] = [
         "uv run python scripts/run_agentic_workspace.py summary --target . --format json",
         "uv run python scripts/run_agentic_workspace.py report --target . --section closeout_trust --format json",
@@ -562,6 +570,22 @@ candidates = []
         record_path=target / ".agentic-workspace" / "planning" / "execplans" / "issue-1981.plan.json",
         record=record,
     )
+    if include_stale_task_posture_residue:
+        _write_json(
+            target / ".agentic-workspace" / "planning" / "lanes" / "lane-1392-open-module-participation.lane.json",
+            {
+                "kind": "planning-lane/v1",
+                "id": "lane-1392-open-module-participation",
+                "slice_sequence": [
+                    {
+                        "id": "state-delta-packet-followthrough",
+                        "title": "Task posture packet follow-through",
+                        "status": "planned",
+                        "purpose_for_lane": "Historical packet follow-through residue retained after the active slice completed.",
+                    }
+                ],
+            },
+        )
     _write_json(
         target / ".agentic-workspace" / "local" / "cache" / "external-intent-evidence.json",
         {
@@ -594,9 +618,26 @@ def test_closeout_trust_derives_intent_proof_from_satisfied_active_execplan(tmp_
     assert payload["completion_gate"]["claim_level_allowed"] == "full-intent-complete"
     assert payload["checks"]["intent_proof"]["status"] == "sufficient_for_claim"
     claim_work = next(option for option in payload["completion_options"] if option["id"] == "claim-work-complete")
-    assert claim_work["allowed"] is False
-    assert claim_work["blocking_fields"] == ["durable_residue"]
+    assert claim_work["allowed"] is True
+    assert "durable_residue" not in claim_work.get("blocking_fields", [])
     assert "planning.active.planning_record.proof_report.intent_proof.status" not in claim_work.get("blocking_fields", [])
+
+
+def test_closeout_trust_does_not_block_on_stale_satisfied_task_posture_residue(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_issue_1981_closeout_fixture(tmp_path, include_proof=True, include_stale_task_posture_residue=True)
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "closeout_trust", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)["answer"]
+
+    assert payload["completion_gate"]["status"] == "allowed"
+    assert payload["completion_gate"]["active_intent_satisfied"] is True
+    assert payload["completion_gate"]["task_posture_followthrough"]["status"] == "stale-satisfied"
+    assert payload["completion_gate"]["task_posture_followthrough"]["blocking"] is False
+    claim_work = next(option for option in payload["completion_options"] if option["id"] == "claim-work-complete")
+    assert "completion_gate" not in claim_work.get("blocking_fields", [])
 
 
 def test_closeout_trust_blocks_full_closeout_when_active_execplan_proof_is_missing(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Treat stale task-posture/package residue as non-blocking when the active execplan already records full intent satisfaction, proof, no continuation, and closeout evidence.
- Keep stale residue visible as `task_posture_followthrough.status=stale-satisfied` in compact closeout output.
- Add a regression for the #1981-style stale residue case.

Closes #2024

## Validation
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
