### PR TITLE
Streamline proof receipt bridge actions

### DIFF
--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -702,23 +702,38 @@ def _proof_receipt_bridge_payload(
                 {
                     "status": "instantiate-before-recording",
                     "placeholders": placeholders,
+                    "next_action": "instantiate placeholders, run the concrete command, then record the actual result",
                     "recording_rule": "Substitute placeholders and run the concrete command before recording a receipt.",
                 }
             )
         else:
             action["status"] = "ready-to-record-after-run"
-            action["record_passed_command"] = _command_with_cli_invoke(
+            record_passed_command = _command_with_cli_invoke(
                 command=(
                     "agentic-workspace proof --target ."
                     f"{changed_part} --record-receipt --receipt-command {_shell_quote(command)} --receipt-result passed --format json"
                 ),
                 cli_invoke=cli_invoke,
             )
+            action["next_action"] = "record the actual proof result after this concrete command has run"
+            action["recording_command"] = record_passed_command
+            action["record_passed_command"] = record_passed_command
         actions.append(action)
+    ready_actions = [action for action in actions if action.get("status") == "ready-to-record-after-run"]
+    template_actions = [action for action in actions if action.get("status") == "instantiate-before-recording"]
+    next_ready_command = str(ready_actions[0].get("recording_command", "")) if ready_actions else ""
     return {
         "kind": "agentic-workspace/proof-receipt-bridge/v1",
         "status": "action-required" if actions else "complete",
         "missing_receipt_count": len(actions),
+        "ready_to_record_count": len(ready_actions),
+        "template_blocked_count": len(template_actions),
+        "next_action": "record the first concrete proof receipt"
+        if ready_actions
+        else "instantiate template proof commands before recording"
+        if template_actions
+        else "no receipt action required",
+        "next_recording_command": next_ready_command,
         "receipt_path": str(proof_receipt_reconciliation.get("receipt_path", PROOF_RECEIPT_RELATIVE_PATH.as_posix())),
         "history_path": str(proof_receipt_reconciliation.get("receipt_history_path", PROOF_RECEIPT_HISTORY_RELATIVE_PATH.as_posix())),
         "actions": actions,

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -1331,8 +1331,14 @@ def test_proof_changed_exposes_receipt_bridge_for_unrecorded_commands(tmp_path: 
     assert bridge["kind"] == "agentic-workspace/proof-receipt-bridge/v1"
     assert bridge["status"] == "action-required"
     assert bridge["missing_receipt_count"] == len(reconciliation["commands"])
+    assert bridge["ready_to_record_count"] >= 1
+    assert bridge["template_blocked_count"] == 0
+    assert bridge["next_action"] == "record the first concrete proof receipt"
+    assert "--record-receipt" in bridge["next_recording_command"]
     action = next(item for item in bridge["actions"] if item["command"] == "make test-workspace")
     assert action["status"] == "ready-to-record-after-run"
+    assert action["next_action"] == "record the actual proof result after this concrete command has run"
+    assert action["recording_command"] == action["record_passed_command"]
     assert action["receipt_state"] in {"not-run-or-not-recorded", "run-but-not-recorded"}
     assert "--record-receipt" in action["record_passed_command"]
     assert '--receipt-command "make test-workspace"' in action["record_passed_command"]
@@ -1362,6 +1368,39 @@ def test_proof_changed_exposes_receipt_bridge_for_unrecorded_commands(tmp_path: 
     compact = json.loads(capsys.readouterr().out)
     assert compact["proof_closeout_summary"]["receipt_bridge"]["status"] == "action-required"
     assert "record_passed_command" not in json.dumps(compact)
+
+
+def test_proof_receipt_bridge_marks_template_commands_unrecordable() -> None:
+    from agentic_workspace.workspace_runtime_proof import _proof_receipt_bridge_payload
+
+    bridge = _proof_receipt_bridge_payload(
+        changed_paths=["src/example.py"],
+        proof_receipt_reconciliation={
+            "commands": [
+                {
+                    "command": "uv run pytest <paths>",
+                    "evidence_state": "not-run-or-not-recorded",
+                    "diagnostic": "no trusted receipt exists for this selected command",
+                },
+                {
+                    "command": "make typecheck",
+                    "evidence_state": "run-but-not-recorded",
+                    "diagnostic": "receipt missing for this command",
+                },
+            ]
+        },
+        cli_invoke=REPO_LOCAL_CLI_INVOKE,
+    )
+
+    assert bridge["status"] == "action-required"
+    assert bridge["ready_to_record_count"] == 1
+    assert bridge["template_blocked_count"] == 1
+    assert "--record-receipt" in bridge["next_recording_command"]
+    template = next(action for action in bridge["actions"] if action["command"] == "uv run pytest <paths>")
+    assert template["status"] == "instantiate-before-recording"
+    assert template["placeholders"] == ["<paths>"]
+    assert "recording_command" not in template
+    assert template["next_action"] == "instantiate placeholders, run the concrete command, then record the actual result"
 
 
 def test_proof_changed_projects_learned_route_model_for_two_route_classes(tmp_path: Path, capsys) -> None:
@@ -2935,6 +2974,10 @@ def test_proof_changed_reconciles_receipt_history_without_duplicate_runs(tmp_pat
     assert states["make typecheck"]["diagnostic"] == "passed receipt accepted"
     assert answer["proof_execution_evidence"]["status"] == "recorded-and-accepted"
     assert answer["proof_receipt_bridge"]["status"] == "complete"
+    assert answer["proof_receipt_bridge"]["ready_to_record_count"] == 0
+    assert answer["proof_receipt_bridge"]["template_blocked_count"] == 0
+    assert answer["proof_receipt_bridge"]["next_action"] == "no receipt action required"
+    assert answer["proof_receipt_bridge"]["next_recording_command"] == ""
     assert answer["proof_receipt_bridge"]["actions"] == []
     assert answer["proof_closeout_summary"]["receipt_bridge"] == {
         "status": "complete",


### PR DESCRIPTION
Closes #2030.\n\n## Summary\n- add aggregate receipt bridge next-action fields for ready-to-record and template-blocked commands\n- expose per-action next_action and recording_command for concrete proof commands\n- keep placeholder commands explicitly instantiate-before-recording without a receipt command\n- preserve complete status after receipts are recorded\n\n## Validation\n- make test-workspace\n- make lint-workspace\n- uv run pytest tests/test_workspace_cli.py -q\n- make typecheck\n- uv run pytest tests/test_workspace_proof_cli.py::test_proof_changed_exposes_receipt_bridge_for_unrecorded_commands tests/test_workspace_proof_cli.py::test_proof_receipt_bridge_marks_template_commands_unrecordable tests/test_workspace_proof_cli.py::test_proof_changed_reconciles_receipt_history_without_duplicate_runs -q