### PR TITLE
Route dogfooding reflection around stale plans

### DIFF
--- a/src/agentic_workspace/contracts/conformance/start.context.process.json
+++ b/src/agentic_workspace/contracts/conformance/start.context.process.json
@@ -44,7 +44,7 @@
             "drill_down",
             "rule"
           ],
-          "equals": "Compact default omits selector inventory and schemas. Use exact --select for one field; use --verbose only for broad diagnostics."
+          "equals": "Compact default omits selector inventory/schemas; use --select or --verbose for detail."
         },
         {
           "path": [

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -23454,12 +23454,16 @@ def _next_safe_action_packet(
         skill = "workspace-intent-discovery"
     elif action == "present-lane-shaping-prompt":
         skill = "planning-decompose"
+    elif action in {"produce-bounded-reflection-report", "archive-or-retire-completed-plan"}:
+        skill = ""
     elif action != "choose-smallest-workflow-shape" and isinstance(preferred_routes, list):
         for route in preferred_routes:
             if isinstance(route, dict) and route.get("skill"):
                 skill = str(route.get("skill"))
                 break
-    if action.startswith(("create", "promote", "checkpoint", "update", "validate-planning", "continue-active-planning")):
+    if action == "archive-or-retire-completed-plan":
+        module_slot = "planning"
+    elif action.startswith(("create", "promote", "checkpoint", "update", "validate-planning", "continue-active-planning")):
         module_slot = "planning"
     elif "closeout" in action:
         module_slot = "planning.closeout"
@@ -23494,6 +23498,8 @@ def _next_safe_action_packet(
         )
     if "closeout" in action:
         forbidden_actions.append("claim completion before closeout trust is reconciled")
+    if action == "archive-or-retire-completed-plan":
+        forbidden_actions.extend(["claim parent or lane completion from active-plan archival alone"])
     if decision in {
         "active-execplan-required",
         "candidate-lane-promotion-required",
@@ -25272,6 +25278,11 @@ def _compact_selector_active_plan_reliance(value: Any) -> dict[str, Any]:
 def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
     if not isinstance(gate, dict):
         return {}
+    task_switch = gate.get("task_switch_reconciliation")
+    compact_route = isinstance(task_switch, dict) and task_switch.get("status") in {
+        "bounded-reflection-reporting",
+        "completed-active-plan-route",
+    }
     compact: dict[str, Any] = {
         "kind": gate.get("kind"),
         "label": "work gate",
@@ -25279,19 +25290,20 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         "status": gate.get("status"),
         "gate_result": gate.get("gate_result") or gate.get("decision"),
         "workflow_sufficient": gate.get("workflow_sufficient"),
-        "reason": gate.get("reason"),
+        "reason": _task_excerpt(str(gate.get("reason") or ""), limit=180) if compact_route else gate.get("reason"),
         "decision_maturity": _tiny_decision_maturity(gate.get("decision_maturity")),
         "required_next_action": gate.get("required_next_action"),
         "active_planning_present": gate.get("active_planning_present"),
         "issue_refs": gate.get("issue_refs", []),
-        "promotion_command": gate.get("promotion_command"),
-        "delegation_decision_command": gate.get("delegation_decision_command"),
-        "new_plan_command": gate.get("new_plan_command"),
         "planning_revision": _compact_selector_planning_revision(gate.get("planning_revision")),
         "implementation_allowed": gate.get("implementation_allowed"),
         "delegation_decision_required": gate.get("delegation_decision_required"),
         "authority_boundary": _compact_authority_boundary(gate.get("authority_boundary")),
     }
+    if not compact_route:
+        compact["promotion_command"] = gate.get("promotion_command")
+        compact["delegation_decision_command"] = gate.get("delegation_decision_command")
+        compact["new_plan_command"] = gate.get("new_plan_command")
     active_plan_reliance = _compact_selector_active_plan_reliance(gate.get("active_plan_reliance"))
     if active_plan_reliance.get("permission_claim") != "direct-work-not-active-plan-continuation" or active_plan_reliance.get(
         "blocked_until_reconciled"
@@ -25322,24 +25334,46 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         }
     if "work_shape_guidance" in gate and gate.get("workflow_sufficient") is False:
         compact["work_shape_guidance"] = _tiny_work_shape_guidance(gate["work_shape_guidance"])
-    task_switch = gate.get("task_switch_reconciliation")
-    if isinstance(task_switch, dict) and task_switch.get("status") == "active":
+    if isinstance(task_switch, dict) and task_switch.get("status") in {
+        "active",
+        "bounded-reflection-reporting",
+        "completed-active-plan-route",
+    }:
         safe_routes = [
             {key: route.get(key) for key in ("id", "command") if isinstance(route, dict) and route.get(key) not in (None, "", [], {})}
             for route in _list_payload(task_switch.get("safe_routes"))[:3]
             if isinstance(route, dict)
         ]
         active_plan_protection = _as_dict(task_switch.get("active_plan_protection"))
-        compact["task_switch_reconciliation"] = {
+        compact_switch = {
             "kind": task_switch.get("kind"),
             "status": task_switch.get("status"),
-            "summary": task_switch.get("summary"),
+            "summary": _task_excerpt(str(task_switch.get("summary") or ""), limit=180),
             "current_task_class": task_switch.get("current_task_class"),
             "recommended_next_action": task_switch.get("recommended_next_action"),
             "safe_route_ids": [route.get("id") for route in safe_routes if route.get("id")],
             "blocked_claims": active_plan_protection.get("blocked_claims", []),
             "detail_selector": "planning_safety_gate.task_switch_reconciliation",
         }
+        if active_plan_protection.get("claim_boundary"):
+            compact_switch["claim_boundary"] = _task_excerpt(str(active_plan_protection.get("claim_boundary") or ""), limit=180)
+        completed_plan = _as_dict(task_switch.get("completed_active_plan"))
+        if completed_plan:
+            compact_switch["completed_active_plan"] = {
+                key: completed_plan.get(key)
+                for key in (
+                    "status",
+                    "active_execplan",
+                    "plan_id",
+                    "evidence_fields",
+                    "archive_command",
+                    "recheck_command",
+                    "parent_lane_boundary",
+                    "claim_boundary",
+                )
+                if completed_plan.get(key) not in (None, "", [], {})
+            }
+        compact["task_switch_reconciliation"] = compact_switch
     custody_planning = gate.get("custody_planning")
     if isinstance(custody_planning, dict) and custody_planning.get("status") not in (None, "", "not-applicable"):
         compact["custody_planning"] = {
@@ -25630,11 +25664,21 @@ def _read_only_meta_task(task_text: str | None) -> bool:
     meta_terms = (
         "dogfooding report",
         "dogfood report",
+        "dogfooding feedback",
         "retrospective",
+        "reflection",
+        "reflect",
+        "estimate aw",
+        "net effect",
         "status report",
         "status check",
         "summarize",
         "summary",
+        "concrete aw dogfooding feedback issues",
+        "feedback issues",
+        "follow-up issues",
+        "issue-shaping",
+        "shape follow-up",
         "review current",
         "read-only",
         "meta analysis",
@@ -27200,18 +27244,34 @@ def _start_tiny_payload_fast(
     payload["active_plan_reliance"] = planning_safety_gate.get("active_plan_reliance", {})
     custody_planning = planning_safety_gate.get("custody_planning", {})
     custody_applies = isinstance(custody_planning, dict) and custody_planning.get("status") not in (None, "", "not-applicable")
-    if planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies:
-        payload["planning_safety_gate"] = planning_safety_gate
     task_switch = planning_safety_gate.get("task_switch_reconciliation", {})
-    if isinstance(task_switch, dict) and task_switch.get("status") == "active":
+    task_switch_visible_by_default = isinstance(task_switch, dict) and task_switch.get("status") in {
+        "active",
+        "bounded-reflection-reporting",
+        "completed-active-plan-route",
+    }
+    if planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies or task_switch_visible_by_default:
+        payload["planning_safety_gate"] = planning_safety_gate
+    if isinstance(task_switch, dict) and task_switch.get("status") in {
+        "active",
+        "bounded-reflection-reporting",
+        "completed-active-plan-route",
+    }:
         next_packet = task_switch.get("next_action_packet", {})
         if isinstance(next_packet, dict):
+            evidence_required = (
+                ["completed active-plan route accepted or dismissed"]
+                if task_switch.get("status") == "completed-active-plan-route"
+                else ["active-plan claim boundary preserved"]
+                if task_switch.get("status") == "bounded-reflection-reporting"
+                else ["current-task route chosen without claiming active-plan progress"]
+            )
             payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
                 surface="start",
                 decision=planning_safety_gate["decision"],
                 reason=planning_safety_gate["reason"],
                 required_next_action=planning_safety_gate["required_next_action"],
-                evidence_required=["current-task route chosen without claiming active-plan progress"],
+                evidence_required=evidence_required,
             )
             payload["immediate_next_allowed_action"] = next_packet
     intent_acknowledgement = _intent_acknowledgement_payload(

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -775,13 +775,14 @@ def _bounded_reflection_reporting_payload(*, task_text: str | None) -> dict[str,
             "matched_reflection_signals": [],
             "matched_mutation_signals": matched_mutation,
         }
-    if matched_mutation and not matched_issue_shaping:
+    if matched_mutation:
         return {
             "kind": "agentic-workspace/bounded-reflection-reporting/v1",
             "status": "implementation-like",
             "matched_reflection_signals": matched_reflection,
+            "matched_issue_shaping_signals": matched_issue_shaping,
             "matched_mutation_signals": matched_mutation,
-            "rule": "Implementation-like tasks keep active-plan task-switch protection.",
+            "rule": "Implementation-like signals win over issue-shaping signals; mixed tasks keep active-plan task-switch protection.",
         }
     current_task_class = "bounded-dogfooding-issue-shaping" if matched_issue_shaping else "bounded-reflection-reporting"
     return {

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -486,8 +486,6 @@ def _task_switch_reconciliation_payload(
 ) -> dict[str, Any]:
     if not active_planning_present:
         return {"kind": "agentic-workspace/task-switch-reconciliation/v1", "status": "not-applicable"}
-    if active_plan_reliance.get("status") != "not-needed-for-current-task":
-        return {"kind": "agentic-workspace/task-switch-reconciliation/v1", "status": "not-applicable"}
     summary_command = _command_with_cli_invoke(command="agentic-workspace summary --target . --format json", cli_invoke=config.cli_invoke)
     closeout_command = _command_with_expected_planning_revision(
         _command_with_cli_invoke(
@@ -496,10 +494,66 @@ def _task_switch_reconciliation_payload(
         ),
         planning_revision=planning_revision,
     )
+    configured_target_root = getattr(config, "target_root", None)
+    if isinstance(configured_target_root, Path):
+        completed_route_target_root = configured_target_root
+    elif configured_target_root:
+        completed_route_target_root = Path(configured_target_root)
+    else:
+        completed_route_target_root = Path.cwd()
+    completed_plan_route = _completed_active_plan_route_payload(
+        target_root=completed_route_target_root,
+        active_summary=active_summary,
+        config=config,
+        planning_revision=planning_revision,
+    )
+    if completed_plan_route.get("status") == "archive-or-retire-recommended":
+        return {
+            "kind": "agentic-workspace/task-switch-reconciliation/v1",
+            "status": "completed-active-plan-route",
+            "summary": "The active execplan has explicit slice completion evidence; route it to archive or retire before treating it as current work.",
+            "active_execplan": active_summary.get("active_execplan", ""),
+            "intent_conflict_state": "completed-active-plan-residue",
+            "mismatch_evidence": _task_switch_mismatch_evidence(active_summary=active_summary, task_text=task_text),
+            "current_task_class": "completed-active-plan-cleanup",
+            "classification_basis": "active-execplan-closeout-evidence",
+            "recommended_next_action": "archive-or-retire-completed-plan",
+            "completed_active_plan": completed_plan_route,
+            "next_action_packet": {
+                "action": "archive-or-retire-completed-plan",
+                "summary": "A completed active execplan is still active; archive, retire, demote, or explicitly keep it active before relying on later startup routing.",
+                "command": completed_plan_route.get("archive_command", ""),
+                "run": completed_plan_route.get("archive_command", ""),
+                "risk": "completed-active-plan-residue",
+                "required_inputs": ["active execplan", "completion evidence"],
+                "next_proof": completed_plan_route.get("recheck_command", summary_command),
+                "read_first": [summary_command],
+                "open_execplan_only_when": "the archive/retire route needs verification of plan-local closeout evidence",
+            },
+            "safe_routes": [
+                {
+                    "id": "archive-completed-active-plan",
+                    "command": completed_plan_route.get("archive_command", ""),
+                    "when": "plan-local proof and closeout evidence are accepted as current-slice completion",
+                },
+                {
+                    "id": "record-plan-remains-active",
+                    "command": summary_command,
+                    "when": "completion evidence is insufficient or the plan intentionally remains active",
+                },
+            ],
+            "implementation_allowed": False,
+            "active_plan_protection": {
+                "claim_boundary": "Completed-plan routing may retire the current slice only; parent/lane closure still requires separate closeout evidence.",
+                "blocked_claims": ["claim-lane-complete", "claim-parent-complete", "silently-close-planning-state"],
+            },
+            "rule": "Completed active-plan cleanup is command-routed; startup never silently archives or closes planning state.",
+        }
     text = " ".join((task_text or "").lower().split())
     maintenance_markers = ("report", "dogfood", "upgrade", "payload", "config", "doctor", "comment", "review", "status")
     matched_maintenance_markers = [marker for marker in maintenance_markers if marker in text]
     maintenance_like = bool(matched_maintenance_markers)
+    bounded_reflection = _bounded_reflection_reporting_payload(task_text=task_text)
     classification_basis = "bounded-maintenance-marker-hint" if maintenance_like else "no-maintenance-marker-hint"
     recommended = "proceed-bounded-repo-maintenance" if maintenance_like else "choose-between-new-task-and-active-plan"
     mismatch_evidence = _task_switch_mismatch_evidence(active_summary=active_summary, task_text=task_text)
@@ -556,6 +610,63 @@ def _task_switch_reconciliation_payload(
             },
             "rule": "Structured issue/PR ref overlap is active-plan continuation evidence; arbitrary prose keyword overlap is not.",
         }
+    if bounded_reflection.get("status") == "bounded":
+        return {
+            "kind": "agentic-workspace/task-switch-reconciliation/v1",
+            "status": "bounded-reflection-reporting",
+            "summary": "Current task is bounded reflection, reporting, dogfooding, or issue-shaping; active-plan state remains protected but does not require a generic task-switch choice.",
+            "active_execplan": active_summary.get("active_execplan", ""),
+            "intent_conflict_state": "bounded-current-task-active-plan-protected",
+            "mismatch_evidence": mismatch_evidence,
+            "current_task_class": bounded_reflection.get("current_task_class", "bounded-reflection-reporting"),
+            "classification_basis": bounded_reflection.get("classification_basis", "read-only-reporting-task-shape"),
+            "matched_maintenance_markers": matched_maintenance_markers,
+            "classification_inputs": [
+                "active_plan_reliance.status=not-needed-for-current-task",
+                f"shared_term_count={len(mismatch_evidence.get('shared_terms', []))}",
+                f"shared_ref_count={len(mismatch_evidence.get('shared_refs', []))}",
+                f"matched_reflection_signal_count={len(bounded_reflection.get('matched_reflection_signals', []))}",
+                f"matched_mutation_signal_count={len(bounded_reflection.get('matched_mutation_signals', []))}",
+            ],
+            "semantic_boundary": bounded_reflection["claim_boundary"],
+            "recommended_next_action": "produce-bounded-reflection-report",
+            "next_action_packet": {
+                "action": "produce-bounded-reflection-report",
+                "summary": "Produce the requested bounded reflection/reporting/dogfooding output without claiming active-plan progress.",
+                "command": "",
+                "run": None,
+                "risk": "bounded-reflection-active-plan-protected",
+                "required_inputs": ["current task", "active plan claim boundary"],
+                "next_proof": "no file proof unless the task later becomes an edit",
+                "read_first": [],
+                "open_execplan_only_when": "the task changes from reflection/reporting into active-plan mutation or implementation",
+            },
+            "safe_routes": [
+                {
+                    "id": "produce-bounded-reflection-report",
+                    "command": "",
+                    "when": "the current task remains read-only reflection, reporting, dogfooding, or issue shaping",
+                },
+                {
+                    "id": "inspect-active-plan",
+                    "command": summary_command,
+                    "when": "the reflection needs active-plan audit detail",
+                },
+                {
+                    "id": "reconcile-active-plan-before-implementation",
+                    "command": closeout_command,
+                    "when": "the task changes into implementation or active-plan mutation",
+                },
+            ],
+            "implementation_allowed": True,
+            "active_plan_protection": {
+                "claim_boundary": bounded_reflection["claim_boundary"],
+                "blocked_claims": ["claim-active-plan-progress", "claim-active-plan-complete", "silently-abandon-active-plan"],
+            },
+            "rule": "Bounded reflection/reporting may proceed while preserving active-plan claim boundaries and selector-backed audit detail.",
+        }
+    if active_plan_reliance.get("status") != "not-needed-for-current-task":
+        return {"kind": "agentic-workspace/task-switch-reconciliation/v1", "status": "not-applicable"}
     return {
         "kind": "agentic-workspace/task-switch-reconciliation/v1",
         "status": "active",
@@ -612,6 +723,170 @@ def _task_switch_reconciliation_payload(
             "blocked_claims": ["claim-active-plan-progress", "claim-active-plan-complete", "silently-abandon-active-plan"],
         },
         "rule": "An unrelated active plan is protected state, not an automatic hard block for explicit bounded maintenance or reporting.",
+    }
+
+
+def _bounded_reflection_reporting_payload(*, task_text: str | None) -> dict[str, Any]:
+    text = " ".join((task_text or "").lower().split())
+    if not text:
+        return {"kind": "agentic-workspace/bounded-reflection-reporting/v1", "status": "not-detected"}
+    reflection_signals = (
+        "estimate",
+        "net effect",
+        "reflection",
+        "reflect",
+        "retrospective",
+        "report",
+        "status",
+        "summarize",
+        "summary",
+        "dogfood",
+        "dogfooding",
+        "feedback",
+        "issue-shaping",
+        "shape follow-up",
+        "concrete feedback",
+    )
+    issue_shaping_signals = (
+        "create concrete",
+        "feedback issues",
+        "dogfooding feedback issues",
+        "new issues",
+        "follow-up issues",
+    )
+    mutation_signals = (
+        "implement",
+        "fix",
+        "edit",
+        "change",
+        "modify",
+        "delete",
+        "write code",
+        "refactor",
+        "make new pull request",
+    )
+    matched_reflection = [signal for signal in reflection_signals if signal in text]
+    matched_issue_shaping = [signal for signal in issue_shaping_signals if signal in text]
+    matched_mutation = [signal for signal in mutation_signals if signal in text]
+    if not matched_reflection and not matched_issue_shaping:
+        return {
+            "kind": "agentic-workspace/bounded-reflection-reporting/v1",
+            "status": "not-detected",
+            "matched_reflection_signals": [],
+            "matched_mutation_signals": matched_mutation,
+        }
+    if matched_mutation and not matched_issue_shaping:
+        return {
+            "kind": "agentic-workspace/bounded-reflection-reporting/v1",
+            "status": "implementation-like",
+            "matched_reflection_signals": matched_reflection,
+            "matched_mutation_signals": matched_mutation,
+            "rule": "Implementation-like tasks keep active-plan task-switch protection.",
+        }
+    current_task_class = "bounded-dogfooding-issue-shaping" if matched_issue_shaping else "bounded-reflection-reporting"
+    return {
+        "kind": "agentic-workspace/bounded-reflection-reporting/v1",
+        "status": "bounded",
+        "current_task_class": current_task_class,
+        "classification_basis": "explicit-read-only-or-issue-shaping-task-shape",
+        "matched_reflection_signals": matched_reflection,
+        "matched_issue_shaping_signals": matched_issue_shaping,
+        "matched_mutation_signals": matched_mutation,
+        "claim_boundary": (
+            "This task may produce reflection, reporting, dogfooding, or issue-shaping output, but it does not authorize "
+            "active-plan progress, completion, abandonment, or unrelated implementation claims."
+        ),
+        "rule": "This classifier only permits bounded reporting/issue-shaping; implementation-like tasks keep active-plan protection.",
+    }
+
+
+def _completed_active_plan_route_payload(
+    *,
+    target_root: Path,
+    active_summary: dict[str, Any],
+    config: WorkspaceConfig,
+    planning_revision: dict[str, Any],
+) -> dict[str, Any]:
+    active_surface, record = _active_execplan_record_payload(target_root=target_root)
+    active_surface = active_surface or str(active_summary.get("active_execplan") or "")
+    if not active_surface or not record:
+        return {"kind": "agentic-workspace/completed-active-plan-route/v1", "status": "not-detected"}
+    closure_check = _as_dict(record.get("closure_check"))
+    proof_report = _as_dict(record.get("proof_report"))
+    intent_satisfaction = _as_dict(record.get("intent_satisfaction"))
+    intent_continuity = _as_dict(record.get("intent_continuity"))
+    required_continuation = _as_dict(record.get("required_continuation"))
+    closure_values = " ".join(
+        str(value).lower()
+        for value in (
+            closure_check.get("slice status"),
+            closure_check.get("larger-intent status"),
+            closure_check.get("closure decision"),
+            intent_satisfaction.get("was original intent fully satisfied?"),
+            intent_continuity.get("this slice completes the larger intended outcome"),
+            required_continuation.get("required follow-on for the larger intended outcome"),
+        )
+        if value
+    )
+    evidence_fields: list[str] = []
+    if "complete" in str(closure_check.get("slice status", "")).lower():
+        evidence_fields.append("closure_check.slice status")
+    if proof_report and any(str(value).strip() for value in proof_report.values()):
+        evidence_fields.append("proof_report")
+    if str(intent_satisfaction.get("was original intent fully satisfied?", "")).strip().lower() in {"yes", "true", "satisfied"}:
+        evidence_fields.append("intent_satisfaction.was original intent fully satisfied?")
+    if str(required_continuation.get("required follow-on for the larger intended outcome", "")).strip().lower() in {"no", "none"}:
+        evidence_fields.append("required_continuation.required follow-on for the larger intended outcome")
+    completed = (
+        "closure_check.slice status" in evidence_fields
+        and "proof_report" in evidence_fields
+        and "intent_satisfaction.was original intent fully satisfied?" in evidence_fields
+    )
+    if not completed:
+        return {
+            "kind": "agentic-workspace/completed-active-plan-route/v1",
+            "status": "insufficient-evidence",
+            "active_execplan": active_surface,
+            "evidence_fields": evidence_fields,
+            "missing_fields": [
+                field
+                for field in (
+                    "closure_check.slice status",
+                    "proof_report",
+                    "intent_satisfaction.was original intent fully satisfied?",
+                )
+                if field not in evidence_fields
+            ],
+            "rule": "Incomplete active plans keep ordinary active-plan protection.",
+        }
+    plan_id = str(record.get("id") or Path(active_surface).name.removesuffix(".plan.json").removesuffix(".json")).strip()
+    archive_command = _command_with_expected_planning_revision(
+        _command_with_cli_invoke(
+            command=(
+                f"agentic-workspace planning archive-plan --plan {plan_id} --target . "
+                "--prepare-closeout --retain-archive --apply-cleanup --format json"
+            ),
+            cli_invoke=config.cli_invoke,
+        ),
+        planning_revision=planning_revision,
+    )
+    recheck_command = _command_with_cli_invoke(command="agentic-workspace start --target . --format json", cli_invoke=config.cli_invoke)
+    parent_boundary = (
+        "current-slice-complete-only"
+        if "closed" not in closure_values and "complete" not in str(closure_check.get("larger-intent status", "")).lower()
+        else "parent-or-lane-closure-still-requires-explicit-closeout-authorization"
+    )
+    return {
+        "kind": "agentic-workspace/completed-active-plan-route/v1",
+        "status": "archive-or-retire-recommended",
+        "active_execplan": active_surface,
+        "plan_id": plan_id,
+        "evidence_fields": evidence_fields,
+        "archive_command": archive_command,
+        "recheck_command": recheck_command,
+        "parent_lane_boundary": parent_boundary,
+        "claim_boundary": "Archive/retire removes stale active-plan pressure; it does not silently close parent or lane intent.",
+        "rule": "Completed active plans require an explicit command-owned archive/retire route; startup reports but does not mutate.",
     }
 
 
@@ -830,6 +1105,23 @@ def _planning_safety_gate_payload(
         reason = "The active execplan is a slice with a recorded parent lane, but no first-class lane owner artifact exists."
         required_next_action = "create-or-promote-lane-owner"
         workflow_sufficient = False
+    elif task_switch_reconciliation.get("status") == "completed-active-plan-route":
+        status = "attention"
+        decision = "archive-or-retire-completed-plan"
+        reason = str(
+            task_switch_reconciliation.get("summary") or "The active execplan appears complete and should be routed to archive or retire."
+        )
+        required_next_action = "archive-or-retire-completed-plan"
+        workflow_sufficient = True
+    elif task_switch_reconciliation.get("status") == "bounded-reflection-reporting":
+        status = "satisfied"
+        decision = "bounded-reflection-reporting"
+        reason = str(
+            task_switch_reconciliation.get("summary")
+            or "Bounded reflection/reporting may proceed while preserving active-plan claim boundaries."
+        )
+        required_next_action = "produce-bounded-reflection-report"
+        workflow_sufficient = True
     elif task_switch_reconciliation.get("status") == "active":
         status = "attention"
         decision = "active-plan-task-switch"

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -815,18 +815,34 @@ def _start_payload(
     payload["active_plan_reliance"] = planning_safety_gate.get("active_plan_reliance", {})
     custody_planning = planning_safety_gate.get("custody_planning", {})
     custody_applies = isinstance(custody_planning, dict) and custody_planning.get("status") not in (None, "", "not-applicable")
-    if planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies:
-        payload["planning_safety_gate"] = planning_safety_gate
     task_switch = planning_safety_gate.get("task_switch_reconciliation", {})
-    if isinstance(task_switch, dict) and task_switch.get("status") == "active":
+    task_switch_visible_by_default = isinstance(task_switch, dict) and task_switch.get("status") in {
+        "active",
+        "bounded-reflection-reporting",
+        "completed-active-plan-route",
+    }
+    if planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies or task_switch_visible_by_default:
+        payload["planning_safety_gate"] = planning_safety_gate
+    if isinstance(task_switch, dict) and task_switch.get("status") in {
+        "active",
+        "bounded-reflection-reporting",
+        "completed-active-plan-route",
+    }:
         next_packet = task_switch.get("next_action_packet", {})
         if isinstance(next_packet, dict):
+            evidence_required = (
+                ["completed active-plan route accepted or dismissed"]
+                if task_switch.get("status") == "completed-active-plan-route"
+                else ["active-plan claim boundary preserved"]
+                if task_switch.get("status") == "bounded-reflection-reporting"
+                else ["current-task route chosen without claiming active-plan progress"]
+            )
             payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
                 surface="start",
                 decision=planning_safety_gate["decision"],
                 reason=planning_safety_gate["reason"],
                 required_next_action=planning_safety_gate["required_next_action"],
-                evidence_required=["current-task route chosen without claiming active-plan progress"],
+                evidence_required=evidence_required,
             )
             payload["immediate_next_allowed_action"] = next_packet
     if not planning_safety_gate["workflow_sufficient"] and (not _is_config_posture_task(task_text)):
@@ -1450,6 +1466,21 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         memory_consult=payload.get("memory_consult"),
     )
     next_safe_action = _compact_selector_next_safe_action(next_safe_action)
+    workflow_payload = payload.get(
+        "workflow_sufficiency",
+        _workflow_sufficiency_payload(
+            surface="start",
+            decision="enough-for-first-contact-routing",
+            reason="Use the next action and selectors; no raw workspace files are needed yet.",
+        ),
+    )
+    compact_workflow = _tiny_workflow_sufficiency(workflow_payload)
+    if read_only_compact_default:
+        compact_workflow = {
+            key: compact_workflow.get(key)
+            for key in ("kind", "surface", "sufficiency_result", "required_next_action", "evidence_required")
+            if compact_workflow.get(key) not in (None, "", [], {})
+        }
     context: dict[str, Any] = {
         "primary_action": payload["immediate_next_allowed_action"],
         "active_state": payload["active_state_summary"],
@@ -1459,23 +1490,21 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             "preferred_routes": list(skill_routing.get("preferred_routes", [])[:2]) if isinstance(skill_routing, dict) else [],
         },
         "planning": {
-            "workflow_sufficiency": _tiny_workflow_sufficiency(
-                payload.get(
-                    "workflow_sufficiency",
-                    _workflow_sufficiency_payload(
-                        surface="start",
-                        decision="enough-for-first-contact-routing",
-                        reason="Use the next action and selectors; no raw workspace files are needed yet.",
-                    ),
-                )
-            ),
+            "workflow_sufficiency": compact_workflow,
             **(
                 {"planning_safety_gate": _selector_first_planning_safety_gate(payload["planning_safety_gate"])}
                 if "planning_safety_gate" in payload
                 else {}
             ),
         },
-        "memory": payload.get("memory_consult", {}),
+        "memory": {
+            "status": payload.get("memory_consult", {}).get("status", "unknown")
+            if isinstance(payload.get("memory_consult"), dict)
+            else "unknown",
+            "detail_selector": "memory_decision_packet",
+        }
+        if read_only_compact_default
+        else payload.get("memory_consult", {}),
     }
     compact_closeout_obligations = _selector_first_closeout_obligations(payload)
     if compact_closeout_obligations:
@@ -1503,7 +1532,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             )
             if key in local_checkpoint
         }
-    if isinstance(work_threads, dict) and _local_work_threads_default_visible(work_threads):
+    if isinstance(work_threads, dict) and _local_work_threads_default_visible(work_threads) and not read_only_compact_default:
         context["work_threads"] = {
             key: work_threads.get(key)
             for key in (
@@ -1559,10 +1588,15 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     if isinstance(task_path_references, dict) and task_path_references.get("status") == "present":
         context["task_path_references"] = task_path_references
     architecture_forecast = payload.get("architecture_principles_forecast", {})
-    if isinstance(architecture_forecast, dict) and architecture_forecast.get("status") in {
-        "provisional-match",
-        "needs-planned-scope",
-    }:
+    if (
+        isinstance(architecture_forecast, dict)
+        and architecture_forecast.get("status")
+        in {
+            "provisional-match",
+            "needs-planned-scope",
+        }
+        and not read_only_compact_default
+    ):
         context["architecture_principles_forecast"] = architecture_forecast
     pr_comment_attention = payload.get("pr_comment_attention", {})
     if isinstance(pr_comment_attention, dict) and pr_comment_attention.get("status") not in {None, "", "not_applicable"}:
@@ -1612,26 +1646,32 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
         context["installed_state_drift_triage"] = _compact_installed_state_drift_triage(installed_state_triage)
     dogfooding_signal_status = payload.get("dogfooding_signal_status", {})
     if isinstance(dogfooding_signal_status, dict) and dogfooding_signal_status.get("status") not in {None, "", "not_applicable"}:
-        context["dogfooding_signal_status"] = {
-            key: dogfooding_signal_status.get(key)
-            for key in (
-                "kind",
-                "status",
-                "outcome",
-                "closeout_blocked",
-                "destinations",
-                "dismissal_reason",
-                "deferred_reason",
-                "signal_count",
-                "sample_signals",
-                "durability",
-                "durable_residue",
-                "canonical_repo_history",
-                "detail_command",
-                "selector",
-            )
-            if key in dogfooding_signal_status and dogfooding_signal_status.get(key) not in (None, "", [], {}, False, 0)
-        }
+        if read_only_compact_default:
+            context["dogfooding_signal_status"] = {
+                "status": dogfooding_signal_status.get("status"),
+                "selector": dogfooding_signal_status.get("selector", "dogfooding_signal_status"),
+            }
+        else:
+            context["dogfooding_signal_status"] = {
+                key: dogfooding_signal_status.get(key)
+                for key in (
+                    "kind",
+                    "status",
+                    "outcome",
+                    "closeout_blocked",
+                    "destinations",
+                    "dismissal_reason",
+                    "deferred_reason",
+                    "signal_count",
+                    "sample_signals",
+                    "durability",
+                    "durable_residue",
+                    "canonical_repo_history",
+                    "detail_command",
+                    "selector",
+                )
+                if key in dogfooding_signal_status and dogfooding_signal_status.get(key) not in (None, "", [], {}, False, 0)
+            }
     uv_guidance = payload.get("uv_cache_guidance", {})
     if not (isinstance(uv_guidance, dict) and uv_guidance.get("status") == "available"):
         cli_invocation = payload.get("cli_invocation", {})
@@ -1653,7 +1693,6 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                 "status": task_intent.get("status", "unknown") if isinstance(task_intent, dict) else "unknown",
                 "requested_outcomes": task_intent.get("requested_outcomes", [])[:8] if isinstance(task_intent, dict) else [],
                 "task_argument_mode": task_intent.get("task_argument_mode") if isinstance(task_intent, dict) else None,
-                "response_posture": read_only_response,
                 "detail_selector": "acceptance",
             }
             if read_only_compact_default
@@ -1671,7 +1710,11 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             )
             context["task"]["acceptance_detail_selector"] = "acceptance"
         if read_only_compact_default:
-            context["read_only_response"] = read_only_response
+            context["read_only_response"] = {
+                "status": read_only_response.get("status", "unknown") if isinstance(read_only_response, dict) else "unknown",
+                "compact_default": True,
+                "detail_selector": "read_only_response",
+            }
         for optional_key in ("task_file", "task_file_instruction", "task_excerpt", "task_digest", "task_text_length"):
             if isinstance(task_intent, dict) and optional_key in task_intent:
                 context["task"][optional_key] = task_intent[optional_key]
@@ -1810,7 +1853,7 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
                     else "",
                     *startup_proof_commands,
                 ]
-                if str(item).strip()
+                if item not in (None, "", []) and str(item).strip() and str(item).strip().lower() != "none"
             ],
             claim_boundary=next_safe_action.get("claim_boundary", "completion claim requires proof"),
             residue_owner="active continuation state" if payload.get("active_state_summary", {}).get("active_execplan") else "none",
@@ -1827,16 +1870,31 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             },
         ),
         "communication_contract": compact_communication_contract_payload(surface="startup"),
-        "skills": _startup_skills_projection(
-            payload=payload,
-            next_safe_action=next_safe_action,
-            target_root=target_root,
-            cli_invoke=cli_invoke,
+        "skills": (
+            {
+                "kind": "agentic-workspace/startup-skills-projection/v1",
+                "status": "selector-only",
+                "rule": "Read-only compact startup omits skill packet detail; use the catalog selector only when needed.",
+                "required": [],
+                "recommended": [],
+                "catalog": {
+                    "available": True,
+                    "detail_selector": "skills",
+                    "command": f'{cli_invoke} skills --target "{target_root or Path(".")}" --task "<task>" --format json',
+                },
+            }
+            if read_only_compact_default
+            else _startup_skills_projection(
+                payload=payload,
+                next_safe_action=next_safe_action,
+                target_root=target_root,
+                cli_invoke=cli_invoke,
+            )
         ),
         "context": context,
         "drill_down": {
-            "ordinary_profile": "primary=next_safe_action;skills=proj;legacy=select/context",
-            "rule": "Compact default omits selector inventory and schemas. Use exact --select for one field; use --verbose only for broad diagnostics.",
+            "ordinary_profile": "primary=next;skills=proj;detail=select",
+            "rule": "Compact default omits selector inventory/schemas; use --select or --verbose for detail.",
             "selector_inventory": {
                 "status": "omitted-from-compact-default",
                 "available_count": len(available_selectors),
@@ -1846,11 +1904,53 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
             },
         },
     }
+    if read_only_compact_default:
+        decision = selected.get("decision_packet", {})
+        if isinstance(decision, dict):
+            selected["decision_packet"] = {
+                key: decision.get(key)
+                for key in (
+                    "kind",
+                    "surface",
+                    "phase_question",
+                    "next_action",
+                    "blocked_actions",
+                    "reasons",
+                    "shown_because",
+                    "absence_states",
+                )
+                if decision.get(key) not in (None, "", [], {})
+            }
+            if decision.get("claim_boundary") not in (None, "", [], {}):
+                claim_boundary = str(decision.get("claim_boundary"))
+                selected["decision_packet"]["claim_boundary"] = (
+                    claim_boundary if len(claim_boundary) <= 180 else f"{claim_boundary[:177]}..."
+                )
+        selected["communication_contract"] = {
+            "status": "selector-only",
+            "detail_selector": "communication_contract",
+            "rule": "Read-only compact startup keeps the decision visible; use the selector for full response-shape detail.",
+        }
+        selected["drill_down"]["omitted_detail"] = {
+            "selectors": [
+                "planning_safety_gate",
+                "active_state_summary",
+                "work_threads",
+                "installed_state_compatibility",
+                "installed_state_drift_triage",
+                "memory_decision_packet",
+                "architecture_principles_forecast",
+                "drill_down.selector_inventory",
+            ],
+            "rule": "Reflection/reporting defaults stay decision-first; exact selectors expose omitted diagnostics.",
+        }
     task_posture_packet = payload.get("task_posture_packet", {})
     if isinstance(task_posture_packet, dict) and task_posture_packet:
         selected["task_posture_packet"] = _compact_task_posture_packet_projection(task_posture_packet)
-    show_state_delta_packets = str(next_safe_action.get("next_safe_action", "")) != "choose-task-switch-route" and not isinstance(
-        payload.get("installed_state_compatibility"), dict
+    show_state_delta_packets = (
+        str(next_safe_action.get("next_safe_action", "")) != "choose-task-switch-route"
+        and not isinstance(payload.get("installed_state_compatibility"), dict)
+        and not read_only_compact_default
     )
     if show_state_delta_packets:
         state_delta_core = state_delta_core_payload(

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -577,6 +577,7 @@ def _write_issue_1981_closeout_fixture(
     include_proof: bool,
     external_status: str = "closed",
     include_stale_task_posture_residue: bool = False,
+    active_milestone_status: str = "active",
 ) -> None:
     from repo_planning_bootstrap import installer as planning_installer
 
@@ -601,7 +602,7 @@ candidates = []
     record = planning_installer._build_execplan_record_from_todo_item(
         title="Issue 1981 state-delta shared core",
         item_id="issue-1981",
-        status="active",
+        status=active_milestone_status,
         why_now="regress closeout trust alignment.",
         next_action="Close complete.",
         done_when="Issue 1981 can honestly be closed.",
@@ -623,6 +624,14 @@ candidates = []
             "agentic-workspace report --section closeout_trust passed",
             "pytest passed",
         ],
+    }
+    record["execution_summary"] = {
+        "outcome delivered": "The shared state-delta core was implemented.",
+        "validation confirmed": "agentic-workspace summary, closeout_trust, and pytest passed",
+        "follow-on routed to": "none",
+        "post-work posterity capture": "none",
+        "knowledge promoted (Memory/Docs/Config)": "none",
+        "resume from": "archive",
     }
     if include_proof:
         record["proof_report"] = {
@@ -705,7 +714,7 @@ def test_closeout_trust_derives_intent_proof_from_satisfied_active_execplan(tmp_
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
     capsys.readouterr()
-    _write_issue_1981_closeout_fixture(tmp_path, include_proof=True)
+    _write_issue_1981_closeout_fixture(tmp_path, include_proof=True, active_milestone_status="completed")
 
     assert cli.main(["report", "--target", str(tmp_path), "--section", "closeout_trust", "--format", "json"]) == 0
     payload = json.loads(capsys.readouterr().out)["answer"]
@@ -2146,7 +2155,7 @@ def test_start_routes_high_assurance_milestone_to_planning_before_implementation
     assert payload["context"]["planning"]["planning_safety_gate"]["decision_maturity"]["level"] == "hard_gate"
 
 
-def test_start_reconciles_unrelated_active_plan_with_explicit_maintenance_task(tmp_path: Path, capsys) -> None:
+def test_start_reconciles_unrelated_active_plan_with_bounded_reflection_task(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
     capsys.readouterr()
@@ -2184,7 +2193,7 @@ candidates = []
                 "--target",
                 str(tmp_path),
                 "--task",
-                "Report AW session experience and upgrade AW payload",
+                "Estimate AW net effect on this thread",
                 "--format",
                 "json",
             ]
@@ -2193,28 +2202,80 @@ candidates = []
     )
     payload = json.loads(capsys.readouterr().out)
 
-    assert payload["next_safe_action"]["next_safe_action"] == "choose-task-switch-route"
+    assert payload["next_safe_action"]["next_safe_action"] == "produce-bounded-reflection-report"
     assert payload["next_safe_action"]["implementation_allowed"] is True
     assert payload["action_signals"]["implementation_allowed"] is True
-    _assert_json_payload_under(payload, 12_000, label="active-plan maintenance start payload", sort_keys=False)
+    _assert_json_payload_under(payload, 9_000, label="active-plan reflection start payload", sort_keys=False)
     decision = payload["decision_packet"]
     assert decision["phase_question"] == "Startup posture?"
-    assert decision["next_action"] == "choose-task-switch-route"
+    assert decision["next_action"] == "produce-bounded-reflection-report"
     assert decision["absence_states"]["verbose_planning_detail"] == "detail_omitted"
     gate = payload["context"]["planning"]["planning_safety_gate"]
     assert gate["label"] == "work gate"
     assert gate["provenance"] == "planning"
-    assert gate["gate_result"] == "active-plan-task-switch"
+    assert gate["gate_result"] == "bounded-reflection-reporting"
     switch = gate["task_switch_reconciliation"]
-    assert switch["status"] == "active"
-    assert switch["recommended_next_action"] == "proceed-bounded-repo-maintenance"
+    assert switch["status"] == "bounded-reflection-reporting"
+    assert switch["recommended_next_action"] == "produce-bounded-reflection-report"
     assert switch["detail_selector"] == "planning_safety_gate.task_switch_reconciliation"
     assert set(switch["safe_route_ids"]) == {
-        "continue-active-plan",
-        "proceed-bounded-repo-maintenance",
+        "produce-bounded-reflection-report",
+        "inspect-active-plan",
         "reconcile-active-plan-before-implementation",
     }
     assert "claim-active-plan-complete" in switch["blocked_claims"]
+    assert "does not authorize active-plan progress" in switch["claim_boundary"]
+    assert "work_threads" not in payload["context"]
+    assert "architecture_principles_forecast" not in payload["context"]
+    assert payload["context"]["read_only_response"]["compact_default"] is True
+    assert "work_threads" in payload["drill_down"]["omitted_detail"]["selectors"]
+
+
+def test_start_reconciles_unrelated_active_plan_for_dogfooding_issue_shaping(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "active-plan", title = "Unrelated active plan", status = "active", surface = ".agentic-workspace/planning/execplans/active-plan.plan.json" },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Create concrete AW dogfooding feedback issues from this thread",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    switch = payload["context"]["planning"]["planning_safety_gate"]["task_switch_reconciliation"]
+
+    _assert_json_payload_under(payload, 9_000, label="dogfooding issue-shaping start payload", sort_keys=False)
+    assert payload["next_safe_action"]["next_safe_action"] == "produce-bounded-reflection-report"
+    assert switch["status"] == "bounded-reflection-reporting"
+    assert switch["current_task_class"] == "bounded-dogfooding-issue-shaping"
+    assert "claim-active-plan-progress" in switch["blocked_claims"]
+    assert "work_threads" not in payload["context"]
 
 
 def test_start_reconciles_unrelated_active_plan_with_new_issue_implementation_task(tmp_path: Path, capsys) -> None:
@@ -2274,6 +2335,108 @@ candidates = []
         "proceed-bounded-repo-maintenance",
         "reconcile-active-plan-before-implementation",
     }
+
+
+def test_start_routes_completed_active_plan_to_archive_before_new_reflection(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_issue_1981_closeout_fixture(tmp_path, include_proof=True, active_milestone_status="completed")
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Estimate AW net effect on this thread",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    gate = payload["context"]["planning"]["planning_safety_gate"]
+    switch = gate["task_switch_reconciliation"]
+    completed = switch["completed_active_plan"]
+
+    assert payload["next_safe_action"]["next_safe_action"] == "archive-or-retire-completed-plan"
+    assert gate["gate_result"] == "archive-or-retire-completed-plan"
+    assert switch["status"] == "completed-active-plan-route"
+    assert completed["active_execplan"] == ".agentic-workspace/planning/execplans/issue-1981.plan.json"
+    assert "closure_check.slice status" in completed["evidence_fields"]
+    assert "proof_report" in completed["evidence_fields"]
+    assert "planning archive-plan --plan issue-1981" in completed["archive_command"]
+    assert completed["parent_lane_boundary"] == "parent-or-lane-closure-still-requires-explicit-closeout-authorization"
+
+    assert (
+        cli.main(
+            [
+                "planning",
+                "archive-plan",
+                "--plan",
+                "issue-1981",
+                "--target",
+                str(tmp_path),
+                "--prepare-closeout",
+                "--retain-archive",
+                "--apply-cleanup",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Estimate AW net effect on this thread",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    after = json.loads(capsys.readouterr().out)
+
+    assert after["next_safe_action"]["next_safe_action"] != "archive-or-retire-completed-plan"
+    assert "planning_safety_gate" not in after["context"]["planning"]
+
+
+def test_start_keeps_incomplete_active_plan_on_task_switch_route(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_issue_1981_closeout_fixture(tmp_path, include_proof=False)
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Implement unrelated parser cleanup",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    gate = payload["context"]["planning"]["planning_safety_gate"]
+
+    assert payload["next_safe_action"]["next_safe_action"] == "choose-task-switch-route"
+    assert gate["gate_result"] == "active-plan-task-switch"
+    assert gate["task_switch_reconciliation"]["status"] == "active"
 
 
 def test_start_treats_shared_issue_ref_as_active_plan_continuation(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -2235,6 +2235,15 @@ def test_start_reconciles_unrelated_active_plan_for_dogfooding_issue_shaping(tmp
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
     capsys.readouterr()
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "active-plan.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "id": "active-plan",
+            "title": "Unrelated active plan",
+            "post_decomposition_delegation": {"status": "ready"},
+        },
+    )
     _write(
         tmp_path / ".agentic-workspace" / "planning" / "state.toml",
         """
@@ -2276,6 +2285,60 @@ candidates = []
     assert switch["current_task_class"] == "bounded-dogfooding-issue-shaping"
     assert "claim-active-plan-progress" in switch["blocked_claims"]
     assert "work_threads" not in payload["context"]
+
+
+def test_start_keeps_mixed_issue_shaping_and_mutation_on_task_switch_route(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "active-plan.plan.json",
+        {
+            "kind": "planning-execplan/v1",
+            "id": "active-plan",
+            "title": "Unrelated active plan",
+            "post_decomposition_delegation": {"status": "ready"},
+        },
+    )
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "active-plan", title = "Unrelated active plan", status = "active", surface = ".agentic-workspace/planning/execplans/active-plan.plan.json" },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Create concrete AW dogfooding feedback issues and change the runtime",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    switch = payload["context"]["planning"]["planning_safety_gate"]["task_switch_reconciliation"]
+
+    assert payload["next_safe_action"]["next_safe_action"] == "choose-task-switch-route"
+    assert switch["status"] == "active"
+    assert switch["recommended_next_action"] == "proceed-bounded-repo-maintenance"
+    assert "claim-active-plan-progress" in switch["blocked_claims"]
 
 
 def test_start_reconciles_unrelated_active_plan_with_new_issue_implementation_task(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## What changed

- Routes bounded dogfooding reflection, reporting, and issue-shaping tasks to `produce-bounded-reflection-report` instead of the generic active-plan task-switch choice.
- Detects completed active execplans with closeout/proof evidence and surfaces an explicit `archive-or-retire-completed-plan` route before new reflection work.
- Keeps read-only reflection startup output compact and selector-first, with full planning/detail packets behind selectors.
- Updates startup conformance expectations and regression coverage.

Closes #2055.
Closes #2056.
Closes #2057.

## Validation

- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run pytest tests/test_generated_tool_conformance.py::test_generated_tool_process_conformance_contracts[start.context.process] tests/test_workspace_cli.py::test_start_default_stays_under_tiny_output_budget_for_docs_task tests/test_workspace_cli.py::test_start_low_risk_docs_task_keeps_checkpoint_detail_selector_only tests/test_workspace_cli.py::test_chat_agent_default_outputs_stay_bounded_without_selector_inventories -q`
- `make test-workspace`
- `make lint-workspace`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`
