### PR TITLE
Propagate report task scope into grounding

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -15088,30 +15088,37 @@ def _run_lazy_report_section_command(
         )
         return _select_report_payload(payload, profile="router", section=normalized)
 
+    normalized_changed_paths = _normalize_changed_paths(changed_paths or [])
+    task_issue_refs = sorted(set(re.findall("#\\d+", task_text or "")))
+
     if normalized in {"assurance_requirements", "verification", "requirement_grounding", "applicable_intent"}:
         assurance_requirements = _assurance_requirements_report_payload(
             config=config,
             target_root=target_root,
             active_planning_record=active_planning_record,
+            task_text=task_text,
+            changed_paths=normalized_changed_paths,
         )
         verification = _verification_report_payload(
             target_root=target_root,
             active_planning_record=active_planning_record,
             assurance_requirements=assurance_requirements,
+            task_text=task_text,
+            changed_paths=normalized_changed_paths,
         )
         payload["verification"] = verification
         payload["assurance_requirements"] = _assurance_requirements_with_verification(assurance_requirements, verification)
         if normalized == "requirement_grounding":
             payload["requirement_grounding"] = _requirement_grounding_payload(
                 target_root=target_root,
-                task_text=None,
-                changed_paths=[],
+                task_text=task_text,
+                changed_paths=normalized_changed_paths,
                 active_planning_record=active_planning_record,
-                issue_scope_evidence={
-                    "kind": "agentic-workspace/issue-scope-evidence/v1",
-                    "status": "not-applicable",
-                    "issue_refs": [],
-                },
+                issue_scope_evidence=_issue_scope_evidence_payload(
+                    target_root=target_root,
+                    config=config,
+                    issue_refs=task_issue_refs,
+                ),
                 assurance_requirements=payload["assurance_requirements"],
                 verification=verification,
             )
@@ -15199,11 +15206,15 @@ def _run_lazy_report_section_command(
             config=config,
             target_root=target_root,
             active_planning_record=active_planning_record,
+            task_text=task_text,
+            changed_paths=normalized_changed_paths,
         )
         verification = _verification_report_payload(
             target_root=target_root,
             active_planning_record=active_planning_record,
             assurance_requirements=assurance_requirements,
+            task_text=task_text,
+            changed_paths=normalized_changed_paths,
         )
         payload["verification"] = verification
         payload["assurance_requirements"] = _assurance_requirements_with_verification(assurance_requirements, verification)

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -5465,6 +5465,79 @@ candidates = []
     assert grounding["agent_interpretation"]["summary"] == "Report the requirement grounding chain."
 
 
+def test_report_sections_preserve_task_and_changed_scope_for_verification_and_grounding(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path)]) == 0
+    capsys.readouterr()
+    _write_empty_planning_state(tmp_path)
+    _write(
+        tmp_path / ".agentic-workspace" / "verification" / "manifest.toml",
+        """
+schema_version = "agentic-workspace/verification-manifest/v1"
+
+[protocols.privacy_review]
+title = "Privacy review"
+purpose = "Configured privacy verification protocol."
+applies_to_task_markers = ["privacy"]
+expected_evidence = ["privacy_reviewed"]
+review_owner = "privacy-review"
+authority_refs = ["docs/compliance/privacy.md"]
+""",
+    )
+
+    task = "Implement privacy lane #2098"
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(tmp_path),
+                "--section",
+                "verification",
+                "--task",
+                task,
+                "--changed",
+                "src/privacy.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    verification = json.loads(capsys.readouterr().out)["answer"]
+    assert verification["active_protocols"][0]["id"] == "privacy_review"
+    assert verification["active_protocols"][0]["applies_because"] == ["task marker matched privacy"]
+    assert verification["match_evidence"]["observed_scope_source"] == "changed paths, task text"
+
+    assert (
+        cli.main(
+            [
+                "report",
+                "--target",
+                str(tmp_path),
+                "--section",
+                "requirement_grounding",
+                "--task",
+                task,
+                "--changed",
+                "src/privacy.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    grounding = json.loads(capsys.readouterr().out)["answer"]
+    assert grounding["status"] == "attention"
+    assert grounding["source_facts"]["changed_paths"] == ["src/privacy.py"]
+    assert grounding["source_facts"]["task_issue_refs"] == ["#2098"]
+    assert grounding["source_facts"]["verification_active_count"] == 1
+    assert grounding["verification_refs"][0]["protocol_id"] == "privacy_review"
+    assert "requirement-grounded-completion" in grounding["closeout_claims"]["blocked"]
+
+
 def test_report_section_scopes_subsystem_assurance_from_active_plan(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path)]) == 0


### PR DESCRIPTION
## Summary

- Propagates `--task` and `--changed` scope through lazy report sections for assurance requirements, verification, and requirement grounding.
- Replaces the previous `requirement_grounding` not-applicable issue evidence with task-derived issue refs.
- Adds a focused regression proving verification marker activation and requirement grounding both see the same task/changed scope.

## Stack

1. This PR: report task-scope propagation for #2101.
2. `codex/2098-closeout-proof-state`: current-task closeout claim/proof-state composition for #2099/#2100/#2102.
3. `codex/2098-diagnostic-closeout-wording`: compact diagnostic wording/scoped health for #2104, with #2103 treated as already covered by existing task-thread behavior.

Refs #2098, #2101.

## Proof

Final top-of-stack proof run after all commits:

- `make test-workspace`
- `make maintainer-surfaces`
- `make lint-workspace`
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make schema-reference-docs`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`

AW transcript is local-only under `.agentic-workspace/local/issue-2098-aw-transcript/`.
