### PR TITLE
Align proof receipt scope with planning closeout

### DIFF
--- a/packages/planning/src/repo_planning_bootstrap/installer.py
+++ b/packages/planning/src/repo_planning_bootstrap/installer.py
@@ -13186,7 +13186,9 @@ def _record_scope_paths(record: dict[str, Any]) -> set[str]:
     return paths
 
 
-def _load_last_proof_receipt(*, target_root: Path, record: dict[str, Any], plan: str) -> tuple[dict[str, Any] | None, str]:
+def _load_last_proof_receipt(
+    *, target_root: Path, record: dict[str, Any], plan: str, record_path: Path
+) -> tuple[dict[str, Any] | None, str]:
     receipt_path = target_root / PLANNING_PROOF_RECEIPT_PATH
     if not receipt_path.is_file():
         return None, "receipt file is absent"
@@ -13208,9 +13210,15 @@ def _load_last_proof_receipt(*, target_root: Path, record: dict[str, Any], plan:
     raw_receipt_paths = receipt.get("changed_paths", [])
     receipt_path_values = raw_receipt_paths if isinstance(raw_receipt_paths, list) else [raw_receipt_paths]
     receipt_paths = {_normalize_receipt_path(path) for path in receipt_path_values if _normalize_receipt_path(path)}
+    plan_record_path = record_path.relative_to(target_root).as_posix()
+    if _normalize_receipt_path(plan_record_path) in receipt_paths:
+        return receipt, ""
     record_paths = _record_scope_paths(record)
     if receipt_paths and record_paths and receipt_paths.isdisjoint(record_paths):
-        return None, "receipt changed paths do not overlap the closeout plan scope"
+        return None, (
+            "receipt changed paths must include "
+            f"plan_id {plan!r}, canonical plan path {plan_record_path!r}, or overlap the closeout plan scope"
+        )
     if receipt_paths or record_paths:
         return receipt, ""
     return None, "receipt has neither matching plan_id nor changed-path scope"
@@ -13425,7 +13433,7 @@ def closeout_execplan(
         proof = existing_proof
         proof_source = "existing"
     else:
-        receipt, receipt_reason = _load_last_proof_receipt(target_root=target_root, record=record, plan=plan)
+        receipt, receipt_reason = _load_last_proof_receipt(target_root=target_root, record=record, plan=plan, record_path=record_path)
         if receipt is not None:
             proof = str(receipt.get("command", receipt.get("validation_command", ""))).strip()
             proof_source = "receipt"

--- a/packages/planning/tests/test_archive.py
+++ b/packages/planning/tests/test_archive.py
@@ -1506,6 +1506,87 @@ def test_planning_closeout_consumes_last_proof_receipt(tmp_path: Path, capsys) -
     assert receipt["changed_paths"] == ["packages/planning/tests/test_archive.py"]
 
 
+def test_planning_closeout_consumes_receipt_scoped_to_canonical_plan_path(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    plan_relative_path = ".agentic-workspace/planning/execplans/plan-alpha.plan.json"
+    receipt_path = tmp_path / ".agentic-workspace" / "local" / "proof-receipts" / "last.json"
+    _write(
+        receipt_path,
+        json.dumps(
+            {
+                "kind": "agentic-workspace/proof-receipt/v1",
+                "command": "uv run pytest packages/planning/tests/test_archive.py::test_receipt -q",
+                "result": "passed",
+                "recorded_at": "2026-07-10T10:00:00+00:00",
+                "changed_paths": [plan_relative_path],
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+    record_path = tmp_path / plan_relative_path
+    _write_execplan_record(record_path, status="active")
+
+    assert (
+        planning_cli.main(
+            [
+                "closeout",
+                "plan-alpha",
+                "--target",
+                str(tmp_path),
+                "--what-happened",
+                "validated and closed the plan record itself.",
+                "--scope-touched",
+                "packages/planning/tests/test_archive.py",
+                "--changed-surfaces",
+                "packages/planning/tests/test_archive.py",
+                "--review-summary",
+                "yes; the receipt is bound to the canonical active plan path.",
+                "--outcome-summary",
+                "plan-path-scoped proof receipts support closeout.",
+                "--format",
+                "json",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    archived = json.loads((tmp_path / ".agentic-workspace/planning/execplans/archive/plan-alpha.plan.json").read_text(encoding="utf-8"))
+
+    assert payload["warnings"] == []
+    assert archived["execution_run"]["validations run"].endswith("::test_receipt -q")
+    assert json.loads(archived["proof_report"]["proof receipt"])["changed_paths"] == [plan_relative_path]
+
+
+def test_planning_closeout_names_receipt_scope_keys_when_paths_do_not_overlap(tmp_path: Path, capsys) -> None:
+    _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
+    receipt_path = tmp_path / ".agentic-workspace/local/proof-receipts/last.json"
+    _write(
+        receipt_path,
+        json.dumps(
+            {
+                "command": "uv run pytest tests/test_unrelated.py -q",
+                "result": "passed",
+                "changed_paths": ["tests/test_unrelated.py"],
+            }
+        ),
+    )
+    record_path = tmp_path / ".agentic-workspace/planning/execplans/plan-alpha.plan.json"
+    _write_execplan_record(record_path, status="active")
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record["execution_run"]["changed surfaces"] = "packages/planning/tests/test_archive.py"
+    installer_mod._write_execplan_record(record_path=record_path, record=record)
+
+    assert planning_cli.main(["closeout", "plan-alpha", "--target", str(tmp_path), "--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    warning = next(item for item in payload["warnings"] if item["warning_class"] == "closeout_receipt_unusable")
+
+    assert "plan_id 'plan-alpha'" in warning["message"]
+    assert ".agentic-workspace/planning/execplans/plan-alpha.plan.json" in warning["message"]
+    assert "overlap the closeout plan scope" in warning["message"]
+    assert record_path.exists()
+
+
 def test_planning_closeout_preserves_existing_last_proof(tmp_path: Path, capsys) -> None:
     _write(tmp_path / ".agentic-workspace/planning/state.toml", "# TODO\n")
     record_path = tmp_path / ".agentic-workspace" / "planning" / "execplans" / "plan-alpha.plan.json"


### PR DESCRIPTION
## What changed

- accept the canonical active execplan path in a successful proof receipt as an explicit closeout binding
- preserve the existing `plan_id` and declared-scope overlap routes
- report the exact accepted plan id and canonical plan path when an unrelated receipt is rejected
- cover both successful plan-path closeout and unrelated-receipt diagnostics

## Root cause

Planning closeout compared receipt `changed_paths` only with work scope recorded inside the plan. A proof receipt produced while validating the execplan file itself therefore looked unrelated, even though the receipt was scoped to the exact plan being closed and the proof command suggested `planning closeout --proof-from last`.

## Impact

The ordinary proof-receipt closeout path now works when the active plan file is the changed surface. Unrelated receipts remain rejected, with actionable scope keys instead of a generic overlap error. This removes the fallback to copying a long proof string and adds no new command or durable surface.

## Validation

- `make test-planning`
- `make lint-planning`
- `make typecheck-planning`
- focused receipt/closeout regression set: 4 passed
- commit hooks: sync-all, workspace lint, prompt semantic markers, memory lint, memory markdownlint, planning lint, verification lint

Closes #2137