### PR TITLE
Clarify lifecycle diagnostic closeout wording

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -1247,6 +1247,9 @@ def _payload_target_sync_commands(*, target_root: Path, config: WorkspaceConfig)
             command=f"agentic-workspace start --target {target} --select installed_state_compatibility --format json",
             cli_invoke=config.cli_invoke,
         ),
+        "reportable_dry_run_command": "agentic-workspace upgrade --target . --to-payload-target --dry-run --format json",
+        "reportable_apply_command": "agentic-workspace upgrade --target . --to-payload-target --format json",
+        "reportable_recheck_command": "agentic-workspace start --target . --select installed_state_compatibility --format json",
     }
 
 
@@ -1328,6 +1331,9 @@ def _payload_target_status_payload(
         "dry_run_command": commands["dry_run_command"],
         "apply_command": commands["apply_command"],
         "recheck_command": commands["recheck_command"],
+        "reportable_dry_run_command": commands["reportable_dry_run_command"],
+        "reportable_apply_command": commands["reportable_apply_command"],
+        "reportable_recheck_command": commands["reportable_recheck_command"],
         "reason": reason,
         "rule": (
             "Repo-declared payload targets compare checked-in payload provenance against a repo-owned target; "
@@ -1631,10 +1637,12 @@ def _payload_upgrade_attention_plan_payload(
         category = str(item["category"])
         category_counts[category] = category_counts.get(category, 0) + 1
     status = "satisfied"
-    if any(item["blocking"] for item in items):
+    blocking_count = sum(1 for item in items if item["blocking"])
+    non_auto_count = sum(1 for item in items if item["category"] != "auto_applied")
+    if non_auto_count:
         status = "manual_attention_required"
-    elif any(item["category"] != "auto_applied" for item in items):
-        status = "manual_attention_required"
+    elif blocking_count:
+        status = "explicit_apply_required"
     elif items:
         status = "auto_apply_available"
     return {
@@ -1646,6 +1654,35 @@ def _payload_upgrade_attention_plan_payload(
         "surface_manifest": manifest,
         "attention_item_count": len(items),
         "category_counts": category_counts,
+        "action_semantics": {
+            "blocking_count": blocking_count,
+            "non_auto_attention_count": non_auto_count,
+            "safe_explicit_apply": bool(items) and non_auto_count == 0,
+            "manual_review_required": non_auto_count > 0,
+            "rule": "Package-owned auto-apply drift may require explicit apply without implying manual review.",
+        },
+        "command_boundary": {
+            "reportable_commands": {
+                "dry_run": str(
+                    payload_target.get("reportable_dry_run_command")
+                    or "agentic-workspace upgrade --target . --to-payload-target --dry-run --format json"
+                ),
+                "apply": str(
+                    payload_target.get("reportable_apply_command")
+                    or "agentic-workspace upgrade --target . --to-payload-target --format json"
+                ),
+                "recheck": str(
+                    payload_target.get("reportable_recheck_command")
+                    or "agentic-workspace start --target . --select installed_state_compatibility --format json"
+                ),
+            },
+            "machine_commands": {
+                "dry_run": dry_run_command,
+                "apply": apply_command,
+                "recheck": recheck_command,
+            },
+            "rule": "Reportable commands stay repo-relative; machine commands may include the configured invocation or absolute target path.",
+        },
         "attention_items": items,
         "recheck_command": recheck_command,
         "release_instruction_policy": {
@@ -1664,6 +1701,8 @@ def _compact_payload_upgrade_attention_plan(plan: dict[str, Any]) -> dict[str, A
         "to_payload": plan.get("to_payload"),
         "attention_item_count": plan.get("attention_item_count", 0),
         "category_counts": plan.get("category_counts", {}),
+        "action_semantics": plan.get("action_semantics", {}),
+        "command_boundary": plan.get("command_boundary", {}),
         "attention_items": plan.get("attention_items", []),
         "recheck_command": plan.get("recheck_command", ""),
         "release_instruction_policy": plan.get("release_instruction_policy", {}),
@@ -9349,6 +9388,8 @@ def _run_lifecycle_command(
         cli_invoke=_lifecycle_cli_invoke(config=config),
     )
     if command_name in {"status", "doctor"}:
+        payload["scoped_health"] = _scoped_lifecycle_health_payload(payload)
+    if command_name in {"status", "doctor"}:
         repair_actions, manual_review_actions = _aggregate_repair_actions_from_reports(
             reports, target_root=target_root, cli_invoke=config.cli_invoke, command_name=command_name
         )
@@ -9621,6 +9662,47 @@ def _compact_status_payload(payload: dict[str, Any], *, cli_invoke: str) -> dict
             "detail_command": detail_command,
         }
     return payload
+
+
+def _scoped_lifecycle_health_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    selected_modules = set(_list_payload(payload.get("selected_modules") or payload.get("modules") or []))
+    reports = payload.get("reports", [])
+    selected_warning_count = 0
+    selected_action_count = 0
+    if isinstance(reports, list):
+        for report in reports:
+            if not isinstance(report, dict):
+                continue
+            module_name = str(report.get("module", ""))
+            if selected_modules and module_name not in selected_modules:
+                continue
+            warnings = report.get("warnings", [])
+            actions = report.get("actions", [])
+            selected_warning_count += len(warnings) if isinstance(warnings, list) else int(report.get("warning_count", 0) or 0)
+            if isinstance(actions, list):
+                selected_action_count += sum(
+                    1
+                    for action in actions
+                    if isinstance(action, dict) and str(action.get("kind", "")) not in {"current", "mode", "source", "source age"}
+                )
+            else:
+                selected_action_count += int(report.get("action_count", 0) or 0)
+    global_warning_count = len(payload.get("warnings", [])) if isinstance(payload.get("warnings"), list) else 0
+    global_review_count = len(payload.get("needs_review", [])) if isinstance(payload.get("needs_review"), list) else 0
+    selected_module_health = "attention-needed" if selected_warning_count or selected_action_count else "healthy"
+    global_health = str(payload.get("health", "unknown") or "unknown")
+    return {
+        "kind": "agentic-workspace/scoped-lifecycle-health/v1",
+        "selected_modules": payload.get("selected_modules", payload.get("modules", [])),
+        "selected_module_health": selected_module_health,
+        "selected_warning_count": selected_warning_count,
+        "selected_action_count": selected_action_count,
+        "global_workspace_health": global_health,
+        "global_warning_count": global_warning_count,
+        "global_review_count": global_review_count,
+        "global_warnings_block_scoped_check": False,
+        "rule": "Top-level health includes global workspace warnings; selected_module_health reports only the scoped module lifecycle reports.",
+    }
 
 
 def _cli_compatibility_warning_messages(cli_compatibility: dict[str, Any]) -> list[str]:
@@ -28187,7 +28269,7 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
                 status = "shape_mismatch"
                 reason = "mirrored helper return-key shape differs"
             else:
-                status = "in_sync"
+                status = "shape_in_sync"
                 reason = "mirrored helper return-key shape matches"
         records.append(
             {
@@ -28198,6 +28280,7 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
                 "core_keys": sorted(core_keys),
                 "runtime_mirror_keys": sorted(primitive_keys),
                 "reason": reason,
+                "proof_strength": "return-key-shape",
             }
         )
     failing = [record for record in records if record["status"] in {"mirror_missing", "shape_mismatch"}]
@@ -28208,10 +28291,12 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
         relative_primitives=relative_primitives,
     )
     selector_branch_mismatch = report_runtime_shadowing["status"] == "selector_branch_mismatch"
-    status = "shape_mismatch" if failing else "shadow_mismatch" if selector_branch_mismatch else "in_sync"
+    status = "shape_mismatch" if failing else "shadow_mismatch" if selector_branch_mismatch else "shape_in_sync"
     return {
         "kind": "agentic-workspace/runtime-mirror-surface-consistency/v1",
         "status": status,
+        "proof_strength": "return-key-shape-plus-selector-ownership",
+        "semantic_equivalence_checked": False,
         "mirrored_surface_count": len(records),
         "records": records,
         "report_runtime_shadowing": report_runtime_shadowing,
@@ -28224,7 +28309,7 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
             command="agentic-workspace report --target ./repo --section runtime_mirror_consistency --format json",
             cli_invoke=cli_invoke,
         ),
-        "rule": "Compare the smallest durable mirrored contract: known helper existence, public packet return-key shape, and active report selector ownership.",
+        "rule": "Compare the smallest durable mirrored contract: known helper existence, public packet return-key shape, and active report selector ownership; this is not semantic equivalence proof.",
     }
 
 

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -728,6 +728,9 @@ def _payload_target_sync_commands(*, target_root: Path, config: WorkspaceConfig)
             command=f"agentic-workspace start --target {target} --select installed_state_compatibility --format json",
             cli_invoke=config.cli_invoke,
         ),
+        "reportable_dry_run_command": "agentic-workspace upgrade --target . --to-payload-target --dry-run --format json",
+        "reportable_apply_command": "agentic-workspace upgrade --target . --to-payload-target --format json",
+        "reportable_recheck_command": "agentic-workspace start --target . --select installed_state_compatibility --format json",
     }
 
 
@@ -809,6 +812,9 @@ def _payload_target_status_payload(
         "dry_run_command": commands["dry_run_command"],
         "apply_command": commands["apply_command"],
         "recheck_command": commands["recheck_command"],
+        "reportable_dry_run_command": commands["reportable_dry_run_command"],
+        "reportable_apply_command": commands["reportable_apply_command"],
+        "reportable_recheck_command": commands["reportable_recheck_command"],
         "reason": reason,
         "rule": (
             "Repo-declared payload targets compare checked-in payload provenance against a repo-owned target; "
@@ -1112,10 +1118,12 @@ def _payload_upgrade_attention_plan_payload(
         category = str(item["category"])
         category_counts[category] = category_counts.get(category, 0) + 1
     status = "satisfied"
-    if any(item["blocking"] for item in items):
+    blocking_count = sum(1 for item in items if item["blocking"])
+    non_auto_count = sum(1 for item in items if item["category"] != "auto_applied")
+    if non_auto_count:
         status = "manual_attention_required"
-    elif any(item["category"] != "auto_applied" for item in items):
-        status = "manual_attention_required"
+    elif blocking_count:
+        status = "explicit_apply_required"
     elif items:
         status = "auto_apply_available"
     return {
@@ -1127,6 +1135,35 @@ def _payload_upgrade_attention_plan_payload(
         "surface_manifest": manifest,
         "attention_item_count": len(items),
         "category_counts": category_counts,
+        "action_semantics": {
+            "blocking_count": blocking_count,
+            "non_auto_attention_count": non_auto_count,
+            "safe_explicit_apply": bool(items) and non_auto_count == 0,
+            "manual_review_required": non_auto_count > 0,
+            "rule": "Package-owned auto-apply drift may require explicit apply without implying manual review.",
+        },
+        "command_boundary": {
+            "reportable_commands": {
+                "dry_run": str(
+                    payload_target.get("reportable_dry_run_command")
+                    or "agentic-workspace upgrade --target . --to-payload-target --dry-run --format json"
+                ),
+                "apply": str(
+                    payload_target.get("reportable_apply_command")
+                    or "agentic-workspace upgrade --target . --to-payload-target --format json"
+                ),
+                "recheck": str(
+                    payload_target.get("reportable_recheck_command")
+                    or "agentic-workspace start --target . --select installed_state_compatibility --format json"
+                ),
+            },
+            "machine_commands": {
+                "dry_run": dry_run_command,
+                "apply": apply_command,
+                "recheck": recheck_command,
+            },
+            "rule": "Reportable commands stay repo-relative; machine commands may include the configured invocation or absolute target path.",
+        },
         "attention_items": items,
         "recheck_command": recheck_command,
         "release_instruction_policy": {
@@ -1145,6 +1182,8 @@ def _compact_payload_upgrade_attention_plan(plan: dict[str, Any]) -> dict[str, A
         "to_payload": plan.get("to_payload"),
         "attention_item_count": plan.get("attention_item_count", 0),
         "category_counts": plan.get("category_counts", {}),
+        "action_semantics": plan.get("action_semantics", {}),
+        "command_boundary": plan.get("command_boundary", {}),
         "attention_items": plan.get("attention_items", []),
         "recheck_command": plan.get("recheck_command", ""),
         "release_instruction_policy": plan.get("release_instruction_policy", {}),
@@ -8405,6 +8444,8 @@ def _run_lifecycle_command(
         cli_invoke=_lifecycle_cli_invoke(config=config),
     )
     if command_name in {"status", "doctor"}:
+        payload["scoped_health"] = _scoped_lifecycle_health_payload(payload)
+    if command_name in {"status", "doctor"}:
         repair_actions, manual_review_actions = _aggregate_repair_actions_from_reports(
             reports, target_root=target_root, cli_invoke=config.cli_invoke, command_name=command_name
         )
@@ -8702,6 +8743,47 @@ def _compact_status_payload(payload: dict[str, Any], *, cli_invoke: str) -> dict
             "detail_command": detail_command,
         }
     return payload
+
+
+def _scoped_lifecycle_health_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    selected_modules = set(_list_payload(payload.get("selected_modules") or payload.get("modules") or []))
+    reports = payload.get("reports", [])
+    selected_warning_count = 0
+    selected_action_count = 0
+    if isinstance(reports, list):
+        for report in reports:
+            if not isinstance(report, dict):
+                continue
+            module_name = str(report.get("module", ""))
+            if selected_modules and module_name not in selected_modules:
+                continue
+            warnings = report.get("warnings", [])
+            actions = report.get("actions", [])
+            selected_warning_count += len(warnings) if isinstance(warnings, list) else int(report.get("warning_count", 0) or 0)
+            if isinstance(actions, list):
+                selected_action_count += sum(
+                    1
+                    for action in actions
+                    if isinstance(action, dict) and str(action.get("kind", "")) not in {"current", "mode", "source", "source age"}
+                )
+            else:
+                selected_action_count += int(report.get("action_count", 0) or 0)
+    global_warning_count = len(payload.get("warnings", [])) if isinstance(payload.get("warnings"), list) else 0
+    global_review_count = len(payload.get("needs_review", [])) if isinstance(payload.get("needs_review"), list) else 0
+    selected_module_health = "attention-needed" if selected_warning_count or selected_action_count else "healthy"
+    global_health = str(payload.get("health", "unknown") or "unknown")
+    return {
+        "kind": "agentic-workspace/scoped-lifecycle-health/v1",
+        "selected_modules": payload.get("selected_modules", payload.get("modules", [])),
+        "selected_module_health": selected_module_health,
+        "selected_warning_count": selected_warning_count,
+        "selected_action_count": selected_action_count,
+        "global_workspace_health": global_health,
+        "global_warning_count": global_warning_count,
+        "global_review_count": global_review_count,
+        "global_warnings_block_scoped_check": False,
+        "rule": "Top-level health includes global workspace warnings; selected_module_health reports only the scoped module lifecycle reports.",
+    }
 
 
 def _cli_compatibility_warning_messages(cli_compatibility: dict[str, Any]) -> list[str]:
@@ -25959,7 +26041,7 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
                 status = "shape_mismatch"
                 reason = "mirrored helper return-key shape differs"
             else:
-                status = "in_sync"
+                status = "shape_in_sync"
                 reason = "mirrored helper return-key shape matches"
         records.append(
             {
@@ -25970,6 +26052,7 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
                 "core_keys": sorted(core_keys),
                 "runtime_mirror_keys": sorted(primitive_keys),
                 "reason": reason,
+                "proof_strength": "return-key-shape",
             }
         )
     failing = [record for record in records if record["status"] in {"mirror_missing", "shape_mismatch"}]
@@ -25980,10 +26063,12 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
         relative_primitives=relative_primitives,
     )
     selector_branch_mismatch = report_runtime_shadowing["status"] == "selector_branch_mismatch"
-    status = "shape_mismatch" if failing else "shadow_mismatch" if selector_branch_mismatch else "in_sync"
+    status = "shape_mismatch" if failing else "shadow_mismatch" if selector_branch_mismatch else "shape_in_sync"
     return {
         "kind": "agentic-workspace/runtime-mirror-surface-consistency/v1",
         "status": status,
+        "proof_strength": "return-key-shape-plus-selector-ownership",
+        "semantic_equivalence_checked": False,
         "mirrored_surface_count": len(records),
         "records": records,
         "report_runtime_shadowing": report_runtime_shadowing,
@@ -25996,7 +26081,7 @@ def _runtime_mirror_surface_consistency_payload(*, target_root: Path, cli_invoke
             command="agentic-workspace report --target ./repo --section runtime_mirror_consistency --format json",
             cli_invoke=cli_invoke,
         ),
-        "rule": "Compare the smallest durable mirrored contract: known helper existence, public packet return-key shape, and active report selector ownership.",
+        "rule": "Compare the smallest durable mirrored contract: known helper existence, public packet return-key shape, and active report selector ownership; this is not semantic equivalence proof.",
     }
 
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1953,9 +1953,14 @@ def test_payload_target_required_before_work_blocks_start_until_target_sync(tmp_
     assert compatibility["action_effect"]["allowed_now"] == "run-payload-target-upgrade-before-ordinary-work"
     attention_plan = compatibility["payload_upgrade_attention_plan"]
     assert attention_plan["kind"] == "agentic-workspace/payload-upgrade-attention-plan/v1"
+    assert attention_plan["status"] == "explicit_apply_required"
     assert attention_plan["strategy"] == "converge-to-current-contract"
     assert attention_plan["release_instruction_policy"]["uses_release_history"] is False
     assert attention_plan["category_counts"]["auto_applied"] >= 1
+    assert attention_plan["action_semantics"]["safe_explicit_apply"] is True
+    assert attention_plan["action_semantics"]["manual_review_required"] is False
+    assert attention_plan["command_boundary"]["reportable_commands"]["dry_run"].startswith("agentic-workspace upgrade --target .")
+    assert tmp_path.as_posix() in attention_plan["command_boundary"]["machine_commands"]["dry_run"]
     assert all("release" not in item["required_action"].lower() for item in attention_plan["attention_items"])
     assert compatibility["payload_surface_manifest"]["kind"] == "agentic-workspace/payload-surface-manifest/v1"
 
@@ -1971,7 +1976,10 @@ def test_payload_target_required_before_work_blocks_start_until_target_sync(tmp_
     selected_doctor = json.loads(capsys.readouterr().out)["values"]["installed_state_compatibility"]
     assert selected_doctor["payload"]["target"]["status"] == "target-mismatch"
     assert selected_doctor["action_effect"]["force"] == "required_before_execution"
-    assert selected_doctor["payload_upgrade_attention_plan"]["status"] == attention_plan["status"]
+    selected_plan = selected_doctor["payload_upgrade_attention_plan"]
+    assert selected_plan["status"] in {"explicit_apply_required", "manual_attention_required"}
+    if selected_plan["status"] == "manual_attention_required":
+        assert selected_plan["action_semantics"]["manual_review_required"] is True
 
     assert (
         cli.main(
@@ -5749,7 +5757,9 @@ def _pr_comment_attention_payload():
     primitives.write_text(core.read_text(encoding="utf-8"), encoding="utf-8")
     assert cli.main(["report", "--target", str(tmp_path), "--section", "runtime_mirror_consistency", "--format", "json"]) == 0
     in_sync = json.loads(capsys.readouterr().out)["answer"]
-    assert in_sync["status"] == "in_sync"
+    assert in_sync["status"] == "shape_in_sync"
+    assert in_sync["proof_strength"] == "return-key-shape-plus-selector-ownership"
+    assert in_sync["semantic_equivalence_checked"] is False
 
 
 def test_report_runtime_mirror_consistency_surfaces_active_selector_shadowing(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_doctor_status_cli.py
+++ b/tests/test_workspace_doctor_status_cli.py
@@ -657,6 +657,9 @@ def test_doctor_module_filter_does_not_warn_about_omitted_installed_modules(tmp_
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["modules"] == ["planning"]
+    assert payload["scoped_health"]["selected_modules"] == ["planning"]
+    assert payload["scoped_health"]["selected_module_health"] == "healthy"
+    assert payload["scoped_health"]["global_warnings_block_scoped_check"] is False
     assert payload["residue_modules"] == []
     assert not any("installed module 'memory' is not enabled" in warning for warning in payload["warnings"])
     assert not any("installed module 'verification' is not enabled" in warning for warning in payload["warnings"])
@@ -666,6 +669,55 @@ def test_doctor_module_filter_does_not_warn_about_omitted_installed_modules(tmp_
     unscoped_payload = json.loads(capsys.readouterr().out)
     assert unscoped_payload["residue_modules"] == ["verification"]
     assert any("installed module 'verification' is not enabled" in warning for warning in unscoped_payload["warnings"])
+
+
+def test_scoped_lifecycle_health_does_not_block_selected_module_on_global_warnings() -> None:
+    from agentic_workspace.workspace_runtime_core import _scoped_lifecycle_health_payload
+
+    payload = {
+        "selected_modules": ["planning"],
+        "health": "attention-needed",
+        "warnings": ["workspace-level warning outside the selected module"],
+        "needs_review": [],
+        "reports": [
+            {
+                "module": "planning",
+                "warnings": [],
+                "actions": [],
+            }
+        ],
+    }
+
+    scoped_health = _scoped_lifecycle_health_payload(payload)
+
+    assert scoped_health["selected_module_health"] == "healthy"
+    assert scoped_health["global_warning_count"] == 1
+    assert scoped_health["global_warnings_block_scoped_check"] is False
+
+
+def test_scoped_lifecycle_health_reports_selected_module_attention_without_global_warning_blocking() -> None:
+    from agentic_workspace.workspace_runtime_core import _scoped_lifecycle_health_payload
+
+    payload = {
+        "selected_modules": ["planning"],
+        "health": "attention-needed",
+        "warnings": [],
+        "needs_review": [],
+        "reports": [
+            {
+                "module": "planning",
+                "warnings": ["planning manifest needs review"],
+                "actions": [],
+            }
+        ],
+    }
+
+    scoped_health = _scoped_lifecycle_health_payload(payload)
+
+    assert scoped_health["selected_module_health"] == "attention-needed"
+    assert scoped_health["selected_warning_count"] == 1
+    assert scoped_health["global_warning_count"] == 0
+    assert scoped_health["global_warnings_block_scoped_check"] is False
 
 
 def test_status_flags_missing_workspace_shared_layer(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

- Splits payload-target diagnostics between safe explicit apply and manual attention, with repo-relative reportable commands separate from machine-local commands.
- Adds scoped lifecycle health for `status`/`doctor` so selected-module health is not blocked by unrelated global workspace warnings or informational module actions.
- Renames runtime mirror success from `in_sync` to `shape_in_sync` and states the proof strength explicitly as return-key shape plus selector ownership, not semantic equivalence.
- Keeps core and primitives mirrored for the changed diagnostic payloads.

## Stack

1. #2106: report task-scope propagation.
2. #2107: current-task closeout proof/claim composition.
3. This PR: diagnostic wording and scoped lifecycle health for #2104.

#2103 remains open unless issue-level evidence separately proves the existing thread-switch acknowledgement/stale-thread behavior satisfies it.

Refs #2098, #2104. Related: #2103.

## Dogfooding

AW transcript/log is combined in `.agentic-workspace/local/issue-2098-aw-transcript/transcript.md`, with raw AW command input/output beside it. Dogfooding closeout surfaced one durable friction point: `skills --task "dogfooding closeout review"` was noisy and ranked generic review ahead of the dogfooding skill. Filed draft follow-up #2105.

## Proof

Review-specific proof after the scoped-health fix:

- `uv run pytest tests/test_workspace_doctor_status_cli.py::test_doctor_module_filter_does_not_warn_about_omitted_installed_modules tests/test_workspace_doctor_status_cli.py::test_scoped_lifecycle_health_does_not_block_selected_module_on_global_warnings tests/test_workspace_doctor_status_cli.py::test_scoped_lifecycle_health_reports_selected_module_attention_without_global_warning_blocking -q` -> 3 passed
- `uv run pytest tests/test_workspace_doctor_status_cli.py -q` -> 41 passed
- `uv run ruff check src/agentic_workspace/workspace_runtime_core.py src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_doctor_status_cli.py`

Final top-of-stack proof run after all review fixes:

- `make test-workspace` -> passed
- `make maintainer-surfaces` -> passed
- `make lint-workspace` -> passed
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success` -> passed
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success` -> passed
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py` -> passed
- `uv run pytest tests/test_workspace_cli.py -q` -> 173 passed
- `make schema-reference-docs` -> passed
- `make typecheck` -> passed
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json` -> `shape_in_sync`

Closeout boundary: #2098 parent closure remains blocked until PR review/merge and planning closeout evidence authorize it.
