### PR TITLE
Minimize ordinary bootstrap footprint

### DIFF
--- a/.agentic-workspace/docs/installer-behavior.md
+++ b/.agentic-workspace/docs/installer-behavior.md
@@ -45,6 +45,14 @@ The installer distinguishes between three classes of files:
 2. **Package Managed**: Contracts and scripts in `docs/` or `scripts/`. These are updated by the installer during upgrades.
 3. **Generated**: Artifacts like `AGENT_QUICKSTART.md` that are derived from canonical manifests.
 
+## Bootstrap Footprint
+
+Root `agentic-workspace init` and `agentic-workspace install` use the necessary-surface footprint by default. They create repo-owned config/startup, a compact adoption receipt, and the smallest selected module state anchors; they preserve durable pre-existing local-mode Planning, Memory, and Verification state; and they omit generic package payload, bundled skills, payload provenance, and upgrade-source provenance.
+
+The invocation source does not decide the host-repo footprint. A released package, dev dependency, editable install, or source checkout can all provide package payload at runtime. Use `--mirror-payload` only when a host repo explicitly wants bundled docs, templates, schemas, skills, provenance, and module upgrade-source files checked in.
+
+Ordinary handoff files live under `.agentic-workspace/local/scratch/` instead of tracked bootstrap handoff paths. Status and doctor treat omitted package payload as healthy only when the checked-in adoption receipt records that package mirroring is not enabled.
+
 ## Local-only Installation
 
 The workspace-level `agentic-workspace install --local-only` command installs the shared workspace surfaces in the normal repository layout, but records `.agentic-workspace/` in git-local exclude metadata instead of expecting the package surfaces to be checked in.

--- a/docs/agentic-workspace-install.md
+++ b/docs/agentic-workspace-install.md
@@ -19,6 +19,8 @@ agentic-workspace defaults --section module_selection --format json
 agentic-workspace init --target . --modules memory
 ```
 
+Ordinary bootstrap writes only necessary checked-in surfaces: repo-owned config/startup, a compact adoption receipt, and the smallest selected module state anchors. Generic package docs, templates, schemas, bundled skills, payload provenance, and upgrade-source provenance stay package-owned and are read from the installed package, dev dependency, editable install, or source checkout at runtime. Use `--mirror-payload` only when the host repo explicitly wants the full bundled payload checked in.
+
 Choose the smallest module set that fits:
 
 - `memory`: durable repo knowledge and anti-rediscovery context.
@@ -50,4 +52,4 @@ agentic-workspace config --target . --format json
 agentic-workspace doctor --target . --format json
 ```
 
-If bootstrap writes `.agentic-workspace/bootstrap-handoff.md` or `.agentic-workspace/bootstrap-handoff.json`, treat that as the bounded finishing brief before normal repo work resumes.
+If ordinary bootstrap needs a finishing brief, it is written under `.agentic-workspace/local/scratch/` and should not be checked in. Payload mirror mode may still write `.agentic-workspace/bootstrap-handoff.md` or `.agentic-workspace/bootstrap-handoff.json`; treat those as bounded finishing briefs before normal repo work resumes.

--- a/docs/package/installed-surfaces.md
+++ b/docs/package/installed-surfaces.md
@@ -17,6 +17,8 @@ An installed host repository gets a small set of checked-in surfaces. Their purp
 
 The package keeps `AGENTS.md` thin. Durable rules and structured state live under `.agentic-workspace/` or in repo-owned docs, not in a growing startup manual.
 
+Bootstrap uses the necessary-surface footprint by default. It creates shared config/startup, a compact adoption receipt, and selected module state anchors while preserving durable pre-existing local-mode Planning, Memory, and Verification state. Generic package payload remains package-owned and is read from the installed package, dev dependency, editable install, or source checkout at runtime. `--mirror-payload` is the explicit opt-in for checking in bundled docs, templates, schemas, skills, payload provenance, and upgrade-source provenance.
+
 ## Participation Boundary
 
 Installed surfaces should expose the operating loop, not every implementation

--- a/docs/package/lifecycle.md
+++ b/docs/package/lifecycle.md
@@ -18,6 +18,10 @@ The `agentic-workspace` CLI has two jobs:
 
 Mutating commands are conservative. They operate on package-owned surfaces, managed fences, and module-owned directories, and report manual-review cases instead of blindly rewriting repo-owned content.
 
+`init` and `install` use the necessary-surface footprint by default. They write repo-owned config/startup, a compact adoption receipt, and the smallest selected module state anchors while preserving durable pre-existing Planning, Memory, and Verification state. Generic package docs, templates, schemas, bundled skills, payload provenance, and upgrade-source provenance remain package-owned and are read from the installed package, dev dependency, editable install, or source checkout at runtime.
+
+Use `--mirror-payload` only when a host repo explicitly wants the full package payload checked in for offline or tool-agnostic operation. Ordinary handoff files are written under `.agentic-workspace/local/scratch/` and should not become durable tracked state.
+
 ## Context Commands
 
 | Command | First question answered |

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -3192,6 +3192,14 @@
         {
           "action": "store_true",
           "flags": [
+            "--mirror-payload"
+          ],
+          "help": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint.",
+          "name": "mirror_payload"
+        },
+        {
+          "action": "store_true",
+          "flags": [
             "--dry-run"
           ],
           "help": "Show planned changes without mutating files.",
@@ -3305,6 +3313,14 @@
           ],
           "help": "Force conservative adopt behavior.",
           "name": "adopt"
+        },
+        {
+          "action": "store_true",
+          "flags": [
+            "--mirror-payload"
+          ],
+          "help": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint.",
+          "name": "mirror_payload"
         },
         {
           "action": "store_true",

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -4278,6 +4278,14 @@
           {
             "action": "store_true",
             "flags": [
+              "--mirror-payload"
+            ],
+            "help": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint.",
+            "name": "mirror_payload"
+          },
+          {
+            "action": "store_true",
+            "flags": [
               "--dry-run"
             ],
             "help": "Show planned changes without mutating files.",
@@ -4446,6 +4454,14 @@
             ],
             "help": "Force conservative adopt behavior.",
             "name": "adopt"
+          },
+          {
+            "action": "store_true",
+            "flags": [
+              "--mirror-payload"
+            ],
+            "help": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint.",
+            "name": "mirror_payload"
           },
           {
             "action": "store_true",

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -4278,6 +4278,14 @@
           {
             "action": "store_true",
             "flags": [
+              "--mirror-payload"
+            ],
+            "help": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint.",
+            "name": "mirror_payload"
+          },
+          {
+            "action": "store_true",
+            "flags": [
               "--dry-run"
             ],
             "help": "Show planned changes without mutating files.",
@@ -4446,6 +4454,14 @@
             ],
             "help": "Force conservative adopt behavior.",
             "name": "adopt"
+          },
+          {
+            "action": "store_true",
+            "flags": [
+              "--mirror-payload"
+            ],
+            "help": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint.",
+            "name": "mirror_payload"
           },
           {
             "action": "store_true",

--- a/generated/workspace/typescript/resources/operations/init.lifecycle.json
+++ b/generated/workspace/typescript/resources/operations/init.lifecycle.json
@@ -32,6 +32,12 @@
       "source": "cli-option"
     },
     {
+      "description": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint.",
+      "name": "mirror_payload",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
       "command_visibility": "non-command-visible",
       "description": "Internal lifecycle adapter value; root init exposes --adopt for command-visible forced adoption behavior.",
       "name": "force",

--- a/generated/workspace/typescript/resources/operations/install.lifecycle.json
+++ b/generated/workspace/typescript/resources/operations/install.lifecycle.json
@@ -32,6 +32,12 @@
       "source": "cli-option"
     },
     {
+      "description": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint.",
+      "name": "mirror_payload",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
       "command_visibility": "non-command-visible",
       "description": "Internal lifecycle adapter value; root install exposes --adopt for command-visible forced adoption behavior.",
       "name": "force",

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -3243,6 +3243,14 @@ const commandDefinitions = [
         {
           "action": "store_true",
           "flags": [
+            "--mirror-payload"
+          ],
+          "help": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint.",
+          "name": "mirror_payload"
+        },
+        {
+          "action": "store_true",
+          "flags": [
             "--dry-run"
           ],
           "help": "Show planned changes without mutating files.",
@@ -3358,6 +3366,14 @@ const commandDefinitions = [
           ],
           "help": "Force conservative adopt behavior.",
           "name": "adopt"
+        },
+        {
+          "action": "store_true",
+          "flags": [
+            "--mirror-payload"
+          ],
+          "help": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint.",
+          "name": "mirror_payload"
         },
         {
           "action": "store_true",

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -19,6 +19,8 @@ WORKSPACE_LOCAL_MEMORY_DEFAULT_PATH = Path(".agentic-workspace/local/memory.toml
 WORKSPACE_LOCAL_INTEGRATION_ROOT_PATH = Path(".agentic-workspace/local/integrations")
 WORKSPACE_LOCAL_INTEGRATION_SUBFOLDER_CONVENTION = "<vendor-or-runtime>/"
 WORKSPACE_LOCAL_SCRATCH_ROOT_PATH = Path(".agentic-workspace/local/scratch")
+WORKSPACE_LOCAL_BOOTSTRAP_HANDOFF_PATH = WORKSPACE_LOCAL_SCRATCH_ROOT_PATH / "bootstrap-handoff.md"
+WORKSPACE_LOCAL_BOOTSTRAP_HANDOFF_RECORD_PATH = WORKSPACE_LOCAL_SCRATCH_ROOT_PATH / "bootstrap-handoff.json"
 WORKSPACE_AGENT_AID_ROOT_PATH = Path(".agentic-workspace/agent-aids")
 WORKSPACE_AGENT_AID_SUBDIRS = (
     "scripts",
@@ -57,6 +59,12 @@ SYSTEM_INTENT_SOURCE_DISCOVERY_CANDIDATES = (
 )
 WORKSPACE_BOOTSTRAP_HANDOFF_PATH = Path(".agentic-workspace/bootstrap-handoff.md")
 WORKSPACE_BOOTSTRAP_HANDOFF_RECORD_PATH = Path(".agentic-workspace/bootstrap-handoff.json")
+WORKSPACE_ADOPTION_RECEIPT_PATH = Path(".agentic-workspace/adoption-receipt.json")
+DEFAULT_BOOTSTRAP_FOOTPRINT_PROFILE = "necessary-surfaces"
+SUPPORTED_BOOTSTRAP_FOOTPRINT_PROFILES = (
+    "necessary-surfaces",
+    "full-payload-mirror",
+)
 DEFAULT_AGENT_INSTRUCTIONS_FILE = "AGENTS.md"
 SUPPORTED_AGENT_INSTRUCTIONS_FILES = (
     "AGENTS.md",

--- a/src/agentic_workspace/contracts/cli_option_groups.json
+++ b/src/agentic_workspace/contracts/cli_option_groups.json
@@ -104,6 +104,14 @@
           "help": "Force conservative adopt behavior."
         },
         {
+          "name": "mirror_payload",
+          "flags": [
+            "--mirror-payload"
+          ],
+          "action": "store_true",
+          "help": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint."
+        },
+        {
           "name": "dry_run",
           "flags": [
             "--dry-run"

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -5626,6 +5626,14 @@
                 "help": "Force conservative adopt behavior."
               },
               {
+                "name": "mirror_payload",
+                "flags": [
+                  "--mirror-payload"
+                ],
+                "action": "store_true",
+                "help": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint."
+              },
+              {
                 "name": "dry_run",
                 "flags": [
                   "--dry-run"
@@ -5796,6 +5804,14 @@
                 ],
                 "action": "store_true",
                 "help": "Force conservative adopt behavior."
+              },
+              {
+                "name": "mirror_payload",
+                "flags": [
+                  "--mirror-payload"
+                ],
+                "action": "store_true",
+                "help": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint."
               },
               {
                 "name": "dry_run",

--- a/src/agentic_workspace/contracts/conformance/init.lifecycle.dry-run.process.json
+++ b/src/agentic_workspace/contracts/conformance/init.lifecycle.dry-run.process.json
@@ -97,7 +97,7 @@
             "next_safe_command",
             "status"
           ],
-          "equals": "review-required"
+          "equals": "ready"
         }
       ]
     },

--- a/src/agentic_workspace/contracts/conformance/install.lifecycle.dry-run.process.json
+++ b/src/agentic_workspace/contracts/conformance/install.lifecycle.dry-run.process.json
@@ -110,7 +110,7 @@
             "next_safe_command",
             "status"
           ],
-          "equals": "review-required"
+          "equals": "ready"
         }
       ]
     },

--- a/src/agentic_workspace/contracts/operations/init.lifecycle.json
+++ b/src/agentic_workspace/contracts/operations/init.lifecycle.json
@@ -23,6 +23,12 @@
       "required": false
     },
     {
+      "name": "mirror_payload",
+      "source": "cli-option",
+      "required": false,
+      "description": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint."
+    },
+    {
       "name": "force",
       "source": "cli-option",
       "command_visibility": "non-command-visible",

--- a/src/agentic_workspace/contracts/operations/install.lifecycle.json
+++ b/src/agentic_workspace/contracts/operations/install.lifecycle.json
@@ -23,6 +23,12 @@
       "required": false
     },
     {
+      "name": "mirror_payload",
+      "source": "cli-option",
+      "required": false,
+      "description": "Opt in to checking in the full generic package payload mirror instead of the ordinary necessary-surface footprint."
+    },
+    {
       "name": "force",
       "source": "cli-option",
       "command_visibility": "non-command-visible",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -35,6 +35,7 @@ from agentic_workspace._schema import ModuleDescriptor, ModuleResultContract, Ro
 from agentic_workspace.config import (
     DEFAULT_AGENT_INSTRUCTIONS_FILE,
     DEFAULT_ASSURANCE_LEVEL,
+    DEFAULT_BOOTSTRAP_FOOTPRINT_PROFILE,
     DEFAULT_CLI_INVOKE,
     DEFAULT_IMPROVEMENT_LATITUDE,
     DEFAULT_OPTIMIZATION_BIAS,
@@ -47,6 +48,7 @@ from agentic_workspace.config import (
     SUPPORTED_AGENT_INSTRUCTIONS_FILES,
     SUPPORTED_ASSURANCE_LEVELS,
     SUPPORTED_ASSURANCE_REQUIREMENT_BLOCKING_CLAIMS,
+    SUPPORTED_BOOTSTRAP_FOOTPRINT_PROFILES,
     SUPPORTED_CAPABILITY_EXECUTION_CLASSES,
     SUPPORTED_CAPABILITY_LOCATIONS,
     SUPPORTED_CLARIFICATION_CONTROL_MODES,
@@ -65,12 +67,15 @@ from agentic_workspace.config import (
     SUPPORTED_WORKFLOW_ARTIFACT_PROFILES,
     SUPPORTED_WORKFLOW_OBLIGATION_FORCES,
     SUPPORTED_WORKFLOW_OBLIGATION_STAGES,
+    WORKSPACE_ADOPTION_RECEIPT_PATH,
     WORKSPACE_AGENT_AID_ROOT_PATH,
     WORKSPACE_AGENT_AID_SUBDIRS,
     WORKSPACE_BOOTSTRAP_HANDOFF_PATH,
     WORKSPACE_BOOTSTRAP_HANDOFF_RECORD_PATH,
     WORKSPACE_CONFIG_PATH,
     WORKSPACE_DELEGATION_OUTCOMES_PATH,
+    WORKSPACE_LOCAL_BOOTSTRAP_HANDOFF_PATH,
+    WORKSPACE_LOCAL_BOOTSTRAP_HANDOFF_RECORD_PATH,
     WORKSPACE_LOCAL_CONFIG_PATH,
     WORKSPACE_LOCAL_INTEGRATION_ALLOWED_AID_KINDS,
     WORKSPACE_LOCAL_INTEGRATION_BOUNDARY_RULES,
@@ -540,6 +545,26 @@ def _installed_package_source_class(*, package: str) -> str:
     return "installed-package"
 
 
+ADOPTION_RECEIPT_KIND = "agentic-workspace/adoption-receipt/v1"
+
+
+def _resolve_bootstrap_footprint_profile(*, target_root: Path, requested_profile: str | None = None, mirror_payload: bool = False) -> str:
+    del target_root
+    if mirror_payload:
+        return "full-payload-mirror"
+    if requested_profile:
+        profile = requested_profile.strip()
+        if profile not in SUPPORTED_BOOTSTRAP_FOOTPRINT_PROFILES:
+            supported = ", ".join(SUPPORTED_BOOTSTRAP_FOOTPRINT_PROFILES)
+            raise WorkspaceUsageError(f"Unsupported bootstrap footprint profile '{profile}'. Supported profiles: {supported}.")
+        return profile
+    return DEFAULT_BOOTSTRAP_FOOTPRINT_PROFILE
+
+
+def _uses_minimal_bootstrap_footprint(profile: str) -> bool:
+    return profile == DEFAULT_BOOTSTRAP_FOOTPRINT_PROFILE
+
+
 def _package_version(package: str) -> str:
     try:
         return importlib.metadata.version(package)
@@ -700,6 +725,87 @@ def _write_payload_provenance_action(*, target_root: Path, dry_run: bool, force:
         "path": relative.as_posix(),
         "detail": "record AW payload provenance for installed-state compatibility checks",
     }
+
+
+def _adoption_receipt_payload(*, selected_modules: list[str], reports: list[dict[str, Any]], payload_mirror: bool) -> dict[str, Any]:
+    adopted_state: list[str] = []
+    for report in reports:
+        for action in report.get("actions", []):
+            if not isinstance(action, dict):
+                continue
+            path = str(action.get("path", "")).replace("\\", "/")
+            if path.startswith(".agentic-workspace/"):
+                path = path.removeprefix(".agentic-workspace/")
+            if path == "planning/execplans" or path.startswith(
+                ("planning/state.toml", "planning/execplans/", "memory/repo/", "verification/")
+            ):
+                _append_unique(adopted_state, path)
+    omitted_package_payload = (
+        []
+        if payload_mirror
+        else _dedupe(
+            [
+                "package-payload",
+                "payload-provenance.json",
+                "AGENTS.md",
+                *[f"{module_name}/package-payload" for module_name in selected_modules],
+            ]
+        )
+    )
+    return {
+        "kind": ADOPTION_RECEIPT_KIND,
+        "checked_in_rule": "necessary-surfaces-only",
+        "adopted_state": sorted(adopted_state),
+        "omitted_package_payload": omitted_package_payload,
+        "local_only": [
+            "local/scratch/bootstrap-handoff.md",
+            "local/scratch/bootstrap-handoff.json",
+            "absolute-path provenance",
+        ],
+        "payload_mirror": payload_mirror,
+        "recheck_command": "agentic-workspace doctor --target . --format json",
+        "rule": (
+            "This receipt is the durable authority that ordinary bootstrap intentionally omitted generic package payload. "
+            "Status and doctor must not infer that decision from missing files alone."
+        ),
+    }
+
+
+def _write_adoption_receipt_action(
+    *, target_root: Path, selected_modules: list[str], reports: list[dict[str, Any]], payload_mirror: bool, dry_run: bool
+) -> dict[str, str]:
+    relative = WORKSPACE_ADOPTION_RECEIPT_PATH
+    path = target_root / relative
+    existing_text = path.read_text(encoding="utf-8") if path.exists() else None
+    payload = _adoption_receipt_payload(selected_modules=selected_modules, reports=reports, payload_mirror=payload_mirror)
+    rendered_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if existing_text == rendered_text:
+        return {"kind": "current", "path": relative.as_posix(), "detail": "adoption receipt already current"}
+    if not dry_run:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(rendered_text, encoding="utf-8")
+    return {
+        "kind": "would create" if dry_run and existing_text is None else "would update" if dry_run else "created",
+        "path": relative.as_posix(),
+        "detail": "record checked-in footprint decision without local absolute paths",
+    }
+
+
+def _read_adoption_receipt(*, target_root: Path) -> dict[str, Any]:
+    path = target_root / WORKSPACE_ADOPTION_RECEIPT_PATH
+    if not path.is_file():
+        return {"status": "missing", "path": WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix()}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"status": "invalid", "path": WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix(), "error": str(exc)}
+    if not isinstance(payload, dict) or payload.get("kind") != ADOPTION_RECEIPT_KIND:
+        return {
+            "status": "invalid",
+            "path": WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix(),
+            "error": "adoption receipt kind is missing or unsupported",
+        }
+    return {"status": "present", "path": WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix(), "payload": payload}
 
 
 def _validate_payload_provenance(payload: dict[str, Any]) -> list[str]:
@@ -1619,7 +1725,7 @@ def _installed_state_compatibility_payload(
     if provenance_status.get("status") in {"invalid"}:
         payload_provenance_drift = "invalid-provenance"
     elif provenance_status.get("status") == "missing" and initialized_payload_present:
-        payload_provenance_drift = "missing-provenance"
+        payload_provenance_drift = "none" if _minimal_bootstrap_footprint_detected(target_root=target_root) else "missing-provenance"
     elif installed_version and _version_key(installed_version) > _version_key(__version__):
         payload_provenance_drift = "executable-too-old"
     elif installed_version and _version_key(installed_version) < _version_key(__version__):
@@ -5705,10 +5811,7 @@ def _module_operations() -> dict[str, ModuleDescriptor]:
             "uninstall_handler": planning_uninstall_bootstrap,
             "doctor_handler": planning_doctor_bootstrap,
             "status_handler": planning_collect_status,
-            "detector": lambda target_root: (
-                (target_root / ".agentic-workspace" / "planning" / "state.toml").exists()
-                and (target_root / ".agentic-workspace" / "planning" / "agent-manifest.json").exists()
-            ),
+            "detector": lambda target_root: (target_root / ".agentic-workspace" / "planning" / "state.toml").exists(),
         },
         "memory": {
             "install_handler": memory_install_bootstrap,
@@ -6877,29 +6980,94 @@ def _sync_workspace_managed_agent_instructions(
     return ([action], [warning])
 
 
+def _minimal_bootstrap_footprint_detected(*, target_root: Path) -> bool:
+    receipt_status = _read_adoption_receipt(target_root=target_root)
+    receipt = receipt_status.get("payload") if receipt_status.get("status") == "present" else {}
+    return isinstance(receipt, dict) and receipt.get("payload_mirror") is False
+
+
+def _filter_minimal_bootstrap_module_report(report: dict[str, Any]) -> dict[str, Any]:
+    def _is_intentional_minimal_warning(item: dict[str, Any]) -> bool:
+        text = " ".join((str(item.get("message", "")), str(item.get("detail", ""))))
+        path = str(item.get("path", ""))
+        kind = str(item.get("kind", ""))
+        role = str(item.get("role", ""))
+        missing_or_package_change = "missing" in text or "planned change" in text
+        return (
+            "shared Workspace layer is not installed" in text
+            or (path == "AGENTS.md" and role == "local-entrypoint" and "missing canonical workflow pointer block" in text)
+            or (path.startswith(".agentic-workspace/docs/") and missing_or_package_change)
+            or (path.startswith(".agentic-workspace/skills/") and missing_or_package_change)
+            or (path.startswith(".agentic-workspace/planning/skills/") and missing_or_package_change)
+            or (path.startswith(".agentic-workspace/planning/schemas/") and missing_or_package_change)
+            or (path.startswith(".agentic-workspace/planning/") and path.endswith("/README.md") and missing_or_package_change)
+            or (path.startswith(".agentic-workspace/planning/") and "/TEMPLATE." in path and missing_or_package_change)
+            or (path.startswith(".agentic-workspace/planning/decompositions/") and missing_or_package_change)
+            or (path == ".agentic-workspace/planning/agent-manifest.json" and missing_or_package_change)
+            or (path.startswith(".agentic-workspace/memory/skills/") and missing_or_package_change)
+            or (path.startswith(".agentic-workspace/memory/bootstrap/") and missing_or_package_change)
+            or (path.startswith(".agentic-workspace/memory/repo/") and path.endswith("/README.md") and missing_or_package_change)
+            or (path.startswith(".agentic-workspace/memory/repo/templates/") and missing_or_package_change)
+            or (path == ".agentic-workspace/memory/repo/manifest.toml" and kind == "would replace" and "planned change" in text)
+            or (
+                path
+                in {".agentic-workspace/memory/SKILLS.md", ".agentic-workspace/memory/VERSION.md", ".agentic-workspace/memory/WORKFLOW.md"}
+                and missing_or_package_change
+            )
+            or path.endswith("/UPGRADE-SOURCE.toml")
+        )
+
+    filtered_warnings = [
+        warning for warning in report.get("warnings", []) if not (isinstance(warning, dict) and _is_intentional_minimal_warning(warning))
+    ]
+    filtered_actions = [
+        action for action in report.get("actions", []) if not (isinstance(action, dict) and _is_intentional_minimal_warning(action))
+    ]
+    if len(filtered_warnings) == len(report.get("warnings", [])) and len(filtered_actions) == len(report.get("actions", [])):
+        return report
+    return {**report, "actions": filtered_actions, "warnings": filtered_warnings}
+
+
 def _workspace_status_report(
     *, target_root: Path, selected_modules: list[str], descriptors: dict[str, ModuleDescriptor], command_name: str, config: WorkspaceConfig
 ) -> dict[str, Any]:
     actions: list[dict[str, str]] = []
     warnings: list[dict[str, str]] = []
     agents_relative = Path(config.agent_instructions_file)
-    for relative in WORKSPACE_PAYLOAD_FILES:
-        path = target_root / relative
-        exists = path.exists()
+    minimal_footprint = _minimal_bootstrap_footprint_detected(target_root=target_root)
+    if minimal_footprint:
         actions.append(
             {
-                "kind": "current" if exists else "missing",
-                "path": relative.as_posix(),
-                "detail": "required workspace file present" if exists else "required workspace file missing",
+                "kind": "current",
+                "path": ".agentic-workspace/package-payload",
+                "detail": "adoption receipt intentionally omits shared package payload; use --mirror-payload to require a checked-in mirror",
             }
         )
-        if not exists:
-            warnings.append({"path": relative.as_posix(), "message": "required workspace file missing"})
-    local_actions, local_warnings = _sync_workspace_managed_agent_instructions(
-        target_root=target_root, config=config, dry_run=False, apply=False
-    )
-    actions.extend(local_actions)
-    warnings.extend(local_warnings)
+        actions.append(
+            {
+                "kind": "current",
+                "path": _workspace_managed_agent_instructions_path(config).as_posix(),
+                "detail": "minimal bootstrap footprint intentionally omits managed .agentic-workspace local instructions",
+            }
+        )
+    else:
+        for relative in WORKSPACE_PAYLOAD_FILES:
+            path = target_root / relative
+            exists = path.exists()
+            actions.append(
+                {
+                    "kind": "current" if exists else "missing",
+                    "path": relative.as_posix(),
+                    "detail": "required workspace file present" if exists else "required workspace file missing",
+                }
+            )
+            if not exists:
+                warnings.append({"path": relative.as_posix(), "message": "required workspace file missing"})
+        local_actions, local_warnings = _sync_workspace_managed_agent_instructions(
+            target_root=target_root, config=config, dry_run=False, apply=False
+        )
+        actions.extend(local_actions)
+        warnings.extend(local_warnings)
     scratch_path = target_root / WORKSPACE_LOCAL_SCRATCH_ROOT_PATH
     actions.append(
         {
@@ -7436,10 +7604,14 @@ def _workspace_init_or_upgrade_report(
     command_name: str,
     config: WorkspaceConfig,
     to_payload_target: bool = False,
+    footprint_profile: str | None = None,
+    module_reports: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     actions: list[dict[str, str]] = []
     warnings: list[dict[str, str]] = []
     conservative = inspection_mode != "install" and command_name == "init"
+    resolved_footprint_profile = _resolve_bootstrap_footprint_profile(target_root=target_root, requested_profile=footprint_profile)
+    minimal_footprint = command_name in {"init", "install"} and _uses_minimal_bootstrap_footprint(resolved_footprint_profile)
     config_action = _seed_workspace_config_action(
         target_root=target_root,
         resolved_preset=resolved_preset,
@@ -7458,60 +7630,108 @@ def _workspace_init_or_upgrade_report(
             requested = set(config.enabled_modules) | set(selected_modules)
             config_modules = [module_name for module_name in ordered_names if module_name in requested]
         actions.append(_set_enabled_modules_action(target_root=target_root, enabled_modules=config_modules, dry_run=dry_run))
-    for relative in WORKSPACE_PAYLOAD_FILES:
-        destination = target_root / relative
-        source_bytes = _workspace_payload_bytes_for_target(relative, target_root=target_root)
-        existing = destination.exists()
-        if not existing:
-            if not dry_run:
-                destination.parent.mkdir(parents=True, exist_ok=True)
-                destination.write_bytes(source_bytes)
-            actions.append(
-                {
-                    "kind": "would create" if dry_run else "created",
-                    "path": relative.as_posix(),
-                    "detail": "install workspace shared-layer file",
-                }
-            )
-            continue
-        if destination.read_bytes() == source_bytes:
+    if minimal_footprint:
+        actions.append(
+            {
+                "kind": "omitted",
+                "path": ".agentic-workspace/package-payload",
+                "detail": (
+                    "ordinary bootstrap omits generic workspace docs, templates, schemas, and bundled skills; "
+                    "use --mirror-payload to copy the package payload"
+                ),
+            }
+        )
+        if (target_root / WORKSPACE_PAYLOAD_PROVENANCE_PATH).exists():
             actions.append(
                 {
                     "kind": "current",
-                    "path": relative.as_posix(),
-                    "detail": _workspace_payload_current_detail(relative=relative, target_root=target_root),
+                    "path": WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
+                    "detail": "preserve existing payload provenance; minimal footprint does not refresh local executable provenance",
                 }
             )
-            continue
-        if conservative:
+        else:
             actions.append(
                 {
-                    "kind": "manual review",
-                    "path": relative.as_posix(),
-                    "detail": "existing workspace shared-layer file differs from managed payload",
+                    "kind": "omitted",
+                    "path": WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
+                    "detail": "ordinary bootstrap keeps local executable provenance out of checked-in adoption state",
                 }
             )
-            continue
-        if not dry_run:
-            destination.write_bytes(source_bytes)
+    else:
+        for relative in WORKSPACE_PAYLOAD_FILES:
+            destination = target_root / relative
+            source_bytes = _workspace_payload_bytes_for_target(relative, target_root=target_root)
+            existing = destination.exists()
+            if not existing:
+                if not dry_run:
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    destination.write_bytes(source_bytes)
+                actions.append(
+                    {
+                        "kind": "would create" if dry_run else "created",
+                        "path": relative.as_posix(),
+                        "detail": "install workspace shared-layer file",
+                    }
+                )
+                continue
+            if destination.read_bytes() == source_bytes:
+                actions.append(
+                    {
+                        "kind": "current",
+                        "path": relative.as_posix(),
+                        "detail": _workspace_payload_current_detail(relative=relative, target_root=target_root),
+                    }
+                )
+                continue
+            if conservative:
+                actions.append(
+                    {
+                        "kind": "manual review",
+                        "path": relative.as_posix(),
+                        "detail": "existing workspace shared-layer file differs from managed payload",
+                    }
+                )
+                continue
+            if not dry_run:
+                destination.write_bytes(source_bytes)
+            actions.append(
+                {
+                    "kind": "would update" if dry_run else "updated",
+                    "path": relative.as_posix(),
+                    "detail": "refresh workspace shared-layer file from package payload while preserving host-owned subsystem overlay"
+                    if relative == Path(".agentic-workspace/OWNERSHIP.toml") and not _is_agentic_workspace_source_checkout(target_root)
+                    else "refresh workspace shared-layer file from package payload",
+                }
+            )
+        actions.append(_write_payload_provenance_action(target_root=target_root, dry_run=dry_run, force=to_payload_target))
+    if command_name in {"init", "install"} and local_only_repo_root is None:
+        receipt_reports = [*(module_reports or []), {"actions": actions}]
+        actions.append(
+            _write_adoption_receipt_action(
+                target_root=target_root,
+                selected_modules=selected_modules,
+                reports=receipt_reports,
+                payload_mirror=not minimal_footprint,
+                dry_run=dry_run,
+            )
+        )
+    if minimal_footprint:
         actions.append(
             {
-                "kind": "would update" if dry_run else "updated",
-                "path": relative.as_posix(),
-                "detail": "refresh workspace shared-layer file from package payload while preserving host-owned subsystem overlay"
-                if relative == Path(".agentic-workspace/OWNERSHIP.toml") and not _is_agentic_workspace_source_checkout(target_root)
-                else "refresh workspace shared-layer file from package payload",
+                "kind": "omitted",
+                "path": ".agentic-workspace/AGENTS.md",
+                "detail": "ordinary bootstrap omits managed local startup payload; the root startup entrypoint carries the shared workflow pointer",
             }
         )
-    actions.append(_write_payload_provenance_action(target_root=target_root, dry_run=dry_run, force=to_payload_target))
-    local_agent_actions, local_agent_warnings = _sync_workspace_managed_agent_instructions(
-        target_root=target_root,
-        config=config,
-        dry_run=dry_run,
-        apply=command_name in {"init", "upgrade"},
-    )
-    actions.extend(local_agent_actions)
-    warnings.extend(local_agent_warnings)
+    else:
+        local_agent_actions, local_agent_warnings = _sync_workspace_managed_agent_instructions(
+            target_root=target_root,
+            config=config,
+            dry_run=dry_run,
+            apply=command_name in {"init", "upgrade"},
+        )
+        actions.extend(local_agent_actions)
+        warnings.extend(local_agent_warnings)
     agents_relative = Path(config.agent_instructions_file)
     agents_path = target_root / agents_relative
     rendered_agents = _workspace_agents_template(
@@ -7629,11 +7849,26 @@ def _workspace_init_or_upgrade_report(
         )
         actions.extend(cast(list[dict[str, str]], scratch_prune.get("actions", [])))
         warnings.extend(cast(list[dict[str, str]], scratch_prune.get("warnings", [])))
-    policy_actions, policy_warnings = _sync_update_policy_actions(
-        target_root=target_root, selected_modules=selected_modules, dry_run=dry_run, command_name=command_name, config=config, apply=True
-    )
-    actions.extend(policy_actions)
-    warnings.extend(policy_warnings)
+    if minimal_footprint:
+        for module_name in selected_modules:
+            actions.append(
+                {
+                    "kind": "omitted",
+                    "path": f".agentic-workspace/{module_name}/UPGRADE-SOURCE.toml",
+                    "detail": "ordinary bootstrap omits package-source provenance; refresh it only with --mirror-payload",
+                }
+            )
+    else:
+        policy_actions, policy_warnings = _sync_update_policy_actions(
+            target_root=target_root,
+            selected_modules=selected_modules,
+            dry_run=dry_run,
+            command_name=command_name,
+            config=config,
+            apply=True,
+        )
+        actions.extend(policy_actions)
+        warnings.extend(policy_warnings)
     verification_next_action = _verification_manifest_next_action(target_root=target_root, selected_modules=selected_modules, config=config)
     if verification_next_action is not None:
         actions.append(verification_next_action)
@@ -7931,26 +8166,43 @@ def _run_init(
     print_prompt: bool,
     write_prompt: str | None,
     config: WorkspaceConfig,
+    footprint_profile: str | None = None,
+    mirror_payload: bool = False,
 ) -> dict[str, Any]:
+    resolved_footprint_profile = _resolve_bootstrap_footprint_profile(
+        target_root=target_root, requested_profile=footprint_profile, mirror_payload=mirror_payload
+    )
     inspection = _inspect_repo_state(
         target_root=target_root, selected_modules=selected_modules, descriptors=descriptors, force_adopt=force_adopt, config=config
     )
     module_command = "install" if inspection.mode == "install" else "adopt"
-    reports = [
-        _normalize_module_report_startup_paths(
-            _invoke_module_command(
-                command_name=module_command,
+    if _uses_minimal_bootstrap_footprint(resolved_footprint_profile):
+        reports = [
+            _minimal_module_footprint_report(
                 module_name=module_name,
-                descriptor=descriptors[module_name],
                 target_root=target_root,
                 dry_run=dry_run,
-                force=False,
-            ),
-            target_root=target_root,
-            config=config,
-        )
-        for module_name in selected_modules
-    ]
+                command_name=module_command,
+                footprint_profile=resolved_footprint_profile,
+            )
+            for module_name in selected_modules
+        ]
+    else:
+        reports = [
+            _normalize_module_report_startup_paths(
+                _invoke_module_command(
+                    command_name=module_command,
+                    module_name=module_name,
+                    descriptor=descriptors[module_name],
+                    target_root=target_root,
+                    dry_run=dry_run,
+                    force=False,
+                ),
+                target_root=target_root,
+                config=config,
+            )
+            for module_name in selected_modules
+        ]
     reports.append(
         _workspace_init_or_upgrade_report(
             target_root=target_root,
@@ -7962,6 +8214,8 @@ def _run_init(
             inspection_mode=inspection.mode,
             command_name="init",
             config=config,
+            footprint_profile=resolved_footprint_profile,
+            module_reports=reports,
         )
     )
     effective_config = config
@@ -7975,12 +8229,21 @@ def _run_init(
         inspection=inspection,
         reports=reports,
         config=effective_config,
+        footprint_profile=resolved_footprint_profile,
     )
     summary["non_interactive"] = non_interactive
     prompt_text = _build_handoff_prompt(summary)
-    prompt_path = _default_handoff_prompt_path(target_root=target_root) if summary["prompt_requirement"] != "none" else None
+    prompt_path = (
+        _default_handoff_prompt_path(target_root=target_root, footprint_profile=resolved_footprint_profile)
+        if summary["prompt_requirement"] != "none"
+        else None
+    )
     handoff_record = _build_bootstrap_handoff_record(summary) if summary["prompt_requirement"] != "none" else None
-    handoff_record_path = _default_handoff_record_path(target_root=target_root) if handoff_record is not None else None
+    handoff_record_path = (
+        _default_handoff_record_path(target_root=target_root, footprint_profile=resolved_footprint_profile)
+        if handoff_record is not None
+        else None
+    )
     if write_prompt:
         prompt_path = Path(write_prompt).expanduser().resolve()
     if prompt_path is not None and (write_prompt or not dry_run):
@@ -7996,6 +8259,13 @@ def _run_init(
         "dry_run": dry_run,
         "non_interactive": non_interactive,
         "module_reports": reports,
+        "bootstrap_footprint": _bootstrap_footprint_payload(
+            target_root=target_root,
+            profile=resolved_footprint_profile,
+            reports=reports,
+            prompt_path=prompt_path,
+            handoff_record_path=handoff_record_path,
+        ),
         "config": _config_payload(config=effective_config),
         "proof_route_hints": {
             "path": PROOF_ROUTE_HINTS_PATH.as_posix(),
@@ -8016,6 +8286,93 @@ def _run_init(
         payload["handoff_record_path"] = handoff_record_path.as_posix()
         payload["next_steps"].append(f"Review the structured handoff record at {handoff_record_path.as_posix()}.")
     return payload
+
+
+def _minimal_module_footprint_report(
+    *, module_name: str, target_root: Path, dry_run: bool, command_name: str, footprint_profile: str
+) -> dict[str, Any]:
+    actions: list[dict[str, str]] = []
+
+    def _ensure_text(relative: Path, text: str, detail: str) -> None:
+        path = target_root / relative
+        if path.exists():
+            actions.append({"kind": "current", "path": relative.as_posix(), "detail": detail + "; preserved existing local-mode state"})
+            return
+        if not dry_run:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+        actions.append({"kind": "would create" if dry_run else "created", "path": relative.as_posix(), "detail": detail})
+
+    if module_name == "planning":
+        _ensure_text(
+            Path(".agentic-workspace/planning/state.toml"),
+            "# Agentic Workspace planning state\nactive_items = []\n",
+            "create minimal planning state anchor without copying planning package templates, schemas, or bundled skills",
+        )
+        execplans = target_root / ".agentic-workspace" / "planning" / "execplans"
+        if execplans.exists():
+            actions.append(
+                {
+                    "kind": "current",
+                    "path": ".agentic-workspace/planning/execplans",
+                    "detail": "preserve existing local-mode execplans without refreshing bundled planning payload",
+                }
+            )
+    elif module_name == "memory":
+        _ensure_text(
+            Path(".agentic-workspace/memory/repo/index.md"),
+            "# Repo Memory\n\nNo durable repo memory has been captured yet.\n",
+            "create minimal memory index without copying memory package bootstrap payload or bundled skills",
+        )
+        _ensure_text(
+            Path(".agentic-workspace/memory/repo/manifest.toml"),
+            'schema_version = "agentic-workspace/memory-repo-manifest/v1"\n',
+            "create minimal memory manifest without package-supplied route templates",
+        )
+    elif module_name == "verification":
+        manifest = Path(".agentic-workspace/verification/manifest.toml")
+        if (target_root / manifest).exists():
+            actions.append(
+                {
+                    "kind": "current",
+                    "path": manifest.as_posix(),
+                    "detail": "preserve repo-owned verification manifest without package payload mutation",
+                }
+            )
+        else:
+            actions.append(
+                {
+                    "kind": "manual review",
+                    "path": manifest.as_posix(),
+                    "detail": "verification remains repo-owned; create a manifest only after choosing host proof protocols",
+                }
+            )
+    else:
+        actions.append(
+            {
+                "kind": "manual review",
+                "path": ".agentic-workspace",
+                "detail": f"ordinary bootstrap does not define state anchors for module '{module_name}'",
+            }
+        )
+    actions.append(
+        {
+            "kind": "omitted",
+            "path": f".agentic-workspace/{module_name}",
+            "detail": (
+                f"ordinary bootstrap keeps generic {module_name} package payload out of the repository; "
+                "use --mirror-payload for an explicit mirrored install"
+            ),
+        }
+    )
+    return {
+        "module": module_name,
+        "message": f"{command_name.title()} report ({footprint_profile})",
+        "target": target_root.as_posix(),
+        "dry_run": dry_run,
+        "actions": actions,
+        "warnings": [],
+    }
 
 
 def _inspect_repo_state(
@@ -8173,6 +8530,7 @@ def _build_init_summary(
     inspection: RepoInspection,
     reports: list[dict[str, Any]],
     config: WorkspaceConfig,
+    footprint_profile: str,
 ) -> dict[str, Any]:
     created: list[str] = []
     updated_managed: list[str] = []
@@ -8225,6 +8583,8 @@ def _build_init_summary(
         "preset": resolved_preset,
         "agent_instructions_file": config.agent_instructions_file,
         "workflow_artifact_profile": config.workflow_artifact_profile,
+        "footprint_profile": footprint_profile,
+        "payload_mirror": not _uses_minimal_bootstrap_footprint(footprint_profile),
         "intent": _bootstrap_intent_payload(selected_modules=selected_modules, resolved_preset=resolved_preset),
         "repo_state": inspection.repo_state,
         "inferred_policy": inspection.inferred_policy,
@@ -8237,7 +8597,7 @@ def _build_init_summary(
         "needs_review": _dedupe(needs_review),
         "placeholders": _dedupe(placeholders),
         "generated_artifacts": _dedupe(generated_artifacts),
-        "validation": _validation_commands(target_root=target_root),
+        "validation": _validation_commands(target_root=target_root, footprint_profile=footprint_profile),
         "next_steps": _init_next_steps(
             target_root=target_root,
             repo_state=inspection.repo_state,
@@ -8247,6 +8607,7 @@ def _build_init_summary(
             needs_review=needs_review,
             placeholders=placeholders,
             agent_instructions_file=config.agent_instructions_file,
+            footprint_profile=footprint_profile,
         ),
     }
 
@@ -8265,25 +8626,42 @@ def _run_lifecycle_command(
     compact_status: bool = True,
     module_scope_explicit: bool = False,
     to_payload_target: bool = False,
+    footprint_profile: str | None = None,
+    mirror_payload: bool = False,
 ) -> dict[str, Any]:
     if command_name == "upgrade" and local_only_repo_root is None and _has_local_only_workspace_state(target_root=target_root):
         local_only_repo_root = target_root
     registry = _module_registry(descriptors=descriptors, target_root=target_root)
-    reports = [
-        _normalize_module_report_startup_paths(
-            _invoke_module_command(
-                command_name=command_name,
+    resolved_footprint_profile = _resolve_bootstrap_footprint_profile(
+        target_root=target_root, requested_profile=footprint_profile, mirror_payload=mirror_payload
+    )
+    if command_name == "install" and _uses_minimal_bootstrap_footprint(resolved_footprint_profile):
+        reports = [
+            _minimal_module_footprint_report(
                 module_name=module_name,
-                descriptor=descriptors[module_name],
                 target_root=target_root,
                 dry_run=dry_run,
-                force=False,
-            ),
-            target_root=target_root,
-            config=config,
-        )
-        for module_name in selected_modules
-    ]
+                command_name=command_name,
+                footprint_profile=resolved_footprint_profile,
+            )
+            for module_name in selected_modules
+        ]
+    else:
+        reports = [
+            _normalize_module_report_startup_paths(
+                _invoke_module_command(
+                    command_name=command_name,
+                    module_name=module_name,
+                    descriptor=descriptors[module_name],
+                    target_root=target_root,
+                    dry_run=dry_run,
+                    force=False,
+                ),
+                target_root=target_root,
+                config=config,
+            )
+            for module_name in selected_modules
+        ]
     if command_name in {"status", "doctor"}:
         reports.append(
             _workspace_status_report(
@@ -8307,6 +8685,7 @@ def _run_lifecycle_command(
                 command_name=command_name,
                 config=config,
                 to_payload_target=to_payload_target,
+                footprint_profile=resolved_footprint_profile,
             )
         )
     elif command_name == "install":
@@ -8321,6 +8700,8 @@ def _run_lifecycle_command(
                 inspection_mode="install",
                 command_name=command_name,
                 config=config,
+                footprint_profile=resolved_footprint_profile,
+                module_reports=reports,
             )
         )
     elif command_name == "uninstall":
@@ -8334,6 +8715,8 @@ def _run_lifecycle_command(
                 local_only_repo_root=local_only_repo_root,
             )
         )
+    if command_name in {"status", "doctor"} and _minimal_bootstrap_footprint_detected(target_root=target_root):
+        reports = [_filter_minimal_bootstrap_module_report(report) for report in reports]
     summary = _summarise_reports(target_root=target_root, reports=reports, descriptors=descriptors, command_name=command_name)
     warnings: list[str] = []
     placeholders: list[str] = []
@@ -8377,6 +8760,8 @@ def _run_lifecycle_command(
         "preset": resolved_preset,
         "dry_run": dry_run,
         "non_interactive": non_interactive,
+        "footprint_profile": resolved_footprint_profile,
+        "payload_mirror": not _uses_minimal_bootstrap_footprint(resolved_footprint_profile),
         "health": "healthy" if not warnings else "attention-needed",
         "created": summary["created"],
         "updated_managed": summary["updated_managed"],
@@ -8427,6 +8812,14 @@ def _run_lifecycle_command(
         "reports": reports,
         "config": _config_payload(config=config),
     }
+    if command_name == "install":
+        payload["bootstrap_footprint"] = _bootstrap_footprint_payload(
+            target_root=target_root,
+            profile=resolved_footprint_profile,
+            reports=reports,
+            prompt_path=None,
+            handoff_record_path=None,
+        )
     if cli_compatibility_warnings:
         payload["executable_drift_warnings"] = cli_compatibility_warnings
     payload["lifecycle_plan"] = _lifecycle_plan_payload(
@@ -38425,6 +38818,8 @@ def _run_prompt_command(
     force_adopt: bool,
     non_interactive: bool,
     config: WorkspaceConfig,
+    footprint_profile: str | None = None,
+    mirror_payload: bool = False,
 ) -> dict[str, Any]:
     if prompt_command == "init":
         payload = _run_init(
@@ -38439,6 +38834,8 @@ def _run_prompt_command(
             print_prompt=True,
             write_prompt=None,
             config=config,
+            footprint_profile=footprint_profile,
+            mirror_payload=mirror_payload,
         )
         return {**payload, "command": "prompt", "prompt_command": "init"}
     payload = _run_lifecycle_command(
@@ -38451,6 +38848,8 @@ def _run_prompt_command(
         dry_run=True,
         non_interactive=non_interactive,
         config=config,
+        footprint_profile=footprint_profile,
+        mirror_payload=mirror_payload,
     )
     payload["command"] = "prompt"
     payload["prompt_command"] = prompt_command
@@ -38631,8 +39030,8 @@ def _normalize_module_report_startup_paths(report: dict[str, Any], *, target_roo
     }
 
 
-def _validation_commands(*, target_root: Path) -> list[str]:
-    target = target_root.as_posix()
+def _validation_commands(*, target_root: Path, footprint_profile: str = DEFAULT_BOOTSTRAP_FOOTPRINT_PROFILE) -> list[str]:
+    target = "." if _uses_minimal_bootstrap_footprint(footprint_profile) else target_root.as_posix()
     return [f"agentic-workspace doctor --target {target}", f"agentic-workspace status --target {target}"]
 
 
@@ -38646,13 +39045,13 @@ def _init_next_steps(
     needs_review: list[str],
     placeholders: list[str],
     agent_instructions_file: str,
+    footprint_profile: str = DEFAULT_BOOTSTRAP_FOOTPRINT_PROFILE,
 ) -> list[str]:
-    target = target_root.as_posix()
+    target = "." if _uses_minimal_bootstrap_footprint(footprint_profile) else target_root.as_posix()
     steps = [f"Run agentic-workspace doctor --target {target} after bootstrap changes settle."]
     if prompt_requirement != "none":
-        steps.append(
-            f"Use the generated finishing brief at {WORKSPACE_BOOTSTRAP_HANDOFF_PATH.as_posix()} for the next bounded bootstrap action."
-        )
+        handoff_path = _handoff_prompt_relative_path(footprint_profile=footprint_profile)
+        steps.append(f"Use the generated finishing brief at {handoff_path.as_posix()} for the next bounded bootstrap action.")
     if prompt_requirement == "none":
         steps.append(f"Tell your coding agent to use {agent_instructions_file} for normal work.")
         return steps
@@ -38686,12 +39085,14 @@ def _lifecycle_next_steps(*, command_name: str, target_root: Path, warnings: lis
 
 def _build_handoff_prompt(summary: dict[str, Any]) -> str:
     agent_instructions_file = str(summary.get("agent_instructions_file", DEFAULT_AGENT_INSTRUCTIONS_FILE))
+    footprint_profile = str(summary.get("footprint_profile", DEFAULT_BOOTSTRAP_FOOTPRINT_PROFILE))
+    target_display = "." if _uses_minimal_bootstrap_footprint(footprint_profile) else str(summary["target"])
     workflow_artifact_profile = _workflow_artifact_profile_payload(
         str(summary.get("workflow_artifact_profile", DEFAULT_WORKFLOW_ARTIFACT_PROFILE))
     )
     intent_payload = summary.get("intent")
     lines = [
-        f"Finish the Agentic Workspace bootstrap in {summary['target']}.",
+        f"Finish the Agentic Workspace bootstrap in {target_display}.",
         "",
         "Repo state:",
         f"- {summary['repo_state']}",
@@ -38701,6 +39102,9 @@ def _build_handoff_prompt(summary: dict[str, Any]) -> str:
         "",
         "Lifecycle mode:",
         f"- {summary['mode']}",
+        "",
+        "Checked-in footprint:",
+        f"- {footprint_profile}",
         "",
         "Selected modules:",
     ]
@@ -38761,13 +39165,19 @@ def _build_handoff_prompt(summary: dict[str, Any]) -> str:
     lines.extend(["", "When done:"])
     if summary["placeholders"]:
         lines.append("- remove or resolve any remaining placeholders before closing the bootstrap task")
-    lines.append("- leave only durable workflow residue; do not keep temporary bootstrap notes around")
+    if _uses_minimal_bootstrap_footprint(footprint_profile):
+        lines.append("- keep temporary bootstrap notes in .agentic-workspace/local/scratch or delete them after use")
+    else:
+        lines.append("- leave only durable workflow residue; do not keep temporary bootstrap notes around")
     lines.append(f"- keep {agent_instructions_file} as the repo startup entrypoint")
     return "\n".join(lines)
 
 
 def _build_bootstrap_handoff_record(summary: dict[str, Any]) -> dict[str, Any]:
     agent_instructions_file = str(summary.get("agent_instructions_file", DEFAULT_AGENT_INSTRUCTIONS_FILE))
+    footprint_profile = str(summary.get("footprint_profile", DEFAULT_BOOTSTRAP_FOOTPRINT_PROFILE))
+    handoff_path = _handoff_prompt_relative_path(footprint_profile=footprint_profile).as_posix()
+    target_display = "." if _uses_minimal_bootstrap_footprint(footprint_profile) else str(summary["target"])
     workflow_artifact_profile = _workflow_artifact_profile_payload(
         str(summary.get("workflow_artifact_profile", DEFAULT_WORKFLOW_ARTIFACT_PROFILE))
     )
@@ -38777,7 +39187,7 @@ def _build_bootstrap_handoff_record(summary: dict[str, Any]) -> dict[str, Any]:
         "kind": "workspace-bootstrap-handoff/v1",
         "intent": summary["intent"],
         "scope": {
-            "target": summary["target"],
+            "target": target_display,
             "selected_modules": summary["modules"],
             "repo_state": summary["repo_state"],
             "inferred_policy": summary["inferred_policy"],
@@ -38785,9 +39195,10 @@ def _build_bootstrap_handoff_record(summary: dict[str, Any]) -> dict[str, Any]:
             "prompt_requirement": summary["prompt_requirement"],
             "non_interactive": bool(summary.get("non_interactive")),
             "workflow_artifact_profile": workflow_artifact_profile,
+            "footprint_profile": footprint_profile,
             "review_items": review_items,
         },
-        "next": {"steps": summary["next_steps"], "immediate_brief": WORKSPACE_BOOTSTRAP_HANDOFF_PATH.as_posix()},
+        "next": {"steps": summary["next_steps"], "immediate_brief": handoff_path},
         "proof": {
             "validation": summary["validation"],
             "done_when": [
@@ -39302,12 +39713,92 @@ def _build_lifecycle_handoff_prompt(payload: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def _default_handoff_prompt_path(*, target_root: Path) -> Path:
-    return (target_root / WORKSPACE_BOOTSTRAP_HANDOFF_PATH).resolve()
+def _bootstrap_footprint_payload(
+    *,
+    target_root: Path,
+    profile: str,
+    reports: list[dict[str, Any]],
+    prompt_path: Path | None,
+    handoff_record_path: Path | None,
+) -> dict[str, Any]:
+    classes: dict[str, list[str]] = {
+        "repo_owned_config": [],
+        "adopted_local_state": [],
+        "package_supplied_payload": [],
+        "transient_handoff": [],
+        "local_environment_provenance": [],
+        "intentional_full_mirror": [],
+    }
+
+    def _add(class_name: str, path: str) -> None:
+        if path and path not in classes[class_name]:
+            classes[class_name].append(path)
+
+    for report in reports:
+        for action in report.get("actions", []):
+            if not isinstance(action, dict):
+                continue
+            path = _display_path(action.get("path", "."), target_root)
+            kind = str(action.get("kind", ""))
+            if path in {WORKSPACE_CONFIG_PATH.as_posix(), DEFAULT_AGENT_INSTRUCTIONS_FILE, "AGENTS.local.md"}:
+                _add("repo_owned_config", path)
+            if path == WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix():
+                _add("repo_owned_config", path)
+            if path.startswith(".agentic-workspace/planning/") or path.startswith(".agentic-workspace/memory/repo/"):
+                _add("adopted_local_state", path)
+            if path.startswith(".agentic-workspace/verification/"):
+                _add("adopted_local_state", path)
+            if path == WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix() or path.endswith("/UPGRADE-SOURCE.toml"):
+                _add("local_environment_provenance", path)
+            if kind == "omitted" and (
+                path == ".agentic-workspace/package-payload"
+                or path in {".agentic-workspace/planning", ".agentic-workspace/memory", ".agentic-workspace/AGENTS.md"}
+                or path.endswith("/UPGRADE-SOURCE.toml")
+                or path == WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix()
+            ):
+                _add("package_supplied_payload", path)
+            if path in {relative.as_posix() for relative in WORKSPACE_PAYLOAD_FILES}:
+                _add("package_supplied_payload", path)
+                if profile == "full-payload-mirror":
+                    _add("intentional_full_mirror", path)
+    for candidate in (prompt_path, handoff_record_path):
+        if candidate is None:
+            continue
+        _add("transient_handoff", _display_path(candidate.as_posix(), target_root))
+    omitted = sorted(classes["package_supplied_payload"])
+    return {
+        "kind": "agentic-workspace/bootstrap-footprint/v1",
+        "profile": profile,
+        "payload_mirror": not _uses_minimal_bootstrap_footprint(profile),
+        "status": "necessary-surfaces" if _uses_minimal_bootstrap_footprint(profile) else "full-mirror",
+        "planned_surface_classes": [{"class": name, "count": len(paths), "paths": sorted(paths)} for name, paths in classes.items()],
+        "omitted_package_payload_count": len(omitted) if _uses_minimal_bootstrap_footprint(profile) else 0,
+        "omitted_package_payload_paths": omitted if _uses_minimal_bootstrap_footprint(profile) else [],
+        "rule": (
+            "ordinary bootstrap writes only necessary checked-in AW surfaces and preserves repo-owned continuity; "
+            "--mirror-payload is the explicit opt-in for mirroring bundled docs, templates, schemas, skills, and provenance"
+        ),
+    }
 
 
-def _default_handoff_record_path(*, target_root: Path) -> Path:
-    return (target_root / WORKSPACE_BOOTSTRAP_HANDOFF_RECORD_PATH).resolve()
+def _handoff_prompt_relative_path(*, footprint_profile: str) -> Path:
+    if _uses_minimal_bootstrap_footprint(footprint_profile):
+        return WORKSPACE_LOCAL_BOOTSTRAP_HANDOFF_PATH
+    return WORKSPACE_BOOTSTRAP_HANDOFF_PATH
+
+
+def _handoff_record_relative_path(*, footprint_profile: str) -> Path:
+    if _uses_minimal_bootstrap_footprint(footprint_profile):
+        return WORKSPACE_LOCAL_BOOTSTRAP_HANDOFF_RECORD_PATH
+    return WORKSPACE_BOOTSTRAP_HANDOFF_RECORD_PATH
+
+
+def _default_handoff_prompt_path(*, target_root: Path, footprint_profile: str = DEFAULT_BOOTSTRAP_FOOTPRINT_PROFILE) -> Path:
+    return (target_root / _handoff_prompt_relative_path(footprint_profile=footprint_profile)).resolve()
+
+
+def _default_handoff_record_path(*, target_root: Path, footprint_profile: str = DEFAULT_BOOTSTRAP_FOOTPRINT_PROFILE) -> Path:
+    return (target_root / _handoff_record_relative_path(footprint_profile=footprint_profile)).resolve()
 
 
 def _write_prompt_file(*, prompt_path: Path, prompt_text: str, dry_run: bool) -> Path:
@@ -41252,6 +41743,8 @@ def _run_init_lifecycle_adapter(args: argparse.Namespace) -> int:
         print_prompt=args.print_prompt,
         write_prompt=args.write_prompt,
         config=config,
+        footprint_profile=getattr(args, "footprint_profile", None),
+        mirror_payload=bool(getattr(args, "mirror_payload", False)),
     )
     payload["command"] = command_name
     payload["lifecycle_plan"] = _lifecycle_plan_payload(
@@ -41310,6 +41803,8 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
         config=config,
         module_scope_explicit=bool(getattr(args, "modules", None)),
         to_payload_target=bool(getattr(args, "to_payload_target", False)),
+        footprint_profile=getattr(args, "footprint_profile", None),
+        mirror_payload=bool(getattr(args, "mirror_payload", False)),
     )
     _emit_payload(payload=payload, format_name=args.format)
     return 0
@@ -46905,6 +47400,7 @@ def _discover_registered_skills(*, target_root: Path) -> tuple[list[RegisteredSk
         registry_file = target_root / source.registry_path
         skills_root = target_root / source.skills_root
         package_registry_file = _package_skill_registry_file(source)
+        package_skills_root = package_registry_file.parent if package_registry_file is not None else None
         source_state = "absent"
         loaded_from_registry: list[RegisteredSkill] = []
         warn_for_missing_registry_entries = False
@@ -46916,7 +47412,14 @@ def _discover_registered_skills(*, target_root: Path) -> tuple[list[RegisteredSk
             source_state = "package-registry"
             loaded_from_registry = _load_registered_skills(source=source, registry_file=package_registry_file)
         for skill in loaded_from_registry:
-            if not (target_root / skill.path).exists():
+            skill_exists = (target_root / skill.path).exists()
+            if (not skill_exists) and source_state == "package-registry" and package_skills_root is not None:
+                try:
+                    package_relative = skill.path.relative_to(source.skills_root)
+                except ValueError:
+                    package_relative = Path(str(skill.path.name))
+                skill_exists = (package_skills_root / package_relative).exists()
+            if not skill_exists:
                 if warn_for_missing_registry_entries:
                     warnings.append(f"{source.registry_path.as_posix()} points at missing skill file {skill.path.as_posix()}")
                 continue
@@ -46972,6 +47475,16 @@ def _discover_registered_skills(*, target_root: Path) -> tuple[list[RegisteredSk
 
 
 def _package_skill_registry_file(source: SkillCatalogSource) -> Path | None:
+    if source.name == "workspace-core":
+        registry_file = Path(__file__).resolve().parent / "_payload" / ".agentic-workspace" / "skills" / "REGISTRY.json"
+        return registry_file if registry_file.exists() else None
+    if source.name in {"memory-core", "memory-bootstrap-temporary"}:
+        try:
+            from repo_memory_bootstrap._installer_paths import payload_root as memory_payload_root
+        except ImportError:
+            return None
+        registry_file = memory_payload_root() / source.registry_path
+        return registry_file if registry_file.exists() else None
     if source.name != "planning-bundled":
         return None
     try:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -1508,7 +1508,9 @@ def _installed_state_compatibility_payload(
     if provenance_status.get("status") in {"invalid"}:
         payload_provenance_drift = "invalid-provenance"
     elif provenance_status.get("status") == "missing" and initialized_payload_present:
-        payload_provenance_drift = "missing-provenance"
+        payload_provenance_drift = (
+            "none" if _workspace_runtime_core._minimal_bootstrap_footprint_detected(target_root=target_root) else "missing-provenance"
+        )
     elif installed_version and _version_key(installed_version) > _version_key(__version__):
         payload_provenance_drift = "executable-too-old"
     elif installed_version and _version_key(installed_version) < _version_key(__version__):
@@ -5588,10 +5590,7 @@ def _module_operations() -> dict[str, ModuleDescriptor]:
             "uninstall_handler": planning_uninstall_bootstrap,
             "doctor_handler": planning_doctor_bootstrap,
             "status_handler": planning_collect_status,
-            "detector": lambda target_root: (
-                (target_root / ".agentic-workspace" / "planning" / "state.toml").exists()
-                and (target_root / ".agentic-workspace" / "planning" / "agent-manifest.json").exists()
-            ),
+            "detector": lambda target_root: (target_root / ".agentic-workspace" / "planning" / "state.toml").exists(),
         },
         "memory": {
             "install_handler": memory_install_bootstrap,
@@ -7304,7 +7303,10 @@ def _workspace_init_or_upgrade_report(
     command_name: str,
     config: WorkspaceConfig,
     to_payload_target: bool = False,
+    footprint_profile: str | None = None,
+    module_reports: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    del footprint_profile, module_reports
     actions: list[dict[str, str]] = []
     warnings: list[dict[str, str]] = []
     conservative = inspection_mode != "install" and command_name == "init"
@@ -7791,7 +7793,10 @@ def _run_init(
     print_prompt: bool,
     write_prompt: str | None,
     config: WorkspaceConfig,
+    footprint_profile: str | None = None,
+    mirror_payload: bool = False,
 ) -> dict[str, Any]:
+    del footprint_profile, mirror_payload
     inspection = _inspect_repo_state(
         target_root=target_root, selected_modules=selected_modules, descriptors=descriptors, force_adopt=force_adopt, config=config
     )
@@ -8125,9 +8130,31 @@ def _run_lifecycle_command(
     compact_status: bool = True,
     module_scope_explicit: bool = False,
     to_payload_target: bool = False,
+    footprint_profile: str | None = None,
+    mirror_payload: bool = False,
 ) -> dict[str, Any]:
     if command_name == "upgrade" and local_only_repo_root is None and _has_local_only_workspace_state(target_root=target_root):
         local_only_repo_root = target_root
+    resolved_footprint_profile = _workspace_runtime_core._resolve_bootstrap_footprint_profile(
+        target_root=target_root, requested_profile=footprint_profile, mirror_payload=mirror_payload
+    )
+    if command_name == "install" and _workspace_runtime_core._uses_minimal_bootstrap_footprint(resolved_footprint_profile):
+        return _workspace_runtime_core._run_lifecycle_command(
+            command_name=command_name,
+            target_root=target_root,
+            local_only_repo_root=local_only_repo_root,
+            selected_modules=selected_modules,
+            resolved_preset=resolved_preset,
+            descriptors=descriptors,
+            dry_run=dry_run,
+            non_interactive=non_interactive,
+            config=config,
+            compact_status=compact_status,
+            module_scope_explicit=module_scope_explicit,
+            to_payload_target=to_payload_target,
+            footprint_profile=resolved_footprint_profile,
+            mirror_payload=mirror_payload,
+        )
     registry = _module_registry(descriptors=descriptors, target_root=target_root)
     reports = [
         _normalize_module_report_startup_paths(
@@ -8167,6 +8194,7 @@ def _run_lifecycle_command(
                 command_name=command_name,
                 config=config,
                 to_payload_target=to_payload_target,
+                footprint_profile=resolved_footprint_profile,
             )
         )
     elif command_name == "install":
@@ -8181,6 +8209,8 @@ def _run_lifecycle_command(
                 inspection_mode="install",
                 command_name=command_name,
                 config=config,
+                footprint_profile=resolved_footprint_profile,
+                module_reports=reports,
             )
         )
     elif command_name == "uninstall":
@@ -8194,6 +8224,8 @@ def _run_lifecycle_command(
                 local_only_repo_root=local_only_repo_root,
             )
         )
+    if command_name in {"status", "doctor"} and _workspace_runtime_core._minimal_bootstrap_footprint_detected(target_root=target_root):
+        reports = [_workspace_runtime_core._filter_minimal_bootstrap_module_report(report) for report in reports]
     summary = _summarise_reports(target_root=target_root, reports=reports, descriptors=descriptors, command_name=command_name)
     warnings: list[str] = []
     placeholders: list[str] = []
@@ -39250,6 +39282,8 @@ def _run_init_lifecycle_adapter(args: argparse.Namespace) -> int:
         print_prompt=args.print_prompt,
         write_prompt=args.write_prompt,
         config=config,
+        footprint_profile=getattr(args, "footprint_profile", None),
+        mirror_payload=bool(getattr(args, "mirror_payload", False)),
     )
     payload["command"] = command_name
     payload["lifecycle_plan"] = _lifecycle_plan_payload(
@@ -39308,6 +39342,8 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
         config=config,
         module_scope_explicit=bool(getattr(args, "modules", None)),
         to_payload_target=bool(getattr(args, "to_payload_target", False)),
+        footprint_profile=getattr(args, "footprint_profile", None),
+        mirror_payload=bool(getattr(args, "mirror_payload", False)),
     )
     _emit_payload(payload=payload, format_name=args.format)
     return 0
@@ -44744,6 +44780,7 @@ def _discover_registered_skills(*, target_root: Path) -> tuple[list[RegisteredSk
         registry_file = target_root / source.registry_path
         skills_root = target_root / source.skills_root
         package_registry_file = _package_skill_registry_file(source)
+        package_skills_root = package_registry_file.parent if package_registry_file is not None else None
         source_state = "absent"
         loaded_from_registry: list[RegisteredSkill] = []
         warn_for_missing_registry_entries = False
@@ -44755,7 +44792,14 @@ def _discover_registered_skills(*, target_root: Path) -> tuple[list[RegisteredSk
             source_state = "package-registry"
             loaded_from_registry = _load_registered_skills(source=source, registry_file=package_registry_file)
         for skill in loaded_from_registry:
-            if not (target_root / skill.path).exists():
+            skill_exists = (target_root / skill.path).exists()
+            if (not skill_exists) and source_state == "package-registry" and package_skills_root is not None:
+                try:
+                    package_relative = skill.path.relative_to(source.skills_root)
+                except ValueError:
+                    package_relative = Path(str(skill.path.name))
+                skill_exists = (package_skills_root / package_relative).exists()
+            if not skill_exists:
                 if warn_for_missing_registry_entries:
                     warnings.append(f"{source.registry_path.as_posix()} points at missing skill file {skill.path.as_posix()}")
                 continue
@@ -44811,6 +44855,16 @@ def _discover_registered_skills(*, target_root: Path) -> tuple[list[RegisteredSk
 
 
 def _package_skill_registry_file(source: SkillCatalogSource) -> Path | None:
+    if source.name == "workspace-core":
+        registry_file = Path(__file__).resolve().parent / "_payload" / ".agentic-workspace" / "skills" / "REGISTRY.json"
+        return registry_file if registry_file.exists() else None
+    if source.name in {"memory-core", "memory-bootstrap-temporary"}:
+        try:
+            from repo_memory_bootstrap._installer_paths import payload_root as memory_payload_root
+        except ImportError:
+            return None
+        registry_file = memory_payload_root() / source.registry_path
+        return registry_file if registry_file.exists() else None
     if source.name != "planning-bundled":
         return None
     try:
@@ -45178,6 +45232,7 @@ _prune_local_scratch_runs: Any = _workspace_runtime_core._prune_local_scratch_ru
 _cleanup_legacy_local_scratch: Any = _workspace_runtime_core._cleanup_legacy_local_scratch
 _workspace_status_report: Any = _workspace_runtime_core._workspace_status_report
 _workspace_init_or_upgrade_report: Any = _workspace_runtime_core._workspace_init_or_upgrade_report
+_run_init: Any = _workspace_runtime_core._run_init
 _run_legacy_scratch_cleanup: Any = _workspace_runtime_core._run_legacy_scratch_cleanup
 _run_lazy_report_section_command: Any = _workspace_runtime_core._run_lazy_report_section_command
 _run_report_command: Any = _workspace_runtime_core._run_report_command

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -187,6 +187,169 @@ def test_lifecycle_guidance_uses_canonical_modules_option(tmp_path: Path, capsys
     assert "--module planning --module memory" not in command_text
 
 
+def test_init_ordinary_footprint_omits_package_payload_and_writes_receipt(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    assert (
+        cli.main(
+            [
+                "init",
+                "--target",
+                str(tmp_path),
+                "--modules",
+                "planning,memory",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["footprint_profile"] == "necessary-surfaces"
+    assert payload["payload_mirror"] is False
+    assert payload["bootstrap_footprint"]["status"] == "necessary-surfaces"
+    assert (tmp_path / ".agentic-workspace" / "planning" / "state.toml").exists()
+    assert (tmp_path / ".agentic-workspace" / "memory" / "repo" / "index.md").exists()
+    receipt = json.loads((tmp_path / ".agentic-workspace" / "adoption-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["kind"] == "agentic-workspace/adoption-receipt/v1"
+    assert receipt["checked_in_rule"] == "necessary-surfaces-only"
+    assert receipt["payload_mirror"] is False
+    assert "absolute-path provenance" in receipt["local_only"]
+    assert not (tmp_path / ".agentic-workspace" / "payload-provenance.json").exists()
+    assert not (tmp_path / ".agentic-workspace" / "AGENTS.md").exists()
+    assert not (tmp_path / ".agentic-workspace" / "planning" / "UPGRADE-SOURCE.toml").exists()
+    assert not (tmp_path / ".agentic-workspace" / "planning" / "skills" / "REGISTRY.json").exists()
+    assert ".agentic-workspace/package-payload" in payload["bootstrap_footprint"]["omitted_package_payload_paths"]
+    assert payload["validation"] == ["agentic-workspace doctor --target .", "agentic-workspace status --target ."]
+
+
+def test_init_adopts_local_state_and_uses_local_scratch_handoff(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    _write(tmp_path / "AGENTS.md", "# Existing instructions\n")
+    _write(tmp_path / ".agentic-workspace" / "planning" / "state.toml", "active_items = []\n")
+    _write(tmp_path / ".agentic-workspace" / "planning" / "execplans" / "existing.plan.json", "{}\n")
+    _write(tmp_path / ".agentic-workspace" / "memory" / "repo" / "index.md", "# Existing Memory\n")
+
+    assert (
+        cli.main(
+            [
+                "init",
+                "--target",
+                str(tmp_path),
+                "--modules",
+                "planning,memory",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["footprint_profile"] == "necessary-surfaces"
+    assert payload["payload_mirror"] is False
+    assert payload["handoff_prompt_path"].endswith(".agentic-workspace/local/scratch/bootstrap-handoff.md")
+    assert payload["handoff_record_path"].endswith(".agentic-workspace/local/scratch/bootstrap-handoff.json")
+    assert payload["handoff_record"]["scope"]["target"] == "."
+    receipt = json.loads((tmp_path / ".agentic-workspace" / "adoption-receipt.json").read_text(encoding="utf-8"))
+    assert "planning/execplans" in "\n".join(receipt["adopted_state"])
+    assert not (tmp_path / ".agentic-workspace" / "bootstrap-handoff.md").exists()
+    assert not (tmp_path / ".agentic-workspace" / "bootstrap-handoff.json").exists()
+    assert (tmp_path / ".agentic-workspace" / "local" / "scratch" / "bootstrap-handoff.md").exists()
+    assert (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "existing.plan.json").exists()
+
+
+def test_install_ordinary_footprint_omits_package_payload(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    assert cli.main(["install", "--target", str(tmp_path), "--modules", "planning,memory", "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["payload_mirror"] is False
+    assert payload["bootstrap_footprint"]["status"] == "necessary-surfaces"
+    receipt = json.loads((tmp_path / ".agentic-workspace" / "adoption-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["payload_mirror"] is False
+    assert not (tmp_path / ".agentic-workspace" / "payload-provenance.json").exists()
+    assert not (tmp_path / ".agentic-workspace" / "planning" / "skills" / "REGISTRY.json").exists()
+
+
+def test_init_mirror_payload_writes_payload_and_receipt(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+
+    assert (
+        cli.main(
+            [
+                "init",
+                "--target",
+                str(tmp_path),
+                "--modules",
+                "planning,memory",
+                "--mirror-payload",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["payload_mirror"] is True
+    assert payload["bootstrap_footprint"]["status"] == "full-mirror"
+    receipt = json.loads((tmp_path / ".agentic-workspace" / "adoption-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["payload_mirror"] is True
+    assert (tmp_path / ".agentic-workspace" / "payload-provenance.json").exists()
+    assert (tmp_path / ".agentic-workspace" / "AGENTS.md").exists()
+    assert (tmp_path / ".agentic-workspace" / "planning" / "UPGRADE-SOURCE.toml").exists()
+
+
+def test_doctor_requires_adoption_receipt_before_treating_missing_payload_as_healthy(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--format", "json"]) == 0
+    capsys.readouterr()
+    (tmp_path / ".agentic-workspace" / "adoption-receipt.json").unlink()
+
+    assert cli.main(["doctor", "--target", str(tmp_path), "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["health"] == "attention-needed"
+    warning_text = "\n".join(payload["warnings"])
+    assert ".agentic-workspace/WORKFLOW.md" in warning_text or "payload-provenance.json" in warning_text
+    assert payload["installed_state_compatibility"]["payload"]["provenance_drift"] == "missing-provenance"
+
+
+@pytest.mark.parametrize(
+    ("command", "missing_path", "expected_warning"),
+    [
+        ("status", ".agentic-workspace/planning/state.toml", "enabled module 'planning' is not installed"),
+        ("doctor", ".agentic-workspace/planning/state.toml", "enabled module 'planning' is not installed"),
+        ("status", ".agentic-workspace/memory/repo/index.md", "enabled module 'memory' is not installed"),
+        ("doctor", ".agentic-workspace/memory/repo/index.md", "enabled module 'memory' is not installed"),
+    ],
+)
+def test_adoption_receipt_does_not_hide_missing_necessary_module_anchors(
+    tmp_path: Path, capsys, command: str, missing_path: str, expected_warning: str
+) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--format", "json"]) == 0
+    capsys.readouterr()
+    assert (tmp_path / ".agentic-workspace" / "adoption-receipt.json").is_file()
+    (tmp_path / missing_path).unlink()
+
+    assert cli.main([command, "--target", str(tmp_path), "--format", "json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["health"] == "attention-needed"
+    assert expected_warning in payload["warnings"]
+
+
+def test_bootstrap_footprint_defaults_to_necessary_surfaces_with_explicit_mirror_opt_in(tmp_path: Path) -> None:
+    from agentic_workspace import workspace_runtime_core
+
+    assert workspace_runtime_core._resolve_bootstrap_footprint_profile(target_root=tmp_path) == "necessary-surfaces"
+    assert workspace_runtime_core._resolve_bootstrap_footprint_profile(target_root=tmp_path, mirror_payload=True) == "full-payload-mirror"
+
+
 def test_setup_surfaces_host_orientation_candidates_for_jumpstarted_repo(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     _write(tmp_path / "README.md", "# Host Repo\n")
@@ -249,7 +412,7 @@ def test_upgrade_preserves_host_owned_ownership_subsystems(tmp_path: Path, capsy
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     ownership_path = target / ".agentic-workspace" / "OWNERSHIP.toml"
     ownership_path.write_text(
@@ -272,7 +435,7 @@ def test_upgrade_refreshes_module_upgrade_source_recorded_at(tmp_path: Path, cap
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--modules", "planning", "--target", str(target), "--format", "json"]) == 0
+    assert cli.main(["init", "--modules", "planning", "--target", str(target), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     source_path = target / ".agentic-workspace" / "planning" / "UPGRADE-SOURCE.toml"
     source_path.write_text(
@@ -712,7 +875,7 @@ candidates = []
 
 def test_closeout_trust_derives_intent_proof_from_satisfied_active_execplan(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     _write_issue_1981_closeout_fixture(tmp_path, include_proof=True, active_milestone_status="completed")
 
@@ -733,7 +896,7 @@ def test_closeout_claim_boundary_returns_fast_claim_packet(tmp_path: Path, capsy
     import tests.workspace_cli_support as workspace_cli_support
 
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     _write_issue_1981_closeout_fixture(tmp_path, include_proof=True, include_stale_task_posture_residue=True)
 
@@ -773,7 +936,7 @@ def test_closeout_claim_boundary_returns_fast_claim_packet(tmp_path: Path, capsy
 
 def test_closeout_trust_does_not_block_on_stale_satisfied_task_posture_residue(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     _write_issue_1981_closeout_fixture(tmp_path, include_proof=True, include_stale_task_posture_residue=True)
 
@@ -790,7 +953,7 @@ def test_closeout_trust_does_not_block_on_stale_satisfied_task_posture_residue(t
 
 def test_closeout_trust_blocks_full_closeout_when_active_execplan_proof_is_missing(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     _write_issue_1981_closeout_fixture(tmp_path, include_proof=False)
 
@@ -808,7 +971,7 @@ def test_closeout_trust_blocks_full_closeout_when_active_execplan_proof_is_missi
 
 def test_closeout_trust_names_external_intent_evidence_blocker_for_open_issue(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     _write_issue_1981_closeout_fixture(tmp_path, include_proof=True, external_status="open")
 
@@ -826,7 +989,7 @@ def test_closeout_trust_scopes_unrelated_active_plan_residue_to_repo_wide_closeo
     from repo_planning_bootstrap import installer as planning_installer
 
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
     _write(
         tmp_path / ".agentic-workspace" / "config.toml",
@@ -909,7 +1072,7 @@ candidates = []
 
 def test_closeout_trust_scopes_pr_comment_repair_to_feedback_claim(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_primitives.py", "VALUE = 1\n")
     capsys.readouterr()
 
@@ -951,7 +1114,7 @@ def test_verbose_aliases_full_diagnostic_output_for_major_workspace_commands(tmp
     _init_git_repo(tmp_path)
     (tmp_path / "README.md").write_text("# Fixture\n", encoding="utf-8")
 
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
 
     cases = [
@@ -1524,7 +1687,7 @@ def test_start_default_compacts_noncompatible_installed_state_signal(tmp_path: P
 
 def test_start_installed_state_treats_stale_compatible_provenance_as_no_repair_needed(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     provenance_path = tmp_path / ".agentic-workspace" / "payload-provenance.json"
     provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
@@ -1565,7 +1728,7 @@ def test_start_installed_state_treats_stale_compatible_provenance_as_no_repair_n
 def test_payload_target_required_before_work_blocks_start_until_target_sync(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     workspace = tmp_path / ".agentic-workspace"
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     (workspace / "config.toml").write_text(
         "schema_version = 1\n\n"
@@ -1648,7 +1811,7 @@ def test_payload_target_required_before_work_blocks_start_until_target_sync(tmp_
 def test_upgrade_to_payload_target_forces_provenance_capability_sync(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     workspace = tmp_path / ".agentic-workspace"
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     (workspace / "config.toml").write_text(
         "schema_version = 1\n\n"
@@ -1750,7 +1913,7 @@ def test_payload_upgrade_attention_plan_classifies_repo_surfaces(tmp_path: Path,
 
 def test_payload_upgrade_attention_plan_routes_unsupported_long_hop(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     provenance_path = tmp_path / ".agentic-workspace" / "payload-provenance.json"
     provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
@@ -1784,7 +1947,7 @@ def test_payload_upgrade_attention_plan_routes_unsupported_long_hop(tmp_path: Pa
 def test_payload_target_required_before_claim_limits_claims_without_blocking_work(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     workspace = tmp_path / ".agentic-workspace"
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     (workspace / "config.toml").write_text(
         "schema_version = 1\n\n"
@@ -1868,7 +2031,7 @@ def test_workspace_config_rejects_invalid_payload_target_policy(tmp_path: Path) 
 
 def test_start_installed_state_blocks_newer_repo_payload_instead_of_downgrading(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     provenance_path = tmp_path / ".agentic-workspace" / "payload-provenance.json"
     provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
@@ -1907,7 +2070,7 @@ def test_start_installed_state_blocks_newer_repo_payload_instead_of_downgrading(
 
 def test_upgrade_dry_run_does_not_rewrite_valid_provenance_for_identity_only_drift(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     provenance_path = tmp_path / ".agentic-workspace" / "payload-provenance.json"
     provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
@@ -1929,7 +2092,7 @@ def test_upgrade_dry_run_does_not_rewrite_valid_provenance_for_identity_only_dri
 
 def test_upgrade_dry_run_repairs_structurally_invalid_provenance_with_matching_file_set(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     provenance_path = tmp_path / ".agentic-workspace" / "payload-provenance.json"
     provenance = json.loads(provenance_path.read_text(encoding="utf-8"))

--- a/tests/test_workspace_config_cli.py
+++ b/tests/test_workspace_config_cli.py
@@ -255,7 +255,7 @@ def test_config_command_reports_effective_defaults_without_repo_file(tmp_path: P
 
 def test_configuration_projection_reports_selector_backed_and_stale_sources(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
-    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
     capsys.readouterr()
     _write(
         tmp_path / ".agentic-workspace/config.toml",

--- a/tests/test_workspace_doctor_status_cli.py
+++ b/tests/test_workspace_doctor_status_cli.py
@@ -26,7 +26,7 @@ def test_doctor_emits_affordance_shaped_repair_and_manual_review_actions(tmp_pat
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     capsys.readouterr()
     (target / ".agentic-workspace" / "WORKFLOW.md").unlink()
     agents_path = target / "AGENTS.md"
@@ -75,7 +75,7 @@ def test_doctor_repair_actions_use_resolved_cli_invoke(tmp_path: Path, capsys) -
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     capsys.readouterr()
     _write(
         target / ".agentic-workspace" / "config.local.toml",
@@ -157,7 +157,7 @@ def test_doctor_routes_workspace_merge_conflict_markers_to_manual_review(tmp_pat
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     capsys.readouterr()
     _write(
         target / ".agentic-workspace" / "config.toml",
@@ -264,7 +264,7 @@ def test_doctor_promotes_safe_module_lifecycle_repairs_for_missing_memory_templa
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     capsys.readouterr()
     template_paths = [
         target / ".agentic-workspace" / "memory" / "repo" / "templates" / "invariant.template.md",
@@ -409,7 +409,7 @@ def test_setup_surfaces_assurance_verification_onboarding_without_optional_modul
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     _write(
         target / ".agentic-workspace" / "verification" / "manifest.toml",
         'schema_version = "agentic-workspace/verification-manifest/v1"\n',
@@ -441,7 +441,7 @@ def test_setup_reports_verification_enabled_unconfigured_state(tmp_path: Path, c
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     config_path = target / ".agentic-workspace" / "config.toml"
     config_text = config_path.read_text(encoding="utf-8")
     config_path.write_text(config_text.replace('enabled = ["planning", "memory"]', 'enabled = ["planning", "memory", "verification"]'))
@@ -477,7 +477,7 @@ def test_doctor_module_filter_does_not_require_llms_adapter(tmp_path: Path, caps
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     capsys.readouterr()
 
     assert cli.main(["doctor", "--verbose", "--target", str(target), "--modules", "planning", "--format", "json"]) == 0
@@ -518,7 +518,7 @@ def test_status_flags_missing_workspace_shared_layer(tmp_path: Path, capsys) -> 
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     (target / ".agentic-workspace" / "WORKFLOW.md").unlink()
     capsys.readouterr()
 
@@ -533,7 +533,7 @@ def test_doctor_flags_missing_workspace_shared_layer(tmp_path: Path, capsys) -> 
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     (target / ".agentic-workspace" / "OWNERSHIP.toml").unlink()
     capsys.readouterr()
 
@@ -635,7 +635,7 @@ def test_doctor_real_init_preserves_package_contract_shortlists_in_reports(tmp_p
     target.mkdir()
     _init_git_repo(target)
 
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     capsys.readouterr()
 
     assert cli.main(["doctor", "--verbose", "--target", str(target), "--format", "json"]) == 0
@@ -664,7 +664,7 @@ def test_doctor_text_output_shows_package_contract_shortlists(tmp_path: Path, ca
     target.mkdir()
     _init_git_repo(target)
 
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     capsys.readouterr()
 
     assert cli.main(["doctor", "--verbose", "--target", str(target)]) == 0
@@ -866,7 +866,7 @@ def test_status_warns_when_module_update_source_metadata_drifts_from_repo_config
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--modules", "planning", "--target", str(target)]) == 0
+    assert cli.main(["init", "--modules", "planning", "--target", str(target), "--mirror-payload"]) == 0
     capsys.readouterr()
     (target / ".agentic-workspace/config.toml").write_text(
         "schema_version = 1\n\n"

--- a/tests/test_workspace_ownership_cli.py
+++ b/tests/test_workspace_ownership_cli.py
@@ -62,7 +62,7 @@ def test_ownership_real_init_does_not_settle_repo_root_memory_as_repo_owned_cont
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target)]) == 0
+    assert cli.main(["init", "--target", str(target), "--mirror-payload"]) == 0
     capsys.readouterr()
 
     assert cli.main(["ownership", "--target", str(target), "--format", "json"]) == 0
@@ -81,7 +81,7 @@ def test_ownership_diagnostics_report_startup_adapter_drift_and_ambiguity(tmp_pa
     target = tmp_path / "repo"
     target.mkdir()
     _init_git_repo(target)
-    assert cli.main(["init", "--target", str(target), "--modules", "planning"]) == 0
+    assert cli.main(["init", "--target", str(target), "--modules", "planning", "--mirror-payload"]) == 0
     capsys.readouterr()
     agents_path = target / "AGENTS.md"
     agents_path.write_text(

--- a/tests/test_workspace_skills_cli.py
+++ b/tests/test_workspace_skills_cli.py
@@ -635,7 +635,7 @@ def test_skills_command_discovers_temporary_memory_bootstrap_skills(tmp_path: Pa
     assert install_skill["path"] == ".agentic-workspace/memory/bootstrap/skills/install/SKILL.md"
     assert payload["recommendations"][0]["id"] == "install"
     assert not payload["warnings"]
-    assert any(source["name"] == "memory-bootstrap-temporary" and source["state"] == "registry" for source in payload["sources"])
+    assert any(source["name"] == "memory-bootstrap-temporary" and source["state"] == "package-registry" for source in payload["sources"])
 
 
 def test_skills_command_recommends_high_risk_workflow_decision_skills(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Implements #2080 by making ordinary `init`/`install` low-footprint by construction instead of exposing a user-facing minimal/full profile choice.

- ordinary bootstrap now writes necessary checked-in surfaces plus a compact `.agentic-workspace/adoption-receipt.json`
- generic package payload, bundled skills, provenance, templates, schemas, and upgrade-source files stay package-owned by default
- `--mirror-payload` is the explicit opt-in for checked-in package mirrors
- status/doctor suppress missing package-payload drift only when the durable adoption receipt says mirroring is disabled
- package-backed skill discovery lets ordinary installs route to bundled workspace/planning/memory skills without checking the skill trees into the host repo
- ordinary handoff output uses ignored local scratch paths instead of durable bootstrap handoff files

## Proof

- `make test-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make lint-workspace`
- `make typecheck`
- `make maintainer-surfaces`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run python scripts/run_agentic_workspace.py defaults --section root_cli_authority --format json`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `git diff --check`