### PR TITLE
Add repo-declared payload target gate

### DIFF
--- a/.agentic-workspace/config.toml
+++ b/.agentic-workspace/config.toml
@@ -93,6 +93,12 @@ enforcement = "advisory"
 source_classes = ["source-checkout"]
 target_relations = ["inside-target"]
 
+[payload]
+target_release = "source-current"
+minimum_capabilities = ["installed-state-sync-v2"]
+policy = "required-before-work"
+dogfood_latest = true
+
 [system_intent]
 sources = ["SYSTEM_INTENT.md", "README.md"]
 preferred_source = "SYSTEM_INTENT.md"

--- a/.agentic-workspace/memory/UPGRADE-SOURCE.toml
+++ b/.agentic-workspace/memory/UPGRADE-SOURCE.toml
@@ -1,5 +1,5 @@
 source_type = "git"
 source_ref = "git+https://github.com/rickardvh/agentic-workspace@master#subdirectory=packages/memory"
 source_label = "agentic-memory monorepo master"
-recorded_at = "2026-07-07"
+recorded_at = "2026-07-08"
 recommended_upgrade_after_days = 30

--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,10 +13,13 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:f6cfade0a059",
-    "version": "0.21.1"
+    "source_identity": "git:5efdd6485bb2",
+    "version": "0.23.1"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
+  "payload_capabilities": [
+    "installed-state-sync-v2"
+  ],
   "payload_files": [
     ".agentic-workspace/WORKFLOW.md",
     ".agentic-workspace/OWNERSHIP.toml",
@@ -37,8 +40,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.21.1",
-    "version": "0.21.1"
+    "tag": "v0.23.1",
+    "version": "0.23.1"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/.agentic-workspace/planning/UPGRADE-SOURCE.toml
+++ b/.agentic-workspace/planning/UPGRADE-SOURCE.toml
@@ -1,5 +1,5 @@
 source_type = "git"
 source_ref = "git+https://github.com/rickardvh/agentic-workspace@master#subdirectory=packages/planning"
 source_label = "agentic-planning monorepo master"
-recorded_at = "2026-07-07"
+recorded_at = "2026-07-08"
 recommended_upgrade_after_days = 30

--- a/.agentic-workspace/planning/execplans/archive/2059-payload-target-gate.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/2059-payload-target-gate.plan.json
@@ -1,0 +1,401 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Implement repo-declared payload target gate",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement issue #2059: repo-declared payload target policy, startup gating, explicit target-sync upgrade command, and source-repo dogfood config.",
+    "hard_constraints": "Keep scope bounded to installed payload target config/runtime/contracts, generated command/schema surfaces, focused tests, and required checked-in payload sync output.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Run focused tests and generated-surface proof, then close out the stack PR honestly.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_cli.py -q",
+      "uv run python scripts/generate/generate_command_packages.py --check",
+      "make schema-reference-docs",
+      "make test-workspace",
+      "make lint-workspace"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/config.py",
+      "src/agentic_workspace/workspace_runtime_core.py",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "src/agentic_workspace/workspace_runtime_startup.py",
+      "src/agentic_workspace/contracts/**",
+      "generated/workspace/**",
+      "docs/reference/**",
+      ".agentic-workspace/config.toml",
+      ".agentic-workspace/payload-provenance.json",
+      ".agentic-workspace/docs/**",
+      "tests/test_workspace_cli.py"
+    ],
+    "completion_criteria": [
+      "Repo config supports [payload] target_release/minimum_capabilities/policy/dogfood_latest.",
+      "Startup reports target mismatch without mutating and applies required-before-work/claim/advisory action effects.",
+      "upgrade --to-payload-target explicitly syncs managed payload/provenance to the declared target.",
+      "Source repo declares and satisfies source-current installed-state-sync-v2 before ordinary work.",
+      "Focused tests and generated-surface checks pass."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Implement issue #2059: repo-declared payload target policy, startup gating, explicit target-sync upgrade command, and source-repo dogfood config."
+  ],
+  "non_goals": [
+    "Do not redesign module update policy, CLI compatibility policy, or unrelated payload/generated surface ownership."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement issue #2059: repo-declared payload target policy, startup gating, explicit target-sync upgrade command, and source-repo dogfood config.",
+      "constraints": "Keep scope bounded to installed payload target config/runtime/contracts, generated command/schema surfaces, focused tests, and required checked-in payload sync output.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "2059-payload-target-gate",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/config.py",
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "src/agentic_workspace/workspace_runtime_startup.py",
+        "src/agentic_workspace/contracts/**",
+        "generated/workspace/**",
+        "docs/reference/**",
+        ".agentic-workspace/config.toml",
+        ".agentic-workspace/payload-provenance.json",
+        ".agentic-workspace/docs/**",
+        "tests/test_workspace_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Implement issue #2059 and publish it as a stacked PR.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Do the follow-up #2059 in a stacked PR.",
+    "inferred intended outcome": "Implement repo-declared payload target policy, startup gate, explicit sync command, source repo dogfood config, and PR it on top of #2061.",
+    "chosen concrete what": "Bounded implementation and proof for #2059.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "Config/runtime/contracts/schema/generated/docs/tests plus required checked-in payload sync surfaces.",
+    "max changed files": "About 35 files including generated docs/packages and checked-in payload sync output.",
+    "required validation commands": "uv run pytest tests/test_workspace_cli.py -q; uv run python scripts/generate/generate_command_packages.py --check; make schema-reference-docs; make test-workspace; make lint-workspace.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue from focused tests, generated checks, and closeout for #2059.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement issue #2059 and publish it as a stacked PR.",
+    "hard constraints": "Keep scope bounded to payload target policy/gating/sync and required generated/payload surfaces.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "2059-payload-target-gate",
+    "status": "completed",
+    "scope": "Repo-declared payload target gate and explicit target sync.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run focused proof and close out the active plan."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/config.py",
+    "src/agentic_workspace/workspace_runtime_core.py",
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "src/agentic_workspace/workspace_runtime_startup.py",
+    "src/agentic_workspace/contracts/**",
+    "generated/workspace/**",
+    "docs/reference/**",
+    ".agentic-workspace/config.toml",
+    ".agentic-workspace/payload-provenance.json",
+    ".agentic-workspace/docs/**",
+    "tests/test_workspace_cli.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_cli.py -q",
+    "uv run python scripts/generate/generate_command_packages.py --check",
+    "make schema-reference-docs",
+    "make test-workspace",
+    "make lint-workspace"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Repo config supports [payload] target policy.",
+    "Startup gates target mismatch according to policy without mutating.",
+    "upgrade --to-payload-target syncs provenance/capabilities explicitly.",
+    "Source repo dogfood target is declared and satisfied.",
+    "Required proof passes or residual risk is stated."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented payload target config parsing, target evaluation, target-aware action effects, startup required-before-work gate, explicit upgrade flag, schema/contracts/docs/generated surfaces, tests, and source repo dogfood config/provenance sync.",
+    "scope touched": "workspace runtime/config/contracts/generated docs/tests plus source repo managed payload sync surfaces",
+    "changed surfaces": "config loader, runtime installed-state packets, generated command packages, schema reference docs, checked-in AW payload provenance and managed docs",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed within #2059 payload target gate, explicit sync command, generated/schema surfaces, source repo dogfood config/provenance, and focused tests.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "PASS: uv run pytest tests/test_workspace_cli.py -q; make test-workspace; make lint-workspace; make maintainer-surfaces; uv run python scripts/generate/generate_command_packages.py --check; make schema-reference-docs; make typecheck; git diff --check",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Implement repo-declared payload target gate.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Implemented repo-declared payload target config and startup policy gate; upgrade --to-payload-target now syncs provenance/capabilities explicitly; source repo target is satisfied.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-08: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Implement repo-declared payload target gate.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: PASS: uv run pytest tests/test_workspace_cli.py -q; make test-workspace; make lint-workspace; make maintainer-surfaces; uv run python scripts/generate/generate_command_packages.py --check; make schema-reference-docs; make typecheck; git diff --check\nChanged surfaces: config loader, runtime installed-state packets, generated command packages, schema reference docs, checked-in AW payload provenance and managed docs\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/docs/reference/startup-context.md
+++ b/docs/reference/startup-context.md
@@ -148,6 +148,9 @@ Startup routing payload returned when an agent needs the minimum safe context fo
 | `installed_state_compatibility.action_state.command` | string | no |  | Primary command for the action when one is available. |  |  |
 | `installed_state_compatibility.action_state.dry_run_command` | string | no |  | Resolved dry-run sync command for safe package-owned repair. |  |  |
 | `installed_state_compatibility.action_state.apply_command` | string | no |  | Resolved apply sync command for safe package-owned repair. |  |  |
+| `installed_state_compatibility.action_state.recheck_command` | string | no |  | Command that rechecks installed-state compatibility after the repair command runs. |  |  |
+| `installed_state_compatibility.action_state.policy` | string | no |  | Repo-declared payload target policy that influenced this action state, when applicable. |  |  |
+| `installed_state_compatibility.action_state.payload_target` | object | no |  | Repo-declared payload target status used for this action state, when applicable. |  |  |
 | `installed_state_compatibility.action_state.safe_to_apply` | boolean | yes |  | Whether the action is bounded to package-owned sync surfaces. |  |  |
 | `installed_state_compatibility.action_state.mutates_on_start` | const `false` | yes |  | Startup may report this state but must not mutate the repo. |  |  |
 | `installed_state_compatibility.action_state.package_owned_surfaces` | array of string | no |  | Managed surfaces covered by safe sync. |  |  |

--- a/docs/reference/workspace-config.md
+++ b/docs/reference/workspace-config.md
@@ -138,6 +138,11 @@ Repo-owned Agentic Workspace configuration stored in .agentic-workspace/config.t
 | `assurance.closeout_postures.<name>.certification_limits` | array of string | no | `[]` | Domain certification limits that final claims must not exceed. |  |  |
 | `assurance.closeout_postures.<name>.notes` | string | no |  | Optional repo-local note about this posture. |  |  |
 | `assurance.test_data_policy` | object | no | `{}` | Repo-specific policy for test data, privacy, fixtures, or generated samples. |  | x-agentic-workspace-unknown-properties: "warn" |
+| `payload` | object | no | `{}` | Repo-owned installed payload target policy. Use this when the checked-in payload must be kept aligned with a release or source-checkout capability target independent of the CLI install location. |  | x-agentic-workspace-doc-role: "maintainer"<br>x-agentic-workspace-unknown-properties: "warn" |
+| `payload.target_release` | string | no |  | Desired checked-in Agentic Workspace payload release. Use source-current for source-checkout dogfooding. | `"0.24.0"`<br>`"source-current"` |  |
+| `payload.minimum_capabilities` | array of string | no | `[]` | Payload capabilities that must be present in checked-in payload provenance before the target is satisfied. | `["installed-state-sync-v2"]` |  |
+| `payload.policy` | enum `"advisory"`, `"required-before-claim"`, `"required-before-work"` | no | `"advisory"` | How strongly startup should gate work when the installed payload does not satisfy the repo-declared target. |  |  |
+| `payload.dogfood_latest` | boolean | no | `false` | For the Agentic Workspace source repo, require the checked-in payload to track the latest source-checkout payload before ordinary work. |  |  |
 | `cli_compatibility` | object | no | `{}` | Expected CLI identity and posture for commands executed in this repo. |  | x-agentic-workspace-doc-role: "maintainer"<br>x-agentic-workspace-unknown-properties: "warn" |
 | `cli_compatibility.enforcement` | enum `"off"`, `"advisory"`, `"blocking"` | no | `"off"` | How strictly CLI compatibility expectations should be enforced. |  |  |
 | `cli_compatibility.minimum_version` | string | no |  | Minimum accepted Agentic Workspace CLI version. | `"0.4.0"` |  |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -67,6 +67,9 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `installed_state_compatibility.action_state.command` | string | no |  | Primary command for the action when one is available. |  |  |
 | `installed_state_compatibility.action_state.dry_run_command` | string | no |  | Resolved dry-run sync command for safe package-owned repair. |  |  |
 | `installed_state_compatibility.action_state.apply_command` | string | no |  | Resolved apply sync command for safe package-owned repair. |  |  |
+| `installed_state_compatibility.action_state.recheck_command` | string | no |  | Command that rechecks installed-state compatibility after the repair command runs. |  |  |
+| `installed_state_compatibility.action_state.policy` | string | no |  | Repo-declared payload target policy that influenced this action state, when applicable. |  |  |
+| `installed_state_compatibility.action_state.payload_target` | object | no |  | Repo-declared payload target status used for this action state, when applicable. |  |  |
 | `installed_state_compatibility.action_state.safe_to_apply` | boolean | yes |  | Whether the action is bounded to package-owned sync surfaces. |  |  |
 | `installed_state_compatibility.action_state.mutates_on_start` | const `false` | yes |  | Startup may report this state but must not mutate the repo. |  |  |
 | `installed_state_compatibility.action_state.package_owned_surfaces` | array of string | no |  | Managed surfaces covered by safe sync. |  |  |

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -3702,6 +3702,14 @@
           ],
           "help": "Refresh only the workspace-managed .agentic-workspace local agent instructions file.",
           "name": "repair_managed_local_instructions"
+        },
+        {
+          "action": "store_true",
+          "flags": [
+            "--to-payload-target"
+          ],
+          "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target.",
+          "name": "to_payload_target"
         }
       ]
     },

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -5061,6 +5061,14 @@
             ],
             "help": "Refresh only the workspace-managed .agentic-workspace local agent instructions file.",
             "name": "repair_managed_local_instructions"
+          },
+          {
+            "action": "store_true",
+            "flags": [
+              "--to-payload-target"
+            ],
+            "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target.",
+            "name": "to_payload_target"
           }
         ]
       },

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -5061,6 +5061,14 @@
             ],
             "help": "Refresh only the workspace-managed .agentic-workspace local agent instructions file.",
             "name": "repair_managed_local_instructions"
+          },
+          {
+            "action": "store_true",
+            "flags": [
+              "--to-payload-target"
+            ],
+            "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target.",
+            "name": "to_payload_target"
           }
         ]
       },

--- a/generated/workspace/typescript/resources/operations/upgrade.lifecycle.json
+++ b/generated/workspace/typescript/resources/operations/upgrade.lifecycle.json
@@ -48,6 +48,11 @@
       "source": "cli-option"
     },
     {
+      "name": "to_payload_target",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
       "name": "format",
       "required": false,
       "source": "cli-option"

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -3763,6 +3763,14 @@ const commandDefinitions = [
           ],
           "help": "Refresh only the workspace-managed .agentic-workspace local agent instructions file.",
           "name": "repair_managed_local_instructions"
+        },
+        {
+          "action": "store_true",
+          "flags": [
+            "--to-payload-target"
+          ],
+          "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target.",
+          "name": "to_payload_target"
         }
       ]
     },

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -232,6 +232,11 @@ SUPPORTED_CLI_TARGET_RELATIONS = (
     "outside-target",
     "no-target",
 )
+SUPPORTED_PAYLOAD_TARGET_POLICIES = (
+    "advisory",
+    "required-before-claim",
+    "required-before-work",
+)
 SUPPORTED_LOCAL_HIGH_RISK_IMPACTS = (
     "advisory",
     "blocking",
@@ -470,6 +475,15 @@ class CLICompatibilityExpectation:
 
 
 @dataclass(frozen=True)
+class PayloadTargetConfig:
+    target_release: str | None
+    minimum_capabilities: tuple[str, ...]
+    policy: str
+    dogfood_latest: bool
+    source: str
+
+
+@dataclass(frozen=True)
 class WorkspaceConfig:
     target_root: Path | None
     path: Path | None
@@ -498,6 +512,7 @@ class WorkspaceConfig:
     system_intent: SystemIntentDeclaration
     assurance: AssuranceConfig
     cli_compatibility: CLICompatibilityExpectation
+    payload_target: PayloadTargetConfig
     local_override: MixedAgentLocalOverride
     warnings: tuple[str, ...] = ()
 
@@ -697,6 +712,21 @@ def _validate_version_string(*, value: Any, field: str, config_path: Path) -> st
     return normalized
 
 
+def _validate_payload_target_release(*, value: Any, config_path: Path) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise WorkspaceUsageError(f"{config_path.as_posix()} payload.target_release must be a non-empty string.")
+    normalized = value.strip()
+    if normalized == "source-current":
+        return normalized
+    if not re.match(r"^\d+(?:\.\d+){0,3}(?:[-+][A-Za-z0-9.-]+)?$", normalized):
+        raise WorkspaceUsageError(
+            f"{config_path.as_posix()} payload.target_release must be `source-current` or a simple version string like 1.2.3."
+        )
+    return normalized
+
+
 def _load_cli_compatibility_expectation(*, raw_cli_compatibility: Any, config_path: Path) -> tuple[CLICompatibilityExpectation, list[str]]:
     warnings: list[str] = []
     if raw_cli_compatibility is None:
@@ -748,6 +778,47 @@ def _load_cli_compatibility_expectation(*, raw_cli_compatibility: Any, config_pa
             target_relations=target_relations,
             command=command.strip() if isinstance(command, str) else None,
             source="repo-config" if raw_cli_compatibility else "product-default",
+        ),
+        warnings,
+    )
+
+
+def _load_payload_target_config(*, raw_payload: Any, config_path: Path) -> tuple[PayloadTargetConfig, list[str]]:
+    warnings: list[str] = []
+    if raw_payload is None:
+        raw_payload = {}
+    if not isinstance(raw_payload, dict):
+        raise WorkspaceUsageError(f"{config_path.as_posix()} [payload] section must be a table.")
+    supported_fields = {
+        "target_release",
+        "minimum_capabilities",
+        "policy",
+        "dogfood_latest",
+    }
+    unknown = sorted(set(raw_payload) - supported_fields)
+    if unknown:
+        warnings.append(f"{config_path.as_posix()} [payload] contains unsupported field(s): {', '.join(unknown)}.")
+    dogfood_latest = _require_bool(payload=raw_payload, key="dogfood_latest", default=False, config_path=config_path)
+    target_release = _validate_payload_target_release(value=raw_payload.get("target_release"), config_path=config_path)
+    if dogfood_latest and target_release is None:
+        target_release = "source-current"
+    return (
+        PayloadTargetConfig(
+            target_release=target_release,
+            minimum_capabilities=require_optional_string_list(
+                payload=raw_payload,
+                key="minimum_capabilities",
+                config_path=config_path,
+            ),
+            policy=require_optional_enum(
+                payload=raw_payload,
+                key="policy",
+                config_path=config_path,
+                allowed=SUPPORTED_PAYLOAD_TARGET_POLICIES,
+                default="advisory",
+            ),
+            dogfood_latest=dogfood_latest,
+            source="repo-config" if raw_payload else "product-default",
         ),
         warnings,
     )
@@ -2484,6 +2555,11 @@ def load_workspace_config(*, target_root: Path, valid_presets: set[str] | None =
         config_path=WORKSPACE_CONFIG_PATH,
     )
     warnings.extend(cli_compatibility_warnings)
+    payload_target, payload_target_warnings = _load_payload_target_config(
+        raw_payload={},
+        config_path=WORKSPACE_CONFIG_PATH,
+    )
+    warnings.extend(payload_target_warnings)
     if local_override.enabled is not None:
         enabled = local_override.enabled
         enabled_source = local_override.field_sources.get("workspace.enabled", "local-override")
@@ -2543,6 +2619,7 @@ def load_workspace_config(*, target_root: Path, valid_presets: set[str] | None =
             ),
             assurance=assurance,
             cli_compatibility=cli_compatibility,
+            payload_target=payload_target,
             local_override=local_override,
             warnings=tuple(warnings),
         )
@@ -2576,6 +2653,7 @@ def load_workspace_config(*, target_root: Path, valid_presets: set[str] | None =
             "system_intent",
             "assurance",
             "cli_compatibility",
+            "payload",
         }
     )
     if unknown_top_level:
@@ -2771,6 +2849,11 @@ def load_workspace_config(*, target_root: Path, valid_presets: set[str] | None =
         config_path=WORKSPACE_CONFIG_PATH,
     )
     warnings.extend(cli_compatibility_warnings)
+    payload_target, payload_target_warnings = _load_payload_target_config(
+        raw_payload=payload.get("payload", {}),
+        config_path=WORKSPACE_CONFIG_PATH,
+    )
+    warnings.extend(payload_target_warnings)
 
     agent_instructions_file, agent_instructions_source, detected_agent_instruction_files = resolve_effective_agent_instructions_file(
         target_root=effective_root,
@@ -2804,6 +2887,7 @@ def load_workspace_config(*, target_root: Path, valid_presets: set[str] | None =
         system_intent=system_intent,
         assurance=assurance,
         cli_compatibility=cli_compatibility,
+        payload_target=payload_target,
         local_override=local_override,
         warnings=tuple(warnings),
     )

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -2672,6 +2672,14 @@
           ],
           "action": "store_true",
           "help": "Refresh only the workspace-managed .agentic-workspace local agent instructions file."
+        },
+        {
+          "name": "to_payload_target",
+          "flags": [
+            "--to-payload-target"
+          ],
+          "action": "store_true",
+          "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target."
         }
       ],
       "role": "core_lifecycle",

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -6410,6 +6410,14 @@
                 ],
                 "action": "store_true",
                 "help": "Refresh only the workspace-managed .agentic-workspace local agent instructions file."
+              },
+              {
+                "name": "to_payload_target",
+                "flags": [
+                  "--to-payload-target"
+                ],
+                "action": "store_true",
+                "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target."
               }
             ]
           },

--- a/src/agentic_workspace/contracts/operations/upgrade.lifecycle.json
+++ b/src/agentic_workspace/contracts/operations/upgrade.lifecycle.json
@@ -38,6 +38,11 @@
       "required": false
     },
     {
+      "name": "to_payload_target",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "format",
       "source": "cli-option",
       "required": false

--- a/src/agentic_workspace/contracts/schemas/startup_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/startup_context.schema.json
@@ -1184,6 +1184,19 @@
               "type": "string",
               "description": "Resolved apply sync command for safe package-owned repair."
             },
+            "recheck_command": {
+              "type": "string",
+              "description": "Command that rechecks installed-state compatibility after the repair command runs."
+            },
+            "policy": {
+              "type": "string",
+              "description": "Repo-declared payload target policy that influenced this action state, when applicable."
+            },
+            "payload_target": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "Repo-declared payload target status used for this action state, when applicable."
+            },
             "safe_to_apply": {
               "type": "boolean",
               "description": "Whether the action is bounded to package-owned sync surfaces."

--- a/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_config.schema.json
@@ -896,6 +896,55 @@
       },
       "additionalProperties": true
     },
+    "payload": {
+      "description": "Repo-owned installed payload target policy. Use this when the checked-in payload must be kept aligned with a release or source-checkout capability target independent of the CLI install location.",
+      "type": "object",
+      "default": {},
+      "x-agentic-workspace-doc-role": "maintainer",
+      "x-agentic-workspace-unknown-properties": "warn",
+      "properties": {
+        "target_release": {
+          "description": "Desired checked-in Agentic Workspace payload release. Use source-current for source-checkout dogfooding.",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "0.24.0",
+            "source-current"
+          ]
+        },
+        "minimum_capabilities": {
+          "description": "Payload capabilities that must be present in checked-in payload provenance before the target is satisfied.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "description": "One required payload capability."
+          },
+          "uniqueItems": true,
+          "default": [],
+          "examples": [
+            [
+              "installed-state-sync-v2"
+            ]
+          ]
+        },
+        "policy": {
+          "description": "How strongly startup should gate work when the installed payload does not satisfy the repo-declared target.",
+          "enum": [
+            "advisory",
+            "required-before-claim",
+            "required-before-work"
+          ],
+          "default": "advisory"
+        },
+        "dogfood_latest": {
+          "description": "For the Agentic Workspace source repo, require the checked-in payload to track the latest source-checkout payload before ordinary work.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": true
+    },
     "cli_compatibility": {
       "description": "Expected CLI identity and posture for commands executed in this repo.",
       "type": "object",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -1432,6 +1432,19 @@
               "type": "string",
               "description": "Resolved apply sync command for safe package-owned repair."
             },
+            "recheck_command": {
+              "type": "string",
+              "description": "Command that rechecks installed-state compatibility after the repair command runs."
+            },
+            "policy": {
+              "type": "string",
+              "description": "Repo-declared payload target policy that influenced this action state, when applicable."
+            },
+            "payload_target": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "Repo-declared payload target status used for this action state, when applicable."
+            },
             "safe_to_apply": {
               "type": "boolean",
               "description": "Whether the action is bounded to package-owned sync surfaces."

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -350,6 +350,7 @@ WORKSPACE_CONFIG_SOURCE_SCHEMA = "src/agentic_workspace/contracts/schemas/worksp
 WORKSPACE_CONFIG_REFERENCE_DOC = "docs/reference/workspace-config.md"
 WORKSPACE_PAYLOAD_PROVENANCE_PATH = Path(".agentic-workspace") / "payload-provenance.json"
 WORKSPACE_PAYLOAD_SCHEMA = "agentic-workspace/payload/v1"
+SUPPORTED_PAYLOAD_CAPABILITIES = ("installed-state-sync-v2",)
 WORKSPACE_POINTER_BLOCK = workspace_pointer_block()
 SYSTEM_INTENT_MIRROR_KIND = str(_WORKSPACE_SURFACES_MANIFEST["system_intent_mirror_kind"])
 SUBSYSTEM_INTENT_KIND = str(_WORKSPACE_SURFACES_MANIFEST["subsystem_intent_kind"])
@@ -640,6 +641,7 @@ def _payload_provenance_payload(*, target_root: Path) -> dict[str, Any]:
             "version": __version__,
             "tag": f"v{__version__}",
         },
+        "payload_capabilities": list(SUPPORTED_PAYLOAD_CAPABILITIES),
         "installed_by": _payload_installer_identity(target_root=target_root),
         "command_generation": _command_generation_package_identity(target_root=target_root),
         "installed_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
@@ -655,7 +657,7 @@ def _stable_payload_provenance(payload: dict[str, Any]) -> dict[str, Any]:
     return {key: copy.deepcopy(value) for key, value in payload.items() if key != "installed_at"}
 
 
-def _write_payload_provenance_action(*, target_root: Path, dry_run: bool) -> dict[str, str]:
+def _write_payload_provenance_action(*, target_root: Path, dry_run: bool, force: bool = False) -> dict[str, str]:
     relative = WORKSPACE_PAYLOAD_PROVENANCE_PATH
     path = target_root / relative
     existing_text = path.read_text(encoding="utf-8") if path.exists() else None
@@ -668,10 +670,10 @@ def _write_payload_provenance_action(*, target_root: Path, dry_run: bool) -> dic
         if isinstance(parsed_existing, dict):
             existing_payload = parsed_existing
     payload = _payload_provenance_payload(target_root=target_root)
-    if existing_payload is not None and _stable_payload_provenance(existing_payload) == _stable_payload_provenance(payload):
+    if not force and existing_payload is not None and _stable_payload_provenance(existing_payload) == _stable_payload_provenance(payload):
         return {"kind": "current", "path": relative.as_posix(), "detail": "payload provenance already current"}
     existing_validation_errors = _validate_payload_provenance(existing_payload) if existing_payload is not None else []
-    if existing_payload is not None and not existing_validation_errors:
+    if not force and existing_payload is not None and not existing_validation_errors:
         existing_payload_files = existing_payload.get("payload_files")
         if existing_payload.get("payload_schema") == WORKSPACE_PAYLOAD_SCHEMA and existing_payload_files == payload["payload_files"]:
             return {
@@ -751,6 +753,11 @@ def _validate_payload_provenance(payload: dict[str, Any]) -> list[str]:
     payload_files = payload.get("payload_files")
     if not isinstance(payload_files, list) or not all(isinstance(item, str) and item for item in payload_files):
         errors.append("payload_files must be a list of non-empty strings")
+    capabilities = payload.get("payload_capabilities", [])
+    if capabilities is not None and (
+        not isinstance(capabilities, list) or not all(isinstance(item, str) and item.strip() for item in capabilities)
+    ):
+        errors.append("payload_capabilities must be a list of non-empty strings")
     return errors
 
 
@@ -804,6 +811,115 @@ def _version_at_least(current: str, minimum: str) -> bool:
     minimum_parts = _version_key(minimum)
     width = max(len(current_parts), len(minimum_parts), 1)
     return current_parts + (0,) * (width - len(current_parts)) >= minimum_parts + (0,) * (width - len(minimum_parts))
+
+
+def _payload_target_configured(config: WorkspaceConfig) -> bool:
+    target = config.payload_target
+    return bool(target.target_release or target.minimum_capabilities or target.dogfood_latest)
+
+
+def _payload_target_sync_commands(*, target_root: Path, config: WorkspaceConfig) -> dict[str, str]:
+    target = target_root.as_posix()
+    return {
+        "dry_run_command": _command_with_cli_invoke(
+            command=f"agentic-workspace upgrade --target {target} --to-payload-target --dry-run --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+        "apply_command": _command_with_cli_invoke(
+            command=f"agentic-workspace upgrade --target {target} --to-payload-target --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+        "recheck_command": _command_with_cli_invoke(
+            command=f"agentic-workspace start --target {target} --select installed_state_compatibility --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+    }
+
+
+def _payload_target_status_payload(
+    *,
+    config: WorkspaceConfig,
+    target_root: Path,
+    provenance_status: dict[str, Any],
+    installed_version: str,
+    current_identity: dict[str, Any],
+) -> dict[str, Any]:
+    target = config.payload_target
+    configured = _payload_target_configured(config)
+    commands = _payload_target_sync_commands(target_root=target_root, config=config)
+    provenance_payload = provenance_status.get("payload") if isinstance(provenance_status.get("payload"), dict) else {}
+    raw_capabilities = provenance_payload.get("payload_capabilities", []) if isinstance(provenance_payload, dict) else []
+    current_capabilities = [str(item) for item in raw_capabilities if isinstance(item, str) and item.strip()]
+    desired_release = target.target_release
+    target_basis = "not-configured"
+    if desired_release == "source-current":
+        resolved_release = __version__
+        target_basis = "source-current"
+    elif desired_release:
+        resolved_release = desired_release
+        target_basis = "explicit-release"
+    else:
+        resolved_release = ""
+        target_basis = "capabilities-only" if target.minimum_capabilities else "not-configured"
+    unsupported_capabilities = [
+        capability for capability in target.minimum_capabilities if capability not in SUPPORTED_PAYLOAD_CAPABILITIES
+    ]
+    if not configured:
+        status = "not-configured"
+        invoked_cli_can_satisfy = True
+        satisfied = True
+        reason = "No repo-declared payload target is configured."
+    else:
+        if unsupported_capabilities:
+            invoked_cli_can_satisfy = False
+        elif desired_release == "source-current":
+            invoked_cli_can_satisfy = current_identity.get("source_class") == "source-checkout"
+        elif desired_release:
+            invoked_cli_can_satisfy = __version__ == desired_release
+        else:
+            invoked_cli_can_satisfy = True
+        release_satisfied = not resolved_release or installed_version == resolved_release
+        capabilities_satisfied = all(capability in current_capabilities for capability in target.minimum_capabilities)
+        provenance_present = provenance_status.get("status") == "present"
+        satisfied = provenance_present and release_satisfied and capabilities_satisfied
+        if satisfied:
+            status = "satisfied"
+            reason = "Installed payload satisfies the repo-declared payload target."
+        elif not invoked_cli_can_satisfy:
+            status = "unsupported-target" if unsupported_capabilities else "compatible-cli-required"
+            reason = "The invoked CLI cannot satisfy the repo-declared payload target."
+        else:
+            status = "target-mismatch"
+            reason = "Installed payload does not satisfy the repo-declared payload target."
+    return {
+        "kind": "agentic-workspace/payload-target-status/v1",
+        "status": status,
+        "configured": configured,
+        "satisfied": satisfied,
+        "policy": target.policy,
+        "source": target.source,
+        "target_release": target.target_release,
+        "resolved_target_release": resolved_release,
+        "target_basis": target_basis,
+        "minimum_capabilities": list(target.minimum_capabilities),
+        "unsupported_capabilities": unsupported_capabilities,
+        "dogfood_latest": target.dogfood_latest,
+        "current_installed_release": installed_version,
+        "current_installed_capabilities": current_capabilities,
+        "current_supported_capabilities": list(SUPPORTED_PAYLOAD_CAPABILITIES),
+        "invoked_cli_version": __version__,
+        "invoked_cli_source_class": current_identity.get("source_class"),
+        "invoked_cli_source_identity": current_identity.get("source_identity"),
+        "invoked_cli_can_satisfy": invoked_cli_can_satisfy,
+        "dry_run_command": commands["dry_run_command"],
+        "apply_command": commands["apply_command"],
+        "recheck_command": commands["recheck_command"],
+        "reason": reason,
+        "rule": (
+            "Repo-declared payload targets compare checked-in payload provenance against a repo-owned target; "
+            "start reports the gate and only explicit upgrade --to-payload-target mutates."
+        ),
+    }
 
 
 def _cli_compatibility_payload(*, config: WorkspaceConfig, compact: bool = False) -> dict[str, Any]:
@@ -969,6 +1085,9 @@ def _installed_state_action_effect(
 ) -> dict[str, Any]:
     action_state = action_state if isinstance(action_state, dict) else {}
     state = str(action_state.get("state") or "")
+    raw_payload_target = action_state.get("payload_target")
+    payload_target = raw_payload_target if isinstance(raw_payload_target, dict) else {}
+    target_policy = str(action_state.get("policy") or payload_target.get("policy") or "")
     resolution_command = str(action_state.get("dry_run_command") or action_state.get("command") or next_action or config.cli_invoke)
     if state == "blocking_incompatible" or status == "blocking-drift":
         return {
@@ -980,11 +1099,40 @@ def _installed_state_action_effect(
             "resolution_command": resolution_command,
         }
     if state == "safe_payload_sync_available" or status == "payload-upgrade-required":
+        if target_policy == "required-before-work":
+            return {
+                "force": "required_before_execution",
+                "allowed_now": "run-payload-target-upgrade-before-ordinary-work",
+                "blocked_until_reconciled": [
+                    "run-workspace-action",
+                    "claim-installed-state-fresh",
+                    "claim-payload-target-satisfied",
+                ],
+                "claim_boundary": "repo-declared payload target must be synced before ordinary workspace work continues",
+                "resolution_selector": "installed_state_compatibility",
+                "resolution_command": resolution_command,
+            }
+        if target_policy == "advisory":
+            return {
+                "force": "advisory",
+                "allowed_now": "continue-bounded-work-with-compatible-claim-limits",
+                "blocked_until_reconciled": ["claim-payload-target-satisfied"],
+                "claim_boundary": "repo-declared payload target drift is advisory but prevents strong payload-target satisfaction claims",
+                "resolution_selector": "installed_state_compatibility",
+                "resolution_command": resolution_command,
+            }
+        blocked_until_reconciled = ["claim-installed-state-fresh", "claim-payload-synced", "claim-generated-surfaces-current"]
+        if target_policy:
+            blocked_until_reconciled.append("claim-payload-target-satisfied")
         return {
             "force": "required_before_claim",
             "allowed_now": "continue-bounded-work-with-compatible-claim-limits",
-            "blocked_until_reconciled": ["claim-installed-state-fresh", "claim-payload-synced", "claim-generated-surfaces-current"],
-            "claim_boundary": "do-not-claim-local-installed-state-or-generated-payload-freshness-before-running-the-sync-check",
+            "blocked_until_reconciled": blocked_until_reconciled,
+            "claim_boundary": (
+                "do-not-claim-local-installed-state, generated-payload freshness, or payload-target satisfaction before running the sync check"
+                if target_policy
+                else "do-not-claim-local-installed-state-or-generated-payload-freshness-before-running-the-sync-check"
+            ),
             "resolution_selector": "installed_state_compatibility",
             "resolution_command": resolution_command,
         }
@@ -1017,16 +1165,22 @@ def _installed_state_action_state_packet(
     provenance_status: dict[str, Any],
     stale_generated_surfaces: Sequence[str],
     cli_status: str,
+    payload_target: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     target = target_root.as_posix()
+    target_commands = _payload_target_sync_commands(target_root=target_root, config=config) if payload_target else {}
+    sync_to_payload_target = bool(payload_target and payload_target.get("status") == "target-mismatch")
     dry_run_sync_command = _command_with_cli_invoke(
-        command=f"agentic-workspace upgrade --target {target} --dry-run --format json",
+        command=f"agentic-workspace upgrade --target {target} {'--to-payload-target ' if sync_to_payload_target else ''}--dry-run --format json",
         cli_invoke=config.cli_invoke,
     )
     apply_sync_command = _command_with_cli_invoke(
-        command=f"agentic-workspace upgrade --target {target} --format json",
+        command=f"agentic-workspace upgrade --target {target} {'--to-payload-target ' if sync_to_payload_target else ''}--format json",
         cli_invoke=config.cli_invoke,
     )
+    if sync_to_payload_target and target_commands:
+        dry_run_sync_command = str(target_commands["dry_run_command"])
+        apply_sync_command = str(target_commands["apply_command"])
     sync_available = state == "safe_payload_sync_available"
     manual_review = state == "manual_review_required"
     blocking = state == "blocking_incompatible"
@@ -1048,16 +1202,21 @@ def _installed_state_action_state_packet(
             "schema_compatible": payload_schema in {"", WORKSPACE_PAYLOAD_SCHEMA} and str(provenance_status.get("status", "")) != "invalid",
             "version_match_required": False,
             "payload_provenance_drift": payload_provenance_drift,
+            "payload_target_status": payload_target.get("status") if isinstance(payload_target, dict) else "not-configured",
             "cli_compatibility_status": cli_status,
         },
-        "repair_mechanism": "upgrade"
+        "repair_mechanism": "payload-target-upgrade"
+        if sync_available and sync_to_payload_target
+        else "upgrade"
         if sync_available
         else "manual-review"
         if manual_review
         else "select-compatible-cli"
         if blocking
         else "none",
-        "action_id": "sync-installed-payload-from-invoked-cli"
+        "action_id": "sync-installed-payload-to-repo-target"
+        if sync_available and sync_to_payload_target
+        else "sync-installed-payload-from-invoked-cli"
         if sync_available
         else "review-installed-state-manually"
         if manual_review
@@ -1067,6 +1226,9 @@ def _installed_state_action_state_packet(
         "command": command,
         "dry_run_command": dry_run_sync_command if sync_available else "",
         "apply_command": apply_sync_command if sync_available else "",
+        "recheck_command": payload_target.get("recheck_command", "") if isinstance(payload_target, dict) else "",
+        "policy": payload_target.get("policy", "") if isinstance(payload_target, dict) else "",
+        "payload_target": payload_target or {},
         "safe_to_apply": sync_available,
         "mutates_on_start": False,
         "package_owned_surfaces": [
@@ -1122,6 +1284,13 @@ def _installed_state_compatibility_payload(
         payload_provenance_drift = "executable-too-old"
     elif installed_version and _version_key(installed_version) < _version_key(__version__):
         payload_provenance_drift = "payload-installed-by-older-aw"
+    payload_target = _payload_target_status_payload(
+        config=config,
+        target_root=target_root,
+        provenance_status=provenance_status,
+        installed_version=installed_version,
+        current_identity=current_identity,
+    )
     if cli_payload.get("status") == "blocking-drift":
         action_state_name = "blocking_incompatible"
         status = "blocking-drift"
@@ -1132,6 +1301,16 @@ def _installed_state_compatibility_payload(
         status = "blocking-drift"
         next_action = config.cli_invoke
         reason = "repo payload provenance was installed by a newer AW version than the current executable"
+    elif payload_target["configured"] and not payload_target["satisfied"] and not payload_target["invoked_cli_can_satisfy"]:
+        action_state_name = "blocking_incompatible"
+        status = "blocking-drift"
+        next_action = config.cli_invoke
+        reason = "repo-declared payload target cannot be satisfied by the invoked CLI"
+    elif payload_target["configured"] and not payload_target["satisfied"]:
+        action_state_name = "safe_payload_sync_available"
+        status = "payload-upgrade-required"
+        next_action = payload_target["dry_run_command"]
+        reason = "repo-declared payload target requires an explicit payload sync"
     elif stale_generated_surfaces:
         action_state_name = "safe_payload_sync_available"
         status = "payload-upgrade-required"
@@ -1184,6 +1363,7 @@ def _installed_state_compatibility_payload(
         provenance_status=provenance_status,
         stale_generated_surfaces=stale_generated_surfaces,
         cli_status=str(cli_payload.get("status") or ""),
+        payload_target=payload_target if payload_target["configured"] else None,
     )
     generated_status = "stale" if stale_generated_surfaces else "compatible"
     if action_state_name == "safe_payload_sync_available":
@@ -1221,15 +1401,16 @@ def _installed_state_compatibility_payload(
             "stale_generated_surfaces": stale_generated_surfaces,
             "provenance": provenance_status,
             "provenance_drift": payload_provenance_drift,
+            "target": payload_target,
             "expected_release_identity": {
                 "package": "agentic-workspace",
-                "version": __version__,
+                "version": payload_target["resolved_target_release"] or __version__,
                 "source_class": current_identity.get("source_class"),
                 "source_identity": current_identity.get("source_identity"),
             },
-            "sync_command": dry_run_sync_command,
-            "dry_run_command": dry_run_sync_command,
-            "apply_command": apply_sync_command,
+            "sync_command": action_state["dry_run_command"] or dry_run_sync_command,
+            "dry_run_command": action_state["dry_run_command"] or dry_run_sync_command,
+            "apply_command": action_state["apply_command"] or apply_sync_command,
             "rule": "Repo payload state is authoritative; stale payloads should be synced deliberately before trusting newer executables.",
         },
         "generated_artifacts": {
@@ -1263,8 +1444,8 @@ def _installed_state_compatibility_payload(
             "action_state": action_state_name,
             "action_id": action_state["action_id"],
             "repair_mechanism": action_state["repair_mechanism"],
-            "dry_run_command": dry_run_sync_command,
-            "apply_command": apply_sync_command,
+            "dry_run_command": action_state["dry_run_command"] or dry_run_sync_command,
+            "apply_command": action_state["apply_command"] or apply_sync_command,
             "waiver": {
                 "allowed": action_state_name == "safe_payload_sync_available",
                 "claim": "source-behavior-validated-installed-payload-freshness-unproven",
@@ -1298,6 +1479,7 @@ def _installed_state_compatibility_payload(
                     "stale_generated_surfaces",
                     "provenance",
                     "provenance_drift",
+                    "target",
                     "dry_run_command",
                     "apply_command",
                 )
@@ -6898,6 +7080,7 @@ def _workspace_init_or_upgrade_report(
     inspection_mode: str,
     command_name: str,
     config: WorkspaceConfig,
+    to_payload_target: bool = False,
 ) -> dict[str, Any]:
     actions: list[dict[str, str]] = []
     warnings: list[dict[str, str]] = []
@@ -6965,7 +7148,7 @@ def _workspace_init_or_upgrade_report(
                 else "refresh workspace shared-layer file from package payload",
             }
         )
-    actions.append(_write_payload_provenance_action(target_root=target_root, dry_run=dry_run))
+    actions.append(_write_payload_provenance_action(target_root=target_root, dry_run=dry_run, force=to_payload_target))
     local_agent_actions, local_agent_warnings = _sync_workspace_managed_agent_instructions(
         target_root=target_root,
         config=config,
@@ -7726,6 +7909,7 @@ def _run_lifecycle_command(
     config: WorkspaceConfig,
     compact_status: bool = True,
     module_scope_explicit: bool = False,
+    to_payload_target: bool = False,
 ) -> dict[str, Any]:
     if command_name == "upgrade" and local_only_repo_root is None and _has_local_only_workspace_state(target_root=target_root):
         local_only_repo_root = target_root
@@ -7767,6 +7951,7 @@ def _run_lifecycle_command(
                 inspection_mode="upgrade",
                 command_name=command_name,
                 config=config,
+                to_payload_target=to_payload_target,
             )
         )
     elif command_name == "install":
@@ -22820,6 +23005,13 @@ def _next_safe_action_packet(
                 "promote or create a slice before lane shaping is recorded",
             ]
         )
+    if action == "run-installed-payload-target-upgrade":
+        forbidden_actions.extend(
+            [
+                "begin ordinary workspace work before installed payload target is satisfied",
+                "claim installed payload target satisfied before recheck passes",
+            ]
+        )
     if "closeout" in action:
         forbidden_actions.append("claim completion before closeout trust is reconciled")
     if decision in {
@@ -26207,6 +26399,40 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
     }
 
 
+def _apply_installed_state_fast_start_gate(
+    *, payload: dict[str, Any], target_root: Path, config: WorkspaceConfig, startup_template: dict[str, Any]
+) -> None:
+    installed_state = payload.get("installed_state_compatibility")
+    if not isinstance(installed_state, dict):
+        return
+    action_effect = _as_dict(installed_state.get("action_effect"))
+    action_state = _as_dict(installed_state.get("action_state"))
+    payload_target = _as_dict(action_state.get("payload_target"))
+    if action_effect.get("force") != "required_before_execution" or payload_target.get("policy") != "required-before-work":
+        return
+    command = str(action_effect.get("resolution_command") or action_state.get("dry_run_command") or "")
+    recheck_command = str(action_state.get("recheck_command") or payload_target.get("recheck_command") or "")
+    payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
+        surface="start",
+        decision="installed-payload-target-required-before-work",
+        reason="Repo-declared payload target policy requires explicit sync before ordinary workspace work.",
+        required_next_action="run-installed-payload-target-upgrade",
+        evidence_required=["installed payload target recheck"],
+        hard_gate=True,
+    )
+    payload["immediate_next_allowed_action"] = {
+        "action": "run-installed-payload-target-upgrade",
+        "summary": str(installed_state.get("reason") or action_effect.get("claim_boundary") or ""),
+        "command": command,
+        "run": command,
+        "risk": "required-before-work payload target gate",
+        "required_inputs": ["target repo"],
+        "next_proof": recheck_command or f"{config.cli_invoke} start --target {target_root.as_posix()} --format json",
+        "read_first": [command] if command else [],
+        "open_execplan_only_when": startup_template["open_execplan_only_when"],
+    }
+
+
 def _start_tiny_payload_fast(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, config: WorkspaceConfig, startup_template: dict[str, Any]
 ) -> dict[str, Any]:
@@ -26395,6 +26621,12 @@ def _start_tiny_payload_fast(
             task_text=task_text,
             changed_paths=changed_paths,
             cli_invoke=config.cli_invoke,
+        )
+        _apply_installed_state_fast_start_gate(
+            payload=payload,
+            target_root=target_root,
+            config=config,
+            startup_template=startup_template,
         )
     sibling_freshness = _sibling_repo_aw_freshness_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)
     if sibling_freshness["status"] != "not-referenced":
@@ -40528,6 +40760,7 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
         non_interactive=args.non_interactive,
         config=config,
         module_scope_explicit=bool(getattr(args, "modules", None)),
+        to_payload_target=bool(getattr(args, "to_payload_target", False)),
     )
     _emit_payload(payload=payload, format_name=args.format)
     return 0
@@ -45346,6 +45579,19 @@ def _config_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
             "wrapper_rule": "normal update execution stays behind agentic-workspace",
             "modules": _module_update_policy_payload(config=config, target_root=config.target_root),
         },
+        "payload": {
+            "target_release": config.payload_target.target_release,
+            "minimum_capabilities": list(config.payload_target.minimum_capabilities),
+            "policy": config.payload_target.policy,
+            "dogfood_latest": config.payload_target.dogfood_latest,
+            "source": config.payload_target.source,
+            "supported_policies": list(config_lib.SUPPORTED_PAYLOAD_TARGET_POLICIES),
+            "supported_capabilities": list(SUPPORTED_PAYLOAD_CAPABILITIES),
+            "rule": (
+                "Repo payload target policy declares the checked-in payload release/capability state startup should require "
+                "before work or claims."
+            ),
+        },
         "assurance": {
             "default_level": assurance.default_level,
             "default_level_source": assurance.default_level_source,
@@ -45461,6 +45707,7 @@ def _compact_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "workflow_obligations": compact_obligations,
             "system_intent_sources": workspace["system_intent"]["sources"],
         },
+        "payload": payload["payload"],
         "reporting_posture": {
             "status": "present",
             "summary": "Use this compact config payload as source evidence; do not read raw config files only to cite line numbers.",

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -247,6 +247,7 @@ WORKSPACE_CONFIG_SOURCE_SCHEMA = "src/agentic_workspace/contracts/schemas/worksp
 WORKSPACE_CONFIG_REFERENCE_DOC = "docs/reference/workspace-config.md"
 WORKSPACE_PAYLOAD_PROVENANCE_PATH = Path(".agentic-workspace") / "payload-provenance.json"
 WORKSPACE_PAYLOAD_SCHEMA = "agentic-workspace/payload/v1"
+SUPPORTED_PAYLOAD_CAPABILITIES = ("installed-state-sync-v2",)
 WORKSPACE_POINTER_BLOCK = workspace_pointer_block()
 SYSTEM_INTENT_MIRROR_KIND = str(_WORKSPACE_SURFACES_MANIFEST["system_intent_mirror_kind"])
 SUBSYSTEM_INTENT_KIND = str(_WORKSPACE_SURFACES_MANIFEST["subsystem_intent_kind"])
@@ -534,6 +535,7 @@ def _payload_provenance_payload(*, target_root: Path) -> dict[str, Any]:
             "version": __version__,
             "tag": f"v{__version__}",
         },
+        "payload_capabilities": list(SUPPORTED_PAYLOAD_CAPABILITIES),
         "installed_by": _payload_installer_identity(target_root=target_root),
         "command_generation": _command_generation_package_identity(target_root=target_root),
         "installed_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
@@ -549,7 +551,7 @@ def _stable_payload_provenance(payload: dict[str, Any]) -> dict[str, Any]:
     return {key: copy.deepcopy(value) for key, value in payload.items() if key != "installed_at"}
 
 
-def _write_payload_provenance_action(*, target_root: Path, dry_run: bool) -> dict[str, str]:
+def _write_payload_provenance_action(*, target_root: Path, dry_run: bool, force: bool = False) -> dict[str, str]:
     relative = WORKSPACE_PAYLOAD_PROVENANCE_PATH
     path = target_root / relative
     existing_text = path.read_text(encoding="utf-8") if path.exists() else None
@@ -562,10 +564,10 @@ def _write_payload_provenance_action(*, target_root: Path, dry_run: bool) -> dic
         if isinstance(parsed_existing, dict):
             existing_payload = parsed_existing
     payload = _payload_provenance_payload(target_root=target_root)
-    if existing_payload is not None and _stable_payload_provenance(existing_payload) == _stable_payload_provenance(payload):
+    if not force and existing_payload is not None and _stable_payload_provenance(existing_payload) == _stable_payload_provenance(payload):
         return {"kind": "current", "path": relative.as_posix(), "detail": "payload provenance already current"}
     existing_validation_errors = _validate_payload_provenance(existing_payload) if existing_payload is not None else []
-    if existing_payload is not None and not existing_validation_errors:
+    if not force and existing_payload is not None and not existing_validation_errors:
         existing_payload_files = existing_payload.get("payload_files")
         if existing_payload.get("payload_schema") == WORKSPACE_PAYLOAD_SCHEMA and existing_payload_files == payload["payload_files"]:
             return {
@@ -645,6 +647,11 @@ def _validate_payload_provenance(payload: dict[str, Any]) -> list[str]:
     payload_files = payload.get("payload_files")
     if not isinstance(payload_files, list) or not all(isinstance(item, str) and item for item in payload_files):
         errors.append("payload_files must be a list of non-empty strings")
+    capabilities = payload.get("payload_capabilities", [])
+    if capabilities is not None and (
+        not isinstance(capabilities, list) or not all(isinstance(item, str) and item.strip() for item in capabilities)
+    ):
+        errors.append("payload_capabilities must be a list of non-empty strings")
     return errors
 
 
@@ -698,6 +705,115 @@ def _version_at_least(current: str, minimum: str) -> bool:
     minimum_parts = _version_key(minimum)
     width = max(len(current_parts), len(minimum_parts), 1)
     return current_parts + (0,) * (width - len(current_parts)) >= minimum_parts + (0,) * (width - len(minimum_parts))
+
+
+def _payload_target_configured(config: WorkspaceConfig) -> bool:
+    target = config.payload_target
+    return bool(target.target_release or target.minimum_capabilities or target.dogfood_latest)
+
+
+def _payload_target_sync_commands(*, target_root: Path, config: WorkspaceConfig) -> dict[str, str]:
+    target = target_root.as_posix()
+    return {
+        "dry_run_command": _command_with_cli_invoke(
+            command=f"agentic-workspace upgrade --target {target} --to-payload-target --dry-run --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+        "apply_command": _command_with_cli_invoke(
+            command=f"agentic-workspace upgrade --target {target} --to-payload-target --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+        "recheck_command": _command_with_cli_invoke(
+            command=f"agentic-workspace start --target {target} --select installed_state_compatibility --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+    }
+
+
+def _payload_target_status_payload(
+    *,
+    config: WorkspaceConfig,
+    target_root: Path,
+    provenance_status: dict[str, Any],
+    installed_version: str,
+    current_identity: dict[str, Any],
+) -> dict[str, Any]:
+    target = config.payload_target
+    configured = _payload_target_configured(config)
+    commands = _payload_target_sync_commands(target_root=target_root, config=config)
+    provenance_payload = provenance_status.get("payload") if isinstance(provenance_status.get("payload"), dict) else {}
+    raw_capabilities = provenance_payload.get("payload_capabilities", []) if isinstance(provenance_payload, dict) else []
+    current_capabilities = [str(item) for item in raw_capabilities if isinstance(item, str) and item.strip()]
+    desired_release = target.target_release
+    target_basis = "not-configured"
+    if desired_release == "source-current":
+        resolved_release = __version__
+        target_basis = "source-current"
+    elif desired_release:
+        resolved_release = desired_release
+        target_basis = "explicit-release"
+    else:
+        resolved_release = ""
+        target_basis = "capabilities-only" if target.minimum_capabilities else "not-configured"
+    unsupported_capabilities = [
+        capability for capability in target.minimum_capabilities if capability not in SUPPORTED_PAYLOAD_CAPABILITIES
+    ]
+    if not configured:
+        status = "not-configured"
+        invoked_cli_can_satisfy = True
+        satisfied = True
+        reason = "No repo-declared payload target is configured."
+    else:
+        if unsupported_capabilities:
+            invoked_cli_can_satisfy = False
+        elif desired_release == "source-current":
+            invoked_cli_can_satisfy = current_identity.get("source_class") == "source-checkout"
+        elif desired_release:
+            invoked_cli_can_satisfy = __version__ == desired_release
+        else:
+            invoked_cli_can_satisfy = True
+        release_satisfied = not resolved_release or installed_version == resolved_release
+        capabilities_satisfied = all(capability in current_capabilities for capability in target.minimum_capabilities)
+        provenance_present = provenance_status.get("status") == "present"
+        satisfied = provenance_present and release_satisfied and capabilities_satisfied
+        if satisfied:
+            status = "satisfied"
+            reason = "Installed payload satisfies the repo-declared payload target."
+        elif not invoked_cli_can_satisfy:
+            status = "unsupported-target" if unsupported_capabilities else "compatible-cli-required"
+            reason = "The invoked CLI cannot satisfy the repo-declared payload target."
+        else:
+            status = "target-mismatch"
+            reason = "Installed payload does not satisfy the repo-declared payload target."
+    return {
+        "kind": "agentic-workspace/payload-target-status/v1",
+        "status": status,
+        "configured": configured,
+        "satisfied": satisfied,
+        "policy": target.policy,
+        "source": target.source,
+        "target_release": target.target_release,
+        "resolved_target_release": resolved_release,
+        "target_basis": target_basis,
+        "minimum_capabilities": list(target.minimum_capabilities),
+        "unsupported_capabilities": unsupported_capabilities,
+        "dogfood_latest": target.dogfood_latest,
+        "current_installed_release": installed_version,
+        "current_installed_capabilities": current_capabilities,
+        "current_supported_capabilities": list(SUPPORTED_PAYLOAD_CAPABILITIES),
+        "invoked_cli_version": __version__,
+        "invoked_cli_source_class": current_identity.get("source_class"),
+        "invoked_cli_source_identity": current_identity.get("source_identity"),
+        "invoked_cli_can_satisfy": invoked_cli_can_satisfy,
+        "dry_run_command": commands["dry_run_command"],
+        "apply_command": commands["apply_command"],
+        "recheck_command": commands["recheck_command"],
+        "reason": reason,
+        "rule": (
+            "Repo-declared payload targets compare checked-in payload provenance against a repo-owned target; "
+            "start reports the gate and only explicit upgrade --to-payload-target mutates."
+        ),
+    }
 
 
 def _cli_compatibility_payload(*, config: WorkspaceConfig, compact: bool = False) -> dict[str, Any]:
@@ -863,6 +979,9 @@ def _installed_state_action_effect(
 ) -> dict[str, Any]:
     action_state = action_state if isinstance(action_state, dict) else {}
     state = str(action_state.get("state") or "")
+    raw_payload_target = action_state.get("payload_target")
+    payload_target = raw_payload_target if isinstance(raw_payload_target, dict) else {}
+    target_policy = str(action_state.get("policy") or payload_target.get("policy") or "")
     resolution_command = str(action_state.get("dry_run_command") or action_state.get("command") or next_action or config.cli_invoke)
     if state == "blocking_incompatible" or status == "blocking-drift":
         return {
@@ -874,11 +993,40 @@ def _installed_state_action_effect(
             "resolution_command": resolution_command,
         }
     if state == "safe_payload_sync_available" or status == "payload-upgrade-required":
+        if target_policy == "required-before-work":
+            return {
+                "force": "required_before_execution",
+                "allowed_now": "run-payload-target-upgrade-before-ordinary-work",
+                "blocked_until_reconciled": [
+                    "run-workspace-action",
+                    "claim-installed-state-fresh",
+                    "claim-payload-target-satisfied",
+                ],
+                "claim_boundary": "repo-declared payload target must be synced before ordinary workspace work continues",
+                "resolution_selector": "installed_state_compatibility",
+                "resolution_command": resolution_command,
+            }
+        if target_policy == "advisory":
+            return {
+                "force": "advisory",
+                "allowed_now": "continue-bounded-work-with-compatible-claim-limits",
+                "blocked_until_reconciled": ["claim-payload-target-satisfied"],
+                "claim_boundary": "repo-declared payload target drift is advisory but prevents strong payload-target satisfaction claims",
+                "resolution_selector": "installed_state_compatibility",
+                "resolution_command": resolution_command,
+            }
+        blocked_until_reconciled = ["claim-installed-state-fresh", "claim-payload-synced", "claim-generated-surfaces-current"]
+        if target_policy:
+            blocked_until_reconciled.append("claim-payload-target-satisfied")
         return {
             "force": "required_before_claim",
             "allowed_now": "continue-bounded-work-with-compatible-claim-limits",
-            "blocked_until_reconciled": ["claim-installed-state-fresh", "claim-payload-synced", "claim-generated-surfaces-current"],
-            "claim_boundary": "do-not-claim-local-installed-state-or-generated-payload-freshness-before-running-the-sync-check",
+            "blocked_until_reconciled": blocked_until_reconciled,
+            "claim_boundary": (
+                "do-not-claim-local-installed-state, generated-payload freshness, or payload-target satisfaction before running the sync check"
+                if target_policy
+                else "do-not-claim-local-installed-state-or-generated-payload-freshness-before-running-the-sync-check"
+            ),
             "resolution_selector": "installed_state_compatibility",
             "resolution_command": resolution_command,
         }
@@ -911,16 +1059,22 @@ def _installed_state_action_state_packet(
     provenance_status: dict[str, Any],
     stale_generated_surfaces: Sequence[str],
     cli_status: str,
+    payload_target: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     target = target_root.as_posix()
+    target_commands = _payload_target_sync_commands(target_root=target_root, config=config) if payload_target else {}
+    sync_to_payload_target = bool(payload_target and payload_target.get("status") == "target-mismatch")
     dry_run_sync_command = _command_with_cli_invoke(
-        command=f"agentic-workspace upgrade --target {target} --dry-run --format json",
+        command=f"agentic-workspace upgrade --target {target} {'--to-payload-target ' if sync_to_payload_target else ''}--dry-run --format json",
         cli_invoke=config.cli_invoke,
     )
     apply_sync_command = _command_with_cli_invoke(
-        command=f"agentic-workspace upgrade --target {target} --format json",
+        command=f"agentic-workspace upgrade --target {target} {'--to-payload-target ' if sync_to_payload_target else ''}--format json",
         cli_invoke=config.cli_invoke,
     )
+    if sync_to_payload_target and target_commands:
+        dry_run_sync_command = str(target_commands["dry_run_command"])
+        apply_sync_command = str(target_commands["apply_command"])
     sync_available = state == "safe_payload_sync_available"
     manual_review = state == "manual_review_required"
     blocking = state == "blocking_incompatible"
@@ -942,16 +1096,21 @@ def _installed_state_action_state_packet(
             "schema_compatible": payload_schema in {"", WORKSPACE_PAYLOAD_SCHEMA} and str(provenance_status.get("status", "")) != "invalid",
             "version_match_required": False,
             "payload_provenance_drift": payload_provenance_drift,
+            "payload_target_status": payload_target.get("status") if isinstance(payload_target, dict) else "not-configured",
             "cli_compatibility_status": cli_status,
         },
-        "repair_mechanism": "upgrade"
+        "repair_mechanism": "payload-target-upgrade"
+        if sync_available and sync_to_payload_target
+        else "upgrade"
         if sync_available
         else "manual-review"
         if manual_review
         else "select-compatible-cli"
         if blocking
         else "none",
-        "action_id": "sync-installed-payload-from-invoked-cli"
+        "action_id": "sync-installed-payload-to-repo-target"
+        if sync_available and sync_to_payload_target
+        else "sync-installed-payload-from-invoked-cli"
         if sync_available
         else "review-installed-state-manually"
         if manual_review
@@ -961,6 +1120,9 @@ def _installed_state_action_state_packet(
         "command": command,
         "dry_run_command": dry_run_sync_command if sync_available else "",
         "apply_command": apply_sync_command if sync_available else "",
+        "recheck_command": payload_target.get("recheck_command", "") if isinstance(payload_target, dict) else "",
+        "policy": payload_target.get("policy", "") if isinstance(payload_target, dict) else "",
+        "payload_target": payload_target or {},
         "safe_to_apply": sync_available,
         "mutates_on_start": False,
         "package_owned_surfaces": [
@@ -1016,6 +1178,13 @@ def _installed_state_compatibility_payload(
         payload_provenance_drift = "executable-too-old"
     elif installed_version and _version_key(installed_version) < _version_key(__version__):
         payload_provenance_drift = "payload-installed-by-older-aw"
+    payload_target = _payload_target_status_payload(
+        config=config,
+        target_root=target_root,
+        provenance_status=provenance_status,
+        installed_version=installed_version,
+        current_identity=current_identity,
+    )
     if cli_payload.get("status") == "blocking-drift":
         action_state_name = "blocking_incompatible"
         status = "blocking-drift"
@@ -1026,6 +1195,16 @@ def _installed_state_compatibility_payload(
         status = "blocking-drift"
         next_action = config.cli_invoke
         reason = "repo payload provenance was installed by a newer AW version than the current executable"
+    elif payload_target["configured"] and not payload_target["satisfied"] and not payload_target["invoked_cli_can_satisfy"]:
+        action_state_name = "blocking_incompatible"
+        status = "blocking-drift"
+        next_action = config.cli_invoke
+        reason = "repo-declared payload target cannot be satisfied by the invoked CLI"
+    elif payload_target["configured"] and not payload_target["satisfied"]:
+        action_state_name = "safe_payload_sync_available"
+        status = "payload-upgrade-required"
+        next_action = payload_target["dry_run_command"]
+        reason = "repo-declared payload target requires an explicit payload sync"
     elif stale_generated_surfaces:
         action_state_name = "safe_payload_sync_available"
         status = "payload-upgrade-required"
@@ -1078,6 +1257,7 @@ def _installed_state_compatibility_payload(
         provenance_status=provenance_status,
         stale_generated_surfaces=stale_generated_surfaces,
         cli_status=str(cli_payload.get("status") or ""),
+        payload_target=payload_target if payload_target["configured"] else None,
     )
     generated_status = "stale" if stale_generated_surfaces else "compatible"
     if action_state_name == "safe_payload_sync_available":
@@ -1115,15 +1295,16 @@ def _installed_state_compatibility_payload(
             "stale_generated_surfaces": stale_generated_surfaces,
             "provenance": provenance_status,
             "provenance_drift": payload_provenance_drift,
+            "target": payload_target,
             "expected_release_identity": {
                 "package": "agentic-workspace",
-                "version": __version__,
+                "version": payload_target["resolved_target_release"] or __version__,
                 "source_class": current_identity.get("source_class"),
                 "source_identity": current_identity.get("source_identity"),
             },
-            "sync_command": dry_run_sync_command,
-            "dry_run_command": dry_run_sync_command,
-            "apply_command": apply_sync_command,
+            "sync_command": action_state["dry_run_command"] or dry_run_sync_command,
+            "dry_run_command": action_state["dry_run_command"] or dry_run_sync_command,
+            "apply_command": action_state["apply_command"] or apply_sync_command,
             "rule": "Repo payload state is authoritative; stale payloads should be synced deliberately before trusting newer executables.",
         },
         "generated_artifacts": {
@@ -1157,8 +1338,8 @@ def _installed_state_compatibility_payload(
             "action_state": action_state_name,
             "action_id": action_state["action_id"],
             "repair_mechanism": action_state["repair_mechanism"],
-            "dry_run_command": dry_run_sync_command,
-            "apply_command": apply_sync_command,
+            "dry_run_command": action_state["dry_run_command"] or dry_run_sync_command,
+            "apply_command": action_state["apply_command"] or apply_sync_command,
             "waiver": {
                 "allowed": action_state_name == "safe_payload_sync_available",
                 "claim": "source-behavior-validated-installed-payload-freshness-unproven",
@@ -1192,6 +1373,7 @@ def _installed_state_compatibility_payload(
                     "stale_generated_surfaces",
                     "provenance",
                     "provenance_drift",
+                    "target",
                     "dry_run_command",
                     "apply_command",
                 )
@@ -6771,6 +6953,7 @@ def _workspace_init_or_upgrade_report(
     inspection_mode: str,
     command_name: str,
     config: WorkspaceConfig,
+    to_payload_target: bool = False,
 ) -> dict[str, Any]:
     actions: list[dict[str, str]] = []
     warnings: list[dict[str, str]] = []
@@ -6838,7 +7021,7 @@ def _workspace_init_or_upgrade_report(
                 else "refresh workspace shared-layer file from package payload",
             }
         )
-    actions.append(_write_payload_provenance_action(target_root=target_root, dry_run=dry_run))
+    actions.append(_write_payload_provenance_action(target_root=target_root, dry_run=dry_run, force=to_payload_target))
     local_agent_actions, local_agent_warnings = _sync_workspace_managed_agent_instructions(
         target_root=target_root,
         config=config,
@@ -7591,6 +7774,7 @@ def _run_lifecycle_command(
     config: WorkspaceConfig,
     compact_status: bool = True,
     module_scope_explicit: bool = False,
+    to_payload_target: bool = False,
 ) -> dict[str, Any]:
     if command_name == "upgrade" and local_only_repo_root is None and _has_local_only_workspace_state(target_root=target_root):
         local_only_repo_root = target_root
@@ -7632,6 +7816,7 @@ def _run_lifecycle_command(
                 inspection_mode="upgrade",
                 command_name=command_name,
                 config=config,
+                to_payload_target=to_payload_target,
             )
         )
     elif command_name == "install":
@@ -21812,6 +21997,13 @@ def _next_safe_action_packet(
                 "promote or create a slice before lane shaping is recorded",
             ]
         )
+    if action == "run-installed-payload-target-upgrade":
+        forbidden_actions.extend(
+            [
+                "begin ordinary workspace work before installed payload target is satisfied",
+                "claim installed payload target satisfied before recheck passes",
+            ]
+        )
     if "closeout" in action:
         forbidden_actions.append("claim completion before closeout trust is reconciled")
     if decision in {
@@ -25042,6 +25234,39 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
     }
 
 
+def _apply_installed_state_fast_start_gate(
+    *, payload: dict[str, Any], target_root: Path, config: WorkspaceConfig, startup_template: dict[str, Any]
+) -> None:
+    installed_state = payload.get("installed_state_compatibility")
+    if not isinstance(installed_state, dict):
+        return
+    action_effect = _as_dict(installed_state.get("action_effect"))
+    action_state = _as_dict(installed_state.get("action_state"))
+    payload_target = _as_dict(action_state.get("payload_target"))
+    if action_effect.get("force") != "required_before_execution" or payload_target.get("policy") != "required-before-work":
+        return
+    command = str(action_effect.get("resolution_command") or action_state.get("dry_run_command") or "")
+    recheck_command = str(action_state.get("recheck_command") or payload_target.get("recheck_command") or "")
+    payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
+        surface="start",
+        decision="installed-payload-target-required-before-work",
+        reason="Repo-declared payload target policy requires explicit sync before ordinary workspace work.",
+        required_next_action="run-installed-payload-target-upgrade",
+        evidence_required=["installed payload target recheck"],
+    )
+    payload["immediate_next_allowed_action"] = {
+        "action": "run-installed-payload-target-upgrade",
+        "summary": str(installed_state.get("reason") or action_effect.get("claim_boundary") or ""),
+        "command": command,
+        "run": command,
+        "risk": "required-before-work payload target gate",
+        "required_inputs": ["target repo"],
+        "next_proof": recheck_command or f"{config.cli_invoke} start --target {target_root.as_posix()} --format json",
+        "read_first": [command] if command else [],
+        "open_execplan_only_when": startup_template["open_execplan_only_when"],
+    }
+
+
 def _start_tiny_payload_fast(
     *, target_root: Path, changed_paths: list[str], task_text: str | None, config: WorkspaceConfig, startup_template: dict[str, Any]
 ) -> dict[str, Any]:
@@ -25215,6 +25440,12 @@ def _start_tiny_payload_fast(
             task_text=task_text,
             changed_paths=changed_paths,
             cli_invoke=config.cli_invoke,
+        )
+        _apply_installed_state_fast_start_gate(
+            payload=payload,
+            target_root=target_root,
+            config=config,
+            startup_template=startup_template,
         )
     sibling_freshness = _sibling_repo_aw_freshness_payload(target_root=target_root, task_text=task_text, cli_invoke=config.cli_invoke)
     if sibling_freshness["status"] != "not-referenced":
@@ -38592,6 +38823,7 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
         non_interactive=args.non_interactive,
         config=config,
         module_scope_explicit=bool(getattr(args, "modules", None)),
+        to_payload_target=bool(getattr(args, "to_payload_target", False)),
     )
     _emit_payload(payload=payload, format_name=args.format)
     return 0
@@ -43271,6 +43503,19 @@ def _config_payload(*, config: WorkspaceConfig) -> dict[str, Any]:
             "wrapper_rule": "normal update execution stays behind agentic-workspace",
             "modules": _module_update_policy_payload(config=config, target_root=config.target_root),
         },
+        "payload": {
+            "target_release": config.payload_target.target_release,
+            "minimum_capabilities": list(config.payload_target.minimum_capabilities),
+            "policy": config.payload_target.policy,
+            "dogfood_latest": config.payload_target.dogfood_latest,
+            "source": config.payload_target.source,
+            "supported_policies": list(config_lib.SUPPORTED_PAYLOAD_TARGET_POLICIES),
+            "supported_capabilities": list(SUPPORTED_PAYLOAD_CAPABILITIES),
+            "rule": (
+                "Repo payload target policy declares the checked-in payload release/capability state startup should require "
+                "before work or claims."
+            ),
+        },
         "assurance": {
             "default_level": assurance.default_level,
             "default_level_source": assurance.default_level_source,
@@ -43384,6 +43629,7 @@ def _compact_config_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "workflow_obligations": compact_obligations,
             "system_intent_sources": workspace["system_intent"]["sources"],
         },
+        "payload": payload["payload"],
         "reporting_posture": {
             "status": "present",
             "summary": "Use this compact config payload as source evidence; do not read raw config files only to cite line numbers.",

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1143,6 +1143,12 @@ def _start_payload(
         or task_posture_packet.get("dogfooding_obligations")
     ) and _task_posture_packet_changes_routing(task_posture_packet):
         payload["task_posture_packet"] = task_posture_packet
+    _apply_required_payload_target_start_gate(
+        payload=payload,
+        target_root=target_root,
+        config=config,
+        startup_template=startup_template,
+    )
     if profile == "tiny":
         payload["routine_work_context"] = _routine_work_context_payload(
             source_payload=payload,
@@ -1396,6 +1402,40 @@ def _compact_start_continuation_reorientation(packet: Any) -> dict[str, Any]:
             "continuation_view": "agentic-workspace summary --select continuation_view --format json",
             "active_intent_contract": "agentic-workspace start --target . --select active_intent_contract --format json",
         },
+    }
+
+
+def _apply_required_payload_target_start_gate(
+    *, payload: dict[str, Any], target_root: Path, config: WorkspaceConfig, startup_template: dict[str, Any]
+) -> None:
+    installed_state = payload.get("installed_state_compatibility")
+    if not isinstance(installed_state, dict):
+        return
+    action_effect = _as_dict(installed_state.get("action_effect"))
+    action_state = _as_dict(installed_state.get("action_state"))
+    payload_target = _as_dict(action_state.get("payload_target"))
+    if action_effect.get("force") != "required_before_execution" or payload_target.get("policy") != "required-before-work":
+        return
+    command = str(action_effect.get("resolution_command") or action_state.get("dry_run_command") or "")
+    recheck_command = str(action_state.get("recheck_command") or payload_target.get("recheck_command") or "")
+    payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
+        surface="start",
+        decision="installed-payload-target-required-before-work",
+        reason="Repo-declared payload target policy requires explicit sync before ordinary workspace work.",
+        required_next_action="run-installed-payload-target-upgrade",
+        evidence_required=["installed payload target recheck"],
+        hard_gate=True,
+    )
+    payload["immediate_next_allowed_action"] = {
+        "action": "run-installed-payload-target-upgrade",
+        "summary": str(installed_state.get("reason") or action_effect.get("claim_boundary") or ""),
+        "command": command,
+        "run": command,
+        "risk": "required-before-work payload target gate",
+        "required_inputs": ["target repo"],
+        "next_proof": recheck_command or f"{config.cli_invoke} start --target {target_root.as_posix()} --format json",
+        "read_first": [command] if command else [],
+        "open_execplan_only_when": startup_template["open_execplan_only_when"],
     }
 
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1513,6 +1513,224 @@ def test_start_installed_state_treats_stale_compatible_provenance_as_no_repair_n
     assert compatibility["action_effect"]["blocked_until_reconciled"] == []
 
 
+def test_payload_target_required_before_work_blocks_start_until_target_sync(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "config.toml").write_text(
+        "schema_version = 1\n\n"
+        "[payload]\n"
+        'target_release = "source-current"\n'
+        'minimum_capabilities = ["installed-state-sync-v2"]\n'
+        'policy = "required-before-work"\n'
+        "dogfood_latest = true\n",
+        encoding="utf-8",
+    )
+    provenance_path = workspace / "payload-provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance.pop("payload_capabilities", None)
+    provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    assert cli.main(["start", "--target", str(tmp_path), "--task", "Do ordinary work", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["next_safe_action"]["next_safe_action"] == "run-installed-payload-target-upgrade"
+    assert payload["next_safe_action"]["implementation_allowed"] is False
+    assert "--to-payload-target --dry-run" in payload["next_safe_action"]["preferred_cli"]
+    assert "installed_state_compatibility=payload-upgrade-required" in payload["action_signals"]["changed_signals"]
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--select",
+                "installed_state_compatibility",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    compatibility = json.loads(capsys.readouterr().out)["values"]["installed_state_compatibility"]
+    assert compatibility["payload"]["target"]["status"] == "target-mismatch"
+    assert compatibility["payload"]["target"]["policy"] == "required-before-work"
+    assert compatibility["action_state"]["repair_mechanism"] == "payload-target-upgrade"
+    assert compatibility["action_state"]["mutates_on_start"] is False
+    assert "--to-payload-target --dry-run" in compatibility["action_state"]["dry_run_command"]
+    assert compatibility["action_effect"]["force"] == "required_before_execution"
+    assert compatibility["action_effect"]["allowed_now"] == "run-payload-target-upgrade-before-ordinary-work"
+
+    assert cli.main(["doctor", "--target", str(tmp_path), "--format", "json"]) == 0
+    doctor_payload = json.loads(capsys.readouterr().out)
+    assert doctor_payload["installed_state_compatibility"]["payload"]["target"]["status"] == "target-mismatch"
+    assert doctor_payload["installed_state_compatibility"]["action_effect"]["force"] == "required_before_execution"
+
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(tmp_path),
+                "--section",
+                "installed_state_compatibility",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    report_payload = json.loads(capsys.readouterr().out)
+    assert report_payload["answer"]["payload"]["target"]["status"] == "target-mismatch"
+    assert report_payload["answer"]["action_state"]["recheck_command"]
+
+
+def test_upgrade_to_payload_target_forces_provenance_capability_sync(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "config.toml").write_text(
+        "schema_version = 1\n\n"
+        "[payload]\n"
+        'target_release = "source-current"\n'
+        'minimum_capabilities = ["installed-state-sync-v2"]\n'
+        'policy = "required-before-claim"\n',
+        encoding="utf-8",
+    )
+    provenance_path = workspace / "payload-provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance.pop("payload_capabilities", None)
+    provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-payload-target", "--dry-run", "--format", "json"]) == 0
+    dry_run_payload = json.loads(capsys.readouterr().out)
+    dry_run_workspace_report = next(report for report in dry_run_payload["reports"] if report["module"] == "workspace")
+    dry_run_action = next(
+        action for action in dry_run_workspace_report["actions"] if action["path"] == ".agentic-workspace/payload-provenance.json"
+    )
+    assert dry_run_action["kind"] == "would update"
+    assert "payload_capabilities" not in json.loads(provenance_path.read_text(encoding="utf-8"))
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-payload-target", "--format", "json"]) == 0
+    capsys.readouterr()
+    updated = json.loads(provenance_path.read_text(encoding="utf-8"))
+    assert "installed-state-sync-v2" in updated["payload_capabilities"]
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--select",
+                "installed_state_compatibility",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    compatibility = json.loads(capsys.readouterr().out)["values"]["installed_state_compatibility"]
+    assert compatibility["status"] == "compatible"
+    assert compatibility["payload"]["target"]["status"] == "satisfied"
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--dry-run", "--format", "json"]) == 0
+    ordinary_dry_run_payload = json.loads(capsys.readouterr().out)
+    ordinary_workspace_report = next(report for report in ordinary_dry_run_payload["reports"] if report["module"] == "workspace")
+    ordinary_action = next(
+        action for action in ordinary_workspace_report["actions"] if action["path"] == ".agentic-workspace/payload-provenance.json"
+    )
+    assert ordinary_action["kind"] == "current"
+
+
+def test_payload_target_required_before_claim_limits_claims_without_blocking_work(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "config.toml").write_text(
+        "schema_version = 1\n\n"
+        "[payload]\n"
+        'target_release = "source-current"\n'
+        'minimum_capabilities = ["installed-state-sync-v2"]\n'
+        'policy = "required-before-claim"\n',
+        encoding="utf-8",
+    )
+    provenance_path = workspace / "payload-provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance.pop("payload_capabilities", None)
+    provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--select",
+                "installed_state_compatibility,next_safe_action",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    selected = json.loads(capsys.readouterr().out)["values"]
+    compatibility = selected["installed_state_compatibility"]
+    assert compatibility["payload"]["target"]["status"] == "target-mismatch"
+    assert compatibility["action_effect"]["force"] == "required_before_claim"
+    assert "claim-payload-target-satisfied" in compatibility["action_effect"]["blocked_until_reconciled"]
+    assert selected["next_safe_action"]["implementation_allowed"] is True
+
+
+def test_payload_target_blocks_when_invoked_cli_cannot_satisfy_explicit_target(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "config.toml").write_text(
+        'schema_version = 1\n\n[payload]\ntarget_release = "999.0.0"\npolicy = "required-before-work"\n',
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--select",
+                "installed_state_compatibility",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    compatibility = json.loads(capsys.readouterr().out)["values"]["installed_state_compatibility"]
+
+    assert compatibility["status"] == "blocking-drift"
+    assert compatibility["payload"]["target"]["status"] == "compatible-cli-required"
+    assert compatibility["payload"]["target"]["invoked_cli_can_satisfy"] is False
+    assert compatibility["action_state"]["state"] == "blocking_incompatible"
+    assert compatibility["action_state"]["safe_to_apply"] is False
+    assert "--to-payload-target" not in compatibility["action_state"]["command"]
+
+
+def test_workspace_config_rejects_invalid_payload_target_policy(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "config.toml",
+        'schema_version = 1\n\n[payload]\ntarget_release = "source-current"\npolicy = "sometimes"\n',
+    )
+
+    with pytest.raises(cli.WorkspaceUsageError, match="policy must be one of"):
+        cli._load_workspace_config(target_root=tmp_path)
+
+
 def test_start_installed_state_blocks_newer_repo_payload_instead_of_downgrading(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0


### PR DESCRIPTION
## Summary
- Adds repo-owned `[payload]` target config with release/capability/policy/dogfood fields.
- Gates startup/report/doctor installed-state behavior when a repo-declared payload target is unmet, including target/current identity, exact `upgrade --to-payload-target` commands, and recheck command.
- Adds explicit `upgrade --to-payload-target` command support, generated command package updates, schema/reference docs, and source-repo dogfood config/provenance sync.

## Validation
- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `make schema-reference-docs`
- `make maintainer-surfaces`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make typecheck`
- `make absolute-paths`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`

Closes #2059