### PR TITLE
Stabilize necessary memory skill EOFs

### DIFF
--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -8350,6 +8350,20 @@ def _sync_bytes_surface_action(
     }
 
 
+_NECESSARY_MEMORY_SKILL_TEXT_SUFFIXES = {".json", ".md", ".yaml", ".yml"}
+
+
+def _canonical_necessary_memory_skill_bytes(*, relative: Path, source_bytes: bytes) -> bytes:
+    if (
+        relative.suffix.lower() not in _NECESSARY_MEMORY_SKILL_TEXT_SUFFIXES
+        or not relative.as_posix().startswith(".agentic-workspace/memory/skills/")
+        or not source_bytes.endswith((b"\n", b"\r"))
+    ):
+        return source_bytes
+    newline = b"\r\n" if source_bytes.endswith(b"\r\n") else b"\n"
+    return source_bytes.rstrip(b"\r\n") + newline
+
+
 def _sync_tree_surface_actions(
     *,
     source_root: Path,
@@ -8369,7 +8383,10 @@ def _sync_tree_surface_actions(
             _sync_bytes_surface_action(
                 target_root=target_root,
                 relative=relative,
-                source_bytes=source.read_bytes(),
+                source_bytes=_canonical_necessary_memory_skill_bytes(
+                    relative=relative,
+                    source_bytes=source.read_bytes(),
+                ),
                 dry_run=dry_run,
                 detail=detail,
             )

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -2153,6 +2153,59 @@ def test_upgrade_to_necessary_surfaces_preserves_durable_state_and_uses_package_
     assert "necessary surfaces" not in json.dumps(status_payload).lower()
 
 
+def test_upgrade_to_necessary_surfaces_keeps_current_memory_skill_eof_stable(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--modules", "memory", "--format", "json"]) == 0
+    capsys.readouterr()
+
+    package_root = tmp_path / "memory-package-payload"
+    package_skills = package_root / ".agentic-workspace" / "memory" / "skills"
+    cases = {
+        Path("REGISTRY.json"): b'{\n  "skills": []\n}\n',
+        Path("memory-refresh") / "SKILL.md": b"---\nname: memory-refresh\n---\n\n# Memory Refresh\n",
+        Path("memory-upgrade") / "agents" / "openai.yaml": b"instructions: keep stable\n",
+    }
+    for relative, canonical in cases.items():
+        source = package_skills / relative
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes(canonical + b"\n")
+        target = workspace / "memory" / "skills" / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(canonical)
+
+    import repo_memory_bootstrap._installer_paths as memory_paths
+
+    monkeypatch.setattr(memory_paths, "payload_root", lambda: package_root)
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-necessary-surfaces", "--format", "json"]) == 0
+    migration = json.loads(capsys.readouterr().out)["migration"]
+
+    actions_by_path = {action["path"]: action for action in migration["actions"]}
+    checked_paths = []
+    for relative, canonical in cases.items():
+        installed = workspace / "memory" / "skills" / relative
+        assert installed.read_bytes() == canonical
+        installed_relative = installed.relative_to(tmp_path).as_posix()
+        checked_paths.append(installed_relative)
+        assert actions_by_path[installed_relative]["kind"] == "current"
+
+    diff_check = subprocess.run(["git", "diff", "--check"], cwd=tmp_path, capture_output=True, text=True, check=False)
+    assert diff_check.returncode == 0, diff_check.stdout + diff_check.stderr
+    skill_diff = subprocess.run(
+        ["git", "diff", "--name-only", "--", *checked_paths],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert skill_diff.returncode == 0
+    assert skill_diff.stdout == ""
+
+
 def test_upgrade_to_necessary_surfaces_leaves_doctor_healthy_after_apply(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     workspace = tmp_path / ".agentic-workspace"


### PR DESCRIPTION
## Summary

Fixes #2096.

- Canonicalizes required memory skill text payloads during `upgrade --to-necessary-surfaces` so generated `.json`, `.md`, `.yaml`, and `.yml` memory skill surfaces end with exactly one newline before byte comparison/write.
- Keeps the normalization scoped to `.agentic-workspace/memory/skills/` so other package payload byte-copy behavior is unchanged.
- Adds a downstream-style regression where package memory skill sources contain an extra blank EOF line but the target already has canonical JSON, Markdown, and YAML files; the upgrade reports them current, leaves them byte-stable, and `git diff --check` passes.

## Validation

- `uv run pytest tests/test_workspace_cli.py::test_upgrade_to_necessary_surfaces_keeps_current_memory_skill_eof_stable -q`
- `make test-workspace` (first run hit tool timeout; rerun with longer timeout passed)
- `make lint-workspace`
- `uv run pytest tests/test_workspace_cli.py -q`
- `make typecheck`
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`
- `uv run python scripts/run_agentic_workspace.py upgrade --target . --to-necessary-surfaces --dry-run --format json`
- `uv run python scripts/run_agentic_workspace.py status --target . --format json`
- `uv run python scripts/run_agentic_workspace.py report --target . --section closeout_trust --task "Implement #2096+" --changed src/agentic_workspace/workspace_runtime_core.py tests/test_workspace_cli.py --format json`
- `git diff --check`

## Notes

AW `status` still reports pre-existing installed payload target drift on the base branch. I did not include the broad payload-target sync in this PR because it would touch many unrelated AW-managed surfaces; the #2096 behavior proof and runtime mirror proof passed.
