### PR TITLE
Bound PR comment repair closeout claims

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -211,6 +211,12 @@ def _planning_safety_gate_payload(*args: Any, **kwargs: Any) -> Any:
     return owner(*args, **kwargs)
 
 
+def _pr_comment_repair_context_payload(*args: Any, **kwargs: Any) -> Any:
+    from agentic_workspace.workspace_runtime_planning import _pr_comment_repair_context_payload as owner
+
+    return owner(*args, **kwargs)
+
+
 def _run_reconcile_report_adapter(*args: Any, **kwargs: Any) -> Any:
     from agentic_workspace.workspace_runtime_planning import _run_reconcile_report_adapter as owner
 
@@ -19049,6 +19055,37 @@ def _report_closeout_trust_payload(
             "rule": "The active plan remains protected repo-wide residue; this scope only classifies current bounded-task closeout blockers.",
         }
 
+    def current_pr_comment_repair_scope() -> dict[str, Any]:
+        if target_root is None or config is None or not normalized_changed_paths or not str(task_text or "").strip():
+            return {"kind": "agentic-workspace/current-task-closeout-scope/v1", "status": "not-applicable"}
+        repair_context = _pr_comment_repair_context_payload(task_text=task_text, changed_paths=normalized_changed_paths)
+        if repair_context.get("status") != "active":
+            return {"kind": "agentic-workspace/current-task-closeout-scope/v1", "status": "not-applicable"}
+        execution_posture = _execution_posture_payload(
+            config=config,
+            changed_paths=normalized_changed_paths,
+            task_text=task_text,
+            target_root=target_root,
+        )
+        planning_safety_gate = _planning_safety_gate_payload(
+            target_root=target_root,
+            config=config,
+            changed_paths=normalized_changed_paths,
+            task_text=task_text,
+            execution_posture=execution_posture,
+        )
+        return {
+            "kind": "agentic-workspace/current-task-closeout-scope/v1",
+            "status": "active",
+            "relationship": "bounded-pr-comment-repair",
+            "changed_paths": normalized_changed_paths,
+            "claim_class": "pr_feedback_addressed",
+            "claim_boundary": repair_context.get("claim_boundary", ""),
+            "planning_safety_gate": _selector_first_planning_safety_gate(planning_safety_gate),
+            "pr_comment_repair_context": repair_context,
+            "rule": "This scope only supports claiming PR feedback addressed with proof; it does not authorize issue, lane, parent, or full-intent completion.",
+        }
+
     def archived_slice_closeout_evidence() -> dict[str, Any]:
         archived_record = _closeout_planning_record_for_report(active_planning_record={}, target_root=target_root)
         if not archived_record:
@@ -19144,6 +19181,8 @@ def _report_closeout_trust_payload(
         return adjusted
 
     task_switch_scope = current_task_switch_scope()
+    pr_comment_repair_scope = current_pr_comment_repair_scope() if task_switch_scope.get("status") != "active" else {}
+    current_bounded_scope = task_switch_scope if task_switch_scope.get("status") == "active" else pr_comment_repair_scope
     planning_report = next((report for report in module_reports if isinstance(report, dict) and report.get("module") == "planning"), None)
     if not isinstance(planning_report, dict):
         gate = strict_gate(trust="unavailable", reason="planning module is not installed", active_planning_record=False)
@@ -19467,15 +19506,20 @@ def _report_closeout_trust_payload(
     )
     completion_options = allow_archived_slice_claim(completion_options, slice_closeout_evidence)
     current_task_closeout: dict[str, Any] = {"status": "not-applicable"}
-    if task_switch_scope.get("status") == "active":
+    if current_bounded_scope.get("status") == "active":
+        relationship = str(current_bounded_scope.get("relationship") or "bounded-task")
         current_task_gate = copy.deepcopy(gate)
         current_task_gate.update(
             {
-                "status": "unrelated-active-plan-residue",
+                "status": "bounded-current-task-residue",
                 "blocking": False,
                 "current_task_blocking": False,
-                "relationship": "bounded-task-switch",
-                "summary": "Strict closeout still protects the unrelated active plan, but it is not a current bounded-task slice blocker.",
+                "relationship": relationship,
+                "summary": (
+                    "Strict closeout still protects broader planning residue, but it is not a bounded PR-feedback-addressed blocker."
+                    if relationship == "bounded-pr-comment-repair"
+                    else "Strict closeout still protects the unrelated active plan, but it is not a current bounded-task slice blocker."
+                ),
             }
         )
         proof_selection = _proof_selection_for_changed_paths(
@@ -19498,17 +19542,35 @@ def _report_closeout_trust_payload(
             durable_residue_action=residue_action,
             lower_trust_closeout_count=effective_lower_trust_count,
             cli_invoke=cli_invoke,
-            current_task_switch_scope=task_switch_scope,
+            current_task_switch_scope=current_bounded_scope,
         )
+        if relationship == "bounded-pr-comment-repair":
+            adjusted_options: list[dict[str, Any]] = []
+            for option in current_task_options:
+                updated = dict(option)
+                if updated.get("id") == "claim-slice-complete":
+                    updated["required_claim_class"] = "pr_feedback_addressed"
+                    updated["bounded_claim_class"] = "pr_feedback_addressed"
+                    updated["why"] = (
+                        "PR feedback proof supports a bounded feedback-addressed claim"
+                        if updated.get("allowed") is True
+                        else "PR feedback-addressed claim is blocked until proof for the repair is visible"
+                    )
+                adjusted_options.append(updated)
+            current_task_options = adjusted_options
         current_task_operating_loop = _operating_loop_decision_payload(
             claim_context="closeout",
-            planning_safety_gate=_as_dict(task_switch_scope.get("planning_safety_gate")),
+            planning_safety_gate=_as_dict(current_bounded_scope.get("planning_safety_gate")),
             proof=proof_selection,
         )
         current_task_closeout = {
             "kind": "agentic-workspace/current-task-closeout/v1",
             "status": "active",
-            "scope": task_switch_scope,
+            "scope": current_bounded_scope,
+            "allowed_claim_classes": [current_bounded_scope.get("claim_class", "slice_complete")]
+            if current_bounded_scope.get("claim_class")
+            else ["slice_complete"],
+            "blocked_claim_classes": ["full_intent_complete", "issue_closure", "lane_complete", "parent_complete"],
             "strict_closeout_gate": current_task_gate,
             "completion_options": current_task_options,
             "operating_loop": current_task_operating_loop,
@@ -19519,7 +19581,10 @@ def _report_closeout_trust_payload(
                 "trust": trust,
                 "lower_trust_closeout_count": effective_lower_trust_count,
             },
-            "rule": "Current-task closeout options do not authorize active-plan progress, parent closure, or issue closure for unrelated planning residue.",
+            "rule": (
+                "Current-task closeout options do not authorize active-plan progress, parent closure, issue closure, "
+                "or full-intent completion for bounded PR-comment repair or unrelated planning residue."
+            ),
         }
     memory_consult = (
         _memory_consult_payload(target_root=target_root, compact=True, cli_invoke=cli_invoke)

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -615,6 +615,28 @@ def _task_switch_reconciliation_payload(
     }
 
 
+def _pr_comment_repair_context_payload(*, task_text: str | None, changed_paths: list[str]) -> dict[str, Any]:
+    text = " ".join(str(task_text or "").lower().split())
+    pr_markers = ("pr", "pull request", "review", "review comment", "review feedback")
+    repair_markers = ("address", "addressing", "fix", "repair", "respond", "resolve", "comment", "feedback")
+    matched_pr_markers = [marker for marker in pr_markers if re.search(rf"(?<![a-z0-9]){re.escape(marker)}(?![a-z0-9])", text)]
+    matched_repair_markers = [marker for marker in repair_markers if marker in text]
+    active = bool(changed_paths and matched_pr_markers and matched_repair_markers)
+    return {
+        "kind": "agentic-workspace/pr-comment-repair-context/v1",
+        "status": "active" if active else "not-detected",
+        "matched_pr_markers": matched_pr_markers,
+        "matched_repair_markers": matched_repair_markers,
+        "changed_path_count": len(changed_paths),
+        "claim_class": "pr_feedback_addressed",
+        "claim_boundary": (
+            "Authorizes only a bounded PR-feedback-addressed claim after proof; it does not authorize lane, parent, "
+            "issue, or full-intent completion."
+        ),
+        "rule": "PR-comment repair routing requires explicit task wording and changed paths; it remains a bounded closeout scope.",
+    }
+
+
 _TASK_SWITCH_STOPWORDS = {
     "about",
     "active",
@@ -783,6 +805,7 @@ def _planning_safety_gate_payload(
         path_classification.get("dirty_shape") == "implementation-with-archived-planning-residue"
         and _as_dict(path_classification.get("archived_planning_residue")).get("status") == "completed-closeout-residue"
     )
+    pr_comment_repair_context = _pr_comment_repair_context_payload(task_text=task_text, changed_paths=changed_paths)
     if active_planning_present and active_delegation_requirement.get("required"):
         status = "blocked"
         decision = "delegation-decision-required"
@@ -824,6 +847,15 @@ def _planning_safety_gate_payload(
         decision = "planning-recovery-or-prep"
         reason = "Only planning surfaces are named; validate planning state before implementation."
         required_next_action = "validate-planning-state"
+        workflow_sufficient = True
+    elif path_classification["dirty_shape"] == "planning-plus-implementation" and pr_comment_repair_context.get("status") == "active":
+        status = "attention"
+        decision = "bounded-pr-comment-repair"
+        reason = (
+            "Implementation paths are mixed with planning residue, but the task is bounded PR-comment repair; "
+            "planning-owner warnings stay visible while only a PR-feedback-addressed claim is in scope."
+        )
+        required_next_action = "prove-pr-feedback-addressed"
         workflow_sufficient = True
     elif path_classification["dirty_shape"] == "planning-plus-implementation":
         status = "violation"
@@ -904,6 +936,7 @@ def _planning_safety_gate_payload(
             f"active_planning_present={active_planning_present}",
             f"dirty_shape={path_classification.get('dirty_shape')}",
             f"hierarchy_owner_status={hierarchy_owner_requirement.get('status')}",
+            f"pr_comment_repair={pr_comment_repair_context.get('status')}",
             *[f"issue_ref={issue_ref}" for issue_ref in issue_refs],
         ],
         recommended_by_aw=[required_next_action] if workflow_sufficient else [],
@@ -955,6 +988,8 @@ def _planning_safety_gate_payload(
                 if decision == "external-issue-scope-unknown"
                 else ["changed-path scope decision"]
                 if decision == "agent-work-shape-decision-required"
+                else ["PR feedback proof"]
+                if decision == "bounded-pr-comment-repair"
                 else []
             ),
             hard_gate=hard_gate,
@@ -973,6 +1008,7 @@ def _planning_safety_gate_payload(
             "rule": "PR/review/merge-conflict wording is provider context, not unknown issue scope. Fetch PR/review state when needed.",
             "provider_requirement": "provider-aware; GitHub is one possible source, not assumed as the only provider.",
         },
+        "pr_comment_repair_context": pr_comment_repair_context,
         "issue_scope_evidence": issue_scope_evidence,
         "candidate_pressure": candidate_pressure,
         "custody_planning": custody_planning,

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -158,6 +158,7 @@ from agentic_workspace.workspace_runtime_planning import (
     _active_planning_record_for_report_section,  # noqa: F401 - compatibility re-export for planning owner boundary
     _planning_candidate_pressure_payload,  # noqa: F401 - compatibility re-export for runtime inventory
     _planning_safety_gate_payload,
+    _pr_comment_repair_context_payload,
     _raw_active_planning_record_for_closeout,  # noqa: F401 - compatibility re-export for planning owner boundary
     _run_reconcile_report_adapter,  # noqa: F401 - compatibility re-export for planning owner boundary
 )
@@ -18391,6 +18392,37 @@ def _report_closeout_trust_payload(
             "rule": "The active plan remains protected repo-wide residue; this scope only classifies current bounded-task closeout blockers.",
         }
 
+    def current_pr_comment_repair_scope() -> dict[str, Any]:
+        if target_root is None or config is None or not normalized_changed_paths or not str(task_text or "").strip():
+            return {"kind": "agentic-workspace/current-task-closeout-scope/v1", "status": "not-applicable"}
+        repair_context = _pr_comment_repair_context_payload(task_text=task_text, changed_paths=normalized_changed_paths)
+        if repair_context.get("status") != "active":
+            return {"kind": "agentic-workspace/current-task-closeout-scope/v1", "status": "not-applicable"}
+        execution_posture = _execution_posture_payload(
+            config=config,
+            changed_paths=normalized_changed_paths,
+            task_text=task_text,
+            target_root=target_root,
+        )
+        planning_safety_gate = _planning_safety_gate_payload(
+            target_root=target_root,
+            config=config,
+            changed_paths=normalized_changed_paths,
+            task_text=task_text,
+            execution_posture=execution_posture,
+        )
+        return {
+            "kind": "agentic-workspace/current-task-closeout-scope/v1",
+            "status": "active",
+            "relationship": "bounded-pr-comment-repair",
+            "changed_paths": normalized_changed_paths,
+            "claim_class": "pr_feedback_addressed",
+            "claim_boundary": repair_context.get("claim_boundary", ""),
+            "planning_safety_gate": _selector_first_planning_safety_gate(planning_safety_gate),
+            "pr_comment_repair_context": repair_context,
+            "rule": "This scope only supports claiming PR feedback addressed with proof; it does not authorize issue, lane, parent, or full-intent completion.",
+        }
+
     def archived_slice_closeout_evidence() -> dict[str, Any]:
         archived_record = _closeout_planning_record_for_report(active_planning_record={}, target_root=target_root)
         if not archived_record:
@@ -18486,6 +18518,8 @@ def _report_closeout_trust_payload(
         return adjusted
 
     task_switch_scope = current_task_switch_scope()
+    pr_comment_repair_scope = current_pr_comment_repair_scope() if task_switch_scope.get("status") != "active" else {}
+    current_bounded_scope = task_switch_scope if task_switch_scope.get("status") == "active" else pr_comment_repair_scope
     planning_report = next((report for report in module_reports if isinstance(report, dict) and report.get("module") == "planning"), None)
     if not isinstance(planning_report, dict):
         gate = strict_gate(trust="unavailable", reason="planning module is not installed", active_planning_record=False)
@@ -18809,15 +18843,20 @@ def _report_closeout_trust_payload(
     )
     completion_options = allow_archived_slice_claim(completion_options, slice_closeout_evidence)
     current_task_closeout: dict[str, Any] = {"status": "not-applicable"}
-    if task_switch_scope.get("status") == "active":
+    if current_bounded_scope.get("status") == "active":
+        relationship = str(current_bounded_scope.get("relationship") or "bounded-task")
         current_task_gate = copy.deepcopy(gate)
         current_task_gate.update(
             {
-                "status": "unrelated-active-plan-residue",
+                "status": "bounded-current-task-residue",
                 "blocking": False,
                 "current_task_blocking": False,
-                "relationship": "bounded-task-switch",
-                "summary": "Strict closeout still protects the unrelated active plan, but it is not a current bounded-task slice blocker.",
+                "relationship": relationship,
+                "summary": (
+                    "Strict closeout still protects broader planning residue, but it is not a bounded PR-feedback-addressed blocker."
+                    if relationship == "bounded-pr-comment-repair"
+                    else "Strict closeout still protects the unrelated active plan, but it is not a current bounded-task slice blocker."
+                ),
             }
         )
         proof_selection = _proof_selection_for_changed_paths(
@@ -18840,17 +18879,35 @@ def _report_closeout_trust_payload(
             durable_residue_action=residue_action,
             lower_trust_closeout_count=effective_lower_trust_count,
             cli_invoke=cli_invoke,
-            current_task_switch_scope=task_switch_scope,
+            current_task_switch_scope=current_bounded_scope,
         )
+        if relationship == "bounded-pr-comment-repair":
+            adjusted_options: list[dict[str, Any]] = []
+            for option in current_task_options:
+                updated = dict(option)
+                if updated.get("id") == "claim-slice-complete":
+                    updated["required_claim_class"] = "pr_feedback_addressed"
+                    updated["bounded_claim_class"] = "pr_feedback_addressed"
+                    updated["why"] = (
+                        "PR feedback proof supports a bounded feedback-addressed claim"
+                        if updated.get("allowed") is True
+                        else "PR feedback-addressed claim is blocked until proof for the repair is visible"
+                    )
+                adjusted_options.append(updated)
+            current_task_options = adjusted_options
         current_task_operating_loop = _operating_loop_decision_payload(
             claim_context="closeout",
-            planning_safety_gate=_as_dict(task_switch_scope.get("planning_safety_gate")),
+            planning_safety_gate=_as_dict(current_bounded_scope.get("planning_safety_gate")),
             proof=proof_selection,
         )
         current_task_closeout = {
             "kind": "agentic-workspace/current-task-closeout/v1",
             "status": "active",
-            "scope": task_switch_scope,
+            "scope": current_bounded_scope,
+            "allowed_claim_classes": [current_bounded_scope.get("claim_class", "slice_complete")]
+            if current_bounded_scope.get("claim_class")
+            else ["slice_complete"],
+            "blocked_claim_classes": ["full_intent_complete", "issue_closure", "lane_complete", "parent_complete"],
             "strict_closeout_gate": current_task_gate,
             "completion_options": current_task_options,
             "operating_loop": current_task_operating_loop,
@@ -18861,7 +18918,10 @@ def _report_closeout_trust_payload(
                 "trust": trust,
                 "lower_trust_closeout_count": effective_lower_trust_count,
             },
-            "rule": "Current-task closeout options do not authorize active-plan progress, parent closure, or issue closure for unrelated planning residue.",
+            "rule": (
+                "Current-task closeout options do not authorize active-plan progress, parent closure, issue closure, "
+                "or full-intent completion for bounded PR-comment repair or unrelated planning residue."
+            ),
         }
     memory_consult = (
         _memory_consult_payload(target_root=target_root, compact=True, cli_invoke=cli_invoke)

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -898,6 +898,46 @@ candidates = []
     assert "completion_gate" not in claim_slice["blocking_fields"]
 
 
+def test_closeout_trust_scopes_pr_comment_repair_to_feedback_claim(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(tmp_path),
+                "--section",
+                "closeout_trust",
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_primitives.py",
+                "--task",
+                "Address PR review comments",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)["answer"]
+
+    current = payload["current_task_closeout"]
+    assert current["status"] == "active"
+    assert current["scope"]["relationship"] == "bounded-pr-comment-repair"
+    assert "does not authorize issue, lane, parent, or full-intent completion" in current["scope"]["rule"]
+    claim_feedback = next(option for option in current["completion_options"] if option["id"] == "claim-slice-complete")
+    assert claim_feedback["required_claim_class"] == "pr_feedback_addressed"
+    assert claim_feedback["bounded_claim_class"] == "pr_feedback_addressed"
+    assert "PR feedback-addressed claim" in claim_feedback["why"]
+    claim_work = next(option for option in current["completion_options"] if option["id"] == "claim-work-complete")
+    close_parent = next(option for option in current["completion_options"] if option["id"] == "close-parent-lane")
+    assert claim_work["allowed"] is False
+    assert close_parent["allowed"] is False
+
+
 def test_verbose_aliases_full_diagnostic_output_for_major_workspace_commands(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     (tmp_path / "README.md").write_text("# Fixture\n", encoding="utf-8")

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -4116,6 +4116,57 @@ def test_start_uses_retrofit_repair_command_for_missing_implementation_owner(tmp
     assert repair_route["work_context"] == "already-started-continuation-or-review-repair"
 
 
+def test_implement_allows_bounded_pr_comment_repair_without_active_plan_owner(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write_empty_planning_state(tmp_path)
+    _write(tmp_path / "src" / "agentic_workspace" / "runtime.py", "VALUE = 1\n")
+    archive_path = ".agentic-workspace/planning/execplans/archive/open-slice.plan.json"
+    _write(
+        tmp_path / archive_path,
+        json.dumps(
+            {
+                "schema_version": "execplan/v1",
+                "id": "open-slice",
+                "status": "completed",
+                "intent_satisfaction": {"was original intent fully satisfied?": "no"},
+                "closure_check": {
+                    "larger-intent status": "open",
+                    "closure decision": "archive-but-keep-lane-open",
+                },
+            }
+        ),
+    )
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/runtime.py",
+                archive_path,
+                "--task",
+                "Address PR review comments on #2061",
+                "--verbose",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    gate = payload["planning_safety_gate"]
+    assert gate["status"] == "attention"
+    assert gate["gate_result"] == "bounded-pr-comment-repair"
+    assert gate["implementation_allowed"] is True
+    assert gate["repair_route"]["status"] == "retired"
+    assert gate["pr_comment_repair_context"]["status"] == "active"
+    assert gate["pr_comment_repair_context"]["claim_class"] == "pr_feedback_addressed"
+    assert gate["changed_path_facts"]["dirty_shape"] == "planning-plus-implementation"
+
+
 def test_implement_blocks_epic_work_with_multiple_roadmap_candidates(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(


### PR DESCRIPTION
## Summary
- detect bounded PR-comment repair tasks with changed paths and avoid forcing the missing-active-plan retrofit route
- add current-task closeout scope for bounded PR feedback repair
- expose only a `pr_feedback_addressed` scoped claim while keeping full work, issue, lane, and parent completion blocked until ordinary evidence supports them

Fixes #2064

Stacked on #2065.

## Proof
- `uv run pytest tests/test_workspace_implement_cli.py -q -k "bounded_pr_comment_repair or missing_implementation_owner"`
- `uv run pytest tests/test_workspace_cli.py -q -k "pr_comment_repair or scopes_unrelated_active_plan_residue"`
- `uv run ruff check src/agentic_workspace/workspace_runtime_core.py src/agentic_workspace/workspace_runtime_primitives.py src/agentic_workspace/workspace_runtime_planning.py tests/test_workspace_cli.py tests/test_workspace_implement_cli.py`
- `make test-workspace`
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`

## Boundary
Runtime edits are report/planning primitive behavior for closeout and implement routing. Host-agnostic judgment is preserved: the bounded repair path is based on explicit PR/review/comment task wording plus changed paths, and it only permits a narrow PR-feedback-addressed claim after proof.