### PR TITLE
Clarify compact proof guidance

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -45511,17 +45511,62 @@ def _proof_command_tier(command: str, *, lane: str = "") -> str:
     return "must_run"
 
 
+def _proof_command_evidence_type(command: str, *, tier: str) -> str:
+    text = command.lower()
+    if "lint" in text or "ruff" in text:
+        return "lint"
+    if "typecheck" in text or "mypy" in text or "pyright" in text:
+        return "typecheck"
+    if "generated_command" in text or "command_package" in text:
+        return "generated-command-contract"
+    if "conformance" in text:
+        return "operation-conformance"
+    if "schema-reference" in text:
+        return "schema-reference"
+    if "check_contract" in text or "check_structured" in text:
+        return "contract-surface"
+    if tier == "manual_review":
+        return "manual-review"
+    return "behavior"
+
+
+def _proof_command_cost(tier: str) -> str:
+    return {
+        "must_run": "workspace",
+        "contract_surface": "focused-contract",
+        "generated_contract": "generated-contract",
+        "environmental": "expensive-environmental",
+        "manual_review": "manual",
+    }.get(tier, "unknown")
+
+
+def _proof_command_reliability(tier: str) -> str:
+    if tier == "manual_review":
+        return "manual-required"
+    if tier == "environmental":
+        return "authoritative-when-environment-available"
+    return "authoritative"
+
+
 def _proof_command_tiers(*, selected_commands: list[dict[str, Any]], required_commands: list[str]) -> dict[str, Any]:
     commands_by_text = {str(command.get("command", "")): command for command in selected_commands}
     tiers: dict[str, list[dict[str, Any]]] = {}
     for command in required_commands:
         selected = commands_by_text.get(str(command), {})
         tier = _proof_command_tier(str(command), lane=str(selected.get("lane", "")))
+        evidence_type = _proof_command_evidence_type(str(command), tier=tier)
+        obligation = str(selected.get("intent_type", "")) or "prove changed-path behavior or surface"
+        duplicate_reason = "" if tier == "must_run" else f"adds {evidence_type} evidence not represented by the minimal command"
         tiers.setdefault(tier, []).append(
             {
                 "command": str(command),
                 "lane": str(selected.get("lane", "")),
-                "obligation": str(selected.get("intent_type", "")) or "prove changed-path behavior or surface",
+                "obligation": obligation,
+                "covers": [obligation],
+                "cost": _proof_command_cost(tier),
+                "evidence_type": evidence_type,
+                "reliability": _proof_command_reliability(tier),
+                **({"duplicates_ok_reason": duplicate_reason} if duplicate_reason else {}),
             }
         )
     ordered = [
@@ -45532,6 +45577,13 @@ def _proof_command_tiers(*, selected_commands: list[dict[str, Any]], required_co
     return {
         "kind": "agentic-workspace/proof-command-tiers/v1",
         "status": "present" if ordered else "empty",
+        "selected_set": {
+            "status": "minimal-sufficient" if len(ordered) <= 1 else "conservative-expanded",
+            "reason": "single evidence tier covers required obligations"
+            if len(ordered) <= 1
+            else "multiple evidence tiers are required; overlap is retained only when it adds distinct evidence",
+            "omitted_candidate_state": "not-reported-in-compact-tier-packet",
+        },
         "rule": "Tiers explain proof obligation and cost; they do not relax required_commands.",
         "tiers": ordered,
     }

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -1055,14 +1055,18 @@ def _tiny_proof_command_tiers_payload(value: Any, *, required_commands: list[str
         commands = [
             {
                 "command": str(item.get("command", "")),
-                "lane": str(item.get("lane", "")),
-                "obligation": str(item.get("obligation", "")),
+                "evidence_type": str(item.get("evidence_type", "")),
+                **(
+                    {"extra_evidence": str(item.get("duplicates_ok_reason", ""))}
+                    if str(item.get("duplicates_ok_reason", "")).strip()
+                    else {}
+                ),
             }
             for item in raw_commands
             if isinstance(item, dict) and str(item.get("command", "")).strip()
         ][:1]
         if commands:
-            tiers.append({"id": str(tier.get("id", "")), "command_count": len(raw_commands), "commands": commands})
+            tiers.append({"id": str(tier.get("id", "")), "commands": commands})
     if len(tiers) <= 1:
         return {}
     minimal_required = ""
@@ -1073,11 +1077,14 @@ def _tiny_proof_command_tiers_payload(value: Any, *, required_commands: list[str
     if not minimal_required and required_commands:
         minimal_required = required_commands[0]
     return {
-        "kind": packet.get("kind", "agentic-workspace/proof-command-tiers/v1"),
-        "status": packet.get("status", "present" if tiers else "empty"),
+        "selected_set": {
+            key: _as_dict(packet.get("selected_set")).get(key)
+            for key in ("status",)
+            if _as_dict(packet.get("selected_set")).get(key) not in (None, "", [], {})
+        },
         "minimal_required_command": minimal_required,
         "tiers": tiers,
-        "closeout_rule": "Name minimal_required_command first; list overlapping commands only with extra tier evidence.",
+        "closeout_rule": "List overlap only when it adds extra_evidence.",
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -1044,6 +1044,43 @@ def _tiny_proof_route_maintenance_payload(value: dict[str, Any]) -> dict[str, An
     }
 
 
+def _tiny_proof_command_tiers_payload(value: Any, *, required_commands: list[str]) -> dict[str, Any]:
+    packet = value if isinstance(value, dict) else {}
+    raw_tiers = packet.get("tiers", [])
+    tiers: list[dict[str, Any]] = []
+    for tier in raw_tiers if isinstance(raw_tiers, list) else []:
+        if not isinstance(tier, dict):
+            continue
+        raw_commands = tier.get("commands", [])
+        commands = [
+            {
+                "command": str(item.get("command", "")),
+                "lane": str(item.get("lane", "")),
+                "obligation": str(item.get("obligation", "")),
+            }
+            for item in raw_commands
+            if isinstance(item, dict) and str(item.get("command", "")).strip()
+        ][:1]
+        if commands:
+            tiers.append({"id": str(tier.get("id", "")), "command_count": len(raw_commands), "commands": commands})
+    if len(tiers) <= 1:
+        return {}
+    minimal_required = ""
+    for tier in tiers:
+        if tier["id"] == "must_run" and tier["commands"]:
+            minimal_required = tier["commands"][0]["command"]
+            break
+    if not minimal_required and required_commands:
+        minimal_required = required_commands[0]
+    return {
+        "kind": packet.get("kind", "agentic-workspace/proof-command-tiers/v1"),
+        "status": packet.get("status", "present" if tiers else "empty"),
+        "minimal_required_command": minimal_required,
+        "tiers": tiers,
+        "closeout_rule": "Name minimal_required_command first; list overlapping commands only with extra tier evidence.",
+    }
+
+
 def _implement_tiny_proof_narrowness_payload(value: Any) -> dict[str, Any]:
     packet = value if isinstance(value, dict) else {}
     if not _include_tiny_proof_narrowness(packet):
@@ -1319,6 +1356,11 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                 payload.get("proof", {}).get("proof_obligations", {}), required_commands=proof_commands
             )
             if isinstance(payload.get("proof"), dict) and isinstance(payload.get("proof", {}).get("proof_obligations"), dict)
+            else {},
+            "proof_command_tiers": _tiny_proof_command_tiers_payload(
+                payload.get("proof", {}).get("proof_command_tiers", {}), required_commands=proof_commands
+            )
+            if isinstance(payload.get("proof"), dict) and isinstance(payload.get("proof", {}).get("proof_command_tiers"), dict)
             else {},
             "proof_narrowness": _implement_tiny_proof_narrowness_payload(payload.get("proof", {}).get("proof_narrowness", {}))
             if isinstance(payload.get("proof"), dict)

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -42486,17 +42486,62 @@ def _proof_command_tier(command: str, *, lane: str = "") -> str:
     return "must_run"
 
 
+def _proof_command_evidence_type(command: str, *, tier: str) -> str:
+    text = command.lower()
+    if "lint" in text or "ruff" in text:
+        return "lint"
+    if "typecheck" in text or "mypy" in text or "pyright" in text:
+        return "typecheck"
+    if "generated_command" in text or "command_package" in text:
+        return "generated-command-contract"
+    if "conformance" in text:
+        return "operation-conformance"
+    if "schema-reference" in text:
+        return "schema-reference"
+    if "check_contract" in text or "check_structured" in text:
+        return "contract-surface"
+    if tier == "manual_review":
+        return "manual-review"
+    return "behavior"
+
+
+def _proof_command_cost(tier: str) -> str:
+    return {
+        "must_run": "workspace",
+        "contract_surface": "focused-contract",
+        "generated_contract": "generated-contract",
+        "environmental": "expensive-environmental",
+        "manual_review": "manual",
+    }.get(tier, "unknown")
+
+
+def _proof_command_reliability(tier: str) -> str:
+    if tier == "manual_review":
+        return "manual-required"
+    if tier == "environmental":
+        return "authoritative-when-environment-available"
+    return "authoritative"
+
+
 def _proof_command_tiers(*, selected_commands: list[dict[str, Any]], required_commands: list[str]) -> dict[str, Any]:
     commands_by_text = {str(command.get("command", "")): command for command in selected_commands}
     tiers: dict[str, list[dict[str, Any]]] = {}
     for command in required_commands:
         selected = commands_by_text.get(str(command), {})
         tier = _proof_command_tier(str(command), lane=str(selected.get("lane", "")))
+        evidence_type = _proof_command_evidence_type(str(command), tier=tier)
+        obligation = str(selected.get("intent_type", "")) or "prove changed-path behavior or surface"
+        duplicate_reason = "" if tier == "must_run" else f"adds {evidence_type} evidence not represented by the minimal command"
         tiers.setdefault(tier, []).append(
             {
                 "command": str(command),
                 "lane": str(selected.get("lane", "")),
-                "obligation": str(selected.get("intent_type", "")) or "prove changed-path behavior or surface",
+                "obligation": obligation,
+                "covers": [obligation],
+                "cost": _proof_command_cost(tier),
+                "evidence_type": evidence_type,
+                "reliability": _proof_command_reliability(tier),
+                **({"duplicates_ok_reason": duplicate_reason} if duplicate_reason else {}),
             }
         )
     ordered = [
@@ -42507,6 +42552,13 @@ def _proof_command_tiers(*, selected_commands: list[dict[str, Any]], required_co
     return {
         "kind": "agentic-workspace/proof-command-tiers/v1",
         "status": "present" if ordered else "empty",
+        "selected_set": {
+            "status": "minimal-sufficient" if len(ordered) <= 1 else "conservative-expanded",
+            "reason": "single evidence tier covers required obligations"
+            if len(ordered) <= 1
+            else "multiple evidence tiers are required; overlap is retained only when it adds distinct evidence",
+            "omitted_candidate_state": "not-reported-in-compact-tier-packet",
+        },
         "rule": "Tiers explain proof obligation and cost; they do not relax required_commands.",
         "tiers": ordered,
     }

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -801,16 +801,28 @@ def _tiny_proof_obligations_payload(value: dict[str, Any], *, required_commands:
             "missing_evidence": item.get("missing_evidence", []),
             "reference_material": item.get("reference_material", []),
             "claim_boundary": str(item.get("claim_boundary", "")),
+            "resolution": {
+                "inspect": item.get("reference_material", []) or item.get("missing_evidence", []),
+                "record": item.get("missing_evidence", []) or ["manual_review_result"],
+                "detail_selector": "proof.proof_obligations.required_proof.manual_obligations",
+                "closeout_format": "manual obligation <id>: inspected <refs>; recorded <evidence>; claim boundary <claim_boundary>",
+            },
         }
         for item in manual_obligations
     ]
     manual_obligation_projection: dict[str, Any]
-    if len(compact_manual_obligations) <= 1:
+    if len(compact_manual_obligations) <= 3:
         manual_obligation_projection = {"manual_obligations": compact_manual_obligations}
     else:
         manual_obligation_projection = {
             "manual_obligation_ids": [str(item.get("id", "")) for item in manual_obligations[:4] if str(item.get("id", "")).strip()],
             "manual_obligations_detail_selector": "proof.proof_obligations.required_proof.manual_obligations",
+            "manual_obligation_record_shape": {
+                "inspect": "reference_material or the affected surface named by the obligation",
+                "record": "missing_evidence item plus review result",
+                "detail_selector": "proof.proof_obligations.required_proof.manual_obligations",
+                "closeout_format": "manual obligation <id>: inspected <refs>; recorded <evidence>; claim boundary <claim_boundary>",
+            },
         }
     return {
         "kind": value.get("kind", "agentic-workspace/proof-obligations/v1"),

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -2566,6 +2566,12 @@ review_aids = ["Record the manual policy finding."]
     assert required["manual_obligations"][0]["id"] == "verification:policy_review"
     assert required["manual_obligations"][0]["missing_evidence"] == ["manual_policy_review"]
     assert required["manual_obligations"][0]["reference_material"] == ["docs/policy.md#rule-1"]
+    assert required["manual_obligations"][0]["resolution"] == {
+        "inspect": ["docs/policy.md#rule-1"],
+        "record": ["manual_policy_review"],
+        "detail_selector": "proof.proof_obligations.required_proof.manual_obligations",
+        "closeout_format": "manual obligation <id>: inspected <refs>; recorded <evidence>; claim boundary <claim_boundary>",
+    }
     assert payload["proof"]["proof_route_maintenance"]["status"] == "attention"
 
 
@@ -2697,6 +2703,12 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert obligations["recommended_confidence_checks"]["status"] == "available"
     assert "do not replace or relax required proof" in obligations["recommended_confidence_checks"]["rule"]
     assert "Completion claims remain blocked" in obligations["completion_claim_rule"]
+    tiers = payload["proof"]["proof_command_tiers"]
+    assert tiers["minimal_required_command"] == "make test-workspace"
+    assert "overlapping commands only with extra tier evidence" in tiers["closeout_rule"]
+    tier_ids = {tier["id"] for tier in tiers["tiers"]}
+    assert "must_run" in tier_ids
+    assert "generated_contract" in tier_ids
     trust = payload["generated_surface_trust"]
     assert trust["status"] == "present"
     assert trust["items"][0]["path"] == "generated/workspace/python/cli.py"

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -867,6 +867,10 @@ def test_implement_command_returns_bounded_context_and_boundary_warnings(tmp_pat
     assert "Python-only proof" in parity["claim_rule"]
     proof_tiers = {tier["id"]: tier["commands"] for tier in payload["proof"]["proof_command_tiers"]["tiers"]}
     assert proof_tiers["generated_contract"][0]["command"] == "uv run python scripts/check/check_generated_command_packages.py"
+    assert proof_tiers["generated_contract"][0]["evidence_type"] == "generated-command-contract"
+    assert proof_tiers["generated_contract"][0]["cost"] == "generated-contract"
+    assert proof_tiers["generated_contract"][0]["reliability"] == "authoritative"
+    assert "not represented by the minimal command" in proof_tiers["generated_contract"][0]["duplicates_ok_reason"]
     assert any(item["command"].endswith("--require-docker") for item in proof_tiers["environmental"])
     retry = payload["proof"]["transient_validation_retry"]
     assert retry["status"] == "available"
@@ -2705,10 +2709,14 @@ def test_implement_tiny_profile_returns_next_decision_without_diagnostics(tmp_pa
     assert "Completion claims remain blocked" in obligations["completion_claim_rule"]
     tiers = payload["proof"]["proof_command_tiers"]
     assert tiers["minimal_required_command"] == "make test-workspace"
-    assert "overlapping commands only with extra tier evidence" in tiers["closeout_rule"]
+    assert tiers["selected_set"]["status"] == "conservative-expanded"
+    assert "extra_evidence" in tiers["closeout_rule"]
     tier_ids = {tier["id"] for tier in tiers["tiers"]}
     assert "must_run" in tier_ids
     assert "generated_contract" in tier_ids
+    generated_tier = next(tier for tier in tiers["tiers"] if tier["id"] == "generated_contract")
+    assert generated_tier["commands"][0]["evidence_type"] == "generated-command-contract"
+    assert "not represented by the minimal command" in generated_tier["commands"][0]["extra_evidence"]
     trust = payload["generated_surface_trust"]
     assert trust["status"] == "present"
     assert trust["items"][0]["path"] == "generated/workspace/python/cli.py"

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -230,9 +230,13 @@ def test_tiny_proof_obligations_summarizes_multiple_manual_obligations() -> None
 
     required = payload["required_proof"]
     assert required["manual_obligation_count"] == 2
-    assert required["manual_obligation_ids"] == ["verification:first", "verification:second"]
-    assert required["manual_obligations_detail_selector"] == "proof.proof_obligations.required_proof.manual_obligations"
-    assert "manual_obligations" not in required
+    assert [item["id"] for item in required["manual_obligations"]] == ["verification:first", "verification:second"]
+    assert required["manual_obligations"][0]["resolution"] == {
+        "inspect": ["docs/first.md"],
+        "record": ["first"],
+        "detail_selector": "proof.proof_obligations.required_proof.manual_obligations",
+        "closeout_format": "manual obligation <id>: inspected <refs>; recorded <evidence>; claim boundary <claim_boundary>",
+    }
 
 
 def test_proof_command_reports_routes_and_current_health(tmp_path: Path, monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary
- add compact multi-tier proof command guidance so overlapping proof commands need distinct tier evidence
- refine #2090 proof tiers with selected-set status, evidence type, cost, reliability, coverage, and duplicate/extra-evidence reasons
- include actionable manual proof obligation resolution details in tiny proof output
- keep tiny implement output compact while exposing the selected proof status and extra-evidence explanation
- cover compact manual-obligation and proof-tier behavior with focused tests

Closes #2090
Closes #2091

## Proof
- make test-workspace
- make lint-workspace
- uv run pytest tests/test_workspace_cli.py -q
- make typecheck
- uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json
- uv run python scripts/run_agentic_workspace.py summary --target . --changed src/agentic_workspace/workspace_runtime_core.py --changed src/agentic_workspace/workspace_runtime_implement.py --changed src/agentic_workspace/workspace_runtime_primitives.py --changed tests/test_workspace_implement_cli.py --format json
- uv run python scripts/run_agentic_workspace.py doctor --target . --format json

## Notes
- Summary still reports inherited planning projection drift in older execplans, and doctor still reports the known checked-in AW payload reduction advisory; this PR does not add those warnings.
- eport --section closeout_trust still blocks broad parent/full-intent closure for unrelated planning residue, so this PR claim remains scoped to #2090/#2091.