### PR TITLE
Add state-delta visible response evidence

### DIFF
--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,8 +13,8 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:cdd4df121269",
-    "version": "0.32.2"
+    "source_identity": "git:d3df0f28c3c2",
+    "version": "0.33.1"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
   "payload_capabilities": [
@@ -40,8 +40,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.32.2",
-    "version": "0.32.2"
+    "tag": "v0.33.1",
+    "version": "0.33.1"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -390,6 +390,113 @@ def evidence_bundle_payload(
     }
 
 
+def visible_state_delta_response_payload(
+    *,
+    surface: str,
+    current_decision: dict[str, Any],
+    message_economy: dict[str, Any] | None = None,
+    evidence_bundle: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    economy = message_economy if isinstance(message_economy, dict) else message_economy_payload(surface=surface)
+    evidence = evidence_bundle if isinstance(evidence_bundle, dict) else {}
+    minimal_surfaces = [
+        str(item.get("id"))
+        for item in _support_list_payload(evidence.get("minimal_evidence_surfaces"))
+        if isinstance(item, dict) and str(item.get("id", "")).strip()
+    ]
+    missing_evidence = [str(item) for item in _support_list_payload(evidence.get("missing_evidence")) if str(item).strip()]
+    expansion_triggers = list(economy.get("expand_when", []))
+    omitted_details = [
+        {
+            "detail": "chronological recap",
+            "reason": "not needed when decision, evidence, boundary, and next action are state-backed",
+            "route": "detail selectors or verbose report output",
+        },
+        {
+            "detail": "full evidence payload",
+            "reason": "minimal evidence surfaces and missing evidence are enough for the visible update",
+            "route": ",".join(minimal_surfaces) if minimal_surfaces else "evidence_bundle",
+        },
+    ]
+    parts = {
+        "decision_or_finding": str(current_decision.get("decision_question") or current_decision.get("status") or ""),
+        "evidence_or_proof_boundary": str(current_decision.get("proof_boundary") or "not-evaluated"),
+        "residue_or_claim_boundary": str(current_decision.get("residue_owner") or "none"),
+        "next_safe_action": str(current_decision.get("next_action") or current_decision.get("safe_probe") or ""),
+    }
+    return {
+        "kind": "agentic-workspace/visible-state-delta-response/v1",
+        "surface": surface,
+        "status": "ready" if all(parts.values()) else "incomplete",
+        "parts": parts,
+        "expansion_triggers": expansion_triggers,
+        "omitted_details": omitted_details,
+        "missing_evidence": missing_evidence,
+        "source_packets": [
+            "current_decision",
+            *([] if message_economy is None else ["message_economy"]),
+            *([] if evidence_bundle is None else ["evidence_bundle"]),
+        ],
+        "ownership_boundary": (
+            "This packet compiles visible answer parts from existing AW packets; it is a renderer and not a new truth source."
+        ),
+        "state_backed": bool(current_decision.get("state_backed", True)),
+    }
+
+
+def state_delta_replay_evidence_payload() -> dict[str, Any]:
+    examples = [
+        {
+            "id": "review-rereview",
+            "workflow_class": "review",
+            "input_packets": ["current_decision", "message_economy", "evidence_bundle"],
+            "visible_parts": ["decision_or_finding", "evidence_or_proof_boundary", "residue_or_claim_boundary", "next_safe_action"],
+            "avoided": ["full prose recap", "manual reconstruction of proof boundary"],
+            "comparison": "Review update can lead with the finding and proof boundary instead of replaying inspected files.",
+        },
+        {
+            "id": "handoff-continuation",
+            "workflow_class": "handoff",
+            "input_packets": ["current_decision", "continuation_capsule", "evidence_bundle"],
+            "visible_parts": ["decision_or_finding", "evidence_or_proof_boundary", "residue_or_claim_boundary", "next_safe_action"],
+            "avoided": ["chat-history reconstruction", "duplicated context already carried by continuation capsule"],
+            "comparison": "Continuation update resumes from preserved intent, unresolved residue, and next safe action.",
+        },
+        {
+            "id": "closeout",
+            "workflow_class": "closeout",
+            "input_packets": ["closeout_ready", "current_decision", "message_economy"],
+            "visible_parts": ["decision_or_finding", "evidence_or_proof_boundary", "residue_or_claim_boundary", "next_safe_action"],
+            "avoided": ["joining multiple closeout reports by hand", "unsafe closure wording without claim boundary"],
+            "comparison": "Closeout update can state strongest safe claim, proof state, residue, and closure boundary directly.",
+        },
+    ]
+    return {
+        "kind": "agentic-workspace/state-delta-replay-evidence/v1",
+        "status": "available",
+        "workflow_class_count": len({example["workflow_class"] for example in examples}),
+        "examples": examples,
+        "required_visible_parts": [
+            "decision_or_finding",
+            "evidence_or_proof_boundary",
+            "residue_or_claim_boundary",
+            "next_safe_action",
+        ],
+        "safety_preserved": [
+            "proof boundary remains visible",
+            "residue or claim boundary remains visible",
+            "next action remains visible",
+            "expansion triggers remain explicit",
+        ],
+        "non_goals": [
+            "hidden reasoning evaluation",
+            "prompt-keyword scoring",
+            "shorter output without proof or residue boundaries",
+        ],
+        "rule": "Replay evidence demonstrates visible response construction from structured packets across ordinary workflow classes.",
+    }
+
+
 def _load_reasoning_economy_evidence_ledger(*, target_root: Path | None) -> dict[str, Any]:
     if target_root is None:
         return {
@@ -487,11 +594,31 @@ def reasoning_economy_evidence_payload(*, target_root: Path | None = None, cli_i
             }
         )
     evidence_ledger_source = _load_reasoning_economy_evidence_ledger(target_root=target_root)
+    sample_decision_packet = {
+        "phase_question": "What changed for the visible update?",
+        "next_action": "Use the compact visible-state-delta response parts.",
+        "claim_boundary": "claim requires proof/residue boundary",
+        "residue_owner": "none",
+        "detail_routes": {"reasoning_economy": "report --section reasoning_economy"},
+    }
+    sample_core = state_delta_core_payload(surface="report", decision_packet=sample_decision_packet)
+    sample_current = current_decision_payload(surface="report", decision_packet=sample_decision_packet, state_delta_core=sample_core)
+    sample_economy = message_economy_payload(surface="report", state_delta_core=sample_core)
+    sample_evidence = evidence_bundle_payload(surface="report", current_decision=sample_current, state_delta_core=sample_core)
+    visible_response_compiler = visible_state_delta_response_payload(
+        surface="report",
+        current_decision=sample_current,
+        message_economy=sample_economy,
+        evidence_bundle=sample_evidence,
+    )
+    replay_evidence = state_delta_replay_evidence_payload()
     return {
         "kind": "agentic-workspace/reasoning-economy-evidence/v1",
         "status": "available",
         "scope": "visible_external_artifacts_only",
         "evidence_ledger_source": evidence_ledger_source,
+        "visible_response_compiler": visible_response_compiler,
+        "state_delta_replay_evidence": replay_evidence,
         "non_goals": [
             "hidden chain-of-thought grading",
             "semantic scoring of private reasoning",
@@ -927,6 +1054,10 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
     if section == "reasoning_economy" and isinstance(answer, dict):
         behavior = answer.get("behavior_check", {})
         behavior = behavior if isinstance(behavior, dict) else {}
+        compiler = answer.get("visible_response_compiler", {})
+        compiler = compiler if isinstance(compiler, dict) else {}
+        replay = answer.get("state_delta_replay_evidence", {})
+        replay = replay if isinstance(replay, dict) else {}
         return _localize_command_fields(
             {
                 "kind": answer.get("kind", "agentic-workspace/reasoning-economy-evidence/v1"),
@@ -936,6 +1067,18 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
                 if isinstance(answer.get("evidence_classes"), dict)
                 else [],
                 "required_visible_fields": behavior.get("required_visible_fields", []),
+                "visible_response_compiler": {
+                    key: compiler.get(key)
+                    for key in ("kind", "status", "surface", "parts", "expansion_triggers", "ownership_boundary")
+                    if key in compiler
+                },
+                "state_delta_replay_evidence": {
+                    "kind": replay.get("kind", "agentic-workspace/state-delta-replay-evidence/v1"),
+                    "status": replay.get("status", "available"),
+                    "workflow_class_count": replay.get("workflow_class_count", 0),
+                    "example_ids": [item.get("id", "") for item in _support_list_payload(replay.get("examples")) if isinstance(item, dict)],
+                    "safety_preserved": replay.get("safety_preserved", []),
+                },
                 "ledger_refs": [
                     item.get("ref", "") for item in _support_list_payload(answer.get("evidence_ledger")) if isinstance(item, dict)
                 ],

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -75,6 +75,8 @@ def test_state_delta_packet_views_derive_from_shared_core() -> None:
         evidence_bundle_payload,
         message_economy_payload,
         state_delta_core_payload,
+        state_delta_replay_evidence_payload,
+        visible_state_delta_response_payload,
     )
 
     decision_packet = {
@@ -107,6 +109,13 @@ def test_state_delta_packet_views_derive_from_shared_core() -> None:
         state_delta_core=core,
     )
     bundle = evidence_bundle_payload(surface="startup", current_decision=current, state_delta_core=core)
+    visible = visible_state_delta_response_payload(
+        surface="startup",
+        current_decision=current,
+        message_economy=economy,
+        evidence_bundle=bundle,
+    )
+    replay = state_delta_replay_evidence_payload()
 
     assert core["kind"] == "agentic-workspace/state-delta-core/v1"
     assert current["proof_boundary"] == core["boundary"]["proof"]
@@ -121,6 +130,17 @@ def test_state_delta_packet_views_derive_from_shared_core() -> None:
     assert economy["expand_when"] == core["output_policy"]["expand_when"]
     assert current["avoid_repeat"] == core["output_policy"]["avoid"]
     assert capsule["do_not_repeat"] == core["output_policy"]["avoid"]
+    assert visible["kind"] == "agentic-workspace/visible-state-delta-response/v1"
+    assert visible["parts"] == {
+        "decision_or_finding": "What changed?",
+        "evidence_or_proof_boundary": "partial-progress",
+        "residue_or_claim_boundary": "planning",
+        "next_safe_action": "Run the focused proof.",
+    }
+    assert visible["ownership_boundary"].endswith("not a new truth source.")
+    assert replay["workflow_class_count"] >= 2
+    assert {"review", "handoff", "closeout"} == {item["workflow_class"] for item in replay["examples"]}
+    assert all("next_safe_action" in item["visible_parts"] for item in replay["examples"])
 
 
 def _assert_selector_inventory_omitted_from_compact_start(payload: dict[str, Any]) -> dict[str, Any]:
@@ -6726,6 +6746,11 @@ def test_report_exposes_reasoning_economy_evidence_section(tmp_path: Path, capsy
         "residue_or_boundary",
         "next_action_or_closure_status",
     ]
+    assert answer["visible_response_compiler"]["kind"] == "agentic-workspace/visible-state-delta-response/v1"
+    assert answer["visible_response_compiler"]["parts"]["next_safe_action"] == "Use the compact visible-state-delta response parts."
+    assert answer["state_delta_replay_evidence"]["kind"] == "agentic-workspace/state-delta-replay-evidence/v1"
+    assert answer["state_delta_replay_evidence"]["workflow_class_count"] >= 2
+    assert "review-rereview" in answer["state_delta_replay_evidence"]["example_ids"]
     assert answer["ledger_refs"] == []
     assert "PR #1955" not in json.dumps(answer)
     fixture_results = {item["id"]: item for item in answer["fixture_results"]}
@@ -6745,6 +6770,14 @@ def test_report_exposes_reasoning_economy_evidence_section(tmp_path: Path, capsy
         "handoff summary",
     ]
     assert full["reasoning_economy"]["evidence_ledger_source"]["status"] == "absent"
+    assert full["reasoning_economy"]["visible_response_compiler"]["source_packets"] == [
+        "current_decision",
+        "message_economy",
+        "evidence_bundle",
+    ]
+    replay_examples = {item["id"]: item for item in full["reasoning_economy"]["state_delta_replay_evidence"]["examples"]}
+    assert replay_examples["handoff-continuation"]["workflow_class"] == "handoff"
+    assert "proof boundary remains visible" in full["reasoning_economy"]["state_delta_replay_evidence"]["safety_preserved"]
 
 
 def test_report_reasoning_economy_reads_repo_owned_evidence_ledger(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Adds a derived `visible-state-delta-response` packet that compiles decision, proof boundary, residue/claim boundary, and next action from existing state-delta packets.
- Adds replay evidence for review, handoff/continuation, and closeout workflows under `reasoning_economy`.
- Keeps the compiler as a renderer/assembly layer, not a new truth source, and preserves explicit expansion/omission reasons.
- Syncs AW payload provenance required by the startup payload-target gate.

## Proof
- `uv run pytest tests/test_workspace_cli.py::test_state_delta_packet_views_derive_from_shared_core tests/test_workspace_cli.py::test_report_exposes_reasoning_economy_evidence_section packages/planning/tests/test_archive.py::test_planning_closeout_reports_unusable_proof_file_without_last_fallback -q`
- `uv run ruff check src/agentic_workspace/reporting_support.py tests/test_workspace_cli.py packages/planning/tests/test_archive.py`
- `make test-workspace`
- `make lint-workspace`
- `make test-planning`
- `make lint-planning`
- `make maintainer-surfaces`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `make absolute-paths`
- `git diff --check`
- `uv run python scripts/run_agentic_workspace.py summary --target . --format json`
- `uv run python scripts/run_agentic_workspace.py doctor --target . --modules planning --format json` (selected planning scoped health healthy; global advisory legacy payload warning remains unrelated)

Fixes #2120
Fixes #2121
Refs #2113