### PR TITLE
Add issue 1969 review recheck evidence

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -993,7 +993,18 @@ def issue_1969_acceptance_evidence_matrix_payload(
             "continuation_recheck_without_recap",
             "Resume or re-review from compact state without a prose recap of the whole history.",
             "satisfied",
-            ["#1978", "#1987", "#2004", "#2005", "#2006", "#2007", "#2008", "#2009", "#2010"],
+            [
+                "#1978",
+                "#1987",
+                "#2004",
+                "#2005",
+                "#2006",
+                "#2007",
+                "#2008",
+                "#2009",
+                "#2010",
+                "issue_1969_review_recheck_evidence",
+            ],
         ),
         row(
             "proof_residue_next_action_closure",
@@ -1086,6 +1097,76 @@ def issue_1969_acceptance_evidence_matrix_payload(
             "dogfooding_boundary": {
                 "without_manual_reread": bool(lane_record or execplan_record),
                 "evidence_source": "checked-in #1969 lane/execplan plus stable issue and PR refs",
+            },
+        },
+        cli_invoke=cli_invoke,
+    )
+
+
+def issue_1969_review_recheck_evidence_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
+    findings = [
+        {
+            "id": "pr-2009-policy-blocked-proof-command",
+            "source": "#2009",
+            "finding_kind": "actionable-review-comment",
+            "historical_state": "addressed",
+            "summary": "Review feedback required preserving policy-blocked proof-command explanation status.",
+            "addressed_by": ["#2009 follow-up fix", "#1969 dogfooding comment"],
+            "recheck_evidence": [
+                "subsequent stack PRs merged after the review fix",
+                "state-delta evidence matrix cites the review/recheck example as historical closure support",
+            ],
+            "current_proof_boundary": "historical review evidence only; rerun selected proof for current HEAD before closure claims",
+            "detail_route": "gh pr view 2009 --comments",
+        },
+        {
+            "id": "pr-2017-duplicate-proof-profile-candidates",
+            "source": "#2017",
+            "finding_kind": "actionable-review-comment",
+            "historical_state": "addressed",
+            "summary": "Review feedback found a duplicate PROOF_PROFILE_CANDIDATES definition and required fix, rebase, and recheck.",
+            "addressed_by": ["#2017 fix/rebase/recheck", "#1969 dogfooding comment"],
+            "recheck_evidence": [
+                "later merged stack PRs depended on the corrected review state",
+                "no active unresolved state is inferred from this historical packet",
+            ],
+            "current_proof_boundary": "historical review evidence only; rerun selected proof for current HEAD before closure claims",
+            "detail_route": "gh pr view 2017 --comments",
+        },
+    ]
+    return _localize_command_fields(
+        {
+            "kind": "agentic-workspace/issue-1969-review-recheck-evidence/v1",
+            "status": "available",
+            "parent_issue": "#1969",
+            "scope": "merged-pr-review-recheck-evidence",
+            "finding_count": len(findings),
+            "actionable_addressed_count": sum(1 for item in findings if item["historical_state"] == "addressed"),
+            "active_unresolved_review_state": {
+                "status": "not-polled",
+                "unresolved_action_count": "unknown",
+                "rule": "This packet preserves historical merged-PR evidence; use pr_comment_attention for active PR review state.",
+                "active_selector": _command_with_cli_invoke(
+                    "agentic-workspace report --target ./repo --section pr_comment_attention --format json",
+                    cli_invoke=cli_invoke,
+                ),
+            },
+            "findings": findings,
+            "raw_comment_dump_policy": {
+                "included_by_default": False,
+                "drill_down": ["gh pr view 2009 --comments", "gh pr view 2017 --comments"],
+                "rule": "Keep closure evidence at finding/recheck granularity; raw comments remain explicit drill-down detail.",
+            },
+            "current_proof_boundary": {
+                "historical_evidence_is_current_proof": False,
+                "rule": "Merged PR review evidence can support #1969 closure criteria, but current HEAD still needs selected proof and closeout gates.",
+            },
+            "integration": {
+                "matrix_selector": _command_with_cli_invoke(
+                    "agentic-workspace report --target ./repo --section issue_1969_evidence_matrix --format json",
+                    cli_invoke=cli_invoke,
+                ),
+                "matrix_row_ids": ["continuation_recheck_without_recap", "proof_residue_next_action_closure"],
             },
         },
         cli_invoke=cli_invoke,

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -116,6 +116,7 @@ from agentic_workspace.reporting_support import (
     closeout_claim_boundary_payload,
     communication_contract_payload,
     issue_1969_acceptance_evidence_matrix_payload,
+    issue_1969_review_recheck_evidence_payload,
     output_contract_payload,
     reasoning_economy_evidence_payload,
     repo_friction_payload,
@@ -10067,6 +10068,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "when reassessing #1969 closure without manually re-reading every merged PR",
     },
     {
+        "section": "issue_1969_review_recheck_evidence",
+        "kind": "agentic-workspace/issue-1969-review-recheck-evidence/v1",
+        "purpose": "merged PR review/recheck evidence for #1969 state-delta closure support",
+        "when_to_use": "when citing addressed review comments after PRs merged without dumping raw comment history",
+    },
+    {
         "section": "local_footprint",
         "kind": "agentic-workspace/local-footprint/v1",
         "purpose": "tracked-vs-ignored AW footprint, local scratch retention, budgets, and largest local offenders",
@@ -13208,6 +13215,10 @@ def _run_lazy_report_section_command(
                 cli_invoke=config.cli_invoke,
                 target_arg="./repo",
             )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "issue_1969_review_recheck_evidence":
+        payload["issue_1969_review_recheck_evidence"] = issue_1969_review_recheck_evidence_payload(cli_invoke=config.cli_invoke)
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "issue_1969_evidence_matrix":

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -117,6 +117,7 @@ from agentic_workspace.reporting_support import (
     closeout_claim_boundary_payload,
     communication_contract_payload,
     issue_1969_acceptance_evidence_matrix_payload,
+    issue_1969_review_recheck_evidence_payload,
     output_contract_payload,
     reasoning_economy_evidence_payload,
     repo_friction_payload,
@@ -10159,6 +10160,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "when reassessing #1969 closure without manually re-reading every merged PR",
     },
     {
+        "section": "issue_1969_review_recheck_evidence",
+        "kind": "agentic-workspace/issue-1969-review-recheck-evidence/v1",
+        "purpose": "merged PR review/recheck evidence for #1969 state-delta closure support",
+        "when_to_use": "when citing addressed review comments after PRs merged without dumping raw comment history",
+    },
+    {
         "section": "workflow_compliance_summary",
         "kind": "agentic-workspace/workflow-compliance-summary/v1",
         "purpose": ("review/recovery summary of expected entrypoint, observed workflow use, gates, trust impact, and recovery action"),
@@ -12723,6 +12730,10 @@ def _run_lazy_report_section_command(
                 cli_invoke=config.cli_invoke,
                 target_arg="./repo",
             )
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "issue_1969_review_recheck_evidence":
+        payload["issue_1969_review_recheck_evidence"] = issue_1969_review_recheck_evidence_payload(cli_invoke=config.cli_invoke)
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "issue_1969_evidence_matrix":

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -696,6 +696,32 @@ def test_issue_1969_evidence_matrix_maps_criteria_without_closure_authority(tmp_
     assert section["payload_is_lazy"] is True
 
 
+def test_issue_1969_review_recheck_evidence_preserves_historical_boundary(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "issue_1969_review_recheck_evidence", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)["answer"]
+
+    assert payload["kind"] == "agentic-workspace/issue-1969-review-recheck-evidence/v1"
+    assert payload["actionable_addressed_count"] >= 2
+    findings_by_source = {finding["source"]: finding for finding in payload["findings"]}
+    assert findings_by_source["#2009"]["historical_state"] == "addressed"
+    assert "policy-blocked proof-command" in findings_by_source["#2009"]["summary"]
+    assert findings_by_source["#2017"]["historical_state"] == "addressed"
+    assert "PROOF_PROFILE_CANDIDATES" in findings_by_source["#2017"]["summary"]
+    assert payload["active_unresolved_review_state"]["status"] == "not-polled"
+    assert "--section pr_comment_attention" in payload["active_unresolved_review_state"]["active_selector"]
+    assert payload["raw_comment_dump_policy"]["included_by_default"] is False
+    assert payload["current_proof_boundary"]["historical_evidence_is_current_proof"] is False
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "section_catalog", "--format", "json"]) == 0
+    catalog = json.loads(capsys.readouterr().out)["answer"]
+    section = next(item for item in catalog["lazy_sections"] if item["section"] == "issue_1969_review_recheck_evidence")
+    assert section["payload_is_lazy"] is True
+
+
 def test_closeout_trust_does_not_block_on_stale_satisfied_task_posture_residue(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0


### PR DESCRIPTION
Closes #2027.\n\n## Summary\n- add a lazy issue_1969_review_recheck_evidence report section\n- preserve addressed review/recheck examples for #2009 and #2017 without raw comment dumps\n- distinguish historical merged-PR evidence from active unresolved review state and current proof requirements\n- link the evidence surface into the #1969 evidence matrix\n\n## Validation\n- make test-workspace\n- make lint-workspace\n- uv run pytest tests/test_workspace_cli.py -q\n- make typecheck\n- uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json\n- uv run python scripts/run_agentic_workspace.py report --target . --section issue_1969_review_recheck_evidence --format json