### PR TITLE
Implement #2113 runtime closeout compression

### DIFF
--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -863,6 +863,7 @@ def closeout_claim_boundary_payload(
                     "allowed_claim_classes",
                     "blocked_claim_classes",
                     "closure_actions",
+                    "closure_keyword_guard",
                     "rule",
                 )
                 if key in claim_authorization

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -1709,6 +1709,83 @@ def _compact_payload_upgrade_attention_plan(plan: dict[str, Any]) -> dict[str, A
     }
 
 
+def _payload_repair_subflow_payload(
+    *,
+    status: str,
+    action_state: dict[str, Any],
+    repair_route: dict[str, Any],
+    payload_upgrade_attention_plan: dict[str, Any],
+) -> dict[str, Any]:
+    action_state = _as_dict(action_state)
+    repair_route = _as_dict(repair_route)
+    plan = _as_dict(payload_upgrade_attention_plan)
+    command_boundary = _as_dict(plan.get("command_boundary"))
+    reportable = _as_dict(command_boundary.get("reportable_commands"))
+    machine = _as_dict(command_boundary.get("machine_commands"))
+    action_semantics = _as_dict(plan.get("action_semantics"))
+    route_status = str(repair_route.get("status") or "")
+    if status == "compatible" or route_status == "not-required":
+        subflow_status = "not-required"
+        next_action = "none"
+    elif route_status == "available" and action_semantics.get("safe_explicit_apply") is True:
+        subflow_status = "safe-explicit-apply"
+        next_action = "run dry-run, review, apply explicitly, then recheck"
+    elif route_status == "manual-review-required" or action_semantics.get("manual_review_required"):
+        subflow_status = "manual-review"
+        next_action = "run dry-run and review manual attention items before applying"
+    elif route_status == "blocking":
+        subflow_status = "blocked"
+        next_action = "select a compatible CLI or resolve the blocker before payload repair"
+    else:
+        subflow_status = "review"
+        next_action = "inspect installed_state_compatibility before applying payload repair"
+    steps = [
+        {
+            "id": "dry_run",
+            "reportable_command": str(reportable.get("dry_run") or ""),
+            "machine_command": str(
+                machine.get("dry_run") or action_state.get("dry_run_command") or repair_route.get("dry_run_command") or ""
+            ),
+            "mutates": False,
+            "purpose": "preview package-owned payload changes and manual attention items",
+        },
+        {
+            "id": "apply",
+            "reportable_command": str(reportable.get("apply") or ""),
+            "machine_command": str(machine.get("apply") or action_state.get("apply_command") or repair_route.get("apply_command") or ""),
+            "mutates": True,
+            "purpose": "explicitly apply the reviewed payload repair",
+        },
+        {
+            "id": "recheck",
+            "reportable_command": str(reportable.get("recheck") or ""),
+            "machine_command": str(machine.get("recheck") or action_state.get("recheck_command") or ""),
+            "mutates": False,
+            "purpose": "confirm installed payload target compatibility after repair",
+        },
+    ]
+    return {
+        "kind": "agentic-workspace/payload-repair-subflow/v1",
+        "status": subflow_status,
+        "source_status": status,
+        "repair_mechanism": str(action_state.get("repair_mechanism") or repair_route.get("repair_mechanism") or ""),
+        "safe_explicit_apply": action_semantics.get("safe_explicit_apply") is True,
+        "manual_review_required": action_semantics.get("manual_review_required") is True,
+        "start_mutates": False,
+        "next_action": next_action,
+        "steps": steps,
+        "reportable_commands": {step["id"]: step["reportable_command"] for step in steps},
+        "machine_commands": {step["id"]: step["machine_command"] for step in steps},
+        "attention_item_count": plan.get("attention_item_count", 0),
+        "category_counts": plan.get("category_counts", {}),
+        "detail_selector": "installed_state_compatibility.payload_repair_subflow",
+        "rule": (
+            "Startup may expose this dry-run/apply/recheck subflow, but only the explicit apply step mutates. "
+            "Reportable commands stay repo-relative while machine commands preserve configured invocation details."
+        ),
+    }
+
+
 def _cli_compatibility_payload(*, config: WorkspaceConfig, compact: bool = False) -> dict[str, Any]:
     expectation = config.cli_compatibility
     identity = _invoked_cli_identity_payload(target_root=config.target_root)
@@ -2172,6 +2249,31 @@ def _installed_state_compatibility_payload(
         action_state=action_state,
         stale_generated_surfaces=stale_generated_surfaces,
     )
+    repair_route = {
+        "status": "available"
+        if action_state_name == "safe_payload_sync_available"
+        else "manual-review-required"
+        if action_state_name == "manual_review_required"
+        else "blocking"
+        if action_state_name == "blocking_incompatible"
+        else "not-required",
+        "action_state": action_state_name,
+        "action_id": action_state["action_id"],
+        "repair_mechanism": action_state["repair_mechanism"],
+        "dry_run_command": action_state["dry_run_command"] or dry_run_sync_command,
+        "apply_command": action_state["apply_command"] or apply_sync_command,
+        "waiver": {
+            "allowed": action_state_name == "safe_payload_sync_available",
+            "claim": "source-behavior-validated-installed-payload-freshness-unproven",
+            "rule": "A waiver can keep narrow source work moving, but final reporting must not claim installed payload freshness.",
+        },
+    }
+    payload_repair_subflow = _payload_repair_subflow_payload(
+        status=status,
+        action_state=action_state,
+        repair_route=repair_route,
+        payload_upgrade_attention_plan=payload_upgrade_attention_plan,
+    )
     payload: dict[str, Any] = {
         "kind": "agentic-workspace/installed-state-compatibility/v1",
         "status": status,
@@ -2180,6 +2282,7 @@ def _installed_state_compatibility_payload(
         "action_state": action_state,
         "payload_surface_manifest": payload_upgrade_attention_plan["surface_manifest"],
         "payload_upgrade_attention_plan": payload_upgrade_attention_plan,
+        "payload_repair_subflow": payload_repair_subflow,
         "executable": {
             "package": "agentic-workspace",
             "version": __version__,
@@ -2233,25 +2336,7 @@ def _installed_state_compatibility_payload(
             },
         ],
         "next_action": next_action,
-        "repair_route": {
-            "status": "available"
-            if action_state_name == "safe_payload_sync_available"
-            else "manual-review-required"
-            if action_state_name == "manual_review_required"
-            else "blocking"
-            if action_state_name == "blocking_incompatible"
-            else "not-required",
-            "action_state": action_state_name,
-            "action_id": action_state["action_id"],
-            "repair_mechanism": action_state["repair_mechanism"],
-            "dry_run_command": action_state["dry_run_command"] or dry_run_sync_command,
-            "apply_command": action_state["apply_command"] or apply_sync_command,
-            "waiver": {
-                "allowed": action_state_name == "safe_payload_sync_available",
-                "claim": "source-behavior-validated-installed-payload-freshness-unproven",
-                "rule": "A waiver can keep narrow source work moving, but final reporting must not claim installed payload freshness.",
-            },
-        },
+        "repair_route": repair_route,
         "action_effect": action_effect,
         "rule": (
             "Every entry surface should classify executable, payload, generated-artifact, and adapter posture through this "
@@ -2266,6 +2351,7 @@ def _installed_state_compatibility_payload(
             "action_state": payload["action_state"],
             "payload_surface_manifest": payload_upgrade_attention_plan["surface_manifest"],
             "payload_upgrade_attention_plan": _compact_payload_upgrade_attention_plan(payload_upgrade_attention_plan),
+            "payload_repair_subflow": payload_repair_subflow,
             "executable": {
                 key: payload["executable"][key]
                 for key in ("compatibility_status", "classification", "failed_checks")
@@ -48742,9 +48828,12 @@ def _skill_catalog_sources() -> tuple[SkillCatalogSource, ...]:
 
 
 def _emit_skills(*, format_name: str, target_root: Path | None, task_text: str | None, select: str | None = None) -> None:
-    payload = _skills_payload(target_root=target_root, task_text=task_text)
+    full_payload = _skills_payload(target_root=target_root, task_text=task_text)
+    payload = (
+        _skills_recommendation_first_payload(full_payload, target_root=target_root, task_text=task_text) if task_text else full_payload
+    )
     if select:
-        payload = _select_payload_fields(payload, select=select, source_command="skills")
+        payload = _select_payload_fields(full_payload, select=select, source_command="skills")
         _emit_payload(payload=payload, format_name=format_name)
         return
     if format_name == "json":
@@ -48766,7 +48855,7 @@ def _emit_skills(*, format_name: str, target_root: Path | None, task_text: str |
     elif payload.get("task"):
         print("Recommended:")
         print("- none")
-    for skill in payload["skills"]:
+    for skill in payload.get("skills", []):
         print(f"{skill['id']}: {skill['summary']}")
         print(f"  path: {skill['path']}")
         print(f"  owner: {skill['owner']}")
@@ -48776,6 +48865,47 @@ def _emit_skills(*, format_name: str, target_root: Path | None, task_text: str |
         print("Warnings:")
         for warning in payload["warnings"]:
             print(f"- {warning}")
+
+
+def _skills_recommendation_first_payload(payload: dict[str, Any], *, target_root: Path | None, task_text: str | None) -> dict[str, Any]:
+    recommendations = [item for item in _list_payload(payload.get("recommendations")) if isinstance(item, dict)]
+    top = recommendations[0] if recommendations else {}
+    top_score = int(top.get("score", 0) or 0) if top else 0
+    tied = [item for item in recommendations if int(item.get("score", 0) or 0) == top_score] if top else []
+    low_confidence = bool(top and top_score <= 1)
+    inventory_command = "agentic-workspace skills --target . --select skills,sources --format json"
+    if target_root is not None:
+        inventory_command = f"agentic-workspace skills --target {target_root.as_posix()} --select skills,sources --format json"
+    return {
+        "target": payload.get("target"),
+        "task": task_text,
+        "profile": "recommendation-first",
+        "status": "recommended" if recommendations else "no-match",
+        "recommendation_summary": {
+            "recommended_skill": top.get("id", "") if top else "",
+            "next_skill_path": top.get("path", "") if top else "",
+            "score": top_score if top else 0,
+            "reasons": top.get("reasons", [])[:3] if top else [],
+            "confidence": "low" if low_confidence else "tie" if len(tied) > 1 else "ranked",
+            "tie_count": len(tied),
+            "low_confidence": low_confidence,
+        },
+        "top_recommendations": payload.get("top_recommendations", recommendations[:3]),
+        "recommendations": recommendations,
+        "agent_aids": payload.get("agent_aids", []),
+        "agent_aid_recommendations": payload.get("agent_aid_recommendations", []),
+        "agent_aid_source": payload.get("agent_aid_source", {}),
+        "warnings": payload.get("warnings", []),
+        "catalog_summary": _skill_catalog_summary_from_payload(payload),
+        "inventory_detail": {
+            "status": "omitted-from-default-task-output",
+            "omitted_skill_count": len(_list_payload(payload.get("skills"))),
+            "command": inventory_command,
+            "selectors": ["skills", "sources", "agent_aids"],
+            "rule": "Default task output is recommendation-first; request the inventory selector when registry detail is needed.",
+        },
+        "rule": "Use top recommendations first. Full skill inventory remains available by explicit selector instead of default task output.",
+    }
 
 
 def _skills_payload(*, target_root: Path | None, task_text: str | None) -> dict[str, Any]:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -1190,6 +1190,83 @@ def _compact_payload_upgrade_attention_plan(plan: dict[str, Any]) -> dict[str, A
     }
 
 
+def _payload_repair_subflow_payload(
+    *,
+    status: str,
+    action_state: dict[str, Any],
+    repair_route: dict[str, Any],
+    payload_upgrade_attention_plan: dict[str, Any],
+) -> dict[str, Any]:
+    action_state = _as_dict(action_state)
+    repair_route = _as_dict(repair_route)
+    plan = _as_dict(payload_upgrade_attention_plan)
+    command_boundary = _as_dict(plan.get("command_boundary"))
+    reportable = _as_dict(command_boundary.get("reportable_commands"))
+    machine = _as_dict(command_boundary.get("machine_commands"))
+    action_semantics = _as_dict(plan.get("action_semantics"))
+    route_status = str(repair_route.get("status") or "")
+    if status == "compatible" or route_status == "not-required":
+        subflow_status = "not-required"
+        next_action = "none"
+    elif route_status == "available" and action_semantics.get("safe_explicit_apply") is True:
+        subflow_status = "safe-explicit-apply"
+        next_action = "run dry-run, review, apply explicitly, then recheck"
+    elif route_status == "manual-review-required" or action_semantics.get("manual_review_required"):
+        subflow_status = "manual-review"
+        next_action = "run dry-run and review manual attention items before applying"
+    elif route_status == "blocking":
+        subflow_status = "blocked"
+        next_action = "select a compatible CLI or resolve the blocker before payload repair"
+    else:
+        subflow_status = "review"
+        next_action = "inspect installed_state_compatibility before applying payload repair"
+    steps = [
+        {
+            "id": "dry_run",
+            "reportable_command": str(reportable.get("dry_run") or ""),
+            "machine_command": str(
+                machine.get("dry_run") or action_state.get("dry_run_command") or repair_route.get("dry_run_command") or ""
+            ),
+            "mutates": False,
+            "purpose": "preview package-owned payload changes and manual attention items",
+        },
+        {
+            "id": "apply",
+            "reportable_command": str(reportable.get("apply") or ""),
+            "machine_command": str(machine.get("apply") or action_state.get("apply_command") or repair_route.get("apply_command") or ""),
+            "mutates": True,
+            "purpose": "explicitly apply the reviewed payload repair",
+        },
+        {
+            "id": "recheck",
+            "reportable_command": str(reportable.get("recheck") or ""),
+            "machine_command": str(machine.get("recheck") or action_state.get("recheck_command") or ""),
+            "mutates": False,
+            "purpose": "confirm installed payload target compatibility after repair",
+        },
+    ]
+    return {
+        "kind": "agentic-workspace/payload-repair-subflow/v1",
+        "status": subflow_status,
+        "source_status": status,
+        "repair_mechanism": str(action_state.get("repair_mechanism") or repair_route.get("repair_mechanism") or ""),
+        "safe_explicit_apply": action_semantics.get("safe_explicit_apply") is True,
+        "manual_review_required": action_semantics.get("manual_review_required") is True,
+        "start_mutates": False,
+        "next_action": next_action,
+        "steps": steps,
+        "reportable_commands": {step["id"]: step["reportable_command"] for step in steps},
+        "machine_commands": {step["id"]: step["machine_command"] for step in steps},
+        "attention_item_count": plan.get("attention_item_count", 0),
+        "category_counts": plan.get("category_counts", {}),
+        "detail_selector": "installed_state_compatibility.payload_repair_subflow",
+        "rule": (
+            "Startup may expose this dry-run/apply/recheck subflow, but only the explicit apply step mutates. "
+            "Reportable commands stay repo-relative while machine commands preserve configured invocation details."
+        ),
+    }
+
+
 def _cli_compatibility_payload(*, config: WorkspaceConfig, compact: bool = False) -> dict[str, Any]:
     expectation = config.cli_compatibility
     identity = _invoked_cli_identity_payload(target_root=config.target_root)
@@ -1655,6 +1732,31 @@ def _installed_state_compatibility_payload(
         action_state=action_state,
         stale_generated_surfaces=stale_generated_surfaces,
     )
+    repair_route = {
+        "status": "available"
+        if action_state_name == "safe_payload_sync_available"
+        else "manual-review-required"
+        if action_state_name == "manual_review_required"
+        else "blocking"
+        if action_state_name == "blocking_incompatible"
+        else "not-required",
+        "action_state": action_state_name,
+        "action_id": action_state["action_id"],
+        "repair_mechanism": action_state["repair_mechanism"],
+        "dry_run_command": action_state["dry_run_command"] or dry_run_sync_command,
+        "apply_command": action_state["apply_command"] or apply_sync_command,
+        "waiver": {
+            "allowed": action_state_name == "safe_payload_sync_available",
+            "claim": "source-behavior-validated-installed-payload-freshness-unproven",
+            "rule": "A waiver can keep narrow source work moving, but final reporting must not claim installed payload freshness.",
+        },
+    }
+    payload_repair_subflow = _payload_repair_subflow_payload(
+        status=status,
+        action_state=action_state,
+        repair_route=repair_route,
+        payload_upgrade_attention_plan=payload_upgrade_attention_plan,
+    )
     payload: dict[str, Any] = {
         "kind": "agentic-workspace/installed-state-compatibility/v1",
         "status": status,
@@ -1663,6 +1765,7 @@ def _installed_state_compatibility_payload(
         "action_state": action_state,
         "payload_surface_manifest": payload_upgrade_attention_plan["surface_manifest"],
         "payload_upgrade_attention_plan": payload_upgrade_attention_plan,
+        "payload_repair_subflow": payload_repair_subflow,
         "executable": {
             "package": "agentic-workspace",
             "version": __version__,
@@ -1716,25 +1819,7 @@ def _installed_state_compatibility_payload(
             },
         ],
         "next_action": next_action,
-        "repair_route": {
-            "status": "available"
-            if action_state_name == "safe_payload_sync_available"
-            else "manual-review-required"
-            if action_state_name == "manual_review_required"
-            else "blocking"
-            if action_state_name == "blocking_incompatible"
-            else "not-required",
-            "action_state": action_state_name,
-            "action_id": action_state["action_id"],
-            "repair_mechanism": action_state["repair_mechanism"],
-            "dry_run_command": action_state["dry_run_command"] or dry_run_sync_command,
-            "apply_command": action_state["apply_command"] or apply_sync_command,
-            "waiver": {
-                "allowed": action_state_name == "safe_payload_sync_available",
-                "claim": "source-behavior-validated-installed-payload-freshness-unproven",
-                "rule": "A waiver can keep narrow source work moving, but final reporting must not claim installed payload freshness.",
-            },
-        },
+        "repair_route": repair_route,
         "action_effect": action_effect,
         "rule": (
             "Every entry surface should classify executable, payload, generated-artifact, and adapter posture through this "
@@ -1749,6 +1834,7 @@ def _installed_state_compatibility_payload(
             "action_state": payload["action_state"],
             "payload_surface_manifest": payload_upgrade_attention_plan["surface_manifest"],
             "payload_upgrade_attention_plan": _compact_payload_upgrade_attention_plan(payload_upgrade_attention_plan),
+            "payload_repair_subflow": payload_repair_subflow,
             "executable": {
                 key: payload["executable"][key]
                 for key in ("compatibility_status", "classification", "failed_checks")
@@ -18218,6 +18304,7 @@ def _closeout_protocol_payload(
             "keep_parent_open_allowed": keep_parent.get("allowed"),
             "close_parent_lane_allowed": close_parent.get("allowed"),
             "closure_actions": claim_authorization.get("closure_actions", []),
+            "closure_keyword_guard": claim_authorization.get("closure_keyword_guard", {}),
             "parent_closure_rule": "Parent/epic closure requires explicit authorization; slice proof never closes parent intent by itself.",
         },
         "task_posture_followthrough": {
@@ -18289,6 +18376,31 @@ def _completion_gate_claim_authorization(
         }
         for ref in sorted(issue_refs)
     ]
+    issue_closure_authorized = "issue_closure" in allowed_claim_classes
+    blocked_parent_or_issue = bool(
+        {"lane_complete", "parent_complete", "full_intent_complete", "issue_closure"} & set(blocked_claim_classes)
+    )
+    closure_keyword_guard = {
+        "kind": "agentic-workspace/closure-keyword-guard/v1",
+        "status": "authorized" if issue_closure_authorized else "blocked",
+        "severity": "strong-warning" if blocked_parent_or_issue else "advisory",
+        "unsafe_when_blocked": ["close", "closes", "closed", "fix", "fixes", "fixed", "resolve", "resolves", "resolved"],
+        "safe_reference_words": ["refs", "references", "related to", "progress toward"],
+        "safe_reference_template": "Refs {issue}; does not close.",
+        "targets": [
+            {
+                "target": ref,
+                "closure_keywords_authorized": issue_closure_authorized,
+                "safe_reference": f"Refs {ref}; does not close.",
+                "unsafe_examples": [f"Closes {ref}", f"Fixes {ref}", f"Resolves {ref}"] if not issue_closure_authorized else [],
+            }
+            for ref in sorted(issue_refs)
+        ],
+        "rule": (
+            "When issue_closure is blocked, renderers and PR bodies must use reference wording rather than host "
+            "closure keywords. This guard is host-agnostic; listed keywords are renderer examples."
+        ),
+    }
     unsafe_examples = [] if active_intent_satisfied else ["done", "implemented", "complete", "finished", "all", "full intent complete"]
     if not active_intent_satisfied:
         unsafe_examples.extend(f"Closes {ref}" for ref in sorted(issue_refs))
@@ -18297,6 +18409,7 @@ def _completion_gate_claim_authorization(
         "allowed_claim_classes": allowed_claim_classes,
         "blocked_claim_classes": blocked_claim_classes,
         "closure_actions": closure_actions,
+        "closure_keyword_guard": closure_keyword_guard,
         "renderer_rule": (
             "Renderers must choose only templates whose required claim class and closure action are authorized here; "
             "unsafe prose examples are diagnostics, not the enforcement model."
@@ -45424,9 +45537,12 @@ def _skill_catalog_sources() -> tuple[SkillCatalogSource, ...]:
 
 
 def _emit_skills(*, format_name: str, target_root: Path | None, task_text: str | None, select: str | None = None) -> None:
-    payload = _skills_payload(target_root=target_root, task_text=task_text)
+    full_payload = _skills_payload(target_root=target_root, task_text=task_text)
+    payload = (
+        _skills_recommendation_first_payload(full_payload, target_root=target_root, task_text=task_text) if task_text else full_payload
+    )
     if select:
-        payload = _select_payload_fields(payload, select=select, source_command="skills")
+        payload = _select_payload_fields(full_payload, select=select, source_command="skills")
         _emit_payload(payload=payload, format_name=format_name)
         return
     if format_name == "json":
@@ -45448,7 +45564,7 @@ def _emit_skills(*, format_name: str, target_root: Path | None, task_text: str |
     elif payload.get("task"):
         print("Recommended:")
         print("- none")
-    for skill in payload["skills"]:
+    for skill in payload.get("skills", []):
         print(f"{skill['id']}: {skill['summary']}")
         print(f"  path: {skill['path']}")
         print(f"  owner: {skill['owner']}")
@@ -45458,6 +45574,47 @@ def _emit_skills(*, format_name: str, target_root: Path | None, task_text: str |
         print("Warnings:")
         for warning in payload["warnings"]:
             print(f"- {warning}")
+
+
+def _skills_recommendation_first_payload(payload: dict[str, Any], *, target_root: Path | None, task_text: str | None) -> dict[str, Any]:
+    recommendations = [item for item in _list_payload(payload.get("recommendations")) if isinstance(item, dict)]
+    top = recommendations[0] if recommendations else {}
+    top_score = int(top.get("score", 0) or 0) if top else 0
+    tied = [item for item in recommendations if int(item.get("score", 0) or 0) == top_score] if top else []
+    low_confidence = bool(top and top_score <= 1)
+    inventory_command = "agentic-workspace skills --target . --select skills,sources --format json"
+    if target_root is not None:
+        inventory_command = f"agentic-workspace skills --target {target_root.as_posix()} --select skills,sources --format json"
+    return {
+        "target": payload.get("target"),
+        "task": task_text,
+        "profile": "recommendation-first",
+        "status": "recommended" if recommendations else "no-match",
+        "recommendation_summary": {
+            "recommended_skill": top.get("id", "") if top else "",
+            "next_skill_path": top.get("path", "") if top else "",
+            "score": top_score if top else 0,
+            "reasons": top.get("reasons", [])[:3] if top else [],
+            "confidence": "low" if low_confidence else "tie" if len(tied) > 1 else "ranked",
+            "tie_count": len(tied),
+            "low_confidence": low_confidence,
+        },
+        "top_recommendations": payload.get("top_recommendations", recommendations[:3]),
+        "recommendations": recommendations,
+        "agent_aids": payload.get("agent_aids", []),
+        "agent_aid_recommendations": payload.get("agent_aid_recommendations", []),
+        "agent_aid_source": payload.get("agent_aid_source", {}),
+        "warnings": payload.get("warnings", []),
+        "catalog_summary": _skill_catalog_summary_from_payload(payload),
+        "inventory_detail": {
+            "status": "omitted-from-default-task-output",
+            "omitted_skill_count": len(_list_payload(payload.get("skills"))),
+            "command": inventory_command,
+            "selectors": ["skills", "sources", "agent_aids"],
+            "rule": "Default task output is recommendation-first; request the inventory selector when registry detail is needed.",
+        },
+        "rule": "Use top recommendations first. Full skill inventory remains available by explicit selector instead of default task output.",
+    }
 
 
 def _skills_payload(*, target_root: Path | None, task_text: str | None) -> dict[str, Any]:

--- a/src/agentic_workspace/workspace_runtime_proof.py
+++ b/src/agentic_workspace/workspace_runtime_proof.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import copy
 import fnmatch
+import hashlib
 import json
 import re
 import tomllib
@@ -80,6 +81,7 @@ from agentic_workspace.workspace_runtime_core import (
     _project_roots_for_changed_paths,
     _proof_adequacy_payload,
     _proof_command_for_target,
+    _proof_command_tier,
     _proof_command_tiers,
     _proof_completion_options,
     _proof_confidence_payload,
@@ -496,13 +498,21 @@ def _proof_receipt_failed(result: Any) -> bool:
 
 
 def _proof_receipt_summary(receipt: dict[str, Any]) -> dict[str, Any]:
-    return {
+    summary = {
         "command": str(receipt.get("command") or "").strip(),
         "result": str(receipt.get("result") or "").strip(),
         "changed_paths": [str(path).strip() for path in _list_payload(receipt.get("changed_paths")) if str(path).strip()],
         "recorded_at": receipt.get("recorded_at", ""),
         "plan_id": receipt.get("plan_id", ""),
     }
+    proof_commands = [str(command).strip() for command in _list_payload(receipt.get("proof_commands")) if str(command).strip()]
+    if proof_commands:
+        summary["proof_commands"] = proof_commands
+    for key in ("selected_proof_id", "selected_proof_fingerprint"):
+        value = str(receipt.get(key) or "").strip()
+        if value:
+            summary[key] = value
+    return summary
 
 
 def _proof_receipt_identity(receipt: dict[str, Any]) -> str:
@@ -562,19 +572,158 @@ def _proof_receipt_path_scope_matches(*, receipt: dict[str, Any], changed_paths:
     return set(normalized_changed_paths).issubset(set(receipt_paths)) if normalized_changed_paths else True
 
 
-def _proof_receipt_reconciliation_payload(
-    *, target_root: Path | None, required_commands: list[str], changed_paths: list[str]
+def _selected_proof_identity(required_commands: list[str]) -> dict[str, Any]:
+    normalized = [str(command).strip() for command in required_commands if str(command).strip()]
+    digest = hashlib.sha256(json.dumps(normalized, sort_keys=True, ensure_ascii=True).encode("utf-8")).hexdigest()
+    return {
+        "kind": "agentic-workspace/selected-proof-identity/v1",
+        "id": f"selected-proof:{digest[:16]}",
+        "fingerprint": digest,
+        "command_count": len(normalized),
+    }
+
+
+def _proof_receipt_aggregate_matches(*, receipt: dict[str, Any], required_commands: list[str]) -> tuple[bool, str]:
+    required = [str(command).strip() for command in required_commands if str(command).strip()]
+    if not required:
+        return False, "no selected commands require aggregate proof"
+    identity = _selected_proof_identity(required)
+    receipt_fingerprint = str(receipt.get("selected_proof_fingerprint") or "").strip()
+    if receipt_fingerprint and receipt_fingerprint == identity["fingerprint"]:
+        return True, "selected proof fingerprint accepted"
+    receipt_id = str(receipt.get("selected_proof_id") or "").strip()
+    if receipt_id and receipt_id == identity["id"]:
+        return True, "selected proof id accepted"
+    proof_commands = [str(command).strip() for command in _list_payload(receipt.get("proof_commands")) if str(command).strip()]
+    if proof_commands and set(required).issubset(set(proof_commands)):
+        return True, "aggregate proof_commands receipt accepted"
+    return False, "receipt is not for this selected proof set"
+
+
+def _proof_requirement_tier_for_command(command: str, *, selected: dict[str, Any]) -> str:
+    tier = _proof_command_tier(command, lane=str(selected.get("lane", "")))
+    if tier == "environmental":
+        return "optional_environmental"
+    if tier == "manual_review":
+        return "manual_required"
+    return "selected_required"
+
+
+def _proof_receipt_blocking_commands(*, required_commands: list[str], selected_commands: list[dict[str, Any]]) -> list[str]:
+    selected_by_text = {str(command.get("command", "")): command for command in selected_commands if isinstance(command, dict)}
+    blocking: list[str] = []
+    for command in required_commands:
+        text = str(command).strip()
+        if not text:
+            continue
+        tier = _proof_requirement_tier_for_command(text, selected=selected_by_text.get(text, {}))
+        if tier == "optional_environmental":
+            continue
+        blocking.append(text)
+    return blocking
+
+
+def _proof_requirement_tiers_payload(
+    *,
+    selected_commands: list[dict[str, Any]],
+    required_commands: list[str],
+    optional_commands: list[str],
+    manual_proof_obligations: list[dict[str, Any]],
+    unavailable_commands: list[dict[str, Any]],
+    host_policy_blocked_commands: list[dict[str, Any]],
 ) -> dict[str, Any]:
+    selected_by_text = {str(command.get("command", "")): command for command in selected_commands if isinstance(command, dict)}
+    categories: dict[str, list[dict[str, Any]]] = {
+        "selected_required": [],
+        "manual_required": [],
+        "recommended_confidence": [],
+        "optional_environmental": [],
+        "not_selected": [],
+    }
+    for command in required_commands:
+        text = str(command).strip()
+        if not text:
+            continue
+        selected = selected_by_text.get(text, {})
+        requirement_tier = _proof_requirement_tier_for_command(text, selected=selected)
+        categories.setdefault(requirement_tier, []).append(
+            {
+                "command": text,
+                "lane": str(selected.get("lane", "")),
+                "blocking": requirement_tier in {"selected_required", "manual_required"},
+                "receipt_required": requirement_tier == "selected_required",
+                "reason": "environmental proof is surfaced as non-blocking context"
+                if requirement_tier == "optional_environmental"
+                else "selected proof blocks closeout until executed or reconciled",
+            }
+        )
+    for item in manual_proof_obligations:
+        if isinstance(item, dict):
+            categories["manual_required"].append(
+                {
+                    "id": str(item.get("id", "")),
+                    "blocking": bool(item.get("required", True)),
+                    "receipt_required": False,
+                    "reason": "manual proof obligation must be recorded outside executable receipt matching",
+                }
+            )
+    for command in optional_commands:
+        text = str(command).strip()
+        if text and text not in {item.get("command") for item in categories["selected_required"]}:
+            categories["recommended_confidence"].append(
+                {"command": text, "blocking": False, "receipt_required": False, "reason": "recommended confidence check"}
+            )
+    for command in [*unavailable_commands, *host_policy_blocked_commands]:
+        if isinstance(command, dict):
+            categories["manual_required"].append(
+                {
+                    "command": str(command.get("command", "")),
+                    "lane": str(command.get("lane", "")),
+                    "blocking": True,
+                    "receipt_required": False,
+                    "reason": str(command.get("reason", "")) or "selected proof is unavailable or blocked",
+                }
+            )
+    counts = {key: len(value) for key, value in categories.items()}
+    blocking_count = sum(1 for items in categories.values() for item in items if item.get("blocking"))
+    return {
+        "kind": "agentic-workspace/proof-requirement-tiers/v1",
+        "status": "present" if any(counts.values()) else "empty",
+        "counts": counts,
+        "blocking_count": blocking_count,
+        "categories": categories,
+        "blocking_rule": (
+            "Closeout blocks on selected_required and manual_required proof. Recommended confidence, optional "
+            "environmental, and not-selected proof remain visible without inflating missing receipt counts."
+        ),
+    }
+
+
+def _proof_receipt_reconciliation_payload(
+    *,
+    target_root: Path | None,
+    required_commands: list[str],
+    changed_paths: list[str],
+    selected_commands: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    blocking_commands = _proof_receipt_blocking_commands(
+        required_commands=required_commands,
+        selected_commands=selected_commands or [],
+    )
+    selected_identity = _selected_proof_identity(blocking_commands)
     command_states: list[dict[str, Any]] = []
     base = {
         "kind": "agentic-workspace/proof-receipt-reconciliation/v1",
         "receipt_path": PROOF_RECEIPT_RELATIVE_PATH.as_posix(),
         "receipt_history_path": PROOF_RECEIPT_HISTORY_RELATIVE_PATH.as_posix(),
-        "required_command_count": len(required_commands),
+        "selected_command_count": len(required_commands),
+        "required_command_count": len(blocking_commands),
+        "non_blocking_selected_count": max(0, len(required_commands) - len(blocking_commands)),
+        "selected_proof_identity": selected_identity,
         "rule": (
             "Receipts are accepted only for exact command matches, compatible changed-path scope, and passed results; "
-            "proof selection alone is never treated as execution evidence. Receipt history may satisfy multiple selected "
-            "commands for the current changed-path boundary without forcing duplicate validation runs."
+            "aggregate receipts may satisfy the selected proof set when they carry matching selected proof identity or "
+            "proof_commands. Optional/environmental proof is reported outside the blocking receipt count."
         ),
     }
     if target_root is None:
@@ -584,7 +733,7 @@ def _proof_receipt_reconciliation_payload(
             "reason": "target root unavailable",
             "commands": [
                 {"command": command, "evidence_state": "not-run-or-not-recorded", "diagnostic": "not run or not recorded"}
-                for command in required_commands
+                for command in blocking_commands
             ],
         }
     receipt_records, latest_receipt, read_error = _read_proof_receipt_records(target_root)
@@ -595,7 +744,7 @@ def _proof_receipt_reconciliation_payload(
             "reason": read_error,
             "commands": [
                 {"command": command, "evidence_state": "record-stale-untrusted", "diagnostic": "record unreadable or untrusted"}
-                for command in required_commands
+                for command in blocking_commands
             ],
         }
     if not receipt_records:
@@ -604,10 +753,23 @@ def _proof_receipt_reconciliation_payload(
             "status": "not-recorded",
             "commands": [
                 {"command": command, "evidence_state": "not-run-or-not-recorded", "diagnostic": "not run or not recorded"}
-                for command in required_commands
+                for command in blocking_commands
             ],
         }
-    for command in required_commands:
+    aggregate_receipts = [
+        receipt
+        for receipt in receipt_records
+        if _proof_receipt_passed(str(receipt.get("result") or ""))
+        and _proof_receipt_path_scope_matches(receipt=receipt, changed_paths=changed_paths)
+        and _proof_receipt_aggregate_matches(receipt=receipt, required_commands=blocking_commands)[0]
+    ]
+    aggregate_receipt = aggregate_receipts[0] if aggregate_receipts else None
+    aggregate_match_reason = (
+        _proof_receipt_aggregate_matches(receipt=aggregate_receipt, required_commands=blocking_commands)[1]
+        if aggregate_receipt is not None
+        else ""
+    )
+    for command in blocking_commands:
         state: dict[str, Any]
         command_receipts = [receipt for receipt in receipt_records if str(receipt.get("command") or "").strip() == command]
         scoped_receipts = [
@@ -627,6 +789,14 @@ def _proof_receipt_reconciliation_payload(
                 "evidence_state": "accepted",
                 "diagnostic": "passed receipt accepted",
                 "receipt": _proof_receipt_summary(accepted_receipt),
+            }
+        elif aggregate_receipt is not None:
+            state = {
+                "command": command,
+                "evidence_state": "accepted",
+                "diagnostic": aggregate_match_reason,
+                "receipt": _proof_receipt_summary(aggregate_receipt),
+                "receipt_match": "aggregate-selected-proof",
             }
         elif failed_receipt is not None:
             state = {
@@ -654,6 +824,8 @@ def _proof_receipt_reconciliation_payload(
                 "diagnostic": "run but not recorded for this selected command",
             }
         state["required"] = True
+        state["blocking"] = True
+        state["proof_requirement_tier"] = "selected_required"
         command_states.append(state)
     accepted_count = sum(1 for state in command_states if state.get("evidence_state") == "accepted")
     return {
@@ -842,6 +1014,194 @@ def _tiny_proof_obligations_payload(value: dict[str, Any], *, required_commands:
             "rule": recommended.get("rule", ""),
         },
         "completion_claim_rule": value.get("completion_claim_rule", ""),
+    }
+
+
+def _closeout_ready_phase_answer_payload(
+    *,
+    completion_gate: dict[str, Any],
+    proof_execution: dict[str, Any],
+    planning_evidence: dict[str, Any],
+    installed_state_residue: dict[str, Any],
+    workflow_compliance_summary: dict[str, Any],
+    detail_commands: dict[str, str],
+) -> dict[str, Any]:
+    claim_authorization = _as_dict(completion_gate.get("claim_authorization"))
+    allowed_claim_classes = [
+        str(item).strip() for item in _list_payload(claim_authorization.get("allowed_claim_classes")) if str(item).strip()
+    ]
+    blocked_claim_classes = [
+        str(item).strip() for item in _list_payload(claim_authorization.get("blocked_claim_classes")) if str(item).strip()
+    ]
+    closure_actions = [dict(item) for item in _list_payload(claim_authorization.get("closure_actions")) if isinstance(item, dict)]
+    closure_keyword_guard = _as_dict(claim_authorization.get("closure_keyword_guard"))
+    unsafe_closure_actions: list[dict[str, Any]] = [
+        {
+            "kind": str(action.get("kind") or "closure_action"),
+            "target": str(action.get("target") or ""),
+            "reason": str(action.get("reason") or "closure action is not authorized by closeout claim authorization"),
+        }
+        for action in closure_actions
+        if action.get("authorized") is not True
+    ]
+    for target in _list_payload(closure_keyword_guard.get("targets")):
+        if not isinstance(target, dict) or str(target.get("status") or "") != "blocked":
+            continue
+        unsafe_closure_actions.append(
+            {
+                "kind": "closure_keyword",
+                "target": str(target.get("target") or ""),
+                "reason": str(closure_keyword_guard.get("rule") or "closure keywords are blocked for this target"),
+                "unsafe_examples": _list_payload(target.get("unsafe_examples")),
+                "safe_reference": str(target.get("safe_reference") or ""),
+            }
+        )
+
+    claim_rank = {
+        "none": 0,
+        "partial_progress": 1,
+        "slice_complete": 2,
+        "lane_complete": 3,
+        "parent_complete": 4,
+        "full_intent_complete": 5,
+        "issue_closure": 6,
+    }
+    strongest_safe_claim = "none"
+    for claim_class in allowed_claim_classes:
+        if claim_rank.get(claim_class, 0) > claim_rank.get(strongest_safe_claim, 0):
+            strongest_safe_claim = claim_class
+
+    proof_status = str(proof_execution.get("status") or "unknown").strip() or "unknown"
+    proof_state = "satisfied" if proof_status in {"recorded", "passed", "satisfied"} else "missing-or-unknown"
+    planning_state = str(planning_evidence.get("state") or "absent").strip() or "absent"
+    payload_status = str(installed_state_residue.get("status") or "unknown").strip() or "unknown"
+    payload_effect = str(installed_state_residue.get("current_task_proof_effect") or "").strip()
+    workflow_status = str(workflow_compliance_summary.get("status") or "unknown").strip() or "unknown"
+    dogfooding_command = detail_commands.get(
+        "dogfooding_signal_status",
+        "agentic-workspace report --target ./repo --section dogfooding_signal_status --format json",
+    )
+    dogfooding_status = {
+        "status": "not-inspected",
+        "source": "dogfooding_signal_status",
+        "detail_selector": "dogfooding_signal_status",
+        "detail_command": dogfooding_command,
+        "claim_boundary": (
+            "Treat missing dogfooding disposition as unresolved for broad closeout; inspect or record no-signal/dismissed/routed state."
+        ),
+    }
+
+    remaining_actions: list[dict[str, Any]] = []
+
+    def add_remaining(action_id: str, status: str, summary: str, selector: str, command: str = "") -> None:
+        remaining_actions.append(
+            {
+                "id": action_id,
+                "status": status,
+                "summary": summary,
+                "detail_selector": selector,
+                **({"command": command} if command else {}),
+            }
+        )
+
+    if proof_state != "satisfied":
+        add_remaining(
+            "proof",
+            proof_status,
+            "Proof execution is not recorded as satisfied for this closeout claim.",
+            "closeout_report.validation",
+            detail_commands.get("closeout_trust", ""),
+        )
+    if payload_status in {"current_task_blocking", "payload-upgrade-required", "blocked", "unknown"} or payload_effect == "blocking":
+        add_remaining(
+            "payload",
+            payload_status,
+            "Installed payload state is missing, unknown, or claim-relevant before broad closeout.",
+            "closeout_report.installed_state_residue",
+        )
+    if workflow_status in {"attention", "unknown"}:
+        add_remaining(
+            "workflow",
+            workflow_status,
+            "Workflow compliance has unresolved or unknown closeout evidence.",
+            "closeout_report.gaps_and_residual_risk.workflow_trust_impact",
+            detail_commands.get("workflow_compliance_summary", ""),
+        )
+    add_remaining(
+        "dogfooding",
+        dogfooding_status["status"],
+        "Dogfooding disposition is not included in this closeout report packet; inspect the dedicated selector.",
+        "dogfooding_signal_status",
+        dogfooding_command,
+    )
+    if strongest_safe_claim == "none" or blocked_claim_classes:
+        add_remaining(
+            "claim_authorization",
+            str(completion_gate.get("status") or "unknown"),
+            "Completion claim classes are blocked or limited by claim authorization.",
+            "closeout_report.completion_gate.claim_authorization",
+        )
+    if unsafe_closure_actions:
+        add_remaining(
+            "closure_actions",
+            "blocked",
+            "One or more closure actions or closure keywords are unsafe for the current claim boundary.",
+            "closeout_report.closeout_ready.unsafe_closure_actions",
+        )
+
+    status = "ready"
+    if any(item["id"] in {"proof", "payload", "claim_authorization", "closure_actions"} for item in remaining_actions):
+        status = "blocked"
+    elif remaining_actions:
+        status = "review-required"
+
+    return {
+        "kind": "agentic-workspace/closeout-ready-phase-answer/v1",
+        "status": status,
+        "phase_question": "What proof remains, what residue matters, and what can safely be claimed now?",
+        "strongest_safe_claim": strongest_safe_claim,
+        "proof_status": {
+            "status": proof_status,
+            "state": proof_state,
+            "proof": proof_execution.get("proof", ""),
+            "source_field": proof_execution.get("source_field", ""),
+        },
+        "planning_owner": {
+            "state": planning_state,
+            "authority": planning_evidence.get("authority", ""),
+            "source": planning_evidence.get("source", {}),
+            "rule": planning_evidence.get("rule", ""),
+        },
+        "payload_status": {
+            "status": payload_status,
+            "current_task_proof_effect": payload_effect or "unknown",
+            "claim_boundary": _as_dict(installed_state_residue.get("triage")).get(
+                "claim_boundary", installed_state_residue.get("claim_boundary", "")
+            ),
+        },
+        "dogfooding_status": dogfooding_status,
+        "claim_authorization": {
+            "allowed_claim_classes": allowed_claim_classes,
+            "blocked_claim_classes": blocked_claim_classes,
+            "closure_actions": closure_actions,
+            "closure_keyword_guard": closure_keyword_guard,
+        },
+        "unsafe_closure_actions": unsafe_closure_actions,
+        "remaining_actions": remaining_actions,
+        "remaining_action_count": len(remaining_actions),
+        "drilldowns": {
+            "closeout_report": detail_commands.get("closeout_report", ""),
+            "closeout_trust": detail_commands.get("closeout_trust", ""),
+            "completion_contract": detail_commands.get("completion_contract", ""),
+            "workflow_compliance_summary": detail_commands.get("workflow_compliance_summary", ""),
+            "dogfooding_signal_status": dogfooding_command,
+        },
+        "conservative_unknown_rule": (
+            "Unknown, stale, or omitted evidence stays visible as remaining action and must not be promoted into a completion or closure claim."
+        ),
+        "boundary": (
+            "This packet composes existing closeout/proof/planning/payload/dogfooding/claim signals; detailed selectors remain canonical."
+        ),
     }
 
 
@@ -1060,6 +1420,14 @@ def _closeout_report_payload(
             command="agentic-workspace report --target ./repo --section decision_pressure --format json",
             cli_invoke=config.cli_invoke,
         ),
+        "workflow_compliance_summary": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section workflow_compliance_summary --format json",
+            cli_invoke=config.cli_invoke,
+        ),
+        "dogfooding_signal_status": _command_with_cli_invoke(
+            command="agentic-workspace report --target ./repo --section dogfooding_signal_status --format json",
+            cli_invoke=config.cli_invoke,
+        ),
     }
     follow_up_owner = str(
         _as_dict(options.get("keep-parent-open")).get("owner") or completion_boundary.get("required_follow_up_owner") or ""
@@ -1103,17 +1471,27 @@ def _closeout_report_payload(
             "semantic completion judgment."
         ),
     )
+    planning_evidence = {
+        "authority": evidence_authority or "no-planning-evidence",
+        "source": evidence_source,
+        "state": evidence_state,
+        "rule": "Retained or archived evidence may explain the just-finished lane, but only active Planning state can govern current work.",
+    }
+    closeout_ready = _closeout_ready_phase_answer_payload(
+        completion_gate=completion_gate,
+        proof_execution=proof_execution,
+        planning_evidence=planning_evidence,
+        installed_state_residue=installed_state_closeout_residue,
+        workflow_compliance_summary=workflow_compliance_summary,
+        detail_commands=detail_commands,
+    )
     return {
         "kind": "agentic-workspace/closeout-report/v1",
         "status": "present" if active_planning_record else "guidance-only",
         "authority": "derived-projection",
         "authority_boundary": closeout_authority_boundary,
-        "planning_evidence": {
-            "authority": evidence_authority or "no-planning-evidence",
-            "source": evidence_source,
-            "state": evidence_state,
-            "rule": "Retained or archived evidence may explain the just-finished lane, but only active Planning state can govern current work.",
-        },
+        "planning_evidence": planning_evidence,
+        "closeout_ready": closeout_ready,
         "profile": profile_policy["selected_profile"],
         "profile_policy": profile_policy,
         "trust": trust,
@@ -3352,12 +3730,19 @@ def _proof_selection_for_changed_paths(
         target_root=target_root,
         required_commands=required_commands,
         changed_paths=changed_paths,
+        selected_commands=selected_commands,
     )
     proof_execution_evidence = {
         "kind": "proof-execution-evidence/v1",
         "status": "recorded-and-accepted" if proof_receipt_reconciliation.get("status") == "accepted" else "not-run-or-not-recorded",
         "state_model": list(_PROOF_EXECUTION_STATUSES),
         "expected_commands": required_commands,
+        "blocking_expected_commands": [
+            str(item.get("command", ""))
+            for item in _list_payload(proof_receipt_reconciliation.get("commands"))
+            if isinstance(item, dict) and item.get("blocking")
+        ],
+        "non_blocking_selected_count": proof_receipt_reconciliation.get("non_blocking_selected_count", 0),
         "manual_verification_expected": manual_verification is not None,
         "receipt_reconciliation": proof_receipt_reconciliation,
         "missing_evidence_diagnostics": {
@@ -3366,6 +3751,7 @@ def _proof_selection_for_changed_paths(
             "record-stale-untrusted": "a receipt exists, but command/path/result trust does not match the current proof selection",
             "recorded-failed": "the selected command was recorded as failed",
             "accepted": "the selected command has an exact matching passed receipt",
+            "aggregate-selected-proof": "a passed receipt covers the selected proof set by identity or proof_commands",
         },
         "rule": (
             "Proof selection describes expected proof only; closeout must record what actually ran, failed, was skipped, "
@@ -3526,6 +3912,14 @@ def _proof_selection_for_changed_paths(
         selected_commands=selected_commands,
         manual_proof_obligations=manual_proof_obligations,
     )
+    proof_requirement_tiers = _proof_requirement_tiers_payload(
+        selected_commands=selected_commands,
+        required_commands=required_commands,
+        optional_commands=optional_commands,
+        manual_proof_obligations=manual_proof_obligations,
+        unavailable_commands=unavailable_commands,
+        host_policy_blocked_commands=host_policy_blocked_commands,
+    )
     intent_proof = _intent_proof_prompt_payload(task_text=task_text, acceptance=acceptance, claim_boundary="slice")
     proof_confidence = _proof_confidence_payload(
         intent_proof=intent_proof,
@@ -3664,6 +4058,7 @@ def _proof_selection_for_changed_paths(
         "proof_execution_evidence": proof_execution_evidence,
         "proof_receipt_reconciliation": proof_receipt_reconciliation,
         "proof_receipt_bridge": proof_receipt_bridge,
+        "proof_requirement_tiers": proof_requirement_tiers,
         "proof_decision": proof_decision,
         "high_assurance_closeout_posture": high_assurance_closeout_posture,
         "intent_proof": intent_proof,

--- a/src/agentic_workspace/workspace_runtime_startup.py
+++ b/src/agentic_workspace/workspace_runtime_startup.py
@@ -1587,6 +1587,9 @@ def _apply_required_payload_target_start_gate(
         return
     command = str(action_effect.get("resolution_command") or action_state.get("dry_run_command") or "")
     recheck_command = str(action_state.get("recheck_command") or payload_target.get("recheck_command") or "")
+    payload_repair_subflow = _as_dict(installed_state.get("payload_repair_subflow"))
+    if payload_repair_subflow:
+        payload["payload_repair_subflow"] = payload_repair_subflow
     payload["workflow_sufficiency"] = _workflow_sufficiency_payload(
         surface="start",
         decision="installed-payload-target-required-before-work",
@@ -1605,6 +1608,7 @@ def _apply_required_payload_target_start_gate(
         "next_proof": recheck_command or f"{config.cli_invoke} start --target {target_root.as_posix()} --format json",
         "read_first": [command] if command else [],
         "open_execplan_only_when": startup_template["open_execplan_only_when"],
+        **({"payload_repair_subflow": payload_repair_subflow} if payload_repair_subflow else {}),
     }
 
 
@@ -1662,6 +1666,26 @@ def _selector_first_start_payload(payload: dict[str, Any], *, cli_invoke: str, t
     compact_closeout_obligations = _selector_first_closeout_obligations(payload)
     if compact_closeout_obligations:
         context["closeout_obligations"] = compact_closeout_obligations
+    payload_repair_subflow = payload.get("payload_repair_subflow")
+    if isinstance(payload_repair_subflow, dict) and payload_repair_subflow:
+        context["payload_repair_subflow"] = {
+            key: payload_repair_subflow.get(key)
+            for key in (
+                "kind",
+                "status",
+                "repair_mechanism",
+                "safe_explicit_apply",
+                "manual_review_required",
+                "start_mutates",
+                "next_action",
+                "steps",
+                "reportable_commands",
+                "machine_commands",
+                "detail_selector",
+                "rule",
+            )
+            if payload_repair_subflow.get(key) not in (None, "", [], {})
+        }
     local_checkpoint = payload.get("local_chat_checkpoint", {})
     work_threads = payload.get("work_threads", {})
     if isinstance(local_checkpoint, dict) and _local_chat_checkpoint_default_visible(local_checkpoint, payload=payload):

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -2402,6 +2402,56 @@ def test_payload_target_required_before_claim_limits_claims_without_blocking_wor
     assert selected["next_safe_action"]["implementation_allowed"] is True
 
 
+def test_payload_target_required_before_work_exposes_repair_subflow(tmp_path: Path, capsys) -> None:
+    _init_git_repo(tmp_path)
+    workspace = tmp_path / ".agentic-workspace"
+    assert cli.main(["init", "--target", str(tmp_path), "--mirror-payload", "--format", "json"]) == 0
+    capsys.readouterr()
+    (workspace / "config.toml").write_text(
+        "schema_version = 1\n\n"
+        "[payload]\n"
+        'target_release = "source-current"\n'
+        'minimum_capabilities = ["installed-state-sync-v2"]\n'
+        'policy = "required-before-work"\n',
+        encoding="utf-8",
+    )
+    provenance_path = workspace / "payload-provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance.pop("payload_capabilities", None)
+    provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    assert (
+        cli.main(
+            [
+                "start",
+                "--target",
+                str(tmp_path),
+                "--select",
+                "installed_state_compatibility,next_safe_action",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    selected = json.loads(capsys.readouterr().out)["values"]
+    compatibility = selected["installed_state_compatibility"]
+    subflow = compatibility["payload_repair_subflow"]
+
+    assert compatibility["status"] == "payload-upgrade-required"
+    assert compatibility["payload_repair_subflow"] == subflow
+    assert subflow["kind"] == "agentic-workspace/payload-repair-subflow/v1"
+    assert subflow["status"] == "safe-explicit-apply"
+    assert subflow["safe_explicit_apply"] is True
+    assert subflow["manual_review_required"] is False
+    assert subflow["start_mutates"] is False
+    assert [step["id"] for step in subflow["steps"]] == ["dry_run", "apply", "recheck"]
+    assert all(step["reportable_command"].startswith("agentic-workspace ") for step in subflow["steps"])
+    assert subflow["reportable_commands"]["dry_run"] == "agentic-workspace upgrade --target . --to-payload-target --dry-run --format json"
+    assert "--to-payload-target --dry-run" in subflow["machine_commands"]["dry_run"]
+    assert selected["next_safe_action"]["next_safe_action"] == "run-installed-payload-target-upgrade"
+
+
 def test_payload_target_blocks_when_invoked_cli_cannot_satisfy_explicit_target(tmp_path: Path, capsys) -> None:
     _init_git_repo(tmp_path)
     workspace = tmp_path / ".agentic-workspace"

--- a/tests/test_workspace_proof_cli.py
+++ b/tests/test_workspace_proof_cli.py
@@ -2991,6 +2991,80 @@ def test_proof_changed_reconciles_receipt_history_without_duplicate_runs(tmp_pat
     assert "closeout review" in answer["proof_execution_evidence"]["rule"]
 
 
+def test_proof_changed_accepts_aggregate_receipt_for_selected_proof_set(tmp_path: Path, capsys) -> None:
+    _write_repo_local_proof_target(tmp_path)
+    receipt_dir = tmp_path / ".agentic-workspace" / "local" / "proof-receipts"
+    receipt = {
+        "kind": "agentic-workspace/proof-receipt/v1",
+        "command": "selected proof set",
+        "result": "passed",
+        "recorded_at": "2026-07-09T00:00:00+00:00",
+        "changed_paths": ["src/agentic_workspace/workspace_runtime_proof.py"],
+        "proof_commands": ["make test-workspace", "make typecheck"],
+        "plan_id": "aggregate-proof",
+    }
+    _write(receipt_dir / "last.json", json.dumps(receipt, indent=2))
+    _write(receipt_dir / "history.jsonl", json.dumps(receipt, sort_keys=True) + "\n")
+
+    assert (
+        cli.main(
+            [
+                "proof",
+                "--verbose",
+                "--target",
+                str(tmp_path),
+                "--changed",
+                "src/agentic_workspace/workspace_runtime_proof.py",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+
+    answer = json.loads(capsys.readouterr().out)["answer"]
+    reconciliation = answer["proof_receipt_reconciliation"]
+    states = {item["command"]: item for item in reconciliation["commands"]}
+    assert reconciliation["status"] == "accepted"
+    assert reconciliation["accepted_count"] == 2
+    assert states["make test-workspace"]["receipt_match"] == "aggregate-selected-proof"
+    assert states["make typecheck"]["diagnostic"] == "aggregate proof_commands receipt accepted"
+    assert answer["proof_receipt_bridge"]["status"] == "complete"
+    assert answer["proof_execution_evidence"]["status"] == "recorded-and-accepted"
+
+
+def test_proof_requirement_tiers_keep_environmental_probes_non_blocking() -> None:
+    from agentic_workspace.workspace_runtime_proof import _proof_receipt_reconciliation_payload, _proof_requirement_tiers_payload
+
+    selected_commands = [
+        {"command": "make test-workspace", "lane": "workspace_cli", "intent_type": "behavior-test"},
+        {"command": "docker compose run conformance", "lane": "release_conformance", "intent_type": "environment-check"},
+    ]
+    required_commands = ["make test-workspace", "docker compose run conformance"]
+
+    tiers = _proof_requirement_tiers_payload(
+        selected_commands=selected_commands,
+        required_commands=required_commands,
+        optional_commands=["agentic-workspace summary --format json"],
+        manual_proof_obligations=[],
+        unavailable_commands=[],
+        host_policy_blocked_commands=[],
+    )
+    assert tiers["counts"]["selected_required"] == 1
+    assert tiers["counts"]["optional_environmental"] == 1
+    assert tiers["categories"]["optional_environmental"][0]["blocking"] is False
+
+    reconciliation = _proof_receipt_reconciliation_payload(
+        target_root=None,
+        required_commands=required_commands,
+        changed_paths=["src/app.py"],
+        selected_commands=selected_commands,
+    )
+    assert reconciliation["required_command_count"] == 1
+    assert reconciliation["non_blocking_selected_count"] == 1
+    assert [item["command"] for item in reconciliation["commands"]] == ["make test-workspace"]
+
+
 def test_proof_changed_marks_receipt_stale_for_changed_path_mismatch(tmp_path: Path, capsys) -> None:
     _write_repo_local_proof_target(tmp_path)
 

--- a/tests/test_workspace_skills_cli.py
+++ b/tests/test_workspace_skills_cli.py
@@ -251,6 +251,11 @@ def test_skills_command_recommends_planning_autopilot_for_active_milestone_task(
     )
 
     payload = json.loads(capsys.readouterr().out)
+    assert payload["profile"] == "recommendation-first"
+    assert payload["recommendation_summary"]["recommended_skill"] == "planning-autopilot"
+    assert payload["recommendation_summary"]["next_skill_path"]
+    assert payload["inventory_detail"]["status"] == "omitted-from-default-task-output"
+    assert "skills" not in payload
     assert payload["recommendations"][0]["id"] == "planning-autopilot"
     assert payload["recommendations"][0]["score"] > 0
     assert any("phrase match" in reason for reason in payload["recommendations"][0]["reasons"])
@@ -408,7 +413,7 @@ def test_skills_command_recommends_jumpstart_for_assurance_verification_populati
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["recommendations"][0]["id"] == "workspace-setup-jumpstart"
-    jumpstart = next(skill for skill in payload["skills"] if skill["id"] == "workspace-setup-jumpstart")
+    jumpstart = payload["recommendations"][0]
     nouns = jumpstart["activation_hints"]["nouns"]
     assert "assurance onboarding" in nouns
     assert "verification onboarding" in nouns
@@ -620,6 +625,8 @@ def test_skills_command_discovers_temporary_memory_bootstrap_skills(tmp_path: Pa
                 str(target),
                 "--task",
                 "finish bootstrap installation review for memory",
+                "--select",
+                "skills,sources,recommendations,warnings",
                 "--format",
                 "json",
             ]
@@ -627,7 +634,7 @@ def test_skills_command_discovers_temporary_memory_bootstrap_skills(tmp_path: Pa
         == 0
     )
 
-    payload = json.loads(capsys.readouterr().out)
+    payload = json.loads(capsys.readouterr().out)["values"]
     install_skill = next(entry for entry in payload["skills"] if entry["id"] == "install")
 
     assert install_skill["source_kind"] == "temporary-memory-bootstrap-skills"

--- a/tests/test_workspace_summary_cli.py
+++ b/tests/test_workspace_summary_cli.py
@@ -194,6 +194,72 @@ def test_closeout_report_keeps_installed_state_drift_blocking_for_owned_surfaces
     assert residue["changed_paths_considered"] == ["src/agentic_workspace/workspace_runtime_core.py"]
 
 
+def test_closeout_report_composes_closeout_ready_phase_answer(tmp_path: Path) -> None:
+    report = _closeout_report_with_installed_state(
+        tmp_path,
+        changed_surfaces="src/agentic_workspace/workspace_runtime_core.py",
+        requested_outcome="Verify payload freshness before release.",
+    )
+
+    ready = report["closeout_ready"]
+    remaining_by_id = {item["id"]: item for item in ready["remaining_actions"]}
+
+    assert ready["kind"] == "agentic-workspace/closeout-ready-phase-answer/v1"
+    assert ready["status"] == "blocked"
+    assert ready["proof_status"]["state"] == "satisfied"
+    assert ready["planning_owner"]["state"] == "active"
+    assert ready["payload_status"]["status"] == "current_task_blocking"
+    assert ready["dogfooding_status"]["status"] == "not-inspected"
+    assert ready["claim_authorization"]["blocked_claim_classes"]
+    assert "payload" in remaining_by_id
+    assert "dogfooding" in remaining_by_id
+    assert "dogfooding_signal_status" in ready["drilldowns"]
+    assert "Unknown, stale, or omitted evidence" in ready["conservative_unknown_rule"]
+
+
+def test_closeout_ready_phase_answer_surfaces_unsafe_closure_actions() -> None:
+    from agentic_workspace.workspace_runtime_proof import _closeout_ready_phase_answer_payload
+
+    ready = _closeout_ready_phase_answer_payload(
+        completion_gate={
+            "status": "blocked",
+            "claim_authorization": {
+                "allowed_claim_classes": ["slice_complete"],
+                "blocked_claim_classes": ["full_intent_complete", "issue_closure"],
+                "closure_actions": [
+                    {
+                        "kind": "issue_closure",
+                        "target": "#2113",
+                        "authorized": False,
+                        "reason": "parent issue closure requires full-intent completion",
+                    }
+                ],
+                "closure_keyword_guard": {
+                    "rule": "Use safe references unless issue closure is authorized.",
+                    "targets": [
+                        {
+                            "target": "#2113",
+                            "status": "blocked",
+                            "unsafe_examples": ["Closes #2113"],
+                            "safe_reference": "Refs #2113; does not close.",
+                        }
+                    ],
+                },
+            },
+        },
+        proof_execution={"status": "recorded", "proof": "pytest"},
+        planning_evidence={"state": "archived", "authority": "archived-planning-evidence"},
+        installed_state_residue={"status": "separate_maintenance_residue", "current_task_proof_effect": "not_blocking_narrow_task_proof"},
+        workflow_compliance_summary={"status": "clear"},
+        detail_commands={},
+    )
+
+    assert ready["status"] == "blocked"
+    assert ready["strongest_safe_claim"] == "slice_complete"
+    assert {item["kind"] for item in ready["unsafe_closure_actions"]} == {"issue_closure", "closure_keyword"}
+    assert any(item["id"] == "closure_actions" for item in ready["remaining_actions"])
+
+
 def test_closeout_report_section_reads_installed_state_residue(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -616,6 +682,26 @@ def test_memory_decision_packet_closeout_states_are_pressure_driven() -> None:
     assert local_memory["capture"]["status"] == "follow_up_required"
     assert follow_up["force"] == "required_at_closeout"
     assert follow_up["capture"]["status"] == "follow_up_required"
+
+
+def test_completion_gate_claim_authorization_surfaces_closure_keyword_guard() -> None:
+    from agentic_workspace.workspace_runtime_primitives import _completion_gate_claim_authorization
+
+    authorization = _completion_gate_claim_authorization(
+        status="continue-required",
+        active_intent_satisfied=False,
+        human_accepted_partial=False,
+        claim_level_requested="full-intent-complete",
+        proof_status="representative",
+        issue_refs={"#2113"},
+    )
+
+    guard = authorization["closure_keyword_guard"]
+    assert "issue_closure" in authorization["blocked_claim_classes"]
+    assert guard["status"] == "blocked"
+    assert guard["severity"] == "strong-warning"
+    assert guard["targets"][0]["safe_reference"] == "Refs #2113; does not close."
+    assert "Closes #2113" in guard["targets"][0]["unsafe_examples"]
 
 
 def test_memory_decision_packet_pull_statuses_distinguish_route_inspection() -> None:


### PR DESCRIPTION
## Stack
Base: `master`
Next: `codex/2113-archived-closeout-idempotence`

## Summary
- Adds aggregate selected-proof receipt reconciliation and proof requirement tiers so optional environmental probes do not block selected proof receipts.
- Adds closeout-ready composition in `closeout_report`, closure keyword guarding, payload repair subflow output, and recommendation-first skills task output.
- Keeps detailed selectors available for proof, payload, dogfooding, claim authorization, and closeout drilldowns.

## Proof
- `make test-workspace`
- `make lint-workspace`
- `make typecheck`
- `uv run pytest tests/test_workspace_cli.py -q`
- focused regression set: 167 passed, 2 skipped
- `uv run python scripts/run_agentic_workspace.py report --target . --section runtime_mirror_consistency --format json`

Refs #2113, #2111, #2114, #2115, #2116, #2118, #2119; does not close.