### PR TITLE
Reduce package-output friction exposed by session-log dogfooding

### DIFF
--- a/.agentic-workspace/memory/UPGRADE-SOURCE.toml
+++ b/.agentic-workspace/memory/UPGRADE-SOURCE.toml
@@ -1,5 +1,5 @@
 source_type = "git"
 source_ref = "git+https://github.com/rickardvh/agentic-workspace@master#subdirectory=packages/memory"
 source_label = "agentic-memory monorepo master"
-recorded_at = "2026-07-09"
+recorded_at = "2026-07-10"
 recommended_upgrade_after_days = 30

--- a/.agentic-workspace/payload-provenance.json
+++ b/.agentic-workspace/payload-provenance.json
@@ -13,8 +13,8 @@
     "python_executable": ".venv/Scripts/python.exe",
     "source": "local-source",
     "source_class": "source-checkout",
-    "source_identity": "git:7337e1011614",
-    "version": "0.33.2"
+    "source_identity": "git:072484405ac5",
+    "version": "0.33.3"
   },
   "kind": "agentic-workspace/payload-provenance/v1",
   "payload_capabilities": [
@@ -40,8 +40,8 @@
   "release_identity": {
     "package": "agentic-workspace",
     "release_model": "coordinated-workspace",
-    "tag": "v0.33.2",
-    "version": "0.33.2"
+    "tag": "v0.33.3",
+    "version": "0.33.3"
   },
   "rule": "Repo payload provenance records the coordinated AW release identity and executable/source identity that installed or last synced the AW payload."
 }

--- a/.agentic-workspace/planning/UPGRADE-SOURCE.toml
+++ b/.agentic-workspace/planning/UPGRADE-SOURCE.toml
@@ -1,5 +1,5 @@
 source_type = "git"
 source_ref = "git+https://github.com/rickardvh/agentic-workspace@master#subdirectory=packages/planning"
 source_label = "agentic-planning monorepo master"
-recorded_at = "2026-07-09"
+recorded_at = "2026-07-10"
 recommended_upgrade_after_days = 30

--- a/.agentic-workspace/planning/execplans/archive/2143-package-output-friction.plan.json
+++ b/.agentic-workspace/planning/execplans/archive/2143-package-output-friction.plan.json
@@ -1,0 +1,365 @@
+{
+  "kind": "planning-execplan/v1",
+  "title": "Reduce package-output friction exposed by session-log dogfooding",
+  "execplan_profile": {
+    "schema": "execplan-profile/v1",
+    "task_shape": "bounded",
+    "required_core": [
+      "kind",
+      "title",
+      "canonical_core",
+      "goal",
+      "non_goals",
+      "active_milestone",
+      "validation_commands",
+      "completion_criteria"
+    ],
+    "optional_sections": [
+      "intent_continuity",
+      "intent_interpretation",
+      "execution_bounds",
+      "stop_conditions",
+      "context_budget",
+      "delegated_judgment",
+      "post_decomposition_delegation"
+    ],
+    "projection_rule": "canonical_core is authoritative for intent, scope, next action, proof, continuation, and closeout; legacy fields remain compatibility projections."
+  },
+  "canonical_core": {
+    "requested_outcome": "Implement the complete #2143 lane (#2149-#2152) in one PR: compact payload output, task-aware proof recovery, structured JSON runtime failures, and exact planning closeout/archive recovery.",
+    "hard_constraints": "Preserve payload, proof, and Planning safety gates; retain explicit drilldowns; do not substitute session-log compression for package-level fixes.",
+    "agent_may_decide": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate_when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+    "next_action": "Implement and test the four child slices, then dogfood the observed #2141 command classes.",
+    "proof_expectations": [
+      "Run focused CLI, session-logging, lifecycle, and Planning closeout tests; regenerate command packages; replay representative commands and compare output/retry behavior."
+    ],
+    "touched_scope": [
+      "src/agentic_workspace runtime, CLI contracts, session logging, generated command projections, focused tests, and active Planning records."
+    ],
+    "completion_criteria": [
+      "Every acceptance criterion in #2143 and #2149-#2152 is implemented in the ordinary CLI path, focused proof passes, dogfooding shows compact/recoverable behavior, and the lane is ready to close from one PR."
+    ],
+    "continuation_owner": "none",
+    "closeout_decision": "archive-and-close"
+  },
+  "goal": [
+    "Complete the full #2143 package-output and recovery lane in one PR."
+  ],
+  "non_goals": [
+    "Do not weaken safety gates, redesign unrelated runtime behavior, or rely on logging artifacts as the fix."
+  ],
+  "machine_readable_contract": {
+    "intent": {
+      "outcome": "Create a bounded plan for Reduce package-output friction exposed by session-log dogfooding.",
+      "constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+      "latitude": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+      "escalation": "Escalate when a better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story.",
+      "proof": "make test-workspace; make lint-workspace; generated Python+Docker conformance; make typecheck"
+    },
+    "execution": {
+      "milestone": "2143-package-output-friction",
+      "status": "completed",
+      "next_step": "No required continuation remains for this archived slice.",
+      "proof": "make test-workspace; make lint-workspace; generated Python+Docker conformance; make typecheck"
+    },
+    "scope": {
+      "touched": [
+        "closeout scope recorded in closure_check and generated_closeout."
+      ],
+      "invariants": [
+        "Preserve the planning contract and keep the work bounded to this plan."
+      ]
+    }
+  },
+  "intent_continuity": {
+    "larger intended outcome": "Create a bounded plan for Reduce package-output friction exposed by session-log dogfooding.",
+    "this slice completes the larger intended outcome": "yes",
+    "continuation surface": "none"
+  },
+  "required_continuation": {
+    "required follow-on for the larger intended outcome": "no",
+    "owner surface": "none",
+    "activation trigger": "none"
+  },
+  "iterative_follow_through": {
+    "what this slice enabled": "none yet",
+    "intentionally deferred": "none",
+    "discovered implications": "none yet",
+    "proof achieved now": "yes; planning closeout consumed the latest successful proof receipt.",
+    "validation still needed": "None for this archived slice; reopen only if new evidence invalidates the proof.",
+    "next likely slice": "No required continuation remains for this archived slice."
+  },
+  "intent_interpretation": {
+    "literal request": "Reduce package-output friction exposed by session-log dogfooding",
+    "inferred intended outcome": "Create a bounded plan for Reduce package-output friction exposed by session-log dogfooding.",
+    "chosen concrete what": "Full #2143 lane is validated and ready for one PR.",
+    "interpretation distance": "low",
+    "review guidance": "Confirm the scaffolded plan still matches the promoted item before broad implementation."
+  },
+  "execution_bounds": {
+    "allowed paths": "src/agentic_workspace, src/agentic_workspace/contracts, generated command packages, tests, scripts/generate, and #2143 Planning/proof residue.",
+    "max changed files": "Up to 45 files including generated projections and payload-sync residue.",
+    "required validation commands": "Focused pytest suites for CLI, blackbox failures, session logging, lifecycle output, and Planning closeout; generation check; AW-selected proof; git diff --check.",
+    "ask-before-refactor threshold": "Ask before broadening beyond the promoted item.",
+    "stop before touching": "Unrelated product features, remote telemetry, or any relaxation of proof/payload/Planning invariants."
+  },
+  "stop_conditions": {
+    "stop when": "The work no longer matches the promoted item or its completion criteria.",
+    "escalate when boundary reached": "A correct fix requires changing the requested outcome or ownership boundary.",
+    "escalate on scope drift": "Implementation needs files outside the filled execution bounds.",
+    "escalate on proof failure": "The selected proof cannot demonstrate the completion criteria."
+  },
+  "context_budget": {
+    "live working set": "This execplan, the promoted item, and the narrow files needed for the current implementation step.",
+    "recoverable later": "Repo background, historical reviews, and deferred backlog unless compact outputs point there.",
+    "externalize before shift": "Update execution_run, proof_report, finished_run_review, and closeout_distillation before pausing.",
+    "pre-work config pull": "Use compact config/startup/summary outputs before opening raw planning or routing files.",
+    "pre-work memory pull": "Route to the narrowest relevant memory only when the task needs durable repo knowledge.",
+    "tiny resumability note": "Archived slice is complete; reopen only if closeout evidence is invalidated.",
+    "context-shift triggers": "Proof failure, scope drift, interruption, handoff, or closeout."
+  },
+  "delegated_judgment": {
+    "requested outcome": "Create a bounded plan for Reduce package-output friction exposed by session-log dogfooding.",
+    "hard constraints": "Keep scope bounded to the promoted TODO item and its stated touched paths.",
+    "agent may decide locally": "Bounded decomposition, touched-path narrowing, validation tightening, and plan-local residue routing.",
+    "escalate when": "A better-looking fix changes the requested outcome, owned surface, time horizon, or meaningful validation story."
+  },
+  "post_decomposition_delegation": {
+    "status": "skipped-local-bounded-slice",
+    "decision rule": "After this slice is bounded, decide whether direct work, read-only exploration, implementation handoff, validation handoff, or stronger review improves quality or saves tokens safely.",
+    "route candidates": "keep-local|delegate-exploration|delegate-implementation|delegate-validation|escalate-review|no-safe-route",
+    "required evidence": "slice id, route, reason, quality risk, token-saving class, read-first refs, write scope, proof burden, stop conditions, and return contract"
+  },
+  "system_intent_alignment": {
+    "relevant system intent": "Preserve the larger intended outcome separately from this bounded slice.",
+    "slice shaping bias": "Keep the slice bounded while carrying any larger follow-on through explicit continuation fields.",
+    "broader-lane validation question": "Did this slice advance the declared larger outcome, or only complete the local task?",
+    "intent evidence source": ".agentic-workspace/docs/system-intent-contract.md"
+  },
+  "references": [],
+  "active_milestone": {
+    "id": "2143-package-output-friction",
+    "status": "completed",
+    "scope": "Deliver #2149, #2150, #2151, and #2152 as the complete #2143 lane.",
+    "ready": "ready",
+    "blocked": "none",
+    "optional_deps": "none"
+  },
+  "immediate_next_action": [
+    "Implement compact lifecycle projection and structured CLI recovery, then tighten Planning recovery and session-log classification."
+  ],
+  "blockers": [
+    "None."
+  ],
+  "touched_paths": [
+    "src/agentic_workspace/workspace_runtime_core.py",
+    "src/agentic_workspace/workspace_runtime_primitives.py",
+    "src/agentic_workspace/session_logging.py",
+    "src/agentic_workspace/contracts/cli_commands.json",
+    "generated/workspace/python/cli.py",
+    "tests/test_workspace_cli.py",
+    "tests/test_workspace_cli_blackbox.py",
+    "tests/test_workspace_session_logging.py"
+  ],
+  "invariants": [
+    "Preserve the planning contract and keep the work bounded to this plan."
+  ],
+  "validation_commands": [
+    "uv run pytest tests/test_workspace_cli.py tests/test_workspace_cli_blackbox.py tests/test_workspace_session_logging.py -q",
+    "uv run python scripts/generate/generate_command_packages.py --check",
+    "git diff --check"
+  ],
+  "required_tools": [
+    "None."
+  ],
+  "completion_criteria": [
+    "Payload defaults are compact with recoverable detail; proof task context works or recovers precisely; unexpected JSON failures are structured and classified; Planning retry states name one exact safe route; focused proof and dogfood replay pass."
+  ],
+  "execution_run": {
+    "run status": "completed",
+    "executor": "agentic-planning closeout",
+    "handoff source": "agentic-planning new-plan",
+    "what happened": "Implemented compact payload-target output, task-aware proof, runtime error envelopes, session-log classification, and exact closeout recovery.",
+    "scope touched": "#2143 parent lane and #2149-#2152 child slices.",
+    "changed surfaces": "CLI contracts, runtime, generated Python/TypeScript adapters, session logging, and focused tests.",
+    "validations run": "make test-workspace; make lint-workspace; generated Python+Docker conformance; make typecheck",
+    "result for continuation": "bounded closeout complete",
+    "next step": "archive this execplan"
+  },
+  "finished_run_review": {
+    "review status": "complete",
+    "scope respected": "Scope preserved payload, proof, and Planning gates; explicit drilldowns and host-agnostic agent judgment remain intact.",
+    "proof status": "passed",
+    "intent served": "yes",
+    "config compliance": "used planning closeout command-owned writer",
+    "misinterpretation risk": "low",
+    "follow-on decision": "none"
+  },
+  "delegation_outcome_feedback": {
+    "route chosen": "not-delegated",
+    "route skipped reason": "No delegation route was recorded; prepare-closeout normalized archive-only residue.",
+    "expected savings": "none recorded",
+    "actual friction": "none recorded",
+    "proof result": "yes; planning closeout consumed the latest successful proof receipt.",
+    "quality concern": "none recorded",
+    "decomposition adjustment": "none"
+  },
+  "proof_report": {
+    "validation proof": "make test-workspace; make lint-workspace; generated Python+Docker conformance; make typecheck",
+    "proof achieved now": "yes; planning closeout consumed the latest successful proof receipt.",
+    "evidence for \"proof achieved\" state": "make test-workspace; make lint-workspace; generated Python+Docker conformance; make typecheck",
+    "proof receipt": "{\"changed_paths\": [\"src/agentic_workspace/cli.py\", \"src/agentic_workspace/session_logging.py\", \"src/agentic_workspace/workspace_runtime_primitives.py\", \"src/agentic_workspace/workspace_runtime_core.py\", \"src/agentic_workspace/contracts/cli_commands.json\", \"src/agentic_workspace/contracts/command_package_ir.json\", \"generated/workspace/python/adapter_commands.json\", \"generated/workspace/typescript/src/cli.mjs\", \"tests/test_workspace_cli.py\", \"tests/test_workspace_cli_blackbox.py\", \"tests/test_workspace_session_logging.py\"], \"path\": \".agentic-workspace/local/proof-receipts/last.json\", \"plan_id\": \"2143-package-output-friction\", \"recorded_at\": \"2026-07-10T10:35:03+00:00\", \"result\": \"passed\"}"
+  },
+  "intent_satisfaction": {
+    "original intent": "Create a bounded plan for Reduce package-output friction exposed by session-log dogfooding.",
+    "was original intent fully satisfied?": "yes",
+    "evidence of intent satisfaction": "make test-workspace; make lint-workspace; generated Python+Docker conformance; make typecheck",
+    "unsolved intent passed to": "none"
+  },
+  "execution_summary": {
+    "outcome delivered": "Full #2143 lane is validated and ready for one PR.",
+    "validation confirmed": "make test-workspace; make lint-workspace; generated Python+Docker conformance; make typecheck",
+    "follow-on routed to": "none",
+    "post-work posterity capture": "archive closeout distillation",
+    "resume from": "archive",
+    "knowledge promoted (Memory/Docs/Config)": "none"
+  },
+  "durable_residue": {
+    "status": "none",
+    "learned constraint": "No future-relevant learning was identified beyond the closeout evidence.",
+    "motivation worth preserving": "Closeout reviewed durable residue and found no live follow-up.",
+    "canonical owner now": "none",
+    "promotion trigger": "none",
+    "retention after promotion": "retain"
+  },
+  "task_intent_promotion": {
+    "decision": "do-not-promote",
+    "accepted values": "do-not-promote|memory|subsystem-intent|system-intent|refine-existing-intent|supersede-existing-intent",
+    "evidence source": "archive-plan --prepare-closeout",
+    "target scope": "none",
+    "proposed durable intent": "Closeout reviewed durable residue and found no live follow-up.",
+    "confidence": "low",
+    "needs review": true,
+    "owner surface": "none"
+  },
+  "closure_check": {
+    "closeout scope": "lane",
+    "slice status": "completed",
+    "larger-intent status": "closed",
+    "closure decision": "archive-and-close",
+    "why this decision is honest": "planning closeout accepted a lane claim with intent-status satisfied.",
+    "evidence carried forward": "make test-workspace; make lint-workspace; generated Python+Docker conformance; make typecheck",
+    "reopen trigger": "None unless new evidence shows the closeout was incomplete."
+  },
+  "improvement_signal_review": {
+    "status": "not_checked",
+    "accepted statuses": "not_checked|signals_routed|signals_fixed|signals_dismissed|no_signal_found",
+    "guidance": "At closeout, report AW smoothness/helpfulness gaps, better-way signals, unused-feature reflections, and places AW could help more. Route each concrete signal to exactly one owner class unless explicitly split, or mark no_signal_found after checking.",
+    "source": "operating_posture",
+    "owner classes": [
+      "issue",
+      "Memory",
+      "Planning",
+      "docs/checks/contracts",
+      "direct fix",
+      "dismissed with reason"
+    ],
+    "ordinary output cap": 3,
+    "signals found": [],
+    "signals fixed": [],
+    "signals routed": [],
+    "signals dismissed": [],
+    "next owner": "agent closeout reflection"
+  },
+  "closeout_distillation": {
+    "buckets": {
+      "discard": [
+        {
+          "summary": "No Memory, docs, or config promotion was needed for local execution detail.",
+          "owner": "discard",
+          "source": "execution_summary.knowledge promoted (Memory/Docs/Config)"
+        }
+      ],
+      "continuation": [],
+      "memory": [],
+      "config_check": [],
+      "docs": [],
+      "issue_follow_up": []
+    }
+  },
+  "drift_log": [
+    "2026-07-10: Scaffolded by agentic-planning new-plan."
+  ],
+  "memory_learning_capture": {
+    "status": "reviewed",
+    "memory consult recommended?": "review startup/report memory_consult",
+    "memory notes read": "not recorded",
+    "future agents should not rediscover": "no",
+    "decision": "none",
+    "target": "none",
+    "reason": "Derived from durable_residue during closeout preparation."
+  },
+  "completion_gate": {
+    "kind": "agentic-workspace/completion-gate/v1",
+    "status": "allowed",
+    "active_intent_satisfied": true,
+    "human_accepted_partial": false,
+    "claim_level_requested": "full-intent-complete",
+    "claim_level_allowed": "full-intent-complete",
+    "required_next_action": "close-complete",
+    "claim_authorization": {
+      "kind": "agentic-workspace/claim-authorization/v1",
+      "allowed_claim_classes": [
+        "partial_progress",
+        "slice_complete",
+        "lane_complete",
+        "parent_complete",
+        "full_intent_complete"
+      ],
+      "blocked_claim_classes": [
+        "issue_closure"
+      ],
+      "closure_actions": [],
+      "renderer_rule": "Renderers must choose only templates whose required claim class and closure action are authorized here; unsafe prose examples are diagnostics, not the enforcement model.",
+      "diagnostics": {
+        "unsafe_claim_examples": [],
+        "diagnostic_only": true
+      }
+    },
+    "residual_intent": "",
+    "self_review": {
+      "question": "Does the delivered work satisfy the active human intent?",
+      "answer": "yes",
+      "reason": "Planning closeout evidence supports the requested completion claim."
+    },
+    "continuation": {
+      "owner_surface": "",
+      "created_or_required": false,
+      "reason": ""
+    },
+    "authority_boundary": {
+      "aw_owns": [
+        "forcing the transition rule",
+        "blocking unsupported structured claim classes and closure actions",
+        "routing continuation"
+      ],
+      "agent_owns": [
+        "semantic satisfaction judgment",
+        "evidence interpretation",
+        "next implementation decisions"
+      ],
+      "human_owns": [
+        "accepting narrower scope",
+        "changing intent",
+        "accepting unresolved residual intent"
+      ]
+    }
+  },
+  "generated_closeout": {
+    "status": "generated",
+    "source": "archive-plan --prepare-closeout",
+    "authority": "derived adapter; intent_satisfaction, closure_check, proof_report, durable_residue, execution_run, and execution_summary remain authoritative",
+    "text": "Generated closeout adapter; structured execplan fields are authoritative.\nIntent: Create a bounded plan for Reduce package-output friction exposed by session-log dogfooding.\nIntent satisfied: yes\nArchive decision: archive-and-close\nProof: make test-workspace; make lint-workspace; generated Python+Docker conformance; make typecheck\nChanged surfaces: CLI contracts, runtime, generated Python/TypeScript adapters, session logging, and focused tests.\nDurable residue: none (none)\nMemory learning: none\nFollow-up: none\nCompletion gate: allowed\nCompletion claim allowed: full-intent-complete"
+  }
+}

--- a/generated/workspace/python/adapter_commands.json
+++ b/generated/workspace/python/adapter_commands.json
@@ -2675,6 +2675,13 @@
         },
         {
           "flags": [
+            "--task"
+          ],
+          "help": "Optional task description used to keep changed-path proof selection aligned with the active task context.",
+          "name": "task"
+        },
+        {
+          "flags": [
             "--route"
           ],
           "help": "Return one proof route by id instead of the full proof surface.",
@@ -3975,6 +3982,21 @@
           "help": "Maximum token age when --strict-preflight is enabled (default: 900).",
           "name": "preflight_max_age_seconds",
           "type": "integer"
+        },
+        {
+          "action": "store_true",
+          "flags": [
+            "--verbose"
+          ],
+          "help": "Emit full lifecycle and per-file detail. The default upgrade output is compact and decision-first.",
+          "name": "verbose"
+        },
+        {
+          "flags": [
+            "--select"
+          ],
+          "help": "Return selected fields from the full upgrade payload.",
+          "name": "select"
         },
         {
           "action": "store_true",

--- a/generated/workspace/python/command_package.json
+++ b/generated/workspace/python/command_package.json
@@ -3214,6 +3214,13 @@
           },
           {
             "flags": [
+              "--task"
+            ],
+            "help": "Optional task description used to keep changed-path proof selection aligned with the active task context.",
+            "name": "task"
+          },
+          {
+            "flags": [
               "--route"
             ],
             "help": "Return one proof route by id instead of the full proof surface.",
@@ -5387,6 +5394,21 @@
           {
             "action": "store_true",
             "flags": [
+              "--verbose"
+            ],
+            "help": "Emit full lifecycle and per-file detail. The default upgrade output is compact and decision-first.",
+            "name": "verbose"
+          },
+          {
+            "flags": [
+              "--select"
+            ],
+            "help": "Return selected fields from the full upgrade payload.",
+            "name": "select"
+          },
+          {
+            "action": "store_true",
+            "flags": [
               "--dry-run"
             ],
             "help": "Show planned changes without mutating files.",
@@ -6571,6 +6593,11 @@
             "attr": "changed",
             "kind": "list_attr",
             "name": "changed_paths"
+          },
+          {
+            "attr": "task",
+            "kind": "attr",
+            "name": "task_text"
           },
           {
             "default": "tiny",

--- a/generated/workspace/python/commands/proof_report.py
+++ b/generated/workspace/python/commands/proof_report.py
@@ -31,16 +31,17 @@ def run(args: argparse.Namespace) -> int:
     _arg_3_route = getattr(args, 'route', None)
     _arg_4_current_only = bool(getattr(args, 'current', False))
     _arg_5_changed_paths = list(getattr(args, 'changed', []) or [])
-    _arg_6_profile = _diagnostic_profile(args, default='tiny')
-    _arg_7_select = getattr(args, 'select', None)
-    _arg_8_record_receipt = bool(getattr(args, 'record_receipt', False))
-    _arg_9_receipt_command = getattr(args, 'receipt_command', '')
-    _arg_10_receipt_result = getattr(args, 'receipt_result', '')
-    _arg_11_receipt_plan = getattr(args, 'receipt_plan', '')
-    _arg_12_receipt_log = getattr(args, 'receipt_log', '')
-    _arg_13_dry_run = bool(getattr(args, 'dry_run', False))
+    _arg_6_task_text = getattr(args, 'task', None)
+    _arg_7_profile = _diagnostic_profile(args, default='tiny')
+    _arg_8_select = getattr(args, 'select', None)
+    _arg_9_record_receipt = bool(getattr(args, 'record_receipt', False))
+    _arg_10_receipt_command = getattr(args, 'receipt_command', '')
+    _arg_11_receipt_result = getattr(args, 'receipt_result', '')
+    _arg_12_receipt_plan = getattr(args, 'receipt_plan', '')
+    _arg_13_receipt_log = getattr(args, 'receipt_log', '')
+    _arg_14_dry_run = bool(getattr(args, 'dry_run', False))
     from agentic_workspace.workspace_runtime_primitives import _emit_proof
-    _emit_proof(format_name=_arg_0_format_name, target_root=_arg_1_target_root, descriptors=_arg_2_descriptors, route=_arg_3_route, current_only=_arg_4_current_only, changed_paths=_arg_5_changed_paths, profile=_arg_6_profile, select=_arg_7_select, record_receipt=_arg_8_record_receipt, receipt_command=_arg_9_receipt_command, receipt_result=_arg_10_receipt_result, receipt_plan=_arg_11_receipt_plan, receipt_log=_arg_12_receipt_log, dry_run=_arg_13_dry_run)
+    _emit_proof(format_name=_arg_0_format_name, target_root=_arg_1_target_root, descriptors=_arg_2_descriptors, route=_arg_3_route, current_only=_arg_4_current_only, changed_paths=_arg_5_changed_paths, task_text=_arg_6_task_text, profile=_arg_7_profile, select=_arg_8_select, record_receipt=_arg_9_record_receipt, receipt_command=_arg_10_receipt_command, receipt_result=_arg_11_receipt_result, receipt_plan=_arg_12_receipt_plan, receipt_log=_arg_13_receipt_log, dry_run=_arg_14_dry_run)
     return 0
 
 

--- a/generated/workspace/typescript/resources/command_package.json
+++ b/generated/workspace/typescript/resources/command_package.json
@@ -3214,6 +3214,13 @@
           },
           {
             "flags": [
+              "--task"
+            ],
+            "help": "Optional task description used to keep changed-path proof selection aligned with the active task context.",
+            "name": "task"
+          },
+          {
+            "flags": [
               "--route"
             ],
             "help": "Return one proof route by id instead of the full proof surface.",
@@ -5383,6 +5390,21 @@
             "help": "Maximum token age when --strict-preflight is enabled (default: 900).",
             "name": "preflight_max_age_seconds",
             "type": "integer"
+          },
+          {
+            "action": "store_true",
+            "flags": [
+              "--verbose"
+            ],
+            "help": "Emit full lifecycle and per-file detail. The default upgrade output is compact and decision-first.",
+            "name": "verbose"
+          },
+          {
+            "flags": [
+              "--select"
+            ],
+            "help": "Return selected fields from the full upgrade payload.",
+            "name": "select"
           },
           {
             "action": "store_true",

--- a/generated/workspace/typescript/src/cli.mjs
+++ b/generated/workspace/typescript/src/cli.mjs
@@ -2706,6 +2706,13 @@ const commandDefinitions = [
         },
         {
           "flags": [
+            "--task"
+          ],
+          "help": "Optional task description used to keep changed-path proof selection aligned with the active task context.",
+          "name": "task"
+        },
+        {
+          "flags": [
             "--route"
           ],
           "help": "Return one proof route by id instead of the full proof surface.",
@@ -4038,6 +4045,21 @@ const commandDefinitions = [
           "help": "Maximum token age when --strict-preflight is enabled (default: 900).",
           "name": "preflight_max_age_seconds",
           "type": "integer"
+        },
+        {
+          "action": "store_true",
+          "flags": [
+            "--verbose"
+          ],
+          "help": "Emit full lifecycle and per-file detail. The default upgrade output is compact and decision-first.",
+          "name": "verbose"
+        },
+        {
+          "flags": [
+            "--select"
+          ],
+          "help": "Return selected fields from the full upgrade payload.",
+          "name": "select"
         },
         {
           "action": "store_true",

--- a/src/agentic_workspace/cli.py
+++ b/src/agentic_workspace/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import sys
 from pathlib import Path
 
@@ -21,7 +22,35 @@ def _load_main():
 def _run_cli(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     generated_main = _load_main()
-    return run_with_session_logging(args, generated_main)
+    try:
+        return run_with_session_logging(args, generated_main)
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 - the root CLI owns the last-resort recovery envelope
+        command = " ".join(args)
+        json_mode = any(token == "--format=json" for token in args) or any(
+            token == "--format" and index + 1 < len(args) and args[index + 1] == "json" for index, token in enumerate(args)
+        )
+        if json_mode:
+            payload = {
+                "kind": "agentic-workspace/runtime-error/v1",
+                "status": "failed",
+                "command": command,
+                "exit_status": 1,
+                "exception_class": type(exc).__name__,
+                "failure_class": "unexpected-runtime-exception",
+                "safe_to_retry": False,
+                "safe_recovery": "Report the exception class and command; rerun only after correcting the package failure or with an explicit debug route.",
+                "completion_boundary": "command-did-not-complete",
+            }
+            print(json.dumps(payload, indent=2))
+        else:
+            print(
+                f"agentic-workspace failed ({type(exc).__name__}): {exc}\n"
+                "The command did not complete. Fix or report the package failure before retrying.",
+                file=sys.stderr,
+            )
+        return 1
 
 
 main = _run_cli

--- a/src/agentic_workspace/contracts/cli_commands.json
+++ b/src/agentic_workspace/contracts/cli_commands.json
@@ -2166,6 +2166,13 @@
           "help": "Optional repository path used to inspect installed modules and proof state."
         },
         {
+          "name": "task",
+          "flags": [
+            "--task"
+          ],
+          "help": "Optional task description used to keep changed-path proof selection aligned with the active task context."
+        },
+        {
           "name": "route",
           "flags": [
             "--route"
@@ -2845,6 +2852,21 @@
         "preflight_gate"
       ],
       "options": [
+        {
+          "name": "verbose",
+          "flags": [
+            "--verbose"
+          ],
+          "action": "store_true",
+          "help": "Emit full lifecycle and per-file detail. The default upgrade output is compact and decision-first."
+        },
+        {
+          "name": "select",
+          "flags": [
+            "--select"
+          ],
+          "help": "Return selected fields from the full upgrade payload."
+        },
         {
           "name": "dry_run",
           "flags": [

--- a/src/agentic_workspace/contracts/command_package_ir.json
+++ b/src/agentic_workspace/contracts/command_package_ir.json
@@ -1143,6 +1143,11 @@
                 "attr": "changed"
               },
               {
+                "name": "task_text",
+                "kind": "attr",
+                "attr": "task"
+              },
+              {
                 "name": "profile",
                 "kind": "diagnostic_profile",
                 "default": "tiny"
@@ -4508,6 +4513,13 @@
                 "help": "Optional repository path used to inspect installed modules and proof state."
               },
               {
+                "name": "task",
+                "flags": [
+                  "--task"
+                ],
+                "help": "Optional task description used to keep changed-path proof selection aligned with the active task context."
+              },
+              {
                 "name": "route",
                 "flags": [
                   "--route"
@@ -6677,6 +6689,21 @@
                 "type": "integer",
                 "default": 900,
                 "help": "Maximum token age when --strict-preflight is enabled (default: 900)."
+              },
+              {
+                "name": "verbose",
+                "flags": [
+                  "--verbose"
+                ],
+                "action": "store_true",
+                "help": "Emit full lifecycle and per-file detail. The default upgrade output is compact and decision-first."
+              },
+              {
+                "name": "select",
+                "flags": [
+                  "--select"
+                ],
+                "help": "Return selected fields from the full upgrade payload."
               },
               {
                 "name": "dry_run",

--- a/src/agentic_workspace/session_logging.py
+++ b/src/agentic_workspace/session_logging.py
@@ -1186,6 +1186,8 @@ def _failure_class(*, command_text: str, capture: CommandCapture) -> str:
     parsed = _parse_jsonish(capture.stdout.strip()) or _parse_jsonish(capture.stderr.strip())
     if isinstance(parsed, dict) and str(parsed.get("kind", "")).endswith("/retryable-cli-error/v1"):
         return str(parsed.get("failure_class") or "retryable-cli-usage")
+    if isinstance(parsed, dict) and str(parsed.get("kind", "")) == "agentic-workspace/runtime-error/v1":
+        return str(parsed.get("failure_class") or "unexpected-runtime-exception")
     command = command_text.lower()
     stderr = capture.stderr.lower()
     if "--verbose" in command and "--section" in command:

--- a/src/agentic_workspace/workspace_runtime_core.py
+++ b/src/agentic_workspace/workspace_runtime_core.py
@@ -42334,6 +42334,7 @@ def _emit_proof(
     route: str | None = None,
     current_only: bool = False,
     changed_paths: list[str] | None = None,
+    task_text: str | None = None,
     profile: str = "full",
     select: str | None = None,
     record_receipt: bool = False,
@@ -42366,7 +42367,12 @@ def _emit_proof(
             _emit_compact_answer_text(payload)
         return
     if profile == "tiny" and normalized_paths:
-        answer = _proof_selection_for_changed_paths(changed_paths=normalized_paths, target_root=target_root, include_durable_intent=False)
+        answer = _proof_selection_for_changed_paths(
+            changed_paths=normalized_paths,
+            target_root=target_root,
+            include_durable_intent=False,
+            task_text=task_text,
+        )
         full_payload = {
             "profile": "compact-contract-answer/v1",
             "surface": "proof",
@@ -42379,6 +42385,8 @@ def _emit_proof(
             full_payload,
             cli_invoke=config.cli_invoke,
         )
+        if task_text:
+            payload["task_context"] = {"status": "applied", "task": task_text}
         if select:
             full_payload.setdefault("sufficiency", payload.get("sufficiency", answer.get("sufficiency")))
             full_payload.setdefault("next", payload.get("next"))
@@ -42390,6 +42398,8 @@ def _emit_proof(
         return
     payload = _proof_payload(target_root=target_root, descriptors=descriptors)
     payload = _select_proof_payload(payload, target_root=target_root, route=route, current_only=current_only, changed_paths=changed_paths)
+    if task_text and changed_paths:
+        payload["task_context"] = {"status": "applied", "task": task_text}
     if profile == "tiny":
         payload = _tiny_proof_payload(payload, cli_invoke=config.cli_invoke)
     if select:

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -39981,15 +39981,18 @@ def _emit_lifecycle_mutation_result(
         "dry_run": bool(getattr(args, "dry_run", False)),
         "changed_count": changed_count,
         "manual_attention_count": manual_attention_count,
-        "safe_explicit_apply": bool(getattr(args, "dry_run", False)) and manual_attention_count == 0,
+        "safe_explicit_apply": action_state.get("safe_to_apply") is True,
         "next_action": {"command": next_command},
         "detail_commands": {
             "verbose": _command_with_cli_invoke(
-                command=f"agentic-workspace upgrade --target {target_root.as_posix()} --verbose --format json",
+                command=f"agentic-workspace upgrade --target {target_root.as_posix()} --to-payload-target --verbose --format json",
                 cli_invoke=config.cli_invoke,
             ),
             "select": _command_with_cli_invoke(
-                command=f"agentic-workspace upgrade --target {target_root.as_posix()} --select <field[,field...]> --format json",
+                command=(
+                    f"agentic-workspace upgrade --target {target_root.as_posix()} --to-payload-target "
+                    "--select <field[,field...]> --format json"
+                ),
                 cli_invoke=config.cli_invoke,
             ),
         },

--- a/src/agentic_workspace/workspace_runtime_primitives.py
+++ b/src/agentic_workspace/workspace_runtime_primitives.py
@@ -39123,6 +39123,7 @@ def _emit_proof(
     route: str | None = None,
     current_only: bool = False,
     changed_paths: list[str] | None = None,
+    task_text: str | None = None,
     profile: str = "full",
     select: str | None = None,
     record_receipt: bool = False,
@@ -39155,7 +39156,12 @@ def _emit_proof(
             _emit_compact_answer_text(payload)
         return
     if profile == "tiny" and normalized_paths:
-        answer = _proof_selection_for_changed_paths(changed_paths=normalized_paths, target_root=target_root, include_durable_intent=False)
+        answer = _proof_selection_for_changed_paths(
+            changed_paths=normalized_paths,
+            target_root=target_root,
+            include_durable_intent=False,
+            task_text=task_text,
+        )
         full_payload = {
             "profile": "compact-contract-answer/v1",
             "surface": "proof",
@@ -39168,6 +39174,8 @@ def _emit_proof(
             full_payload,
             cli_invoke=config.cli_invoke,
         )
+        if task_text:
+            payload["task_context"] = {"status": "applied", "task": task_text}
         if select:
             full_payload.setdefault("sufficiency", payload.get("sufficiency", answer.get("sufficiency")))
             full_payload.setdefault("next", payload.get("next"))
@@ -39179,6 +39187,8 @@ def _emit_proof(
         return
     payload = _proof_payload(target_root=target_root, descriptors=descriptors)
     payload = _select_proof_payload(payload, target_root=target_root, route=route, current_only=current_only, changed_paths=changed_paths)
+    if task_text and changed_paths:
+        payload["task_context"] = {"status": "applied", "task": task_text}
     if profile == "tiny":
         payload = _tiny_proof_payload(payload, cli_invoke=config.cli_invoke)
     if select:
@@ -39771,6 +39781,44 @@ def _run_planning_closeout_adapter(args: argparse.Namespace) -> int:
             ("agentic-memory ", "agentic-workspace memory "),
         ):
             output = output.replace(old, new)
+        if getattr(args, "format", "text") == "json" and output.strip():
+            try:
+                closeout_payload = json.loads(output)
+            except json.JSONDecodeError:
+                closeout_payload = None
+            if (
+                isinstance(closeout_payload, dict)
+                and int(result or 0) != 0
+                or (isinstance(closeout_payload, dict) and closeout_payload.get("warnings"))
+            ):
+                warnings = _list_payload(closeout_payload.get("warnings")) if isinstance(closeout_payload, dict) else []
+                warning = next((item for item in reversed(warnings) if isinstance(item, dict) and item.get("warning_class")), {})
+                suggested = str(warning.get("suggested_fix") or "").strip()
+                warning_class = str(warning.get("warning_class") or "planning-closeout-precondition")
+                plan_token = f" {plan}" if plan not in (None, "", []) else ""
+                if warning_class in {"closeout_missing_proof", "closeout_receipt_unusable"}:
+                    next_safe_command = (
+                        f"agentic-workspace planning closeout{plan_token} --target . "
+                        '--proof-from "<proof command or evidence>" --format json'
+                    )
+                elif warning_class == "closeout_missing_finish_run_evidence":
+                    next_safe_command = (
+                        f"agentic-workspace planning closeout{plan_token} --target . --proof-from last "
+                        '--what-happened "<summary>" --scope-touched "<scope>" '
+                        '--changed-surfaces "<paths>" --review-summary "<review>" '
+                        '--outcome-summary "<outcome>" --format json'
+                    )
+                else:
+                    next_safe_command = f"agentic-workspace planning closeout{plan_token} --target . --proof-from last --format json"
+                closeout_payload["recovery"] = {
+                    "status": "blocked",
+                    "blocking_rule": warning_class,
+                    "blocking_field": str(warning.get("path") or "planning closeout evidence"),
+                    "next_safe_command": next_safe_command,
+                    "guidance": suggested,
+                    "stop_condition": "Do not retry archive mechanics until this closeout precondition is satisfied.",
+                }
+                output = json.dumps(closeout_payload, indent=2) + "\n"
         print(output, end="")
         return int(result or 0)
     except ImportError as exc:
@@ -39892,6 +39940,64 @@ def _run_init_lifecycle_adapter(args: argparse.Namespace) -> int:
     return 0
 
 
+def _lifecycle_count(value: Any) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value)
+    return 0
+
+
+def _emit_lifecycle_mutation_result(
+    *, args: argparse.Namespace, payload: dict[str, Any], target_root: Path, config: WorkspaceConfig
+) -> None:
+    command_name = str(args.command)
+    select = getattr(args, "select", None)
+    if select:
+        _emit_payload(payload=_select_payload_fields(payload, select=select, source_command=command_name), format_name=args.format)
+        return
+    compact_payload_route = command_name == "upgrade" and bool(getattr(args, "to_payload_target", False))
+    if not compact_payload_route or bool(getattr(args, "verbose", False)):
+        _emit_payload(payload=payload, format_name=args.format)
+        return
+    changed_count = sum(_lifecycle_count(payload.get(key)) for key in ("created", "updated_managed", "removed"))
+    manual_attention_count = sum(_lifecycle_count(payload.get(key)) for key in ("needs_review", "warnings"))
+    compatibility = _as_dict(payload.get("installed_state_compatibility"))
+    action_state = _as_dict(compatibility.get("action_state"))
+    apply_command = str(action_state.get("apply_command") or "").strip()
+    next_command = (
+        apply_command
+        if bool(getattr(args, "dry_run", False)) and apply_command
+        else _command_with_cli_invoke(
+            command=f"agentic-workspace doctor --target {target_root.as_posix()} --format json", cli_invoke=config.cli_invoke
+        )
+    )
+    compact = {
+        "kind": "agentic-workspace/lifecycle-mutation-summary/v1",
+        "command": command_name,
+        "status": compatibility.get("status") or payload.get("health") or ("attention-needed" if manual_attention_count else "ready"),
+        "dry_run": bool(getattr(args, "dry_run", False)),
+        "changed_count": changed_count,
+        "manual_attention_count": manual_attention_count,
+        "safe_explicit_apply": bool(getattr(args, "dry_run", False)) and manual_attention_count == 0,
+        "next_action": {"command": next_command},
+        "detail_commands": {
+            "verbose": _command_with_cli_invoke(
+                command=f"agentic-workspace upgrade --target {target_root.as_posix()} --verbose --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+            "select": _command_with_cli_invoke(
+                command=f"agentic-workspace upgrade --target {target_root.as_posix()} --select <field[,field...]> --format json",
+                cli_invoke=config.cli_invoke,
+            ),
+        },
+        "rule": "Default lifecycle output answers the decision question; request verbose or selected fields for per-file detail.",
+    }
+    _emit_payload(payload=compact, format_name=args.format)
+
+
 def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
     command_name = str(args.command)
     target_root, local_only_repo_root, selected_modules, resolved_preset, descriptors, config = _load_lifecycle_mutation_context(
@@ -39910,7 +40016,7 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
             resolved_preset=resolved_preset,
             non_interactive=args.non_interactive,
         )
-        _emit_payload(payload=payload, format_name=args.format)
+        _emit_lifecycle_mutation_result(args=args, payload=payload, target_root=target_root, config=config)
         return 0
     if command_name == "upgrade" and bool(getattr(args, "repair_managed_local_instructions", False)):
         payload = _run_managed_local_instructions_repair(
@@ -39921,7 +40027,7 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
             resolved_preset=resolved_preset,
             non_interactive=args.non_interactive,
         )
-        _emit_payload(payload=payload, format_name=args.format)
+        _emit_lifecycle_mutation_result(args=args, payload=payload, target_root=target_root, config=config)
         return 0
     if command_name == "upgrade" and bool(getattr(args, "repair_root_startup_pointer", False)):
         payload = _run_root_startup_pointer_repair(
@@ -39932,7 +40038,7 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
             resolved_preset=resolved_preset,
             non_interactive=args.non_interactive,
         )
-        _emit_payload(payload=payload, format_name=args.format)
+        _emit_lifecycle_mutation_result(args=args, payload=payload, target_root=target_root, config=config)
         return 0
     if command_name == "upgrade" and bool(getattr(args, "adopt_local_only", False)):
         adoption_modules = [entry.name for entry in _module_registry(descriptors=descriptors, target_root=target_root) if entry.installed]
@@ -39944,7 +40050,7 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
             resolved_preset=resolved_preset,
             non_interactive=args.non_interactive,
         )
-        _emit_payload(payload=payload, format_name=args.format)
+        _emit_lifecycle_mutation_result(args=args, payload=payload, target_root=target_root, config=config)
         return 0
     if command_name == "upgrade" and bool(getattr(args, "to_necessary_surfaces", False)):
         migration = _workspace_runtime_core._necessary_surfaces_migration_payload(
@@ -39969,7 +40075,7 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
             "reports": [report],
             **summary,
         }
-        _emit_payload(payload=payload, format_name=args.format)
+        _emit_lifecycle_mutation_result(args=args, payload=payload, target_root=target_root, config=config)
         return 0
     payload = _run_lifecycle_command(
         command_name=command_name,
@@ -39986,7 +40092,7 @@ def _run_lifecycle_mutation_adapter(args: argparse.Namespace) -> int:
         footprint_profile=getattr(args, "footprint_profile", None),
         mirror_payload=bool(getattr(args, "mirror_payload", False)),
     )
-    _emit_payload(payload=payload, format_name=args.format)
+    _emit_lifecycle_mutation_result(args=args, payload=payload, target_root=target_root, config=config)
     return 0
 
 

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -2040,6 +2040,13 @@ def test_upgrade_to_payload_target_forces_provenance_capability_sync(tmp_path: P
     provenance_path.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     assert cli.main(["upgrade", "--target", str(tmp_path), "--to-payload-target", "--dry-run", "--format", "json"]) == 0
+    compact_payload = json.loads(capsys.readouterr().out)
+    assert compact_payload["kind"] == "agentic-workspace/lifecycle-mutation-summary/v1"
+    assert set(("status", "changed_count", "manual_attention_count", "safe_explicit_apply", "next_action")) <= compact_payload.keys()
+    assert len(json.dumps(compact_payload)) < 4_000
+    assert "--verbose" in compact_payload["detail_commands"]["verbose"]
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-payload-target", "--dry-run", "--verbose", "--format", "json"]) == 0
     dry_run_payload = json.loads(capsys.readouterr().out)
     dry_run_plan = dry_run_payload["installed_state_compatibility"]["payload_upgrade_attention_plan"]
     assert dry_run_plan["strategy"] == "converge-to-current-contract"
@@ -2075,7 +2082,7 @@ def test_upgrade_to_payload_target_forces_provenance_capability_sync(tmp_path: P
     assert compatibility["status"] == "compatible"
     assert compatibility["payload"]["target"]["status"] == "satisfied"
 
-    assert cli.main(["upgrade", "--target", str(tmp_path), "--dry-run", "--format", "json"]) == 0
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--dry-run", "--verbose", "--format", "json"]) == 0
     ordinary_dry_run_payload = json.loads(capsys.readouterr().out)
     ordinary_workspace_report = next(report for report in ordinary_dry_run_payload["reports"] if report["module"] == "workspace")
     ordinary_action = next(
@@ -6663,8 +6670,12 @@ impact = "claim-limiting"
     )
     _write(tmp_path / "tools" / "run.py", "print('ok')\n")
 
-    assert cli.main(["proof", "--target", str(tmp_path), "--changed", "tools/run.py", "--format", "json"]) == 0
+    assert (
+        cli.main(["proof", "--target", str(tmp_path), "--changed", "tools/run.py", "--task", "Validate the local tool", "--format", "json"])
+        == 0
+    )
     payload = json.loads(capsys.readouterr().out)
+    assert payload["task_context"] == {"status": "applied", "task": "Validate the local tool"}
     assert payload["local_overlay"]["status"] == "active"
     assert payload["local_overlay"]["ordinary_guidance_count"] == 1
     assert payload.get("high_risk_overlay") is None

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -2044,7 +2044,12 @@ def test_upgrade_to_payload_target_forces_provenance_capability_sync(tmp_path: P
     assert compact_payload["kind"] == "agentic-workspace/lifecycle-mutation-summary/v1"
     assert set(("status", "changed_count", "manual_attention_count", "safe_explicit_apply", "next_action")) <= compact_payload.keys()
     assert len(json.dumps(compact_payload)) < 4_000
-    assert "--verbose" in compact_payload["detail_commands"]["verbose"]
+    assert compact_payload["detail_commands"]["verbose"].endswith(
+        f"upgrade --target {tmp_path.as_posix()} --to-payload-target --verbose --format json"
+    )
+    assert compact_payload["detail_commands"]["select"].endswith(
+        f"upgrade --target {tmp_path.as_posix()} --to-payload-target --select <field[,field...]> --format json"
+    )
 
     assert cli.main(["upgrade", "--target", str(tmp_path), "--to-payload-target", "--dry-run", "--verbose", "--format", "json"]) == 0
     dry_run_payload = json.loads(capsys.readouterr().out)
@@ -2511,6 +2516,47 @@ def test_payload_target_blocks_when_invoked_cli_cannot_satisfy_explicit_target(t
     assert compatibility["action_state"]["state"] == "blocking_incompatible"
     assert compatibility["action_state"]["safe_to_apply"] is False
     assert "--to-payload-target" not in compatibility["action_state"]["command"]
+
+    assert cli.main(["upgrade", "--target", str(tmp_path), "--to-payload-target", "--dry-run", "--format", "json"]) == 0
+    compact_upgrade = json.loads(capsys.readouterr().out)
+    assert compact_upgrade["status"] == "blocking-drift"
+    assert compact_upgrade["safe_explicit_apply"] is False
+
+
+def test_compact_payload_upgrade_projects_authoritative_unsafe_action_without_manual_attention(tmp_path: Path, capsys) -> None:
+    from types import SimpleNamespace
+
+    args = SimpleNamespace(
+        command="upgrade",
+        select=None,
+        to_payload_target=True,
+        verbose=False,
+        dry_run=True,
+        format="json",
+    )
+    payload = {
+        "installed_state_compatibility": {
+            "status": "blocking-drift",
+            "action_state": {
+                "state": "blocking_incompatible",
+                "safe_to_apply": False,
+                "apply_command": "",
+            },
+        },
+        "warnings": [],
+        "needs_review": [],
+    }
+
+    cli._emit_lifecycle_mutation_result(
+        args=args,
+        payload=payload,
+        target_root=tmp_path,
+        config=SimpleNamespace(cli_invoke="agentic-workspace"),
+    )
+
+    compact = json.loads(capsys.readouterr().out)
+    assert compact["manual_attention_count"] == 0
+    assert compact["safe_explicit_apply"] is False
 
 
 def test_workspace_config_rejects_invalid_payload_target_policy(tmp_path: Path) -> None:

--- a/tests/test_workspace_cli_blackbox.py
+++ b/tests/test_workspace_cli_blackbox.py
@@ -4,6 +4,8 @@ import json
 import subprocess
 from pathlib import Path
 
+from agentic_workspace import cli as source_cli
+
 
 def _run_cli(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
@@ -56,6 +58,20 @@ def test_blackbox_near_miss_command_guides_to_startup() -> None:
     assert payload["suggested_command"] == "agentic-workspace summary --format json"
     assert "Did you mean: summary?" in payload["message"]
     assert "Startup tip: run 'agentic-workspace start --task \"<task>\" --format json'" in payload["message"]
+
+
+def test_unexpected_json_runtime_exception_has_structured_recovery(monkeypatch, capsys) -> None:
+    def fail(_argv: list[str]) -> int:
+        raise RuntimeError("representative package failure")
+
+    monkeypatch.setattr(source_cli, "_load_main", lambda: fail)
+    assert source_cli.main(["summary", "--format", "json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "agentic-workspace/runtime-error/v1"
+    assert payload["exception_class"] == "RuntimeError"
+    assert payload["failure_class"] == "unexpected-runtime-exception"
+    assert payload["safe_to_retry"] is False
+    assert payload["completion_boundary"] == "command-did-not-complete"
 
 
 def test_blackbox_selector_conflict_guides_to_correct_usage() -> None:

--- a/tests/test_workspace_session_logging.py
+++ b/tests/test_workspace_session_logging.py
@@ -725,6 +725,20 @@ def test_session_log_provenance_and_kind_classes_are_recorded(tmp_path: Path, mo
     assert "created" not in payload["packet_kinds"]
 
 
+def test_session_log_classifies_structured_runtime_exception() -> None:
+    capture = session_logging.CommandCapture(
+        stdout=json.dumps(
+            {
+                "kind": "agentic-workspace/runtime-error/v1",
+                "failure_class": "unexpected-runtime-exception",
+            }
+        ),
+        stderr="",
+        exit_code=1,
+    )
+    assert session_logging._failure_class(command_text="summary --format json", capture=capture) == "unexpected-runtime-exception"
+
+
 def test_session_log_share_safe_export_redacts_all_surfaces_and_preserves_originals(tmp_path: Path, capsys, monkeypatch) -> None:
     target = _target(tmp_path)
     _write(target / ".agentic-workspace/config.local.toml", "schema_version = 1\n\n[session_logging]\nenabled = true\n")


### PR DESCRIPTION
## What changed

- compacted `upgrade --to-payload-target` into a decision-first default with status, changed/manual-attention counts, safe apply state, next action, and explicit `--verbose`/`--select` drilldowns
- made `proof --task` a generated Python/TypeScript CLI input and propagated task context into changed-path proof selection
- added root JSON-mode envelopes for unexpected runtime exceptions and a distinct session-log failure classification
- added structured Planning closeout recovery with the blocking rule/field, one exact next command, and an archive-retry stop condition
- retained the checked-in Planning closeout record and refreshed required payload provenance

## Why

The #2141 dogfooding archive showed that logging could hide package noise but could not remove the underlying completion cost. The ordinary package path still emitted thousands of payload lines, rejected task-scoped proof context, exposed weak unexpected-exception recovery, and encouraged interpretive closeout retries.

## Impact

The reproduced payload-target dry-run fell from 7,144 lines to 17 lines by default while full per-file detail remains available. Task-scoped proof no longer needs a failed discovery command. Unexpected JSON failures are non-empty and machine-routable. Planning closeout blocks now tell the agent exactly what is missing and what to run next.

## Validation

- `make test-workspace` — 1,108 passed, 2 skipped
- `make lint-workspace`
- contract tooling and structured-file inventory checks
- generated command-package static, Python, operation, and Docker conformance
- `make typecheck`
- runtime mirror consistency report: `shape_in_sync`
- dogfooding replays for payload output, `proof --task`, runtime envelope classification, and Planning closeout recovery

Closes #2143
Closes #2149
Closes #2150
Closes #2151
Closes #2152