### PR TITLE
Repair contract tooling and runtime boundary proof drift

### DIFF
--- a/docs/reference/workspace-report.md
+++ b/docs/reference/workspace-report.md
@@ -77,6 +77,29 @@ Combined workspace report payload for installed modules, config posture, diagnos
 | `installed_state_compatibility.action_state.rule` | string | no |  | Policy rule for applying this action state. |  |  |
 | `installed_state_compatibility.payload_surface_manifest` | object | no |  | Current payload surface contract used to classify installed-state upgrade work. |  |  |
 | `installed_state_compatibility.payload_upgrade_attention_plan` | object | no |  | Structured current-state convergence plan for payload upgrade attention items. |  |  |
+| `installed_state_compatibility.payload_repair_subflow` | ref `#/$defs/payload_repair_subflow` | yes |  | Explicit dry-run, apply, and recheck route for installed payload repair. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.kind` | const `"agentic-workspace/payload-repair-subflow/v1"` | yes |  | Discriminator identifying the payload-repair subflow. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.status` | enum `"not-required"`, `"safe-explicit-apply"`, `"manual-review"`, `"blocked"`, `"review"` | yes |  | Current payload-repair route classification. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.source_status` | enum `"compatible"`, `"upgrade-recommended"`, `"payload-upgrade-required"`, `"blocking-drift"` | yes |  | Installed-state compatibility status that produced this subflow. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.repair_mechanism` | string | yes |  | Package-owned repair mechanism selected for the current state. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.safe_explicit_apply` | boolean | yes |  | Whether an explicit reviewed apply step is safe. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.manual_review_required` | boolean | yes |  | Whether payload attention items require manual review. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.start_mutates` | const `false` | yes |  | Startup and report surfaces never apply payload repair implicitly. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.next_action` | string | yes |  | Decision-first next action for the repair subflow. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.steps` | array of object | yes |  | Ordered dry-run, apply, and recheck steps. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.reportable_commands` | ref `#/$defs/payload_repair_commands` | yes |  | Repo-relative commands exposed in human-facing reports. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.reportable_commands.dry_run` | string | yes |  | Payload repair preview command. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.reportable_commands.apply` | string | yes |  | Explicit payload repair apply command. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.reportable_commands.recheck` | string | yes |  | Post-repair compatibility recheck command. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.machine_commands` | ref `#/$defs/payload_repair_commands` | yes |  | Configured commands used by machine execution. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.machine_commands.dry_run` | string | yes |  | Payload repair preview command. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.machine_commands.apply` | string | yes |  | Explicit payload repair apply command. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.machine_commands.recheck` | string | yes |  | Post-repair compatibility recheck command. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.attention_item_count` | integer | yes |  | Number of payload attention items in the current plan. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.category_counts` | object | yes |  | Payload attention item counts by category. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.category_counts.<name>` | integer | no |  | Count for one payload attention category. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.detail_selector` | const `"installed_state_compatibility.payload_repair_subflow"` | yes |  | Selector for the full payload-repair subflow. |  |  |
+| `installed_state_compatibility.payload_repair_subflow.rule` | string | yes |  | Safety and command-rendering boundary for payload repair. |  |  |
 | `installed_state_compatibility.executable` | object | yes |  | Executable identity and compatibility classification. |  |  |
 | `installed_state_compatibility.payload` | object | yes |  | Installed repo payload compatibility and sync guidance. |  |  |
 | `installed_state_compatibility.generated_artifacts` | object | yes |  | Generated artifact freshness classification. |  |  |

--- a/scripts/check/check_generated_command_packages.py
+++ b/scripts/check/check_generated_command_packages.py
@@ -288,6 +288,9 @@ PYTHON_FULL_COMPLETION_ACCEPTED_RUNTIME_FACADE_PATHS = (
     "generated/planning/python/primitives/planning_runtime.py",
     "generated/memory/python/primitives/memory_runtime.py",
 )
+PYTHON_FULL_COMPLETION_ACCEPTED_RUNTIME_HANDLER_COMMAND_PATHS = (
+    "generated/workspace/python/commands/session_log_manage.py",
+)
 PYTHON_ACCEPTED_RUNTIME_BOUNDARY_PERMANENCE_STATUS = "accepted-permanent-package-domain-boundary"
 GENERATED_CLI_COMPATIBILITY_VOCABULARY = (
     "generated_cli_package",
@@ -1920,6 +1923,7 @@ def _validate_python_completion_accepted_runtime_boundaries(*, require_exact: bo
         "agentic_workspace.workspace_runtime_implement": "src/agentic_workspace/workspace_runtime_implement.py",
         "agentic_workspace.workspace_runtime_startup": "src/agentic_workspace/workspace_runtime_startup.py",
         "agentic_workspace.doctor": "src/agentic_workspace/doctor.py",
+        "agentic_workspace.session_logging": "src/agentic_workspace/session_logging.py",
         "repo_planning_bootstrap.installer": "packages/planning/src/repo_planning_bootstrap/installer.py",
         "repo_planning_bootstrap.runtime_projection": "packages/planning/src/repo_planning_bootstrap/runtime_projection.py",
         "repo_memory_bootstrap.installer": "packages/memory/src/repo_memory_bootstrap/installer.py",
@@ -3170,6 +3174,7 @@ def _generated_runtime_facade_package_runtime_bindings() -> list[dict[str, str]]
         "agentic_workspace.workspace_runtime_implement",
         "agentic_workspace.workspace_runtime_startup",
         "agentic_workspace.doctor",
+        "agentic_workspace.session_logging",
         "repo_planning_bootstrap.installer",
         "repo_planning_bootstrap.runtime_projection",
         "repo_memory_bootstrap.installer",
@@ -3179,7 +3184,11 @@ def _generated_runtime_facade_package_runtime_bindings() -> list[dict[str, str]]
     }
     metadata = _python_runtime_boundary_metadata()
     bindings: list[dict[str, str]] = []
-    for relative_path in PYTHON_FULL_COMPLETION_ACCEPTED_RUNTIME_FACADE_PATHS:
+    accepted_caller_paths = (
+        *PYTHON_FULL_COMPLETION_ACCEPTED_RUNTIME_FACADE_PATHS,
+        *PYTHON_FULL_COMPLETION_ACCEPTED_RUNTIME_HANDLER_COMMAND_PATHS,
+    )
+    for relative_path in accepted_caller_paths:
         path = REPO_ROOT / relative_path
         if not path.is_file():
             continue

--- a/src/agentic_workspace/contracts/python_runtime_projection_inventory.json
+++ b/src/agentic_workspace/contracts/python_runtime_projection_inventory.json
@@ -12,6 +12,7 @@
     "required_granularity": "source-symbol",
     "status": "exact-symbol-proof-satisfied",
     "baseline_symbols": [
+      "runtime-facade-call|generated/workspace/python/commands/session_log_manage.py|run|agentic_workspace.session_logging|_run_session_log_adapter",
       "operation-function-call|generated/memory/python/operations/memory.adopt.lifecycle.json|memory.adopt.lifecycle|repo_memory_bootstrap.installer|adopt_bootstrap",
       "operation-function-call|generated/memory/python/operations/memory.bootstrap-cleanup.apply.json|memory.bootstrap-cleanup.apply|repo_memory_bootstrap.installer|cleanup_bootstrap_workspace",
       "operation-function-call|generated/memory/python/operations/memory.capture-note.report.json|memory.capture-note.report|repo_memory_bootstrap.installer|suggest_memory_note_capture",
@@ -89,6 +90,34 @@
       "runtime-facade-call|generated/workspace/python/primitives/workspace_runtime.py|_run_summary_report_adapter|agentic_workspace.workspace_runtime_primitives|_run_summary_report_adapter"
     ],
     "entries": [
+      {
+        "binding_kind": "runtime-facade-call",
+        "facade_path": "generated/workspace/python/commands/session_log_manage.py",
+        "facade_symbol": "run",
+        "source_module": "agentic_workspace.session_logging",
+        "source_symbol": "_run_session_log_adapter",
+        "owner_package": "workspace package runtime boundary",
+        "operation_ids": [
+          "session-log.manage"
+        ],
+        "primitive_refs": [
+          "runtime_module_handler:session-log.manage"
+        ],
+        "runtime_boundary_class": "package-specific-judgment",
+        "why_not_generic_deterministic": "The symbol owns ignored-local session log path containment, pointer validation, append/write policy, and compatibility output rather than generic deterministic target-executor logic.",
+        "conformance_ref": "session-log.manage.process",
+        "status": "accepted-permanent-package-domain-boundary",
+        "generic_behavior_audit": "Classified as package-specific-judgment; generated parser and command dispatch own the command projection while the package runtime boundary owns ignored-local session log containment, pointer validation, append/write policy, and compatibility output.",
+        "minimization_category": "package-specific-judgment",
+        "minimization_route": "keep-as-hand-owned-primitive",
+        "minimization_owner": "package runtime primitive owner for semantic package judgment",
+        "minimization_tracking_issue": "#2153",
+        "stale_when": "Stale when session log status, note append, and new-session behavior can be represented as stable declarative dataflow with equivalent ignored-local containment and compatibility safeguards.",
+        "direct_edit_reasons_allowed": [
+          "existing-primitive-bugfix",
+          "new-primitive-implementation"
+        ]
+      },
       {
         "binding_kind": "operation-function-call",
         "operation_path": "generated/memory/python/operations/memory.adopt.lifecycle.json",

--- a/src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json
+++ b/src/agentic_workspace/contracts/schemas/python_runtime_projection_inventory.schema.json
@@ -367,7 +367,7 @@
         },
         "facade_path": {
           "type": "string",
-          "pattern": "^generated/(workspace/python/primitives/(workspace_runtime|workspace_implement_runtime|workspace_startup_runtime)|planning/python/primitives/(planning_installer|planning_runtime)|memory/python/primitives/memory_runtime)\\.py$",
+          "pattern": "^generated/(workspace/python/(primitives/(workspace_runtime|workspace_implement_runtime|workspace_startup_runtime)|commands/[a-z0-9_]+)|planning/python/primitives/(planning_installer|planning_runtime)|memory/python/primitives/memory_runtime)\\.py$",
           "description": "Generated runtime facade path containing the wrapper."
         },
         "facade_symbol": {
@@ -391,6 +391,7 @@
             "agentic_workspace.workspace_runtime_implement",
             "agentic_workspace.workspace_runtime_startup",
             "agentic_workspace.doctor",
+            "agentic_workspace.session_logging",
             "repo_planning_bootstrap.installer",
             "repo_planning_bootstrap.runtime_projection",
             "repo_memory_bootstrap.installer",

--- a/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
+++ b/src/agentic_workspace/contracts/schemas/workspace_report.schema.json
@@ -1345,7 +1345,8 @@
         "authority",
         "executable",
         "payload",
-        "generated_artifacts"
+        "generated_artifacts",
+        "payload_repair_subflow"
       ],
       "properties": {
         "kind": {
@@ -1492,6 +1493,10 @@
           "additionalProperties": true,
           "description": "Structured current-state convergence plan for payload upgrade attention items."
         },
+        "payload_repair_subflow": {
+          "$ref": "#/$defs/payload_repair_subflow",
+          "description": "Explicit dry-run, apply, and recheck route for installed payload repair."
+        },
         "executable": {
           "type": "object",
           "description": "Executable identity and compatibility classification.",
@@ -1571,6 +1576,168 @@
       },
       "additionalProperties": false,
       "description": "Installed-state compatibility details used by startup and report surfaces."
+    },
+    "payload_repair_subflow": {
+      "type": "object",
+      "required": [
+        "kind",
+        "status",
+        "source_status",
+        "repair_mechanism",
+        "safe_explicit_apply",
+        "manual_review_required",
+        "start_mutates",
+        "next_action",
+        "steps",
+        "reportable_commands",
+        "machine_commands",
+        "attention_item_count",
+        "category_counts",
+        "detail_selector",
+        "rule"
+      ],
+      "properties": {
+        "kind": {
+          "const": "agentic-workspace/payload-repair-subflow/v1",
+          "description": "Discriminator identifying the payload-repair subflow."
+        },
+        "status": {
+          "enum": [
+            "not-required",
+            "safe-explicit-apply",
+            "manual-review",
+            "blocked",
+            "review"
+          ],
+          "description": "Current payload-repair route classification."
+        },
+        "source_status": {
+          "enum": [
+            "compatible",
+            "upgrade-recommended",
+            "payload-upgrade-required",
+            "blocking-drift"
+          ],
+          "description": "Installed-state compatibility status that produced this subflow."
+        },
+        "repair_mechanism": {
+          "type": "string",
+          "description": "Package-owned repair mechanism selected for the current state."
+        },
+        "safe_explicit_apply": {
+          "type": "boolean",
+          "description": "Whether an explicit reviewed apply step is safe."
+        },
+        "manual_review_required": {
+          "type": "boolean",
+          "description": "Whether payload attention items require manual review."
+        },
+        "start_mutates": {
+          "const": false,
+          "description": "Startup and report surfaces never apply payload repair implicitly."
+        },
+        "next_action": {
+          "type": "string",
+          "description": "Decision-first next action for the repair subflow."
+        },
+        "steps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "reportable_command",
+              "machine_command",
+              "mutates",
+              "purpose"
+            ],
+            "properties": {
+              "id": {
+                "enum": [
+                  "dry_run",
+                  "apply",
+                  "recheck"
+                ],
+                "description": "Stable payload-repair step identifier."
+              },
+              "reportable_command": {
+                "type": "string",
+                "description": "Repo-relative command safe to show in reports."
+              },
+              "machine_command": {
+                "type": "string",
+                "description": "Configured invocation used for execution."
+              },
+              "mutates": {
+                "type": "boolean",
+                "description": "Whether this step changes installed payload state."
+              },
+              "purpose": {
+                "type": "string",
+                "description": "Purpose of this repair step."
+              }
+            },
+            "additionalProperties": false
+          },
+          "description": "Ordered dry-run, apply, and recheck steps."
+        },
+        "reportable_commands": {
+          "$ref": "#/$defs/payload_repair_commands",
+          "description": "Repo-relative commands exposed in human-facing reports."
+        },
+        "machine_commands": {
+          "$ref": "#/$defs/payload_repair_commands",
+          "description": "Configured commands used by machine execution."
+        },
+        "attention_item_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of payload attention items in the current plan."
+        },
+        "category_counts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Count for one payload attention category."
+          },
+          "description": "Payload attention item counts by category."
+        },
+        "detail_selector": {
+          "const": "installed_state_compatibility.payload_repair_subflow",
+          "description": "Selector for the full payload-repair subflow."
+        },
+        "rule": {
+          "type": "string",
+          "description": "Safety and command-rendering boundary for payload repair."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Explicit non-mutating preview and reviewed payload-repair workflow."
+    },
+    "payload_repair_commands": {
+      "type": "object",
+      "required": [
+        "dry_run",
+        "apply",
+        "recheck"
+      ],
+      "properties": {
+        "dry_run": {
+          "type": "string",
+          "description": "Payload repair preview command."
+        },
+        "apply": {
+          "type": "string",
+          "description": "Explicit payload repair apply command."
+        },
+        "recheck": {
+          "type": "string",
+          "description": "Post-repair compatibility recheck command."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Commands for one payload-repair subflow."
     },
     "cli_compatibility_check": {
       "type": "object",

--- a/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
+++ b/src/agentic_workspace/contracts/workspace_runtime_primitive_families.json
@@ -629,6 +629,7 @@
           "_pre_test_evidence_guardrail_payload",
           "_proof_adequacy_payload",
           "_proof_command_for_target",
+          "_proof_command_tier",
           "_proof_command_tiers",
           "_proof_completion_options",
           "_proof_confidence_payload",

--- a/tests/test_generated_command_package_proof_runner.py
+++ b/tests/test_generated_command_package_proof_runner.py
@@ -362,6 +362,25 @@ def test_full_python_completion_rejects_wrong_operation_function_call_metadata()
     assert any("must declare operation_ids" in error for error in errors)
 
 
+def test_full_python_completion_proves_generated_runtime_handler_command_boundary() -> None:
+    checker = _load_checker()
+
+    bindings = checker._generated_runtime_facade_package_runtime_bindings()
+    session_log_binding = next(
+        binding for binding in bindings if binding["facade_path"] == "generated/workspace/python/commands/session_log_manage.py"
+    )
+
+    assert session_log_binding == {
+        "facade_path": "generated/workspace/python/commands/session_log_manage.py",
+        "facade_symbol": "run",
+        "source_module": "agentic_workspace.session_logging",
+        "source_symbol": "_run_session_log_adapter",
+        "operation_ids": ["session-log.manage"],
+        "primitive_refs": ["runtime_module_handler:session-log.manage"],
+    }
+    assert checker._validate_python_completion_accepted_runtime_boundaries()[0] == []
+
+
 def test_full_python_completion_rejects_weak_runtime_boundary_minimization_metadata() -> None:
     errors = _checker_case_errors(
         """


### PR DESCRIPTION
## Summary

Fixes #2140 and adds #2153 on the same clean-`master` PR:

- models the already-emitted `installed_state_compatibility.payload_repair_subflow` packet in `workspace_report.schema.json`;
- registers the already-imported `_proof_command_tier` helper in the shared-core primitive family;
- extends exact runtime-boundary proof to generated runtime-handler command modules;
- records the `session-log.manage` command-to-`agentic_workspace.session_logging._run_session_log_adapter` boundary at source-symbol granularity;
- refreshes the generated workspace report schema reference.

## Root cause

Two contract inventories had drifted from existing runtime output/imports (#2140). Separately, the command-surface bundle required a runtime-projection inventory row for `session-log.manage`, while exact-boundary validation only discovered generated primitive facades, so either proof could pass but not both (#2153).

## Impact

Contract tooling is green again, and `session-log.manage` now has one canonical, mechanically checked boundary representation shared by bundle-presence and exact-symbol validation. Runtime behavior and visible command surfaces are unchanged.

## Validation

- `uv run pytest tests/test_generated_command_package_proof_runner.py -q` (68 passed)
- `uv run python scripts/check/check_command_surface_bundle.py --operation-id session-log.manage --format json`
- `uv run python scripts/check/check_generated_command_packages.py`
- `uv run python scripts/check/run_operation_conformance_tests.py --target all` (19 passed)
- contract tooling and structured-file inventory checks
- required Ruff surfaces
- generated command package freshness (`--check`)
- `make test-workspace`
- `make lint-workspace`
- `make maintainer-surfaces`
- `make schema-reference-docs`
- Planning surface check

## Dogfooding and cost assessment

- workflow cost: removes recurring false-negative proof and manual baseline attribution;
- architecture cost: restores exact ownership between runtime output/imports and their schema/family/runtime-boundary registries;
- visible/default surfaces: unchanged; only contract and generated reference detail grows;
- validation role: fail-closed schema validation caught the missing generated-command path/module admission before final proof passed;
- anti-overfitting: generated command paths are schema-admissible, but the checker still uses an explicit caller allowlist and exact module/symbol/operation/primitive matching;
- durable residue: no new improvement candidate found during closeout;
- net operating-cost direction: lower.

Closes #2140
Closes #2153