### PR TITLE
Scope session logs to portable logical sessions

### DIFF
--- a/.agentic-workspace/planning/execplans/archive/session-log-logical-session-registry.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/session-log-logical-session-registry.plan.json
@@ -1,0 +1,402 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Scope session logs to portable logical sessions",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement #2157 so opaque logical-session identities resolve stable isolated log namespaces across A/B/A interleaving.",
+    "hard_constraints": "Keep identity host-neutral and local-only; never infer it from task, branch, PID, time, or vendor-specific fields; preserve identity-less and legacy-pointer compatibility plus explicit id/path selection.",
+    "agent_may_decide": "Choose the ignored registry schema, privacy-safe fingerprinting, atomic local locking, compatibility projection, and focused test fixtures within the session-logging owner.",
+    "escalate_when": "The implementation requires a new visible command, remote service, checked-in state, vendor-specific identity, or ownership outside session logging.",
+    "next_action": "Implement the ignored identity registry and resolution boundary in session_logging.py, then prove same identity, A/B/A isolation, concurrency, fallback, and legacy behavior.",
+    "proof_expectations": [
+      "uv run pytest tests/test_workspace_session_logging.py -q",
+      "make test-workspace",
+      "make lint-workspace"
+    ],
+    "touched_scope": [
+      "src/agentic_workspace/session_logging.py",
+      "tests/test_workspace_session_logging.py",
+      ".agentic-workspace/planning/execplans/session-log-logical-session-registry.plan.json",
+      ".agentic-workspace/planning/state.toml"
+    ],
+    "completion_criteria": [
+      "Scope session logs to portable logical sessions is implemented, validated, and closed out honestly."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Give each optional opaque logical-session identity one stable local Markdown/index/artifact namespace, including A/B/A interleaving and concurrent resolution."
+  ],
+  "non_goals": [
+    "Do not infer identity from task, plan, branch, PID, terminal, timeout, or vendor-specific session concepts.",
+    "Do not add a remote service, authoritative workflow state, or replace segment metadata.",
+    "Do not change generated command surfaces; identity enters through a host-neutral optional environment boundary."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Stable isolated local log namespaces per opaque logical-session identity.",
+      "constraints": "Host-neutral, privacy-safe, ignored-local, atomic, backwards-compatible, and non-authoritative.",
+      "latitude": "Registry schema, salted fingerprint representation, lock implementation, status metadata, and focused tests.",
+      "escalation": "Escalate for new visible commands, remote state, vendor coupling, or cross-module ownership.",
+      "proof": "See proof_report.validation proof."
+    },
+    "execution": {
+      "milestone": "session-log-logical-session-registry",
+      "status": "completed",
+      "next_step": "Continue via tests/test_workspace_session_logging.py.",
+      "proof": "See proof_report.validation proof."
+    },
+    "scope": {
+      "touched": [
+        "src/agentic_workspace/session_logging.py",
+        "tests/test_workspace_session_logging.py",
+        ".agentic-workspace/planning/execplans/session-log-logical-session-registry.plan.json",
+        ".agentic-workspace/planning/state.toml"
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Scope session logs to portable logical sessions.",
+    "this slice completes the larger intended outcome": "no",
+    "continuation surface": "tests/test_workspace_session_logging.py"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "Continue via tests/test_workspace_session_logging.py."
+  },
+  "intent_interpretation": {
+    "literal request": "Scope session logs to portable logical sessions",
+    "inferred intended outcome": "Create a bounded plan for Scope session logs to portable logical sessions.",
+    "chosen concrete what": "One local Markdown/index/artifact namespace now maps stably to one opaque logical session, including interleaved and concurrent use, while identity-less and legacy callers retain a deterministic default bucket.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "session_logging.py, its focused tests, and this plan/state closeout only.",
+    "max changed files": "4",
+    "required validation commands": "uv run pytest tests/test_workspace_session_logging.py -q; make test-workspace; make lint-workspace",
+    "ask-before-refactor threshold": "Ask before changing CLI/contracts, config schema, other modules, or adding a visible workflow surface.",
+    "stop before touching": "Generated packages, remote integrations, vendor-specific adapters, or checked-in identity state."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Scope session logs to portable logical sessions.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "closed-with-continuation-routed",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "session-log-logical-session-registry",
+    "status": "completed",
+    "scope": "Keep this execution thread bounded to the promoted TODO item.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "No required continuation remains for this archived slice."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "closeout scope recorded in closure_check and generated_closeout."
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "See proof_report.validation proof."
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "A/B/A identity interleaving reuses A without cross-appends or extra files.",
+    "Concurrent first resolution of one identity converges on one session namespace.",
+    "Identity-less and legacy pointers retain deterministic documented behavior and manual rotation.",
+    "Raw logical identities never appear in pointer, registry mappings, Markdown, index, artifacts, status, analysis, or export.",
+    "Focused and full workspace proof pass and #2157 is linked for closure."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented a salted ignored-local identity registry with stable A/B/A mapping, atomic lock/pointer updates, default-bucket legacy migration, privacy-safe status metadata, and caller-scoped analyze/repair/export resolution.",
+    "scope touched": "Session logging runtime, focused session tests, and bounded Planning state.",
+    "changed surfaces": "src/agentic_workspace/session_logging.py; tests/test_workspace_session_logging.py; active execplan/state",
+    "validations run": "See proof_report.validation proof.",
+    "result for continuation": "none; #2157 is fully implemented and remains open only until PR merge",
+    "next step": "merge PR #2154 to close #2157"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope respected. Host-neutral environment input only; no vendor coupling, generated commands, remote state, or heuristic identity inference. Automated and real-checkout proof satisfy #2157.",
+    "proof status": "passed",
+    "intent served": "yes; the refined #2157 end state is satisfied",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout recorded explicit proof input.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+  },
+  "proof_report": {
+    "validation proof": "26 focused session-log tests; make test-workspace; make lint-workspace; make typecheck-workspace; planning summary and scoped planning doctor; real-checkout A/B/A dogfood reused A, isolated B, and found zero raw identity leaks",
+    "proof achieved now": "yes; planning closeout recorded explicit proof input.",
+    "evidence for \"proof achieved\" state": "See proof_report.validation proof."
+  },
+  "intent_satisfaction": {
+    "original intent": "Give each optional opaque logical-session identity one stable isolated local log namespace across interleaved and concurrent use.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "See proof_report.validation proof.",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "One local Markdown/index/artifact namespace now maps stably to one opaque logical session, including interleaved and concurrent use, while identity-less and legacy callers retain a deterministic default bucket.",
+    "validation confirmed": "See proof_report.validation proof.",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "none",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "contract",
+    "learned constraint": "Logical-session identity must stay opaque, salted, ignored-local, host-neutral, and stable across A/B/A interleaving.",
+    "motivation worth preserving": "Runtime code and focused tests now enforce the portable identity registry and privacy boundary.",
+    "canonical owner now": "src/agentic_workspace/session_logging.py and tests/test_workspace_session_logging.py",
+    "promotion trigger": "none; promoted during this slice",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "tests/test_workspace_session_logging.py",
+    "proposed durable intent": "Future agents should continue from tests/test_workspace_session_logging.py rather than rediscover this closeout residue.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "tests/test_workspace_session_logging.py"
+  },
+  "closure_check": {
+    "closeout scope": "slice",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "Focused, full-suite, concurrency, privacy, compatibility, and real-checkout A/B/A evidence satisfy the refined #2157 contract.",
+    "evidence carried forward": "See proof_report.validation proof.",
+    "reopen trigger": "Reopen if distinct supplied identities share a namespace, A/B/A creates a third file, raw identity leaks, or legacy/default resolution regresses."
+  },
+  "improvement_signal_review": {
+    "status": "signals_fixed",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [
+      "One repository-wide pointer merged 210 commands, 20 segments, and 9 task values into one physical session file."
+    ],
+    "signals fixed": [
+      "#2157: stable identity registry, concurrency lock, default-bucket migration, and privacy-safe resolution"
+    ],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "none"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [
+        {
+          "summary": "Opaque identity, A/B/A reuse, concurrency, privacy, default migration, and manual rotation are enforced in runtime code and focused tests.",
+          "owner": "src/agentic_workspace/session_logging.py and tests/test_workspace_session_logging.py",
+          "source": "durable_residue"
+        }
+      ],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "cost_assessment": {
+    "workflow_cost_found": "Agents previously had to remember manual new-session rotation or analyze many logical sessions after they were merged into one file.",
+    "architecture_cost_found": "One repository-wide compatibility pointer was serving as both last-resolved projection and canonical session owner.",
+    "needless_complexity_found": "The fix keeps one existing environment boundary and local pointer while adding only an ignored registry and lock; no new command or task concept was added.",
+    "correct_by_design_assessment": "Supplying an opaque identity now constructs the correct namespace before logging; tests and dogfooding confirm rather than teach manual repair.",
+    "surfaces_added": "One optional host-neutral environment input and ignored local registry; status adds compact resolution metadata.",
+    "surfaces_removed_merged_or_demoted": "The global pointer is demoted from canonical owner to last-resolved compatibility projection.",
+    "artifact_footprint_changed": "Separate Markdown/index/artifact namespaces are created only for distinct supplied identities; one compact archived execplan records proof.",
+    "shipped_default_footprint_changed": "Identity-less callers retain the deterministic default bucket; no new command or remote surface is shipped.",
+    "signals_consumed": [
+      "#2157",
+      "observed 210-command mixed session file"
+    ],
+    "signals_still_accumulating": [],
+    "durable_residue_consumed_or_routed": "The host-neutral identity and privacy boundary is enforced by session_logging.py and focused tests.",
+    "human_steering_avoided_next_time": "Agents no longer need a human reminder to rotate files between integrations that supply stable logical identities.",
+    "validation_role": "Focused tests caught compatibility details; final full-suite and real-checkout dogfooding confirmed the constructed path.",
+    "follow_up_routed": "none",
+    "net_cost_direction": "lower"
+  },
+  "drift_log": [
+    "2026-07-10: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "yes",
+    "decision": "promote_to_docs_contracts_checks_code",
+    "target": "src/agentic_workspace/session_logging.py and tests/test_workspace_session_logging.py",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [
+          "done",
+          "implemented",
+          "complete",
+          "finished",
+          "all",
+          "full intent complete"
+        ],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "The refined #2157 acceptance criteria are covered by focused, full-suite, and real-checkout proof."
+    },
+    "continuation": {
+      "owner_surface": "none",
+      "created_or_required": false,
+      "reason": "none"
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Give each opaque logical-session identity one stable isolated local log namespace.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: 26 focused session-log tests; make test-workspace; make lint-workspace; make typecheck-workspace; planning summary and scoped planning doctor; real-checkout A/B/A dogfood reused A, isolated B, and found zero raw identity leaks\nChanged surfaces: src/agentic_workspace/session_logging.py; tests/test_workspace_session_logging.py; archived execplan\nDurable residue: contract (runtime code and focused tests)\nMemory learning: promote_to_docs_contracts_checks_code\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/.agentic-workspace/planning/execplans/archive/session-log-logical-session-registry.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/session-log-logical-session-registry.plan.json
@@ -67,7 +67,7 @@
     "execution": {
       "milestone": "session-log-logical-session-registry",
       "status": "completed",
-      "next_step": "Continue via tests/test_workspace_session_logging.py.",
+      "next_step": "No required continuation remains; merge PR #2158 to close #2157.",
       "proof": "See proof_report.validation proof."
     },
     "scope": {
@@ -83,9 +83,9 @@
     }
   },
   "intent_continuity": {
-    "larger intended outcome": "Create a bounded plan for Scope session logs to portable logical sessions.",
-    "this slice completes the larger intended outcome": "no",
-    "continuation surface": "tests/test_workspace_session_logging.py"
+    "larger intended outcome": "Scope session-log files to portable logical sessions as refined in #2157.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
   },
   "required_continuation": {
     "required follow-on for the larger intended outcome": "no",
@@ -93,19 +93,19 @@
     "activation trigger": "none"
   },
   "iterative_follow_through": {
-    "what this slice enabled": "none yet",
+    "what this slice enabled": "Stable isolated log namespaces for opaque identity-aware callers with deterministic identity-less compatibility.",
     "intentionally deferred": "none",
-    "discovered implications": "none yet",
+    "discovered implications": "A missing default mapping must never adopt the last identified compatibility pointer once the registry exists.",
     "proof achieved now": "yes; planning closeout recorded explicit proof input.",
     "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
-    "next likely slice": "Continue via tests/test_workspace_session_logging.py."
+    "next likely slice": "No required continuation remains for this archived slice."
   },
   "intent_interpretation": {
     "literal request": "Scope session logs to portable logical sessions",
-    "inferred intended outcome": "Create a bounded plan for Scope session logs to portable logical sessions.",
+    "inferred intended outcome": "Give every supplied opaque logical-session identity one stable isolated namespace without merging identity-less work.",
     "chosen concrete what": "One local Markdown/index/artifact namespace now maps stably to one opaque logical session, including interleaved and concurrent use, while identity-less and legacy callers retain a deterministic default bucket.",
     "interpretation distance": "low",
-    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+    "review guidance": "Reopen only if identity isolation, default-bucket separation, privacy, concurrency, or legacy migration regresses."
   },
   "execution_bounds": {
     "allowed paths": "session_logging.py, its focused tests, and this plan/state closeout only.",
@@ -130,21 +130,21 @@
     "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
   },
   "delegated_judgment": {
-    "requested outcome": "Create a bounded plan for Scope session logs to portable logical sessions.",
-    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
-    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
-    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+    "requested outcome": "Implement the refined #2157 portable logical-session registry contract.",
+    "hard constraints": "Keep identity host-neutral, private, local-only, non-authoritative, concurrency-safe, and compatible with identity-less and legacy callers.",
+    "agent may decide locally": "Registry schema, salted fingerprinting, local lock mechanics, pointer projection, and focused proof.",
+    "escalate when": "A fix requires vendor coupling, remote state, heuristic identity inference, or new workflow ownership."
   },
   "post_decomposition_delegation": {
-    "status": "closed-with-continuation-routed",
+    "status": "skipped-local-bounded-slice",
     "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
     "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
     "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
   },
   "system_intent_alignment": {
-    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
-    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
-    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "relevant system intent": "Keep local dogfooding evidence trustworthy, privacy-safe, and cheap for agents to interpret.",
+    "slice shaping bias": "Prefer one host-neutral ignored registry over vendor-specific or heuristic session concepts.",
+    "broader-lane validation question": "Does each physical namespace now correspond to one portable logical session without merging the default bucket?",
     "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
   },
   "references": [],
@@ -190,7 +190,7 @@
     "changed surfaces": "src/agentic_workspace/session_logging.py; tests/test_workspace_session_logging.py; active execplan/state",
     "validations run": "See proof_report.validation proof.",
     "result for continuation": "none; #2157 is fully implemented and remains open only until PR merge",
-    "next step": "merge PR #2154 to close #2157"
+    "next step": "merge PR #2158 to close #2157"
   },
   "finished_run_review": {
     "review status": "complete",
@@ -208,7 +208,7 @@
     "actual friction": "none recorded",
     "proof result": "yes; planning closeout recorded explicit proof input.",
     "quality concern": "none recorded",
-    "decomposition adjustment": "larger intent remains routed through the continuation owner"
+    "decomposition adjustment": "none; the refined #2157 intent is fully satisfied"
   },
   "proof_report": {
     "validation proof": "26 focused session-log tests; make test-workspace; make lint-workspace; make typecheck-workspace; planning summary and scoped planning doctor; real-checkout A/B/A dogfood reused A, isolated B, and found zero raw identity leaks",
@@ -241,11 +241,11 @@
     "decision": "do-not-promote",
     "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
     "evidence source": "archive-plan --prepare-closeout",
-    "target scope": "tests/test_workspace_session_logging.py",
-    "proposed durable intent": "Future agents should continue from tests/test_workspace_session_logging.py rather than rediscover this closeout residue.",
+    "target scope": "",
+    "proposed durable intent": "",
     "confidence": "low",
     "needs review": true,
-    "owner surface": "tests/test_workspace_session_logging.py"
+    "owner surface": "none"
   },
   "closure_check": {
     "closeout scope": "slice",

--- a/.agentic-workspace/planning/execplans/archive/session-log-logical-session-registry.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/session-log-logical-session-registry.plan.json
@@ -211,7 +211,7 @@
     "decomposition adjustment": "none; the refined #2157 intent is fully satisfied"
   },
   "proof_report": {
-    "validation proof": "26 focused session-log tests; make test-workspace; make lint-workspace; make typecheck-workspace; planning summary and scoped planning doctor; real-checkout A/B/A dogfood reused A, isolated B, and found zero raw identity leaks",
+    "validation proof": "27 focused session-log tests; make test-workspace; make lint-workspace; make typecheck-workspace; planning summary and scoped planning doctor; real-checkout A/B/A dogfood reused A, isolated B, and found zero raw identity leaks",
     "proof achieved now": "yes; planning closeout recorded explicit proof input.",
     "evidence for \"proof achieved\" state": "See proof_report.validation proof."
   },
@@ -397,6 +397,6 @@
     "status": "generated",
     "source": "archive-plan --prepare-closeout",
     "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
-    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Give each opaque logical-session identity one stable isolated local log namespace.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: 26 focused session-log tests; make test-workspace; make lint-workspace; make typecheck-workspace; planning summary and scoped planning doctor; real-checkout A/B/A dogfood reused A, isolated B, and found zero raw identity leaks\nChanged surfaces: src/agentic_workspace/session_logging.py; tests/test_workspace_session_logging.py; archived execplan\nDurable residue: contract (runtime code and focused tests)\nMemory learning: promote_to_docs_contracts_checks_code\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Give each opaque logical-session identity one stable isolated local log namespace.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: 27 focused session-log tests; make test-workspace; make lint-workspace; make typecheck-workspace; planning summary and scoped planning doctor; real-checkout A/B/A dogfood reused A, isolated B, and found zero raw identity leaks\nChanged surfaces: src/agentic_workspace/session_logging.py; tests/test_workspace_session_logging.py; archived execplan\nDurable residue: contract (runtime code and focused tests)\nMemory learning: promote_to_docs_contracts_checks_code\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
   }
 }

--- a/src/agentic_workspace/session_logging.py
+++ b/src/agentic_workspace/session_logging.py
@@ -354,7 +354,7 @@ def ensure_session(*, state: SessionLoggingState, force_new: bool = False, logic
         current = None
         if not force_new:
             current = _registered_session(registry=registry, registry_key=registry_key, target_root=state.target_root)
-            if current is None and not identity:
+            if current is None and not identity and not registry_existed:
                 current = read_session_pointer(target_root=state.target_root)
         if current:
             if isinstance(sessions, dict) and sessions.get(registry_key) != current:
@@ -435,10 +435,11 @@ def _registered_session(*, registry: dict[str, Any], registry_key: str, target_r
 
 
 def _session_for_caller(*, target_root: Path, logical_identity: str) -> dict[str, str] | None:
+    registry_existed = (target_root / SESSION_REGISTRY_PATH).is_file()
     registry = _read_session_registry(target_root=target_root)
     registry_key = _logical_identity_fingerprint(identity=logical_identity, registry=registry) if logical_identity else "default"
     registered = _registered_session(registry=registry, registry_key=registry_key, target_root=target_root)
-    if registered is not None or logical_identity:
+    if registered is not None or logical_identity or registry_existed:
         return registered
     return read_session_pointer(target_root=target_root)
 

--- a/src/agentic_workspace/session_logging.py
+++ b/src/agentic_workspace/session_logging.py
@@ -27,6 +27,10 @@ from agentic_workspace.result_adapter import serialise_value
 SESSION_LOG_ROOT = Path(".agentic-workspace") / "local" / "logs"
 SESSION_POINTER_PATH = Path(".agentic-workspace") / "local" / "session-logging" / "current.json"
 SESSION_POINTER_KIND = "agentic-workspace/session-logging-current/v1"
+SESSION_REGISTRY_PATH = Path(".agentic-workspace") / "local" / "session-logging" / "sessions.json"
+SESSION_REGISTRY_LOCK_PATH = Path(".agentic-workspace") / "local" / "session-logging" / ".sessions.lock"
+SESSION_REGISTRY_KIND = "agentic-workspace/session-logging-registry/v1"
+LOGICAL_SESSION_IDENTITY_ENV = "AW_SESSION_LOGICAL_IDENTITY"
 SESSION_LOG_KIND = "agentic-workspace/session-log/v1"
 SESSION_LOG_INDEX_KIND = "agentic-workspace/session-log-index/v1"
 DEFAULT_MAX_INLINE_OUTPUT_BYTES = 64 * 1024
@@ -316,7 +320,8 @@ def reset_session(*, state: SessionLoggingState) -> dict[str, Any]:
 
 
 def status_payload(*, state: SessionLoggingState) -> dict[str, Any]:
-    session = read_session_pointer(target_root=state.target_root)
+    logical_identity = _logical_session_identity()
+    session = _session_for_caller(target_root=state.target_root, logical_identity=logical_identity)
     return {
         "kind": "agentic-workspace/session-logging-status/v1",
         "enabled": state.enabled,
@@ -325,6 +330,9 @@ def status_payload(*, state: SessionLoggingState) -> dict[str, Any]:
         "path": session.get("log_path", "") if session else "",
         "index_path": _index_path_for_session(session).as_posix() if session else "",
         "session_id": session.get("session_id", "") if session else "",
+        "logical_session_resolution": "identity-registry" if logical_identity else "legacy-default-bucket",
+        "logical_session_identity_source": LOGICAL_SESSION_IDENTITY_ENV if logical_identity else "",
+        "raw_logical_session_identity_stored": False,
         "path_redaction": _path_redaction_payload(state),
         "local_only": True,
         "authoritative": False,
@@ -332,12 +340,39 @@ def status_payload(*, state: SessionLoggingState) -> dict[str, Any]:
     }
 
 
-def ensure_session(*, state: SessionLoggingState, force_new: bool = False) -> dict[str, str]:
-    current = None if force_new else read_session_pointer(target_root=state.target_root)
-    if current:
-        log_path = state.target_root / current["log_path"]
-        if log_path.exists():
+def ensure_session(*, state: SessionLoggingState, force_new: bool = False, logical_identity: str | None = None) -> dict[str, str]:
+    identity = _logical_session_identity() if logical_identity is None else logical_identity.strip()
+    with _session_registry_lock(target_root=state.target_root):
+        registry_existed = (state.target_root / SESSION_REGISTRY_PATH).is_file()
+        registry = _read_session_registry(target_root=state.target_root)
+        sessions = registry.setdefault("sessions", {})
+        legacy_pointer = read_session_pointer(target_root=state.target_root)
+        if not registry_existed and isinstance(sessions, dict) and "default" not in sessions and legacy_pointer is not None:
+            sessions["default"] = legacy_pointer
+            registry["updated_at"] = datetime.now(UTC).isoformat()
+        registry_key = _logical_identity_fingerprint(identity=identity, registry=registry) if identity else "default"
+        current = None
+        if not force_new:
+            current = _registered_session(registry=registry, registry_key=registry_key, target_root=state.target_root)
+            if current is None and not identity:
+                current = read_session_pointer(target_root=state.target_root)
+        if current:
+            if isinstance(sessions, dict) and sessions.get(registry_key) != current:
+                sessions[registry_key] = current
+                registry["updated_at"] = datetime.now(UTC).isoformat()
+                _write_json_atomic(state.target_root / SESSION_REGISTRY_PATH, registry)
+            _write_session_pointer(target_root=state.target_root, session=current)
             return current
+        session = _create_session(state=state)
+        if isinstance(sessions, dict):
+            sessions[registry_key] = session
+        registry["updated_at"] = datetime.now(UTC).isoformat()
+        _write_json_atomic(state.target_root / SESSION_REGISTRY_PATH, registry)
+        _write_session_pointer(target_root=state.target_root, session=session)
+        return session
+
+
+def _create_session(*, state: SessionLoggingState) -> dict[str, str]:
     created_at = datetime.now(UTC)
     session_id = f"{created_at.strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
     log_path = SESSION_LOG_ROOT / f"aw-session-{session_id}.md"
@@ -350,11 +385,94 @@ def ensure_session(*, state: SessionLoggingState, force_new: bool = False) -> di
     absolute_log_path = state.target_root / log_path
     absolute_log_path.parent.mkdir(parents=True, exist_ok=True)
     absolute_log_path.write_text(_session_prelude(state=state, session=session), encoding="utf-8")
-    pointer_path = state.target_root / SESSION_POINTER_PATH
-    pointer_path.parent.mkdir(parents=True, exist_ok=True)
-    pointer_path.write_text(json.dumps(session, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     _write_index(state=state, session=session, entries=(), notes=())
     return session
+
+
+def _logical_session_identity() -> str:
+    return os.environ.get(LOGICAL_SESSION_IDENTITY_ENV, "").strip()
+
+
+def _new_session_registry() -> dict[str, Any]:
+    return {
+        "kind": SESSION_REGISTRY_KIND,
+        "salt": uuid.uuid4().hex,
+        "sessions": {},
+        "updated_at": datetime.now(UTC).isoformat(),
+        "local_only": True,
+        "authoritative": False,
+    }
+
+
+def _read_session_registry(*, target_root: Path) -> dict[str, Any]:
+    path = target_root / SESSION_REGISTRY_PATH
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return _new_session_registry()
+    if (
+        not isinstance(payload, dict)
+        or payload.get("kind") != SESSION_REGISTRY_KIND
+        or not isinstance(payload.get("salt"), str)
+        or not isinstance(payload.get("sessions"), dict)
+    ):
+        return _new_session_registry()
+    return payload
+
+
+def _logical_identity_fingerprint(*, identity: str, registry: dict[str, Any]) -> str:
+    salt = str(registry.get("salt", ""))
+    return hashlib.sha256(f"{salt}\0{identity}".encode()).hexdigest()
+
+
+def _registered_session(*, registry: dict[str, Any], registry_key: str, target_root: Path) -> dict[str, str] | None:
+    sessions = registry.get("sessions", {})
+    candidate = sessions.get(registry_key) if isinstance(sessions, dict) else None
+    session = _validated_session(candidate)
+    if session and (target_root / session["log_path"]).is_file():
+        return session
+    return None
+
+
+def _session_for_caller(*, target_root: Path, logical_identity: str) -> dict[str, str] | None:
+    registry = _read_session_registry(target_root=target_root)
+    registry_key = _logical_identity_fingerprint(identity=logical_identity, registry=registry) if logical_identity else "default"
+    registered = _registered_session(registry=registry, registry_key=registry_key, target_root=target_root)
+    if registered is not None or logical_identity:
+        return registered
+    return read_session_pointer(target_root=target_root)
+
+
+def _write_session_pointer(*, target_root: Path, session: dict[str, str]) -> None:
+    _write_json_atomic(target_root / SESSION_POINTER_PATH, session)
+
+
+@contextlib.contextmanager
+def _session_registry_lock(*, target_root: Path) -> Iterator[None]:
+    lock_path = target_root / SESSION_REGISTRY_LOCK_PATH
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + 5
+    while True:
+        try:
+            lock_path.mkdir()
+            break
+        except FileExistsError:
+            try:
+                stale = time.time() - lock_path.stat().st_mtime > 30
+            except OSError:
+                stale = False
+            if stale:
+                with contextlib.suppress(OSError):
+                    lock_path.rmdir()
+                continue
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"timed out waiting for session registry lock: {lock_path}")
+            time.sleep(0.01)
+    try:
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            lock_path.rmdir()
 
 
 def read_session_pointer(*, target_root: Path) -> dict[str, str] | None:
@@ -365,6 +483,10 @@ def read_session_pointer(*, target_root: Path) -> dict[str, str] | None:
         payload = json.loads(pointer_path.read_text(encoding="utf-8-sig"))
     except (OSError, json.JSONDecodeError):
         return None
+    return _validated_session(payload)
+
+
+def _validated_session(payload: Any) -> dict[str, str] | None:
     if not isinstance(payload, dict) or payload.get("kind") != SESSION_POINTER_KIND:
         return None
     session_id = str(payload.get("session_id", "")).strip()
@@ -409,6 +531,11 @@ def _session_prelude(*, state: SessionLoggingState, session: dict[str, str]) -> 
             "redaction": _path_redaction_payload(state),
             "failure_behavior": "Logging failures are warning-only and must not block ordinary AW operation, proof, or closeout claims.",
             "promotion_boundary": "Logs are dogfooding evidence only until explicitly promoted into checked-in Planning, Memory, docs, or proof receipts.",
+            "logical_session": {
+                "resolution": "identity-registry" if _logical_session_identity() else "legacy-default-bucket",
+                "identity_source": LOGICAL_SESSION_IDENTITY_ENV if _logical_session_identity() else "",
+                "raw_identity_stored": False,
+            },
         },
     }
     return "# Agentic Workspace Session Log\n\n```json\n" + json.dumps(serialise_value(snapshot), indent=2) + "\n```\n"
@@ -1310,7 +1437,7 @@ def _coverage_payload(*, markdown_entries: list[dict[str, Any]], index: dict[str
 
 
 def repair_session_log_index(*, state: SessionLoggingState, path: str = "", session_id: str = "") -> dict[str, Any]:
-    session = read_session_pointer(target_root=state.target_root)
+    session = _session_for_caller(target_root=state.target_root, logical_identity=_logical_session_identity())
     log_path = _analysis_log_path(state=state, path=path, session_id=session_id, session=session)
     if log_path is None:
         return {"kind": "agentic-workspace/session-log-index-repair/v1", "status": "missing-log", "path": ""}
@@ -1386,7 +1513,7 @@ def _share_safe_value(*, state: SessionLoggingState, value: Any) -> Any:
 def export_session_log(
     *, state: SessionLoggingState, path: str = "", session_id: str = "", include_artifacts: bool = True
 ) -> dict[str, Any]:
-    session = read_session_pointer(target_root=state.target_root)
+    session = _session_for_caller(target_root=state.target_root, logical_identity=_logical_session_identity())
     log_path = _analysis_log_path(state=state, path=path, session_id=session_id, session=session)
     if log_path is None:
         return {"kind": "agentic-workspace/session-log-export/v1", "status": "missing-log", "path": ""}
@@ -1496,7 +1623,7 @@ def _segment_summaries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def analyze_session_log(*, state: SessionLoggingState, path: str = "", session_id: str = "", segment_id: str = "") -> dict[str, Any]:
-    session = read_session_pointer(target_root=state.target_root)
+    session = _session_for_caller(target_root=state.target_root, logical_identity=_logical_session_identity())
     log_path = _analysis_log_path(state=state, path=path, session_id=session_id, session=session)
     if log_path is None:
         return {

--- a/tests/test_workspace_session_logging.py
+++ b/tests/test_workspace_session_logging.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 import zipfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from agentic_workspace import cli as source_cli
@@ -101,6 +102,104 @@ def test_session_logging_enabled_reuses_one_session_log_and_records_config_prelu
     assert index["entries"][0]["artifact"]["path"].startswith(".agentic-workspace/local/logs/artifacts/")
 
 
+def test_session_logging_reuses_identity_across_interleaved_sessions(tmp_path: Path, monkeypatch) -> None:
+    target = _target(tmp_path)
+    _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
+    monkeypatch.setattr(session_logging, "DEFAULT_MAX_INLINE_OUTPUT_BYTES", 1)
+
+    def run(identity: str) -> dict[str, str]:
+        monkeypatch.setenv(session_logging.LOGICAL_SESSION_IDENTITY_ENV, identity)
+
+        def runner(_argv: list[str]) -> int:
+            print("session output")
+            return 0
+
+        assert session_logging.run_with_session_logging(["config", "--target", str(target)], runner) == 0
+        pointer = json.loads((target / session_logging.SESSION_POINTER_PATH).read_text(encoding="utf-8"))
+        return {"session_id": pointer["session_id"], "log_path": pointer["log_path"]}
+
+    session_a = run("host-session-a")
+    session_b = run("host-session-b")
+    session_a_again = run("host-session-a")
+
+    assert session_a_again == session_a
+    assert session_b["session_id"] != session_a["session_id"]
+    assert (target / session_a["log_path"]).read_text(encoding="utf-8").count("## Command - ") == 2
+    assert (target / session_b["log_path"]).read_text(encoding="utf-8").count("## Command - ") == 1
+    for session in (session_a, session_b):
+        index = json.loads(
+            (target / session_logging.SESSION_LOG_ROOT / "indexes" / f"{session['session_id']}.json").read_text(encoding="utf-8")
+        )
+        assert all(f"/artifacts/{session['session_id']}/" in f"/{entry['artifact']['path']}" for entry in index["entries"])
+    registry = json.loads((target / session_logging.SESSION_REGISTRY_PATH).read_text(encoding="utf-8"))
+    assert len(registry["sessions"]) == 2
+    assert "host-session-a" not in json.dumps(registry)
+    assert "host-session-b" not in json.dumps(registry)
+
+
+def test_session_logging_concurrent_identity_resolution_converges(tmp_path: Path) -> None:
+    target = _target(tmp_path)
+    _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
+    state = session_logging.load_state_for_argv(["--target", str(target)])
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        sessions = list(executor.map(lambda _index: session_logging.ensure_session(state=state, logical_identity="shared"), range(16)))
+
+    assert len({session["session_id"] for session in sessions}) == 1
+    assert len(list((target / session_logging.SESSION_LOG_ROOT).glob("aw-session-*.md"))) == 1
+    assert not (target / session_logging.SESSION_REGISTRY_LOCK_PATH).exists()
+
+
+def test_session_logging_preserves_legacy_default_bucket_when_identity_registry_starts(tmp_path: Path) -> None:
+    target = _target(tmp_path)
+    _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
+    state = session_logging.load_state_for_argv(["--target", str(target)])
+    legacy = session_logging.ensure_session(state=state)
+    (target / session_logging.SESSION_REGISTRY_PATH).unlink()
+
+    identified = session_logging.ensure_session(state=state, logical_identity="new-host-session")
+    default_again = session_logging.ensure_session(state=state, logical_identity="")
+
+    assert identified["session_id"] != legacy["session_id"]
+    assert default_again == legacy
+    registry = json.loads((target / session_logging.SESSION_REGISTRY_PATH).read_text(encoding="utf-8"))
+    assert registry["sessions"]["default"] == legacy
+
+
+def test_session_logging_identity_is_private_and_caller_drilldowns_resolve_it(tmp_path: Path, monkeypatch) -> None:
+    target = _target(tmp_path)
+    _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
+    raw_identity = "vendor-thread-secret-123"
+    monkeypatch.setenv(session_logging.LOGICAL_SESSION_IDENTITY_ENV, raw_identity)
+    assert session_logging.run_with_session_logging(["config", "--target", str(target)], lambda _argv: 0) == 0
+    state = session_logging.load_state_for_argv(["--target", str(target)])
+    status = session_logging.status_payload(state=state)
+    analysis = session_logging.analyze_session_log(state=state)
+    exported = session_logging.export_session_log(state=state, include_artifacts=False)
+
+    assert status["logical_session_resolution"] == "identity-registry"
+    assert analysis["path"] == status["path"]
+    assert exported["session_id"] == status["session_id"]
+    for path in (target / ".agentic-workspace/local").rglob("*"):
+        if path.is_file():
+            assert raw_identity.encode() not in path.read_bytes()
+
+
+def test_session_logging_new_session_replaces_only_callers_identity_mapping(tmp_path: Path, monkeypatch) -> None:
+    target = _target(tmp_path)
+    _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
+    state = session_logging.load_state_for_argv(["--target", str(target)])
+    session_a = session_logging.ensure_session(state=state, logical_identity="a")
+    session_b = session_logging.ensure_session(state=state, logical_identity="b")
+    monkeypatch.setenv(session_logging.LOGICAL_SESSION_IDENTITY_ENV, "a")
+
+    replacement_a = session_logging.reset_session(state=state)
+
+    assert replacement_a["session_id"] != session_a["session_id"]
+    assert session_logging.ensure_session(state=state, logical_identity="a")["session_id"] == replacement_a["session_id"]
+    assert session_logging.ensure_session(state=state, logical_identity="b") == session_b
+
+
 def test_session_logging_note_command_appends_optional_note(tmp_path: Path, capsys) -> None:
     target = _target(tmp_path)
     _write(target / ".agentic-workspace" / "config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
@@ -137,7 +236,7 @@ def test_session_logging_invalid_pointer_path_is_ignored(tmp_path: Path, capsys)
     capsys.readouterr()
 
     second_log = _current_log(target)
-    assert second_log != first_log
+    assert second_log == first_log
     assert not (target.parent / "outside-session-log.md").exists()
     assert ".agentic-workspace/local/logs/" in second_log.as_posix()
 

--- a/tests/test_workspace_session_logging.py
+++ b/tests/test_workspace_session_logging.py
@@ -166,6 +166,23 @@ def test_session_logging_preserves_legacy_default_bucket_when_identity_registry_
     assert registry["sessions"]["default"] == legacy
 
 
+def test_session_logging_identityless_default_never_adopts_identified_pointer(tmp_path: Path) -> None:
+    target = _target(tmp_path)
+    _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")
+    state = session_logging.load_state_for_argv(["--target", str(target)])
+    session_a = session_logging.ensure_session(state=state, logical_identity="a")
+    session_b = session_logging.ensure_session(state=state, logical_identity="b")
+
+    assert session_logging.status_payload(state=state)["session_id"] == ""
+    default_session = session_logging.ensure_session(state=state, logical_identity="")
+    default_again = session_logging.ensure_session(state=state, logical_identity="")
+
+    assert default_again == default_session
+    assert default_session["session_id"] not in {session_a["session_id"], session_b["session_id"]}
+    registry = json.loads((target / session_logging.SESSION_REGISTRY_PATH).read_text(encoding="utf-8"))
+    assert registry["sessions"]["default"] == default_session
+
+
 def test_session_logging_identity_is_private_and_caller_drilldowns_resolve_it(tmp_path: Path, monkeypatch) -> None:
     target = _target(tmp_path)
     _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")


### PR DESCRIPTION
## Summary

Implements #2157 after PR #2154 merged:

- accepts an optional opaque logical-session identity through `AW_SESSION_LOGICAL_IDENTITY`;
- maps a salted fingerprint to a stable ignored-local session id;
- preserves A/B/A reuse without pointer ping-pong or extra files;
- serializes registry creation and pointer projection with a local atomic lock;
- migrates legacy and identity-less callers into a deterministic default bucket;
- resolves status, analyze, repair, and export against the caller identity while preserving explicit id/path authority;
- records privacy-safe resolution metadata without storing the raw identity;
- retains `session-log new-session` as the manual rotation escape hatch.

## Root cause

The repository-wide `current.json` pointer was both the last-used projection and the canonical session owner. It was reused whenever its file existed, so unrelated logical sessions accumulated in one Markdown/index/artifact namespace. Rotating on pointer mismatch would not solve interleaved A/B/A sessions.

## Impact

Integrations can supply a stable host-neutral identity and receive one isolated physical log namespace per logical session. Identity-less callers keep the legacy default-bucket behavior. No vendor-specific identifier, remote service, task heuristic, or new command is introduced.

## Validation

- `uv run pytest tests/test_workspace_session_logging.py -q` — 27 passed
- `make test-workspace`
- `make lint-workspace`
- `make typecheck-workspace`
- Planning summary and scoped Planning doctor
- real-checkout A/B/A dogfood: A reused its original session, B was isolated, and raw identity leakage count was zero

## Cost and residue

The existing pointer is demoted to a compatibility projection; one ignored registry and lock replace manual rotation and post-hoc mixed-file analysis. Runtime code and focused tests own the durable host-neutral identity/privacy contract. Net operating-cost direction: lower.

## Review follow-up

- identity-less callers now fall back to current.json only when no registry exists; an existing registry with no default mapping creates a distinct default session;
- added identified A/B then identity-less default isolation coverage;
- corrected all archived closeout, continuation, PR, and intent fields to consistently reference PR #2158 and full #2157 satisfaction.

Closes #2157