### PR TITLE
Add closeout claim boundary selector

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -843,6 +843,7 @@ def closeout_claim_boundary_payload(
         or closeout_protocol.get("status")
         or ""
     )
+    source_surface = str(closeout_trust.get("source_surface") or "closeout_trust")
     detail_command = _command_with_cli_invoke(
         "agentic-workspace report --target ./repo --section closeout_trust --format json",
         cli_invoke=cli_invoke,
@@ -892,6 +893,7 @@ def closeout_claim_boundary_payload(
                         "verification_active_count",
                         "required",
                         "proof_status",
+                        "claim_boundary",
                         "command",
                         "rule",
                     ),
@@ -911,7 +913,9 @@ def closeout_claim_boundary_payload(
             "next_action": next_action,
             "source_detail_command": detail_command,
             "detail_selector": "closeout_trust",
-            "rule": "Derived from closeout_trust; use this selector for the compact claim boundary and closeout_trust for full proof and residue detail.",
+            "source_surface": source_surface,
+            "computation": closeout_trust.get("computation", {}),
+            "rule": "Derived from a compact closeout gate source; use this selector for the claim boundary and closeout_trust for full proof and residue detail.",
         },
         cli_invoke=cli_invoke,
         target_arg=target_arg,

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -792,6 +792,132 @@ def _resolve_report_section(payload: dict[str, Any], section: str) -> tuple[str,
     return section, None
 
 
+def closeout_claim_boundary_payload(
+    closeout_trust: dict[str, Any], *, cli_invoke: str = DEFAULT_CLI_INVOKE, target_arg: str = "./repo"
+) -> dict[str, Any]:
+    if not isinstance(closeout_trust, dict):
+        closeout_trust = {}
+
+    def compact(value: Any, keys: tuple[str, ...]) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            return {}
+        return {key: value.get(key) for key in keys if key in value}
+
+    completion_gate = closeout_trust.get("completion_gate", {})
+    completion_gate = completion_gate if isinstance(completion_gate, dict) else {}
+    claim_authorization = completion_gate.get("claim_authorization", {})
+    claim_authorization = claim_authorization if isinstance(claim_authorization, dict) else {}
+    strict_gate = closeout_trust.get("strict_closeout_gate", {})
+    strict_gate = strict_gate if isinstance(strict_gate, dict) else {}
+    terminal_action = closeout_trust.get("terminal_action", {})
+    terminal_action = terminal_action if isinstance(terminal_action, dict) else {}
+    closeout_protocol = closeout_trust.get("closeout_protocol", {})
+    closeout_protocol = closeout_protocol if isinstance(closeout_protocol, dict) else {}
+    readiness = closeout_protocol.get("readiness", {})
+    readiness = readiness if isinstance(readiness, dict) else {}
+    residue_routing = closeout_protocol.get("residue_routing", {})
+    residue_routing = residue_routing if isinstance(residue_routing, dict) else {}
+    closure_permission = closeout_protocol.get("closure_permission", {})
+    closure_permission = closure_permission if isinstance(closure_permission, dict) else {}
+    proof_dependency = closeout_protocol.get("proof_dependency", {})
+    proof_dependency = proof_dependency if isinstance(proof_dependency, dict) else {}
+    proof_dependency_status = "unknown"
+    if proof_dependency.get("run_proof_allowed") is True:
+        proof_dependency_status = "proof-required"
+    elif proof_dependency.get("run_proof_allowed") is False:
+        proof_dependency_status = "satisfied"
+
+    blocking_fields: list[str] = []
+    for option in _support_list_payload(closeout_trust.get("completion_options")):
+        if not isinstance(option, dict) or option.get("allowed") is True:
+            continue
+        for field in _support_list_payload(option.get("blocking_fields")):
+            field_text = str(field)
+            if field_text and field_text not in blocking_fields:
+                blocking_fields.append(field_text)
+
+    next_action = (
+        terminal_action.get("recommended_next_action")
+        or completion_gate.get("required_next_action")
+        or strict_gate.get("recommended_next_action")
+        or closeout_protocol.get("status")
+        or ""
+    )
+    detail_command = _command_with_cli_invoke(
+        "agentic-workspace report --target ./repo --section closeout_trust --format json",
+        cli_invoke=cli_invoke,
+        target_arg=target_arg,
+    )
+
+    return _localize_command_fields(
+        {
+            "kind": "agentic-workspace/closeout-claim-boundary/v1",
+            "status": completion_gate.get("status", closeout_trust.get("status", "unavailable")),
+            "trust": closeout_trust.get("trust", ""),
+            "active_intent_satisfied": completion_gate.get("active_intent_satisfied", False),
+            "claim_level_allowed": completion_gate.get("claim_level_allowed", "none"),
+            "claim_authorization": {
+                key: claim_authorization.get(key)
+                for key in (
+                    "allowed_claim_classes",
+                    "blocked_claim_classes",
+                    "closure_actions",
+                    "rule",
+                )
+                if key in claim_authorization
+            },
+            "blocking_fields": blocking_fields,
+            "strict_closeout": compact(strict_gate, ("status", "blocking", "required_for_broad_work", "recommended_next_action")),
+            "readiness": compact(readiness, ("status", "can_close", "blocking_fields", "warning_fields", "rule")),
+            "residue_routing": compact(
+                residue_routing,
+                (
+                    "required",
+                    "durable_residue_required",
+                    "safe_destination",
+                    "destination",
+                    "owner",
+                    "next_action",
+                    "rule",
+                ),
+            ),
+            "proof_dependency": {
+                "status": proof_dependency_status,
+                **compact(
+                    proof_dependency,
+                    (
+                        "run_proof_allowed",
+                        "proof_confidence",
+                        "verification_status",
+                        "verification_active_count",
+                        "required",
+                        "proof_status",
+                        "command",
+                        "rule",
+                    ),
+                ),
+            },
+            "closure_permission": compact(
+                closure_permission,
+                (
+                    "status",
+                    "allowed",
+                    "claim_work_complete_allowed",
+                    "keep_parent_open_allowed",
+                    "blocked_reason",
+                    "rule",
+                ),
+            ),
+            "next_action": next_action,
+            "source_detail_command": detail_command,
+            "detail_selector": "closeout_trust",
+            "rule": "Derived from closeout_trust; use this selector for the compact claim boundary and closeout_trust for full proof and residue detail.",
+        },
+        cli_invoke=cli_invoke,
+        target_arg=target_arg,
+    )
+
+
 def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str, target_arg: str = "./repo") -> Any:
     if section == "reasoning_economy" and isinstance(answer, dict):
         behavior = answer.get("behavior_check", {})
@@ -2287,6 +2413,7 @@ def report_section_hints(
         "surface_value_guardrail": "surface growth review pressure",
         "assurance_requirements": "repo-declared assurance authority, evidence, proof profile, and claim-boundary facts",
         "closeout_trust": "closeout trust and lower-trust residue signals",
+        "closeout_claim_boundary": "compact closeout claim permission, blockers, residue route, and proof dependency",
         "external_work_reconciliation": "one provider-agnostic external-work route for evidence freshness, closeout reconciliation, and landed-open checks",
         "external_evidence_safety": "compact external freshness, divergence, and closeout-safety decision support",
         "completion_contract": "Planning completion-contract lens for what must become true, proof, constraints, and blocked stop",
@@ -2333,6 +2460,7 @@ def report_section_hints(
         "surface_value_guardrail": "inspect before adding or expanding a visible surface",
         "assurance_requirements": "inspect when repo-declared assurance requirements may affect authority lookup, proof, review, or closeout claims",
         "closeout_trust": "inspect before closing broad work or auditing package-use evidence",
+        "closeout_claim_boundary": "inspect immediately before final messages, PR readiness, issue closure, or closeout handoff",
         "external_work_reconciliation": "inspect when deciding whether checked-in planning, external work state, and landed evidence agree",
         "external_evidence_safety": "inspect before closeout when external issue, CI, scanner, or ticket evidence may be stale or divergent",
         "completion_contract": "inspect when deciding whether work is done, partial, blocked, or continuation-required",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -113,6 +113,7 @@ from agentic_workspace.contract_tooling import (
     workspace_surfaces_manifest,
 )
 from agentic_workspace.reporting_support import (
+    closeout_claim_boundary_payload,
     communication_contract_payload,
     output_contract_payload,
     reasoning_economy_evidence_payload,
@@ -8793,6 +8794,11 @@ def _run_report_command(
         "findings": aggregated_findings,
         "decision_pressure": decision_pressure,
         "closeout_trust": closeout_trust,
+        "closeout_claim_boundary": closeout_claim_boundary_payload(
+            closeout_trust,
+            cli_invoke=config.cli_invoke,
+            target_arg="./repo",
+        ),
         "successful_completion_cost": _successful_completion_cost_payload(target_root=target_root, cli_invoke=config.cli_invoke),
         "reasoning_economy": reasoning_economy_evidence_payload(target_root=target_root, cli_invoke=config.cli_invoke),
         "external_work_reconciliation": external_work_reconciliation,
@@ -10046,6 +10052,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "kind": "agentic-workspace/closeout-trust/v1",
         "purpose": "compact strict closeout gate, claim permission, proof, and residue routing posture",
         "when_to_use": "before ordinary lane closeout or broad completion claims, without loading the full report",
+    },
+    {
+        "section": "closeout_claim_boundary",
+        "kind": "agentic-workspace/closeout-claim-boundary/v1",
+        "purpose": "fast derived claim boundary for what can be honestly said or closed",
+        "when_to_use": "immediately before final messages, PR readiness, issue closure, or closeout handoff",
     },
     {
         "section": "local_footprint",
@@ -13173,8 +13185,8 @@ def _run_lazy_report_section_command(
         payload["reasoning_economy"] = reasoning_economy_evidence_payload(target_root=target_root, cli_invoke=config.cli_invoke)
         return _select_report_payload(payload, profile="router", section=normalized)
 
-    if normalized == "closeout_trust":
-        payload["closeout_trust"] = _report_closeout_trust_payload(
+    if normalized in {"closeout_claim_boundary", "closeout_trust"}:
+        closeout_trust = _report_closeout_trust_payload(
             module_reports=_selected_module_reports(target_root=target_root, selected_modules=selected_modules),
             target_root=target_root,
             config=config,
@@ -13182,6 +13194,13 @@ def _run_lazy_report_section_command(
             task_text=task_text,
             changed_paths=changed_paths,
         )
+        payload["closeout_trust"] = closeout_trust
+        if normalized == "closeout_claim_boundary":
+            payload["closeout_claim_boundary"] = closeout_claim_boundary_payload(
+                closeout_trust,
+                cli_invoke=config.cli_invoke,
+                target_arg="./repo",
+            )
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized in {

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -13185,7 +13185,15 @@ def _run_lazy_report_section_command(
         payload["reasoning_economy"] = reasoning_economy_evidence_payload(target_root=target_root, cli_invoke=config.cli_invoke)
         return _select_report_payload(payload, profile="router", section=normalized)
 
-    if normalized in {"closeout_claim_boundary", "closeout_trust"}:
+    if normalized == "closeout_claim_boundary":
+        payload["closeout_claim_boundary"] = _fast_closeout_claim_boundary_payload(
+            target_root=target_root,
+            config=config,
+            cli_invoke=config.cli_invoke,
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "closeout_trust":
         closeout_trust = _report_closeout_trust_payload(
             module_reports=_selected_module_reports(target_root=target_root, selected_modules=selected_modules),
             target_root=target_root,
@@ -13195,12 +13203,6 @@ def _run_lazy_report_section_command(
             changed_paths=changed_paths,
         )
         payload["closeout_trust"] = closeout_trust
-        if normalized == "closeout_claim_boundary":
-            payload["closeout_claim_boundary"] = closeout_claim_boundary_payload(
-                closeout_trust,
-                cli_invoke=config.cli_invoke,
-                target_arg="./repo",
-            )
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized in {
@@ -17502,6 +17504,8 @@ def _closeout_protocol_payload(
         "proof_dependency": {
             "run_proof_allowed": run_proof.get("allowed"),
             "proof_confidence": proof_confidence.get("confidence") or proof_confidence.get("status"),
+            "proof_status": proof_confidence.get("intent_proof_status"),
+            "claim_boundary": proof_confidence.get("claim_boundary"),
             "verification_status": verification.get("status", "absent"),
             "verification_active_count": verification.get("active_count", 0),
             "rule": "Closeout consumes proof evidence; it does not replace proof selection or execution.",
@@ -18040,6 +18044,267 @@ def _assurance_claim_blockers(assurance_requirements: dict[str, Any] | None) -> 
             if claim in blockers:
                 blockers[claim].append(f"assurance_evidence:{requirement_id}")
     return {claim: _dedupe(values) for claim, values in blockers.items()}
+
+
+def _closeout_strict_gate_payload(
+    *, strict_closeout: bool, trust: str, reason: str = "", active_planning_record: bool = False
+) -> dict[str, Any]:
+    if not strict_closeout:
+        status = "disabled"
+        blocking = False
+        summary = "Strict closeout is disabled in assurance config."
+    elif not active_planning_record and trust == "normal":
+        status = "not-applicable"
+        blocking = False
+        summary = "Strict closeout has no active planning record to gate; use normal direct-work proof and issue checks."
+    elif trust == "normal":
+        status = "allowed"
+        blocking = False
+        summary = "Strict closeout is satisfied by the available planning and closeout-trust evidence."
+    elif trust == "lower-trust":
+        status = "blocked"
+        blocking = True
+        summary = "Strict closeout blocks closure until lower-trust planning residue or package evidence is resolved."
+    else:
+        status = "requires-review"
+        blocking = True
+        summary = "Strict closeout requires review because closeout evidence is unavailable or incomplete."
+    return {
+        "status": status,
+        "strict_closeout": strict_closeout,
+        "blocking": blocking,
+        "reason": reason,
+        "summary": summary,
+        "source": "assurance.strict_closeout",
+    }
+
+
+def _closeout_terminal_action_payload(*, trust: str, recommended_next_action: str, cli_invoke: str) -> dict[str, Any]:
+    blocking = trust != "normal"
+    return {
+        "next_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section closeout_trust --format json", cli_invoke=cli_invoke
+        )
+        if blocking
+        else "none",
+        "why": "Lower-trust closeout signals need routed residue before closure is reliable."
+        if trust == "lower-trust"
+        else "Closeout trust is unavailable; recover planning output before claiming closure."
+        if blocking
+        else "No closeout trust blocker is visible; use normal proof and issue-state checks.",
+        "blocking": blocking,
+        "recommended_next_action": recommended_next_action,
+        "changes_closure": "Route missing planning residue, rerun summary/reconcile, then close only when lower_trust_closeout_count is 0."
+        if trust == "lower-trust"
+        else "Recover planning closeout evidence; closure is blocked until closeout_trust is present."
+        if blocking
+        else "None for closeout trust; closure changes only if proof, intent satisfaction, issue state, or new residue changes.",
+    }
+
+
+def _closeout_durable_residue_action_payload(*, trust: str, cli_invoke: str) -> dict[str, Any]:
+    action = {
+        "action": "route-durable-residue",
+        "visible_states": ["none-found", "capture", "route-to-owner", "dismissed"],
+        "summary": "Review lower-trust closeout signals and route missing residue to planning, Memory, docs, checks, or issue follow-up."
+        if trust == "lower-trust"
+        else "If closeout produced reusable learning, route it to the narrowest durable owner; otherwise record no durable residue.",
+        "command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section closeout_trust --format json", cli_invoke=cli_invoke
+        ),
+        "risk": "read-only routing; mutations happen only through the selected owner surface",
+        "required_inputs": ["validation result", "issue or lane scope", "future relevance of any learning"],
+        "destinations": ["none", "planning", "Memory", "docs", "contracts/checks", "issue follow-up", "review/archive evidence"],
+        "destination_rule": "future work goes to planning; reusable non-canonical knowledge goes to Memory; stable rules go to docs/contracts/checks; evidence-only stays in review/archive; otherwise choose none",
+        "next_proof": "rerun summary/reconcile after routing residue before closing the issue or lane",
+    }
+    action["run"] = action["command"]
+    return action
+
+
+def _fast_closeout_claim_boundary_payload(
+    *,
+    target_root: Path,
+    config: WorkspaceConfig,
+    cli_invoke: str = DEFAULT_CLI_INVOKE,
+) -> dict[str, Any]:
+    strict_closeout = bool(config.assurance.strict_closeout)
+    try:
+        from repo_planning_bootstrap.installer import planning_report
+
+        planning_module_report = planning_report(target=target_root)
+    except Exception:
+        planning_module_report = {"module": "planning", "health": "unknown", "findings": []}
+
+    planning_report_payload = planning_module_report if isinstance(planning_module_report, dict) else {}
+    intent_validation = planning_report_payload.get("intent_validation", {})
+    intent_validation = intent_validation if isinstance(intent_validation, dict) else {}
+    counts = intent_validation.get("counts", {})
+    signals = intent_validation.get("signals", [])
+    lower_trust_closeout_count = int(counts.get("lower_trust_closeout_count", 0) or 0) if isinstance(counts, dict) else 0
+    sample_signals = [
+        str(signal.get("message", "")).strip()
+        for signal in signals
+        if isinstance(signal, dict) and signal.get("kind") == "closed_without_planning_residue"
+    ]
+    sample_signals = [message for message in sample_signals if message][:3]
+    package_workflow_evidence = _package_workflow_evidence_payload(planning_report=planning_report_payload)
+    intent_satisfaction_check = _intent_satisfaction_check_payload(planning_report=planning_report_payload, target_root=target_root)
+    acceptance_reconciliation = _acceptance_criteria_reconciliation_payload(planning_report=planning_report_payload)
+    intent_proof_check = _intent_proof_check_payload(planning_report=planning_report_payload, target_root=target_root)
+    active_payload = _as_dict(planning_report_payload.get("active"))
+    raw_active_planning_record = _raw_active_planning_record_for_closeout(
+        planning_record=active_payload.get("planning_record", {}),
+        target_root=target_root,
+    )
+    assurance_requirements = _assurance_requirements_report_payload(
+        config=config,
+        target_root=target_root,
+        active_planning_record=raw_active_planning_record,
+    )
+    verification = _verification_report_payload(
+        target_root=target_root,
+        active_planning_record=raw_active_planning_record,
+        assurance_requirements=assurance_requirements,
+    )
+    assurance_requirements = _assurance_requirements_with_verification(assurance_requirements, verification)
+    applicable_intent_status = _applicable_intent_status_payload(
+        active_planning_record=raw_active_planning_record,
+        verification=verification,
+        assurance_requirements=assurance_requirements,
+    )
+    parent_intent_status = _parent_intent_status_payload(
+        active_planning_record=raw_active_planning_record,
+        intent_check=intent_satisfaction_check,
+        completion_boundary=intent_satisfaction_check.get("completion_boundary", {}),
+    )
+    active_closeout_satisfied = _active_closeout_evidence_satisfied(
+        active_planning_record=raw_active_planning_record,
+        intent_satisfaction_check=intent_satisfaction_check,
+        acceptance_reconciliation=acceptance_reconciliation,
+        intent_proof_check=intent_proof_check,
+        parent_intent_status=parent_intent_status,
+        applicable_intent_status=applicable_intent_status,
+    )
+    active_planning_record_present = package_workflow_evidence.get("status") == "present"
+    package_absence_signals: list[str] = []
+    if (
+        package_workflow_evidence.get("status") == "present"
+        and package_workflow_evidence.get("trust") == "lower-trust"
+        and not active_closeout_satisfied
+    ):
+        missing = ", ".join((str(item) for item in package_workflow_evidence.get("missing_expected_surfaces", [])))
+        missing = missing or "package workflow evidence"
+        package_absence_signals.append(
+            f"Active planning record is present, but package workflow evidence is incomplete or absent: missing {missing}."
+        )
+    effective_lower_trust_count = lower_trust_closeout_count + len(package_absence_signals)
+    if acceptance_reconciliation.get("trust") == "lower-trust":
+        effective_lower_trust_count += 1
+    intent_satisfaction_trust = str(intent_satisfaction_check.get("trust", ""))
+    intent_satisfaction_lower_trust_count = 1 if intent_satisfaction_trust in {"follow-up-required", "needs-review"} else 0
+    effective_lower_trust_count += intent_satisfaction_lower_trust_count
+    intent_satisfaction_signals: list[str] = []
+    if intent_satisfaction_lower_trust_count:
+        continuation_surface = str(intent_satisfaction_check.get("continuation_surface", "")).strip()
+        continuation_summary = f" via {continuation_surface}" if continuation_surface else ""
+        intent_satisfaction_signals.append(
+            f"Intent satisfaction is {intent_satisfaction_trust}{continuation_summary}; closeout needs package-owned continuation evidence before it is normal-trust."
+        )
+    trust = "lower-trust" if effective_lower_trust_count > 0 else "normal"
+    if not intent_validation:
+        trust = "unavailable"
+    if trust == "lower-trust":
+        recommended_next_action = str(
+            intent_validation.get("recommended_next_action")
+            or "Review the lower-trust closeout signals before treating planning closeout as normal."
+        )
+    elif trust == "unavailable":
+        recommended_next_action = "Inspect planning report before trusting closeout state."
+    else:
+        recommended_next_action = "No extra closeout trust review is needed beyond normal report inspection."
+    gate = _closeout_strict_gate_payload(
+        strict_closeout=strict_closeout,
+        trust=trust,
+        reason="active planning record present" if active_planning_record_present else "no active planning record",
+        active_planning_record=active_planning_record_present,
+    )
+    residue_action = _closeout_durable_residue_action_payload(trust=trust, cli_invoke=cli_invoke)
+    completion_gate = _completion_gate_payload(
+        active_planning_record=raw_active_planning_record,
+        intent_check=intent_satisfaction_check,
+        acceptance_reconciliation=acceptance_reconciliation,
+        intent_proof_check=intent_proof_check,
+        parent_intent_status=parent_intent_status,
+        applicable_intent_status=applicable_intent_status,
+        durable_residue_action=residue_action,
+    )
+    task_posture_followthrough = _as_dict(completion_gate.get("task_posture_followthrough"))
+    proof_confidence = _proof_confidence_payload(intent_proof=intent_proof_check)
+    completion_options = _closeout_completion_options(
+        status="present" if trust != "unavailable" else "unavailable",
+        trust=trust,
+        strict_gate=gate,
+        completion_gate=completion_gate,
+        intent_check=intent_satisfaction_check,
+        acceptance_reconciliation=acceptance_reconciliation,
+        intent_proof_check=intent_proof_check,
+        assurance_requirements=assurance_requirements,
+        durable_residue_action=residue_action,
+        lower_trust_closeout_count=effective_lower_trust_count,
+        cli_invoke=cli_invoke,
+    )
+    closeout_protocol = _closeout_protocol_payload(
+        status="present" if trust != "unavailable" else "unavailable",
+        trust=trust,
+        strict_gate=gate,
+        completion_gate=completion_gate,
+        completion_options=completion_options,
+        durable_residue_action=residue_action,
+        knowledge_authority_review={},
+        proof_confidence=proof_confidence,
+        verification=verification,
+        task_posture_followthrough=task_posture_followthrough,
+        recommended_next_action=recommended_next_action,
+        cli_invoke=cli_invoke,
+    )
+    source_payload = {
+        "kind": "agentic-workspace/closeout-claim-boundary-source/v1",
+        "source_surface": "closeout_claim_boundary.direct",
+        "status": "present" if trust != "unavailable" else "unavailable",
+        "trust": trust,
+        "strict_closeout_gate": gate,
+        "completion_gate": completion_gate,
+        "task_posture_followthrough": task_posture_followthrough,
+        "lower_trust_closeout_count": effective_lower_trust_count,
+        "sample_signals": [*sample_signals, *package_absence_signals, *intent_satisfaction_signals][:3],
+        "intent_satisfaction_check": intent_satisfaction_check,
+        "acceptance_criteria_reconciliation": acceptance_reconciliation,
+        "intent_proof_check": intent_proof_check,
+        "proof_confidence": proof_confidence,
+        "verification": verification,
+        "durable_residue_action": residue_action,
+        "terminal_action": _closeout_terminal_action_payload(
+            trust=trust, recommended_next_action=recommended_next_action, cli_invoke=cli_invoke
+        ),
+        "completion_options": completion_options,
+        "closeout_protocol": closeout_protocol,
+        "recommended_next_action": recommended_next_action,
+        "computation": {
+            "path": "direct-compact-claim-boundary",
+            "avoids_full_closeout_trust": True,
+            "required_source": "planning_report",
+            "omitted_full_sections": [
+                "memory_consult",
+                "memory_decision_packet",
+                "operating_loop",
+                "historical_review_artifacts",
+                "architecture_decision_closeout",
+            ],
+            "structural_evidence": "report --section closeout_claim_boundary builds this source directly instead of calling _report_closeout_trust_payload",
+        },
+    }
+    return closeout_claim_boundary_payload(source_payload, cli_invoke=cli_invoke, target_arg="./repo")
 
 
 def _report_closeout_trust_payload(

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -12700,7 +12700,15 @@ def _run_lazy_report_section_command(
         payload["reasoning_economy"] = reasoning_economy_evidence_payload(target_root=target_root, cli_invoke=config.cli_invoke)
         return _select_report_payload(payload, profile="router", section=normalized)
 
-    if normalized in {"closeout_claim_boundary", "closeout_trust"}:
+    if normalized == "closeout_claim_boundary":
+        payload["closeout_claim_boundary"] = _fast_closeout_claim_boundary_payload(
+            target_root=target_root,
+            config=config,
+            cli_invoke=config.cli_invoke,
+        )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "closeout_trust":
         closeout_trust = _report_closeout_trust_payload(
             module_reports=_selected_module_reports(target_root=target_root, selected_modules=selected_modules),
             target_root=target_root,
@@ -12710,12 +12718,6 @@ def _run_lazy_report_section_command(
             changed_paths=changed_paths,
         )
         payload["closeout_trust"] = closeout_trust
-        if normalized == "closeout_claim_boundary":
-            payload["closeout_claim_boundary"] = closeout_claim_boundary_payload(
-                closeout_trust,
-                cli_invoke=config.cli_invoke,
-                target_arg="./repo",
-            )
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized in {
@@ -16815,6 +16817,8 @@ def _closeout_protocol_payload(
         "proof_dependency": {
             "run_proof_allowed": run_proof.get("allowed"),
             "proof_confidence": proof_confidence.get("confidence") or proof_confidence.get("status"),
+            "proof_status": proof_confidence.get("intent_proof_status"),
+            "claim_boundary": proof_confidence.get("claim_boundary"),
             "verification_status": verification.get("status", "absent"),
             "verification_active_count": verification.get("active_count", 0),
             "rule": "Closeout consumes proof evidence; it does not replace proof selection or execution.",
@@ -17353,6 +17357,267 @@ def _assurance_claim_blockers(assurance_requirements: dict[str, Any] | None) -> 
             if claim in blockers:
                 blockers[claim].append(f"assurance_evidence:{requirement_id}")
     return {claim: _dedupe(values) for claim, values in blockers.items()}
+
+
+def _closeout_strict_gate_payload(
+    *, strict_closeout: bool, trust: str, reason: str = "", active_planning_record: bool = False
+) -> dict[str, Any]:
+    if not strict_closeout:
+        status = "disabled"
+        blocking = False
+        summary = "Strict closeout is disabled in assurance config."
+    elif not active_planning_record and trust == "normal":
+        status = "not-applicable"
+        blocking = False
+        summary = "Strict closeout has no active planning record to gate; use normal direct-work proof and issue checks."
+    elif trust == "normal":
+        status = "allowed"
+        blocking = False
+        summary = "Strict closeout is satisfied by the available planning and closeout-trust evidence."
+    elif trust == "lower-trust":
+        status = "blocked"
+        blocking = True
+        summary = "Strict closeout blocks closure until lower-trust planning residue or package evidence is resolved."
+    else:
+        status = "requires-review"
+        blocking = True
+        summary = "Strict closeout requires review because closeout evidence is unavailable or incomplete."
+    return {
+        "status": status,
+        "strict_closeout": strict_closeout,
+        "blocking": blocking,
+        "reason": reason,
+        "summary": summary,
+        "source": "assurance.strict_closeout",
+    }
+
+
+def _closeout_terminal_action_payload(*, trust: str, recommended_next_action: str, cli_invoke: str) -> dict[str, Any]:
+    blocking = trust != "normal"
+    return {
+        "next_command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section closeout_trust --format json", cli_invoke=cli_invoke
+        )
+        if blocking
+        else "none",
+        "why": "Lower-trust closeout signals need routed residue before closure is reliable."
+        if trust == "lower-trust"
+        else "Closeout trust is unavailable; recover planning output before claiming closure."
+        if blocking
+        else "No closeout trust blocker is visible; use normal proof and issue-state checks.",
+        "blocking": blocking,
+        "recommended_next_action": recommended_next_action,
+        "changes_closure": "Route missing planning residue, rerun summary/reconcile, then close only when lower_trust_closeout_count is 0."
+        if trust == "lower-trust"
+        else "Recover planning closeout evidence; closure is blocked until closeout_trust is present."
+        if blocking
+        else "None for closeout trust; closure changes only if proof, intent satisfaction, issue state, or new residue changes.",
+    }
+
+
+def _closeout_durable_residue_action_payload(*, trust: str, cli_invoke: str) -> dict[str, Any]:
+    action = {
+        "action": "route-durable-residue",
+        "visible_states": ["none-found", "capture", "route-to-owner", "dismissed"],
+        "summary": "Review lower-trust closeout signals and route missing residue to planning, Memory, docs, checks, or issue follow-up."
+        if trust == "lower-trust"
+        else "If closeout produced reusable learning, route it to the narrowest durable owner; otherwise record no durable residue.",
+        "command": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section closeout_trust --format json", cli_invoke=cli_invoke
+        ),
+        "risk": "read-only routing; mutations happen only through the selected owner surface",
+        "required_inputs": ["validation result", "issue or lane scope", "future relevance of any learning"],
+        "destinations": ["none", "planning", "Memory", "docs", "contracts/checks", "issue follow-up", "review/archive evidence"],
+        "destination_rule": "future work goes to planning; reusable non-canonical knowledge goes to Memory; stable rules go to docs/contracts/checks; evidence-only stays in review/archive; otherwise choose none",
+        "next_proof": "rerun summary/reconcile after routing residue before closing the issue or lane",
+    }
+    action["run"] = action["command"]
+    return action
+
+
+def _fast_closeout_claim_boundary_payload(
+    *,
+    target_root: Path,
+    config: WorkspaceConfig,
+    cli_invoke: str = DEFAULT_CLI_INVOKE,
+) -> dict[str, Any]:
+    strict_closeout = bool(config.assurance.strict_closeout)
+    try:
+        from repo_planning_bootstrap.installer import planning_report
+
+        planning_module_report = planning_report(target=target_root)
+    except Exception:
+        planning_module_report = {"module": "planning", "health": "unknown", "findings": []}
+
+    planning_report_payload = planning_module_report if isinstance(planning_module_report, dict) else {}
+    intent_validation = planning_report_payload.get("intent_validation", {})
+    intent_validation = intent_validation if isinstance(intent_validation, dict) else {}
+    counts = intent_validation.get("counts", {})
+    signals = intent_validation.get("signals", [])
+    lower_trust_closeout_count = int(counts.get("lower_trust_closeout_count", 0) or 0) if isinstance(counts, dict) else 0
+    sample_signals = [
+        str(signal.get("message", "")).strip()
+        for signal in signals
+        if isinstance(signal, dict) and signal.get("kind") == "closed_without_planning_residue"
+    ]
+    sample_signals = [message for message in sample_signals if message][:3]
+    package_workflow_evidence = _package_workflow_evidence_payload(planning_report=planning_report_payload)
+    intent_satisfaction_check = _intent_satisfaction_check_payload(planning_report=planning_report_payload, target_root=target_root)
+    acceptance_reconciliation = _acceptance_criteria_reconciliation_payload(planning_report=planning_report_payload)
+    intent_proof_check = _intent_proof_check_payload(planning_report=planning_report_payload, target_root=target_root)
+    active_payload = _as_dict(planning_report_payload.get("active"))
+    raw_active_planning_record = _raw_active_planning_record_for_closeout(
+        planning_record=active_payload.get("planning_record", {}),
+        target_root=target_root,
+    )
+    assurance_requirements = _assurance_requirements_report_payload(
+        config=config,
+        target_root=target_root,
+        active_planning_record=raw_active_planning_record,
+    )
+    verification = _verification_report_payload(
+        target_root=target_root,
+        active_planning_record=raw_active_planning_record,
+        assurance_requirements=assurance_requirements,
+    )
+    assurance_requirements = _assurance_requirements_with_verification(assurance_requirements, verification)
+    applicable_intent_status = _applicable_intent_status_payload(
+        active_planning_record=raw_active_planning_record,
+        verification=verification,
+        assurance_requirements=assurance_requirements,
+    )
+    parent_intent_status = _parent_intent_status_payload(
+        active_planning_record=raw_active_planning_record,
+        intent_check=intent_satisfaction_check,
+        completion_boundary=intent_satisfaction_check.get("completion_boundary", {}),
+    )
+    active_closeout_satisfied = _active_closeout_evidence_satisfied(
+        active_planning_record=raw_active_planning_record,
+        intent_satisfaction_check=intent_satisfaction_check,
+        acceptance_reconciliation=acceptance_reconciliation,
+        intent_proof_check=intent_proof_check,
+        parent_intent_status=parent_intent_status,
+        applicable_intent_status=applicable_intent_status,
+    )
+    active_planning_record_present = package_workflow_evidence.get("status") == "present"
+    package_absence_signals: list[str] = []
+    if (
+        package_workflow_evidence.get("status") == "present"
+        and package_workflow_evidence.get("trust") == "lower-trust"
+        and not active_closeout_satisfied
+    ):
+        missing = ", ".join((str(item) for item in package_workflow_evidence.get("missing_expected_surfaces", [])))
+        missing = missing or "package workflow evidence"
+        package_absence_signals.append(
+            f"Active planning record is present, but package workflow evidence is incomplete or absent: missing {missing}."
+        )
+    effective_lower_trust_count = lower_trust_closeout_count + len(package_absence_signals)
+    if acceptance_reconciliation.get("trust") == "lower-trust":
+        effective_lower_trust_count += 1
+    intent_satisfaction_trust = str(intent_satisfaction_check.get("trust", ""))
+    intent_satisfaction_lower_trust_count = 1 if intent_satisfaction_trust in {"follow-up-required", "needs-review"} else 0
+    effective_lower_trust_count += intent_satisfaction_lower_trust_count
+    intent_satisfaction_signals: list[str] = []
+    if intent_satisfaction_lower_trust_count:
+        continuation_surface = str(intent_satisfaction_check.get("continuation_surface", "")).strip()
+        continuation_summary = f" via {continuation_surface}" if continuation_surface else ""
+        intent_satisfaction_signals.append(
+            f"Intent satisfaction is {intent_satisfaction_trust}{continuation_summary}; closeout needs package-owned continuation evidence before it is normal-trust."
+        )
+    trust = "lower-trust" if effective_lower_trust_count > 0 else "normal"
+    if not intent_validation:
+        trust = "unavailable"
+    if trust == "lower-trust":
+        recommended_next_action = str(
+            intent_validation.get("recommended_next_action")
+            or "Review the lower-trust closeout signals before treating planning closeout as normal."
+        )
+    elif trust == "unavailable":
+        recommended_next_action = "Inspect planning report before trusting closeout state."
+    else:
+        recommended_next_action = "No extra closeout trust review is needed beyond normal report inspection."
+    gate = _closeout_strict_gate_payload(
+        strict_closeout=strict_closeout,
+        trust=trust,
+        reason="active planning record present" if active_planning_record_present else "no active planning record",
+        active_planning_record=active_planning_record_present,
+    )
+    residue_action = _closeout_durable_residue_action_payload(trust=trust, cli_invoke=cli_invoke)
+    completion_gate = _completion_gate_payload(
+        active_planning_record=raw_active_planning_record,
+        intent_check=intent_satisfaction_check,
+        acceptance_reconciliation=acceptance_reconciliation,
+        intent_proof_check=intent_proof_check,
+        parent_intent_status=parent_intent_status,
+        applicable_intent_status=applicable_intent_status,
+        durable_residue_action=residue_action,
+    )
+    task_posture_followthrough = _as_dict(completion_gate.get("task_posture_followthrough"))
+    proof_confidence = _proof_confidence_payload(intent_proof=intent_proof_check)
+    completion_options = _closeout_completion_options(
+        status="present" if trust != "unavailable" else "unavailable",
+        trust=trust,
+        strict_gate=gate,
+        completion_gate=completion_gate,
+        intent_check=intent_satisfaction_check,
+        acceptance_reconciliation=acceptance_reconciliation,
+        intent_proof_check=intent_proof_check,
+        assurance_requirements=assurance_requirements,
+        durable_residue_action=residue_action,
+        lower_trust_closeout_count=effective_lower_trust_count,
+        cli_invoke=cli_invoke,
+    )
+    closeout_protocol = _closeout_protocol_payload(
+        status="present" if trust != "unavailable" else "unavailable",
+        trust=trust,
+        strict_gate=gate,
+        completion_gate=completion_gate,
+        completion_options=completion_options,
+        durable_residue_action=residue_action,
+        knowledge_authority_review={},
+        proof_confidence=proof_confidence,
+        verification=verification,
+        task_posture_followthrough=task_posture_followthrough,
+        recommended_next_action=recommended_next_action,
+        cli_invoke=cli_invoke,
+    )
+    source_payload = {
+        "kind": "agentic-workspace/closeout-claim-boundary-source/v1",
+        "source_surface": "closeout_claim_boundary.direct",
+        "status": "present" if trust != "unavailable" else "unavailable",
+        "trust": trust,
+        "strict_closeout_gate": gate,
+        "completion_gate": completion_gate,
+        "task_posture_followthrough": task_posture_followthrough,
+        "lower_trust_closeout_count": effective_lower_trust_count,
+        "sample_signals": [*sample_signals, *package_absence_signals, *intent_satisfaction_signals][:3],
+        "intent_satisfaction_check": intent_satisfaction_check,
+        "acceptance_criteria_reconciliation": acceptance_reconciliation,
+        "intent_proof_check": intent_proof_check,
+        "proof_confidence": proof_confidence,
+        "verification": verification,
+        "durable_residue_action": residue_action,
+        "terminal_action": _closeout_terminal_action_payload(
+            trust=trust, recommended_next_action=recommended_next_action, cli_invoke=cli_invoke
+        ),
+        "completion_options": completion_options,
+        "closeout_protocol": closeout_protocol,
+        "recommended_next_action": recommended_next_action,
+        "computation": {
+            "path": "direct-compact-claim-boundary",
+            "avoids_full_closeout_trust": True,
+            "required_source": "planning_report",
+            "omitted_full_sections": [
+                "memory_consult",
+                "memory_decision_packet",
+                "operating_loop",
+                "historical_review_artifacts",
+                "architecture_decision_closeout",
+            ],
+            "structural_evidence": "report --section closeout_claim_boundary builds this source directly instead of calling _report_closeout_trust_payload",
+        },
+    }
+    return closeout_claim_boundary_payload(source_payload, cli_invoke=cli_invoke, target_arg="./repo")
 
 
 def _report_closeout_trust_payload(

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -114,6 +114,7 @@ from agentic_workspace.contract_tooling import (
     workspace_surfaces_manifest,
 )
 from agentic_workspace.reporting_support import (
+    closeout_claim_boundary_payload,
     communication_contract_payload,
     output_contract_payload,
     reasoning_economy_evidence_payload,
@@ -8885,6 +8886,11 @@ def _run_report_command(
         "findings": aggregated_findings,
         "decision_pressure": decision_pressure,
         "closeout_trust": closeout_trust,
+        "closeout_claim_boundary": closeout_claim_boundary_payload(
+            closeout_trust,
+            cli_invoke=config.cli_invoke,
+            target_arg="./repo",
+        ),
         "successful_completion_cost": _successful_completion_cost_payload(target_root=target_root, cli_invoke=config.cli_invoke),
         "reasoning_economy": reasoning_economy_evidence_payload(target_root=target_root, cli_invoke=config.cli_invoke),
         "external_work_reconciliation": external_work_reconciliation,
@@ -10138,6 +10144,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "kind": "agentic-workspace/closeout-trust/v1",
         "purpose": "compact strict closeout gate, claim permission, proof, and residue routing posture",
         "when_to_use": "before ordinary lane closeout or broad completion claims, without loading the full report",
+    },
+    {
+        "section": "closeout_claim_boundary",
+        "kind": "agentic-workspace/closeout-claim-boundary/v1",
+        "purpose": "fast derived claim boundary for what can be honestly said or closed",
+        "when_to_use": "immediately before final messages, PR readiness, issue closure, or closeout handoff",
     },
     {
         "section": "workflow_compliance_summary",
@@ -12688,8 +12700,8 @@ def _run_lazy_report_section_command(
         payload["reasoning_economy"] = reasoning_economy_evidence_payload(target_root=target_root, cli_invoke=config.cli_invoke)
         return _select_report_payload(payload, profile="router", section=normalized)
 
-    if normalized == "closeout_trust":
-        payload["closeout_trust"] = _report_closeout_trust_payload(
+    if normalized in {"closeout_claim_boundary", "closeout_trust"}:
+        closeout_trust = _report_closeout_trust_payload(
             module_reports=_selected_module_reports(target_root=target_root, selected_modules=selected_modules),
             target_root=target_root,
             config=config,
@@ -12697,6 +12709,13 @@ def _run_lazy_report_section_command(
             task_text=task_text,
             changed_paths=changed_paths,
         )
+        payload["closeout_trust"] = closeout_trust
+        if normalized == "closeout_claim_boundary":
+            payload["closeout_claim_boundary"] = closeout_claim_boundary_payload(
+                closeout_trust,
+                cli_invoke=config.cli_invoke,
+                target_arg="./repo",
+            )
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized in {

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -623,6 +623,31 @@ def test_closeout_trust_derives_intent_proof_from_satisfied_active_execplan(tmp_
     assert "planning.active.planning_record.proof_report.intent_proof.status" not in claim_work.get("blocking_fields", [])
 
 
+def test_closeout_claim_boundary_returns_fast_claim_packet(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_issue_1981_closeout_fixture(tmp_path, include_proof=True, include_stale_task_posture_residue=True)
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "closeout_claim_boundary", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)["answer"]
+
+    assert payload["kind"] == "agentic-workspace/closeout-claim-boundary/v1"
+    assert payload["status"] == "allowed"
+    assert payload["active_intent_satisfied"] is True
+    assert payload["claim_level_allowed"] == "full-intent-complete"
+    assert "full_intent_complete" in payload["claim_authorization"]["allowed_claim_classes"]
+    assert payload["blocking_fields"] == []
+    assert payload["residue_routing"]["required"] is False
+    assert payload["proof_dependency"]["status"] == "satisfied"
+    assert "--section closeout_trust" in payload["source_detail_command"]
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "section_catalog", "--format", "json"]) == 0
+    catalog = json.loads(capsys.readouterr().out)["answer"]
+    section = next(item for item in catalog["lazy_sections"] if item["section"] == "closeout_claim_boundary")
+    assert section["payload_is_lazy"] is True
+
+
 def test_closeout_trust_does_not_block_on_stale_satisfied_task_posture_residue(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -623,11 +623,24 @@ def test_closeout_trust_derives_intent_proof_from_satisfied_active_execplan(tmp_
     assert "planning.active.planning_record.proof_report.intent_proof.status" not in claim_work.get("blocking_fields", [])
 
 
-def test_closeout_claim_boundary_returns_fast_claim_packet(tmp_path: Path, capsys) -> None:
+def test_closeout_claim_boundary_returns_fast_claim_packet(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    import tests.workspace_cli_support as workspace_cli_support
+
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
     capsys.readouterr()
     _write_issue_1981_closeout_fixture(tmp_path, include_proof=True, include_stale_task_posture_residue=True)
+
+    def fail_full_closeout_trust(**_: Any) -> dict[str, Any]:
+        raise AssertionError("closeout_claim_boundary must not build full closeout_trust")
+
+    for runtime_module in (
+        workspace_runtime_core,
+        workspace_runtime_primitives,
+        workspace_cli_support._generated_cli,
+    ):
+        if hasattr(runtime_module, "_report_closeout_trust_payload"):
+            monkeypatch.setattr(runtime_module, "_report_closeout_trust_payload", fail_full_closeout_trust)
 
     assert cli.main(["report", "--target", str(tmp_path), "--section", "closeout_claim_boundary", "--format", "json"]) == 0
     payload = json.loads(capsys.readouterr().out)["answer"]
@@ -640,6 +653,10 @@ def test_closeout_claim_boundary_returns_fast_claim_packet(tmp_path: Path, capsy
     assert payload["blocking_fields"] == []
     assert payload["residue_routing"]["required"] is False
     assert payload["proof_dependency"]["status"] == "satisfied"
+    assert payload["proof_dependency"]["proof_status"] == "sufficient_for_claim"
+    assert payload["proof_dependency"]["claim_boundary"] == "full-intent"
+    assert payload["source_surface"] == "closeout_claim_boundary.direct"
+    assert payload["computation"]["avoids_full_closeout_trust"] is True
     assert "--section closeout_trust" in payload["source_detail_command"]
 
     assert cli.main(["report", "--target", str(tmp_path), "--section", "section_catalog", "--format", "json"]) == 0


### PR DESCRIPTION
Closes #2025.\n\n## Summary\n- add a derived closeout_claim_boundary report packet for the pre-message claim boundary\n- expose it through the lazy report section catalog and lazy selector path\n- preserve closeout_trust as the drill-down source of truth\n\n## Evidence\n- compact selector output includes claim level, blockers, proof dependency, residue route, closure permission, next action, and closeout_trust drill-down\n- section_catalog marks closeout_claim_boundary as lazy, giving structural evidence that it avoids the broad report path\n\n## Validation\n- make test-workspace\n- make lint-workspace\n- uv run pytest tests/test_workspace_cli.py -q\n- make typecheck\n- uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json