### PR TITLE
Fix necessary-surface AGENTS skill pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Ordinary route:
 Boundaries:
 - Known dedicated Agentic Workspace commands are allowed only when the request maps directly to that command and no takeover, recovery, active-planning, or ambiguous safety decision is needed first.
 - Do not bake machine-local AW invocation paths into checked-in generic guidance; concrete commands come from the configured invocation or live router output.
+- Treat checked-in `.agentic-workspace/skills` and module skill trees as required operating surfaces, not optional payload mirror content.
 - Treat `preflight`, `config`, `defaults`, `skills`, `modules`, `ownership`, and `report` as routed drill-down or recovery surfaces, not the ordinary startup loop.
 - Report repo-relative paths, not local absolute paths.
 <!-- agentic-workspace:workflow:end -->

--- a/packages/planning/scripts/check/check_planning_surfaces.py
+++ b/packages/planning/scripts/check/check_planning_surfaces.py
@@ -1123,6 +1123,7 @@ def _check_startup_policy(repo_root: Path) -> list[PlanningWarning]:
         "skills",
         "before opening raw `.agentic-workspace` files",
         "do not bake machine-local aw invocation paths into checked-in generic guidance",
+        "module skill trees as required operating surfaces",
         "routed drill-down or recovery surfaces",
         ".agentic-workspace/workflow.md",
         "<!-- agentic-workspace:workflow:end -->",

--- a/src/agentic_workspace/config.py
+++ b/src/agentic_workspace/config.py
@@ -201,6 +201,7 @@ def workspace_pointer_block(*, cli_invoke: str = DEFAULT_CLI_INVOKE) -> str:
         "Boundaries:\n"
         "- Known dedicated Agentic Workspace commands are allowed only when the request maps directly to that command and no takeover, recovery, active-planning, or ambiguous safety decision is needed first.\n"
         "- Do not bake machine-local AW invocation paths into checked-in generic guidance; concrete commands come from the configured invocation or live router output.\n"
+        "- Treat checked-in `.agentic-workspace/skills` and module skill trees as required operating surfaces, not optional payload mirror content.\n"
         "- Treat `preflight`, `config`, `defaults`, `skills`, `modules`, `ownership`, and `report` as routed drill-down or recovery surfaces, not the ordinary startup loop.\n"
         "- Report repo-relative paths, not local absolute paths.\n"
         f"{WORKSPACE_WORKFLOW_MARKER_END}"

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -815,6 +815,12 @@ NECESSARY_SURFACE_DURABLE_PREFIXES = (
     ".agentic-workspace/verification/",
 )
 
+NECESSARY_SURFACE_REQUIRED_SKILL_PREFIXES = (
+    ".agentic-workspace/skills",
+    ".agentic-workspace/planning/skills",
+    ".agentic-workspace/memory/skills",
+)
+
 NECESSARY_SURFACE_REPO_OWNED_PATHS = (
     "AGENTS.md",
     ".agentic-workspace/config.toml",
@@ -836,8 +842,6 @@ NECESSARY_SURFACE_PACKAGE_PAYLOAD_PATHS = (
     ".agentic-workspace/bootstrap-handoff.md",
     ".agentic-workspace/bootstrap-handoff.json",
     ".agentic-workspace/docs",
-    ".agentic-workspace/skills",
-    ".agentic-workspace/planning/skills",
     ".agentic-workspace/planning/schemas",
     ".agentic-workspace/planning/decompositions/README.md",
     ".agentic-workspace/planning/decompositions/TEMPLATE.decomposition.json",
@@ -851,7 +855,6 @@ NECESSARY_SURFACE_PACKAGE_PAYLOAD_PATHS = (
     ".agentic-workspace/planning/pre-ingestion-refinement.md",
     ".agentic-workspace/planning/agent-manifest.json",
     ".agentic-workspace/memory/bootstrap",
-    ".agentic-workspace/memory/skills",
     ".agentic-workspace/memory/SKILLS.md",
     ".agentic-workspace/memory/VERSION.md",
     ".agentic-workspace/memory/WORKFLOW.md",
@@ -872,10 +875,17 @@ def _path_is_under_or_equal(path: str, parent: str) -> bool:
     return path == parent or path.startswith(parent.rstrip("/") + "/")
 
 
+def _is_necessary_skill_surface_path(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    return any(_path_is_under_or_equal(normalized, candidate) for candidate in NECESSARY_SURFACE_REQUIRED_SKILL_PREFIXES)
+
+
 def _necessary_surface_path_class(path: str) -> str:
     normalized = path.replace("\\", "/")
     if any(_path_is_under_or_equal(normalized, candidate) for candidate in NECESSARY_SURFACE_REPO_OWNED_PATHS):
         return "necessary-repo-owned-state"
+    if _is_necessary_skill_surface_path(normalized):
+        return "required-skill-surface"
     if normalized in {WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix(), *[p.as_posix() for p in MODULE_UPGRADE_SOURCE_PATHS.values()]}:
         return "local-environment-provenance"
     if normalized in NECESSARY_SURFACE_TRANSIENT_PATHS:
@@ -918,6 +928,7 @@ def _necessary_surface_preserve_candidates(target_root: Path) -> list[str]:
         ".agentic-workspace/memory/repo",
         ".agentic-workspace/verification",
         WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix(),
+        *NECESSARY_SURFACE_REQUIRED_SKILL_PREFIXES,
     ):
         path = target_root / relative
         if path.exists():
@@ -1006,7 +1017,13 @@ def _necessary_surfaces_migration_payload(
             }
         )
     else:
-        status = "safe-apply-available" if remove_candidates else "already-necessary-surfaces"
+        skill_actions = [
+            _necessary_surface_action(action["kind"], action["path"], action["detail"])
+            for action in _required_skill_surface_actions(target_root=target_root, selected_modules=selected_modules, dry_run=dry_run)
+        ]
+        skill_write_actions = [action for action in skill_actions if action["kind"] not in {"current"}]
+        status = "safe-apply-available" if remove_candidates or skill_write_actions else "already-necessary-surfaces"
+        actions.extend(skill_actions)
         for relative in remove_candidates:
             actions.append(
                 _necessary_surface_action(
@@ -1060,11 +1077,7 @@ def _necessary_surfaces_migration_payload(
             )
         status = "applied" if any(action["kind"] in {"removed", "created", "updated"} for action in actions) else status
     remove_actions = [action for action in actions if action["kind"] in {"would remove", "remove", "removed"}]
-    write_actions = [
-        action
-        for action in actions
-        if action["path"] == WORKSPACE_ADOPTION_RECEIPT_PATH.as_posix() and action["kind"] not in {"current", "preserve"}
-    ]
+    write_actions = [action for action in actions if action["kind"] not in {"current", "preserve", "would remove", "remove", "removed"}]
     return {
         "kind": "agentic-workspace/necessary-surface-migration/v1",
         "status": status,
@@ -7943,12 +7956,13 @@ def _workspace_init_or_upgrade_report(
             config_modules = [module_name for module_name in ordered_names if module_name in requested]
         actions.append(_set_enabled_modules_action(target_root=target_root, enabled_modules=config_modules, dry_run=dry_run))
     if minimal_footprint:
+        actions.extend(_workspace_required_skill_actions(target_root=target_root, dry_run=dry_run))
         actions.append(
             {
                 "kind": "omitted",
                 "path": ".agentic-workspace/package-payload",
                 "detail": (
-                    "ordinary bootstrap omits generic workspace docs, templates, schemas, and bundled skills; "
+                    "ordinary bootstrap omits generic workspace docs, templates, schemas, and provenance; "
                     "use --mirror-payload to copy the package payload"
                 ),
             }
@@ -8191,6 +8205,120 @@ def _workspace_init_or_upgrade_report(
     return _workspace_report(
         target_root=target_root, message=f"{command_name.title()} report", dry_run=dry_run, actions=actions, warnings=warnings
     )
+
+
+def _sync_bytes_surface_action(
+    *,
+    target_root: Path,
+    relative: Path,
+    source_bytes: bytes,
+    dry_run: bool,
+    detail: str,
+) -> dict[str, str]:
+    destination = target_root / relative
+    existing = destination.read_bytes() if destination.is_file() else None
+    if existing == source_bytes:
+        return {"kind": "current", "path": relative.as_posix(), "detail": detail + "; already current"}
+    if not dry_run:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(source_bytes)
+    return {
+        "kind": "would create"
+        if dry_run and existing is None
+        else "would update"
+        if dry_run
+        else "created"
+        if existing is None
+        else "updated",
+        "path": relative.as_posix(),
+        "detail": detail,
+    }
+
+
+def _sync_tree_surface_actions(
+    *,
+    source_root: Path,
+    target_root: Path,
+    destination_root: Path,
+    dry_run: bool,
+    detail: str,
+) -> list[dict[str, str]]:
+    if not source_root.is_dir():
+        return [{"kind": "manual review", "path": destination_root.as_posix(), "detail": f"{detail}; source directory is missing"}]
+    actions: list[dict[str, str]] = []
+    for source in sorted(source_root.rglob("*")):
+        if not source.is_file() or "__pycache__" in source.parts or source.suffix == ".pyc":
+            continue
+        relative = destination_root / source.relative_to(source_root)
+        actions.append(
+            _sync_bytes_surface_action(
+                target_root=target_root,
+                relative=relative,
+                source_bytes=source.read_bytes(),
+                dry_run=dry_run,
+                detail=detail,
+            )
+        )
+    return actions
+
+
+def _workspace_required_skill_actions(*, target_root: Path, dry_run: bool) -> list[dict[str, str]]:
+    actions: list[dict[str, str]] = []
+    for relative in sorted(
+        (relative for relative in WORKSPACE_PAYLOAD_FILES if _is_necessary_skill_surface_path(relative.as_posix())),
+        key=lambda path: path.as_posix(),
+    ):
+        source = _workspace_payload_source(relative)
+        if not source.is_file():
+            actions.append(
+                {
+                    "kind": "manual review",
+                    "path": relative.as_posix(),
+                    "detail": "required workspace skill payload source is missing",
+                }
+            )
+            continue
+        actions.append(
+            _sync_bytes_surface_action(
+                target_root=target_root,
+                relative=relative,
+                source_bytes=source.read_bytes(),
+                dry_run=dry_run,
+                detail="sync required workspace skill surface for routed agent workflows",
+            )
+        )
+    return actions
+
+
+def _module_required_skill_actions(*, module_name: str, target_root: Path, dry_run: bool) -> list[dict[str, str]]:
+    if module_name == "planning":
+        from repo_planning_bootstrap.installer import skills_root as planning_skills_root
+
+        return _sync_tree_surface_actions(
+            source_root=planning_skills_root(),
+            target_root=target_root,
+            destination_root=Path(".agentic-workspace/planning/skills"),
+            dry_run=dry_run,
+            detail="sync required planning skill surface for routed agent workflows",
+        )
+    if module_name == "memory":
+        from repo_memory_bootstrap._installer_paths import payload_root as memory_payload_root
+
+        return _sync_tree_surface_actions(
+            source_root=memory_payload_root() / ".agentic-workspace" / "memory" / "skills",
+            target_root=target_root,
+            destination_root=Path(".agentic-workspace/memory/skills"),
+            dry_run=dry_run,
+            detail="sync required memory skill surface for routed agent workflows",
+        )
+    return []
+
+
+def _required_skill_surface_actions(*, target_root: Path, selected_modules: list[str], dry_run: bool) -> list[dict[str, str]]:
+    actions = _workspace_required_skill_actions(target_root=target_root, dry_run=dry_run)
+    for module_name in selected_modules:
+        actions.extend(_module_required_skill_actions(module_name=module_name, target_root=target_root, dry_run=dry_run))
+    return actions
 
 
 def _workspace_uninstall_report(
@@ -8667,12 +8795,13 @@ def _minimal_module_footprint_report(
                 "detail": f"ordinary bootstrap does not define state anchors for module '{module_name}'",
             }
         )
+    actions.extend(_module_required_skill_actions(module_name=module_name, target_root=target_root, dry_run=dry_run))
     actions.append(
         {
             "kind": "omitted",
             "path": f".agentic-workspace/{module_name}",
             "detail": (
-                f"ordinary bootstrap keeps generic {module_name} package payload out of the repository; "
+                f"ordinary bootstrap keeps generic {module_name} docs, templates, schemas, and provenance out of the repository; "
                 "use --mirror-payload for an explicit mirrored install"
             ),
         }
@@ -40099,6 +40228,7 @@ def _bootstrap_footprint_payload(
         "repo_owned_config": [],
         "adopted_local_state": [],
         "package_supplied_payload": [],
+        "required_skill_surfaces": [],
         "transient_handoff": [],
         "local_environment_provenance": [],
         "intentional_full_mirror": [],
@@ -40124,6 +40254,9 @@ def _bootstrap_footprint_payload(
                 _add("adopted_local_state", path)
             if path == WORKSPACE_PAYLOAD_PROVENANCE_PATH.as_posix() or path.endswith("/UPGRADE-SOURCE.toml"):
                 _add("local_environment_provenance", path)
+            if _is_necessary_skill_surface_path(path):
+                _add("required_skill_surfaces", path)
+                continue
             if kind == "omitted" and (
                 path == ".agentic-workspace/package-payload"
                 or path in {".agentic-workspace/planning", ".agentic-workspace/memory", ".agentic-workspace/AGENTS.md"}

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -166,6 +166,7 @@ Ordinary route:
 Boundaries:
 - Known dedicated Agentic Workspace commands are allowed only when the request maps directly to that command and no takeover, recovery, active-planning, or ambiguous safety decision is needed first.
 - Do not bake machine-local AW invocation paths into checked-in generic guidance; concrete commands come from the configured invocation or live router output.
+- Treat checked-in `.agentic-workspace/skills` and module skill trees as required operating surfaces, not optional payload mirror content.
 - Treat `preflight`, `config`, `defaults`, `skills`, `modules`, `ownership`, and `report` as routed drill-down or recovery surfaces, not the ordinary startup loop.
 - Report repo-relative paths, not local absolute paths.
 <!-- agentic-workspace:workflow:end -->

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import re
+import shutil
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
@@ -219,7 +220,9 @@ def test_init_ordinary_footprint_omits_package_payload_and_writes_receipt(tmp_pa
     assert not (tmp_path / ".agentic-workspace" / "payload-provenance.json").exists()
     assert not (tmp_path / ".agentic-workspace" / "AGENTS.md").exists()
     assert not (tmp_path / ".agentic-workspace" / "planning" / "UPGRADE-SOURCE.toml").exists()
-    assert not (tmp_path / ".agentic-workspace" / "planning" / "skills" / "REGISTRY.json").exists()
+    assert (tmp_path / ".agentic-workspace" / "skills" / "workspace-startup" / "SKILL.md").exists()
+    assert (tmp_path / ".agentic-workspace" / "planning" / "skills" / "REGISTRY.json").exists()
+    assert (tmp_path / ".agentic-workspace" / "memory" / "skills" / "memory-router" / "SKILL.md").exists()
     assert ".agentic-workspace/package-payload" in payload["bootstrap_footprint"]["omitted_package_payload_paths"]
     assert payload["validation"] == ["agentic-workspace doctor --target .", "agentic-workspace status --target ."]
 
@@ -271,7 +274,9 @@ def test_install_ordinary_footprint_omits_package_payload(tmp_path: Path, capsys
     receipt = json.loads((tmp_path / ".agentic-workspace" / "adoption-receipt.json").read_text(encoding="utf-8"))
     assert receipt["payload_mirror"] is False
     assert not (tmp_path / ".agentic-workspace" / "payload-provenance.json").exists()
-    assert not (tmp_path / ".agentic-workspace" / "planning" / "skills" / "REGISTRY.json").exists()
+    assert (tmp_path / ".agentic-workspace" / "skills" / "workspace-startup" / "SKILL.md").exists()
+    assert (tmp_path / ".agentic-workspace" / "planning" / "skills" / "REGISTRY.json").exists()
+    assert (tmp_path / ".agentic-workspace" / "memory" / "skills" / "memory-router" / "SKILL.md").exists()
 
 
 def test_init_mirror_payload_writes_payload_and_receipt(tmp_path: Path, capsys) -> None:
@@ -1896,10 +1901,9 @@ def test_report_bootstrap_footprint_recommends_legacy_payload_migration(tmp_path
     assert plan["status"] == "safe-apply-available"
     assert plan["safe_to_apply"] is True
     assert "--to-necessary-surfaces --dry-run" in plan["dry_run_command"]
+    assert not any(action["kind"] == "would remove" and action["path"] == ".agentic-workspace/skills" for action in plan["actions"])
     assert any(
-        action["kind"] == "would remove"
-        and action["path"] == ".agentic-workspace/skills"
-        and action["class"] == "removable-package-owned-payload"
+        action["kind"] == "preserve" and action["path"] == ".agentic-workspace/skills" and action["class"] == "required-skill-surface"
         for action in plan["actions"]
     )
     assert any(
@@ -1944,9 +1948,9 @@ def test_upgrade_to_necessary_surfaces_preserves_durable_state_and_uses_package_
     assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--format", "json"]) == 0
     applied = json.loads(capsys.readouterr().out)["migration"]
     assert applied["status"] == "applied"
-    assert not (workspace / "skills").exists()
-    assert not (workspace / "planning" / "skills").exists()
-    assert not (workspace / "memory" / "skills").exists()
+    assert (workspace / "skills" / "workspace-operating-loop" / "SKILL.md").exists()
+    assert (workspace / "planning" / "skills" / "planning-reporting" / "SKILL.md").exists()
+    assert (workspace / "memory" / "skills" / "memory-router" / "SKILL.md").exists()
     assert not (workspace / "payload-provenance.json").exists()
     for path in package_seed_paths:
         assert not path.exists()
@@ -1985,6 +1989,24 @@ def test_upgrade_to_necessary_surfaces_leaves_doctor_healthy_after_apply(tmp_pat
     assert doctor_payload["health"] == "healthy"
     assert doctor_payload["needs_review"] == []
     assert doctor_payload["warnings"] == []
+
+
+def test_upgrade_to_necessary_surfaces_repairs_missing_required_skills(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "planning,memory", "--format", "json"]) == 0
+    capsys.readouterr()
+    shutil.rmtree(workspace / "skills")
+    shutil.rmtree(workspace / "planning" / "skills")
+    shutil.rmtree(workspace / "memory" / "skills")
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--format", "json"]) == 0
+    applied = json.loads(capsys.readouterr().out)["migration"]
+
+    assert applied["status"] == "applied"
+    assert (workspace / "skills" / "workspace-startup" / "SKILL.md").exists()
+    assert (workspace / "planning" / "skills" / "planning-reporting" / "SKILL.md").exists()
+    assert (workspace / "memory" / "skills" / "memory-router" / "SKILL.md").exists()
 
 
 def test_upgrade_to_necessary_surfaces_preserves_verification_state(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- Keep the canonical AGENTS startup block pointed at `.agentic-workspace/skills/workspace-startup/SKILL.md`.
- Treat root, planning, and memory skill trees as required operating surfaces in the necessary-surface footprint.
- Make ordinary init/install write required skill surfaces while still omitting docs, templates, schemas, provenance, and other mirror-only payload.
- Make `upgrade --to-necessary-surfaces` preserve existing skill trees and repair missing required skills from package sources.
- Update maintainer-surface drift checks and installer tests for the corrected footprint contract.

## Root cause

The necessary-surface migration treated skill trees as removable package payload even though startup and module routing can return concrete `SKILL.md` paths that agents must read from the checkout. That made host repos with reduced payloads report referenced skills as missing.

## Validation

- `uv run pytest tests/test_workspace_cli.py -q`
- `uv run pytest tests/test_workspace_cli.py::test_init_ordinary_footprint_omits_package_payload_and_writes_receipt tests/test_workspace_cli.py::test_install_ordinary_footprint_omits_package_payload tests/test_workspace_cli.py::test_report_bootstrap_footprint_recommends_legacy_payload_migration tests/test_workspace_cli.py::test_upgrade_to_necessary_surfaces_preserves_durable_state_and_uses_package_skills tests/test_workspace_cli.py::test_upgrade_to_necessary_surfaces_repairs_missing_required_skills -q`
- `uv run pytest tests/test_workspace_doctor_status_cli.py::test_doctor_compact_payload_closure_plan_names_full_repair_lane -q`
- `make maintainer-surfaces`
- `make lint-workspace`
- `make lint-planning`
- `make test-workspace`
- `make test-planning`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`