### PR TITLE
Add necessary-surface payload migration

### DIFF
--- a/docs/package/lifecycle.md
+++ b/docs/package/lifecycle.md
@@ -22,6 +22,8 @@ Mutating commands are conservative. They operate on package-owned surfaces, mana
 
 Use `--mirror-payload` only when a host repo explicitly wants the full package payload checked in for offline or tool-agnostic operation. Ordinary handoff files are written under `.agentic-workspace/local/scratch/` and should not become durable tracked state.
 
+Existing repositories that adopted AW before the necessary-surface default may still have checked-in generic package payload. Inspect that footprint with `agentic-workspace report --target . --section bootstrap_footprint --format json`. The dry-run classifies exact preserve, remove, and receipt-write actions. Apply the reviewed plan with `agentic-workspace upgrade --target . --to-necessary-surfaces --format json`. The migration preserves repo-owned config/startup and adopted Planning, Memory, and Verification state, removes known package-owned docs/templates/schemas/skill trees/provenance, refreshes the adoption receipt, and refuses to reduce an explicit full-payload mirror receipt automatically.
+
 ## Context Commands
 
 | Command | First question answered |

--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -181,6 +181,7 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `architecture_principles` | object | yes |  | Structured architecture-principle routing packet derived from the normalized system-intent record and changed paths. |  |  |
 | `local_aw_state` | object | yes |  | Compact ownership-aware status for tracked, ignored, local-only, cache, payload, policy, and proof AW surfaces. |  |  |
 | `local_footprint` | object | yes |  | Tracked-vs-ignored AW footprint, local scratch retention budgets, largest offenders, and cleanup routing. |  |  |
+| `bootstrap_footprint` | object | no |  | Legacy checked-in AW payload migration plan with preserve/remove/write actions, durable state preservation, and explicit mirror-intent guard. |  |  |
 | `stale_cleanup` | object | no |  | Cleanup routing for stale local and checked-in planning surfaces. |  |  |
 | `workflow_obligations` | object | yes |  | Repo-configured workflow obligations surfaced for report consumers. |  |  |
 | `workflow_obligation_effects` | array of object | no |  | Evaluated behavior and closeout effects for configured workflow obligations. |  |  |

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -3735,6 +3735,14 @@
           ],
           "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target.",
           "name": "to_payload_target"
+        },
+        {
+          "action": "store_true",
+          "flags": [
+            "--to-necessary-surfaces"
+          ],
+          "help": "Migrate legacy checked-in AW package payload to necessary repo surfaces while preserving durable Planning, Memory, and Verification state.",
+          "name": "to_necessary_surfaces"
         }
       ]
     },

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -5094,6 +5094,14 @@
             ],
             "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target.",
             "name": "to_payload_target"
+          },
+          {
+            "action": "store_true",
+            "flags": [
+              "--to-necessary-surfaces"
+            ],
+            "help": "Migrate legacy checked-in AW package payload to necessary repo surfaces while preserving durable Planning, Memory, and Verification state.",
+            "name": "to_necessary_surfaces"
           }
         ]
       },

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -5094,6 +5094,14 @@
             ],
             "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target.",
             "name": "to_payload_target"
+          },
+          {
+            "action": "store_true",
+            "flags": [
+              "--to-necessary-surfaces"
+            ],
+            "help": "Migrate legacy checked-in AW package payload to necessary repo surfaces while preserving durable Planning, Memory, and Verification state.",
+            "name": "to_necessary_surfaces"
           }
         ]
       },

--- a/generated/workspace/typescript/resources/operations/upgrade.lifecycle.json
+++ b/generated/workspace/typescript/resources/operations/upgrade.lifecycle.json
@@ -13,7 +13,8 @@
   "guards": [
     "Enforce strict preflight when configured.",
     "Respect dry-run mode by avoiding writes.",
-    "Keep legacy scratch cleanup explicit and scoped to guarded entries under .agentic-workspace/local/scratch."
+    "Keep legacy scratch cleanup explicit and scoped to guarded entries under .agentic-workspace/local/scratch.",
+    "Keep necessary-surface migration explicit, preserve durable Planning/Memory/Verification state, and do not reduce explicit full-payload mirror intent automatically."
   ],
   "id": "upgrade.lifecycle",
   "inputs": [
@@ -49,6 +50,11 @@
     },
     {
       "name": "to_payload_target",
+      "required": false,
+      "source": "cli-option"
+    },
+    {
+      "name": "to_necessary_surfaces",
       "required": false,
       "source": "cli-option"
     },
@@ -138,12 +144,12 @@
       "uses": "workspace.selection.resolve"
     },
     {
-      "description": "Plan upgrade changes or explicit legacy scratch cleanup when selected.",
+      "description": "Plan upgrade changes, explicit legacy scratch cleanup, or necessary-surface migration when selected.",
       "id": "plan_lifecycle",
       "uses": "workspace.lifecycle.plan"
     },
     {
-      "description": "Apply upgrade changes when not a dry run; apply legacy scratch cleanup only when explicitly requested.",
+      "description": "Apply upgrade changes when not a dry run; apply legacy scratch cleanup and necessary-surface migration only when explicitly requested.",
       "id": "apply_lifecycle",
       "uses": "workspace.lifecycle.apply"
     },

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -3796,6 +3796,14 @@ const commandDefinitions = [
           ],
           "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target.",
           "name": "to_payload_target"
+        },
+        {
+          "action": "store_true",
+          "flags": [
+            "--to-necessary-surfaces"
+          ],
+          "help": "Migrate legacy checked-in AW package payload to necessary repo surfaces while preserving durable Planning, Memory, and Verification state.",
+          "name": "to_necessary_surfaces"
         }
       ]
     },

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -2689,6 +2689,14 @@
           ],
           "action": "store_true",
           "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target."
+        },
+        {
+          "name": "to_necessary_surfaces",
+          "flags": [
+            "--to-necessary-surfaces"
+          ],
+          "action": "store_true",
+          "help": "Migrate legacy checked-in AW package payload to necessary repo surfaces while preserving durable Planning, Memory, and Verification state."
         }
       ],
       "role": "core_lifecycle",

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -6443,6 +6443,14 @@
                 ],
                 "action": "store_true",
                 "help": "Read [payload] from repo config and sync managed payload/provenance to the declared target."
+              },
+              {
+                "name": "to_necessary_surfaces",
+                "flags": [
+                  "--to-necessary-surfaces"
+                ],
+                "action": "store_true",
+                "help": "Migrate legacy checked-in AW package payload to necessary repo surfaces while preserving durable Planning, Memory, and Verification state."
               }
             ]
           },

--- a/src/agentic_workspace/contracts/operations/upgrade.lifecycle.json
+++ b/src/agentic_workspace/contracts/operations/upgrade.lifecycle.json
@@ -43,6 +43,11 @@
       "required": false
     },
     {
+      "name": "to_necessary_surfaces",
+      "source": "cli-option",
+      "required": false
+    },
+    {
       "name": "format",
       "source": "cli-option",
       "required": false
@@ -108,12 +113,12 @@
     {
       "id": "plan_lifecycle",
       "uses": "workspace.lifecycle.plan",
-      "description": "Plan upgrade changes or explicit legacy scratch cleanup when selected."
+      "description": "Plan upgrade changes, explicit legacy scratch cleanup, or necessary-surface migration when selected."
     },
     {
       "id": "apply_lifecycle",
       "uses": "workspace.lifecycle.apply",
-      "description": "Apply upgrade changes when not a dry run; apply legacy scratch cleanup only when explicitly requested."
+      "description": "Apply upgrade changes when not a dry run; apply legacy scratch cleanup and necessary-surface migration only when explicitly requested."
     },
     {
       "id": "emit_output",
@@ -124,7 +129,8 @@
   "guards": [
     "Enforce strict preflight when configured.",
     "Respect dry-run mode by avoiding writes.",
-    "Keep legacy scratch cleanup explicit and scoped to guarded entries under .agentic-workspace/local/scratch."
+    "Keep legacy scratch cleanup explicit and scoped to guarded entries under .agentic-workspace/local/scratch.",
+    "Keep necessary-surface migration explicit, preserve durable Planning/Memory/Verification state, and do not reduce explicit full-payload mirror intent automatically."
   ],
   "proof": [
     "operation contract validates against operation.schema.json",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -284,6 +284,11 @@
       "description": "Tracked-vs-ignored AW footprint, local scratch retention budgets, largest offenders, and cleanup routing.",
       "additionalProperties": true
     },
+    "bootstrap_footprint": {
+      "type": "object",
+      "description": "Legacy checked-in AW payload migration plan with preserve/remove/write actions, durable state preservation, and explicit mirror-intent guard.",
+      "additionalProperties": true
+    },
     "stale_cleanup": {
       "type": "object",
       "description": "Cleanup routing for stale local and checked-in planning surfaces.",

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -638,6 +638,7 @@
           "_proof_route_decision_payload",
           "_proof_route_explanation_payload",
           "_proof_route_source_for_lane",
+          "PROOF_ROUTE_HINTS_PATH",
           "_run_lifecycle_command",
           "_session_improvement_pressure_payload",
           "_skill_behavior_impact_review_for_changed_paths",

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -808,6 +808,295 @@ def _read_adoption_receipt(*, target_root: Path) -> dict[str, Any]:
     return {"status": "present", "path": WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix(), "payload": payload}
 
 
+NECESSARY_SURFACE_DURABLE_PREFIXES = (
+    ".agentic-workspace/planning/state.toml",
+    ".agentic-workspace/planning/execplans/",
+    ".agentic-workspace/memory/repo/",
+    ".agentic-workspace/verification/",
+)
+
+NECESSARY_SURFACE_REPO_OWNED_PATHS = (
+    "AGENTS.md",
+    ".agentic-workspace/config.toml",
+    ".agentic-workspace/config.local.toml",
+    ".agentic-workspace/OWNERSHIP.toml",
+    ".agentic-workspace/system-intent",
+    ".agentic-workspace/subsystem-intent",
+)
+
+NECESSARY_SURFACE_TRANSIENT_PATHS = (
+    ".agentic-workspace/bootstrap-handoff.md",
+    ".agentic-workspace/bootstrap-handoff.json",
+    ".agentic-workspace/local/scratch/bootstrap-handoff.md",
+    ".agentic-workspace/local/scratch/bootstrap-handoff.json",
+)
+
+NECESSARY_SURFACE_PACKAGE_PAYLOAD_PATHS = (
+    ".agentic-workspace/AGENTS.md",
+    ".agentic-workspace/bootstrap-handoff.md",
+    ".agentic-workspace/bootstrap-handoff.json",
+    ".agentic-workspace/docs",
+    ".agentic-workspace/skills",
+    ".agentic-workspace/planning/skills",
+    ".agentic-workspace/planning/schemas",
+    ".agentic-workspace/planning/decompositions/README.md",
+    ".agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json",
+    ".agentic-workspace/planning/execplans/README.md",
+    ".agentic-workspace/planning/execplans/TEMPLATE.plan.json",
+    ".agentic-workspace/planning/execplans/archive/README.md",
+    ".agentic-workspace/planning/lanes/README.md",
+    ".agentic-workspace/planning/lanes/TEMPLATE.lane.json",
+    ".agentic-workspace/planning/reviews",
+    ".agentic-workspace/planning/upstream-task-intake.md",
+    ".agentic-workspace/planning/pre-ingestion-refinement.md",
+    ".agentic-workspace/planning/agent-manifest.json",
+    ".agentic-workspace/memory/bootstrap",
+    ".agentic-workspace/memory/skills",
+    ".agentic-workspace/memory/SKILLS.md",
+    ".agentic-workspace/memory/VERSION.md",
+    ".agentic-workspace/memory/WORKFLOW.md",
+    ".agentic-workspace/memory/repo/templates",
+    ".agentic-workspace/memory/repo/decisions/README.md",
+    ".agentic-workspace/memory/repo/domains/README.md",
+    ".agentic-workspace/memory/repo/invariants/README.md",
+    ".agentic-workspace/memory/repo/runbooks/README.md",
+)
+
+
+def _necessary_surface_cli_command(*, cli_invoke: str, dry_run: bool) -> str:
+    command = f"agentic-workspace upgrade --target . --to-necessary-surfaces {'--dry-run ' if dry_run else ''}--format json"
+    return _command_with_cli_invoke(command=command, cli_invoke=cli_invoke)
+
+
+def _path_is_under_or_equal(path: str, parent: str) -> bool:
+    return path == parent or path.startswith(parent.rstrip("/") + "/")
+
+
+def _necessary_surface_path_class(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    if any(_path_is_under_or_equal(normalized, candidate) for candidate in NECESSARY_SURFACE_REPO_OWNED_PATHS):
+        return "necessary-repo-owned-state"
+    if normalized in {WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(), *[p.as_posix() for p in MODULE_UPGRADE_SOURCE_PATHS.values()]}:
+        return "local-environment-provenance"
+    if normalized in NECESSARY_SURFACE_TRANSIENT_PATHS:
+        return "transient-handoff-scratch"
+    if normalized in {relative.as_posix() for relative in WORKSPACE_PAYLOAD_FILES} or any(
+        _path_is_under_or_equal(normalized, candidate) for candidate in NECESSARY_SURFACE_PACKAGE_PAYLOAD_PATHS
+    ):
+        return "removable-package-owned-payload"
+    if any(_path_is_under_or_equal(normalized, candidate) for candidate in NECESSARY_SURFACE_DURABLE_PREFIXES):
+        return "adopted-durable-state"
+    if normalized == WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix():
+        return "footprint-adoption-receipt"
+    if normalized.startswith(".agentic-workspace/local/"):
+        return "local-runtime-state"
+    return "manual-review"
+
+
+def _necessary_surface_remove_candidates() -> list[str]:
+    candidates = {
+        WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(),
+        *[relative.as_posix() for relative in WORKSPACE_PAYLOAD_FILES],
+        *[relative.as_posix() for relative in MODULE_UPGRADE_SOURCE_PATHS.values()],
+        *NECESSARY_SURFACE_PACKAGE_PAYLOAD_PATHS,
+        ".agentic-workspace/local/scratch/bootstrap-handoff.md",
+        ".agentic-workspace/local/scratch/bootstrap-handoff.json",
+    }
+    return sorted(candidates, key=lambda item: (item.count("/"), item))
+
+
+def _necessary_surface_preserve_candidates(target_root: Path) -> list[str]:
+    candidates: set[str] = set()
+    for relative in NECESSARY_SURFACE_REPO_OWNED_PATHS:
+        path = target_root / relative
+        if path.exists():
+            candidates.add(relative)
+    aw_root = target_root / ".agentic-workspace"
+    for relative in (
+        ".agentic-workspace/planning/state.toml",
+        ".agentic-workspace/planning/execplans",
+        ".agentic-workspace/memory/repo",
+        ".agentic-workspace/verification",
+        WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix(),
+    ):
+        path = target_root / relative
+        if path.exists():
+            candidates.add(relative)
+    if aw_root.exists():
+        for prefix in NECESSARY_SURFACE_DURABLE_PREFIXES:
+            root = target_root / prefix
+            if root.is_file():
+                candidates.add(prefix)
+            elif root.is_dir():
+                for child in root.rglob("*"):
+                    if child.is_file():
+                        candidates.add(_repo_relative_path(child, target_root))
+    return sorted(candidates)
+
+
+def _existing_necessary_surface_remove_candidates(target_root: Path) -> list[str]:
+    selected: list[str] = []
+    for relative in _necessary_surface_remove_candidates():
+        path = target_root / relative
+        if not path.exists() and not path.is_symlink():
+            continue
+        if _necessary_surface_path_class(relative) not in {
+            "removable-package-owned-payload",
+            "local-environment-provenance",
+            "transient-handoff-scratch",
+        }:
+            continue
+        if any((target_root / parent).is_dir() and _path_is_under_or_equal(relative, parent) for parent in selected):
+            continue
+        selected.append(relative)
+    return selected
+
+
+def _necessary_surface_action(kind: str, path: str, detail: str) -> dict[str, str]:
+    return {
+        "kind": kind,
+        "path": path,
+        "class": _necessary_surface_path_class(path),
+        "detail": detail,
+    }
+
+
+def _remove_necessary_surface_candidate(*, target_root: Path, relative: str) -> tuple[bool, str | None]:
+    path = target_root / relative
+    if not path.exists() and not path.is_symlink():
+        return False, None
+    candidate = path.resolve(strict=False)
+    aw_root = (target_root / ".agentic-workspace").resolve(strict=False)
+    if not _path_under_root(candidate, aw_root):
+        return False, "candidate failed .agentic-workspace path guard"
+    if _necessary_surface_path_class(relative) not in {
+        "removable-package-owned-payload",
+        "local-environment-provenance",
+        "transient-handoff-scratch",
+    }:
+        return False, "candidate is not classified as removable package/local residue"
+    _remove_tree_no_follow(path)
+    return True, None
+
+
+def _necessary_surfaces_migration_payload(
+    *,
+    target_root: Path,
+    selected_modules: list[str],
+    config: WorkspaceConfig,
+    dry_run: bool,
+) -> dict[str, Any]:
+    receipt_status = _read_adoption_receipt(target_root=target_root)
+    receipt = receipt_status.get("payload") if receipt_status.get("status") == "present" else {}
+    payload_mirror = receipt.get("payload_mirror") if isinstance(receipt, dict) else None
+    explicit_mirror = payload_mirror is True
+    remove_candidates = _existing_necessary_surface_remove_candidates(target_root)
+    preserve_actions = [
+        _necessary_surface_action("preserve", relative, "preserve necessary repo-owned or adopted durable AW state")
+        for relative in _necessary_surface_preserve_candidates(target_root)
+    ]
+    actions: list[dict[str, str]] = list(preserve_actions)
+    warnings: list[dict[str, str]] = []
+    if explicit_mirror:
+        status = "mirror-intent-present"
+        warnings.append(
+            {
+                "path": receipt_status.get("path", WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix()),
+                "message": "explicit payload mirror intent is present; necessary-surface reduction requires changing that intent first",
+            }
+        )
+    else:
+        status = "safe-apply-available" if remove_candidates else "already-necessary-surfaces"
+        for relative in remove_candidates:
+            actions.append(
+                _necessary_surface_action(
+                    "would remove" if dry_run else "remove",
+                    relative,
+                    "remove package-owned generic AW payload, transient handoff residue, or local executable provenance",
+                )
+            )
+        receipt_report = {"actions": preserve_actions}
+        receipt_action = _write_adoption_receipt_action(
+            target_root=target_root,
+            selected_modules=selected_modules,
+            reports=[receipt_report],
+            payload_mirror=False,
+            dry_run=True,
+        )
+        if receipt_action["kind"] != "current":
+            actions.append(
+                _necessary_surface_action(
+                    "would " + receipt_action["kind"].removeprefix("would ") if dry_run else receipt_action["kind"].replace("would ", ""),
+                    receipt_action["path"],
+                    "write necessary-surfaces adoption receipt after preserving durable state",
+                )
+            )
+    if not dry_run and not explicit_mirror:
+        applied_actions: list[dict[str, str]] = []
+        for action in actions:
+            if action["kind"] != "remove":
+                applied_actions.append(action)
+                continue
+            removed, warning = _remove_necessary_surface_candidate(target_root=target_root, relative=action["path"])
+            if removed:
+                applied_actions.append({**action, "kind": "removed"})
+            elif warning:
+                warnings.append({"path": action["path"], "message": warning})
+        actions = applied_actions
+        receipt_action = _write_adoption_receipt_action(
+            target_root=target_root,
+            selected_modules=selected_modules,
+            reports=[{"actions": preserve_actions}],
+            payload_mirror=False,
+            dry_run=False,
+        )
+        if receipt_action["kind"] != "current":
+            actions.append(
+                _necessary_surface_action(
+                    receipt_action["kind"],
+                    receipt_action["path"],
+                    "write necessary-surfaces adoption receipt after preserving durable state",
+                )
+            )
+        status = "applied" if any(action["kind"] in {"removed", "created", "updated"} for action in actions) else status
+    remove_actions = [action for action in actions if action["kind"] in {"would remove", "remove", "removed"}]
+    write_actions = [
+        action
+        for action in actions
+        if action["path"] == WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix() and action["kind"] not in {"current", "preserve"}
+    ]
+    return {
+        "kind": "agentic-workspace/necessary-surface-migration/v1",
+        "status": status,
+        "dry_run": dry_run,
+        "target_state": "necessary-surfaces-only",
+        "payload_mirror_intent": "explicit-full-mirror"
+        if explicit_mirror
+        else "necessary-surfaces"
+        if payload_mirror is False
+        else "absent",
+        "safe_to_apply": not explicit_mirror,
+        "actions": actions,
+        "warnings": warnings,
+        "summary": {
+            "preserve_count": len(preserve_actions),
+            "remove_count": len(remove_actions),
+            "write_count": len(write_actions),
+        },
+        "dry_run_command": _necessary_surface_cli_command(cli_invoke=config.cli_invoke, dry_run=True),
+        "apply_command": _necessary_surface_cli_command(cli_invoke=config.cli_invoke, dry_run=False),
+        "recheck_command": _command_with_cli_invoke(
+            command="agentic-workspace doctor --target . --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+        "rule": (
+            "Necessary-surface migration removes only known package-owned AW payload, transient handoff residue, "
+            "and local executable provenance while preserving repo-owned config/startup state and adopted Planning, "
+            "Memory, and Verification state. Explicit full-payload mirror intent is not reduced automatically."
+        ),
+    }
+
+
 def _validate_payload_provenance(payload: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     if payload.get("payload_schema") != WORKSPACE_PAYLOAD_SCHEMA:
@@ -7091,6 +7380,29 @@ def _workspace_status_report(
                 "message": "AW local footprint exceeds budget or has scratch eligible for retention cleanup; inspect report --section local_footprint.",
             }
         )
+    bootstrap_footprint = _necessary_surfaces_migration_payload(
+        target_root=target_root,
+        selected_modules=selected_modules,
+        config=config,
+        dry_run=True,
+    )
+    if bootstrap_footprint.get("status") == "safe-apply-available":
+        actions.append(
+            {
+                "kind": "warning",
+                "path": ".agentic-workspace",
+                "detail": "legacy checked-in AW package payload can be migrated to necessary surfaces",
+            }
+        )
+        warnings.append(
+            {
+                "path": ".agentic-workspace",
+                "message": (
+                    "legacy checked-in AW package payload can be reduced; inspect report --section bootstrap_footprint "
+                    "or run upgrade --to-necessary-surfaces --dry-run."
+                ),
+            }
+        )
     agents_path = target_root / agents_relative
     if not agents_path.exists():
         actions.append({"kind": "missing", "path": agents_relative.as_posix(), "detail": "root startup entrypoint missing"})
@@ -11340,6 +11652,12 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "when .agentic-workspace size, local scratch growth, or cleanup routing needs diagnosis",
     },
     {
+        "section": "bootstrap_footprint",
+        "kind": "agentic-workspace/necessary-surface-migration/v1",
+        "purpose": "legacy checked-in AW payload reduction plan with preserve/remove/write actions and mirror-intent guard",
+        "when_to_use": "when a repo has historical checked-in AW package payload and should converge to necessary surfaces",
+    },
+    {
         "section": "workflow_compliance_summary",
         "kind": "agentic-workspace/workflow-compliance-summary/v1",
         "purpose": ("review/recovery summary of expected entrypoint, observed workflow use, gates, trust impact, and recovery action"),
@@ -14379,6 +14697,15 @@ def _run_lazy_report_section_command(
 
     if normalized == "local_footprint":
         payload["local_footprint"] = _local_footprint_payload(target_root=target_root, cli_invoke=config.cli_invoke)
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "bootstrap_footprint":
+        payload["bootstrap_footprint"] = _necessary_surfaces_migration_payload(
+            target_root=target_root,
+            selected_modules=selected_modules,
+            config=config,
+            dry_run=True,
+        )
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "architecture_principles":
@@ -41874,6 +42201,31 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
             resolved_preset=resolved_preset,
             non_interactive=args.non_interactive,
         )
+        _emit_payload(payload=payload, format_name=args.format)
+        return 0
+    if command_name == "upgrade" and bool(getattr(args, "to_necessary_surfaces", False)):
+        migration = _necessary_surfaces_migration_payload(
+            target_root=target_root,
+            selected_modules=selected_modules,
+            config=config,
+            dry_run=bool(getattr(args, "dry_run", False)),
+        )
+        report = _workspace_report(
+            target_root=target_root,
+            message="Necessary surface migration",
+            dry_run=bool(getattr(args, "dry_run", False)),
+            actions=cast(list[dict[str, str]], migration.get("actions", [])),
+            warnings=cast(list[dict[str, str]], migration.get("warnings", [])),
+        )
+        summary = _summarise_reports(target_root=target_root, reports=[report], descriptors={}, command_name="upgrade")
+        payload = {
+            "kind": "agentic-workspace/necessary-surface-migration-command/v1",
+            "command": "upgrade",
+            "dry_run": bool(getattr(args, "dry_run", False)),
+            "migration": migration,
+            "reports": [report],
+            **summary,
+        }
         _emit_payload(payload=payload, format_name=args.format)
         return 0
     payload = _run_lifecycle_command(

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -11089,6 +11089,18 @@ _LAZY_REPORT_SECTION_CATALOG: tuple[dict[str, str], ...] = (
         "when_to_use": "immediately before final messages, PR readiness, issue closure, or closeout handoff",
     },
     {
+        "section": "local_footprint",
+        "kind": "agentic-workspace/local-footprint/v1",
+        "purpose": "tracked-vs-ignored AW footprint, local scratch retention, budgets, and largest local offenders",
+        "when_to_use": "when .agentic-workspace size, local scratch growth, or cleanup routing needs diagnosis",
+    },
+    {
+        "section": "bootstrap_footprint",
+        "kind": "agentic-workspace/necessary-surface-migration/v1",
+        "purpose": "legacy checked-in AW payload reduction plan with preserve/remove/write actions and mirror-intent guard",
+        "when_to_use": "when a repo has historical checked-in AW package payload and should converge to necessary surfaces",
+    },
+    {
         "section": "workflow_compliance_summary",
         "kind": "agentic-workspace/workflow-compliance-summary/v1",
         "purpose": ("review/recovery summary of expected entrypoint, observed workflow use, gates, trust impact, and recovery action"),
@@ -13549,6 +13561,15 @@ def _run_lazy_report_section_command(
 
     if normalized == "local_footprint":
         payload["local_footprint"] = _local_footprint_payload(target_root=target_root, cli_invoke=config.cli_invoke)
+        return _select_report_payload(payload, profile="router", section=normalized)
+
+    if normalized == "bootstrap_footprint":
+        payload["bootstrap_footprint"] = _workspace_runtime_core._necessary_surfaces_migration_payload(
+            target_root=target_root,
+            selected_modules=selected_modules,
+            config=config,
+            dry_run=True,
+        )
         return _select_report_payload(payload, profile="router", section=normalized)
 
     if normalized == "local_overlay":
@@ -39413,6 +39434,31 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
             resolved_preset=resolved_preset,
             non_interactive=args.non_interactive,
         )
+        _emit_payload(payload=payload, format_name=args.format)
+        return 0
+    if command_name == "upgrade" and bool(getattr(args, "to_necessary_surfaces", False)):
+        migration = _workspace_runtime_core._necessary_surfaces_migration_payload(
+            target_root=target_root,
+            selected_modules=selected_modules,
+            config=config,
+            dry_run=bool(getattr(args, "dry_run", False)),
+        )
+        report = _workspace_report(
+            target_root=target_root,
+            message="Necessary surface migration",
+            dry_run=bool(getattr(args, "dry_run", False)),
+            actions=cast(list[dict[str, str]], migration.get("actions", [])),
+            warnings=cast(list[dict[str, str]], migration.get("warnings", [])),
+        )
+        summary = _summarise_reports(target_root=target_root, reports=[report], descriptors={}, command_name="upgrade")
+        payload = {
+            "kind": "agentic-workspace/necessary-surface-migration-command/v1",
+            "command": "upgrade",
+            "dry_run": bool(getattr(args, "dry_run", False)),
+            "migration": migration,
+            "reports": [report],
+            **summary,
+        }
         _emit_payload(payload=payload, format_name=args.format)
         return 0
     payload = _run_lifecycle_command(

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1879,6 +1879,161 @@ def test_upgrade_to_payload_target_forces_provenance_capability_sync(tmp_path: P
     assert ordinary_action["kind"] == "current"
 
 
+def test_report_bootstrap_footprint_recommends_legacy_payload_migration(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "adoption-receipt.json").unlink()
+    _write(workspace / "planning" / "state.toml", 'kind = "agentic-workspace/planning-state"\n')
+    _write(workspace / "memory" / "repo" / "decisions" / "kept.md", "# Kept decision\n")
+
+    assert cli.main(["report", "--target", str(tmp_path), "--section", "bootstrap_footprint", "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    plan = payload["answer"]
+
+    assert plan["kind"] == "agentic-workspace/necessary-surface-migration/v1"
+    assert plan["status"] == "safe-apply-available"
+    assert plan["safe_to_apply"] is True
+    assert "--to-necessary-surfaces --dry-run" in plan["dry_run_command"]
+    assert any(
+        action["kind"] == "would remove"
+        and action["path"] == ".agentic-workspace/skills"
+        and action["class"] == "removable-package-owned-payload"
+        for action in plan["actions"]
+    )
+    assert any(
+        action["kind"] == "preserve"
+        and action["path"] == ".agentic-workspace/planning/state.toml"
+        and action["class"] == "adopted-durable-state"
+        for action in plan["actions"]
+    )
+    assert any(action["path"] == ".agentic-workspace/adoption-receipt.json" for action in plan["actions"])
+
+
+def test_upgrade_to_necessary_surfaces_preserves_durable_state_and_uses_package_skills(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--mirror-payload", "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "adoption-receipt.json").unlink()
+    _write(workspace / "planning" / "state.toml", 'kind = "agentic-workspace/planning-state"\n')
+    _write(workspace / "planning" / "execplans" / "active.plan.json", '{"kind":"planning-execplan/v1"}\n')
+    _write(workspace / "memory" / "repo" / "decisions" / "decision.md", "# Durable decision\n")
+    package_seed_paths = [
+        workspace / "planning" / "execplans" / "TEMPLATE.plan.json",
+        workspace / "planning" / "execplans" / "README.md",
+        workspace / "planning" / "execplans" / "archive" / "README.md",
+        workspace / "memory" / "repo" / "templates",
+        workspace / "memory" / "repo" / "decisions" / "README.md",
+        workspace / "memory" / "repo" / "domains" / "README.md",
+        workspace / "memory" / "repo" / "invariants" / "README.md",
+        workspace / "memory" / "repo" / "runbooks" / "README.md",
+    ]
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--dry-run", "--format", "json"]) == 0
+    dry_run = json.loads(capsys.readouterr().out)["migration"]
+    assert dry_run["status"] == "safe-apply-available"
+    remove_actions = {action["path"]: action for action in dry_run["actions"] if action["kind"] == "would remove"}
+    for path in package_seed_paths:
+        relative = path.relative_to(tmp_path).as_posix()
+        assert remove_actions[relative]["class"] == "removable-package-owned-payload"
+    assert (workspace / "skills" / "workspace-operating-loop" / "SKILL.md").exists()
+    assert (workspace / "memory" / "repo" / "decisions" / "decision.md").exists()
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--format", "json"]) == 0
+    applied = json.loads(capsys.readouterr().out)["migration"]
+    assert applied["status"] == "applied"
+    assert not (workspace / "skills").exists()
+    assert not (workspace / "planning" / "skills").exists()
+    assert not (workspace / "memory" / "skills").exists()
+    assert not (workspace / "payload-provenance.json").exists()
+    for path in package_seed_paths:
+        assert not path.exists()
+    assert (workspace / "planning" / "state.toml").exists()
+    assert (workspace / "planning" / "execplans" / "active.plan.json").exists()
+    assert (workspace / "memory" / "repo" / "decisions" / "decision.md").exists()
+    receipt = json.loads((workspace / "adoption-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["payload_mirror"] is False
+    assert "planning/state.toml" in receipt["adopted_state"]
+    assert any(path.startswith("memory/repo/decisions/decision.md") for path in receipt["adopted_state"])
+
+    assert cli.main(["skills", "--target", str(tmp_path), "--format", "json"]) == 0
+    skills_payload = json.loads(capsys.readouterr().out)
+    skill_ids = {entry["id"] for entry in skills_payload["skills"]}
+    assert "workspace-operating-loop" in skill_ids
+    assert "memory-router" in skill_ids
+
+    assert cli.main(["status", "--target", str(tmp_path), "--format", "json"]) == 0
+    status_payload = json.loads(capsys.readouterr().out)
+    assert "necessary surfaces" not in json.dumps(status_payload).lower()
+
+
+def test_upgrade_to_necessary_surfaces_leaves_doctor_healthy_after_apply(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--mirror-payload", "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "adoption-receipt.json").unlink()
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--format", "json"]) == 0
+    applied = json.loads(capsys.readouterr().out)["migration"]
+    assert applied["status"] == "applied"
+
+    assert cli.main(["doctor", "--target", str(tmp_path), "--format", "json"]) == 0
+    doctor_payload = json.loads(capsys.readouterr().out)
+    assert doctor_payload["health"] == "healthy"
+    assert doctor_payload["needs_review"] == []
+    assert doctor_payload["warnings"] == []
+
+
+def test_upgrade_to_necessary_surfaces_preserves_verification_state(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--mirror-payload", "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "adoption-receipt.json").unlink()
+    _write(workspace / "verification" / "manifest.toml", "schema_version = 1\n")
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (workspace / "verification" / "manifest.toml").exists()
+
+
+def test_upgrade_to_necessary_surfaces_respects_explicit_mirror_receipt(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--dry-run", "--format", "json"]) == 0
+    dry_run = json.loads(capsys.readouterr().out)["migration"]
+    assert dry_run["status"] == "mirror-intent-present"
+    assert dry_run["safe_to_apply"] is False
+    assert not any(action["kind"] == "would remove" for action in dry_run["actions"])
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--format", "json"]) == 0
+    applied = json.loads(capsys.readouterr().out)["migration"]
+    assert applied["status"] == "mirror-intent-present"
+    assert (workspace / "skills" / "workspace-operating-loop" / "SKILL.md").exists()
+    receipt = json.loads((workspace / "adoption-receipt.json").read_text(encoding="utf-8"))
+    assert receipt["payload_mirror"] is True
+
+
+def test_doctor_surfaces_legacy_bootstrap_footprint_migration(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "adoption-receipt.json").unlink()
+
+    assert cli.main(["doctor", "--target", str(tmp_path), "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert any("bootstrap_footprint" in warning for warning in payload["warnings"])
+
+
 def test_payload_upgrade_attention_plan_classifies_repo_surfaces(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     workspace = tmp_path / ".agentic-workspace"

--- a/tests/test_workspace_doctor_status_cli.py
+++ b/tests/test_workspace_doctor_status_cli.py
@@ -590,6 +590,24 @@ def test_doctor_json_exposes_standardised_summary_fields(monkeypatch, tmp_path: 
         cli._workspace_managed_agent_instructions_text(config=cli.config_lib.load_workspace_config(target_root=tmp_path)),
         encoding="utf-8",
     )
+    _write(
+        tmp_path / ".agentic-workspace" / "adoption-receipt.json",
+        json.dumps(
+            {
+                "kind": "agentic-workspace/adoption-receipt/v1",
+                "checked_in_rule": "necessary-surfaces-only",
+                "adopted_state": [],
+                "omitted_package_payload": [],
+                "local_only": [],
+                "payload_mirror": True,
+                "recheck_command": "agentic-workspace doctor --target . --format json",
+                "rule": "Test fixture declares explicit mirror intent so doctor has no bootstrap-footprint migration warning.",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
     monkeypatch.setattr(cli, "_module_operations", lambda: _fake_descriptors(tmp_path, calls))
 
     assert cli.main(["doctor", "--verbose", "--modules", "planning,memory", "--target", str(tmp_path), "--format", "json"]) == 0


### PR DESCRIPTION
## Summary

Adds an explicit necessary-surface migration path for repositories that still have checked-in generic Agentic Workspace package payload from older local/full-payload installs.

## What changed

- Adds `agentic-workspace upgrade --to-necessary-surfaces` with dry-run/apply behavior.
- Adds `report --section bootstrap_footprint` and doctor/status discoverability for legacy reducible payload.
- Preserves repo-owned startup/config plus durable Planning, Memory, and Verification state while removing known package-owned docs, schemas, templates, skill trees, provenance, and transient handoff residue.
- Refreshes the adoption receipt with `payload_mirror=false` after migration.
- Refuses to reduce explicit full-payload mirror intent automatically.
- Regenerates Python/TypeScript generated command metadata and schema reference docs.

## Validation

- `uv run pytest tests/test_workspace_cli.py -q`
- `make test-workspace`
- `make maintainer-surfaces`
- `make lint-workspace`
- `make typecheck`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `uv run python scripts/check/check_command_surface_bundle.py --operation-id upgrade.lifecycle`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
