### PR TITLE
Guard release workflow against stale master pushes

### DIFF
--- a/.github/workflows/release-from-semver-label.yml
+++ b/.github/workflows/release-from-semver-label.yml
@@ -10,6 +10,10 @@ permissions:
   issues: read
   pull-requests: read
 
+concurrency:
+  group: release-from-semver-label-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-from-label:
     name: Bump coordinated workspace version and tag merged package changes
@@ -430,6 +434,11 @@ jobs:
           git add pyproject.toml packages/memory/pyproject.toml packages/planning/pyproject.toml packages/verification/pyproject.toml generated/workspace/typescript/package.json generated/memory/typescript/package.json generated/planning/typescript/package.json generated/verification/typescript/package.json uv.lock
           RELEASE_DIFF="$(git diff --cached --name-only)"
           if [ -n "$RELEASE_DIFF" ]; then
+            git fetch origin master --tags
+            if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/master)" ]; then
+              echo "::notice::origin/master advanced while this release proof was running; skip this stale release attempt and let the newer master run decide the release."
+              exit 0
+            fi
             python - <<'PY'
           import json
           import subprocess
@@ -447,9 +456,7 @@ jobs:
             git commit -m "Release ${{ steps.release-bump.outputs.tag }}"
           fi
           git tag "${{ steps.release-bump.outputs.tag }}"
-          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/master)" ]; then
-            git push origin HEAD:master
-          fi
+          git push origin HEAD:master
           git push origin "${{ steps.release-bump.outputs.tag }}"
 
       - name: Publish GitHub release

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -119,6 +119,9 @@ def test_post_merge_release_workflow_bumps_all_packages_from_pr_label() -> None:
     assert "contents: write" in workflow
     assert "issues: read" in workflow
     assert "pull-requests: read" in workflow
+    assert "concurrency:" in workflow
+    assert "release-from-semver-label-${{ github.ref }}" in workflow
+    assert "cancel-in-progress: false" in workflow
     assert ".github/release-ownership.json" in workflow
     assert 'ownership["packages"]' in workflow
     assert 'ownership["first_coordinated_release"]["floor_version"]' in workflow
@@ -153,7 +156,13 @@ def test_post_merge_release_workflow_bumps_all_packages_from_pr_label() -> None:
     assert "agentic-workspace-release-manifest.json" in workflow
     assert "SHA256SUMS" in workflow
     assert "Release commit contains disallowed product changes" in workflow
+    assert "git fetch origin master --tags" in workflow
+    assert "origin/master advanced while this release proof was running" in workflow
     assert 'git commit -m "Release ${{ steps.release-bump.outputs.tag }}"' in workflow
+    assert workflow.index("git fetch origin master --tags") < workflow.index(
+        'git commit -m "Release ${{ steps.release-bump.outputs.tag }}"'
+    )
+    assert "git push origin HEAD:master" in workflow
     assert 'git push origin "${{ steps.release-bump.outputs.tag }}"' in workflow
     assert "softprops/action-gh-release@v3.0.0" in workflow
 


### PR DESCRIPTION
## Summary
- Adds a non-canceling concurrency group to the post-merge coordinated release workflow.
- Fetches `origin/master` before creating the release commit and exits cleanly when the workflow checkout is stale.
- Adds release workflow contract coverage for the serialization and stale-master guard ordering.

## Root Cause
After the #2113 stack merged, release workflow runs for #2125 and #2126 both reached `Commit version bump and push release tag` while newer master commits already existed. Each created a local `Release v0.34.0` commit, then failed with `! [rejected] HEAD -> master (fetch first)`.

Failing runs:
- https://github.com/rickardvh/agentic-workspace/actions/runs/29034310982
- https://github.com/rickardvh/agentic-workspace/actions/runs/29034332387

## Proof
- `uv run pytest tests/test_release_workflows.py -q`
- `make lint-workspace`
- YAML parse check for `.github/workflows/release-from-semver-label.yml`

Refs #2113; does not close.