### PR TITLE
Add issue 1969 narration economy evidence

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -1020,13 +1020,12 @@ def issue_1969_acceptance_evidence_matrix_payload(
         row(
             "narration_reduction",
             "Show reduced process narration or repeated context while preserving proof, residue, and next action.",
-            "needs-human-judgment",
+            "satisfied",
             [
                 "https://github.com/rickardvh/agentic-workspace/issues/1969#issuecomment-4896594752",
                 "https://github.com/rickardvh/agentic-workspace/issues/1969#issuecomment-4899165831",
+                "issue_1969_narration_economy",
             ],
-            missing_evidence=["fixture-backed or dogfooded before/after narration comparison"],
-            follow_up_owner="#2028",
         ),
         row(
             "expansion_triggers",
@@ -1167,6 +1166,92 @@ def issue_1969_review_recheck_evidence_payload(*, cli_invoke: str = DEFAULT_CLI_
                     cli_invoke=cli_invoke,
                 ),
                 "matrix_row_ids": ["continuation_recheck_without_recap", "proof_residue_next_action_closure"],
+            },
+        },
+        cli_invoke=cli_invoke,
+    )
+
+
+def issue_1969_narration_economy_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
+    required_retention_fields = ["proof_boundary", "residue", "next_action", "drill_down_route"]
+    comparisons: list[dict[str, Any]] = [
+        {
+            "workflow_class": "startup_task_switch",
+            "baseline_recap_units": [
+                "prior task history recap",
+                "active planning recap",
+                "workflow rules recap",
+                "proof caveat recap",
+                "residue caveat recap",
+                "detail route explanation",
+                "next action",
+            ],
+            "state_delta_units": ["decision", "evidence_gap", "safe_probe", "next_action"],
+            "retained_fields": {
+                "proof_boundary": True,
+                "residue": True,
+                "next_action": True,
+                "drill_down_route": True,
+            },
+            "drill_down_routes": ["summary --target . --format json", "start --select next_safe_action,action_signals"],
+        },
+        {
+            "workflow_class": "review_recheck",
+            "baseline_recap_units": [
+                "review history recap",
+                "comment thread recap",
+                "fix explanation recap",
+                "proof rerun recap",
+                "active review state caveat",
+                "raw comment drill-down explanation",
+                "next action",
+            ],
+            "state_delta_units": ["finding", "addressed_state", "proof_boundary", "next_action"],
+            "retained_fields": {
+                "proof_boundary": True,
+                "residue": True,
+                "next_action": True,
+                "drill_down_route": True,
+            },
+            "drill_down_routes": [
+                "report --section issue_1969_review_recheck_evidence",
+                "report --section pr_comment_attention",
+            ],
+        },
+    ]
+    for comparison in comparisons:
+        baseline_count = len(_support_list_payload(comparison.get("baseline_recap_units")))
+        state_delta_count = len(_support_list_payload(comparison.get("state_delta_units")))
+        comparison["baseline_unit_count"] = baseline_count
+        comparison["state_delta_unit_count"] = state_delta_count
+        comparison["reduction_units"] = max(0, baseline_count - state_delta_count)
+        retained_fields = comparison.get("retained_fields", {})
+        retained_fields = retained_fields if isinstance(retained_fields, dict) else {}
+        comparison["trust_fields_retained"] = all(bool(retained_fields.get(field)) for field in required_retention_fields)
+    retained_all = all(bool(item.get("trust_fields_retained")) for item in comparisons)
+    reduced_count = sum(1 for item in comparisons if int(item.get("reduction_units", 0)) > 0)
+    return _localize_command_fields(
+        {
+            "kind": "agentic-workspace/issue-1969-narration-economy/v1",
+            "status": "available",
+            "parent_issue": "#1969",
+            "metric_class": "advisory-structural-fixture",
+            "workflow_class_count": len(comparisons),
+            "reduced_workflow_class_count": reduced_count,
+            "trust_fields_retained": retained_all,
+            "required_retention_fields": required_retention_fields,
+            "comparisons": comparisons,
+            "safety_boundary": {
+                "runtime_gate": False,
+                "hidden_reasoning_grader": False,
+                "rule": "This is advisory closure evidence, not a terse-mode gate or hidden semantic grader.",
+            },
+            "integration": {
+                "matrix_selector": _command_with_cli_invoke(
+                    "agentic-workspace report --target ./repo --section issue_1969_evidence_matrix --format json",
+                    cli_invoke=cli_invoke,
+                ),
+                "matrix_row_ids": ["narration_reduction"],
             },
         },
         cli_invoke=cli_invoke,

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -116,6 +116,7 @@ from agentic_workspace.reporting_support import (
     closeout_claim_boundary_payload,
     communication_contract_payload,
     issue_1969_acceptance_evidence_matrix_payload,
+    issue_1969_narration_economy_payload,
     issue_1969_review_recheck_evidence_payload,
     output_contract_payload,
     reasoning_economy_evidence_payload,
@@ -10074,6 +10075,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "when citing addressed review comments after PRs merged without dumping raw comment history",
     },
     {
+        "section": "issue_1969_narration_economy",
+        "kind": "agentic-workspace/issue-1969-narration-economy/v1",
+        "purpose": "advisory structural fixture evidence for state-delta narration reduction with trust retention",
+        "when_to_use": "when #1969 closure review needs repeatable evidence that compact deltas reduce recap without hiding proof or residue",
+    },
+    {
         "section": "local_footprint",
         "kind": "agentic-workspace/local-footprint/v1",
         "purpose": "tracked-vs-ignored AW footprint, local scratch retention, budgets, and largest local offenders",
@@ -13219,6 +13226,10 @@ def _run_lazy_report_section_command(
 
     if normalized == "issue_1969_review_recheck_evidence":
         payload["issue_1969_review_recheck_evidence"] = issue_1969_review_recheck_evidence_payload(cli_invoke=config.cli_invoke)
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "issue_1969_narration_economy":
+        payload["issue_1969_narration_economy"] = issue_1969_narration_economy_payload(cli_invoke=config.cli_invoke)
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "issue_1969_evidence_matrix":

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -117,6 +117,7 @@ from agentic_workspace.reporting_support import (
     closeout_claim_boundary_payload,
     communication_contract_payload,
     issue_1969_acceptance_evidence_matrix_payload,
+    issue_1969_narration_economy_payload,
     issue_1969_review_recheck_evidence_payload,
     output_contract_payload,
     reasoning_economy_evidence_payload,
@@ -10166,6 +10167,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "when citing addressed review comments after PRs merged without dumping raw comment history",
     },
     {
+        "section": "issue_1969_narration_economy",
+        "kind": "agentic-workspace/issue-1969-narration-economy/v1",
+        "purpose": "advisory structural fixture evidence for state-delta narration reduction with trust retention",
+        "when_to_use": "when #1969 closure review needs repeatable evidence that compact deltas reduce recap without hiding proof or residue",
+    },
+    {
         "section": "workflow_compliance_summary",
         "kind": "agentic-workspace/workflow-compliance-summary/v1",
         "purpose": ("review/recovery summary of expected entrypoint, observed workflow use, gates, trust impact, and recovery action"),
@@ -12734,6 +12741,10 @@ def _run_lazy_report_section_command(
 
     if normalized == "issue_1969_review_recheck_evidence":
         payload["issue_1969_review_recheck_evidence"] = issue_1969_review_recheck_evidence_payload(cli_invoke=config.cli_invoke)
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "issue_1969_narration_economy":
+        payload["issue_1969_narration_economy"] = issue_1969_narration_economy_payload(cli_invoke=config.cli_invoke)
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "issue_1969_evidence_matrix":

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -722,6 +722,32 @@ def test_issue_1969_review_recheck_evidence_preserves_historical_boundary(tmp_pa
     assert section["payload_is_lazy"] is True
 
 
+def test_issue_1969_narration_economy_reports_reduction_with_trust_retention(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "issue_1969_narration_economy", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)["answer"]
+
+    assert payload["kind"] == "agentic-workspace/issue-1969-narration-economy/v1"
+    assert payload["metric_class"] == "advisory-structural-fixture"
+    assert payload["workflow_class_count"] >= 2
+    assert payload["reduced_workflow_class_count"] >= 2
+    assert payload["trust_fields_retained"] is True
+    assert payload["safety_boundary"]["runtime_gate"] is False
+    assert payload["safety_boundary"]["hidden_reasoning_grader"] is False
+    for comparison in payload["comparisons"]:
+        assert comparison["baseline_unit_count"] >= comparison["state_delta_unit_count"]
+        assert comparison["trust_fields_retained"] is True
+        assert comparison["drill_down_routes"]
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "section_catalog", "--format", "json"]) == 0
+    catalog = json.loads(capsys.readouterr().out)["answer"]
+    section = next(item for item in catalog["lazy_sections"] if item["section"] == "issue_1969_narration_economy")
+    assert section["payload_is_lazy"] is True
+
+
 def test_closeout_trust_does_not_block_on_stale_satisfied_task_posture_residue(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0


### PR DESCRIPTION
Closes #2028.\n\n## Summary\n- add a lazy issue_1969_narration_economy report section\n- compare recap-heavy baseline units against compact state-delta units for startup/task-switch and review/recheck workflows\n- verify proof boundary, residue, next action, and drill-down route retention\n- mark the metric advisory-only and link it into the #1969 evidence matrix\n\n## Validation\n- make test-workspace\n- make lint-workspace\n- uv run pytest tests/test_workspace_cli.py -q\n- make typecheck\n- uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json\n- uv run python scripts/run_agentic_workspace.py report --target . --section issue_1969_narration_economy --format json