### PR TITLE
Prefer dogfooding skill for dogfooding closeout routing

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -49022,6 +49022,10 @@ def _recommend_skills(*, task_text: str, skills: list[RegisteredSkill]) -> list[
         if summary_overlap:
             score += len(summary_overlap)
             reasons.append(f"summary overlap: {', '.join(summary_overlap)}")
+        if _dogfooding_skill_route_boost(task_tokens=task_tokens, skill=skill):
+            score += 8
+            hint_score += 8
+            reasons.append("explicit dogfooding task route")
         if score > 0:
             recommendations.append(SkillRecommendation(skill=skill, hint_score=hint_score, score=score, reasons=tuple(reasons)))
     if any((recommendation.hint_score > 0 for recommendation in recommendations)):
@@ -49095,6 +49099,13 @@ def _summary_overlap_tokens(*, skill: RegisteredSkill, task_tokens: set[str]) ->
         if len(token) >= 4 and token not in {"skill", "skills", "task", "tasks", "repo", "repository", "current"}
     }
     return sorted(candidate_tokens & task_tokens)
+
+
+def _dogfooding_skill_route_boost(*, task_tokens: set[str], skill: RegisteredSkill) -> bool:
+    if not ({"dogfood", "dogfooding"} & task_tokens):
+        return False
+    skill_tokens = set(_skill_match_tokens(f"{skill.skill_id} {skill.summary}"))
+    return bool({"dogfood", "dogfooding"} & skill_tokens)
 
 
 def _skill_match_tokens(text: str) -> list[str]:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -45747,6 +45747,10 @@ def _recommend_skills(*, task_text: str, skills: list[RegisteredSkill]) -> list[
         if summary_overlap:
             score += len(summary_overlap)
             reasons.append(f"summary overlap: {', '.join(summary_overlap)}")
+        if _dogfooding_skill_route_boost(task_tokens=task_tokens, skill=skill):
+            score += 8
+            hint_score += 8
+            reasons.append("explicit dogfooding task route")
         if score > 0:
             recommendations.append(SkillRecommendation(skill=skill, hint_score=hint_score, score=score, reasons=tuple(reasons)))
     if any((recommendation.hint_score > 0 for recommendation in recommendations)):
@@ -45820,6 +45824,13 @@ def _summary_overlap_tokens(*, skill: RegisteredSkill, task_tokens: set[str]) ->
         if len(token) >= 4 and token not in {"skill", "skills", "task", "tasks", "repo", "repository", "current"}
     }
     return sorted(candidate_tokens & task_tokens)
+
+
+def _dogfooding_skill_route_boost(*, task_tokens: set[str], skill: RegisteredSkill) -> bool:
+    if not ({"dogfood", "dogfooding"} & task_tokens):
+        return False
+    skill_tokens = set(_skill_match_tokens(f"{skill.skill_id} {skill.summary}"))
+    return bool({"dogfood", "dogfooding"} & skill_tokens)
 
 
 def _skill_match_tokens(text: str) -> list[str]:

--- a/tests/test_workspace_skills_cli.py
+++ b/tests/test_workspace_skills_cli.py
@@ -708,6 +708,29 @@ def test_skills_command_prefers_dogfooding_for_evaluation_scenarios(capsys) -> N
     assert payload["recommendations"][0]["id"] == "self-improvement-dogfooding"
 
 
+def test_skills_command_prefers_dogfooding_for_closeout_review(capsys) -> None:
+    assert (
+        cli.main(
+            [
+                "skills",
+                "--target",
+                ".",
+                "--task",
+                "dogfooding closeout review",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["recommendations"]
+    assert payload["recommendations"][0]["id"] == "self-improvement-dogfooding"
+    assert payload["top_recommendations"][0]["id"] == "self-improvement-dogfooding"
+    assert "explicit dogfooding task route" in payload["recommendations"][0]["reasons"]
+
+
 def test_skills_command_recommends_self_improvement_for_hyphenated_dogfooding_task(tmp_path: Path, capsys) -> None:
     target = tmp_path / "repo"
     target.mkdir()


### PR DESCRIPTION
## Summary

- Adds a narrow explicit-dogfooding routing boost for skills whose own id or summary is dogfooding-shaped.
- Keeps ordinary review routing unchanged while making `dogfooding closeout review` rank `self-improvement-dogfooding` first.
- Mirrors the helper in `workspace_runtime_primitives.py` and pins the exact #2105 phrase in the skills CLI tests.

Closes #2105.

## Transcript

Combined AW transcript/log continues at `.agentic-workspace/local/issue-2098-aw-transcript/transcript.md` with entries 032-039 for this issue.

## Proof

- `uv run pytest tests/test_workspace_skills_cli.py::test_skills_command_prefers_dogfooding_for_closeout_review tests/test_workspace_skills_cli.py::test_skills_command_recommends_review_skill_for_natural_review_request tests/test_workspace_skills_cli.py::test_skills_command_recommends_repo_dogfooding_for_skill_optimisation_loop tests/test_workspace_skills_cli.py::test_skills_command_prefers_dogfooding_for_evaluation_scenarios -q` -> 4 passed
- `uv run pytest tests/test_workspace_skills_cli.py -q` -> 26 passed
- `uv run ruff check src/agentic_workspace/workspace_runtime_core.py src/agentic_workspace/workspace_runtime_primitives.py tests/test_workspace_skills_cli.py`
- `uv run python scripts/run_agentic_workspace.py skills --target . --task "dogfooding closeout review" --format json` -> top recommendation `self-improvement-dogfooding`
- `make test-workspace` -> passed
- `make lint-workspace` -> passed
- `uv run pytest tests/test_workspace_cli.py -q` -> 173 passed
- `make typecheck` -> passed
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json` -> `shape_in_sync`
- `make maintainer-surfaces` -> passed

Closeout boundary: AW closeout reports broad/full closure remains blocked without proof receipts or active planning closeout state; this PR is a bounded #2105 implementation slice with command proof above.
