### PR TITLE
Add issue 1969 evidence matrix

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -918,6 +918,180 @@ def closeout_claim_boundary_payload(
     )
 
 
+def issue_1969_acceptance_evidence_matrix_payload(
+    *,
+    target_root: Path | None,
+    closeout_claim_boundary: dict[str, Any] | None = None,
+    cli_invoke: str = DEFAULT_CLI_INVOKE,
+) -> dict[str, Any]:
+    root = target_root or Path(".")
+    lane_path = root / ".agentic-workspace" / "planning" / "lanes" / "issue-1969-state-delta-loop.lane.json"
+    execplan_path = root / ".agentic-workspace" / "planning" / "execplans" / "issue-1969-lane-stack.plan.json"
+
+    def read_json(path: Path) -> dict[str, Any]:
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+        return value if isinstance(value, dict) else {}
+
+    lane_record = read_json(lane_path)
+    execplan_record = read_json(execplan_path)
+    closeout_claim_boundary = closeout_claim_boundary if isinstance(closeout_claim_boundary, dict) else {}
+    source_refs = [
+        ref
+        for ref, present in (
+            (".agentic-workspace/planning/lanes/issue-1969-state-delta-loop.lane.json", bool(lane_record)),
+            (".agentic-workspace/planning/execplans/issue-1969-lane-stack.plan.json", bool(execplan_record)),
+            ("https://github.com/rickardvh/agentic-workspace/issues/1969", True),
+        )
+        if present
+    ]
+
+    def row(
+        row_id: str,
+        criterion: str,
+        state: str,
+        evidence_refs: list[str],
+        *,
+        missing_evidence: list[str] | None = None,
+        follow_up_owner: str = "none-known",
+        current_proof_boundary: str = "historical evidence only; current HEAD still requires selected proof and closeout gates",
+    ) -> dict[str, Any]:
+        return {
+            "id": row_id,
+            "criterion": criterion,
+            "state": state,
+            "evidence_refs": evidence_refs,
+            "missing_evidence": missing_evidence or [],
+            "follow_up_owner": follow_up_owner,
+            "current_proof_boundary": current_proof_boundary,
+        }
+
+    rows = [
+        row(
+            "state_delta_model",
+            "Define a compact state-delta-first message model for the AW operating loop.",
+            "satisfied",
+            [
+                ".agentic-workspace/planning/lanes/issue-1969-state-delta-loop.lane.json",
+                ".agentic-workspace/planning/execplans/issue-1969-lane-stack.plan.json",
+                "#1976",
+                "#1977",
+                "#1978",
+                "#1979",
+                "#1980",
+            ],
+        ),
+        row(
+            "ordinary_workflow_decision_packet",
+            "Expose current decision, known evidence, missing evidence, safe probe, and response shape before visible output.",
+            "satisfied",
+            ["#1976", "#1979", ".agentic-workspace/planning/execplans/issue-1969-lane-stack.plan.json"],
+        ),
+        row(
+            "continuation_recheck_without_recap",
+            "Resume or re-review from compact state without a prose recap of the whole history.",
+            "satisfied",
+            ["#1978", "#1987", "#2004", "#2005", "#2006", "#2007", "#2008", "#2009", "#2010"],
+        ),
+        row(
+            "proof_residue_next_action_closure",
+            "Preserve proof boundary, residue, next action, and honest closure in state-delta closeout.",
+            "stale",
+            ["#1981", "#1982", "#2021", "#2023", "#2024", "#2025"],
+            missing_evidence=[
+                "current closeout authorization must be checked separately through closeout_claim_boundary or closeout_trust"
+            ],
+            follow_up_owner="#2030",
+            current_proof_boundary="matrix evidence is not closeout authorization; use closeout gates for current closure claims",
+        ),
+        row(
+            "narration_reduction",
+            "Show reduced process narration or repeated context while preserving proof, residue, and next action.",
+            "needs-human-judgment",
+            [
+                "https://github.com/rickardvh/agentic-workspace/issues/1969#issuecomment-4896594752",
+                "https://github.com/rickardvh/agentic-workspace/issues/1969#issuecomment-4899165831",
+            ],
+            missing_evidence=["fixture-backed or dogfooded before/after narration comparison"],
+            follow_up_owner="#2028",
+        ),
+        row(
+            "expansion_triggers",
+            "Make expansion triggers explicit and preserve proof, safety, uncertainty, and residue detail when needed.",
+            "satisfied",
+            ["#1977", "#1979", "#1980", "src/agentic_workspace/reporting_support.py"],
+        ),
+        row(
+            "structured_state_not_prompt_keywords",
+            "Use structured state rather than prompt-prose classifiers or broad always-on dumps.",
+            "satisfied",
+            [
+                "#1976",
+                "#1977",
+                "#1978",
+                "#1979",
+                "#1980",
+                "#1983",
+                "#2004",
+                "#2024",
+                "#2025",
+            ],
+        ),
+        row(
+            "omission_proof",
+            "Show why compact operating-loop outputs can omit hidden detail without losing needed state.",
+            "missing",
+            [],
+            missing_evidence=["omission proof packet or fixture evidence for selector-hidden context"],
+            follow_up_owner="#2029",
+        ),
+    ]
+    counts = {
+        state: sum(1 for item in rows if item["state"] == state) for state in ("satisfied", "missing", "stale", "needs-human-judgment")
+    }
+    closeout_status = {
+        "status": closeout_claim_boundary.get("status", "unavailable"),
+        "trust": closeout_claim_boundary.get("trust", ""),
+        "claim_level_allowed": closeout_claim_boundary.get("claim_level_allowed", ""),
+        "closure_permission": closeout_claim_boundary.get("closure_permission", {}),
+        "detail_selector": closeout_claim_boundary.get("detail_selector", "closeout_trust"),
+    }
+    matrix_authorizes_closure = False
+    return _localize_command_fields(
+        {
+            "kind": "agentic-workspace/issue-1969-acceptance-evidence-matrix/v1",
+            "status": "available",
+            "parent_issue": "#1969",
+            "criterion_count": len(rows),
+            "state_counts": counts,
+            "source_refs": source_refs,
+            "rows": rows,
+            "closeout_gate_boundary": {
+                "matrix_authorizes_closure": matrix_authorizes_closure,
+                "rule": "This matrix maps evidence; it does not authorize #1969 closure without current proof and closeout gates.",
+                "current_closeout_claim_boundary": closeout_status,
+                "claim_boundary_selector": _command_with_cli_invoke(
+                    "agentic-workspace report --target ./repo --section closeout_claim_boundary --format json",
+                    cli_invoke=cli_invoke,
+                ),
+            },
+            "update_model": {
+                "historical_refs_are_inputs": True,
+                "current_proof_required": True,
+                "smallest_follow_up_owner_field": "rows[].follow_up_owner",
+                "rule": "Update row states from durable issue, PR, packet, test, doc, or comment refs; do not infer closure from raw merged count.",
+            },
+            "dogfooding_boundary": {
+                "without_manual_reread": bool(lane_record or execplan_record),
+                "evidence_source": "checked-in #1969 lane/execplan plus stable issue and PR refs",
+            },
+        },
+        cli_invoke=cli_invoke,
+    )
+
+
 def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str, target_arg: str = "./repo") -> Any:
     if section == "reasoning_economy" and isinstance(answer, dict):
         behavior = answer.get("behavior_check", {})

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -115,6 +115,7 @@ from agentic_workspace.contract_tooling import (
 from agentic_workspace.reporting_support import (
     closeout_claim_boundary_payload,
     communication_contract_payload,
+    issue_1969_acceptance_evidence_matrix_payload,
     output_contract_payload,
     reasoning_economy_evidence_payload,
     repo_friction_payload,
@@ -10060,6 +10061,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "immediately before final messages, PR readiness, issue closure, or closeout handoff",
     },
     {
+        "section": "issue_1969_evidence_matrix",
+        "kind": "agentic-workspace/issue-1969-acceptance-evidence-matrix/v1",
+        "purpose": "#1969 criterion-to-evidence matrix with gaps and closeout boundary",
+        "when_to_use": "when reassessing #1969 closure without manually re-reading every merged PR",
+    },
+    {
         "section": "local_footprint",
         "kind": "agentic-workspace/local-footprint/v1",
         "purpose": "tracked-vs-ignored AW footprint, local scratch retention, budgets, and largest local offenders",
@@ -13201,6 +13208,27 @@ def _run_lazy_report_section_command(
                 cli_invoke=config.cli_invoke,
                 target_arg="./repo",
             )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "issue_1969_evidence_matrix":
+        closeout_trust = _report_closeout_trust_payload(
+            module_reports=_selected_module_reports(target_root=target_root, selected_modules=selected_modules),
+            target_root=target_root,
+            config=config,
+            cli_invoke=config.cli_invoke,
+            task_text=task_text,
+            changed_paths=changed_paths,
+        )
+        closeout_boundary = closeout_claim_boundary_payload(
+            closeout_trust,
+            cli_invoke=config.cli_invoke,
+            target_arg="./repo",
+        )
+        payload["issue_1969_evidence_matrix"] = issue_1969_acceptance_evidence_matrix_payload(
+            target_root=target_root,
+            closeout_claim_boundary=closeout_boundary,
+            cli_invoke=config.cli_invoke,
+        )
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized in {

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -116,6 +116,7 @@ from agentic_workspace.contract_tooling import (
 from agentic_workspace.reporting_support import (
     closeout_claim_boundary_payload,
     communication_contract_payload,
+    issue_1969_acceptance_evidence_matrix_payload,
     output_contract_payload,
     reasoning_economy_evidence_payload,
     repo_friction_payload,
@@ -10152,6 +10153,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "immediately before final messages, PR readiness, issue closure, or closeout handoff",
     },
     {
+        "section": "issue_1969_evidence_matrix",
+        "kind": "agentic-workspace/issue-1969-acceptance-evidence-matrix/v1",
+        "purpose": "#1969 criterion-to-evidence matrix with gaps and closeout boundary",
+        "when_to_use": "when reassessing #1969 closure without manually re-reading every merged PR",
+    },
+    {
         "section": "workflow_compliance_summary",
         "kind": "agentic-workspace/workflow-compliance-summary/v1",
         "purpose": ("review/recovery summary of expected entrypoint, observed workflow use, gates, trust impact, and recovery action"),
@@ -12716,6 +12723,27 @@ def _run_lazy_report_section_command(
                 cli_invoke=config.cli_invoke,
                 target_arg="./repo",
             )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "issue_1969_evidence_matrix":
+        closeout_trust = _report_closeout_trust_payload(
+            module_reports=_selected_module_reports(target_root=target_root, selected_modules=selected_modules),
+            target_root=target_root,
+            config=config,
+            cli_invoke=config.cli_invoke,
+            task_text=task_text,
+            changed_paths=changed_paths,
+        )
+        closeout_boundary = closeout_claim_boundary_payload(
+            closeout_trust,
+            cli_invoke=config.cli_invoke,
+            target_arg="./repo",
+        )
+        payload["issue_1969_evidence_matrix"] = issue_1969_acceptance_evidence_matrix_payload(
+            target_root=target_root,
+            closeout_claim_boundary=closeout_boundary,
+            cli_invoke=config.cli_invoke,
+        )
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized in {

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -648,6 +648,54 @@ def test_closeout_claim_boundary_returns_fast_claim_packet(tmp_path: Path, capsy
     assert section["payload_is_lazy"] is True
 
 
+def test_issue_1969_evidence_matrix_maps_criteria_without_closure_authority(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "lanes" / "issue-1969-state-delta-loop.lane.json",
+        {
+            "kind": "planning-lane/v1",
+            "id": "issue-1969-state-delta-loop",
+            "lane_outcome": "Make ordinary AW operating-loop packets state-delta-first for issue #1969.",
+        },
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "issue-1969-lane-stack.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "canonical_core": {
+                "completion_criteria": [
+                    "#1970 current_decision packet is exposed and tested in an ordinary workflow.",
+                    "#1969 parent evidence shows state-delta-first behavior across more than one workflow class.",
+                ]
+            },
+        },
+    )
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "issue_1969_evidence_matrix", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)["answer"]
+
+    assert payload["kind"] == "agentic-workspace/issue-1969-acceptance-evidence-matrix/v1"
+    assert payload["parent_issue"] == "#1969"
+    assert payload["state_counts"]["satisfied"] >= 1
+    assert payload["state_counts"]["missing"] >= 1
+    rows_by_id = {row["id"]: row for row in payload["rows"]}
+    assert rows_by_id["state_delta_model"]["state"] == "satisfied"
+    assert "#1976" in rows_by_id["state_delta_model"]["evidence_refs"]
+    assert rows_by_id["omission_proof"]["state"] == "missing"
+    assert rows_by_id["omission_proof"]["follow_up_owner"] == "#2029"
+    assert payload["closeout_gate_boundary"]["matrix_authorizes_closure"] is False
+    assert "--section closeout_claim_boundary" in payload["closeout_gate_boundary"]["claim_boundary_selector"]
+    assert ".agentic-workspace/planning/lanes/issue-1969-state-delta-loop.lane.json" in payload["source_refs"]
+    assert payload["dogfooding_boundary"]["without_manual_reread"] is True
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "section_catalog", "--format", "json"]) == 0
+    catalog = json.loads(capsys.readouterr().out)["answer"]
+    section = next(item for item in catalog["lazy_sections"] if item["section"] == "issue_1969_evidence_matrix")
+    assert section["payload_is_lazy"] is True
+
+
 def test_closeout_trust_does_not_block_on_stale_satisfied_task_posture_residue(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0


### PR DESCRIPTION
Closes #2026.\n\n## Summary\n- add a lazy issue_1969_evidence_matrix report section\n- map #1969 acceptance criteria to concrete evidence refs, missing/stale/needs-human-judgment states, and follow-up owners\n- keep the matrix separate from closeout authorization by pointing to closeout_claim_boundary\n\n## Evidence\n- real selector output on this checkout reports 8 criteria: 5 satisfied, 1 missing, 1 stale, and 1 needs-human-judgment\n- matrix cites checked-in #1969 planning records, PR refs, and issue comment refs without manual PR rereads\n\n## Validation\n- make test-workspace\n- make lint-workspace\n- uv run pytest tests/test_workspace_cli.py -q\n- make typecheck\n- uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json\n- uv run python scripts/run_agentic_workspace.py report --target . --section issue_1969_evidence_matrix --format json