### PR TITLE
Finish remaining continuation routing issues

### DIFF
--- a/.agentic-workspace/memory/UPGRADE-SOURCE.toml
+++ b/.agentic-workspace/memory/UPGRADE-SOURCE.toml
@@ -1,5 +1,5 @@
 source_type = "git"
 source_ref = "git+https://github.com/rickardvh/agentic-workspace@master#subdirectory=packages/memory"
 source_label = "agentic-memory monorepo master"
-recorded_at = "2026-07-08"
+recorded_at = "2026-07-09"
 recommended_upgrade_after_days = 30

--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,8 +13,8 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:6ddd6b72041f",
-    "version": "0.29.1"
+    "source_identity": "git:c16d91f23a93",
+    "version": "0.32.1"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
   "payload_capabilities": [
@@ -40,8 +40,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.29.1",
-    "version": "0.29.1"
+    "tag": "v0.32.1",
+    "version": "0.32.1"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/.agentic-workspace/planning/UPGRADE-SOURCE.toml
+++ b/.agentic-workspace/planning/UPGRADE-SOURCE.toml
@@ -1,5 +1,5 @@
 source_type = "git"
 source_ref = "git+https://github.com/rickardvh/agentic-workspace@master#subdirectory=packages/planning"
 source_label = "agentic-planning monorepo master"
-recorded_at = "2026-07-08"
+recorded_at = "2026-07-09"
 recommended_upgrade_after_days = 30

--- a/.agentic-workspace/planning/execplans/archive/issue-2097-2098-2103.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/issue-2097-2098-2103.plan.json
@@ -1,0 +1,402 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Finish #2097/#2103/#2098 continuation routing",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Resolve the remaining #2096+ issues: #2097 post-closeout verification routing, #2103 task-switch acknowledgement and stale-thread cleanup, and #2098 parent-lane closure evidence; keep the installed payload synced.",
+    "hard_constraints": "Keep scope bounded to the continuation-routing fixes, local work-thread cleanup, compact payload visibility, focused regression tests, and payload sync surfaces already identified for this branch.",
+    "agent_may_decide": "Tighten compact output shape, add focused regressions, update operation contracts for local checkpoint pruning, and choose the narrowest proof that covers runtime, payload, and planning custody.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Run the selected proof, reconcile acceptance for #2097/#2103/#2098, then close out this active plan.",
+    "proof_expectations": [
+      "Focused workspace CLI regressions for post-closeout routing, current-task acknowledgement, and stale checkpoint pruning pass.",
+      "Workspace-wide proof selected by AW implement passes for runtime, payload, contract, lint, typecheck, and mirror consistency surfaces."
+    ],
+    "touched_scope": [
+      ".agentic-workspace payload sync surfaces",
+      ".agentic-workspace/planning/state.toml",
+      ".agentic-workspace/planning/execplans/archive/issue-2097-2098-2103.plan.json",
+      "src/agentic_workspace/contracts/operations/work-thread.prune.json",
+      "src/agentic_workspace/workspace_runtime_core.py",
+      "src/agentic_workspace/workspace_runtime_implement.py",
+      "src/agentic_workspace/workspace_runtime_planning.py",
+      "src/agentic_workspace/workspace_runtime_primitives.py",
+      "tests/test_workspace_cli.py",
+      "tests/test_workspace_implement_cli.py"
+    ],
+    "completion_criteria": [
+      "#2097 no longer hard-blocks post-closeout implementation checks when completed archived planning residue accompanies implementation paths.",
+      "#2103 returns visible current-task acknowledgement, active-plan return guidance, and stale local checkpoint cleanup routing.",
+      "#2098 has child-issue closure evidence and payload sync proof without weakening conservative active-plan claim boundaries."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Resolve #2097, #2103, and #2098 while syncing the installed payload."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Resolve #2097, #2103, and #2098 while syncing the installed payload.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "issue-2097-2098-2103",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        ".agentic-workspace payload sync surfaces",
+        ".agentic-workspace/planning/state.toml",
+        ".agentic-workspace/planning/execplans/archive/issue-2097-2098-2103.plan.json",
+        "src/agentic_workspace/contracts/operations/work-thread.prune.json",
+        "src/agentic_workspace/workspace_runtime_core.py",
+        "src/agentic_workspace/workspace_runtime_implement.py",
+        "src/agentic_workspace/workspace_runtime_planning.py",
+        "src/agentic_workspace/workspace_runtime_primitives.py",
+        "tests/test_workspace_cli.py"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Resolve the remaining #2096+ continuation-routing issues and keep the AW payload synced.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "A single checked-in owner for the #2097/#2103/#2098 remainder after the prior #2096-only PR merged.",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "focused regressions passed; broad proof still pending",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Finish #2097/#2103/#2098 continuation routing",
+    "inferred intended outcome": "Resolve the remaining #2096+ continuation-routing issues and keep the AW payload synced.",
+    "chosen concrete what": "Patch routing payloads, compact implementation output, local checkpoint pruning, operation contract write safety, and focused regressions.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": ".agentic-workspace payload sync surfaces, this plan/state closeout residue, work-thread prune contract, workspace runtime routing modules, and focused workspace CLI tests.",
+    "max changed files": "Expected upper bound: about 15 checked-in files including payload sync and closeout residue.",
+    "required validation commands": "Focused regressions plus the AW-selected proof list from implement --changed.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated backlog, adjacent modules, or canonical contracts not named by this plan."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue by running the selected proof and closing out #2097/#2103/#2098 with payload sync evidence.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Resolve #2097, #2103, and #2098 while syncing the installed payload.",
+    "hard constraints": "Keep scope bounded to the continuation-routing fixes, local checkpoint cleanup, compact output visibility, tests, and payload sync surfaces.",
+    "agent may decide locally": "Adjust compact/detail payload shape, focused regressions, and local-only cleanup contract wording needed for the accepted issue behavior.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "issue-2097-2098-2103",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run the selected proof, reconcile acceptance for #2097/#2103/#2098, and close out the plan."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    ".agentic-workspace payload sync surfaces",
+    ".agentic-workspace/planning/state.toml",
+    ".agentic-workspace/planning/execplans/archive/issue-2097-2098-2103.plan.json",
+    "src/agentic_workspace/contracts/operations/work-thread.prune.json",
+    "src/agentic_workspace/workspace_runtime_core.py",
+    "src/agentic_workspace/workspace_runtime_implement.py",
+    "src/agentic_workspace/workspace_runtime_planning.py",
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "tests/test_workspace_cli.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_cli.py::test_implement_routes_post_closeout_archive_residue_as_verification tests/test_workspace_cli.py::test_implement_acknowledges_current_task_switch_with_return_and_cleanup_routes tests/test_workspace_cli.py::test_local_work_threads_prune_can_remove_stale_checkpoint_fallback -q",
+    "AW-selected broad proof commands before closeout"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "#2097, #2103, and #2098 acceptance evidence is satisfied or explicitly qualified, payload sync is current, and the active plan is closed out honestly."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented the remaining #2096+ issues: #2097 post-closeout verification routing, #2103 task-switch acknowledgement and stale local checkpoint pruning, and #2098 parent-lane closure evidence, with installed payload sync.",
+    "scope touched": "Workspace runtime planning/core/implement/primitives, work-thread prune operation contract and generated TypeScript resource, focused workspace CLI regressions, installed payload provenance/source files, and this planning closeout.",
+    "changed surfaces": "Runtime routing and compact implement output; local work-thread cleanup; work-thread prune write contract; generated operation resource; tests/test_workspace_cli.py; tests/test_workspace_implement_cli.py; AW payload sync files; planning state/closeout residue.",
+    "validations run": "Passed: focused regression trio; make test-workspace; make lint-workspace; uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/check/run_operation_conformance_tests.py --target all; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; uv run pytest tests/test_workspace_cli.py -q; make typecheck; AW summary, planning doctor, defaults root_cli_authority, and runtime_mirror_consistency report.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed bounded to #2097/#2103/#2098 plus payload sync. Host-agnostic routing was preserved by using explicit changed-path/planning/checkpoint state rather than repo-specific issue taxonomy. Generated CLI freshness and runtime mirror checks passed.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Passed: focused regression trio; make test-workspace; make lint-workspace; uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/check/run_operation_conformance_tests.py --target all; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; uv run pytest tests/test_workspace_cli.py -q; make typecheck; AW summary, planning doctor, defaults root_cli_authority, and runtime_mirror_consistency report.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "Passed: focused regression trio; make test-workspace; make lint-workspace; uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/check/run_operation_conformance_tests.py --target all; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; uv run pytest tests/test_workspace_cli.py -q; make typecheck; AW summary, planning doctor, defaults root_cli_authority, and runtime_mirror_consistency report."
+  },
+  "intent_satisfaction": {
+    "original intent": "Resolve #2097, #2103, and #2098 while syncing the installed payload.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "#2097 routes completed archived planning residue as post-closeout verification instead of missing-owner failure; #2103 exposes current-task return/cleanup commands and prunes stale checkpoint fallback; #2098 has closure evidence for the remaining child issues with conservative active-plan claim boundaries preserved; payload is synced to 0.32.1.",
+    "validation confirmed": "Passed: focused regression trio; make test-workspace; make lint-workspace; uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/check/run_operation_conformance_tests.py --target all; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; uv run pytest tests/test_workspace_cli.py -q; make typecheck; AW summary, planning doctor, defaults root_cli_authority, and runtime_mirror_consistency report.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a lane claim with intent-status satisfied.",
+    "evidence carried forward": "Passed: focused regression trio; make test-workspace; make lint-workspace; uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/check/run_operation_conformance_tests.py --target all; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; uv run pytest tests/test_workspace_cli.py -q; make typecheck; AW summary, planning doctor, defaults root_cli_authority, and runtime_mirror_consistency report.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-09: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete",
+        "issue_closure"
+      ],
+      "blocked_claim_classes": [],
+      "closure_actions": [
+        {
+          "kind": "issue_closure",
+          "target": "#2097",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        },
+        {
+          "kind": "issue_closure",
+          "target": "#2098",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        },
+        {
+          "kind": "issue_closure",
+          "target": "#2103",
+          "authorized": true,
+          "reason": "issue closure requires full-intent completion authorization from the completion gate"
+        }
+      ],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Resolve #2097, #2103, and #2098 while syncing the installed payload.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Passed: focused regression trio; make test-workspace; make lint-workspace; uv run python scripts/generate/generate_command_packages.py --check; uv run python scripts/check/check_generated_command_packages.py; uv run python scripts/check/run_operation_conformance_tests.py --target all; uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success; uv run python scripts/check/check_structured_file_inventory.py --quiet-success; uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py; uv run pytest tests/test_workspace_cli.py -q; make typecheck; AW summary, planning doctor, defaults root_cli_authority, and runtime_mirror_consistency report.\nChanged surfaces: Runtime routing and compact implement output; local work-thread cleanup; work-thread prune write contract; generated operation resource; tests/test_workspace_cli.py; tests/test_workspace_implement_cli.py; AW payload sync files; planning state/closeout residue.\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/generated/workspace/typescript/resources/operations/work-thread.prune.json
+++ b/generated/workspace/typescript/resources/operations/work-thread.prune.json
@@ -14,7 +14,7 @@
   },
   "guards": [
     "Prune only records already present in work_threads.cleanup.prune_candidates.",
-    "Delete only .agentic-workspace/local/work-threads/*.json files, never index.json, chat-checkpoint.json, Planning, Memory, Verification, docs, issues, PRs, or proof receipts.",
+    "Delete only current cleanup candidates under .agentic-workspace/local/work-threads/*.json or the stale checkpoint fallback at .agentic-workspace/local/chat-checkpoint.json; never delete index.json, Planning, Memory, Verification, docs, issues, PRs, or proof receipts.",
     "Do not infer task completion from stale or pruned local state."
   ],
   "id": "work-thread.prune",
@@ -122,6 +122,11 @@
       "required": false,
       "surface": ".agentic-workspace/local/work-threads/*.json",
       "when": "remove selected safe local work-thread prune candidates"
+    },
+    {
+      "required": false,
+      "surface": ".agentic-workspace/local/chat-checkpoint.json",
+      "when": "remove the selected stale checkpoint fallback candidate"
     }
   ]
 }

--- a/src/agentic_workspace/contracts/operations/work-thread.prune.json
+++ b/src/agentic_workspace/contracts/operations/work-thread.prune.json
@@ -66,6 +66,11 @@
       "surface": ".agentic-workspace/local/work-threads/*.json",
       "required": false,
       "when": "remove selected safe local work-thread prune candidates"
+    },
+    {
+      "surface": ".agentic-workspace/local/chat-checkpoint.json",
+      "required": false,
+      "when": "remove the selected stale checkpoint fallback candidate"
     }
   ],
   "steps": [
@@ -87,7 +92,7 @@
   ],
   "guards": [
     "Prune only records already present in work_threads.cleanup.prune_candidates.",
-    "Delete only .agentic-workspace/local/work-threads/*.json files, never index.json, chat-checkpoint.json, Planning, Memory, Verification, docs, issues, PRs, or proof receipts.",
+    "Delete only current cleanup candidates under .agentic-workspace/local/work-threads/*.json or the stale checkpoint fallback at .agentic-workspace/local/chat-checkpoint.json; never delete index.json, Planning, Memory, Verification, docs, issues, PRs, or proof receipts.",
     "Do not infer task completion from stale or pruned local state."
   ],
   "proof": [

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -26725,9 +26725,17 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         changed_path_facts = _as_dict(gate.get("changed_path_facts") or gate.get("changed_path_classification"))
         compact["changed_path_facts"] = {
             key: changed_path_facts.get(key)
-            for key in ("dirty_shape", "surface_root_count", "scope_growth_detected", "scope_growth_reasons")
+            for key in (
+                "dirty_shape",
+                "surface_root_count",
+                "scope_growth_detected",
+                "scope_growth_reasons",
+                "archived_planning_residue",
+            )
             if changed_path_facts.get(key) not in (None, "", [], {})
         }
+        if compact.get("gate_result") == "post-closeout-verification" and "archived_planning_residue" not in compact["changed_path_facts"]:
+            compact["changed_path_facts"]["archived_planning_residue"] = {"status": "completed-closeout-residue"}
     if "work_shape_guidance" in gate and gate.get("workflow_sufficient") is False:
         compact["work_shape_guidance"] = _tiny_work_shape_guidance(gate["work_shape_guidance"])
     if isinstance(task_switch, dict) and task_switch.get("status") in {
@@ -26756,7 +26764,15 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         if route_acknowledgement:
             compact_switch["route_acknowledgement"] = {
                 key: route_acknowledgement.get(key)
-                for key in ("status", "route", "changed_path_count", "claim_boundary", "proof_rule")
+                for key in (
+                    "status",
+                    "route",
+                    "changed_path_count",
+                    "claim_boundary",
+                    "proof_rule",
+                    "return_to_active_plan",
+                    "stale_thread_cleanup",
+                )
                 if route_acknowledgement.get(key) not in (None, "", [], {})
             }
         if active_plan_protection.get("claim_boundary"):
@@ -26891,6 +26907,8 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         }
     if compact.get("status") in {"clear", "satisfied", "attention"}:
         for noisy_key in ("authority_boundary", "candidate_pressure", "decomposition", "changed_path_facts", "planning_revision"):
+            if noisy_key == "changed_path_facts" and compact.get("gate_result") == "post-closeout-verification":
+                continue
             compact.pop(noisy_key, None)
     compact["detail_selector"] = "planning_safety_gate"
     return {key: value for key, value in compact.items() if value is not None}
@@ -31858,6 +31876,25 @@ def _local_work_threads_projection(*, target_root: Path, cli_invoke: str, task_t
             or "branch-missing" in thread["stale_reasons"]
         )
     ]
+    prune_candidates.extend(
+        {
+            "id": thread["id"],
+            "path": thread["path"],
+            "stale_reasons": thread["stale_reasons"],
+            "safe_to_forget": True,
+            "source": "local_chat_checkpoint",
+            "rule": "Forgetting removes only ignored local checkpoint fallback state and never proves completion.",
+        }
+        for thread in stale_threads
+        if thread["source"] == "local_chat_checkpoint"
+        and thread["id"] == "checkpoint-default"
+        and thread["path"] == LOCAL_CHAT_CHECKPOINT_PATH.as_posix()
+        and (
+            "old-unused-thread" in thread["stale_reasons"]
+            or "external-owner-closed" in thread["stale_reasons"]
+            or "branch-missing" in thread["stale_reasons"]
+        )
+    )
     if unreadable:
         status = "unreadable"
     elif selected_id and not selected_matches:
@@ -32147,6 +32184,14 @@ def _resolve_local_work_thread_prune_path(*, target_root: Path, candidate: dict[
     relative = Path(relative_text)
     if relative.is_absolute() or relative.name == "index.json" or relative.suffix != ".json":
         return None
+    if (
+        str(candidate.get("id") or "") == "checkpoint-default"
+        and str(candidate.get("source") or "") == "local_chat_checkpoint"
+        and relative.as_posix() == LOCAL_CHAT_CHECKPOINT_PATH.as_posix()
+    ):
+        target = (target_root / relative).resolve()
+        expected = (target_root / LOCAL_CHAT_CHECKPOINT_PATH).resolve()
+        return target if target == expected else None
     expected_root = _local_work_thread_root(target_root).resolve()
     target = (target_root / relative).resolve()
     try:

--- a/src/agentic_workspace/workspace_runtime_implement.py
+++ b/src/agentic_workspace/workspace_runtime_implement.py
@@ -1734,6 +1734,7 @@ def _tiny_implement_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     "surface_root_count",
                     "scope_growth_detected",
                     "scope_growth_reasons",
+                    "archived_planning_residue",
                 )
                 if key in changed_path_facts
             }

--- a/src/agentic_workspace/workspace_runtime_planning.py
+++ b/src/agentic_workspace/workspace_runtime_planning.py
@@ -760,6 +760,17 @@ def _acknowledged_current_task_switch_payload(
         "changed_path_count": len(changed_paths),
         "claim_boundary": "Current task is intentionally separate; do not claim active-plan progress, completion, or abandonment.",
         "proof_rule": "Use current-task proof only.",
+        "return_to_active_plan": {
+            "status": "available",
+            "command": "agentic-workspace summary --target . --format json",
+            "rule": "Return by rereading checked-in Planning; route acknowledgement is not an active-plan mutation.",
+        },
+        "stale_thread_cleanup": {
+            "status": "available",
+            "inspect_command": "agentic-workspace start --target . --select work_threads --format json",
+            "prune_command": "agentic-workspace work-thread prune --target . --all-candidates --dry-run --format json",
+            "rule": "Prune only local advisory candidates; never use pruning as completion proof.",
+        },
     }
     acknowledged["rule"] = (
         "Changed-path implementation context can acknowledge the current-task route when planning-owned surfaces are not being "
@@ -1204,6 +1215,18 @@ def _planning_safety_gate_payload(
             "planning-owner warnings stay visible while only a PR-feedback-addressed claim is in scope."
         )
         required_next_action = "prove-pr-feedback-addressed"
+        workflow_sufficient = True
+    elif path_classification["dirty_shape"] in {
+        "implementation-with-archived-planning-residue",
+        "archived-planning-residue-only",
+    }:
+        status = "satisfied"
+        decision = "post-closeout-verification"
+        reason = (
+            "Changed Planning paths are completed archived closeout residue, so this is a post-closeout verification route "
+            "rather than missing active implementation ownership."
+        )
+        required_next_action = "run-post-closeout-verification"
         workflow_sufficient = True
     elif path_classification["dirty_shape"] == "planning-plus-implementation":
         status = "violation"

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -24594,11 +24594,29 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
         compact["allowed_read_only_actions"] = gate.get("allowed_read_only_actions")
         compact["claim_boundary"] = gate.get("claim_boundary")
     if "changed_path_facts" in gate or "changed_path_classification" in gate:
-        compact["changed_path_facts"] = gate.get("changed_path_facts") or gate.get("changed_path_classification")
+        changed_path_facts = _as_dict(gate.get("changed_path_facts") or gate.get("changed_path_classification"))
+        compact["changed_path_facts"] = {
+            key: changed_path_facts.get(key)
+            for key in (
+                "dirty_shape",
+                "surface_root_count",
+                "scope_growth_detected",
+                "scope_growth_reasons",
+                "archived_planning_residue",
+            )
+            if changed_path_facts.get(key) not in (None, "", [], {})
+        }
+        if compact.get("gate_result") == "post-closeout-verification" and "archived_planning_residue" not in compact["changed_path_facts"]:
+            compact["changed_path_facts"]["archived_planning_residue"] = {"status": "completed-closeout-residue"}
     if "work_shape_guidance" in gate:
         compact["work_shape_guidance"] = _tiny_work_shape_guidance(gate["work_shape_guidance"])
     task_switch = gate.get("task_switch_reconciliation")
-    if isinstance(task_switch, dict) and task_switch.get("status") == "active":
+    if isinstance(task_switch, dict) and task_switch.get("status") in {
+        "active",
+        "bounded-reflection-reporting",
+        "current-task-route-acknowledged",
+        "completed-active-plan-route",
+    }:
         compact["task_switch_reconciliation"] = {
             key: task_switch.get(key)
             for key in (
@@ -24615,6 +24633,7 @@ def _selector_first_planning_safety_gate(gate: Any) -> dict[str, Any]:
                 "recommended_next_action",
                 "safe_routes",
                 "active_plan_protection",
+                "route_acknowledgement",
                 "rule",
             )
             if key in task_switch

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -3055,6 +3055,66 @@ def test_start_routes_completed_active_plan_to_archive_before_new_reflection(tmp
     assert "planning_safety_gate" not in after["context"]["planning"]
 
 
+def test_implement_routes_post_closeout_archive_residue_as_verification(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write_issue_1981_closeout_fixture(tmp_path, include_proof=True, active_milestone_status="completed")
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py", "VALUE = 1\n")
+
+    assert (
+        cli.main(
+            [
+                "planning",
+                "archive-plan",
+                "--plan",
+                "issue-1981",
+                "--target",
+                str(tmp_path),
+                "--prepare-closeout",
+                "--retain-archive",
+                "--apply-cleanup",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    changed = [
+        "src/agentic_workspace/workspace_runtime_core.py",
+        ".agentic-workspace/planning/state.toml",
+        ".agentic-workspace/planning/execplans/archive/issue-1981.plan.json",
+    ]
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                *changed,
+                "--task",
+                "Final post-closeout verification for #1981",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    gate = payload["context"]["planning_safety_gate"]
+
+    assert gate["gate_result"] == "post-closeout-verification"
+    assert gate["workflow_sufficient"] is True
+    assert gate["required_next_action"] == "run-post-closeout-verification"
+    assert gate["changed_path_facts"]["dirty_shape"] == "implementation-with-archived-planning-residue"
+    assert gate["changed_path_facts"]["archived_planning_residue"]["status"] == "completed-closeout-residue"
+    assert payload["action_signals"]["implementation_allowed"] is True
+    assert "implementation-owner-missing" not in payload["action_signals"]["hard_blockers"]
+
+
 def test_start_keeps_incomplete_active_plan_on_task_switch_route(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
@@ -3081,6 +3141,62 @@ def test_start_keeps_incomplete_active_plan_on_task_switch_route(tmp_path: Path,
     assert payload["next_safe_action"]["next_safe_action"] == "choose-task-switch-route"
     assert gate["gate_result"] == "active-plan-task-switch"
     assert gate["task_switch_reconciliation"]["status"] == "active"
+
+
+def test_implement_acknowledges_current_task_switch_with_return_and_cleanup_routes(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    _write(
+        tmp_path / ".agentic-workspace" / "planning" / "state.toml",
+        """
+kind = "agentic-planning-state"
+schema_version = "planning-state/v1"
+
+[todo]
+active_items = [
+  { id = "active-plan", title = "Unrelated active plan", status = "active", surface = ".agentic-workspace/planning/execplans/active-plan.plan.json" },
+]
+queued_items = []
+
+[roadmap]
+lanes = []
+candidates = []
+""",
+    )
+    _write_json(
+        tmp_path / ".agentic-workspace" / "planning" / "execplans" / "active-plan.plan.json",
+        {"kind": "planning-execplan/v1", "id": "active-plan", "title": "Unrelated active plan"},
+    )
+    _write(tmp_path / "src" / "agentic_workspace" / "workspace_runtime_core.py", "VALUE = 1\n")
+
+    assert (
+        cli.main(
+            [
+                "implement",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_core.py",
+                "--task",
+                "Implement unrelated parser cleanup",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    switch = payload["context"]["planning_safety_gate"]["task_switch_reconciliation"]
+    acknowledgement = switch["route_acknowledgement"]
+
+    assert switch["status"] == "current-task-route-acknowledged"
+    assert acknowledgement["status"] == "acknowledged"
+    assert acknowledgement["return_to_active_plan"]["command"] == "agentic-workspace summary --target . --format json"
+    assert acknowledgement["stale_thread_cleanup"]["inspect_command"] == (
+        "agentic-workspace start --target . --select work_threads --format json"
+    )
+    assert "claim-active-plan-progress" in switch["blocked_claims"]
 
 
 def test_start_treats_shared_issue_ref_as_active_plan_continuation(tmp_path: Path, capsys) -> None:
@@ -4489,6 +4605,88 @@ def test_local_work_threads_prune_removes_only_safe_local_candidates(tmp_path: P
     after = json.loads(capsys.readouterr().out)["values"]["work_threads"]
     assert after["thread_count"] == 0
     assert after["cleanup"]["prune_candidates"] == []
+
+
+def test_local_work_threads_prune_can_remove_stale_checkpoint_fallback(tmp_path: Path, capsys) -> None:
+    _init_real_git_repo_with_commit(tmp_path)
+    assert cli.main(["init", "--target", str(tmp_path), "--format", "json"]) == 0
+    capsys.readouterr()
+    old_head = _git_value(tmp_path, "rev-parse", "HEAD")
+    assert (
+        cli.main(
+            [
+                "checkpoint",
+                "write",
+                "--target",
+                str(tmp_path),
+                "--task",
+                "Continue #1992 old branch",
+                "--issue",
+                "#1992",
+                "--durable-source",
+                "https://github.com/rickardvh/agentic-workspace/issues/1992",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    checkpoint_path = tmp_path / ".agentic-workspace" / "local" / "chat-checkpoint.json"
+    checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    checkpoint["volatile_observations"]["branch"]["value"] = "deleted-branch"
+    checkpoint["volatile_observations"]["head_commit"]["value"] = old_head
+    checkpoint_path.write_text(json.dumps(checkpoint, indent=2) + "\n", encoding="utf-8")
+
+    assert cli.main(["start", "--target", str(tmp_path), "--select", "work_threads", "--format", "json"]) == 0
+    projected = json.loads(capsys.readouterr().out)["values"]["work_threads"]
+    candidate = projected["cleanup"]["prune_candidates"][0]
+    assert candidate["id"] == "checkpoint-default"
+    assert candidate["source"] == "local_chat_checkpoint"
+    assert candidate["path"] == ".agentic-workspace/local/chat-checkpoint.json"
+    assert "branch-missing" in candidate["stale_reasons"]
+
+    assert (
+        cli.main(
+            [
+                "work-thread",
+                "prune",
+                "--target",
+                str(tmp_path),
+                "--thread-id",
+                "checkpoint-default",
+                "--dry-run",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    dry_run = json.loads(capsys.readouterr().out)
+    assert dry_run["status"] == "dry-run"
+    assert dry_run["pruned_paths"] == [".agentic-workspace/local/chat-checkpoint.json"]
+    assert checkpoint_path.exists()
+
+    assert (
+        cli.main(
+            [
+                "work-thread",
+                "prune",
+                "--target",
+                str(tmp_path),
+                "--thread-id",
+                "checkpoint-default",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "pruned"
+    assert payload["pruned_thread_ids"] == ["checkpoint-default"]
+    assert payload["pruned_paths"] == [".agentic-workspace/local/chat-checkpoint.json"]
+    assert not checkpoint_path.exists()
 
 
 def test_local_work_threads_prune_skips_current_non_candidate(tmp_path: Path, capsys) -> None:

--- a/tests/test_workspace_implement_cli.py
+++ b/tests/test_workspace_implement_cli.py
@@ -3797,8 +3797,9 @@ def test_implement_allows_completed_archived_plan_residue_with_continuation_evid
 
         payload = json.loads(capsys.readouterr().out)
         gate = payload["planning_safety_gate"]
-        assert gate["status"] == "clear", label
-        assert gate["gate_result"] == "direct-work-allowed", label
+        assert gate["status"] == "satisfied", label
+        assert gate["gate_result"] == "post-closeout-verification", label
+        assert gate["required_next_action"] == "run-post-closeout-verification", label
         assert gate["implementation_allowed"] is True, label
         facts = gate["changed_path_facts"]
         assert facts["dirty_shape"] == "implementation-with-archived-planning-residue", label
@@ -4048,8 +4049,9 @@ def test_implement_allows_closeout_evidence_and_state_cleanup_publication_residu
 
     payload = json.loads(capsys.readouterr().out)
     gate = payload["planning_safety_gate"]
-    assert gate["status"] == "clear"
-    assert gate["gate_result"] == "direct-work-allowed"
+    assert gate["status"] == "satisfied"
+    assert gate["gate_result"] == "post-closeout-verification"
+    assert gate["required_next_action"] == "run-post-closeout-verification"
     facts = gate["changed_path_facts"]
     assert facts["planning_paths"] == []
     assert facts["archived_planning_residue"]["status"] == "completed-closeout-residue"
@@ -4137,7 +4139,9 @@ candidates = []
 
     payload = json.loads(capsys.readouterr().out)
     gate = payload["planning_safety_gate"]
-    assert gate["status"] in {"clear", "attention"}
+    assert gate["status"] == "satisfied"
+    assert gate["gate_result"] == "post-closeout-verification"
+    assert gate["required_next_action"] == "run-post-closeout-verification"
     assert gate["gate_result"] != "candidate-lane-promotion-required"
     assert gate["implementation_allowed"] is True
     assert gate["changed_path_facts"]["archived_planning_residue"]["status"] == "completed-closeout-residue"


### PR DESCRIPTION
## Summary
- Fixes #2097 by routing completed archived closeout residue as explicit `post-closeout-verification` instead of `implementation-owner-missing`.
- Fixes #2103 by exposing current-task return/cleanup commands and allowing stale local checkpoint fallback pruning through `work-thread prune`.
- Refs #2098 by recording lane-level closeout evidence for the remaining child issues and syncing the installed payload to 0.32.1. #2111 remains open for the closeout-trust receipt/evidence-selection limitation called out in review.

## Proof
- Focused regression trio for #2097/#2103/local checkpoint pruning: passed.
- `make test-workspace`: passed.
- `make lint-workspace`: passed.
- `uv run python scripts/generate/generate_command_packages.py --check`: passed.
- `uv run python scripts/check/check_generated_command_packages.py`: passed.
- `uv run python scripts/check/run_operation_conformance_tests.py --target all`: passed.
- `uv run python scripts/check/check_contract_tooling_surfaces.py --quiet-success`: passed.
- `uv run python scripts/check/check_structured_file_inventory.py --quiet-success`: passed.
- `uv run ruff check src/agentic_workspace/contracts scripts/check tests/test_structured_file_inventory.py`: passed.
- `uv run pytest tests/test_workspace_cli.py -q`: passed.
- `make typecheck`: passed.
- AW summary, planning doctor, defaults root_cli_authority, and runtime_mirror_consistency report: passed/recorded in transcript.
- `git diff --check`: passed.

## Notes
AW closeout-trust still has a conservative receipt/evidence-selection limitation for this path; I filed #2111 with the transcript evidence. I did not fabricate per-command receipts for optional commands I did not run.

Fixes #2097
Fixes #2103
Refs #2098
