### PR TITLE
Add ordinary command migration boundary check

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-2044-ordinary-command-ir-boundary.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-2044-ordinary-command-ir-boundary.plan.json
@@ -1,0 +1,394 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Issue 2044 ordinary-command IR boundary",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement a first #2044 slice that makes one ordinary command migration explicitly IR/codegen-owned and fail-closed.",
+    "hard_constraints": "Keep scope bounded to runtime projection inventory contracts, generated-command package checker validation, focused checker tests, and planning state.",
+    "agent_may_decide": "Representative command selection, exact inventory field names, checker validation shape, and focused test placement.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Validate the planning.closeout representative migration against command-package IR, generated Python command/operation files, and exact runtime boundary metadata.",
+    "proof_expectations": [
+      "uv run pytest tests/test_generated_command_package_proof_runner.py -q",
+      "uv run python scripts/check/check_generated_command_packages.py",
+      "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+      "uv run ruff check scripts/check/check_generated_command_packages.py tests/test_generated_command_package_proof_runner.py",
+      "make schema-reference-docs",
+      "make test-workspace",
+      "make lint-workspace"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
+      "src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json",
+      "scripts/check/check_generated_command_packages.py",
+      "tests/test_generated_command_package_proof_runner.py",
+      "docs/reference/python-runtime-projection-inventory.md",
+      ".agentic-workspace/planning/execplans/issue-2044-ordinary-command-ir-boundary.plan.json",
+      ".agentic-workspace/planning/state.toml"
+    ],
+    "completion_criteria": [
+      "The runtime projection inventory names a representative ordinary command migration and the remaining runtime primitive boundary.",
+      "The generated-command package checker fails closed if the representative generated command, generated operation, IR adapter, or accepted runtime boundary drift.",
+      "Focused tests cover current validity and failure when generated command evidence is missing."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Make a representative ordinary command migration explicitly IR/codegen-owned and fail-closed."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Make a representative ordinary command migration explicitly IR/codegen-owned and fail-closed.",
+      "constraints": "Keep scope bounded to runtime projection inventory contracts, generated-command package checker validation, focused checker tests, and planning state.",
+      "latitude": "Representative command selection, exact inventory field names, checker validation shape, and focused test placement.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "passed"
+    },
+    "execution": {
+      "milestone": "issue-2044-ordinary-command-ir-boundary",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "passed"
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
+        "src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json",
+        "scripts/check/check_generated_command_packages.py",
+        "tests/test_generated_command_package_proof_runner.py",
+        "docs/reference/python-runtime-projection-inventory.md",
+        ".agentic-workspace/planning/execplans/issue-2044-ordinary-command-ir-boundary.plan.json",
+        ".agentic-workspace/planning/state.toml"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Move ordinary Agentic Workspace command behavior authority behind IR/codegen so runtime-owned code is limited to named primitives.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "A representative ordinary command can now prove which behavior is IR/codegen-owned and which exact runtime boundary remains.",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes",
+    "validation still needed": "none for this slice",
+    "next likely slice": "none"
+  },
+  "intent_interpretation": {
+    "literal request": "Issue 2044 ordinary-command IR boundary",
+    "inferred intended outcome": "Make a representative ordinary command migration explicitly IR/codegen-owned and fail-closed.",
+    "chosen concrete what": "Add inventory metadata and checker enforcement for planning.closeout.lifecycle as the representative migrated ordinary command path.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "Runtime projection inventory schema/data, generated command package checker, focused checker tests, and planning state.",
+    "max changed files": "About 6 files.",
+    "required validation commands": "uv run pytest tests/test_generated_command_package_proof_runner.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run ruff check scripts/check/check_generated_command_packages.py tests/test_generated_command_package_proof_runner.py; make schema-reference-docs; make test-workspace; make lint-workspace.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue #2044 by validating ordinary_command_migration metadata and checker enforcement for planning.closeout.lifecycle.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Make a representative ordinary command migration explicitly IR/codegen-owned and fail-closed.",
+    "hard constraints": "Keep scope bounded to runtime projection inventory contracts, generated-command package checker validation, focused checker tests, and planning state.",
+    "agent may decide locally": "Representative command selection, exact inventory field names, checker validation shape, and focused test placement.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-2044-ordinary-command-ir-boundary",
+    "status": "completed",
+    "scope": "Representative ordinary-command migration inventory and fail-closed checker for #2044.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run focused validation for the ordinary-command migration inventory checker."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/contracts/python_runtime_projection_inventory.json",
+    "src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json",
+    "scripts/check/check_generated_command_packages.py",
+    "tests/test_generated_command_package_proof_runner.py",
+    "docs/reference/python-runtime-projection-inventory.md",
+    ".agentic-workspace/planning/execplans/issue-2044-ordinary-command-ir-boundary.plan.json",
+    ".agentic-workspace/planning/state.toml"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_generated_command_package_proof_runner.py -q",
+    "uv run python scripts/check/check_generated_command_packages.py",
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "uv run ruff check scripts/check/check_generated_command_packages.py tests/test_generated_command_package_proof_runner.py",
+    "make schema-reference-docs",
+    "make test-workspace",
+    "make lint-workspace"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "The runtime projection inventory names a representative ordinary command migration and the remaining runtime primitive boundary.",
+    "The generated-command package checker fails closed if the representative generated command, generated operation, IR adapter, or accepted runtime boundary drift.",
+    "Focused tests cover current validity and failure when generated command evidence is missing."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added ordinary_command_migration contract metadata for planning.closeout.lifecycle, checker enforcement that cross-checks the IR adapter, generated command module, generated operation contract, and accepted runtime boundary, plus focused positive and fail-closed tests.",
+    "scope touched": "Runtime projection inventory schema/data, generated-command package checker, focused checker tests, rendered schema reference docs, and planning state.",
+    "changed surfaces": "src/agentic_workspace/contracts/python_runtime_projection_inventory.json; src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json; scripts/check/check_generated_command_packages.py; tests/test_generated_command_package_proof_runner.py; docs/reference/python-runtime-projection-inventory.md; planning closeout state.",
+    "validations run": "uv run pytest tests/test_generated_command_package_proof_runner.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run ruff check scripts/check/check_generated_command_packages.py tests/test_generated_command_package_proof_runner.py; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; uv run python scripts/check/run_operation_conformance_tests.py --target all; make schema-reference-docs; make test-workspace; make lint-workspace.",
+    "result for continuation": "No continuation required for the #2044 slice.",
+    "next step": "Archive and close the plan item."
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "yes",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "yes",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "passed",
+    "proof achieved now": "yes",
+    "evidence for \"proof achieved\" state": "Passed: uv run pytest tests/test_generated_command_package_proof_runner.py -q; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run ruff check scripts/check/check_generated_command_packages.py tests/test_generated_command_package_proof_runner.py; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; uv run python scripts/check/run_operation_conformance_tests.py --target all; make schema-reference-docs; make test-workspace; make lint-workspace. Doctor exited 0 with inherited checked-in payload reduction advisory."
+  },
+  "intent_satisfaction": {
+    "original intent": "Make a representative ordinary command migration explicitly IR/codegen-owned and fail-closed.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "The inventory names planning.closeout.lifecycle as the representative migrated ordinary command, records its command-package IR source, generated command module, generated operation path, migrated behavior fields, and remaining runtime boundary. The checker now fails closed when those surfaces drift, including missing generated command evidence.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Representative ordinary-command migration boundary proof and fail-closed checker enforcement for #2044.",
+    "validation confirmed": "yes",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "plan closeout",
+    "resume from": "none",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "This was an issue-specific implementation with no new durable operating rule beyond existing contract/check surfaces.",
+    "target scope": "none",
+    "proposed durable intent": "none yet",
+    "confidence": "high",
+    "needs review": false,
+    "owner surface": "none"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "complete",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "The issue requested a representative ordinary command migration behind IR/codegen, not a full migration of every command. The implemented representative is contract-recorded and fail-closed by generated-command package checks.",
+    "evidence carried forward": "Runtime projection inventory ordinary_command_migration section plus generated-command package checker tests.",
+    "reopen trigger": "Reopen if ordinary_command_migration metadata can drift from command_package_ir, generated command modules, generated operation contracts, or accepted runtime boundaries without check failure."
+  },
+  "improvement_signal_review": {
+    "status": "signals_fixed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      "schema-reference-docs caught missing descriptions for the new schema section and stale rendered reference docs during closeout validation."
+    ],
+    "signals fixed": [
+      "Added missing schema descriptions and regenerated docs/reference/python-runtime-projection-inventory.md."
+    ],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "Added missing schema descriptions and regenerated docs/reference/python-runtime-projection-inventory.md.",
+          "owner": "",
+          "source": "improvement_signal_review.signals fixed"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-08: Scaffolded by agentic-planning new-plan.",
+    "2026-07-08: Completed representative ordinary-command migration boundary proof for planning.closeout.lifecycle and fixed schema reference documentation surfaced by validation."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Make a representative ordinary command migration explicitly IR/codegen-owned and fail-closed.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: passed\nChanged surfaces: src/agentic_workspace/contracts/python_runtime_projection_inventory.json; src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json; scripts/check/check_generated_command_packages.py; tests/test_generated_command_package_proof_runner.py; docs/reference/python-runtime-projection-inventory.md; planning closeout state.\nDurable residue: none (none)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/docs/reference/python-runtime-projection-inventory.md
+++ b/docs/reference/python-runtime-projection-inventory.md
@@ -22,4 +22,9 @@ Inventory proving whether generated Python runtime projection files are rendered
 | `accepted_runtime_boundaries.status` | enum `"exact-symbol-proof-required"`, `"exact-symbol-proof-satisfied"` | yes |  | Whether exact symbol-level proof is still required or satisfied. |  |  |
 | `accepted_runtime_boundaries.baseline_symbols` | array of string | yes |  | Exact accepted runtime boundary symbol ids captured before the #1079 reduction slices so reports can show added and removed accepted runtime symbols. |  |  |
 | `accepted_runtime_boundaries.entries` | array of ref `#/$defs/accepted_runtime_boundary` | yes |  | Exact source-symbol package-domain runtime boundaries. |  |  |
+| `ordinary_command_migration` | object | yes |  | Representative ordinary command behavior that has moved behind command-package IR/codegen, plus the remaining runtime primitive boundary. |  |  |
+| `ordinary_command_migration.kind` | const `"agentic-workspace/ordinary-command-migration/v1"` | yes |  | Stable document kind for the ordinary-command migration proof section. |  |  |
+| `ordinary_command_migration.status` | enum `"representative-slice-present"`, `"missing-representative-slice"` | yes |  | Whether the inventory includes at least one ordinary command migration representative. |  |  |
+| `ordinary_command_migration.rule` | string | yes |  | Rule for proving migrated ordinary command behavior is IR/codegen-owned and fail-closed. |  |  |
+| `ordinary_command_migration.representative_migrations` | array of ref `#/$defs/ordinary_command_migration` | yes |  | Representative ordinary command migrations that prove the IR/codegen ownership boundary. |  |  |
 | `entries` | array of ref `#/$defs/entry` | yes |  | Runtime projection files that must be accounted for before Python generated CLI completion can be claimed. |  |  |

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -2050,6 +2050,100 @@ def _validate_python_completion_accepted_runtime_boundaries(*, require_exact: bo
     return errors, accepted_nonblocking_paths
 
 
+def _find_command_adapter(payload: object, *, adapter_id: str) -> dict[str, object] | None:
+    if isinstance(payload, dict):
+        if payload.get("adapter_id") == adapter_id:
+            return payload
+        for value in payload.values():
+            found = _find_command_adapter(value, adapter_id=adapter_id)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for item in payload:
+            found = _find_command_adapter(item, adapter_id=adapter_id)
+            if found is not None:
+                return found
+    return None
+
+
+def _validate_ordinary_command_migration_inventory() -> list[str]:
+    errors: list[str] = []
+    try:
+        inventory = python_runtime_projection_inventory_manifest()
+    except Exception as exc:  # noqa: BLE001
+        return [f"python_runtime_projection_inventory.json is missing or invalid: {exc}"]
+    migration = inventory.get("ordinary_command_migration", {})
+    if not isinstance(migration, dict):
+        return ["python_runtime_projection_inventory.json missing ordinary_command_migration"]
+    if migration.get("status") != "representative-slice-present":
+        errors.append("python_runtime_projection_inventory.json ordinary_command_migration must be representative-slice-present")
+    records = migration.get("representative_migrations", [])
+    if not isinstance(records, list) or not records:
+        return [*errors, "python_runtime_projection_inventory.json ordinary_command_migration representative_migrations is empty"]
+    ir = load_workspace_command_package_ir(repo_root=REPO_ROOT)
+    accepted = inventory.get("accepted_runtime_boundaries", {})
+    boundary_entries = accepted.get("entries", []) if isinstance(accepted, dict) else []
+    boundary_index = {
+        (str(entry.get("source_module", "")), str(entry.get("source_symbol", ""))): entry
+        for entry in boundary_entries
+        if isinstance(entry, dict)
+    }
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            errors.append(f"ordinary_command_migration.representative_migrations[{index}] must be an object")
+            continue
+        location = f"ordinary_command_migration.representative_migrations[{index}]"
+        operation_id = str(record.get("operation_id", ""))
+        adapter_id = str(record.get("adapter_id", ""))
+        adapter = _find_command_adapter(ir, adapter_id=adapter_id)
+        if adapter is None:
+            errors.append(f"{location} adapter_id {adapter_id!r} is not present in command_package_ir.json")
+            continue
+        operation_ref = adapter.get("operation_ref", {})
+        if not isinstance(operation_ref, dict) or operation_ref.get("id") != operation_id:
+            errors.append(f"{location} adapter {adapter_id!r} must reference operation_id {operation_id!r}")
+        runtime_binding = adapter.get("runtime_binding", {})
+        primitive_refs = runtime_binding.get("primitive_refs", []) if isinstance(runtime_binding, dict) else []
+        migrated_fields = set(record.get("migrated_behavior_fields", [])) if isinstance(record.get("migrated_behavior_fields"), list) else set()
+        for required_field in ("command identity", "option schema", "effect hints", "primitive refs", "generated Python command module"):
+            if required_field not in migrated_fields:
+                errors.append(f"{location} migrated_behavior_fields must include {required_field!r}")
+        if not primitive_refs:
+            errors.append(f"{location} adapter {adapter_id!r} must have primitive_refs in command_package_ir.json")
+        generated_command = REPO_ROOT / str(record.get("generated_command_module", ""))
+        if not generated_command.is_file():
+            errors.append(f"{location} generated_command_module {record.get('generated_command_module')!r} does not exist")
+        else:
+            command_text = generated_command.read_text(encoding="utf-8")
+            if f"Operation: {operation_id}" not in command_text or "DO NOT EDIT DIRECTLY" not in command_text:
+                errors.append(f"{location} generated command module must name operation {operation_id!r} and reject direct edits")
+        generated_operation = REPO_ROOT / str(record.get("generated_operation_path", ""))
+        if not generated_operation.is_file():
+            errors.append(f"{location} generated_operation_path {record.get('generated_operation_path')!r} does not exist")
+        else:
+            try:
+                generated_operation_payload = json.loads(generated_operation.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                errors.append(f"{location} generated operation JSON is invalid: {exc}")
+            else:
+                if generated_operation_payload.get("id") != operation_id:
+                    errors.append(f"{location} generated operation must have id {operation_id!r}")
+        boundary = record.get("remaining_runtime_boundary", {})
+        if not isinstance(boundary, dict):
+            errors.append(f"{location} remaining_runtime_boundary must be an object")
+            continue
+        boundary_key = (str(boundary.get("source_module", "")), str(boundary.get("source_symbol", "")))
+        accepted_entry = boundary_index.get(boundary_key)
+        if accepted_entry is None:
+            errors.append(f"{location} remaining_runtime_boundary {boundary_key!r} is not accepted at source-symbol granularity")
+            continue
+        if accepted_entry.get("runtime_boundary_class") != boundary.get("runtime_boundary_class"):
+            errors.append(f"{location} remaining runtime boundary class must match accepted_runtime_boundaries")
+        if operation_id not in set(accepted_entry.get("operation_ids", [])):
+            errors.append(f"{location} remaining runtime boundary must name operation_id {operation_id!r}")
+    return errors
+
+
 def _validate_python_completion_output_boundary_audit(entry: dict[str, object], *, location: str) -> list[str]:
     source_symbol = str(entry.get("source_symbol", ""))
     if "emit" not in source_symbol:
@@ -4944,6 +5038,7 @@ def _validate_static_surfaces() -> list[str]:
                     full_completion=python_cli_completion.get("current_state") == "full-generated-cli-complete",
                 )
             )
+            errors.extend(_validate_ordinary_command_migration_inventory())
         errors.extend(_validate_python_operation_execution_inventory(ir))
         errors.extend(_validate_retired_command_generation_primitive_usage_inventory())
         errors.extend(_validate_generated_command_check_inventory_removals())
@@ -5327,6 +5422,7 @@ def _python_completion_blockers_report(ir: dict[str, object]) -> dict[str, objec
     blockers.extend(_validate_full_python_completion_runtime_ownership(forced_full_ir))
     blockers.extend(_validate_full_python_completion_executable_ownership(forced_full_ir))
     blockers.extend(_validate_python_runtime_projection_inventory(full_completion=True))
+    blockers.extend(_validate_ordinary_command_migration_inventory())
     blockers.extend(_validate_python_operation_execution_inventory(forced_full_ir))
     blockers.extend(_validate_lifecycle_dry_run_generation())
     blockers.extend(_validate_declarative_view_specs())

--- a/src/agentic_workspace/contracts/python_runtime_projection_inventory.json
+++ b/src/agentic_workspace/contracts/python_runtime_projection_inventory.json
@@ -2220,6 +2220,39 @@
       }
     ]
   },
+  "ordinary_command_migration": {
+    "kind": "agentic-workspace/ordinary-command-migration/v1",
+    "status": "representative-slice-present",
+    "rule": "Ordinary command behavior should be represented by command-package IR and generated command/operation artifacts; package runtime remains only for named primitive boundaries with exact source-symbol ownership.",
+    "representative_migrations": [
+      {
+        "id": "planning-closeout-lifecycle",
+        "operation_id": "planning.closeout.lifecycle",
+        "adapter_id": "planning.closeout.cli",
+        "source_ir_path": "src/agentic_workspace/contracts/command_package_ir.json",
+        "generated_command_module": "generated/planning/python/commands/planning_closeout_lifecycle.py",
+        "generated_operation_path": "generated/planning/python/operations/planning.closeout.lifecycle.json",
+        "migrated_behavior_fields": [
+          "command identity",
+          "option schema",
+          "help text",
+          "effect hints",
+          "operation steps",
+          "primitive refs",
+          "conformance refs",
+          "generated Python command module"
+        ],
+        "remaining_runtime_boundary": {
+          "source_module": "repo_planning_bootstrap.runtime_projection",
+          "source_symbol": "apply_planning_closeout_operation",
+          "runtime_boundary_class": "mutation-orchestration",
+          "owner": "planning package runtime boundary",
+          "why_runtime_owned": "Planning closeout still owns package-specific mutation safety, proof-to-claim reconciliation, archive decisions, and continuation/residue updates behind the generated operation primitive."
+        },
+        "fail_closed_rule": "The checker must fail when the generated command module, generated operation contract, command-package IR adapter, or accepted runtime boundary no longer matches this representative migration."
+      }
+    ]
+  },
   "entries": [
     {
       "path": "generated/workspace/python/cli.py",

--- a/src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json
+++ b/src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json
@@ -12,6 +12,7 @@
     "completion_rule",
     "allowed_provenance_statuses",
     "accepted_runtime_boundaries",
+    "ordinary_command_migration",
     "entries"
   ],
   "properties": {
@@ -90,6 +91,43 @@
         }
       },
       "description": "Exact package-domain runtime boundaries. Whole-file runtime source or generated facade entries are not accepted."
+    },
+    "ordinary_command_migration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "status",
+        "rule",
+        "representative_migrations"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/ordinary-command-migration/v1",
+          "description": "Stable document kind for the ordinary-command migration proof section."
+        },
+        "status": {
+          "enum": [
+            "representative-slice-present",
+            "missing-representative-slice"
+          ],
+          "description": "Whether the inventory includes at least one ordinary command migration representative."
+        },
+        "rule": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Rule for proving migrated ordinary command behavior is IR/codegen-owned and fail-closed."
+        },
+        "representative_migrations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/ordinary_command_migration"
+          },
+          "description": "Representative ordinary command migrations that prove the IR/codegen ownership boundary."
+        }
+      },
+      "description": "Representative ordinary command behavior that has moved behind command-package IR/codegen, plus the remaining runtime primitive boundary."
     },
     "entries": {
       "type": "array",
@@ -181,6 +219,120 @@
           "description": "Resolution required if the entry blocks completion or maintenance action required if it does not."
         }
       }
+    },
+    "ordinary_command_migration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "operation_id",
+        "adapter_id",
+        "source_ir_path",
+        "generated_command_module",
+        "generated_operation_path",
+        "migrated_behavior_fields",
+        "remaining_runtime_boundary",
+        "fail_closed_rule"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier for this representative ordinary command migration."
+        },
+        "operation_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Generated operation id that owns the migrated command behavior."
+        },
+        "adapter_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Command package IR adapter id that binds the command surface to the operation."
+        },
+        "source_ir_path": {
+          "const": "src/agentic_workspace/contracts/command_package_ir.json",
+          "description": "Repo-relative command package IR source path."
+        },
+        "generated_command_module": {
+          "type": "string",
+          "pattern": "^generated/(workspace|planning|memory|verification)/python/commands/[A-Za-z0-9_]+\\.py$",
+          "description": "Repo-relative generated Python command module rendered from the command package IR."
+        },
+        "generated_operation_path": {
+          "type": "string",
+          "pattern": "^generated/(workspace|planning|memory|verification)/python/operations/[A-Za-z0-9_.-]+\\.json$",
+          "description": "Repo-relative generated operation contract path reached by the command adapter."
+        },
+        "migrated_behavior_fields": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": [
+              "command identity",
+              "option schema",
+              "help text",
+              "effect hints",
+              "operation steps",
+              "primitive refs",
+              "conformance refs",
+              "generated Python command module"
+            ]
+          },
+          "uniqueItems": true,
+          "description": "Command behavior fields that are now owned by command package IR and generated artifacts."
+        },
+        "remaining_runtime_boundary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "source_module",
+            "source_symbol",
+            "runtime_boundary_class",
+            "owner",
+            "why_runtime_owned"
+          ],
+          "properties": {
+            "source_module": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Runtime source module that still owns nondeterministic or mutation behavior."
+            },
+            "source_symbol": {
+              "type": "string",
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+              "description": "Exact runtime source symbol accepted as the remaining boundary."
+            },
+            "runtime_boundary_class": {
+              "enum": [
+                "front-door-dispatch",
+                "live-workspace-inspection",
+                "mutation-orchestration",
+                "package-specific-judgment",
+                "provider-integration"
+              ],
+              "description": "Accepted runtime boundary class for the remaining source symbol."
+            },
+            "owner": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Owner responsible for the remaining runtime boundary."
+            },
+            "why_runtime_owned": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Reason this behavior remains runtime-owned instead of deterministic IR/codegen data."
+            }
+          },
+          "description": "Exact accepted runtime boundary that remains after the representative command migration."
+        },
+        "fail_closed_rule": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Rule enforced by checks when the IR, generated command, generated operation, or runtime boundary drifts."
+        }
+      },
+      "description": "One representative ordinary command migration from handwritten behavior to IR/codegen ownership."
     },
     "accepted_runtime_boundary": {
       "type": "object",

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -399,6 +399,26 @@ def test_full_python_completion_rejects_weak_output_boundary_audit() -> None:
     assert any("output-emission boundary audit must include 'generated-owned output coverage:'" in error for error in errors)
 
 
+def test_ordinary_command_migration_inventory_is_current() -> None:
+    checker = _load_checker()
+
+    assert checker._validate_ordinary_command_migration_inventory() == []
+
+
+def test_ordinary_command_migration_inventory_fails_closed_when_generated_command_missing() -> None:
+    errors = _checker_case_errors(
+        """
+        inventory = copy.deepcopy(checker.python_runtime_projection_inventory_manifest())
+        migration = inventory["ordinary_command_migration"]["representative_migrations"][0]
+        migration["generated_command_module"] = "generated/planning/python/commands/missing_closeout.py"
+        checker.python_runtime_projection_inventory_manifest = lambda: inventory
+        _emit({"errors": checker._validate_ordinary_command_migration_inventory()})
+        """
+    )
+
+    assert any("generated_command_module" in error and "does not exist" in error for error in errors)
+
+
 def test_current_python_completion_state_is_satisfied_by_exact_symbol_proof() -> None:
     checker = _load_checker()
     ir = checker.load_workspace_command_package_ir(repo_root=checker.REPO_ROOT)


### PR DESCRIPTION
Refs #2044.

## Summary
- records `planning.closeout.lifecycle` as the representative ordinary-command migration in the runtime projection inventory
- validates the representative against command-package IR, the generated command module, generated operation JSON, and exact accepted runtime boundary metadata
- adds focused positive/fail-closed tests and refreshes the schema reference docs

## Closure boundary
- This is a bounded representative slice for #2044.
- It does not close #2044 by itself; the parent issue remains open for the broader command-semantics inventory/exception accounting and architecture-wide enforcement required by the issue completion rule.

## Proof
- `uv run pytest tests/test_generated_command_package_proof_runner.py -q`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run ruff check scripts/check/check_generated_command_packages.py tests/test_generated_command_package_proof_runner.py`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`
- `make schema-reference-docs`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` (exit 0; existing checked-in payload reduction advisory remains)