### PR TITLE
Cover planning closeout proof-file rejection

### DIFF
--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,8 +13,8 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:cdd4df121269",
-    "version": "0.32.2"
+    "source_identity": "git:d3df0f28c3c2",
+    "version": "0.33.1"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
   "payload_capabilities": [
@@ -40,8 +40,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.32.2",
-    "version": "0.32.2"
+    "tag": "v0.33.1",
+    "version": "0.33.1"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/.agentic-workspace/planning/execplans/archive/github-2120-2121-2123-response-evidence.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/github-2120-2121-2123-response-evidence.plan.json
@@ -1,0 +1,375 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "State-delta response evidence and proof-file diagnostics",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement remaining open #2120/#2121 state-delta visible-response evidence and #2123 proof-file diagnostic coverage, while recognizing #2111/#2113-#2119 were already implemented on merged PRs.",
+    "hard_constraints": "Do not duplicate the merged #2113 child implementation; keep the new product work to derived response/evidence packets and focused proof-file diagnostics.",
+    "agent_may_decide": "Exact helper names, report projection shape, and focused tests as long as existing packet ownership remains authoritative.",
+    "escalate_when": "A fix requires weakening proof, Planning, payload, claim, or host-agnostic boundaries, or adding broad new runtime truth sources.",
+    "next_action": "Run focused tests, selected proof, and closeout after the bounded edits.",
+    "proof_expectations": [
+      "Focused workspace/reporting and planning closeout tests.",
+      "AW-selected workspace/planning proof before completion claim."
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/reporting_support.py",
+      "tests/test_workspace_cli.py",
+      "packages/planning/tests/test_archive.py",
+      ".agentic-workspace/payload-provenance.json",
+      ".agentic-workspace/planning/execplans/github-2120-2121-2123-response-evidence.plan.json"
+    ],
+    "completion_criteria": [
+      "Visible response compiler packet exists and is reportable.",
+      "State-delta replay evidence covers at least two workflow classes.",
+      "Proof-file rejection warning/action coverage names the rejected path and avoids misleading last-receipt fallback wording."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Create a bounded plan for State-delta response evidence and proof-file diagnostics."
+  ],
+  "non_goals": [
+    "Leave adjacent backlog or follow-on work out of this plan."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Implement remaining open #2120/#2121 state-delta visible-response evidence and #2123 proof-file diagnostic coverage, while recognizing #2111/#2113-#2119 were already implemented on merged PRs.",
+      "constraints": "Do not duplicate the merged #2113 child implementation; keep the new product work to derived response/evidence packets and focused proof-file diagnostics.",
+      "latitude": "Exact helper names, report projection shape, and focused tests as long as existing packet ownership remains authoritative.",
+      "escalation": "Escalate when a fix requires weakening proof, Planning, payload, claim, or host-agnostic boundaries.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "github-2120-2121-2123-response-evidence",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/reporting_support.py",
+        "tests/test_workspace_cli.py",
+        "packages/planning/tests/test_archive.py",
+        ".agentic-workspace/payload-provenance.json",
+        ".agentic-workspace/planning/execplans/github-2120-2121-2123-response-evidence.plan.json"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Implement the remaining open issue gaps in the #2111-#2123 range that were not already covered by merged PRs.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Implement issues #2111 through #2123 in stacked PRs grouped by related issues",
+    "inferred intended outcome": "Group by related issue clusters, avoid reimplementing already-merged #2113/#2122 work, and publish narrow follow-up PRs for remaining open gaps.",
+    "chosen concrete what": "Add a derived visible-response compiler/replay evidence surface for #2120/#2121 and proof-file rejection coverage for #2123.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace/reporting_support.py; tests/test_workspace_cli.py; packages/planning/tests/test_archive.py; AW payload/provenance sync and this plan.",
+    "max changed files": "about 8 tracked files including required AW payload sync and plan custody.",
+    "required validation commands": "Focused pytest for state-delta/reporting and planning closeout proof-file diagnostics; ruff on touched Python files; AW-selected workspace/planning proof before closeout.",
+    "ask-before-refactor threshold": "Ask before changing existing state-delta ownership, closeout/proof semantics, or broad report routing.",
+    "stop before touching": "Unrelated #2113 child runtime implementation, session logging, release workflows, or host-specific tracker automation."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, #2120/#2121/#2123 issue bodies, reporting_support.py, workspace CLI tests, and planning archive tests.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Continue from the focused response compiler/replay evidence and proof-file diagnostic test changes; #2113 child work is already merged.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Implement remaining open #2120/#2121 state-delta visible-response evidence and #2123 proof-file diagnostic coverage, while recognizing #2111/#2113-#2119 were already implemented on merged PRs.",
+    "hard constraints": "Do not duplicate the merged #2113 child implementation; keep the new product work to derived response/evidence packets and focused proof-file diagnostics.",
+    "agent may decide locally": "Exact helper names, report projection shape, and focused tests as long as existing packet ownership remains authoritative.",
+    "escalate when": "A fix requires weakening proof, Planning, payload, claim, or host-agnostic boundaries."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "github-2120-2121-2123-response-evidence",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to #2120/#2121/#2123 follow-up evidence and diagnostics.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Run focused tests, selected proof, and closeout after the bounded edits."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/reporting_support.py",
+    "tests/test_workspace_cli.py",
+    "packages/planning/tests/test_archive.py",
+    ".agentic-workspace/payload-provenance.json",
+    ".agentic-workspace/planning/execplans/github-2120-2121-2123-response-evidence.plan.json"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_cli.py::test_state_delta_packet_views_derive_from_shared_core tests/test_workspace_cli.py::test_report_exposes_reasoning_economy_evidence_section packages/planning/tests/test_archive.py::test_planning_closeout_reports_unusable_proof_file_without_last_fallback -q",
+    "uv run ruff check src/agentic_workspace/reporting_support.py tests/test_workspace_cli.py packages/planning/tests/test_archive.py",
+    "AW-selected workspace/planning proof before closeout."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Visible response compiler packet exists and is reportable.",
+    "State-delta replay evidence covers at least two workflow classes.",
+    "Proof-file rejection warning/action coverage names the rejected path and avoids misleading last-receipt fallback wording.",
+    "Already-merged #2113 child stack is referenced as existing evidence, not duplicated."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Added a visible state-delta response compiler packet and replay evidence in reasoning_economy for #2120/#2121, plus proof-file rejection coverage for #2123.",
+    "scope touched": "src/agentic_workspace/reporting_support.py; tests/test_workspace_cli.py; packages/planning/tests/test_archive.py; .agentic-workspace payload provenance and planning custody surfaces.",
+    "changed surfaces": "reporting_support.py; tests/test_workspace_cli.py; packages/planning/tests/test_archive.py; .agentic-workspace/payload-provenance.json; .agentic-workspace/planning/state.toml; .agentic-workspace/planning/execplans/github-2120-2121-2123-response-evidence.plan.json",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope stayed bounded. Host-agnostic agent judgment was preserved: the compiler derives visible parts from existing structured packets and does not infer routing from prose or create a new truth source. Test evidence review inspected docs/maintainer/testing-strategy.md, docs/maintainer/test-knowledge-inventory.md, and Verification runtime guidance; the added tests are additive behavior coverage for high-risk report/closeout surfaces, not pruning or replacement evidence.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "Passed: focused pytest for state-delta/reporting and proof-file diagnostics; ruff on touched Python files; make test-workspace; make lint-workspace; make test-planning; make lint-planning; git diff docs/manual review; summary; planning doctor; maintainer-surfaces; generated command package check; absolute-paths; git diff --check.",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for State-delta response evidence and proof-file diagnostics.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Remaining open gaps in #2120/#2121/#2123 are implemented and validated; #2111/#2113-#2119 were already covered by merged PRs #2125-#2127 and release v0.33.1, and #2122 was already closed.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "archive",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "archive",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "archive"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a slice claim with intent-status satisfied.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-09: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for State-delta response evidence and proof-file diagnostics.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: Passed: focused pytest for state-delta/reporting and proof-file diagnostics; ruff on touched Python files; make test-workspace; make lint-workspace; make test-planning; make lint-planning; git diff docs/manual review; summary; planning doctor; maintainer-surfaces; generated command package check; absolute-paths; git diff --check.\nChanged surfaces: reporting_support.py; tests/test_workspace_cli.py; packages/planning/tests/test_archive.py; .agentic-workspace/payload-provenance.json; .agentic-workspace/planning/state.toml; .agentic-workspace/planning/execplans/github-2120-2121-2123-response-evidence.plan.json\nDurable residue: none (archive)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -1127,6 +1127,53 @@ def test_planning_closeout_reads_shell_sensitive_proof_from_file(tmp_path: Path,
     assert archived["execution_run"]["validations run"] == proof_text
 
 
+def test_planning_closeout_reports_unusable_proof_file_without_last_fallback(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="active")
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--proof-file",
+                ".agentic-workspace/local/proof-receipts/missing-closeout.md",
+                "--what-happened",
+                "attempted closeout with a missing proof file.",
+                "--scope-touched",
+                "packages/planning/src/repo_planning_bootstrap/installer.py",
+                "--changed-surfaces",
+                "planning closeout command",
+                "--review-summary",
+                "blocked on proof-file input.",
+                "--outcome-summary",
+                "proof-file rejection is explicit.",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    warning = payload["warnings"][0]
+    payload_text = json.dumps(payload)
+
+    assert warning["warning_class"] == "closeout_proof_file_unusable"
+    assert warning["path"] == ".agentic-workspace/local/proof-receipts/missing-closeout.md"
+    assert warning["message"] == "--proof-file path does not exist or is not a file"
+    assert "--proof-file <path>" in warning["suggested_fix"]
+    assert any(
+        action["kind"] == "manual review"
+        and str(action["path"]).replace("\\", "/").endswith(".agentic-workspace/local/proof-receipts/missing-closeout.md")
+        for action in payload["actions"]
+    )
+    assert "--proof-from last" not in payload_text
+    assert not (tmp_path / ".agentic-workspace" / "planning" / "execplans" / "archive" / "plan-alpha.plan.json").exists()
+
+
 def test_planning_closeout_dry_run_previews_normalized_completed_state(tmp_path: Path, capsys) -> None:
     _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
     record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"

--- a/src/agentic_workspace/reporting_support.py
+++ b/src/agentic_workspace/reporting_support.py
@@ -390,6 +390,113 @@ def evidence_bundle_payload(
     }
 
 
+def visible_state_delta_response_payload(
+    *,
+    surface: str,
+    current_decision: dict[str, Any],
+    message_economy: dict[str, Any] | None = None,
+    evidence_bundle: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    economy = message_economy if isinstance(message_economy, dict) else message_economy_payload(surface=surface)
+    evidence = evidence_bundle if isinstance(evidence_bundle, dict) else {}
+    minimal_surfaces = [
+        str(item.get("id"))
+        for item in _support_list_payload(evidence.get("minimal_evidence_surfaces"))
+        if isinstance(item, dict) and str(item.get("id", "")).strip()
+    ]
+    missing_evidence = [str(item) for item in _support_list_payload(evidence.get("missing_evidence")) if str(item).strip()]
+    expansion_triggers = list(economy.get("expand_when", []))
+    omitted_details = [
+        {
+            "detail": "chronological recap",
+            "reason": "not needed when decision, evidence, boundary, and next action are state-backed",
+            "route": "detail selectors or verbose report output",
+        },
+        {
+            "detail": "full evidence payload",
+            "reason": "minimal evidence surfaces and missing evidence are enough for the visible update",
+            "route": ",".join(minimal_surfaces) if minimal_surfaces else "evidence_bundle",
+        },
+    ]
+    parts = {
+        "decision_or_finding": str(current_decision.get("decision_question") or current_decision.get("status") or ""),
+        "evidence_or_proof_boundary": str(current_decision.get("proof_boundary") or "not-evaluated"),
+        "residue_or_claim_boundary": str(current_decision.get("residue_owner") or "none"),
+        "next_safe_action": str(current_decision.get("next_action") or current_decision.get("safe_probe") or ""),
+    }
+    return {
+        "kind": "agentic-workspace/visible-state-delta-response/v1",
+        "surface": surface,
+        "status": "ready" if all(parts.values()) else "incomplete",
+        "parts": parts,
+        "expansion_triggers": expansion_triggers,
+        "omitted_details": omitted_details,
+        "missing_evidence": missing_evidence,
+        "source_packets": [
+            "current_decision",
+            *([] if message_economy is None else ["message_economy"]),
+            *([] if evidence_bundle is None else ["evidence_bundle"]),
+        ],
+        "ownership_boundary": (
+            "This packet compiles visible answer parts from existing AW packets; it is a renderer and not a new truth source."
+        ),
+        "state_backed": bool(current_decision.get("state_backed", True)),
+    }
+
+
+def state_delta_replay_evidence_payload() -> dict[str, Any]:
+    examples = [
+        {
+            "id": "review-rereview",
+            "workflow_class": "review",
+            "input_packets": ["current_decision", "message_economy", "evidence_bundle"],
+            "visible_parts": ["decision_or_finding", "evidence_or_proof_boundary", "residue_or_claim_boundary", "next_safe_action"],
+            "avoided": ["full prose recap", "manual reconstruction of proof boundary"],
+            "comparison": "Review update can lead with the finding and proof boundary instead of replaying inspected files.",
+        },
+        {
+            "id": "handoff-continuation",
+            "workflow_class": "handoff",
+            "input_packets": ["current_decision", "continuation_capsule", "evidence_bundle"],
+            "visible_parts": ["decision_or_finding", "evidence_or_proof_boundary", "residue_or_claim_boundary", "next_safe_action"],
+            "avoided": ["chat-history reconstruction", "duplicated context already carried by continuation capsule"],
+            "comparison": "Continuation update resumes from preserved intent, unresolved residue, and next safe action.",
+        },
+        {
+            "id": "closeout",
+            "workflow_class": "closeout",
+            "input_packets": ["closeout_ready", "current_decision", "message_economy"],
+            "visible_parts": ["decision_or_finding", "evidence_or_proof_boundary", "residue_or_claim_boundary", "next_safe_action"],
+            "avoided": ["joining multiple closeout reports by hand", "unsafe closure wording without claim boundary"],
+            "comparison": "Closeout update can state strongest safe claim, proof state, residue, and closure boundary directly.",
+        },
+    ]
+    return {
+        "kind": "agentic-workspace/state-delta-replay-evidence/v1",
+        "status": "available",
+        "workflow_class_count": len({example["workflow_class"] for example in examples}),
+        "examples": examples,
+        "required_visible_parts": [
+            "decision_or_finding",
+            "evidence_or_proof_boundary",
+            "residue_or_claim_boundary",
+            "next_safe_action",
+        ],
+        "safety_preserved": [
+            "proof boundary remains visible",
+            "residue or claim boundary remains visible",
+            "next action remains visible",
+            "expansion triggers remain explicit",
+        ],
+        "non_goals": [
+            "hidden reasoning evaluation",
+            "prompt-keyword scoring",
+            "shorter output without proof or residue boundaries",
+        ],
+        "rule": "Replay evidence demonstrates visible response construction from structured packets across ordinary workflow classes.",
+    }
+
+
 def _load_reasoning_economy_evidence_ledger(*, target_root: Path | None) -> dict[str, Any]:
     if target_root is None:
         return {
@@ -487,11 +594,31 @@ def reasoning_economy_evidence_payload(*, target_root: Path | None = None, cli_i
             }
         )
     evidence_ledger_source = _load_reasoning_economy_evidence_ledger(target_root=target_root)
+    sample_decision_packet = {
+        "phase_question": "What changed for the visible update?",
+        "next_action": "Use the compact visible-state-delta response parts.",
+        "claim_boundary": "claim requires proof/residue boundary",
+        "residue_owner": "none",
+        "detail_routes": {"reasoning_economy": "report --section reasoning_economy"},
+    }
+    sample_core = state_delta_core_payload(surface="report", decision_packet=sample_decision_packet)
+    sample_current = current_decision_payload(surface="report", decision_packet=sample_decision_packet, state_delta_core=sample_core)
+    sample_economy = message_economy_payload(surface="report", state_delta_core=sample_core)
+    sample_evidence = evidence_bundle_payload(surface="report", current_decision=sample_current, state_delta_core=sample_core)
+    visible_response_compiler = visible_state_delta_response_payload(
+        surface="report",
+        current_decision=sample_current,
+        message_economy=sample_economy,
+        evidence_bundle=sample_evidence,
+    )
+    replay_evidence = state_delta_replay_evidence_payload()
     return {
         "kind": "agentic-workspace/reasoning-economy-evidence/v1",
         "status": "available",
         "scope": "visible_external_artifacts_only",
         "evidence_ledger_source": evidence_ledger_source,
+        "visible_response_compiler": visible_response_compiler,
+        "state_delta_replay_evidence": replay_evidence,
         "non_goals": [
             "hidden chain-of-thought grading",
             "semantic scoring of private reasoning",
@@ -927,6 +1054,10 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
     if section == "reasoning_economy" and isinstance(answer, dict):
         behavior = answer.get("behavior_check", {})
         behavior = behavior if isinstance(behavior, dict) else {}
+        compiler = answer.get("visible_response_compiler", {})
+        compiler = compiler if isinstance(compiler, dict) else {}
+        replay = answer.get("state_delta_replay_evidence", {})
+        replay = replay if isinstance(replay, dict) else {}
         return _localize_command_fields(
             {
                 "kind": answer.get("kind", "agentic-workspace/reasoning-economy-evidence/v1"),
@@ -936,6 +1067,18 @@ def _compact_report_section_answer(section: str, answer: Any, *, cli_invoke: str
                 if isinstance(answer.get("evidence_classes"), dict)
                 else [],
                 "required_visible_fields": behavior.get("required_visible_fields", []),
+                "visible_response_compiler": {
+                    key: compiler.get(key)
+                    for key in ("kind", "status", "surface", "parts", "expansion_triggers", "ownership_boundary")
+                    if key in compiler
+                },
+                "state_delta_replay_evidence": {
+                    "kind": replay.get("kind", "agentic-workspace/state-delta-replay-evidence/v1"),
+                    "status": replay.get("status", "available"),
+                    "workflow_class_count": replay.get("workflow_class_count", 0),
+                    "example_ids": [item.get("id", "") for item in _support_list_payload(replay.get("examples")) if isinstance(item, dict)],
+                    "safety_preserved": replay.get("safety_preserved", []),
+                },
                 "ledger_refs": [
                     item.get("ref", "") for item in _support_list_payload(answer.get("evidence_ledger")) if isinstance(item, dict)
                 ],

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -75,6 +75,8 @@ def test_state_delta_packet_views_derive_from_shared_core() -> None:
         evidence_bundle_payload,
         message_economy_payload,
         state_delta_core_payload,
+        state_delta_replay_evidence_payload,
+        visible_state_delta_response_payload,
     )
 
     decision_packet = {
@@ -107,6 +109,13 @@ def test_state_delta_packet_views_derive_from_shared_core() -> None:
         state_delta_core=core,
     )
     bundle = evidence_bundle_payload(surface="startup", current_decision=current, state_delta_core=core)
+    visible = visible_state_delta_response_payload(
+        surface="startup",
+        current_decision=current,
+        message_economy=economy,
+        evidence_bundle=bundle,
+    )
+    replay = state_delta_replay_evidence_payload()
 
     assert core["kind"] == "agentic-workspace/state-delta-core/v1"
     assert current["proof_boundary"] == core["boundary"]["proof"]
@@ -121,6 +130,17 @@ def test_state_delta_packet_views_derive_from_shared_core() -> None:
     assert economy["expand_when"] == core["output_policy"]["expand_when"]
     assert current["avoid_repeat"] == core["output_policy"]["avoid"]
     assert capsule["do_not_repeat"] == core["output_policy"]["avoid"]
+    assert visible["kind"] == "agentic-workspace/visible-state-delta-response/v1"
+    assert visible["parts"] == {
+        "decision_or_finding": "What changed?",
+        "evidence_or_proof_boundary": "partial-progress",
+        "residue_or_claim_boundary": "planning",
+        "next_safe_action": "Run the focused proof.",
+    }
+    assert visible["ownership_boundary"].endswith("not a new truth source.")
+    assert replay["workflow_class_count"] >= 2
+    assert {"review", "handoff", "closeout"} == {item["workflow_class"] for item in replay["examples"]}
+    assert all("next_safe_action" in item["visible_parts"] for item in replay["examples"])
 
 
 def _assert_selector_inventory_omitted_from_compact_start(payload: dict[str, Any]) -> dict[str, Any]:
@@ -6726,6 +6746,11 @@ def test_report_exposes_reasoning_economy_evidence_section(tmp_path: Path, capsy
         "residue_or_boundary",
         "next_action_or_closure_status",
     ]
+    assert answer["visible_response_compiler"]["kind"] == "agentic-workspace/visible-state-delta-response/v1"
+    assert answer["visible_response_compiler"]["parts"]["next_safe_action"] == "Use the compact visible-state-delta response parts."
+    assert answer["state_delta_replay_evidence"]["kind"] == "agentic-workspace/state-delta-replay-evidence/v1"
+    assert answer["state_delta_replay_evidence"]["workflow_class_count"] >= 2
+    assert "review-rereview" in answer["state_delta_replay_evidence"]["example_ids"]
     assert answer["ledger_refs"] == []
     assert "PR #1955" not in json.dumps(answer)
     fixture_results = {item["id"]: item for item in answer["fixture_results"]}
@@ -6745,6 +6770,14 @@ def test_report_exposes_reasoning_economy_evidence_section(tmp_path: Path, capsy
         "handoff summary",
     ]
     assert full["reasoning_economy"]["evidence_ledger_source"]["status"] == "absent"
+    assert full["reasoning_economy"]["visible_response_compiler"]["source_packets"] == [
+        "current_decision",
+        "message_economy",
+        "evidence_bundle",
+    ]
+    replay_examples = {item["id"]: item for item in full["reasoning_economy"]["state_delta_replay_evidence"]["examples"]}
+    assert replay_examples["handoff-continuation"]["workflow_class"] == "handoff"
+    assert "proof boundary remains visible" in full["reasoning_economy"]["state_delta_replay_evidence"]["safety_preserved"]
 
 
 def test_report_reasoning_economy_reads_repo_owned_evidence_ledger(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Adds regression coverage for `planning closeout --proof-file <path>` when the supplied proof file is unusable.
- Verifies the proof-file-specific warning names the rejected path, recommends the `--proof-file` repair route, avoids misleading `--proof-from last` fallback messaging, and does not archive the plan.
- Carries command-owned closeout evidence for the bounded #2120/#2121/#2123 follow-up slice.

## Proof
- `uv run pytest tests/test_workspace_cli.py::test_state_delta_packet_views_derive_from_shared_core tests/test_workspace_cli.py::test_report_exposes_reasoning_economy_evidence_section packages/planning/tests/test_archive.py::test_planning_closeout_reports_unusable_proof_file_without_last_fallback -q`
- `uv run ruff check src/agentic_workspace/reporting_support.py tests/test_workspace_cli.py packages/planning/tests/test_archive.py`
- `make test-workspace`
- `make lint-workspace`
- `make test-planning`
- `make lint-planning`
- `make maintainer-surfaces`
- `uv run python scripts/generate/generate_command_packages.py --check`
- `make absolute-paths`
- `git diff --check`
- Planning closeout completed with explicit proof after `--proof-from last` exposed a receipt-scope mismatch.

## Dogfooding
Filed #2137 for the durable receipt/closeout mismatch discovered during closeout.

Fixes #2123
Refs #2120
Refs #2121
Refs #2137