### PR TITLE
Sync verification ownership payload

### DIFF
--- a/.agentic-workspace/OWNERSHIP.toml
+++ b/.agentic-workspace/OWNERSHIP.toml
@@ -157,6 +157,14 @@ authority = "primary"
 summary = "Memory-owned shared workflow, version, bootstrap, and skill support surfaces."
 
 [[authority_surfaces]]
+concern = "verification-manifest"
+surface = ".agentic-workspace/verification/manifest.toml"
+owner = "verification"
+ownership = "repo_owned"
+authority = "primary"
+summary = "Repo-owned Verification protocol manifest for reusable proof routes, scenarios, and known evidence gaps."
+
+[[authority_surfaces]]
 concern = "workspace-workflow-pointer"
 surface = "AGENTS.md#agentic-workspace:workflow"
 owner = "workspace"
@@ -177,6 +185,14 @@ paths = [".agentic-workspace/memory/**", "packages/memory/**"]
 owns = ["durable repo knowledge", "memory note routing", "memory package workflow semantics"]
 does_not_own = ["active execution planning", "workspace command runtime internals"]
 escalate_when = ["change widens what memory may store", "promotion policy changes"]
+
+[[subsystems]]
+id = "verification"
+paths = [".agentic-workspace/verification/**", "packages/verification/**"]
+owns = ["reusable proof protocols", "verification evidence routing", "verification package workflow semantics"]
+does_not_own = ["semantic user acceptance", "active execution planning", "issue or parent-lane closure"]
+proof = ["uv run pytest packages/verification/tests -q"]
+escalate_when = ["change makes Verification a proof authority", "protocol changes widen closeout or acceptance semantics"]
 
 [[subsystems]]
 id = "workspace-cli-runtime"

--- a/.agentic-workspace/docs/workspace-config-contract.md
+++ b/.agentic-workspace/docs/workspace-config-contract.md
@@ -29,7 +29,6 @@ Planning and Memory remain behavior modules inside that substrate rather than am
 ## Authority Map
 
 - **Repo-owned workspace policy** lives in `.agentic-workspace/config.toml`.
-- **Effective operation enablement** is `[workspace].enabled`. It defaults to `true`; `.agentic-workspace/config.local.toml` may override it for one machine.
 - **Workspace-owned shared contract docs** live in `.agentic-workspace/docs/`.
 - **Ownership and authority lookup** live in `.agentic-workspace/OWNERSHIP.toml` and `agentic-workspace ownership --target ./repo --format json`.
 - **Module descriptors** define installed module capabilities, workflow surfaces, generated artifacts, dependencies, and conflicts.
@@ -38,19 +37,6 @@ Planning and Memory remain behavior modules inside that substrate rather than am
 - **Repo-owned prose startup surfaces** remain useful, but they are adapters over the structured substrate once the workspace is installed.
 
 Do not treat prose surfaces as the primary authority once the structured substrate can answer the same question directly.
-
-## Operation Enablement
-
-`[workspace].enabled` controls whether ordinary Agentic Workspace workflow is active for a repository.
-
-- Default: `enabled = true`.
-- Repo-owned policy: `.agentic-workspace/config.toml [workspace] enabled = true|false`.
-- Machine-local override: `.agentic-workspace/config.local.toml [workspace] enabled = true|false`.
-- Precedence: local config overrides repo config for the effective value.
-
-When the effective value is `false`, ordinary workflow commands such as `start`, `summary`, `report`, `implement`, `proof`, and closeout routes stop before normal workflow loading and return an `agentic-workspace/disabled-state/v1` packet. Diagnostic and recovery commands remain available enough to inspect or re-enable the workspace, including `config`, `status`, `doctor`, `defaults`, `modules`, `skills`, and `preflight`.
-
-This switch does not uninstall Agentic Workspace, delete workspace files, disable individual modules, or supersede host repo instructions. It is an operation gate for AW workflow participation.
 
 ## Managed File Headers
 

--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,8 +13,8 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:5efdd6485bb2",
-    "version": "0.23.1"
+    "source_identity": "git:73e7355b59eb",
+    "version": "0.25.0"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
   "payload_capabilities": [
@@ -40,8 +40,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.23.1",
-    "version": "0.23.1"
+    "tag": "v0.25.0",
+    "version": "0.25.0"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/src/agentic_workspace/_payload/.agentic-workspace/OWNERSHIP.toml
+++ b/src/agentic_workspace/_payload/.agentic-workspace/OWNERSHIP.toml
@@ -157,6 +157,14 @@ authority = "primary"
 summary = "Memory-owned shared workflow, version, bootstrap, and skill support surfaces."
 
 [[authority_surfaces]]
+concern = "verification-manifest"
+surface = ".agentic-workspace/verification/manifest.toml"
+owner = "verification"
+ownership = "repo_owned"
+authority = "primary"
+summary = "Repo-owned Verification protocol manifest for reusable proof routes, scenarios, and known evidence gaps."
+
+[[authority_surfaces]]
 concern = "workspace-workflow-pointer"
 surface = "AGENTS.md#agentic-workspace:workflow"
 owner = "workspace"
@@ -177,6 +185,14 @@ paths = [".agentic-workspace/memory/**", "packages/memory/**"]
 owns = ["durable repo knowledge", "memory note routing", "memory package workflow semantics"]
 does_not_own = ["active execution planning", "workspace command runtime internals"]
 escalate_when = ["change widens what memory may store", "promotion policy changes"]
+
+[[subsystems]]
+id = "verification"
+paths = [".agentic-workspace/verification/**", "packages/verification/**"]
+owns = ["reusable proof protocols", "verification evidence routing", "verification package workflow semantics"]
+does_not_own = ["semantic user acceptance", "active execution planning", "issue or parent-lane closure"]
+proof = ["uv run pytest packages/verification/tests -q"]
+escalate_when = ["change makes Verification a proof authority", "protocol changes widen closeout or acceptance semantics"]
 
 [[subsystems]]
 id = "workspace-cli-runtime"


### PR DESCRIPTION
## Summary
- Sync the installed AW payload provenance to 0.25.0 for this source checkout.
- Add Verification as an explicit ownership authority surface and subsystem in both the installed ledger and source payload mirror.
- Remove stale `[workspace].enabled` documentation from the workspace config contract.

## Why
The jumpstart/manual review found the installed payload needed to stay synced in this repo, and Verification was present as a repo-populated payload surface without an explicit ownership-ledger entry.

## Validation
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `make absolute-paths`
- `git diff --check`
- `uv run pytest packages/verification/tests -q`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --format json`
- `uv run python scripts/run_agentic_workspace.py status --target . --format json`
- `uv run python scripts/run_agentic_workspace.py ownership --target . --path .agentic-workspace/verification/manifest.toml --format json`
