### PR TITLE
Expose state-delta packets across operating loop

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/issue-1969-state-delta-operating-loop-closeout.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-1969-state-delta-operating-loop-closeout.plan.json
@@ -1,0 +1,401 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Issue 1969 state-delta operating loop closeout",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Close #1969 honestly by making the state-delta-first packet model visible across startup and implementation workflows.",
+    "hard_constraints": "Keep scope bounded to structured packet projection, implementer schema/reference docs, focused CLI tests, generated mirrors, and planning state.",
+    "agent_may_decide": "Exact implement packet evidence basis, test assertions, and proof command set.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Expose current_decision, message_economy, and evidence_bundle in implement tiny output from the existing decision_packet.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_implement_cli.py::test_implement_exposes_communication_contract_for_changed_paths tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q",
+      "uv run pytest tests/test_workspace_cli.py::test_start_exposes_communication_contract_in_ordinary_path tests/test_workspace_cli.py::test_start_select_surfaces_state_delta_packets -q",
+      "make schema-reference-docs",
+      "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+      "make test-workspace",
+      "make lint-workspace",
+      "make maintainer-surfaces",
+      "make typecheck"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/workspace_runtime_implement.py",
+      "src/agentic_workspace/workspace_runtime_startup.py",
+      "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+      "docs/reference/implementer-context.md",
+      "tests/test_workspace_cli.py",
+      "tests/test_workspace_implement_cli.py",
+      ".agentic-workspace/planning/execplans/issue-1969-state-delta-operating-loop-closeout.plan.json",
+      ".agentic-workspace/planning/state.toml"
+    ],
+    "completion_criteria": [
+      "Startup continues to expose the state-delta-first model.",
+      "Implement exposes current decision, known/missing evidence, safe probe, response shape, message economy, and evidence bundle before a visible implementation update.",
+      "Schema/reference docs name the implement state-delta packets.",
+      "The closure claim is explicit that the mechanism is structured-state-backed and avoids prompt-prose classifiers or broad dumps."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Make state-delta-first operating-loop packets visible across startup and implementation workflows so #1969 can close honestly."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Close #1969 honestly by making the state-delta-first packet model visible across startup and implementation workflows.",
+      "constraints": "Keep scope bounded to structured packet projection, implementer schema/reference docs, focused CLI tests, generated mirrors, and planning state.",
+      "latitude": "Exact implement packet evidence basis, test assertions, and proof command set.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "passed"
+    },
+    "execution": {
+      "milestone": "issue-1969-state-delta-operating-loop-closeout",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "passed"
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/workspace_runtime_implement.py",
+        "src/agentic_workspace/workspace_runtime_startup.py",
+        "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+        "docs/reference/implementer-context.md",
+        "tests/test_workspace_cli.py",
+        "tests/test_workspace_implement_cli.py",
+        ".agentic-workspace/planning/execplans/issue-1969-state-delta-operating-loop-closeout.plan.json",
+        ".agentic-workspace/planning/state.toml"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Make ordinary AW operating-loop messages state-delta-first across more than one workflow class.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement all open issues, including #1969.",
+    "inferred intended outcome": "Close the state-delta-first parent only if startup plus another ordinary workflow expose structured packets that let agents answer in compact deltas.",
+    "chosen concrete what": "Add implement tiny-output current_decision, message_economy, and evidence_bundle derived from the existing implement decision_packet, then prove startup and implement both expose the model.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "workspace_runtime_implement packet projection, workspace_runtime_startup selector hydration, implementer-context schema/reference docs, focused implement/start tests, and planning state.",
+    "max changed files": "About 8 files.",
+    "required validation commands": "Focused implement/start packet tests; schema-reference-docs; contract tooling; implement changed-path AW routing; standard workspace test/lint if generated mirrors change.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue #1969 by exposing shared state-delta packets through implement tiny output and proving startup + implement packet behavior.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Close #1969 honestly by making the state-delta-first packet model visible across startup and implementation workflows.",
+    "hard constraints": "Keep scope bounded to structured packet projection, implementer schema/reference docs, focused CLI tests, generated mirrors, and planning state.",
+    "agent may decide locally": "Exact implement packet evidence basis, test assertions, and proof command set.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-1969-state-delta-operating-loop-closeout",
+    "status": "completed",
+    "scope": "Implement state-delta packet projection for implement tiny output and prove #1969 across startup plus implementation.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Expose current_decision, message_economy, and evidence_bundle in implement tiny output from the existing decision_packet."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_implement.py",
+    "src/agentic_workspace/workspace_runtime_startup.py",
+    "src/agentic_workspace/contracts/schemas/implementer_context.schema.json",
+    "docs/reference/implementer-context.md",
+    "tests/test_workspace_cli.py",
+    "tests/test_workspace_implement_cli.py",
+    ".agentic-workspace/planning/execplans/issue-1969-state-delta-operating-loop-closeout.plan.json",
+    ".agentic-workspace/planning/state.toml"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_implement_cli.py::test_implement_exposes_communication_contract_for_changed_paths tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q",
+    "uv run pytest tests/test_workspace_cli.py::test_start_exposes_communication_contract_in_ordinary_path tests/test_workspace_cli.py::test_start_select_surfaces_state_delta_packets -q",
+    "make schema-reference-docs",
+    "uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success",
+    "make test-workspace",
+    "make lint-workspace",
+    "make maintainer-surfaces",
+    "make typecheck"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Startup continues to expose the state-delta-first model.",
+    "Implement exposes current decision, known/missing evidence, safe probe, response shape, message economy, and evidence bundle before a visible implementation update.",
+    "Schema/reference docs name the implement state-delta packets.",
+    "The closure claim is explicit that the mechanism is structured-state-backed and avoids prompt-prose classifiers or broad dumps."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "Codex",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented state-delta-first packets across startup and implementation. Implement tiny output now derives current_decision, message_economy, and evidence_bundle from its existing decision_packet. Startup --select now hydrates the same state-delta packets so they are queryable, not only present in default output.",
+    "scope touched": "Startup selector hydration, implement tiny packet projection, implementer schema/reference docs, startup and implement CLI tests, and planning state.",
+    "changed surfaces": "src/agentic_workspace/workspace_runtime_startup.py; src/agentic_workspace/workspace_runtime_implement.py; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; docs/reference/implementer-context.md; tests/test_workspace_cli.py; tests/test_workspace_implement_cli.py; planning closeout state.",
+    "validations run": "uv run pytest tests/test_workspace_cli.py::test_start_exposes_communication_contract_in_ordinary_path tests/test_workspace_cli.py::test_start_select_surfaces_state_delta_packets tests/test_workspace_implement_cli.py::test_implement_exposes_communication_contract_for_changed_paths tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q; make test-workspace; make lint-workspace; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; make maintainer-surfaces; uv run pytest tests/test_workspace_cli.py -q; make schema-reference-docs; make typecheck; startup/implement selector samples for current_decision,message_economy,evidence_bundle; summary; doctor.",
+    "result for continuation": "No continuation required for #1969; the parent completion rule is satisfied across startup and implementation workflow classes.",
+    "next step": "Archive and close the plan item."
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "yes",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "yes",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "passed",
+    "proof achieved now": "yes",
+    "evidence for \"proof achieved\" state": "Passed broad proof commands plus selector samples: start --select and implement --select both returned current_decision, message_economy, and evidence_bundle with known_evidence, missing_evidence, safe_probe, response_shape, proof/residue boundary, expansion triggers, avoid_repeat, and state_backed=true. Doctor exited 0 with inherited checked-in payload reduction advisory."
+  },
+  "intent_satisfaction": {
+    "original intent": "Make operating-loop messages state-delta-first across the ordinary AW loop.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "The mechanism is now present and queryable across startup and implementation workflow classes. Startup supplies state-delta packets in default output and --select. Implement supplies the same packet family before visible implementation updates. Both packets are derived from structured decision packets and selector routes, preserve proof/residue/next-action boundaries, expose explicit expansion triggers, and discourage repeated recaps.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "State-delta-first operating-loop packets are visible and queryable across startup and implementation.",
+    "validation confirmed": "yes",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "plan closeout",
+    "resume from": "none",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "none yet",
+    "motivation worth preserving": "none yet",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "The durable product rule is now encoded in runtime packet builders, schema/reference docs, skill text already present, and tests.",
+    "target scope": "none",
+    "proposed durable intent": "none yet",
+    "confidence": "high",
+    "needs review": false,
+    "owner surface": "none"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "complete",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "#1969 allowed closure only when the ordinary AW loop had a demonstrated state-delta-first mechanism across more than one workflow class. Startup and implementation now both expose current decision, evidence, missing proof, safe probe, response shape, proof/residue boundary, next action, expansion triggers, and recap-avoidance policy from structured state.",
+    "evidence carried forward": "Focused tests plus real start/implement selector samples; implementer schema/reference docs; startup selector hydration; implement tiny packet projection.",
+    "reopen trigger": "Reopen if state-delta packets disappear from startup or implement, become prompt-prose-classifier driven, stop exposing missing evidence/safe probes, or force broad always-on context dumps."
+  },
+  "improvement_signal_review": {
+    "status": "signals_fixed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      "Startup default exposed state-delta packets, but --select current_decision,message_economy,evidence_bundle initially reported them missing."
+    ],
+    "signals fixed": [
+      "Hydrated startup state-delta packets in selector handling and added a focused selector test."
+    ],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "Hydrated startup state-delta packets in selector handling and added a focused selector test.",
+          "owner": "",
+          "source": "improvement_signal_review.signals fixed"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-08: Scaffolded by agentic-planning new-plan.",
+    "2026-07-08: Completed #1969 closeout slice with startup and implementation state-delta packets plus selector-backed proof."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Make operating-loop messages state-delta-first across the ordinary AW loop.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: passed\nChanged surfaces: src/agentic_workspace/workspace_runtime_startup.py; src/agentic_workspace/workspace_runtime_implement.py; src/agentic_workspace/contracts/schemas/implementer_context.schema.json; docs/reference/implementer-context.md; tests/test_workspace_cli.py; tests/test_workspace_implement_cli.py; planning closeout state.\nDurable residue: none (none)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/docs/reference/implementer-context.md
+++ b/docs/reference/implementer-context.md
@@ -14,6 +14,9 @@ Cheap implementer context for a bounded changed-path scope.
 | `kind` | const `"implementer-context/v1"` | yes |  | Discriminator for the implementer context payload shape. |  |  |
 | `target` | string | yes |  | Resolved target repository for the implementation context. |  |  |
 | `communication_contract` | object | no |  | Compact communication and reasoning-economy contract for decision-first, state-backed implementer output. |  |  |
+| `current_decision` | object | no |  | Compact state-delta decision packet for the implementation workflow, derived from the implement decision packet rather than prompt prose. |  |  |
+| `message_economy` | object | no |  | State-backed message economy packet that tells agents when to speak, stay compact, or expand during implementation. |  |  |
+| `evidence_bundle` | object | no |  | Minimal selector-backed evidence bundle for the implementation current decision, including missing proof evidence when stronger claims are blocked. |  |  |
 | `action_signals` | object | no |  | Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment. |  |  |
 | `task_posture_packet` | ref `#/$defs/task_posture_packet` | no |  | Optional dynamic instruction packet emitted when changed paths, task facts, config posture, workflow obligations, or module contributions affect implementation routing. |  |  |
 | `task_posture_packet.kind` | const `"agentic-workspace/task-posture-packet/v1"` | yes |  | Discriminator for dynamic task posture. |  |  |

--- a/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
+++ b/src/agentic_workspace/contracts/schemas/implementer_context.schema.json
@@ -53,6 +53,21 @@
       "description": "Compact communication and reasoning-economy contract for decision-first, state-backed implementer output.",
       "additionalProperties": true
     },
+    "current_decision": {
+      "type": "object",
+      "description": "Compact state-delta decision packet for the implementation workflow, derived from the implement decision packet rather than prompt prose.",
+      "additionalProperties": true
+    },
+    "message_economy": {
+      "type": "object",
+      "description": "State-backed message economy packet that tells agents when to speak, stay compact, or expand during implementation.",
+      "additionalProperties": true
+    },
+    "evidence_bundle": {
+      "type": "object",
+      "description": "Minimal selector-backed evidence bundle for the implementation current decision, including missing proof evidence when stronger claims are blocked.",
+      "additionalProperties": true
+    },
     "action_signals": {
       "type": "object",
       "description": "Compact action-first summary ordered as blockers, allowed next action, proof, changed signals, selector-backed advisory detail, and agent-owned judgment.",

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -15,6 +15,10 @@ from agentic_workspace.config import WorkspaceUsageError
 from agentic_workspace.reporting_support import (
     communication_contract_payload,
     compact_communication_contract_payload,
+    current_decision_payload,
+    evidence_bundle_payload,
+    message_economy_payload,
+    state_delta_core_payload,
 )
 from agentic_workspace.runtime_source_review import (
     tiny_generated_cli_freshness_payload,
@@ -1125,10 +1129,69 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
         ),
         "takeover_or_recovery": _command_with_cli_invoke(command="agentic-workspace preflight --format json", cli_invoke=config.cli_invoke),
     }
+    communication_contract = compact_communication_contract_payload(surface="implementation")
+    decision_packet = _ordinary_decision_packet(
+        surface="implement",
+        phase_question="What narrow working set is safe to touch now?",
+        next_action=next_action,
+        blocked_actions=[str(item) for item in _as_dict(payload.get("applicable_intent_status")).get("blocked_claims", [])],
+        required_commands=[str(item) for item in proof_commands if str(item).strip()],
+        claim_boundary=_as_dict(payload.get("parent_intent_status")).get("proof_boundary")
+        or "claim after changed-path proof and acceptance reconciliation",
+        residue_owner="active continuation state"
+        if _as_dict(payload.get("planning_safety_gate")).get("active_planning_present")
+        else "none",
+        reasons=[
+            f"changed_path_count={len(_normalize_changed_paths(payload.get('changed_paths', [])))}",
+            f"workflow={workflow_sufficiency.get('sufficiency_result', workflow_sufficiency.get('decision', 'unknown'))}"
+            if isinstance(workflow_sufficiency, dict)
+            else "workflow=unknown",
+        ],
+        detail_routes={
+            "proof_detail": _command_with_cli_invoke(
+                command="agentic-workspace proof --target . --changed <paths> --format json", cli_invoke=config.cli_invoke
+            ),
+            "why_blocked": _command_with_cli_invoke(
+                command="agentic-workspace implement --changed <paths> --select context.planning_safety_gate,next,proof --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+            "omitted_diagnostics": detail_commands["full_context"],
+        },
+        shown_because=[
+            "command_phase=implement",
+            "changed_path_ownership=present" if payload.get("changed_paths") else "changed_path_ownership=absent",
+            "proof_selection=changed_paths",
+        ],
+        absence_states={
+            "full_selector_inventory": "hidden_behind_detail_route",
+            "architecture_detail": "not_action_changing",
+            "raw_workspace_files": "not_action_changing",
+        },
+    )
+    state_delta_missing_evidence = [str(item) for item in proof_commands if str(item).strip()] or [
+        "proof execution evidence before hard completion claim"
+    ]
+    state_delta_core = state_delta_core_payload(
+        surface="implementation",
+        decision_packet=decision_packet,
+        communication_contract=communication_contract,
+        evidence_basis=[
+            "implement.decision_packet",
+            "implement.proof.required_commands",
+            "implement.context.scope.changed_paths",
+        ],
+        missing_evidence=state_delta_missing_evidence,
+        safe_probe=primary_command or detail_commands["proof_detail"],
+    )
+    current_decision = current_decision_payload(
+        surface="implementation",
+        decision_packet=decision_packet,
+        state_delta_core=state_delta_core,
+    )
     projected = {
         "kind": "implementer-context-tiny/v1",
         "target": payload.get("target"),
-        "communication_contract": compact_communication_contract_payload(surface="implementation"),
+        "communication_contract": communication_contract,
         "action_signals": _compact_action_signals_payload(
             surface="implement",
             allowed_next_action=str(next_action),
@@ -1216,43 +1279,17 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
             "status": payload.get("orientation", {}).get("status", "unknown"),
             "ask_human_only_if": "blocked",
         },
-        "decision_packet": _ordinary_decision_packet(
-            surface="implement",
-            phase_question="What narrow working set is safe to touch now?",
-            next_action=next_action,
-            blocked_actions=[str(item) for item in _as_dict(payload.get("applicable_intent_status")).get("blocked_claims", [])],
-            required_commands=[str(item) for item in proof_commands if str(item).strip()],
-            claim_boundary=_as_dict(payload.get("parent_intent_status")).get("proof_boundary")
-            or "claim after changed-path proof and acceptance reconciliation",
-            residue_owner="active continuation state"
-            if _as_dict(payload.get("planning_safety_gate")).get("active_planning_present")
-            else "none",
-            reasons=[
-                f"changed_path_count={len(_normalize_changed_paths(payload.get('changed_paths', [])))}",
-                f"workflow={workflow_sufficiency.get('sufficiency_result', workflow_sufficiency.get('decision', 'unknown'))}"
-                if isinstance(workflow_sufficiency, dict)
-                else "workflow=unknown",
-            ],
-            detail_routes={
-                "proof_detail": _command_with_cli_invoke(
-                    command="agentic-workspace proof --target . --changed <paths> --format json", cli_invoke=config.cli_invoke
-                ),
-                "why_blocked": _command_with_cli_invoke(
-                    command="agentic-workspace implement --changed <paths> --select context.planning_safety_gate,next,proof --format json",
-                    cli_invoke=config.cli_invoke,
-                ),
-                "omitted_diagnostics": detail_commands["full_context"],
-            },
-            shown_because=[
-                "command_phase=implement",
-                "changed_path_ownership=present" if payload.get("changed_paths") else "changed_path_ownership=absent",
-                "proof_selection=changed_paths",
-            ],
-            absence_states={
-                "full_selector_inventory": "hidden_behind_detail_route",
-                "architecture_detail": "not_action_changing",
-                "raw_workspace_files": "not_action_changing",
-            },
+        "decision_packet": decision_packet,
+        "current_decision": current_decision,
+        "message_economy": message_economy_payload(
+            surface="implementation",
+            communication_contract=communication_contract,
+            state_delta_core=state_delta_core,
+        ),
+        "evidence_bundle": evidence_bundle_payload(
+            surface="implementation",
+            current_decision=current_decision,
+            state_delta_core=state_delta_core,
         ),
         "proof": {
             "kind": payload.get("proof", {}).get("kind", "proof-selection/v1")

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -476,6 +476,67 @@ def _tiny_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
         ],
         agent_judgment="Agent owns work-shape unless blocked.",
     )
+    startup_proof_commands = _tiny_required_proof_commands(payload.get("proof", {})) if isinstance(payload.get("proof"), dict) else []
+    projected["decision_packet"] = _ordinary_decision_packet(
+        surface="start",
+        phase_question="Startup posture?",
+        next_action=str(projected["next_safe_action"].get("next_safe_action", "")),
+        blocked_actions=[str(item) for item in projected["next_safe_action"].get("forbidden_actions", []) if str(item).strip()],
+        required_commands=list(
+            dict.fromkeys(
+                str(item)
+                for item in [
+                    projected["next_safe_action"].get("preferred_cli"),
+                    immediate.get("command") if isinstance(immediate, dict) else "",
+                    *startup_proof_commands,
+                ]
+                if item not in (None, "", []) and str(item).strip() and str(item).strip().lower() != "none"
+            )
+        ),
+        claim_boundary=projected["next_safe_action"].get("claim_boundary", "completion claim requires proof"),
+        residue_owner="active continuation state" if payload.get("active_state_summary", {}).get("active_execplan") else "none",
+        reasons=list(projected["action_signals"].get("changed_signals", []))[:6],
+        detail_routes={
+            "why_blocked": "agentic-workspace start --target . --select next_safe_action,action_signals --format json",
+            "active_plan": "agentic-workspace summary --target . --format json",
+            "proof_detail": "agentic-workspace proof --target . --changed <paths> --format json",
+        },
+        shown_because=["command_phase=start", *list(projected["action_signals"].get("changed_signals", []))[:3]],
+        absence_states={
+            "full_selector_inventory": "hidden_behind_detail_route",
+            "verbose_planning_detail": "detail_omitted",
+        },
+    )
+    state_delta_core = state_delta_core_payload(
+        surface="startup",
+        decision_packet=projected["decision_packet"],
+        communication_contract=compact_communication_contract_payload(surface="startup"),
+        evidence_basis=[
+            "next_safe_action",
+            "action_signals",
+            "active planning summary" if payload.get("active_state_summary", {}).get("active_execplan") else "startup routing state",
+        ],
+        safe_probe=str(
+            projected["next_safe_action"].get("preferred_cli")
+            or projected["decision_packet"].get("detail_routes", {}).get("active_plan")
+            or ""
+        ),
+    )
+    projected["message_economy"] = message_economy_payload(
+        surface="startup",
+        communication_contract=compact_communication_contract_payload(surface="startup"),
+        state_delta_core=state_delta_core,
+    )
+    projected["current_decision"] = current_decision_payload(
+        surface="startup",
+        decision_packet=projected["decision_packet"],
+        state_delta_core=state_delta_core,
+    )
+    projected["evidence_bundle"] = evidence_bundle_payload(
+        surface="startup",
+        current_decision=projected["current_decision"],
+        state_delta_core=state_delta_core,
+    )
     return projected
 
 
@@ -1188,8 +1249,96 @@ def _hydrate_selected_start_advisory_payloads(
     task_text: str | None,
     config: WorkspaceConfig,
 ) -> None:
-    if _selector_requests(select, "next_safe_action") or _selector_requests(select, "action_signals"):
+    state_delta_requested = any(
+        _selector_requests(select, field)
+        for field in (
+            "decision_packet",
+            "current_decision",
+            "message_economy",
+            "evidence_bundle",
+            "continuation_capsule",
+        )
+    )
+    if _selector_requests(select, "next_safe_action") or _selector_requests(select, "action_signals") or state_delta_requested:
         _attach_start_router_fields(payload)
+    if state_delta_requested:
+        next_safe_action = payload.get("next_safe_action", {}) if isinstance(payload.get("next_safe_action"), dict) else {}
+        action_signals = payload.get("action_signals", {}) if isinstance(payload.get("action_signals"), dict) else {}
+        startup_proof_commands = _tiny_required_proof_commands(payload.get("proof", {})) if isinstance(payload.get("proof"), dict) else []
+        if "decision_packet" not in payload:
+            payload["decision_packet"] = _ordinary_decision_packet(
+                surface="start",
+                phase_question="Startup posture?",
+                next_action=str(next_safe_action.get("next_safe_action", "")),
+                blocked_actions=[str(item) for item in next_safe_action.get("forbidden_actions", []) if str(item).strip()],
+                required_commands=list(
+                    dict.fromkeys(
+                        str(item)
+                        for item in [
+                            next_safe_action.get("preferred_cli"),
+                            payload.get("immediate_next_allowed_action", {}).get("command")
+                            if isinstance(payload.get("immediate_next_allowed_action"), dict)
+                            else "",
+                            *startup_proof_commands,
+                        ]
+                        if item not in (None, "", []) and str(item).strip() and str(item).strip().lower() != "none"
+                    )
+                ),
+                claim_boundary=next_safe_action.get("claim_boundary", "completion claim requires proof"),
+                residue_owner="active continuation state" if payload.get("active_state_summary", {}).get("active_execplan") else "none",
+                reasons=list(action_signals.get("changed_signals", []))[:6],
+                detail_routes={
+                    "why_blocked": f"{config.cli_invoke} start --target . --select next_safe_action,action_signals --format json",
+                    "active_plan": f"{config.cli_invoke} summary --target . --format json",
+                    "proof_detail": f"{config.cli_invoke} proof --target . --changed <paths> --format json",
+                },
+                shown_because=["command_phase=start", *list(action_signals.get("changed_signals", []))[:3]],
+                absence_states={
+                    "full_selector_inventory": "hidden_behind_detail_route",
+                    "verbose_planning_detail": "detail_omitted",
+                },
+            )
+        state_delta_core = state_delta_core_payload(
+            surface="startup",
+            decision_packet=payload["decision_packet"],
+            communication_contract=compact_communication_contract_payload(surface="startup"),
+            evidence_basis=[
+                "next_safe_action",
+                "action_signals",
+                "active planning summary"
+                if isinstance(payload.get("active_state_summary"), dict) and payload["active_state_summary"].get("active_execplan")
+                else "startup routing state",
+            ],
+            safe_probe=str(
+                next_safe_action.get("preferred_cli") or payload["decision_packet"].get("detail_routes", {}).get("active_plan") or ""
+            ),
+        )
+        payload["message_economy"] = message_economy_payload(
+            surface="startup",
+            communication_contract=compact_communication_contract_payload(surface="startup"),
+            state_delta_core=state_delta_core,
+        )
+        payload["current_decision"] = current_decision_payload(
+            surface="startup",
+            decision_packet=payload["decision_packet"],
+            state_delta_core=state_delta_core,
+        )
+        payload["evidence_bundle"] = evidence_bundle_payload(
+            surface="startup",
+            current_decision=payload["current_decision"],
+            state_delta_core=state_delta_core,
+        )
+        if _selector_requests(select, "continuation_capsule") and isinstance(payload.get("continuation_view"), dict):
+            continuation_answers = (
+                payload.get("continuation_view", {}).get("answers", {}) if isinstance(payload.get("continuation_view"), dict) else {}
+            )
+            payload["continuation_capsule"] = continuation_capsule_payload(
+                surface="startup",
+                current_decision=payload["current_decision"],
+                message_economy=payload["message_economy"],
+                preserved_intent=str(continuation_answers.get("preserved_intent", "")) if isinstance(continuation_answers, dict) else "",
+                state_delta_core=state_delta_core,
+            )
     vague_orientation: dict[str, Any] | None = None
     if _selector_requests(select, "vague_outcome_orientation"):
         vague_orientation = _vague_outcome_orientation_payload(task_text=task_text, cli_invoke=config.cli_invoke)

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1520,6 +1520,49 @@ def test_start_exposes_communication_contract_in_ordinary_path(tmp_path: Path, c
     assert operating_loop_skill["packets"] == ["current_decision", "message_economy", "evidence_bundle"]
 
 
+def test_start_select_surfaces_state_delta_packets(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Fix one docs typo",
+                "--select",
+                "current_decision,message_economy,evidence_bundle",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    values = payload["values"]
+    assert payload.get("missing", []) == []
+    assert values["current_decision"]["kind"] == "agentic-workspace/current-decision/v1"
+    assert values["current_decision"]["decision_question"] == "Startup posture?"
+    assert values["current_decision"]["known_evidence"] == ["next_safe_action"]
+    assert values["current_decision"]["response_shape"] == [
+        "decision_or_finding",
+        "evidence_or_proof_boundary",
+        "residue_or_claim_boundary",
+        "next_safe_action",
+    ]
+    assert values["current_decision"]["state_backed"] is True
+    assert values["message_economy"]["surface"] == "startup"
+    assert values["message_economy"]["state_backed"] is True
+    assert "repeated_state_recaps" in values["message_economy"]["discourage"]
+    assert values["evidence_bundle"]["supports_decision"] == "Startup posture?"
+    assert values["evidence_bundle"]["minimal_evidence_surfaces"][0]["id"] == "why_blocked"
+    assert values["evidence_bundle"]["state_backed"] is True
+
+
 def test_start_exposes_continuation_capsule_when_active_planning_exists(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -147,8 +147,42 @@ def test_implement_exposes_communication_contract_for_changed_paths(tmp_path: Pa
         "repeated_rereads",
         "context_reconstruction",
     ]
-    assert "current_decision" not in payload
-    assert "message_economy" not in payload
+    current_decision = payload["current_decision"]
+    assert current_decision["kind"] == "agentic-workspace/current-decision/v1"
+    assert current_decision["surface"] == "implementation"
+    assert current_decision["decision_question"] == "What narrow working set is safe to touch now?"
+    assert current_decision["known_evidence"] == ["implement.decision_packet"]
+    assert current_decision["missing_evidence"]
+    assert current_decision["safe_probe"] == "agentic-workspace proof --verbose --changed <paths> --format json"
+    assert current_decision["response_shape"] == [
+        "decision_or_finding",
+        "evidence_or_proof_boundary",
+        "residue_or_claim_boundary",
+        "next_safe_action",
+    ]
+    assert current_decision["proof_boundary"] == payload["decision_packet"]["claim_boundary"]
+    assert current_decision["next_action"] == payload["next"]["action"]
+    assert "repeated_context_reconstruction" in current_decision["avoid_repeat"]
+    assert current_decision["state_backed"] is True
+    message_economy = payload["message_economy"]
+    assert message_economy["kind"] == "agentic-workspace/message-economy/v1"
+    assert message_economy["surface"] == "implementation"
+    assert "decision_changed" in message_economy["speak_when"]
+    assert "detail_route_available" in message_economy["stay_compact_when"]
+    assert "stale_missing_or_failed_proof" in message_economy["expand_when"]
+    assert "proof_boundary" in message_economy["preserve"]
+    assert message_economy["state_backed"] is True
+    bundle = payload["evidence_bundle"]
+    assert bundle["kind"] == "agentic-workspace/evidence-bundle/v1"
+    assert bundle["surface"] == "implementation"
+    assert bundle["supports_decision"] == "What narrow working set is safe to touch now?"
+    assert {item["id"] for item in bundle["minimal_evidence_surfaces"]} == {
+        "proof_detail",
+        "why_blocked",
+        "omitted_diagnostics",
+    }
+    assert bundle["missing_evidence"] == current_decision["missing_evidence"]
+    assert bundle["state_backed"] is True
 
 
 def _write_architecture_principles(target_root: Path) -> None:
@@ -2400,8 +2434,13 @@ def test_implement_default_stays_under_tiny_output_budget_for_docs_task(tmp_path
     )
     payload = json.loads(capsys.readouterr().out)
 
-    _assert_json_payload_under(payload, 13_000, label="implement tiny docs-task payload", sort_keys=False)
+    _assert_json_payload_under(payload, 15_000, label="implement tiny docs-task payload", sort_keys=False)
     assert payload["kind"] == "implementer-context-tiny/v1"
+    assert payload["current_decision"]["state_backed"] is True
+    assert payload["current_decision"]["known_evidence"] == ["implement.decision_packet"]
+    assert payload["message_economy"]["state_backed"] is True
+    assert "repeated_state_recaps" in payload["message_economy"]["discourage"]
+    assert payload["evidence_bundle"]["state_backed"] is True
     assert payload["next"]["action"]
     assert payload["proof"]["required_commands"]
     assert payload["proof"]["proof_obligations"]["required_proof"]["status"] == "required"
@@ -2449,8 +2488,13 @@ def test_implement_default_stays_under_tiny_output_budget_for_code_task(tmp_path
     )
     payload = json.loads(capsys.readouterr().out)
 
-    _assert_json_payload_under(payload, 12_000, label="implement tiny code-task payload", sort_keys=False)
+    _assert_json_payload_under(payload, 14_000, label="implement tiny code-task payload", sort_keys=False)
     assert payload["kind"] == "implementer-context-tiny/v1"
+    assert payload["current_decision"]["state_backed"] is True
+    assert payload["current_decision"]["known_evidence"] == ["implement.decision_packet"]
+    assert payload["message_economy"]["state_backed"] is True
+    assert "repeated_state_recaps" in payload["message_economy"]["discourage"]
+    assert payload["evidence_bundle"]["state_backed"] is True
     assert payload["next"]["action"]
     assert payload["proof"]["proof_obligations"]["required_proof"]["status"] == "required"
     assert payload["proof"]["proof_obligations"]["required_proof"]["manual_verification_required"] is True
@@ -2581,6 +2625,9 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
         "communication_contract",
         "action_signals",
         "decision_packet",
+        "current_decision",
+        "message_economy",
+        "evidence_bundle",
         "next",
         "proof",
         "generated_surface_trust",
@@ -2596,6 +2643,23 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert decision["phase_question"] == "What narrow working set is safe to touch now?"
     assert decision["next_action"] == payload["next"]["action"]
     assert decision["absence_states"]["full_selector_inventory"] == "hidden_behind_detail_route"
+    assert payload["current_decision"]["surface"] == "implementation"
+    assert payload["current_decision"]["known_evidence"] == ["implement.decision_packet"]
+    assert payload["current_decision"]["safe_probe"] == "make test-workspace"
+    assert payload["current_decision"]["response_shape"] == [
+        "decision_or_finding",
+        "evidence_or_proof_boundary",
+        "residue_or_claim_boundary",
+        "next_safe_action",
+    ]
+    assert payload["message_economy"]["state_backed"] is True
+    assert "repeated_state_recaps" in payload["message_economy"]["discourage"]
+    assert payload["evidence_bundle"]["minimal_evidence_surfaces"] == [
+        {"id": "proof_detail"},
+        {"id": "why_blocked"},
+        {"id": "omitted_diagnostics"},
+    ]
+    assert payload["evidence_bundle"]["state_backed"] is True
     assert signals["kind"] == "agentic-workspace/action-signals/v1"
     assert signals["order"] == [
         "hard_blockers",
@@ -2674,7 +2738,7 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
         sort_keys=False,
     )
     _assert_json_payload_under(payload["operating_loop"], 1000, label="implement operating-loop compact projection", sort_keys=False)
-    _assert_json_payload_under(payload, 18000, label="implement generated-surface tiny payload", sort_keys=False)
+    _assert_json_payload_under(payload, 21000, label="implement generated-surface tiny payload", sort_keys=False)
 
 
 def test_implement_surfaces_runtime_source_edit_review_for_generated_cli_boundary(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
Refs #1969.

## Summary
- exposes `current_decision`, `message_economy`, and `evidence_bundle` in implement tiny output from the existing structured `decision_packet`
- hydrates the same state-delta packets for startup `--select`, making the startup workflow queryable as well as visible by default
- documents implementer state-delta packets and adds focused startup/implement tests for known evidence, missing evidence, safe probe, response shape, expansion triggers, and recap avoidance

## Closure boundary
- This is a bounded startup/implementation slice for #1969.
- It does not close #1969 by itself; the parent lane remains open for review/recheck/handoff/closeout state-delta coverage and continuation/review evidence.

## Slice evidence
- startup selector sample returns `current_decision`, `message_economy`, and `evidence_bundle` with `state_backed=true`
- implement selector sample returns the same packet family with proof/residue boundaries and required proof commands as missing evidence
- packets are derived from structured decision packets and selector routes, not prompt-prose classifiers or broad always-on dumps

## Proof
- `uv run pytest tests/test_workspace_cli.py::test_start_exposes_communication_contract_in_ordinary_path tests/test_workspace_cli.py::test_start_select_surfaces_state_delta_packets tests/test_workspace_implement_cli.py::test_implement_exposes_communication_contract_for_changed_paths tests/test_workspace_implement_cli.py::test_implement_tiny_profile_returns_next_decision_without_diagnostics -q`
- `make test-workspace`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `make maintainer-surfaces`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make schema-reference-docs`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py start --target . --task "Implement issue #1969 state-delta-first operating-loop messages" --select current_decision,message_economy,evidence_bundle --format json`
- `uv run python scripts/run_agentic_workspace.py implement --target . --changed src/agentic_workspace/workspace_runtime_implement.py --changed src/agentic_workspace/workspace_runtime_startup.py --changed tests/test_workspace_implement_cli.py --changed tests/test_workspace_cli.py --task "Implement issue #1969 state-delta-first operating-loop messages" --select current_decision,message_economy,evidence_bundle --format json`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` (exit 0; inherited checked-in payload reduction advisory remains)