### PR TITLE
Acknowledge bounded task switches

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -17125,9 +17125,9 @@ def _operating_loop_planning_state(
         }
     task_switch = _as_dict(gate.get("task_switch_reconciliation"))
     if (
-        str(gate.get("gate_result") or "") == "active-plan-task-switch"
+        str(gate.get("gate_result") or "") in {"active-plan-task-switch", "current-task-route-acknowledged"}
         and gate.get("workflow_sufficient") is True
-        and str(task_switch.get("status") or "") == "active"
+        and str(task_switch.get("status") or "") in {"active", "current-task-route-acknowledged"}
     ):
         return {"state": "unrelated_active_plan", "plan_ref": plan_ref, "blocks_full_closure": False}
     if str(reliance.get("status") or "") not in {"", "no-active-plan", "not-applicable", "clear", "satisfied"}:
@@ -20476,9 +20476,9 @@ def _report_closeout_trust_payload(
         )
         task_switch = _as_dict(planning_safety_gate.get("task_switch_reconciliation"))
         if (
-            str(planning_safety_gate.get("gate_result") or "") != "active-plan-task-switch"
+            str(planning_safety_gate.get("gate_result") or "") not in {"active-plan-task-switch", "current-task-route-acknowledged"}
             or planning_safety_gate.get("workflow_sufficient") is not True
-            or str(task_switch.get("status") or "") != "active"
+            or str(task_switch.get("status") or "") not in {"active", "current-task-route-acknowledged"}
         ):
             return {
                 "kind": "agentic-workspace/current-task-closeout-scope/v1",
@@ -26372,6 +26372,7 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
     task_switch = gate.get("task_switch_reconciliation")
     compact_route = isinstance(task_switch, dict) and task_switch.get("status") in {
         "bounded-reflection-reporting",
+        "current-task-route-acknowledged",
         "completed-active-plan-route",
     }
     compact: dict[str, Any] = {
@@ -26428,6 +26429,7 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
     if isinstance(task_switch, dict) and task_switch.get("status") in {
         "active",
         "bounded-reflection-reporting",
+        "current-task-route-acknowledged",
         "completed-active-plan-route",
     }:
         safe_routes = [
@@ -26446,6 +26448,13 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
             "blocked_claims": active_plan_protection.get("blocked_claims", []),
             "detail_selector": "planning_safety_gate.task_switch_reconciliation",
         }
+        route_acknowledgement = _as_dict(task_switch.get("route_acknowledgement"))
+        if route_acknowledgement:
+            compact_switch["route_acknowledgement"] = {
+                key: route_acknowledgement.get(key)
+                for key in ("status", "route", "changed_path_count", "claim_boundary", "proof_rule")
+                if route_acknowledgement.get(key) not in (None, "", [], {})
+            }
         if active_plan_protection.get("claim_boundary"):
             compact_switch["claim_boundary"] = _task_excerpt(str(active_plan_protection.get("claim_boundary") or ""), limit=180)
         completed_plan = _as_dict(task_switch.get("completed_active_plan"))

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -1718,10 +1718,13 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
         compact_gate.pop("work_shape_guidance", None)
         if compact_gate.get("status") in {"clear", "satisfied"}:
             active_plan_reliance = _as_dict(compact_gate.get("active_plan_reliance"))
-            keep_active_plan_reliance = active_plan_reliance.get("permission_claim") != "direct-work-no-active-plan"
             candidate_pressure = _as_dict(compact_gate.get("candidate_pressure"))
             custody_planning = _as_dict(compact_gate.get("custody_planning"))
             issue_scope_evidence = _as_dict(compact_gate.get("issue_scope_evidence"))
+            task_switch_reconciliation = _as_dict(compact_gate.get("task_switch_reconciliation"))
+            keep_active_plan_reliance = (
+                active_plan_reliance.get("permission_claim") != "direct-work-no-active-plan" and not task_switch_reconciliation
+            )
             changed_path_facts = _as_dict(compact_gate.get("changed_path_facts"))
             compact_changed_path_facts = {
                 key: changed_path_facts.get(key)
@@ -1747,11 +1750,15 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     "implementation_allowed",
                     "delegation_decision_required",
                     "custody_planning",
+                    "task_switch_reconciliation",
+                    "detail_selector",
                 )
                 if key in compact_gate
             }
             if not custody_planning:
                 compact_gate.pop("custody_planning", None)
+            if not task_switch_reconciliation:
+                compact_gate.pop("task_switch_reconciliation", None)
             if compact_changed_path_facts:
                 compact_gate["changed_path_facts"] = compact_changed_path_facts
             if candidate_pressure.get("status") == "observed":

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -726,6 +726,48 @@ def _task_switch_reconciliation_payload(
     }
 
 
+def _acknowledged_current_task_switch_payload(
+    task_switch: dict[str, Any], *, changed_paths: list[str], path_classification: dict[str, Any]
+) -> dict[str, Any]:
+    if task_switch.get("status") != "active" or not changed_paths:
+        return task_switch
+    dirty_shape = str(path_classification.get("dirty_shape") or "")
+    if dirty_shape in {"planning-only", "planning-plus-implementation", "implementation-with-archived-planning-residue"}:
+        return task_switch
+    acknowledged = dict(task_switch)
+    acknowledged["status"] = "current-task-route-acknowledged"
+    acknowledged["intent_conflict_state"] = "current-task-route-acknowledged-active-plan-protected"
+    acknowledged["summary"] = (
+        "Current task route is acknowledged from the changed-path implementation context; continue current-task proof "
+        "without claiming active-plan progress."
+    )
+    acknowledged["recommended_next_action"] = "prove-current-task"
+    acknowledged["next_action_packet"] = {
+        "action": "prove-current-task",
+        "summary": "Continue current-task implementation proof; active-plan progress remains out of scope.",
+        "command": "",
+        "run": None,
+        "risk": "active-plan-protected-current-task",
+        "required_inputs": ["changed paths", "current task", "active plan claim boundary"],
+        "next_proof": "run implement/proof-selected commands for the changed paths; do not claim active-plan progress",
+        "read_first": [],
+        "open_execplan_only_when": "the task mutates active-plan-owned surfaces or needs active plan ownership changed",
+    }
+    acknowledged["route_acknowledgement"] = {
+        "status": "acknowledged",
+        "route": "current-task",
+        "acknowledged_by": "changed-path implementation context",
+        "changed_path_count": len(changed_paths),
+        "claim_boundary": "Current task is intentionally separate; do not claim active-plan progress, completion, or abandonment.",
+        "proof_rule": "Use current-task proof only.",
+    }
+    acknowledged["rule"] = (
+        "Changed-path implementation context can acknowledge the current-task route when planning-owned surfaces are not being "
+        "mutated; active-plan protection still blocks active-plan progress claims."
+    )
+    return acknowledged
+
+
 def _bounded_reflection_reporting_payload(*, task_text: str | None) -> dict[str, Any]:
     text = " ".join((task_text or "").lower().split())
     if not text:
@@ -1077,6 +1119,11 @@ def _planning_safety_gate_payload(
         config=config,
         planning_revision=planning_revision,
     )
+    task_switch_reconciliation = _acknowledged_current_task_switch_payload(
+        task_switch_reconciliation,
+        changed_paths=changed_paths,
+        path_classification=path_classification,
+    )
     closeout_publication_residue = (
         path_classification.get("dirty_shape") == "implementation-with-archived-planning-residue"
         and _as_dict(path_classification.get("archived_planning_residue")).get("status") == "completed-closeout-residue"
@@ -1122,6 +1169,14 @@ def _planning_safety_gate_payload(
             or "Bounded reflection/reporting may proceed while preserving active-plan claim boundaries."
         )
         required_next_action = "produce-bounded-reflection-report"
+        workflow_sufficient = True
+    elif task_switch_reconciliation.get("status") == "current-task-route-acknowledged":
+        status = "satisfied"
+        decision = "current-task-route-acknowledged"
+        reason = str(
+            task_switch_reconciliation.get("summary") or "Current task route is acknowledged; active-plan state remains protected."
+        )
+        required_next_action = "prove-current-task"
         workflow_sufficient = True
     elif task_switch_reconciliation.get("status") == "active":
         status = "attention"

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -880,6 +880,7 @@ def _start_payload(
     task_switch_visible_by_default = isinstance(task_switch, dict) and task_switch.get("status") in {
         "active",
         "bounded-reflection-reporting",
+        "current-task-route-acknowledged",
         "completed-active-plan-route",
     }
     if planning_safety_gate["status"] not in {"satisfied", "clear"} or custody_applies or task_switch_visible_by_default:
@@ -887,6 +888,7 @@ def _start_payload(
     if isinstance(task_switch, dict) and task_switch.get("status") in {
         "active",
         "bounded-reflection-reporting",
+        "current-task-route-acknowledged",
         "completed-active-plan-route",
     }:
         next_packet = task_switch.get("next_action_packet", {})
@@ -896,6 +898,8 @@ def _start_payload(
                 if task_switch.get("status") == "completed-active-plan-route"
                 else ["active-plan claim boundary preserved"]
                 if task_switch.get("status") == "bounded-reflection-reporting"
+                else ["current-task proof", "active-plan claim boundary preserved"]
+                if task_switch.get("status") == "current-task-route-acknowledged"
                 else ["current-task route chosen without claiming active-plan progress"]
             )
             payload["workflow_sufficiency"] = _workflow_sufficiency_payload(

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1067,7 +1067,10 @@ candidates = []
     current = payload["current_task_closeout"]
     assert current["status"] == "active"
     assert current["scope"]["relationship"] == "bounded-task-switch"
-    assert current["scope"]["planning_safety_gate"]["gate_result"] == "active-plan-task-switch"
+    assert current["scope"]["planning_safety_gate"]["gate_result"] == "current-task-route-acknowledged"
+    switch = current["scope"]["planning_safety_gate"]["task_switch_reconciliation"]
+    assert switch["status"] == "current-task-route-acknowledged"
+    assert switch["route_acknowledgement"]["status"] == "acknowledged"
     assert current["strict_closeout_gate"]["blocking"] is False
     assert current["strict_closeout_gate"]["current_task_blocking"] is False
     assert current["operating_loop"]["planning"]["state"] == "unrelated_active_plan"

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -444,7 +444,15 @@ candidates = []
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["context"]["workflow_sufficiency"]["sufficiency_result"] == "enough-for-bounded-implementation"
-    assert payload["context"]["planning_safety_gate"]["gate_result"] == "active-plan-task-switch"
+    gate = payload["context"]["planning_safety_gate"]
+    assert gate["gate_result"] == "current-task-route-acknowledged"
+    switch = gate["task_switch_reconciliation"]
+    assert switch["status"] == "current-task-route-acknowledged"
+    assert switch["recommended_next_action"] == "prove-current-task"
+    assert switch["route_acknowledgement"]["status"] == "acknowledged"
+    assert switch["route_acknowledgement"]["route"] == "current-task"
+    assert switch["route_acknowledgement"]["changed_path_count"] == 1
+    assert "claim-active-plan-progress" in switch["blocked_claims"]
     packet = payload["operating_loop"]
     assert packet["verification"]["state"] == "proof_missing"
     assert packet["closeout_state"] == "blocked_missing_proof"
@@ -453,6 +461,56 @@ candidates = []
     assert packet["planning"]["plan_ref"] == ".agentic-workspace/planning/execplans/active-plan.plan.json"
     assert packet["planning"]["blocks_full_closure"] is False
     assert packet["required_before_full_closure"] == ["run_or_refresh_proof"]
+
+
+def test_implement_task_switch_still_warns_for_planning_owned_changes(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "active-plan", title = "Unrelated active plan", status = "active", surface = ".agentic-workspace/planning/execplans/active-plan.plan.json" },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "active-plan.plan.json",
+        {"kind": "planning-execplan/v1", "id": "active-plan", "title": "Unrelated active plan"},
+    )
+    capsys.readouterr()
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                ".agentic-workspace/planning/execplans/active-plan.plan.json",
+                "--task",
+                "Implement issue #3000 parser cache cleanup",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    gate = payload["context"]["planning_safety_gate"]
+    assert gate["gate_result"] == "active-plan-task-switch"
+    assert gate["task_switch_reconciliation"]["status"] == "active"
+    assert "route_acknowledgement" not in gate["task_switch_reconciliation"]
 
 
 def test_implement_does_not_require_stale_deleted_test_inventory_sweep(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- add a current-task-route acknowledgement state for active-plan task switches once changed-path implementation chooses a separate bounded route
- keep active-plan protection visible through blocked claims and closeout scope while avoiding repeated route-choice pressure
- preserve the warning path when changed paths touch planning-owned surfaces

Closes #2092

## Proof
- make test-workspace
- make lint-workspace
- uv run pytest tests/test_workspace_cli.py -q
- make typecheck
- uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json
- uv run python scripts/run_agentic_workspace.py summary --target . --changed src/agentic_workspace/workspace_runtime_core.py --changed src/agentic_workspace/workspace_runtime_implement.py --changed src/agentic_workspace/workspace_runtime_planning.py --changed src/agentic_workspace/workspace_runtime_startup.py --changed tests/test_workspace_implement_cli.py --changed tests/test_workspace_cli.py --format json
- uv run python scripts/run_agentic_workspace.py doctor --target . --format json

## Notes
- Summary still reports inherited execplan canonical projection drift in older planning files, and doctor still reports the known checked-in AW payload reduction advisory; this PR does not introduce those warnings.