### PR TITLE
Gate payload closure proof by lifecycle lane

### DIFF
--- a/.agentic-workspace/memory/UPGRADE-SOURCE.toml
+++ b/.agentic-workspace/memory/UPGRADE-SOURCE.toml
@@ -1,5 +1,5 @@
 source_type = "git"
 source_ref = "git+https://github.com/rickardvh/agentic-workspace@master#subdirectory=packages/memory"
 source_label = "agentic-memory monorepo master"
-recorded_at = "2026-07-03"
+recorded_at = "2026-07-07"
 recommended_upgrade_after_days = 30

--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,8 +13,8 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:f7715b240219",
-    "version": "0.18.0"
+    "source_identity": "git:f6cfade0a059",
+    "version": "0.21.1"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
   "payload_files": [
@@ -37,8 +37,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.18.0",
-    "version": "0.18.0"
+    "tag": "v0.21.1",
+    "version": "0.21.1"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/.agentic-workspace/planning/UPGRADE-SOURCE.toml
+++ b/.agentic-workspace/planning/UPGRADE-SOURCE.toml
@@ -1,5 +1,5 @@
 source_type = "git"
 source_ref = "git+https://github.com/rickardvh/agentic-workspace@master#subdirectory=packages/planning"
 source_label = "agentic-planning monorepo master"
-recorded_at = "2026-07-03"
+recorded_at = "2026-07-07"
 recommended_upgrade_after_days = 30

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -7753,14 +7753,20 @@ def _payload_doctor_closure_plan(
     provenance_drift = str(payload_state.get("provenance_drift", "unknown"))
     installed_payload_needs_sync = payload_status == "sync-required" or provenance_drift not in {"none", "unknown"}
     scratch_repos = _local_scratch_nested_repo_paths(target_root=target_root)
-    proof_commands = [
+    installed_lane_proof_commands = [
         _command_with_cli_invoke(command=f"agentic-workspace doctor --target {target} --format json", cli_invoke=cli_invoke),
+        _command_with_cli_invoke(command=f"agentic-workspace status --target {target} --format json", cli_invoke=cli_invoke),
+        "git diff --check",
+    ]
+    source_checkout_proof_commands = [
         "make test-workspace",
         "make maintainer-surfaces",
         "uv run python scripts/generate/generate_command_packages.py --check",
         "make absolute-paths",
-        "git diff --check",
     ]
+    proof_commands = [*installed_lane_proof_commands]
+    if source_checkout:
+        proof_commands[2:2] = source_checkout_proof_commands
     installed_dry_run = _command_with_cli_invoke(
         command=f"agentic-workspace upgrade --target {target} --dry-run --format json", cli_invoke=cli_invoke
     )
@@ -7788,6 +7794,9 @@ def _payload_doctor_closure_plan(
             "status": "check-required" if source_checkout else "not-source-checkout",
             "paths": sorted(source_mirror_paths),
             "check_command": "make maintainer-surfaces" if source_checkout else None,
+            "not_applicable_reason": None
+            if source_checkout
+            else "Source payload mirror checks require an agentic-workspace source checkout.",
             "rule": "When the invoked CLI is a source checkout, verify source payload mirrors with the maintainer surface lane.",
         },
         {
@@ -7795,6 +7804,9 @@ def _payload_doctor_closure_plan(
             "status": "check-required" if source_checkout else "not-source-checkout",
             "refresh_command": "uv run python scripts/generate/generate_command_packages.py" if source_checkout else None,
             "check_command": "uv run python scripts/generate/generate_command_packages.py --check" if source_checkout else None,
+            "not_applicable_reason": None
+            if source_checkout
+            else "Generated command-package projection checks are source-checkout maintainer proof.",
             "rule": "Refresh generated command-package projections before broad tests discover stale generated targets.",
         },
         {
@@ -7812,7 +7824,8 @@ def _payload_doctor_closure_plan(
             else "check-required",
             "path": WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
             "normalize_command": installed_apply,
-            "hygiene_check": "make absolute-paths",
+            "hygiene_check": "make absolute-paths" if source_checkout else None,
+            "hygiene_status": "source-checkout-required" if source_checkout else "not-applicable",
             "rule": "Payload provenance must stay repo-portable and free of machine-local absolute paths.",
         },
         {
@@ -7822,7 +7835,7 @@ def _payload_doctor_closure_plan(
             "rule": "Run this proof lane after repair steps so later checks do not reveal omitted payload-surface work.",
         },
     ]
-    repair_sequence = [
+    repair_sequence: list[dict[str, Any]] = [
         {
             "id": "inspect_installed_payload",
             "surface_class": "installed_payload",
@@ -7835,32 +7848,41 @@ def _payload_doctor_closure_plan(
             "command": installed_apply,
             "when": "dry-run shows only managed payload sync or provenance normalization",
         },
-        {
-            "id": "check_source_payload_mirrors",
-            "surface_class": "source_payload_mirrors",
-            "command": "make maintainer-surfaces",
-            "when": "running from an agentic-workspace source checkout or touching payload mirrors",
-        },
-        {
-            "id": "refresh_generated_projections",
-            "surface_class": "generated_payload_projections",
-            "command": "uv run python scripts/generate/generate_command_packages.py",
-            "when": "source payload mirrors or generated command-package inputs changed",
-        },
-        {
-            "id": "review_local_scratch_cleanup",
-            "surface_class": "local_scratch_blockers",
-            "command": scratch_dry_run_command,
-            "when": "manual scratch cleanup is explicitly requested",
-        },
-        {
-            "id": "normalize_provenance",
-            "surface_class": "provenance",
-            "command": installed_apply,
-            "when": "payload provenance is missing, invalid, stale, or contains local absolute paths",
-        },
-        {"id": "run_final_proof", "surface_class": "proof", "commands": proof_commands, "when": "all repair steps are complete"},
     ]
+    if source_checkout:
+        repair_sequence.extend(
+            [
+                {
+                    "id": "check_source_payload_mirrors",
+                    "surface_class": "source_payload_mirrors",
+                    "command": "make maintainer-surfaces",
+                    "when": "running from an agentic-workspace source checkout or touching payload mirrors",
+                },
+                {
+                    "id": "refresh_generated_projections",
+                    "surface_class": "generated_payload_projections",
+                    "command": "uv run python scripts/generate/generate_command_packages.py",
+                    "when": "source payload mirrors or generated command-package inputs changed",
+                },
+            ]
+        )
+    repair_sequence.extend(
+        [
+            {
+                "id": "review_local_scratch_cleanup",
+                "surface_class": "local_scratch_blockers",
+                "command": scratch_dry_run_command,
+                "when": "manual scratch cleanup is explicitly requested",
+            },
+            {
+                "id": "normalize_provenance",
+                "surface_class": "provenance",
+                "command": installed_apply,
+                "when": "payload provenance is missing, invalid, stale, or contains local absolute paths",
+            },
+            {"id": "run_final_proof", "surface_class": "proof", "commands": proof_commands, "when": "all repair steps are complete"},
+        ]
+    )
     plan_status = "attention" if installed_payload_needs_sync or repair_actions or manual_review_actions else "available"
     payload_action_required = installed_payload_needs_sync or bool(repair_actions)
     if installed_payload_needs_sync:

--- a/tests/test_workspace_doctor_status_cli.py
+++ b/tests/test_workspace_doctor_status_cli.py
@@ -343,7 +343,10 @@ def test_doctor_compact_payload_closure_plan_names_full_repair_lane(monkeypatch,
         "Ignore AW local scratch contents for payload closure; cleanup remains explicitly scoped to local scratch roots."
     )
     assert surface_classes["provenance"]["hygiene_check"] == "make absolute-paths"
+    assert surface_classes["provenance"]["hygiene_status"] == "source-checkout-required"
     proof_commands = surface_classes["proof"]["commands"]
+    assert any(command.startswith("agentic-workspace doctor --target ") for command in proof_commands)
+    assert any(command.startswith("agentic-workspace status --target ") for command in proof_commands)
     assert "make test-workspace" in proof_commands
     assert "make maintainer-surfaces" in proof_commands
     assert "uv run python scripts/generate/generate_command_packages.py --check" in proof_commands
@@ -354,6 +357,46 @@ def test_doctor_compact_payload_closure_plan_names_full_repair_lane(monkeypatch,
         "installed_payload",
         "source_payload_mirrors",
         "generated_payload_projections",
+        "local_scratch_blockers",
+        "provenance",
+        "proof",
+    ]
+
+
+def test_doctor_payload_closure_plan_omits_source_maintainer_proof_for_installed_target(monkeypatch, tmp_path: Path, capsys) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    _init_git_repo(target)
+    assert cli.main(["init", "--target", str(target), "--format", "json"]) == 0
+    capsys.readouterr()
+    monkeypatch.setattr(cli, "_is_agentic_workspace_source_checkout", lambda target_root: False)
+
+    assert cli.main(["doctor", "--target", str(target), "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    plan = payload["payload_closure_plan"]
+    assert plan["source_checkout"] is False
+    surface_classes = {item["id"]: item for item in plan["surface_classes"]}
+    assert surface_classes["source_payload_mirrors"]["status"] == "not-source-checkout"
+    assert surface_classes["source_payload_mirrors"]["check_command"] is None
+    assert surface_classes["source_payload_mirrors"]["not_applicable_reason"]
+    assert surface_classes["generated_payload_projections"]["status"] == "not-source-checkout"
+    assert surface_classes["generated_payload_projections"]["refresh_command"] is None
+    assert surface_classes["generated_payload_projections"]["check_command"] is None
+    assert surface_classes["generated_payload_projections"]["not_applicable_reason"]
+    assert surface_classes["provenance"]["hygiene_check"] is None
+    assert surface_classes["provenance"]["hygiene_status"] == "not-applicable"
+    proof_commands = surface_classes["proof"]["commands"]
+    assert any(command.startswith("agentic-workspace doctor --target ") for command in proof_commands)
+    assert any(command.startswith("agentic-workspace status --target ") for command in proof_commands)
+    assert "git diff --check" in proof_commands
+    assert "make test-workspace" not in proof_commands
+    assert "make maintainer-surfaces" not in proof_commands
+    assert "uv run python scripts/generate/generate_command_packages.py --check" not in proof_commands
+    assert "make absolute-paths" not in proof_commands
+    assert [step["surface_class"] for step in plan["repair_sequence"]] == [
+        "installed_payload",
+        "installed_payload",
         "local_scratch_blockers",
         "provenance",
         "proof",


### PR DESCRIPTION
## Summary

Closes #2038.

- Gate payload closure proof commands by the target lifecycle lane.
- Keep source-checkout maintainer checks in source-checkout closure proof, while installed/non-source-checkout targets get host-valid doctor/status/diff proof only.
- Mark source-only payload checks as not applicable for installed targets and omit source-only repair steps there.
- Sync the local AW payload provenance/source metadata to v0.21.1.

## Validation

- `uv run pytest tests/test_workspace_doctor_status_cli.py::test_doctor_compact_payload_closure_plan_names_full_repair_lane tests/test_workspace_doctor_status_cli.py::test_doctor_payload_closure_plan_omits_source_maintainer_proof_for_installed_target -q`
- `uv run python scripts/run_agentic_workspace.py upgrade --target . --modules planning,memory,verification --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --format json`
- `uv run python scripts/run_agentic_workspace.py status --target . --format json`
- `make maintainer-surfaces`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `make absolute-paths`
- `git diff --check`
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json`

## Notes

Full `doctor`/`status` still report the pre-existing local-only nested repo warning at `scratch/tmp-reasoning-test`; the scoped planning-module doctor is healthy and installed payload compatibility is clean.