### PR TITLE
Add installed-state action states

### DIFF
--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -135,6 +135,24 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `installed_state_compatibility.status` | enum `"compatible"`, `"upgrade-recommended"`, `"payload-upgrade-required"`, `"blocking-drift"` | yes |  | Current installed-state compatibility classification. |  |  |
 | `installed_state_compatibility.reason` | string | no |  | Short explanation for the selected status. |  |  |
 | `installed_state_compatibility.authority` | const `"repo-state-authoritative"` | yes |  | Repo payload state owns compatibility for the current target. |  |  |
+| `installed_state_compatibility.action_state` | object | no |  | Public installed-state action-state machine result. |  |  |
+| `installed_state_compatibility.action_state.kind` | const `"agentic-workspace/installed-state-action-state/v1"` | yes |  | Discriminator for the installed-state action-state packet. |  |  |
+| `installed_state_compatibility.action_state.state` | enum `"no_repair_needed"`, `"safe_payload_sync_available"`, `"manual_review_required"`, `"blocking_incompatible"` | yes |  | Decisive action state for installed repo payload freshness. |  |  |
+| `installed_state_compatibility.action_state.status` | enum `"no_repair_needed"`, `"safe_payload_sync_available"`, `"manual_review_required"`, `"blocking_incompatible"` | yes |  | Alias of state for compact routing surfaces. |  |  |
+| `installed_state_compatibility.action_state.reason` | string | no |  | Short explanation for the selected action state. |  |  |
+| `installed_state_compatibility.action_state.repo_payload_authority` | const `"repo-state-authoritative"` | yes |  | The checked-in repo payload contract owns freshness decisions. |  |  |
+| `installed_state_compatibility.action_state.invoked_cli_role` | const `"compatibility-evaluator-and-projection-source"` | yes |  | The invoked CLI evaluates and proposes explicit repair but is not automatically authoritative. |  |  |
+| `installed_state_compatibility.action_state.compatibility_basis` | object | yes |  | Payload contract and provenance facts used for the action-state decision. |  |  |
+| `installed_state_compatibility.action_state.repair_mechanism` | string | yes |  | Visible repair mechanism, if any. |  |  |
+| `installed_state_compatibility.action_state.action_id` | string | yes |  | Stable internal action identifier. |  |  |
+| `installed_state_compatibility.action_state.command` | string | no |  | Primary command for the action when one is available. |  |  |
+| `installed_state_compatibility.action_state.dry_run_command` | string | no |  | Resolved dry-run sync command for safe package-owned repair. |  |  |
+| `installed_state_compatibility.action_state.apply_command` | string | no |  | Resolved apply sync command for safe package-owned repair. |  |  |
+| `installed_state_compatibility.action_state.safe_to_apply` | boolean | yes |  | Whether the action is bounded to package-owned sync surfaces. |  |  |
+| `installed_state_compatibility.action_state.mutates_on_start` | const `false` | yes |  | Startup may report this state but must not mutate the repo. |  |  |
+| `installed_state_compatibility.action_state.package_owned_surfaces` | array of string | no |  | Managed surfaces covered by safe sync. |  |  |
+| `installed_state_compatibility.action_state.manual_review_surfaces` | array of string | no |  | Surfaces requiring explicit manual review. |  |  |
+| `installed_state_compatibility.action_state.rule` | string | no |  | Policy rule for applying this action state. |  |  |
 | `installed_state_compatibility.executable` | object | yes |  | Executable identity and compatibility classification. |  |  |
 | `installed_state_compatibility.payload` | object | yes |  | Installed repo payload compatibility and sync guidance. |  |  |
 | `installed_state_compatibility.generated_artifacts` | object | yes |  | Generated artifact freshness classification. |  |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -54,6 +54,24 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `installed_state_compatibility.status` | enum `"compatible"`, `"upgrade-recommended"`, `"payload-upgrade-required"`, `"blocking-drift"` | yes |  | Current installed-state compatibility classification. |  |  |
 | `installed_state_compatibility.reason` | string | no |  | Short explanation for the selected status. |  |  |
 | `installed_state_compatibility.authority` | const `"repo-state-authoritative"` | yes |  | Repo payload state owns compatibility for the current target. |  |  |
+| `installed_state_compatibility.action_state` | object | no |  | Public installed-state action-state machine result. |  |  |
+| `installed_state_compatibility.action_state.kind` | const `"agentic-workspace/installed-state-action-state/v1"` | yes |  | Discriminator for the installed-state action-state packet. |  |  |
+| `installed_state_compatibility.action_state.state` | enum `"no_repair_needed"`, `"safe_payload_sync_available"`, `"manual_review_required"`, `"blocking_incompatible"` | yes |  | Decisive action state for installed repo payload freshness. |  |  |
+| `installed_state_compatibility.action_state.status` | enum `"no_repair_needed"`, `"safe_payload_sync_available"`, `"manual_review_required"`, `"blocking_incompatible"` | yes |  | Alias of state for compact routing surfaces. |  |  |
+| `installed_state_compatibility.action_state.reason` | string | no |  | Short explanation for the selected action state. |  |  |
+| `installed_state_compatibility.action_state.repo_payload_authority` | const `"repo-state-authoritative"` | yes |  | The checked-in repo payload contract owns freshness decisions. |  |  |
+| `installed_state_compatibility.action_state.invoked_cli_role` | const `"compatibility-evaluator-and-projection-source"` | yes |  | The invoked CLI evaluates and proposes explicit repair but is not automatically authoritative. |  |  |
+| `installed_state_compatibility.action_state.compatibility_basis` | object | yes |  | Payload contract and provenance facts used for the action-state decision. |  |  |
+| `installed_state_compatibility.action_state.repair_mechanism` | string | yes |  | Visible repair mechanism, if any. |  |  |
+| `installed_state_compatibility.action_state.action_id` | string | yes |  | Stable internal action identifier. |  |  |
+| `installed_state_compatibility.action_state.command` | string | no |  | Primary command for the action when one is available. |  |  |
+| `installed_state_compatibility.action_state.dry_run_command` | string | no |  | Resolved dry-run sync command for safe package-owned repair. |  |  |
+| `installed_state_compatibility.action_state.apply_command` | string | no |  | Resolved apply sync command for safe package-owned repair. |  |  |
+| `installed_state_compatibility.action_state.safe_to_apply` | boolean | yes |  | Whether the action is bounded to package-owned sync surfaces. |  |  |
+| `installed_state_compatibility.action_state.mutates_on_start` | const `false` | yes |  | Startup may report this state but must not mutate the repo. |  |  |
+| `installed_state_compatibility.action_state.package_owned_surfaces` | array of string | no |  | Managed surfaces covered by safe sync. |  |  |
+| `installed_state_compatibility.action_state.manual_review_surfaces` | array of string | no |  | Surfaces requiring explicit manual review. |  |  |
+| `installed_state_compatibility.action_state.rule` | string | no |  | Policy rule for applying this action state. |  |  |
 | `installed_state_compatibility.executable` | object | yes |  | Executable identity and compatibility classification. |  |  |
 | `installed_state_compatibility.payload` | object | yes |  | Installed repo payload compatibility and sync guidance. |  |  |
 | `installed_state_compatibility.generated_artifacts` | object | yes |  | Generated artifact freshness classification. |  |  |
@@ -81,6 +99,12 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `task_posture_packet.kind` | const `"agentic-workspace/task-posture-packet/v1"` | yes |  | Discriminator for dynamic task posture. |  |  |
 | `task_posture_packet.operating_posture` | object | yes |  | Resolved optimization, artifact, initiative, assurance, and delegation posture for this task. |  |  |
 | `task_posture_packet.workflow_obligations` | array of object | yes |  | Matched workflow obligations with stage, force, scope, and provenance. |  |  |
+| `task_posture_packet.workflow_obligation_effects` | array of object | no |  | Evaluated behavior and closeout effects for configured workflow obligations. |  |  |
+| `task_posture_packet.improvement_pressure_evaluation` | object | no |  | Session and repository improvement-pressure evaluation compiled into task posture. |  |  |
+| `task_posture_packet.dogfooding_signal_status` | object | no |  | Session dogfooding signal disposition and capture routing status. |  |  |
+| `task_posture_packet.dogfooding_obligations` | array of object | no |  | Dogfooding obligations that affect closeout and improvement capture. |  |  |
+| `task_posture_packet.optimization_effect` | object | no |  | Operational effects of the configured optimization posture. |  |  |
+| `task_posture_packet.operational_effectiveness` | object | no |  | Operational effectiveness matrix combining friction, proof, output, and optimization signals. |  |  |
 | `task_posture_packet.improvement_obligations` | array of object | yes |  | Active improvement-pressure obligations that affect proof, closeout, allowed actions, or posture adherence. |  |  |
 | `task_posture_packet.skill_routes` | array of object | yes |  | Task-selected skills, prompts, or routing fragments. |  |  |
 | `task_posture_packet.allowed_actions` | array of string | yes |  | Actions allowed under the resolved posture. |  |  |
@@ -154,6 +178,12 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `local_footprint` | object | yes |  | Tracked-vs-ignored AW footprint, local scratch retention budgets, largest offenders, and cleanup routing. |  |  |
 | `stale_cleanup` | object | no |  | Cleanup routing for stale local and checked-in planning surfaces. |  |  |
 | `workflow_obligations` | object | yes |  | Repo-configured workflow obligations surfaced for report consumers. |  |  |
+| `workflow_obligation_effects` | array of object | no |  | Evaluated behavior and closeout effects for configured workflow obligations. |  |  |
+| `improvement_pressure_evaluation` | object | no |  | Session and repository improvement-pressure evaluation compiled into report posture. |  |  |
+| `dogfooding_signal_status` | object | no |  | Session dogfooding signal disposition and capture routing status. |  |  |
+| `dogfooding_obligations` | array of object | no |  | Dogfooding obligations that affect closeout and improvement capture. |  |  |
+| `optimization_effect` | object | no |  | Operational effects of the configured optimization posture. |  |  |
+| `operational_effectiveness` | object | no |  | Operational effectiveness matrix combining friction, proof, output, and optimization signals. |  |  |
 | `assurance_requirements` | object | yes |  | Repo-declared assurance requirements, active matches, and evidence status projection; task-marker matches cite explicit config while semantic acceptance remains agent/human owned. |  |  |
 | `verification` | object | yes |  | Repo-native verification protocols, scenarios, bounded evidence bundles, and soft verification routing projection; task-marker matches are configured protocol evidence, not AW-owned intent classification. |  |  |
 | `requirement_grounding` | object | no |  | Report-visible requirement grounding projection for selected report sections. |  |  |

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -1110,6 +1110,106 @@
           "const": "repo-state-authoritative",
           "description": "Repo payload state owns compatibility for the current target."
         },
+        "action_state": {
+          "type": "object",
+          "required": [
+            "kind",
+            "state",
+            "status",
+            "repo_payload_authority",
+            "invoked_cli_role",
+            "compatibility_basis",
+            "repair_mechanism",
+            "action_id",
+            "safe_to_apply",
+            "mutates_on_start"
+          ],
+          "properties": {
+            "kind": {
+              "const": "agentic-workspace/installed-state-action-state/v1",
+              "description": "Discriminator for the installed-state action-state packet."
+            },
+            "state": {
+              "enum": [
+                "no_repair_needed",
+                "safe_payload_sync_available",
+                "manual_review_required",
+                "blocking_incompatible"
+              ],
+              "description": "Decisive action state for installed repo payload freshness."
+            },
+            "status": {
+              "enum": [
+                "no_repair_needed",
+                "safe_payload_sync_available",
+                "manual_review_required",
+                "blocking_incompatible"
+              ],
+              "description": "Alias of state for compact routing surfaces."
+            },
+            "reason": {
+              "type": "string",
+              "description": "Short explanation for the selected action state."
+            },
+            "repo_payload_authority": {
+              "const": "repo-state-authoritative",
+              "description": "The checked-in repo payload contract owns freshness decisions."
+            },
+            "invoked_cli_role": {
+              "const": "compatibility-evaluator-and-projection-source",
+              "description": "The invoked CLI evaluates and proposes explicit repair but is not automatically authoritative."
+            },
+            "compatibility_basis": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "Payload contract and provenance facts used for the action-state decision."
+            },
+            "repair_mechanism": {
+              "type": "string",
+              "description": "Visible repair mechanism, if any."
+            },
+            "action_id": {
+              "type": "string",
+              "description": "Stable internal action identifier."
+            },
+            "command": {
+              "type": "string",
+              "description": "Primary command for the action when one is available."
+            },
+            "dry_run_command": {
+              "type": "string",
+              "description": "Resolved dry-run sync command for safe package-owned repair."
+            },
+            "apply_command": {
+              "type": "string",
+              "description": "Resolved apply sync command for safe package-owned repair."
+            },
+            "safe_to_apply": {
+              "type": "boolean",
+              "description": "Whether the action is bounded to package-owned sync surfaces."
+            },
+            "mutates_on_start": {
+              "const": false,
+              "description": "Startup may report this state but must not mutate the repo."
+            },
+            "package_owned_surfaces": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Managed surfaces covered by safe sync."
+            },
+            "manual_review_surfaces": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Surfaces requiring explicit manual review."
+            },
+            "rule": {
+              "type": "string",
+              "description": "Policy rule for applying this action state."
+            }
+          },
+          "additionalProperties": false,
+          "description": "Public installed-state action-state machine result."
+        },
         "executable": {
           "type": "object",
           "description": "Executable identity and compatibility classification.",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -293,6 +293,36 @@
       "type": "object",
       "description": "Repo-configured workflow obligations surfaced for report consumers."
     },
+    "workflow_obligation_effects": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true },
+      "description": "Evaluated behavior and closeout effects for configured workflow obligations."
+    },
+    "improvement_pressure_evaluation": {
+      "type": "object",
+      "description": "Session and repository improvement-pressure evaluation compiled into report posture.",
+      "additionalProperties": true
+    },
+    "dogfooding_signal_status": {
+      "type": "object",
+      "description": "Session dogfooding signal disposition and capture routing status.",
+      "additionalProperties": true
+    },
+    "dogfooding_obligations": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true },
+      "description": "Dogfooding obligations that affect closeout and improvement capture."
+    },
+    "optimization_effect": {
+      "type": "object",
+      "description": "Operational effects of the configured optimization posture.",
+      "additionalProperties": true
+    },
+    "operational_effectiveness": {
+      "type": "object",
+      "description": "Operational effectiveness matrix combining friction, proof, output, and optimization signals.",
+      "additionalProperties": true
+    },
     "assurance_requirements": {
       "type": "object",
       "description": "Repo-declared assurance requirements, active matches, and evidence status projection; task-marker matches cite explicit config while semantic acceptance remains agent/human owned."
@@ -554,6 +584,42 @@
             "additionalProperties": true
           },
           "description": "Matched workflow obligations with stage, force, scope, and provenance."
+        },
+        "workflow_obligation_effects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Evaluated behavior and closeout effects for configured workflow obligations."
+        },
+        "improvement_pressure_evaluation": {
+          "type": "object",
+          "description": "Session and repository improvement-pressure evaluation compiled into task posture.",
+          "additionalProperties": true
+        },
+        "dogfooding_signal_status": {
+          "type": "object",
+          "description": "Session dogfooding signal disposition and capture routing status.",
+          "additionalProperties": true
+        },
+        "dogfooding_obligations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": "Dogfooding obligations that affect closeout and improvement capture."
+        },
+        "optimization_effect": {
+          "type": "object",
+          "description": "Operational effects of the configured optimization posture.",
+          "additionalProperties": true
+        },
+        "operational_effectiveness": {
+          "type": "object",
+          "description": "Operational effectiveness matrix combining friction, proof, output, and optimization signals.",
+          "additionalProperties": true
         },
         "improvement_obligations": {
           "type": "array",
@@ -1291,6 +1357,106 @@
         "authority": {
           "const": "repo-state-authoritative",
           "description": "Repo payload state owns compatibility for the current target."
+        },
+        "action_state": {
+          "type": "object",
+          "required": [
+            "kind",
+            "state",
+            "status",
+            "repo_payload_authority",
+            "invoked_cli_role",
+            "compatibility_basis",
+            "repair_mechanism",
+            "action_id",
+            "safe_to_apply",
+            "mutates_on_start"
+          ],
+          "properties": {
+            "kind": {
+              "const": "agentic-workspace/installed-state-action-state/v1",
+              "description": "Discriminator for the installed-state action-state packet."
+            },
+            "state": {
+              "enum": [
+                "no_repair_needed",
+                "safe_payload_sync_available",
+                "manual_review_required",
+                "blocking_incompatible"
+              ],
+              "description": "Decisive action state for installed repo payload freshness."
+            },
+            "status": {
+              "enum": [
+                "no_repair_needed",
+                "safe_payload_sync_available",
+                "manual_review_required",
+                "blocking_incompatible"
+              ],
+              "description": "Alias of state for compact routing surfaces."
+            },
+            "reason": {
+              "type": "string",
+              "description": "Short explanation for the selected action state."
+            },
+            "repo_payload_authority": {
+              "const": "repo-state-authoritative",
+              "description": "The checked-in repo payload contract owns freshness decisions."
+            },
+            "invoked_cli_role": {
+              "const": "compatibility-evaluator-and-projection-source",
+              "description": "The invoked CLI evaluates and proposes explicit repair but is not automatically authoritative."
+            },
+            "compatibility_basis": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "Payload contract and provenance facts used for the action-state decision."
+            },
+            "repair_mechanism": {
+              "type": "string",
+              "description": "Visible repair mechanism, if any."
+            },
+            "action_id": {
+              "type": "string",
+              "description": "Stable internal action identifier."
+            },
+            "command": {
+              "type": "string",
+              "description": "Primary command for the action when one is available."
+            },
+            "dry_run_command": {
+              "type": "string",
+              "description": "Resolved dry-run sync command for safe package-owned repair."
+            },
+            "apply_command": {
+              "type": "string",
+              "description": "Resolved apply sync command for safe package-owned repair."
+            },
+            "safe_to_apply": {
+              "type": "boolean",
+              "description": "Whether the action is bounded to package-owned sync surfaces."
+            },
+            "mutates_on_start": {
+              "const": false,
+              "description": "Startup may report this state but must not mutate the repo."
+            },
+            "package_owned_surfaces": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Managed surfaces covered by safe sync."
+            },
+            "manual_review_surfaces": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Surfaces requiring explicit manual review."
+            },
+            "rule": {
+              "type": "string",
+              "description": "Policy rule for applying this action state."
+            }
+          },
+          "additionalProperties": false,
+          "description": "Public installed-state action-state machine result."
         },
         "executable": {
           "type": "object",

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -639,6 +639,7 @@
           "_proof_route_explanation_payload",
           "_proof_route_source_for_lane",
           "_run_lifecycle_command",
+          "_session_improvement_pressure_payload",
           "_skill_behavior_impact_review_for_changed_paths",
           "_split_validation_command",
           "_startup_closeout_report_route",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -670,6 +670,14 @@ def _write_payload_provenance_action(*, target_root: Path, dry_run: bool) -> dic
     payload = _payload_provenance_payload(target_root=target_root)
     if existing_payload is not None and _stable_payload_provenance(existing_payload) == _stable_payload_provenance(payload):
         return {"kind": "current", "path": relative.as_posix(), "detail": "payload provenance already current"}
+    if existing_payload is not None and not _validate_payload_provenance(existing_payload):
+        existing_payload_files = existing_payload.get("payload_files")
+        if existing_payload.get("payload_schema") == WORKSPACE_PAYLOAD_SCHEMA and existing_payload_files == payload["payload_files"]:
+            return {
+                "kind": "current",
+                "path": relative.as_posix(),
+                "detail": "payload provenance schema and managed file set are compatible; installer identity drift does not require rewrite",
+            }
     if existing_payload is not None and existing_payload.get("installed_at"):
         payload["installed_at"] = existing_payload["installed_at"]
     rendered_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
@@ -951,9 +959,17 @@ def _cli_compatibility_remediation(
     }
 
 
-def _installed_state_action_effect(*, status: str, next_action: str | None, config: WorkspaceConfig) -> dict[str, Any]:
-    resolution_command = next_action or config.cli_invoke
-    if status == "blocking-drift":
+def _installed_state_action_effect(
+    *,
+    status: str,
+    next_action: str | None,
+    config: WorkspaceConfig,
+    action_state: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    action_state = action_state if isinstance(action_state, dict) else {}
+    state = str(action_state.get("state") or "")
+    resolution_command = str(action_state.get("dry_run_command") or action_state.get("command") or next_action or config.cli_invoke)
+    if state == "blocking_incompatible" or status == "blocking-drift":
         return {
             "force": "required_before_execution",
             "allowed_now": "switch-to-compatible-invocation-before-running-workspace-actions",
@@ -962,16 +978,16 @@ def _installed_state_action_effect(*, status: str, next_action: str | None, conf
             "resolution_selector": "installed_state_compatibility",
             "resolution_command": resolution_command,
         }
-    if status == "payload-upgrade-required":
+    if state == "safe_payload_sync_available" or status == "payload-upgrade-required":
         return {
             "force": "required_before_claim",
-            "allowed_now": "continue-bounded-work-with-repo-local-invocation",
+            "allowed_now": "continue-bounded-work-with-compatible-claim-limits",
             "blocked_until_reconciled": ["claim-installed-state-fresh", "claim-payload-synced", "claim-generated-surfaces-current"],
             "claim_boundary": "do-not-claim-local-installed-state-or-generated-payload-freshness-before-running-the-sync-check",
             "resolution_selector": "installed_state_compatibility",
             "resolution_command": resolution_command,
         }
-    if status == "upgrade-recommended":
+    if state == "manual_review_required" or status == "upgrade-recommended":
         return {
             "force": "advisory",
             "allowed_now": "continue-bounded-work-with-compatible-claim-limits",
@@ -987,6 +1003,85 @@ def _installed_state_action_effect(*, status: str, next_action: str | None, conf
         "claim_boundary": "installed-state-compatible-does-not-replace-task-proof-or-acceptance-reconciliation",
         "resolution_selector": "installed_state_compatibility",
         "resolution_command": resolution_command,
+    }
+
+
+def _installed_state_action_state_packet(
+    *,
+    state: str,
+    reason: str,
+    target_root: Path,
+    config: WorkspaceConfig,
+    payload_provenance_drift: str,
+    provenance_status: dict[str, Any],
+    stale_generated_surfaces: Sequence[str],
+    cli_status: str,
+) -> dict[str, Any]:
+    target = target_root.as_posix()
+    dry_run_sync_command = _command_with_cli_invoke(
+        command=f"agentic-workspace upgrade --target {target} --dry-run --format json",
+        cli_invoke=config.cli_invoke,
+    )
+    apply_sync_command = _command_with_cli_invoke(
+        command=f"agentic-workspace upgrade --target {target} --format json",
+        cli_invoke=config.cli_invoke,
+    )
+    sync_available = state == "safe_payload_sync_available"
+    manual_review = state == "manual_review_required"
+    blocking = state == "blocking_incompatible"
+    command = dry_run_sync_command if sync_available else config.cli_invoke if blocking or manual_review else ""
+    payload_schema = ""
+    provenance_payload = provenance_status.get("payload") if isinstance(provenance_status.get("payload"), dict) else {}
+    if isinstance(provenance_payload, dict):
+        payload_schema = str(provenance_payload.get("payload_schema") or "")
+    return {
+        "kind": "agentic-workspace/installed-state-action-state/v1",
+        "state": state,
+        "status": state,
+        "reason": reason,
+        "repo_payload_authority": "repo-state-authoritative",
+        "invoked_cli_role": "compatibility-evaluator-and-projection-source",
+        "compatibility_basis": {
+            "payload_schema": payload_schema or WORKSPACE_PAYLOAD_SCHEMA,
+            "current_supported_payload_schema": WORKSPACE_PAYLOAD_SCHEMA,
+            "schema_compatible": payload_schema in {"", WORKSPACE_PAYLOAD_SCHEMA} and str(provenance_status.get("status", "")) != "invalid",
+            "version_match_required": False,
+            "payload_provenance_drift": payload_provenance_drift,
+            "cli_compatibility_status": cli_status,
+        },
+        "repair_mechanism": "upgrade"
+        if sync_available
+        else "manual-review"
+        if manual_review
+        else "select-compatible-cli"
+        if blocking
+        else "none",
+        "action_id": "sync-installed-payload-from-invoked-cli"
+        if sync_available
+        else "review-installed-state-manually"
+        if manual_review
+        else "select-compatible-cli-or-payload"
+        if blocking
+        else "none",
+        "command": command,
+        "dry_run_command": dry_run_sync_command if sync_available else "",
+        "apply_command": apply_sync_command if sync_available else "",
+        "safe_to_apply": sync_available,
+        "mutates_on_start": False,
+        "package_owned_surfaces": [
+            WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
+            *[relative.as_posix() for relative in WORKSPACE_PAYLOAD_FILES],
+            *[str(surface) for surface in stale_generated_surfaces],
+        ]
+        if sync_available
+        else [],
+        "manual_review_surfaces": ["invoked_cli_identity", WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix()]
+        if manual_review or blocking
+        else [],
+        "rule": (
+            "Installed-state actions are classified from repo-authoritative payload contract state; "
+            "the invoked CLI may propose explicit package-owned sync but start never mutates the repo."
+        ),
     }
 
 
@@ -1027,35 +1122,41 @@ def _installed_state_compatibility_payload(
     elif installed_version and _version_key(installed_version) < _version_key(__version__):
         payload_provenance_drift = "payload-installed-by-older-aw"
     if cli_payload.get("status") == "blocking-drift":
+        action_state_name = "blocking_incompatible"
         status = "blocking-drift"
         next_action = cli_payload.get("remediation", {}).get("command") or config.cli_invoke
         reason = "executable compatibility is blocking"
     elif payload_provenance_drift == "executable-too-old":
+        action_state_name = "blocking_incompatible"
         status = "blocking-drift"
         next_action = config.cli_invoke
         reason = "repo payload provenance was installed by a newer AW version than the current executable"
     elif stale_generated_surfaces:
+        action_state_name = "safe_payload_sync_available"
         status = "payload-upgrade-required"
         next_action = _command_with_cli_invoke(
             command=f"agentic-workspace upgrade --target {target_root.as_posix()} --dry-run --format json",
             cli_invoke=config.cli_invoke,
         )
         reason = "module-managed or generated payload surfaces are stale"
-    elif payload_provenance_drift in {"missing-provenance", "invalid-provenance", "payload-installed-by-older-aw"}:
+    elif payload_provenance_drift in {"missing-provenance", "invalid-provenance"}:
+        action_state_name = "safe_payload_sync_available"
         status = "payload-upgrade-required"
         next_action = _command_with_cli_invoke(
             command=f"agentic-workspace upgrade --target {target_root.as_posix()} --dry-run --format json",
             cli_invoke=config.cli_invoke,
         )
-        reason = "repo payload provenance must be synced before strong installed-state compatibility claims"
+        reason = "repo payload provenance needs an explicit package-owned sync"
     elif cli_payload.get("status") == "advisory-drift":
+        action_state_name = "manual_review_required"
         status = "upgrade-recommended"
         next_action = cli_payload.get("remediation", {}).get("command") or config.cli_invoke
         reason = "executable compatibility drift is advisory"
     else:
+        action_state_name = "no_repair_needed"
         status = "compatible"
         next_action = None
-        reason = "no executable or payload drift detected by current compatibility checks"
+        reason = "repo payload contract is compatible; provenance version drift alone does not require sync"
     executable_class = "compatible"
     if failed_cli_checks & {"exact_version", "minimum_version"}:
         executable_class = "executable-too-old-or-wrong-version"
@@ -1065,9 +1166,6 @@ def _installed_state_compatibility_payload(
         executable_class = "use-repo-runner-required"
     elif cli_payload.get("status") == "advisory-drift":
         executable_class = "upgrade-recommended"
-    generated_status = "stale" if stale_generated_surfaces else "compatible"
-    payload_status = "sync-required" if stale_generated_surfaces or payload_provenance_drift != "none" else "observed-compatible"
-    action_effect = _installed_state_action_effect(status=status, next_action=next_action, config=config)
     dry_run_sync_command = _command_with_cli_invoke(
         command=f"agentic-workspace upgrade --target {target_root.as_posix()} --dry-run --format json",
         cli_invoke=config.cli_invoke,
@@ -1076,11 +1174,32 @@ def _installed_state_compatibility_payload(
         command=f"agentic-workspace upgrade --target {target_root.as_posix()} --format json",
         cli_invoke=config.cli_invoke,
     )
+    action_state = _installed_state_action_state_packet(
+        state=action_state_name,
+        reason=reason,
+        target_root=target_root,
+        config=config,
+        payload_provenance_drift=payload_provenance_drift,
+        provenance_status=provenance_status,
+        stale_generated_surfaces=stale_generated_surfaces,
+        cli_status=str(cli_payload.get("status") or ""),
+    )
+    generated_status = "stale" if stale_generated_surfaces else "compatible"
+    if action_state_name == "safe_payload_sync_available":
+        payload_status = "sync-required"
+    elif action_state_name == "manual_review_required":
+        payload_status = "manual-review-required"
+    elif action_state_name == "blocking_incompatible":
+        payload_status = "incompatible"
+    else:
+        payload_status = "observed-compatible"
+    action_effect = _installed_state_action_effect(status=status, next_action=next_action, config=config, action_state=action_state)
     payload: dict[str, Any] = {
         "kind": "agentic-workspace/installed-state-compatibility/v1",
         "status": status,
         "reason": reason,
         "authority": "repo-state-authoritative",
+        "action_state": action_state,
         "executable": {
             "package": "agentic-workspace",
             "version": __version__,
@@ -1133,11 +1252,20 @@ def _installed_state_compatibility_payload(
         ],
         "next_action": next_action,
         "repair_route": {
-            "status": "available" if status == "payload-upgrade-required" else "not-required",
+            "status": "available"
+            if action_state_name == "safe_payload_sync_available"
+            else "manual-review-required"
+            if action_state_name == "manual_review_required"
+            else "blocking"
+            if action_state_name == "blocking_incompatible"
+            else "not-required",
+            "action_state": action_state_name,
+            "action_id": action_state["action_id"],
+            "repair_mechanism": action_state["repair_mechanism"],
             "dry_run_command": dry_run_sync_command,
             "apply_command": apply_sync_command,
             "waiver": {
-                "allowed": status == "payload-upgrade-required",
+                "allowed": action_state_name == "safe_payload_sync_available",
                 "claim": "source-behavior-validated-installed-payload-freshness-unproven",
                 "rule": "A waiver can keep narrow source work moving, but final reporting must not claim installed payload freshness.",
             },
@@ -1153,6 +1281,7 @@ def _installed_state_compatibility_payload(
             "kind": payload["kind"],
             "status": payload["status"],
             "authority": payload["authority"],
+            "action_state": payload["action_state"],
             "executable": {
                 key: payload["executable"][key]
                 for key in ("compatibility_status", "classification", "failed_checks")
@@ -23248,6 +23377,7 @@ def _apply_lane_shaping_gate_to_start_payload(
 
 
 def _compact_startup_installed_state_signal(installed_state: dict[str, Any]) -> dict[str, Any]:
+    action_state = _as_dict(installed_state.get("action_state"))
     executable = _as_dict(installed_state.get("executable"))
     payload = _as_dict(installed_state.get("payload"))
     generated_artifacts = _as_dict(installed_state.get("generated_artifacts"))
@@ -23256,6 +23386,23 @@ def _compact_startup_installed_state_signal(installed_state: dict[str, Any]) -> 
         "status": installed_state.get("status", ""),
         "reason": installed_state.get("reason", ""),
         "authority": installed_state.get("authority", "repo-state-authoritative"),
+        "action_state": {
+            key: action_state.get(key)
+            for key in (
+                "kind",
+                "state",
+                "status",
+                "reason",
+                "repair_mechanism",
+                "action_id",
+                "command",
+                "dry_run_command",
+                "apply_command",
+                "safe_to_apply",
+                "mutates_on_start",
+            )
+            if action_state.get(key) not in (None, "", [], {})
+        },
         "executable": {
             key: executable.get(key)
             for key in ("compatibility_status", "classification", "failed_checks")
@@ -24862,6 +25009,18 @@ def _installed_state_drift_triage_payload(
     *, installed_state: dict[str, Any], task_text: str | None, changed_paths: Sequence[str], cli_invoke: str
 ) -> dict[str, Any]:
     status = str(installed_state.get("status") or "compatible")
+    action_state = installed_state.get("action_state", {}) if isinstance(installed_state.get("action_state"), dict) else {}
+    action_state_name = str(action_state.get("state") or "")
+    if not action_state_name:
+        action_state_name = (
+            "safe_payload_sync_available"
+            if status == "payload-upgrade-required"
+            else "blocking_incompatible"
+            if status == "blocking-drift"
+            else "manual_review_required"
+            if status == "upgrade-recommended"
+            else "no_repair_needed"
+        )
     action_effect = installed_state.get("action_effect", {}) if isinstance(installed_state.get("action_effect"), dict) else {}
     force = str(action_effect.get("force") or "advisory")
     task = " ".join(str(task_text or "").lower().split())
@@ -24881,9 +25040,9 @@ def _installed_state_drift_triage_payload(
     )
     claim_relevant_paths = _installed_state_drift_relevant_changed_paths(changed_paths)
     claim_relevant = bool(claim_relevant_paths) or any(term in task for term in freshness_terms)
-    if status == "compatible":
+    if action_state_name == "no_repair_needed" or status == "compatible":
         triage = "not_applicable"
-    elif force == "required_before_execution":
+    elif action_state_name == "blocking_incompatible" or force == "required_before_execution":
         triage = "claim_blocking"
     elif claim_relevant:
         triage = "actionable_now"
@@ -24898,6 +25057,23 @@ def _installed_state_drift_triage_payload(
         "kind": "agentic-workspace/installed-state-drift-triage/v1",
         "status": triage,
         "installed_state_status": status,
+        "action_state": {
+            key: action_state.get(key)
+            for key in (
+                "kind",
+                "state",
+                "status",
+                "reason",
+                "repair_mechanism",
+                "action_id",
+                "command",
+                "dry_run_command",
+                "apply_command",
+                "safe_to_apply",
+                "mutates_on_start",
+            )
+            if action_state.get(key) not in (None, "", [], {})
+        },
         "force": force,
         "claim_relevant": claim_relevant,
         "claim_relevant_paths": claim_relevant_paths,
@@ -24920,6 +25096,7 @@ def _compact_installed_state_drift_triage(triage: Any) -> dict[str, Any]:
             "kind",
             "status",
             "installed_state_status",
+            "action_state",
             "force",
             "claim_relevant",
             "claim_relevant_paths",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -670,13 +670,14 @@ def _write_payload_provenance_action(*, target_root: Path, dry_run: bool) -> dic
     payload = _payload_provenance_payload(target_root=target_root)
     if existing_payload is not None and _stable_payload_provenance(existing_payload) == _stable_payload_provenance(payload):
         return {"kind": "current", "path": relative.as_posix(), "detail": "payload provenance already current"}
-    if existing_payload is not None and not _validate_payload_provenance(existing_payload):
+    existing_validation_errors = _validate_payload_provenance(existing_payload) if existing_payload is not None else []
+    if existing_payload is not None and not existing_validation_errors:
         existing_payload_files = existing_payload.get("payload_files")
         if existing_payload.get("payload_schema") == WORKSPACE_PAYLOAD_SCHEMA and existing_payload_files == payload["payload_files"]:
             return {
                 "kind": "current",
                 "path": relative.as_posix(),
-                "detail": "payload provenance schema and managed file set are compatible; installer identity drift does not require rewrite",
+                "detail": "valid payload provenance schema and managed file set are compatible; installer identity drift does not require rewrite",
             }
     if existing_payload is not None and existing_payload.get("installed_at"):
         payload["installed_at"] = existing_payload["installed_at"]

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -564,6 +564,14 @@ def _write_payload_provenance_action(*, target_root: Path, dry_run: bool) -> dic
     payload = _payload_provenance_payload(target_root=target_root)
     if existing_payload is not None and _stable_payload_provenance(existing_payload) == _stable_payload_provenance(payload):
         return {"kind": "current", "path": relative.as_posix(), "detail": "payload provenance already current"}
+    if existing_payload is not None and not _validate_payload_provenance(existing_payload):
+        existing_payload_files = existing_payload.get("payload_files")
+        if existing_payload.get("payload_schema") == WORKSPACE_PAYLOAD_SCHEMA and existing_payload_files == payload["payload_files"]:
+            return {
+                "kind": "current",
+                "path": relative.as_posix(),
+                "detail": "payload provenance schema and managed file set are compatible; installer identity drift does not require rewrite",
+            }
     if existing_payload is not None and existing_payload.get("installed_at"):
         payload["installed_at"] = existing_payload["installed_at"]
     rendered_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
@@ -845,9 +853,17 @@ def _cli_compatibility_remediation(
     }
 
 
-def _installed_state_action_effect(*, status: str, next_action: str | None, config: WorkspaceConfig) -> dict[str, Any]:
-    resolution_command = next_action or config.cli_invoke
-    if status == "blocking-drift":
+def _installed_state_action_effect(
+    *,
+    status: str,
+    next_action: str | None,
+    config: WorkspaceConfig,
+    action_state: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    action_state = action_state if isinstance(action_state, dict) else {}
+    state = str(action_state.get("state") or "")
+    resolution_command = str(action_state.get("dry_run_command") or action_state.get("command") or next_action or config.cli_invoke)
+    if state == "blocking_incompatible" or status == "blocking-drift":
         return {
             "force": "required_before_execution",
             "allowed_now": "switch-to-compatible-invocation-before-running-workspace-actions",
@@ -856,16 +872,16 @@ def _installed_state_action_effect(*, status: str, next_action: str | None, conf
             "resolution_selector": "installed_state_compatibility",
             "resolution_command": resolution_command,
         }
-    if status == "payload-upgrade-required":
+    if state == "safe_payload_sync_available" or status == "payload-upgrade-required":
         return {
             "force": "required_before_claim",
-            "allowed_now": "continue-bounded-work-with-repo-local-invocation",
+            "allowed_now": "continue-bounded-work-with-compatible-claim-limits",
             "blocked_until_reconciled": ["claim-installed-state-fresh", "claim-payload-synced", "claim-generated-surfaces-current"],
             "claim_boundary": "do-not-claim-local-installed-state-or-generated-payload-freshness-before-running-the-sync-check",
             "resolution_selector": "installed_state_compatibility",
             "resolution_command": resolution_command,
         }
-    if status == "upgrade-recommended":
+    if state == "manual_review_required" or status == "upgrade-recommended":
         return {
             "force": "advisory",
             "allowed_now": "continue-bounded-work-with-compatible-claim-limits",
@@ -881,6 +897,85 @@ def _installed_state_action_effect(*, status: str, next_action: str | None, conf
         "claim_boundary": "installed-state-compatible-does-not-replace-task-proof-or-acceptance-reconciliation",
         "resolution_selector": "installed_state_compatibility",
         "resolution_command": resolution_command,
+    }
+
+
+def _installed_state_action_state_packet(
+    *,
+    state: str,
+    reason: str,
+    target_root: Path,
+    config: WorkspaceConfig,
+    payload_provenance_drift: str,
+    provenance_status: dict[str, Any],
+    stale_generated_surfaces: Sequence[str],
+    cli_status: str,
+) -> dict[str, Any]:
+    target = target_root.as_posix()
+    dry_run_sync_command = _command_with_cli_invoke(
+        command=f"agentic-workspace upgrade --target {target} --dry-run --format json",
+        cli_invoke=config.cli_invoke,
+    )
+    apply_sync_command = _command_with_cli_invoke(
+        command=f"agentic-workspace upgrade --target {target} --format json",
+        cli_invoke=config.cli_invoke,
+    )
+    sync_available = state == "safe_payload_sync_available"
+    manual_review = state == "manual_review_required"
+    blocking = state == "blocking_incompatible"
+    command = dry_run_sync_command if sync_available else config.cli_invoke if blocking or manual_review else ""
+    payload_schema = ""
+    provenance_payload = provenance_status.get("payload") if isinstance(provenance_status.get("payload"), dict) else {}
+    if isinstance(provenance_payload, dict):
+        payload_schema = str(provenance_payload.get("payload_schema") or "")
+    return {
+        "kind": "agentic-workspace/installed-state-action-state/v1",
+        "state": state,
+        "status": state,
+        "reason": reason,
+        "repo_payload_authority": "repo-state-authoritative",
+        "invoked_cli_role": "compatibility-evaluator-and-projection-source",
+        "compatibility_basis": {
+            "payload_schema": payload_schema or WORKSPACE_PAYLOAD_SCHEMA,
+            "current_supported_payload_schema": WORKSPACE_PAYLOAD_SCHEMA,
+            "schema_compatible": payload_schema in {"", WORKSPACE_PAYLOAD_SCHEMA} and str(provenance_status.get("status", "")) != "invalid",
+            "version_match_required": False,
+            "payload_provenance_drift": payload_provenance_drift,
+            "cli_compatibility_status": cli_status,
+        },
+        "repair_mechanism": "upgrade"
+        if sync_available
+        else "manual-review"
+        if manual_review
+        else "select-compatible-cli"
+        if blocking
+        else "none",
+        "action_id": "sync-installed-payload-from-invoked-cli"
+        if sync_available
+        else "review-installed-state-manually"
+        if manual_review
+        else "select-compatible-cli-or-payload"
+        if blocking
+        else "none",
+        "command": command,
+        "dry_run_command": dry_run_sync_command if sync_available else "",
+        "apply_command": apply_sync_command if sync_available else "",
+        "safe_to_apply": sync_available,
+        "mutates_on_start": False,
+        "package_owned_surfaces": [
+            WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
+            *[relative.as_posix() for relative in WORKSPACE_PAYLOAD_FILES],
+            *[str(surface) for surface in stale_generated_surfaces],
+        ]
+        if sync_available
+        else [],
+        "manual_review_surfaces": ["invoked_cli_identity", WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix()]
+        if manual_review or blocking
+        else [],
+        "rule": (
+            "Installed-state actions are classified from repo-authoritative payload contract state; "
+            "the invoked CLI may propose explicit package-owned sync but start never mutates the repo."
+        ),
     }
 
 
@@ -921,35 +1016,41 @@ def _installed_state_compatibility_payload(
     elif installed_version and _version_key(installed_version) < _version_key(__version__):
         payload_provenance_drift = "payload-installed-by-older-aw"
     if cli_payload.get("status") == "blocking-drift":
+        action_state_name = "blocking_incompatible"
         status = "blocking-drift"
         next_action = cli_payload.get("remediation", {}).get("command") or config.cli_invoke
         reason = "executable compatibility is blocking"
     elif payload_provenance_drift == "executable-too-old":
+        action_state_name = "blocking_incompatible"
         status = "blocking-drift"
         next_action = config.cli_invoke
         reason = "repo payload provenance was installed by a newer AW version than the current executable"
     elif stale_generated_surfaces:
+        action_state_name = "safe_payload_sync_available"
         status = "payload-upgrade-required"
         next_action = _command_with_cli_invoke(
             command=f"agentic-workspace upgrade --target {target_root.as_posix()} --dry-run --format json",
             cli_invoke=config.cli_invoke,
         )
         reason = "module-managed or generated payload surfaces are stale"
-    elif payload_provenance_drift in {"missing-provenance", "invalid-provenance", "payload-installed-by-older-aw"}:
+    elif payload_provenance_drift in {"missing-provenance", "invalid-provenance"}:
+        action_state_name = "safe_payload_sync_available"
         status = "payload-upgrade-required"
         next_action = _command_with_cli_invoke(
             command=f"agentic-workspace upgrade --target {target_root.as_posix()} --dry-run --format json",
             cli_invoke=config.cli_invoke,
         )
-        reason = "repo payload provenance must be synced before strong installed-state compatibility claims"
+        reason = "repo payload provenance needs an explicit package-owned sync"
     elif cli_payload.get("status") == "advisory-drift":
+        action_state_name = "manual_review_required"
         status = "upgrade-recommended"
         next_action = cli_payload.get("remediation", {}).get("command") or config.cli_invoke
         reason = "executable compatibility drift is advisory"
     else:
+        action_state_name = "no_repair_needed"
         status = "compatible"
         next_action = None
-        reason = "no executable or payload drift detected by current compatibility checks"
+        reason = "repo payload contract is compatible; provenance version drift alone does not require sync"
     executable_class = "compatible"
     if failed_cli_checks & {"exact_version", "minimum_version"}:
         executable_class = "executable-too-old-or-wrong-version"
@@ -959,9 +1060,6 @@ def _installed_state_compatibility_payload(
         executable_class = "use-repo-runner-required"
     elif cli_payload.get("status") == "advisory-drift":
         executable_class = "upgrade-recommended"
-    generated_status = "stale" if stale_generated_surfaces else "compatible"
-    payload_status = "sync-required" if stale_generated_surfaces or payload_provenance_drift != "none" else "observed-compatible"
-    action_effect = _installed_state_action_effect(status=status, next_action=next_action, config=config)
     dry_run_sync_command = _command_with_cli_invoke(
         command=f"agentic-workspace upgrade --target {target_root.as_posix()} --dry-run --format json",
         cli_invoke=config.cli_invoke,
@@ -970,11 +1068,32 @@ def _installed_state_compatibility_payload(
         command=f"agentic-workspace upgrade --target {target_root.as_posix()} --format json",
         cli_invoke=config.cli_invoke,
     )
+    action_state = _installed_state_action_state_packet(
+        state=action_state_name,
+        reason=reason,
+        target_root=target_root,
+        config=config,
+        payload_provenance_drift=payload_provenance_drift,
+        provenance_status=provenance_status,
+        stale_generated_surfaces=stale_generated_surfaces,
+        cli_status=str(cli_payload.get("status") or ""),
+    )
+    generated_status = "stale" if stale_generated_surfaces else "compatible"
+    if action_state_name == "safe_payload_sync_available":
+        payload_status = "sync-required"
+    elif action_state_name == "manual_review_required":
+        payload_status = "manual-review-required"
+    elif action_state_name == "blocking_incompatible":
+        payload_status = "incompatible"
+    else:
+        payload_status = "observed-compatible"
+    action_effect = _installed_state_action_effect(status=status, next_action=next_action, config=config, action_state=action_state)
     payload: dict[str, Any] = {
         "kind": "agentic-workspace/installed-state-compatibility/v1",
         "status": status,
         "reason": reason,
         "authority": "repo-state-authoritative",
+        "action_state": action_state,
         "executable": {
             "package": "agentic-workspace",
             "version": __version__,
@@ -1027,11 +1146,20 @@ def _installed_state_compatibility_payload(
         ],
         "next_action": next_action,
         "repair_route": {
-            "status": "available" if status == "payload-upgrade-required" else "not-required",
+            "status": "available"
+            if action_state_name == "safe_payload_sync_available"
+            else "manual-review-required"
+            if action_state_name == "manual_review_required"
+            else "blocking"
+            if action_state_name == "blocking_incompatible"
+            else "not-required",
+            "action_state": action_state_name,
+            "action_id": action_state["action_id"],
+            "repair_mechanism": action_state["repair_mechanism"],
             "dry_run_command": dry_run_sync_command,
             "apply_command": apply_sync_command,
             "waiver": {
-                "allowed": status == "payload-upgrade-required",
+                "allowed": action_state_name == "safe_payload_sync_available",
                 "claim": "source-behavior-validated-installed-payload-freshness-unproven",
                 "rule": "A waiver can keep narrow source work moving, but final reporting must not claim installed payload freshness.",
             },
@@ -1047,6 +1175,7 @@ def _installed_state_compatibility_payload(
             "kind": payload["kind"],
             "status": payload["status"],
             "authority": payload["authority"],
+            "action_state": payload["action_state"],
             "executable": {
                 key: payload["executable"][key]
                 for key in ("compatibility_status", "classification", "failed_checks")
@@ -7960,11 +8089,14 @@ def _payload_doctor_closure_plan(
     source_checkout = _is_agentic_workspace_source_checkout(target_root)
     payload_state = installed_state_compatibility.get("payload", {})
     payload_state = payload_state if isinstance(payload_state, dict) else {}
+    action_state = installed_state_compatibility.get("action_state", {})
+    action_state = action_state if isinstance(action_state, dict) else {}
+    action_state_name = str(action_state.get("state") or "no_repair_needed")
     payload_status = str(payload_state.get("status", "unknown"))
     provenance = payload_state.get("provenance", {})
     provenance_status = str(provenance.get("status", "unknown")) if isinstance(provenance, dict) else "unknown"
     provenance_drift = str(payload_state.get("provenance_drift", "unknown"))
-    installed_payload_needs_sync = payload_status == "sync-required" or provenance_drift not in {"none", "unknown"}
+    installed_payload_needs_sync = action_state_name == "safe_payload_sync_available" or payload_status == "sync-required"
     scratch_repos = _local_scratch_nested_repo_paths(target_root=target_root)
     installed_lane_proof_commands = [
         _command_with_cli_invoke(command=f"agentic-workspace doctor --target {target} --format json", cli_invoke=cli_invoke),
@@ -7997,7 +8129,8 @@ def _payload_doctor_closure_plan(
     surface_classes = [
         {
             "id": "installed_payload",
-            "status": "sync-required" if installed_payload_needs_sync else "compatible",
+            "status": action_state_name if action_state_name != "no_repair_needed" else "compatible",
+            "action_state": action_state,
             "dry_run_command": installed_dry_run,
             "apply_command": installed_apply,
             "rule": "Sync installed target-repo payload before claiming doctor compatibility.",
@@ -8135,6 +8268,7 @@ def _payload_doctor_closure_plan(
         "kind": "agentic-workspace/payload-doctor-closure-plan/v1",
         "command": command_name,
         "status": plan_status,
+        "action_state": action_state,
         "target_root": target,
         "selected_modules": list(selected_modules),
         "source_checkout": source_checkout,
@@ -22235,6 +22369,7 @@ def _apply_lane_shaping_gate_to_start_payload(
 
 
 def _compact_startup_installed_state_signal(installed_state: dict[str, Any]) -> dict[str, Any]:
+    action_state = _as_dict(installed_state.get("action_state"))
     executable = _as_dict(installed_state.get("executable"))
     payload = _as_dict(installed_state.get("payload"))
     generated_artifacts = _as_dict(installed_state.get("generated_artifacts"))
@@ -22243,6 +22378,23 @@ def _compact_startup_installed_state_signal(installed_state: dict[str, Any]) -> 
         "status": installed_state.get("status", ""),
         "reason": installed_state.get("reason", ""),
         "authority": installed_state.get("authority", "repo-state-authoritative"),
+        "action_state": {
+            key: action_state.get(key)
+            for key in (
+                "kind",
+                "state",
+                "status",
+                "reason",
+                "repair_mechanism",
+                "action_id",
+                "command",
+                "dry_run_command",
+                "apply_command",
+                "safe_to_apply",
+                "mutates_on_start",
+            )
+            if action_state.get(key) not in (None, "", [], {})
+        },
         "executable": {
             key: executable.get(key)
             for key in ("compatibility_status", "classification", "failed_checks")
@@ -23758,6 +23910,18 @@ def _installed_state_drift_triage_payload(
     *, installed_state: dict[str, Any], task_text: str | None, changed_paths: Sequence[str], cli_invoke: str
 ) -> dict[str, Any]:
     status = str(installed_state.get("status") or "compatible")
+    action_state = installed_state.get("action_state", {}) if isinstance(installed_state.get("action_state"), dict) else {}
+    action_state_name = str(action_state.get("state") or "")
+    if not action_state_name:
+        action_state_name = (
+            "safe_payload_sync_available"
+            if status == "payload-upgrade-required"
+            else "blocking_incompatible"
+            if status == "blocking-drift"
+            else "manual_review_required"
+            if status == "upgrade-recommended"
+            else "no_repair_needed"
+        )
     action_effect = installed_state.get("action_effect", {}) if isinstance(installed_state.get("action_effect"), dict) else {}
     force = str(action_effect.get("force") or "advisory")
     task = " ".join(str(task_text or "").lower().split())
@@ -23777,9 +23941,9 @@ def _installed_state_drift_triage_payload(
     )
     claim_relevant_paths = _installed_state_drift_relevant_changed_paths(changed_paths)
     claim_relevant = bool(claim_relevant_paths) or any(term in task for term in freshness_terms)
-    if status == "compatible":
+    if action_state_name == "no_repair_needed" or status == "compatible":
         triage = "not_applicable"
-    elif force == "required_before_execution":
+    elif action_state_name == "blocking_incompatible" or force == "required_before_execution":
         triage = "claim_blocking"
     elif claim_relevant:
         triage = "actionable_now"
@@ -23794,6 +23958,23 @@ def _installed_state_drift_triage_payload(
         "kind": "agentic-workspace/installed-state-drift-triage/v1",
         "status": triage,
         "installed_state_status": status,
+        "action_state": {
+            key: action_state.get(key)
+            for key in (
+                "kind",
+                "state",
+                "status",
+                "reason",
+                "repair_mechanism",
+                "action_id",
+                "command",
+                "dry_run_command",
+                "apply_command",
+                "safe_to_apply",
+                "mutates_on_start",
+            )
+            if action_state.get(key) not in (None, "", [], {})
+        },
         "force": force,
         "claim_relevant": claim_relevant,
         "claim_relevant_paths": claim_relevant_paths,
@@ -23816,6 +23997,7 @@ def _compact_installed_state_drift_triage(triage: Any) -> dict[str, Any]:
             "kind",
             "status",
             "installed_state_status",
+            "action_state",
             "force",
             "claim_relevant",
             "claim_relevant_paths",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -564,13 +564,14 @@ def _write_payload_provenance_action(*, target_root: Path, dry_run: bool) -> dic
     payload = _payload_provenance_payload(target_root=target_root)
     if existing_payload is not None and _stable_payload_provenance(existing_payload) == _stable_payload_provenance(payload):
         return {"kind": "current", "path": relative.as_posix(), "detail": "payload provenance already current"}
-    if existing_payload is not None and not _validate_payload_provenance(existing_payload):
+    existing_validation_errors = _validate_payload_provenance(existing_payload) if existing_payload is not None else []
+    if existing_payload is not None and not existing_validation_errors:
         existing_payload_files = existing_payload.get("payload_files")
         if existing_payload.get("payload_schema") == WORKSPACE_PAYLOAD_SCHEMA and existing_payload_files == payload["payload_files"]:
             return {
                 "kind": "current",
                 "path": relative.as_posix(),
-                "detail": "payload provenance schema and managed file set are compatible; installer identity drift does not require rewrite",
+                "detail": "valid payload provenance schema and managed file set are compatible; installer identity drift does not require rewrite",
             }
     if existing_payload is not None and existing_payload.get("installed_at"):
         payload["installed_at"] = existing_payload["installed_at"]

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1455,9 +1455,14 @@ def test_start_default_compacts_noncompatible_installed_state_signal(tmp_path: P
     selected = json.loads(capsys.readouterr().out)
     full = selected["values"]["installed_state_compatibility"]
     assert full["status"] == "payload-upgrade-required"
+    assert full["action_state"]["state"] == "safe_payload_sync_available"
+    assert full["action_state"]["repair_mechanism"] == "upgrade"
+    assert full["action_state"]["safe_to_apply"] is True
+    assert full["action_state"]["mutates_on_start"] is False
+    assert "agentic-workspace upgrade" in full["action_state"]["dry_run_command"]
     assert full["payload"]["provenance"]["status"] == "invalid"
     assert full["action_effect"]["force"] == "required_before_claim"
-    assert full["action_effect"]["allowed_now"] == "continue-bounded-work-with-repo-local-invocation"
+    assert full["action_effect"]["allowed_now"] == "continue-bounded-work-with-compatible-claim-limits"
     assert full["action_effect"]["blocked_until_reconciled"] == [
         "claim-installed-state-fresh",
         "claim-payload-synced",
@@ -1466,6 +1471,107 @@ def test_start_default_compacts_noncompatible_installed_state_signal(tmp_path: P
     assert full["action_effect"]["resolution_selector"] == "installed_state_compatibility"
     assert "agentic-workspace upgrade" in full["action_effect"]["resolution_command"]
     assert full["adapter_contracts"]
+
+
+def test_start_installed_state_treats_stale_compatible_provenance_as_no_repair_needed(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    provenance_path = tmp_path / ".agentic-workspace" / "payload-provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance["release_identity"]["version"] = "0.0.1"
+    provenance["release_identity"]["tag"] = "v0.0.1"
+    provenance["installed_by"]["version"] = "0.0.1"
+    provenance["installed_by"]["source_class"] = "source-checkout"
+    provenance["installed_by"]["source"] = "local-source"
+    provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Inspect installed state",
+                "--select",
+                "installed_state_compatibility",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    compatibility = json.loads(capsys.readouterr().out)["values"]["installed_state_compatibility"]
+
+    assert compatibility["status"] == "compatible"
+    assert compatibility["payload"]["status"] == "observed-compatible"
+    assert compatibility["payload"]["provenance_drift"] == "payload-installed-by-older-aw"
+    assert compatibility["action_state"]["state"] == "no_repair_needed"
+    assert compatibility["action_state"]["compatibility_basis"]["version_match_required"] is False
+    assert compatibility["repair_route"]["status"] == "not-required"
+    assert compatibility["action_effect"]["blocked_until_reconciled"] == []
+
+
+def test_start_installed_state_blocks_newer_repo_payload_instead_of_downgrading(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    provenance_path = tmp_path / ".agentic-workspace" / "payload-provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance["release_identity"]["version"] = "999.0.0"
+    provenance["release_identity"]["tag"] = "v999.0.0"
+    provenance["installed_by"]["version"] = "999.0.0"
+    provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Inspect installed state",
+                "--select",
+                "installed_state_compatibility",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    compatibility = json.loads(capsys.readouterr().out)["values"]["installed_state_compatibility"]
+
+    assert compatibility["status"] == "blocking-drift"
+    assert compatibility["payload"]["status"] == "incompatible"
+    assert compatibility["payload"]["provenance_drift"] == "executable-too-old"
+    assert compatibility["action_state"]["state"] == "blocking_incompatible"
+    assert compatibility["action_state"]["safe_to_apply"] is False
+    assert compatibility["repair_route"]["status"] == "blocking"
+    assert compatibility["repair_route"]["waiver"]["allowed"] is False
+    assert "upgrade --target" not in compatibility["action_state"]["command"]
+
+
+def test_upgrade_dry_run_does_not_rewrite_valid_provenance_for_identity_only_drift(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    provenance_path = tmp_path / ".agentic-workspace" / "payload-provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance["release_identity"]["version"] = "0.0.1"
+    provenance["release_identity"]["tag"] = "v0.0.1"
+    provenance["installed_by"]["version"] = "0.0.1"
+    provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--dry-run", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    workspace_report = next(report for report in payload["reports"] if report["module"] == "workspace")
+    provenance_action = next(
+        action for action in workspace_report["actions"] if action["path"] == ".agentic-workspace/payload-provenance.json"
+    )
+    assert provenance_action["kind"] == "current"
+    assert "installer identity drift does not require rewrite" in provenance_action["detail"]
 
 
 def test_payload_provenance_payload_uses_portable_path_identities(tmp_path: Path) -> None:
@@ -1507,6 +1613,8 @@ def test_start_select_installed_state_blocking_drift_blocks_execution(tmp_path: 
     compatibility = json.loads(capsys.readouterr().out)["values"]["installed_state_compatibility"]
 
     assert compatibility["status"] == "blocking-drift"
+    assert compatibility["action_state"]["state"] == "blocking_incompatible"
+    assert compatibility["repair_route"]["status"] == "blocking"
     assert compatibility["executable"]["classification"] == "executable-too-old-or-wrong-version"
     assert compatibility["action_effect"]["force"] == "required_before_execution"
     assert compatibility["action_effect"]["allowed_now"] == "switch-to-compatible-invocation-before-running-workspace-actions"
@@ -1549,6 +1657,8 @@ def test_start_select_installed_state_advisory_drift_limits_currentness_claims(t
     compatibility = json.loads(capsys.readouterr().out)["values"]["installed_state_compatibility"]
 
     assert compatibility["status"] == "upgrade-recommended"
+    assert compatibility["action_state"]["state"] == "manual_review_required"
+    assert compatibility["repair_route"]["status"] == "manual-review-required"
     assert compatibility["action_effect"]["force"] == "advisory"
     assert compatibility["action_effect"]["allowed_now"] == "continue-bounded-work-with-compatible-claim-limits"
     assert compatibility["action_effect"]["blocked_until_reconciled"] == [
@@ -2184,6 +2294,9 @@ def test_start_installed_state_drift_triage_is_actionable_for_payload_claims(tmp
 
     triage = payload["context"]["installed_state_drift_triage"]
     assert triage["status"] == "actionable_now"
+    assert triage["action_state"]["state"] == "safe_payload_sync_available"
+    assert triage["action_state"]["repair_mechanism"] == "upgrade"
+    assert triage["action_state"]["mutates_on_start"] is False
     assert triage["claim_relevant"] is True
     assert "agentic-workspace upgrade" in triage["repair_command"]
     assert "installed_state_drift_triage=actionable_now" in payload["action_signals"]["changed_signals"]

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1574,6 +1574,45 @@ def test_upgrade_dry_run_does_not_rewrite_valid_provenance_for_identity_only_dri
     assert "installer identity drift does not require rewrite" in provenance_action["detail"]
 
 
+def test_upgrade_dry_run_repairs_structurally_invalid_provenance_with_matching_file_set(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    provenance_path = tmp_path / ".agentic-workspace" / "payload-provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance.pop("release_identity")
+    provenance.pop("installed_by")
+    provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--select",
+                "installed_state_compatibility",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    compatibility = json.loads(capsys.readouterr().out)["values"]["installed_state_compatibility"]
+    assert compatibility["status"] == "payload-upgrade-required"
+    assert compatibility["payload"]["provenance"]["status"] == "invalid"
+    assert compatibility["action_state"]["state"] == "safe_payload_sync_available"
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--dry-run", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    workspace_report = next(report for report in payload["reports"] if report["module"] == "workspace")
+    provenance_action = next(
+        action for action in workspace_report["actions"] if action["path"] == ".agentic-workspace/payload-provenance.json"
+    )
+    assert provenance_action["kind"] == "would update"
+
+
 def test_payload_provenance_payload_uses_portable_path_identities(tmp_path: Path) -> None:
     payload = cli._payload_provenance_payload(target_root=tmp_path)
     encoded = json.dumps(payload, sort_keys=True)

--- a/tests/test_workspace_doctor_status_cli.py
+++ b/tests/test_workspace_doctor_status_cli.py
@@ -317,6 +317,7 @@ def test_doctor_compact_payload_closure_plan_names_full_repair_lane(monkeypatch,
     payload = json.loads(capsys.readouterr().out)
     plan = payload["payload_closure_plan"]
     assert plan["kind"] == "agentic-workspace/payload-doctor-closure-plan/v1"
+    assert plan["action_state"]["state"] == "no_repair_needed"
     surface_classes = {item["id"]: item for item in plan["surface_classes"]}
     assert set(surface_classes) == {
         "installed_payload",
@@ -342,6 +343,7 @@ def test_doctor_compact_payload_closure_plan_names_full_repair_lane(monkeypatch,
     assert surface_classes["local_scratch_blockers"]["rule"] == (
         "Ignore AW local scratch contents for payload closure; cleanup remains explicitly scoped to local scratch roots."
     )
+    assert surface_classes["installed_payload"]["action_state"]["state"] == "no_repair_needed"
     assert surface_classes["provenance"]["hygiene_check"] == "make absolute-paths"
     assert surface_classes["provenance"]["hygiene_status"] == "source-checkout-required"
     proof_commands = surface_classes["proof"]["commands"]


### PR DESCRIPTION
## Summary
- Add a public installed-state `action_state` packet with `no_repair_needed`, `safe_payload_sync_available`, `manual_review_required`, and `blocking_incompatible` states.
- Route startup compaction, drift triage, repair routes, and doctor closure planning through the same classifier.
- Stop treating compatible older payload provenance as a sync requirement, and avoid provenance rewrites when only installer identity/version drifted.
- Update schemas, reference docs, primitive-family coverage, and regression tests for safe sync, stale compatible payloads, downgrade prevention, and diagnostic agreement.

Closes #2058

## Validation
- `make maintainer-surfaces`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make schema-reference-docs`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`

## Dogfood follow-up
Filed #2060 for a separate external-intent cache friction found during closeout: AW does not reuse issue evidence already fetched through structured `gh issue view`.
