### PR TITLE
Add issue 1969 omission proof

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -1052,10 +1052,8 @@ def issue_1969_acceptance_evidence_matrix_payload(
         row(
             "omission_proof",
             "Show why compact operating-loop outputs can omit hidden detail without losing needed state.",
-            "missing",
-            [],
-            missing_evidence=["omission proof packet or fixture evidence for selector-hidden context"],
-            follow_up_owner="#2029",
+            "satisfied",
+            ["issue_1969_omission_proof"],
         ),
     ]
     counts = {
@@ -1252,6 +1250,131 @@ def issue_1969_narration_economy_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE
                     cli_invoke=cli_invoke,
                 ),
                 "matrix_row_ids": ["narration_reduction"],
+            },
+        },
+        cli_invoke=cli_invoke,
+    )
+
+
+def issue_1969_omission_proof_payload(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> dict[str, Any]:
+    surfaces = [
+        {
+            "surface": "startup_task_switch",
+            "omission_states": [
+                {
+                    "field": "local_chat_checkpoint",
+                    "state": "not_checked",
+                    "why_safe": "not read unless current task or checkpoint selector requires it",
+                    "drill_down_route": "start --select work_threads --format json",
+                },
+                {
+                    "field": "selector_inventory",
+                    "state": "hidden-behind-detail-route",
+                    "why_safe": "compact output includes exact selector command and omits broad inventory by default",
+                    "drill_down_route": "start --select <field[,field...]> --format json",
+                },
+                {
+                    "field": "active_pr_context",
+                    "state": "absent",
+                    "why_safe": "no PR-specific review state is part of a generic startup/task-switch decision",
+                    "drill_down_route": "report --section pr_comment_attention",
+                },
+            ],
+            "blocked_non_omittable": [
+                {
+                    "field": "proof_required",
+                    "state": "blocked",
+                    "reason": "proof gaps affect completion safety and remain visible",
+                }
+            ],
+            "retained_trust_fields": ["proof_boundary", "residue_owner", "next_safe_action"],
+        },
+        {
+            "surface": "review_recheck",
+            "omission_states": [
+                {
+                    "field": "raw_review_comments",
+                    "state": "hidden-behind-detail-route",
+                    "why_safe": "finding/recheck packet keeps actionable state while raw comments stay explicit drill-down",
+                    "drill_down_route": "gh pr view <pr> --comments",
+                },
+                {
+                    "field": "active_unresolved_review_state",
+                    "state": "not_checked",
+                    "why_safe": "historical merged-PR evidence does not claim active thread status",
+                    "drill_down_route": "report --section pr_comment_attention",
+                },
+            ],
+            "blocked_non_omittable": [
+                {
+                    "field": "current_proof_boundary",
+                    "state": "blocked",
+                    "reason": "historical review evidence must not stand in for current proof",
+                }
+            ],
+            "retained_trust_fields": ["proof_boundary", "next_action", "drill_down_route"],
+        },
+        {
+            "surface": "closeout_claim_boundary",
+            "omission_states": [
+                {
+                    "field": "full_closeout_trust_detail",
+                    "state": "hidden-behind-detail-route",
+                    "why_safe": "compact claim boundary exposes blockers, proof dependency, residue, and next action",
+                    "drill_down_route": "report --section closeout_trust",
+                },
+                {
+                    "field": "parent_lane_auto_close",
+                    "state": "not-applicable",
+                    "why_safe": "claim-boundary selector reports permission; it does not close issues",
+                    "drill_down_route": "report --section issue_1969_evidence_matrix",
+                },
+            ],
+            "blocked_non_omittable": [
+                {
+                    "field": "blocking_fields",
+                    "state": "blocked",
+                    "reason": "proof, residue, safety, and closure blockers stay visible",
+                }
+            ],
+            "retained_trust_fields": ["proof_dependency", "residue_routing", "next_action"],
+        },
+    ]
+    state_counts: dict[str, int] = {}
+    for surface in surfaces:
+        for item in _support_list_payload(surface.get("omission_states")):
+            if isinstance(item, dict):
+                state = str(item.get("state", "unknown"))
+                state_counts[state] = state_counts.get(state, 0) + 1
+        for item in _support_list_payload(surface.get("blocked_non_omittable")):
+            if isinstance(item, dict):
+                state = str(item.get("state", "unknown"))
+                state_counts[state] = state_counts.get(state, 0) + 1
+    return _localize_command_fields(
+        {
+            "kind": "agentic-workspace/issue-1969-omission-proof/v1",
+            "status": "available",
+            "parent_issue": "#1969",
+            "state_vocabulary": [
+                "absent",
+                "not_checked",
+                "not-applicable",
+                "hidden-behind-detail-route",
+                "blocked",
+            ],
+            "state_counts": state_counts,
+            "surface_count": len(surfaces),
+            "surfaces": surfaces,
+            "trust_boundary": {
+                "hides_safety_or_proof_warnings": False,
+                "rule": "Blocked proof, residue, safety, uncertainty, and closure fields remain visible rather than being classified as safely omitted.",
+            },
+            "integration": {
+                "matrix_selector": _command_with_cli_invoke(
+                    "agentic-workspace report --target ./repo --section issue_1969_evidence_matrix --format json",
+                    cli_invoke=cli_invoke,
+                ),
+                "matrix_row_ids": ["omission_proof"],
             },
         },
         cli_invoke=cli_invoke,

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -117,6 +117,7 @@ from agentic_workspace.reporting_support import (
     communication_contract_payload,
     issue_1969_acceptance_evidence_matrix_payload,
     issue_1969_narration_economy_payload,
+    issue_1969_omission_proof_payload,
     issue_1969_review_recheck_evidence_payload,
     output_contract_payload,
     reasoning_economy_evidence_payload,
@@ -10081,6 +10082,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "when #1969 closure review needs repeatable evidence that compact deltas reduce recap without hiding proof or residue",
     },
     {
+        "section": "issue_1969_omission_proof",
+        "kind": "agentic-workspace/issue-1969-omission-proof/v1",
+        "purpose": "compact omission-state proof for selector-hidden, absent, not-checked, not-applicable, and blocked detail",
+        "when_to_use": "when compact operating-loop output needs proof that omitted detail has a safe drill-down or must stay visible",
+    },
+    {
         "section": "local_footprint",
         "kind": "agentic-workspace/local-footprint/v1",
         "purpose": "tracked-vs-ignored AW footprint, local scratch retention, budgets, and largest local offenders",
@@ -13230,6 +13237,10 @@ def _run_lazy_report_section_command(
 
     if normalized == "issue_1969_narration_economy":
         payload["issue_1969_narration_economy"] = issue_1969_narration_economy_payload(cli_invoke=config.cli_invoke)
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "issue_1969_omission_proof":
+        payload["issue_1969_omission_proof"] = issue_1969_omission_proof_payload(cli_invoke=config.cli_invoke)
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "issue_1969_evidence_matrix":

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -118,6 +118,7 @@ from agentic_workspace.reporting_support import (
     communication_contract_payload,
     issue_1969_acceptance_evidence_matrix_payload,
     issue_1969_narration_economy_payload,
+    issue_1969_omission_proof_payload,
     issue_1969_review_recheck_evidence_payload,
     output_contract_payload,
     reasoning_economy_evidence_payload,
@@ -10173,6 +10174,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "when #1969 closure review needs repeatable evidence that compact deltas reduce recap without hiding proof or residue",
     },
     {
+        "section": "issue_1969_omission_proof",
+        "kind": "agentic-workspace/issue-1969-omission-proof/v1",
+        "purpose": "compact omission-state proof for selector-hidden, absent, not-checked, not-applicable, and blocked detail",
+        "when_to_use": "when compact operating-loop output needs proof that omitted detail has a safe drill-down or must stay visible",
+    },
+    {
         "section": "workflow_compliance_summary",
         "kind": "agentic-workspace/workflow-compliance-summary/v1",
         "purpose": ("review/recovery summary of expected entrypoint, observed workflow use, gates, trust impact, and recovery action"),
@@ -12745,6 +12752,10 @@ def _run_lazy_report_section_command(
 
     if normalized == "issue_1969_narration_economy":
         payload["issue_1969_narration_economy"] = issue_1969_narration_economy_payload(cli_invoke=config.cli_invoke)
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "issue_1969_omission_proof":
+        payload["issue_1969_omission_proof"] = issue_1969_omission_proof_payload(cli_invoke=config.cli_invoke)
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "issue_1969_evidence_matrix":

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -679,12 +679,12 @@ def test_issue_1969_evidence_matrix_maps_criteria_without_closure_authority(tmp_
     assert payload["kind"] == "agentic-workspace/issue-1969-acceptance-evidence-matrix/v1"
     assert payload["parent_issue"] == "#1969"
     assert payload["state_counts"]["satisfied"] >= 1
-    assert payload["state_counts"]["missing"] >= 1
+    assert payload["state_counts"]["stale"] + payload["state_counts"]["needs-human-judgment"] >= 1
     rows_by_id = {row["id"]: row for row in payload["rows"]}
     assert rows_by_id["state_delta_model"]["state"] == "satisfied"
     assert "#1976" in rows_by_id["state_delta_model"]["evidence_refs"]
-    assert rows_by_id["omission_proof"]["state"] == "missing"
-    assert rows_by_id["omission_proof"]["follow_up_owner"] == "#2029"
+    assert rows_by_id["omission_proof"]["state"] == "satisfied"
+    assert "issue_1969_omission_proof" in rows_by_id["omission_proof"]["evidence_refs"]
     assert payload["closeout_gate_boundary"]["matrix_authorizes_closure"] is False
     assert "--section closeout_claim_boundary" in payload["closeout_gate_boundary"]["claim_boundary_selector"]
     assert ".agentic-workspace/planning/lanes/issue-1969-state-delta-loop.lane.json" in payload["source_refs"]
@@ -745,6 +745,33 @@ def test_issue_1969_narration_economy_reports_reduction_with_trust_retention(tmp
     assert cli.main(["report", "--target", str(tmp_path), "--section", "section_catalog", "--format", "json"]) == 0
     catalog = json.loads(capsys.readouterr().out)["answer"]
     section = next(item for item in catalog["lazy_sections"] if item["section"] == "issue_1969_narration_economy")
+    assert section["payload_is_lazy"] is True
+
+
+def test_issue_1969_omission_proof_covers_compact_state_boundaries(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "issue_1969_omission_proof", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)["answer"]
+
+    assert payload["kind"] == "agentic-workspace/issue-1969-omission-proof/v1"
+    assert payload["surface_count"] >= 2
+    for state in ("absent", "not_checked", "not-applicable", "hidden-behind-detail-route", "blocked"):
+        assert state in payload["state_vocabulary"]
+        assert payload["state_counts"][state] >= 1
+    assert payload["trust_boundary"]["hides_safety_or_proof_warnings"] is False
+    startup = next(surface for surface in payload["surfaces"] if surface["surface"] == "startup_task_switch")
+    assert any(item["state"] == "hidden-behind-detail-route" and item["drill_down_route"] for item in startup["omission_states"])
+    review = next(surface for surface in payload["surfaces"] if surface["surface"] == "review_recheck")
+    assert any(item["state"] == "not_checked" and item["drill_down_route"] for item in review["omission_states"])
+    closeout = next(surface for surface in payload["surfaces"] if surface["surface"] == "closeout_claim_boundary")
+    assert any(item["state"] == "blocked" for item in closeout["blocked_non_omittable"])
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "section_catalog", "--format", "json"]) == 0
+    catalog = json.loads(capsys.readouterr().out)["answer"]
+    section = next(item for item in catalog["lazy_sections"] if item["section"] == "issue_1969_omission_proof")
     assert section["payload_is_lazy"] is True
 
 


### PR DESCRIPTION
Closes #2029.\n\n## Summary\n- add a lazy issue_1969_omission_proof report section\n- cover absent, not_checked, not-applicable, hidden-behind-detail-route, and blocked omission states\n- include drill-down routes for safely omitted detail and keep proof/residue/safety blockers visible\n- update the #1969 evidence matrix to cite omission proof\n\n## Validation\n- make test-workspace\n- make lint-workspace\n- uv run pytest tests/test_workspace_cli.py -q\n- make typecheck\n- uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json\n- uv run python scripts/run_agentic_workspace.py report --target . --section issue_1969_omission_proof --format json